### PR TITLE
[BEAM-115] WIP: JSON Schema definition of pipeline

### DIFF
--- a/model/pipeline/pom.xml
+++ b/model/pipeline/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-model-parent</artifactId>
+    <version>0.2.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>beam-model-pipeline</artifactId>
+  <name>Apache Beam :: Model :: Pipeline</name>
+  <description>The Beam Model for a Pipeline includes language-independent
+  definitions of the pieces that make up a Beam pipeline</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <timestamp>${maven.build.timestamp}</timestamp>
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.github.fge</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>2.2.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/model/pipeline/src/main/resources/org/apache/beam/model/pipeline/pipeline.json
+++ b/model/pipeline/src/main/resources/org/apache/beam/model/pipeline/pipeline.json
@@ -1,0 +1,320 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "type": "object",
+
+  "$ref": "#/definitions/Pipeline",
+
+  "definitions": {
+    // A Pipeline contains the entire hierarchical graph including
+    // nodes for all values.
+    //
+    // Nodes (transform or value or other) are identified by some unique id. This need
+    // not be readable. It is simplest to think of it as a reified pointer or UUID.
+    // Cyclic pointer structures are forbidden throughout.
+    "Pipeline": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [ "userFns", "transforms", "values", "windowingStrategies", "coders" ],
+      "properties": {
+
+        // A mapping containing all user-definable functions in the pipeline.
+        // The keys must be unique to this pipeline definition, but otherwise are
+        // arbitrary.
+        "userFns": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/UserFn" }
+        },
+
+        // A mapping containing all transforms in the pipeline.
+        "transforms": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/TransformNode" }
+        },
+
+        // A mapping containing all the primitive values in the pipeline.
+        "values": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/Value" }
+        },
+
+        // A flat list of windowing strategies. These may be referenced repeatedly.
+        "windowingStrategies": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/WindowingStrategy" }
+        },
+
+        "coders": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/Coder" }
+        }
+
+        // TODO: aggregators
+        // TODO: pipeline options
+        // TODO: pipeline-level display metadata
+        // TODO: SDK capabilities
+      }
+    },
+
+    // A user-defined function.
+    //
+    // TODO: the exact details of this will be fleshed out as the Fn API matures.
+    "UserFn": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        // A cross-language, stable, unique identifier for the function. It should indicate
+        // enough information that naive optimization (or language-to-language replacement)
+        // may be possible, since the runner will have no insight into the SDK-specific data.
+        "urn": { "type": "string" },
+
+        // A URL for the container image containing the SDK that understands how to run
+        // this user-definable function.
+        "sdkContainer": { "type": "string" },
+
+        // A free-form object containing SDK-specific data.
+        "data":  { "type": "object" }
+      },
+
+      "required": ["urn", "data"]
+    },
+
+    // A windowing strategy describes the window function, triggering, allowed lateness
+    // for a PCollection
+    "WindowingStrategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        // The id of a user-definable function that assigns windows, merges windows, and shifts
+        // timestamps.
+        "windowFn": { "type": "string" },
+
+        // Whether or not the window fn is merging; this affects how a runner may implement things
+        //
+        // TBD whether this metadata will live in the UserFn record or here or both
+        "isMergingWindowFn": { "type": "boolean" },
+
+        // The encoding node of the windows for the window_fn.
+        "windowCoder": { "type": "string" },
+
+        // The trigger, as a simple syntax tree
+        // TODO: the referenced definition
+        "trigger": { "$ref": "#/definitions/Trigger" },
+
+        // The accumulation mode indicates whether new panes are a full replacement for
+        // prior panes or whether they are deltas to be combined with other panes (the combine
+        // should correspond to whatever the upstream grouping transform is).
+        "accumulationMode": { "$ref": "#/definitions/AccumulationMode" },
+
+        // The OutputTime specifies, for a grouping transform, how to compute the
+        // aggregate timestamp. The window_fn will first possibly shift it later, then the
+        // OutputTime takes the max, min, or ignores it and takes the end of window.
+        "outputTime": { "$ref": "#/definitions/OutputTime" },
+
+        // After the watermark gets this far past the end of the window, new elements are dropped.
+        // in milliseconds
+        "allowedLateness": { "type": "number" }
+      }
+    },
+
+    "SideInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        // Only "multimap" is supported for initial Beam model
+        "accessPattern": { "type": "string" },
+
+        // The SDK converts the access pattern to an SDK-specific type, and this function
+        // converts it to the users desired side input type
+        "viewFn": { "type": "string" },
+
+        // A function that maps from the main input window to the desired side input window
+        "windowMappingFn": { "type": "string" }
+      }
+    },
+
+     // The parameters to a ParDo transform and further metatdata
+    "ParDoPayload": {
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+        // The DoFn for this ParDo
+        "doFn": { "type": "string" },
+
+        // Whether the ParDo requires access to the current window (this may force runners to perform
+        // additional work prior to executing this ParDo)
+        "requiresWindowAccess": { "type": "boolean" },
+
+        // A map from PCollection id to the specification for how to materialize and read it
+        // as a side input
+        "sideInputs": {
+          "type": "object",
+          "additionalProperties": { "$ref" : "#/definitions/SideInput" }
+        }
+      }
+    },
+
+    // The parameters to a Read transform and further metadata.
+    //
+    // TODO: decide what metadata should be here in runner-readable form vs what is part of the
+    // UDF.
+    "ReadPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        // The ID of the user-definable source fn
+        "source": { "type": "string" },
+
+        "isBounded": { "type": "boolean" },
+        "doesNotRequireSplitting": { "type": "boolean" },
+        "producesSortedKeys": { "type": "boolean" }
+      }
+    },
+
+    // The parameters to a Combine transform and further metadata.
+    "CombinePayload": {
+      "type": "object",
+      "additionalProperties": false,
+
+      "properties": {
+        // The ID of the user-defined CombineFn
+        "combineFn": { "type": "string" }
+      }
+    },
+
+    "WindowIntoPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "windowingStrategy": { "type": "string" }
+      }
+    },
+
+    // A transform node contains pointers to its inputs and outputs, whether
+    // or not it is composite. If it is part of a composite, it contains a pointer
+    // to its parent.
+    "TransformNode": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        // The stable name of the transform application node.
+        "label": { "type": "string" },
+
+        // Whether or not it is composite, it contains a "kind" string that uniquely
+        // identifies what it computes. This is a stable, cross-language string, that
+        // can be used for replacement-based implementation and also to parse the node
+        // to a concrete language-specific class.
+        //
+        // A stable, cross-language identifier identifying what the transform computes.
+        // This is to be used for replacement-based implementation, whether it is a primitive
+        // or composite. Examples include "GroupByKey", "Sum", "ParDo". We should likely
+        // adopt a standard namespacing convention, such as URIs.
+        "urn":  { "type": [ "null", "string" ] },
+
+        // All of the inputs and outputs for the transform, whether it is composite or primitive.
+        // The inputs and outputs of parent and child transforms nodes must be coherent:
+        //
+        // - The unexpanded inputs of every child transforms must be contained
+        //   within some level of the recursive expansion of the inputs to the parent.
+        // - Every level of the expanded output of a composite must be contained within
+        //   some level of the expansion of some child.
+        //
+        // These collections of values are unordered. References to values are managed in
+        // a transform-specific way. For example, a DoFn will call processContext.output(tag, value)
+        // and the tag should contain sufficient information to identify the target PCollection.
+        "inputs": { "type": "array", "items": { "type": "string" } },
+        "outputs": { "type": "array", "items": { "type": "string" } },
+
+        // If the node is contained within a composite, a pointer to the parent.
+        "parent": { "type": [ "null", "string" ] },
+
+        // If the node is a runner-specific replacement for a user's runner-agnostic node,
+        // it contains a pointer back to it so the user's graph can be reconstructed.
+        "replacementFor": { "type": [ "null", "string" ] },
+
+        // If the node is a defunct user node that has been replaced, it contains a bit
+        // to distinguish it from an active node in the graph.
+        "replaced": { "type": "boolean" },
+
+        // Static display data
+        "display_data": { "type": "object", "additionalProperties": { "type": "string" } },
+
+        // The payload must correspond to the kind string and must be null for transforms that
+        // are not predefined as part of the Beam model.
+        "payload": {
+          "type": [ "null", "object" ],
+          "oneOf": [
+            { "$ref": "#/definitions/ParDoPayload" },
+            { "$ref": "#/definitions/ReadPayload" },
+            { "$ref": "#/definitions/WindowIntoPayload" },
+            { "$ref": "#/definitions/CombinePayload" }
+          ]
+        }
+      }
+    },
+
+    // A value node represents a PValue. There are only two primitive types:
+    // A PCollection (many values per window) or a PCollectionView (one value per window).
+    "Value": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        // A unique program-readable name for the value, such as "foo/baz/bar.out
+        "label": { "type": "string" },
+
+        // The node ID for the coder of this PCollection
+        "coder": { "type": "string" },
+
+        // Windowing strategy node id
+        "windowingStrategy": { "type": "string" },
+
+        // This is the static display data recently proposed
+        "displayData": { "$ref": "#/definitions/DisplayData" }
+      }
+    },
+
+    "DisplayData": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+
+    // An coder represents a particular binary format.
+    "Coder": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+
+        // A cross-language, stable, unique identifier for the (possibly parametric) encoding.
+        "urn": { "type": "string" },
+
+        // If this coder is parametric, such as ListCoder(VarIntCoder), this is a list
+        // of the components. In order for encodings to be identical, the encoding_id
+        // and all components must be identical.
+        "componentEncodings": { "type": "array", "items": { "type": "string" } },
+
+        // The SDK-specific user-definable coder implementing the described encoding.
+        //
+        // If present, then the SDK can utilize this coder without a priori knowledge of the
+        // encoded format.
+        //
+        // TBD: multi-SDK support
+        "customCoder": { "type": [ "null", "string" ] }
+      }
+    },
+
+    "OutputTime": {
+      "type": "string",
+      "pattern": "^latest|earliest|eow$"
+    },
+
+    "AccumulationMode": {
+      "type": "string",
+      "pattern": "^discarding|accumulating$"
+    }
+  }
+}

--- a/model/pipeline/src/test/java/org/apache/beam/model/pipeline/PipelineTest.java
+++ b/model/pipeline/src/test/java/org/apache/beam/model/pipeline/PipelineTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.model.pipeline;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.JsonParser.NumberType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class PipelineTest {
+
+  private static final String SCHEMA_URI = "resource:/org/apache/beam/model/pipeline/pipeline.json";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static JsonSchema getSchema() throws ProcessingException {
+    return JsonSchemaFactory.newBuilder()
+            .setLoadingConfiguration(
+                LoadingConfiguration.newBuilder()
+                    .addParserFeature(JsonParser.Feature.ALLOW_COMMENTS)
+                    .freeze())
+            .freeze()
+            .getJsonSchema(SCHEMA_URI);
+  }
+
+  @Test
+  public void testFails() throws Exception {
+    ProcessingReport report = getSchema().validate(MAPPER.readTree("{ \"ziggle\": 3 }"));
+    assertFalse(report.isSuccess());
+  }
+
+  @Test
+  public void testPasses() throws Exception {
+    ProcessingReport report = getSchema().validate(MAPPER.readTree(
+        "{ \"userFns\": {}, \"windowingStrategies\": {}, \"coders\": {}, \"transforms\": {},"
+        + "\"values\": {} }"));
+
+    if (!report.isSuccess()) {
+      throw new ProcessingException(report.iterator().next());
+    }
+  }
+}

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-parent</artifactId>
+    <version>0.2.0-incubating-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>beam-model-parent</artifactId>
+
+  <packaging>pom</packaging>
+
+  <name>Apache Beam :: Model</name>
+
+  <modules>
+    <module>pipeline</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,7 @@
   <packaging>pom</packaging>
 
   <modules>
+    <module>model</module>
     <module>sdks</module>
     <!-- Expose Dataflow runner as top level module to satisfy dependencies in sdks/java/maven-archetypes 
       and examples/java. Until these are refactored out, we need to modify the build order. -->


### PR DESCRIPTION
This is a json-schema sketch of the concrete schema from the [Pipeline Runner API proposal document](https://s.apache.org/beam-runner-api). Because our [serialization tech discussion](http://mail-archives.apache.org/mod_mbox/beam-dev/201606.mbox/%3CCAN_Ypr2ZPQG3OgPWu==kF-zztG06k0v5i0AY3DABCHJyvEr9pA@mail.gmail.com%3E) seemed to favor JSON on the front end and Proto on the backend, I made this quick port. The original Avro IDL definition is also on [a branch with a test](https://github.com/kennknowles/incubator-beam/blob/pipeline-model/model/pipeline/src/main/avro/org/apache/beam/model/pipeline/pipeline.avdl).

Notes & Caveats:
- I did not try to flesh out any more details; this was a straight port. There's plenty to add, but a PR seems like a place that will attract a desired kind of concrete discussion even in the current state.
- Typing this makes my hands hurt. Luckily, it should change exceedingly rarely. There are many libraries that can generate json-schema in various ways, including Jackson itself, but I'm not so sure any of them are applicable.
- Reading this makes my eyes hurt. This is a real problem. We need a readable spec, not just a test suite for validation.
- I am not so sure that [the schema library](https://github.com/daveclayton/json-schema-validator) I've used to build my smoke test is a good long term choice. I chose it because it was Jackson-based.
- I've left comments in the JSON even though that is frowned upon, and taken advantage of Jackson's feature to allow them. They can also go into `"description"` fields.
- Perhaps we could write YAML and convert to json-schema with no loss of precision?

Feel free to leave comments here about the schema or meta issues of e.g. where the schema should live and what libraries we might want to use.
