### PR TITLE
[BEAM-974] Add PubSub attributes support to PubsubIO.

### DIFF
--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -252,7 +252,8 @@ public class GameStats extends LeaderBoard {
 
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
-        .apply(PubsubIO.Read.timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
+        .apply(PubsubIO.<String>read()
+            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     // Extract username/score pairs from the event stream

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -24,6 +24,7 @@ import org.apache.beam.examples.common.ExampleUtils;
 import org.apache.beam.examples.complete.game.utils.WriteWindowedToBigQuery;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.PubsubIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -253,7 +254,8 @@ public class GameStats extends LeaderBoard {
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
         .apply(PubsubIO.<String>read()
-            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
+            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic())
+            .withCoder(StringUtf8Coder.of()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     // Extract username/score pairs from the event stream

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -27,6 +27,7 @@ import org.apache.beam.examples.complete.game.utils.WriteToBigQuery;
 import org.apache.beam.examples.complete.game.utils.WriteWindowedToBigQuery;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.PubsubIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -191,7 +192,8 @@ public class LeaderBoard extends HourlyTeamScore {
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
         .apply(PubsubIO.<String>read()
-            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
+            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic())
+            .withCoder(StringUtf8Coder.of()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     gameEvents.apply("CalculateTeamScores",

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -190,7 +190,8 @@ public class LeaderBoard extends HourlyTeamScore {
     // Read game events from Pub/Sub using custom timestamps, which are extracted from the pubsub
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
-        .apply(PubsubIO.Read.timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
+        .apply(PubsubIO.<String>read()
+            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     gameEvents.apply("CalculateTeamScores",

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -336,8 +336,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       builder.put(Window.Bound.class, AssignWindows.class);
       // In streaming mode must use either the custom Pubsub unbounded source/sink or
       // defer to Windmill's built-in implementation.
-      builder.put(PubsubIO.Read.Bound.PubsubBoundedReader.class, UnsupportedIO.class);
-      builder.put(PubsubIO.Write.Bound.PubsubBoundedWriter.class, UnsupportedIO.class);
+      builder.put(PubsubIO.Read.PubsubBoundedReader.class, UnsupportedIO.class);
+      builder.put(PubsubIO.Write.PubsubBoundedWriter.class, UnsupportedIO.class);
       if (options.getExperiments() == null
           || !options.getExperiments().contains("enable_custom_pubsub_source")) {
         builder.put(PubsubUnboundedSource.class, StreamingPubsubIORead.class);
@@ -2738,7 +2738,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
      */
     @SuppressWarnings("unused") // used via reflection in DataflowRunner#apply()
     public UnsupportedIO(DataflowRunner runner,
-                         PubsubIO.Read.Bound<?>.PubsubBoundedReader doFn) {
+                         PubsubIO.Read<?>.PubsubBoundedReader doFn) {
       this.doFn = doFn;
     }
 
@@ -2747,7 +2747,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
      */
     @SuppressWarnings("unused") // used via reflection in DataflowRunner#apply()
     public UnsupportedIO(DataflowRunner runner,
-                         PubsubIO.Write.Bound<?>.PubsubBoundedWriter doFn) {
+                         PubsubIO.Write<?>.PubsubBoundedWriter doFn) {
       this.doFn = doFn;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -154,7 +154,7 @@ public class PubsubIO {
           .withLabel("Pubsub Topic"));
     }
   }
-  
+
   /**
    * Class representing a Pub/Sub message. Each message contains a single message payload and
    * a map of attached attributes.
@@ -566,7 +566,7 @@ public class PubsubIO {
     public static <T> Bound<T> withCoder(Coder<T> coder) {
       return new Bound<>(coder);
     }
-    
+
     /**
      * Causes the source to return a PubsubMessage that includes Pubsub attributes.
      * The user must supply a parsing function to transform the PubsubMessage into an output type.
@@ -628,7 +628,7 @@ public class PubsubIO {
 
       /** User function for parsing PubsubMessage object. */
       SimpleFunction<PubsubMessage, T> parseFn;
-      
+
       private Bound(Coder<T> coder) {
         this(null, null, null, null, coder, null, 0, null, null);
       }
@@ -743,12 +743,12 @@ public class PubsubIO {
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
             null);
       }
-  
+
       /**
        * Causes the source to return a PubsubMessage that includes Pubsub attributes.
        * The user must supply a parsing function to transform the PubsubMessage into an output type.
        * A Coder for the output type T must be registered or set on the output via
-       * {@link PCollection.setCoder}.
+       * {@link PCollection.setCoder(Coder<T>)}.
        */
       public <T> Bound<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
         return new Bound<T>(
@@ -871,7 +871,7 @@ public class PubsubIO {
       public Duration getMaxReadTime() {
         return maxReadTime;
       }
-      
+
       public SimpleFunction<PubsubMessage, T> getPubSubMessageParseFn() {
           return parseFn;
         }
@@ -966,7 +966,8 @@ public class PubsubIO {
             for (IncomingMessage message : messages) {
               T element = null;
               if (parseFn != null) {
-                element = parseFn.apply(new PubsubMessage(message.elementBytes, message.attributes));
+                element = parseFn.apply(new PubsubMessage(
+                        message.elementBytes, message.attributes));
               } else {
                 element = CoderUtils.decodeFromByteArray(getCoder(), message.elementBytes);
               }
@@ -1054,8 +1055,8 @@ public class PubsubIO {
     public static <T> Bound<T> withCoder(Coder<T> coder) {
       return new Bound<>(coder);
     }
-    
-    /** 
+
+    /**
      * Used to write a PubSub message together with PubSub attributes. The user-supplied format
      * function translates the input type T to a PubsubMessage object, which is used by the sink
      * to separately set the PubSub message's payload and attributes.
@@ -1075,7 +1076,7 @@ public class PubsubIO {
       @Nullable private final String timestampLabel;
       /** The name of the message attribute to publish unique message IDs in. */
       @Nullable private final String idLabel;
-      /** The input type Coder */
+      /** The input type Coder. */
       private final Coder<T> coder;
       /** The format function for input PubsubMessage objects. */
       SimpleFunction<T, PubsubMessage> formatFn;
@@ -1151,13 +1152,12 @@ public class PubsubIO {
       public <X> Bound<X> withCoder(Coder<X> coder) {
         return new Bound<>(name, topic, timestampLabel, idLabel, coder, null);
       }
-      
-    
-      /** 
+
+      /**
        * Used to write a PubSub message together with PubSub attributes. The user-supplied format
        * function translates the input type T to a PubsubMessage object, which is used by the sink
        * to separately set the PubSub message's payload and attributes.
-       */  
+       */
       public <T> Bound<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
           return new Bound<T>(name, topic, timestampLabel, idLabel, null, formatFn);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -468,8 +468,8 @@ public class PubsubIO {
    *
    * <p>When running with a {@link PipelineRunner} that only supports bounded
    * {@link PCollection PCollections}, only a bounded portion of the input Pub/Sub stream
-   * can be processed. As such, either {@link PubsubIO#Read#maxNumRecords(int)} or
-   * {@link PubsubIO#Read#maxReadTime(Duration)} must be set.
+   * can be processed. As such, either {@link PubsubIO.Read#maxNumRecords(int)} or
+   * {@link PubsubIO.Read#maxReadTime(Duration)} must be set.
    */
    public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
       /** The Cloud Pub/Sub topic to read from. */
@@ -515,19 +515,19 @@ public class PubsubIO {
         this.parseFn = parseFn;
       }
 
-    /**
-     * Returns a transform that's like this one but reading from the
-     * given subscription.
-     *
-     * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
-     * of the {@code subscription} string.
-     *
-     * <p>Multiple readers reading from the same subscription will each receive
-     * some arbitrary portion of the data.  Most likely, separate readers should
-     * use their own subscriptions.
-     *
-     * <p>Does not modify this object.
-     */
+      /**
+       * Returns a transform that's like this one but reading from the
+       * given subscription.
+       *
+       * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
+       * of the {@code subscription} string.
+       *
+       * <p>Multiple readers reading from the same subscription will each receive
+       * some arbitrary portion of the data.  Most likely, separate readers should
+       * use their own subscriptions.
+       *
+       * <p>Does not modify this object.
+       */
       public Read<T> subscription(String subscription) {
         return subscription(StaticValueProvider.of(subscription));
       }
@@ -545,17 +545,17 @@ public class PubsubIO {
             topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, parseFn);
       }
 
-    /**
-     * Creates and returns a transform for reading from a Cloud Pub/Sub topic. Mutually exclusive
-     * with {@link #subscription(String)}.
-     *
-     * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format
-     * of the {@code topic} string.
-     *
-     * <p>The Beam runner will start reading data published on this topic from the time the pipeline
-     * is started. Any data published on the topic before the pipeline is started will not be read
-     * by the runner.
-     */
+      /**
+       * Creates and returns a transform for reading from a Cloud Pub/Sub topic. Mutually exclusive
+       * with {@link #subscription(String)}.
+       *
+       * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format
+       * of the {@code topic} string.
+       *
+       * <p>The Beam runner will start reading data published on this topic from the time the
+       * pipeline is started. Any data published on the topic before the pipeline is started will
+       * not be read by the runner.
+       */
       public Read<T> topic(String topic) {
         return topic(StaticValueProvider.of(topic));
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -468,8 +468,8 @@ public class PubsubIO {
    *
    * <p>When running with a {@link PipelineRunner} that only supports bounded
    * {@link PCollection PCollections}, only a bounded portion of the input Pub/Sub stream
-   * can be processed. As such, either {@link Read#maxNumRecords(int)} or
-   * {@link Read#maxReadTime(Duration)} must be set.
+   * can be processed. As such, either {@link #Read#maxNumRecords(int)} or
+   * {@link #Read#maxReadTime(Duration)} must be set.
    */
    public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
       /** The Cloud Pub/Sub topic to read from. */
@@ -1057,7 +1057,7 @@ public class PubsubIO {
     }
 
     /**
-     * Returns the {@linkValueProvider} for the topic being read from.
+     * Returns the {@link ValueProvider} for the topic being read from.
      */
     public ValueProvider<PubsubTopic> getTopicProvider() {
       return topic;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -686,6 +686,10 @@ public class PubsubIO {
           throw new IllegalStateException("Can't set both the topic and the subscription for "
               + "a PubsubIO.Read transform");
         }
+        if (coder == null)  {
+          throw new IllegalStateException("PubsubIO.Read requires that a coder be set using "
+              + "the withCoder method.");
+        }
 
         boolean boundedOutput = getMaxNumRecords() > 0 || getMaxReadTime() != null;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -159,7 +159,7 @@ public class PubsubIO {
    * Class representing a Pub/Sub message. Each message contains a single message payload and
    * a map of attached attributes.
    */
-  public static class PubsubMessage {
+  public static class PubsubMessage implements Serializable {
     private byte[] message;
     private Map<String, String> attributes;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Strings;
@@ -29,7 +30,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.options.PubsubOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -75,9 +75,6 @@ public class PubsubIO {
 
   /** Factory for creating pubsub client to manage transport. */
   private static final PubsubClient.PubsubClientFactory FACTORY = PubsubJsonClient.FACTORY;
-
-  /** The default {@link Coder} used to translate to/from Cloud Pub/Sub messages. */
-  public static final Coder<String> DEFAULT_PUBSUB_CODER = StringUtf8Coder.of();
 
   /**
    * Project IDs must contain 6-63 lowercase letters, digits, or dashes.
@@ -178,7 +175,9 @@ public class PubsubIO {
     /**
      * Returns the given attribute value. If not such attribute exists, returns null.
      */
+    @Nullable
     public String getAttribute(String attribute) {
+      checkNotNull(attribute, "attribute");
       return attributes.get(attribute);
     }
 
@@ -454,6 +453,14 @@ public class PubsubIO {
     }
   }
 
+  public static <T> Read<T> read() {
+    return new Read<>();
+  }
+
+  public static <T> Write<T> write() {
+    return new Write<>();
+  }
+
   /**
    * A {@link PTransform} that continuously reads from a Cloud Pub/Sub stream and
    * returns a {@link PCollection} of {@link String Strings} containing the items from
@@ -461,150 +468,10 @@ public class PubsubIO {
    *
    * <p>When running with a {@link PipelineRunner} that only supports bounded
    * {@link PCollection PCollections}, only a bounded portion of the input Pub/Sub stream
-   * can be processed. As such, either {@link Bound#maxNumRecords(int)} or
-   * {@link Bound#maxReadTime(Duration)} must be set.
+   * can be processed. As such, either {@link Read#maxNumRecords(int)} or
+   * {@link Read#maxReadTime(Duration)} must be set.
    */
-  public static class Read {
-
-    /**
-     * Creates and returns a transform for reading from a Cloud Pub/Sub topic. Mutually exclusive
-     * with {@link #subscription(String)}.
-     *
-     * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format
-     * of the {@code topic} string.
-     *
-     * <p>The Beam runner will start reading data published on this topic from the time the pipeline
-     * is started. Any data published on the topic before the pipeline is started will not be read
-     * by the runner.
-     */
-    public static Bound<String> topic(String topic) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).topic(StaticValueProvider.of(topic));
-    }
-
-    /**
-     * Like {@code topic()} but with a {@link ValueProvider}.
-     */
-    public static Bound<String> topic(ValueProvider<String> topic) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).topic(topic);
-    }
-
-    /**
-     * Creates and returns a transform for reading from a specific Cloud Pub/Sub subscription.
-     * Mutually exclusive with {@link #topic(String)}.
-     *
-     * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
-     * of the {@code subscription} string.
-     */
-    public static Bound<String> subscription(String subscription) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).subscription(StaticValueProvider.of(subscription));
-    }
-
-    /**
-     * Like {@code topic()} but with a {@link ValueProvider}.
-     */
-    public static Bound<String> subscription(ValueProvider<String> subscription) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).subscription(subscription);
-    }
-
-    /**
-     * Creates and returns a transform reading from Cloud Pub/Sub where record timestamps are
-     * expected to be provided as Pub/Sub message attributes. The {@code timestampLabel}
-     * parameter specifies the name of the attribute that contains the timestamp.
-     *
-     * <p>The timestamp value is expected to be represented in the attribute as either:
-     *
-     * <ul>
-     * <li>a numerical value representing the number of milliseconds since the Unix epoch. For
-     * example, if using the Joda time classes, {@link Instant#getMillis()} returns the correct
-     * value for this attribute.
-     * <li>a String in RFC 3339 format. For example, {@code 2015-10-29T23:41:41.123Z}. The
-     * sub-second component of the timestamp is optional, and digits beyond the first three
-     * (i.e., time units smaller than milliseconds) will be ignored.
-     * </ul>
-     *
-     * <p>If {@code timestampLabel} is not provided, the system will generate record timestamps
-     * the first time it sees each record. All windowing will be done relative to these timestamps.
-     *
-     * <p>By default, windows are emitted based on an estimate of when this source is likely
-     * done producing data for a given timestamp (referred to as the Watermark; see
-     * {@link AfterWatermark} for more details). Any late data will be handled by the trigger
-     * specified with the windowing strategy &ndash; by default it will be output immediately.
-     *
-     * <p>Note that the system can guarantee that no late data will ever be seen when it assigns
-     * timestamps by arrival time (i.e. {@code timestampLabel} is not provided).
-     *
-     * @see <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>
-     */
-    public static Bound<String> timestampLabel(String timestampLabel) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).timestampLabel(timestampLabel);
-    }
-
-    /**
-     * Creates and returns a transform for reading from Cloud Pub/Sub where unique record
-     * identifiers are expected to be provided as Pub/Sub message attributes. The {@code idLabel}
-     * parameter specifies the attribute name. The value of the attribute can be any string
-     * that uniquely identifies this record.
-     *
-     * <p>Pub/Sub cannot guarantee that no duplicate data will be delivered on the Pub/Sub stream.
-     * If {@code idLabel} is not provided, Beam cannot guarantee that no duplicate data will
-     * be delivered, and deduplication of the stream will be strictly best effort.
-     */
-    public static Bound<String> idLabel(String idLabel) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).idLabel(idLabel);
-    }
-
-    /**
-     * Creates and returns a transform for reading from Cloud Pub/Sub that uses the given
-     * {@link Coder} to decode Pub/Sub messages into a value of type {@code T}.
-     *
-     * <p>By default, uses {@link StringUtf8Coder}, which just
-     * returns the text lines as Java strings.
-     *
-     * @param <T> the type of the decoded elements, and the elements
-     * of the resulting PCollection.
-     */
-    public static <T> Bound<T> withCoder(Coder<T> coder) {
-      return new Bound<>(coder);
-    }
-
-    /**
-     * Causes the source to return a PubsubMessage that includes Pubsub attributes.
-     * The user must supply a parsing function to transform the PubsubMessage into an output type.
-     * A Coder for the output type T must be registered or set on the output via
-     * {@link PCollection#setCoder(Coder)}.
-     */
-    public <T> Bound<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
-      return new Bound<T>(null).withAttributes(parseFn);
-    }
-
-    /**
-     * Creates and returns a transform for reading from Cloud Pub/Sub with a maximum number of
-     * records that will be read. The transform produces a <i>bounded</i> {@link PCollection}.
-     *
-     * <p>Either this option or {@link #maxReadTime(Duration)} must be set in order to create a
-     * bounded source.
-     */
-    public static Bound<String> maxNumRecords(int maxNumRecords) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).maxNumRecords(maxNumRecords);
-    }
-
-    /**
-     * Creates and returns a transform for reading from Cloud Pub/Sub with a maximum number of
-     * duration during which records will be read.  The transform produces a <i>bounded</i>
-     * {@link PCollection}.
-     *
-     * <p>Either this option or {@link #maxNumRecords(int)} must be set in order to create a bounded
-     * source.
-     */
-    public static Bound<String> maxReadTime(Duration maxReadTime) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).maxReadTime(maxReadTime);
-    }
-
-    /**
-     * A {@link PTransform} that reads from a Cloud Pub/Sub source and returns
-     * a unbounded {@link PCollection} containing the items from the stream.
-     */
-    public static class Bound<T> extends PTransform<PBegin, PCollection<T>> {
+   public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
       /** The Cloud Pub/Sub topic to read from. */
       @Nullable private final ValueProvider<PubsubTopic> topic;
 
@@ -629,11 +496,11 @@ public class PubsubIO {
       /** User function for parsing PubsubMessage object. */
       SimpleFunction<PubsubMessage, T> parseFn;
 
-      private Bound(Coder<T> coder) {
-        this(null, null, null, null, coder, null, 0, null, null);
+      private Read() {
+        this(null, null, null, null, null, null, 0, null, null);
       }
 
-      private Bound(String name, ValueProvider<PubsubSubscription> subscription,
+      private Read(String name, ValueProvider<PubsubSubscription> subscription,
           ValueProvider<PubsubTopic> topic, String timestampLabel, Coder<T> coder,
           String idLabel, int maxNumRecords, Duration maxReadTime,
           SimpleFunction<PubsubMessage, T> parseFn) {
@@ -648,100 +515,125 @@ public class PubsubIO {
         this.parseFn = parseFn;
       }
 
-      /**
-       * Returns a transform that's like this one but reading from the
-       * given subscription.
-       *
-       * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
-       * of the {@code subscription} string.
-       *
-       * <p>Multiple readers reading from the same subscription will each receive
-       * some arbitrary portion of the data.  Most likely, separate readers should
-       * use their own subscriptions.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> subscription(String subscription) {
+    /**
+     * Returns a transform that's like this one but reading from the
+     * given subscription.
+     *
+     * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
+     * of the {@code subscription} string.
+     *
+     * <p>Multiple readers reading from the same subscription will each receive
+     * some arbitrary portion of the data.  Most likely, separate readers should
+     * use their own subscriptions.
+     *
+     * <p>Does not modify this object.
+     */
+      public Read<T> subscription(String subscription) {
         return subscription(StaticValueProvider.of(subscription));
       }
 
       /**
        * Like {@code subscription()} but with a {@link ValueProvider}.
        */
-      public Bound<T> subscription(ValueProvider<String> subscription) {
+      public Read<T> subscription(ValueProvider<String> subscription) {
         if (subscription.isAccessible()) {
           // Validate.
           PubsubSubscription.fromPath(subscription.get());
         }
-        return new Bound<>(name,
+        return new Read<>(name,
             NestedValueProvider.of(subscription, new SubscriptionTranslator()),
             topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, parseFn);
       }
 
-      /**
-       * Returns a transform that's like this one but that reads from the specified topic.
-       *
-       * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the
-       * format of the {@code topic} string.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> topic(String topic) {
+    /**
+     * Creates and returns a transform for reading from a Cloud Pub/Sub topic. Mutually exclusive
+     * with {@link #subscription(String)}.
+     *
+     * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format
+     * of the {@code topic} string.
+     *
+     * <p>The Beam runner will start reading data published on this topic from the time the pipeline
+     * is started. Any data published on the topic before the pipeline is started will not be read
+     * by the runner.
+     */
+      public Read<T> topic(String topic) {
         return topic(StaticValueProvider.of(topic));
       }
 
       /**
        * Like {@code topic()} but with a {@link ValueProvider}.
        */
-      public Bound<T> topic(ValueProvider<String> topic) {
+      public Read<T> topic(ValueProvider<String> topic) {
         if (topic.isAccessible()) {
           // Validate.
-          PubsubTopic.fromPath(topic.get());
+            PubsubTopic.fromPath(topic.get());
         }
-        return new Bound<>(name, subscription,
+        return new Read<>(name, subscription,
             NestedValueProvider.of(topic, new TopicTranslator()),
             timestampLabel, coder, idLabel, maxNumRecords, maxReadTime, parseFn);
       }
 
       /**
-       * Returns a transform that's like this one but that reads message timestamps
-       * from the given message attribute. See {@link PubsubIO.Read#timestampLabel(String)} for
-       * more details on the format of the timestamp attribute.
+       * Creates and returns a transform reading from Cloud Pub/Sub where record timestamps are
+       * expected to be provided as Pub/Sub message attributes. The {@code timestampLabel}
+       * parameter specifies the name of the attribute that contains the timestamp.
        *
-       * <p>Does not modify this object.
+       * <p>The timestamp value is expected to be represented in the attribute as either:
+       *
+       * <ul>
+       * <li>a numerical value representing the number of milliseconds since the Unix epoch. For
+       * example, if using the Joda time classes, {@link Instant#getMillis()} returns the correct
+       * value for this attribute.
+       * <li>a String in RFC 3339 format. For example, {@code 2015-10-29T23:41:41.123Z}. The
+       * sub-second component of the timestamp is optional, and digits beyond the first three
+       * (i.e., time units smaller than milliseconds) will be ignored.
+       * </ul>
+       *
+       * <p>If {@code timestampLabel} is not provided, the system will generate record timestamps
+       * the first time it sees each record. All windowing will be done relative to these timestamps.
+       *
+       * <p>By default, windows are emitted based on an estimate of when this source is likely
+       * done producing data for a given timestamp (referred to as the Watermark; see
+       * {@link AfterWatermark} for more details). Any late data will be handled by the trigger
+       * specified with the windowing strategy &ndash; by default it will be output immediately.
+       *
+       * <p>Note that the system can guarantee that no late data will ever be seen when it assigns
+       * timestamps by arrival time (i.e. {@code timestampLabel} is not provided).
+       *
+       * @see <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>
        */
-      public Bound<T> timestampLabel(String timestampLabel) {
-        return new Bound<>(
+      public Read<T> timestampLabel(String timestampLabel) {
+        return new Read<>(
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
             parseFn);
       }
 
-      /**
-       * Returns a transform that's like this one but that reads unique message IDs
-       * from the given message attribute. See {@link PubsubIO.Read#idLabel(String)} for more
-       * details on the format of the ID attribute.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> idLabel(String idLabel) {
-        return new Bound<>(
+     /**
+      * Creates and returns a transform for reading from Cloud Pub/Sub where unique record
+      * identifiers are expected to be provided as Pub/Sub message attributes. The {@code idLabel}
+      * parameter specifies the attribute name. The value of the attribute can be any string
+      * that uniquely identifies this record.
+      *
+      * <p>Pub/Sub cannot guarantee that no duplicate data will be delivered on the Pub/Sub stream.
+      * If {@code idLabel} is not provided, Beam cannot guarantee that no duplicate data will
+      * be delivered, and deduplication of the stream will be strictly best effort.
+      */
+      public Read<T> idLabel(String idLabel) {
+        return new Read<>(
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
             parseFn);
       }
 
       /**
        * Returns a transform that's like this one but that uses the given
-       * {@link Coder} to decode each record into a value of type {@code X}.
+       * {@link Coder} to decode each record into a value of type {@code T}.
        *
        * <p>Does not modify this object.
-       *
-       * @param <X> the type of the decoded elements, and the
-       * elements of the resulting PCollection.
        */
-      public <X> Bound<X> withCoder(Coder<X> coder) {
-        return new Bound<>(
+      public Read<T> withCoder(Coder<T> coder) {
+        return new Read<>(
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
-            null);
+            parseFn);
       }
 
       /**
@@ -750,30 +642,35 @@ public class PubsubIO {
        * A Coder for the output type T must be registered or set on the output via
        * {@link PCollection#setCoder(Coder)}.
        */
-      public <T> Bound<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
-        return new Bound<T>(
-            name, subscription, topic, timestampLabel, null, idLabel,
+      public Read<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
+        return new Read<T>(
+            name, subscription, topic, timestampLabel, coder, idLabel,
             maxNumRecords, maxReadTime, parseFn);
       }
 
-      /**
-       * Returns a transform that's like this one but will only read up to the specified
-       * maximum number of records from Cloud Pub/Sub. The transform produces a <i>bounded</i>
-       * {@link PCollection}. See {@link PubsubIO.Read#maxNumRecords(int)} for more details.
-       */
-      public Bound<T> maxNumRecords(int maxNumRecords) {
-        return new Bound<>(
+     /**
+      * Creates and returns a transform for reading from Cloud Pub/Sub with a maximum number of
+      * records that will be read. The transform produces a <i>bounded</i> {@link PCollection}.
+      *
+      * <p>Either this option or {@link #maxReadTime(Duration)} must be set in order to create a
+      * bounded source.
+      */
+      public Read<T> maxNumRecords(int maxNumRecords) {
+        return new Read<>(
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
             parseFn);
       }
 
-      /**
-       * Returns a transform that's like this one but will only read during the specified
-       * duration from Cloud Pub/Sub. The transform produces a <i>bounded</i> {@link PCollection}.
-       * See {@link PubsubIO.Read#maxReadTime(Duration)} for more details.
-       */
-      public Bound<T> maxReadTime(Duration maxReadTime) {
-        return new Bound<>(
+     /**
+      * Creates and returns a transform for reading from Cloud Pub/Sub with a maximum number of
+      * duration during which records will be read.  The transform produces a <i>bounded</i>
+      * {@link PCollection}.
+      *
+      * <p>Either this option or {@link #maxNumRecords(int)} must be set in order to create a
+      * bounded source.
+      */
+      public Read<T> maxReadTime(Duration maxReadTime) {
+        return new Read<>(
             name, subscription, topic, timestampLabel, coder, idLabel, maxNumRecords, maxReadTime,
             parseFn);
       }
@@ -978,14 +875,10 @@ public class PubsubIO {
 
         @Override
         public void populateDisplayData(DisplayData.Builder builder) {
-          builder.delegate(Bound.this);
+          builder.delegate(Read.this);
         }
       }
     }
-
-    /** Disallow construction of utility class. */
-    private Read() {}
-  }
 
 
   /////////////////////////////////////////////////////////////////////////////
@@ -993,27 +886,54 @@ public class PubsubIO {
   /** Disallow construction of utility class. */
   private PubsubIO() {}
 
+
   /**
-   * A {@link PTransform} that continuously writes a
-   * {@link PCollection} of {@link String Strings} to a Cloud Pub/Sub stream.
+   * A {@link PTransform} that writes an unbounded {@link PCollection} of {@link String Strings}
+   * to a Cloud Pub/Sub stream.
    */
-  // TODO: Support non-String encodings.
-  public static class Write {
+  public static class Write<T> extends PTransform<PCollection<T>, PDone> {
+    /** The Cloud Pub/Sub topic to publish to. */
+    @Nullable private final ValueProvider<PubsubTopic> topic;
+    /** The name of the message attribute to publish message timestamps in. */
+    @Nullable private final String timestampLabel;
+    /** The name of the message attribute to publish unique message IDs in. */
+    @Nullable private final String idLabel;
+    /** The input type Coder. */
+    private final Coder<T> coder;
+    /** The format function for input PubsubMessage objects. */
+    SimpleFunction<T, PubsubMessage> formatFn;
+
+    private Write() {
+      this(null, null, null, null, null, null);
+    }
+
+    private Write(
+        String name, ValueProvider<PubsubTopic> topic, String timestampLabel,
+        String idLabel, Coder<T> coder, SimpleFunction<T, PubsubMessage> formatFn) {
+      super(name);
+      this.topic = topic;
+      this.timestampLabel = timestampLabel;
+      this.idLabel = idLabel;
+      this.coder = coder;
+      this.formatFn = formatFn;
+    }
+
     /**
      * Creates a transform that publishes to the specified topic.
      *
      * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format of the
      * {@code topic} string.
      */
-    public static Bound<String> topic(String topic) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).topic(StaticValueProvider.of(topic));
+    public Write<T> topic(String topic) {
+      return topic(StaticValueProvider.of(topic));
     }
 
     /**
      * Like {@code topic()} but with a {@link ValueProvider}.
      */
-    public static Bound<String> topic(ValueProvider<String> topic) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).topic(topic);
+    public Write<T> topic(ValueProvider<String> topic) {
+      return new Write<>(name, NestedValueProvider.of(topic, new TopicTranslator()),
+          timestampLabel, idLabel, coder, formatFn);
     }
 
     /**
@@ -1026,8 +946,8 @@ public class PubsubIO {
      * {@link PubsubIO.Read#timestampLabel(String)} can be used to ensure the other source reads
      * these timestamps from the appropriate attribute.
      */
-    public static Bound<String> timestampLabel(String timestampLabel) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).timestampLabel(timestampLabel);
+    public Write<T> timestampLabel(String timestampLabel) {
+      return new Write<>(name, topic, timestampLabel, idLabel, coder, formatFn);
     }
 
     /**
@@ -1039,256 +959,172 @@ public class PubsubIO {
      * {@link PubsubIO.Read#idLabel(String)} can be used to ensure that* the other source reads
      * these unique identifiers from the appropriate attribute.
      */
-    public static Bound<String> idLabel(String idLabel) {
-      return new Bound<>(DEFAULT_PUBSUB_CODER).idLabel(idLabel);
+    public Write<T> idLabel(String idLabel) {
+      return new Write<>(name, topic, timestampLabel, idLabel, coder, formatFn);
     }
 
     /**
-     * Creates a transform that  uses the given {@link Coder} to encode each of the
-     * elements of the input collection into an output message.
+     * Returns a new transform that's like this one
+     * but that uses the given {@link Coder} to encode each of
+     * the elements of the input {@link PCollection} into an
+     * output record.
      *
-     * <p>By default, uses {@link StringUtf8Coder}, which writes input Java strings directly as
-     * records.
-     *
-     * @param <T> the type of the elements of the input PCollection
+     * <p>Does not modify this object.
      */
-    public static <T> Bound<T> withCoder(Coder<T> coder) {
-      return new Bound<>(coder);
+    public Write<T> withCoder(Coder<T> coder) {
+      return new Write<>(name, topic, timestampLabel, idLabel, coder, formatFn);
     }
 
     /**
      * Used to write a PubSub message together with PubSub attributes. The user-supplied format
      * function translates the input type T to a PubsubMessage object, which is used by the sink
-     * to publish a message to PubSub with payload and attributes set separately.
+     * to separately set the PubSub message's payload and attributes.
      */
-    public static <T> Bound<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
-        return new Bound<T>(null).withAttributes(formatFn);
+    public Write<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
+        return new Write<T>(name, topic, timestampLabel, idLabel, coder, formatFn);
+    }
+
+    @Override
+    public PDone expand(PCollection<T> input) {
+      if (topic == null) {
+        throw new IllegalStateException("need to set the topic of a PubsubIO.Write transform");
       }
+      switch (input.isBounded()) {
+        case BOUNDED:
+          input.apply(ParDo.of(new PubsubBoundedWriter()));
+          return PDone.in(input.getPipeline());
+        case UNBOUNDED:
+          return input.apply(new PubsubUnboundedSink<T>(
+              FACTORY,
+              NestedValueProvider.of(topic, new TopicPathTranslator()),
+              coder,
+              timestampLabel,
+              idLabel,
+              formatFn,
+              100 /* numShards */));
+      }
+      throw new RuntimeException(); // cases are exhaustive.
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      populateCommonDisplayData(builder, timestampLabel, idLabel, topic);
+    }
+
+    @Override
+    protected Coder<Void> getDefaultOutputCoder() {
+      return VoidCoder.of();
+    }
 
     /**
-     * A {@link PTransform} that writes an unbounded {@link PCollection} of {@link String Strings}
-     * to a Cloud Pub/Sub stream.
+     * Returns the PubSub topic.
      */
-    public static class Bound<T> extends PTransform<PCollection<T>, PDone> {
-      /** The Cloud Pub/Sub topic to publish to. */
-      @Nullable private final ValueProvider<PubsubTopic> topic;
-      /** The name of the message attribute to publish message timestamps in. */
-      @Nullable private final String timestampLabel;
-      /** The name of the message attribute to publish unique message IDs in. */
-      @Nullable private final String idLabel;
-      /** The input type Coder. */
-      private final Coder<T> coder;
-      /** The format function for input PubsubMessage objects. */
-      SimpleFunction<T, PubsubMessage> formatFn;
+    public PubsubTopic getTopic() {
+      return topic.get();
+    }
 
-      private Bound(Coder<T> coder) {
-        this(null, null, null, null, coder, null);
+    /**
+     * Returns the topic @link{ValueProvider}
+     */
+    public ValueProvider<PubsubTopic> getTopicProvider() {
+      return topic;
+    }
+
+    /**
+     * Returns the timestamp label.
+     */
+    public String getTimestampLabel() {
+      return timestampLabel;
+    }
+
+    /**
+     * Returns the id label.
+     */
+    public String getIdLabel() {
+      return idLabel;
+    }
+
+    /**
+     * Returns the output coder.
+     */
+    public Coder<T> getCoder() {
+      return coder;
+    }
+
+    /**
+     * Returns the formatting function used if publishing attributes.
+     */
+    public SimpleFunction<T, PubsubMessage> getFormatFn() {
+        return formatFn;
+    }
+
+    /**
+     * Writer to Pubsub which batches messages from bounded collections.
+     *
+     * <p>NOTE: This is not the implementation used when running on the Google Cloud Dataflow
+     * service in streaming mode.
+     *
+     * <p>Public so can be suppressed by runners.
+     */
+    public class PubsubBoundedWriter extends DoFn<T, Void> {
+      private static final int MAX_PUBLISH_BATCH_SIZE = 100;
+      private transient List<OutgoingMessage> output;
+      private transient PubsubClient pubsubClient;
+
+      @StartBundle
+      public void startBundle(Context c) throws IOException {
+        this.output = new ArrayList<>();
+        // NOTE: idLabel is ignored.
+        this.pubsubClient =
+            FACTORY.newClient(timestampLabel, null,
+                              c.getPipelineOptions().as(PubsubOptions.class));
       }
 
-      private Bound(
-          String name, ValueProvider<PubsubTopic> topic, String timestampLabel,
-          String idLabel, Coder<T> coder, SimpleFunction<T, PubsubMessage> formatFn) {
-        super(name);
-        this.topic = topic;
-        this.timestampLabel = timestampLabel;
-        this.idLabel = idLabel;
-        this.coder = coder;
-        this.formatFn = formatFn;
-      }
-
-      /**
-       * Returns a new transform that's like this one but that writes to the specified
-       * topic.
-       *
-       * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format of the
-       * {@code topic} string.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> topic(String topic) {
-        return topic(StaticValueProvider.of(topic));
-      }
-
-      /**
-       * Like {@code topic()} but with a {@link ValueProvider}.
-       */
-      public Bound<T> topic(ValueProvider<String> topic) {
-        return new Bound<>(name, NestedValueProvider.of(topic, new TopicTranslator()),
-            timestampLabel, idLabel, coder, formatFn);
-      }
-
-      /**
-       * Returns a new transform that's like this one but that publishes record timestamps
-       * to a message attribute with the specified name. See
-       * {@link PubsubIO.Write#timestampLabel(String)} for more details.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> timestampLabel(String timestampLabel) {
-        return new Bound<>(name, topic, timestampLabel, idLabel, coder, formatFn);
-      }
-
-      /**
-       * Returns a new transform that's like this one but that publishes unique record IDs
-       * to a message attribute with the specified name. See {@link PubsubIO.Write#idLabel(String)}
-       * for more details.
-       *
-       * <p>Does not modify this object.
-       */
-      public Bound<T> idLabel(String idLabel) {
-        return new Bound<>(name, topic, timestampLabel, idLabel, coder, formatFn);
-      }
-
-      /**
-       * Returns a new transform that's like this one
-       * but that uses the given {@link Coder} to encode each of
-       * the elements of the input {@link PCollection} into an
-       * output record.
-       *
-       * <p>Does not modify this object.
-       *
-       * @param <X> the type of the elements of the input {@link PCollection}
-       */
-      public <X> Bound<X> withCoder(Coder<X> coder) {
-        return new Bound<>(name, topic, timestampLabel, idLabel, coder, null);
-      }
-
-      /**
-       * Used to write a PubSub message together with PubSub attributes. The user-supplied format
-       * function translates the input type T to a PubsubMessage object, which is used by the sink
-       * to separately set the PubSub message's payload and attributes.
-       */
-      public <T> Bound<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
-          return new Bound<T>(name, topic, timestampLabel, idLabel, null, formatFn);
-      }
-
-      @Override
-      public PDone expand(PCollection<T> input) {
-        if (topic == null) {
-          throw new IllegalStateException("need to set the topic of a PubsubIO.Write transform");
+      @ProcessElement
+      public void processElement(ProcessContext c) throws IOException {
+        byte[] payload = null;
+        Map<String, String> attributes = null;
+        if (formatFn != null) {
+          PubsubMessage message = formatFn.apply(c.element());
+          payload = message.getMessage();
+          attributes = message.getAttributeMap();
+        } else {
+          payload = CoderUtils.encodeToByteArray(getCoder(), c.element());
         }
-        switch (input.isBounded()) {
-          case BOUNDED:
-            input.apply(ParDo.of(new PubsubBoundedWriter()));
-            return PDone.in(input.getPipeline());
-          case UNBOUNDED:
-            return input.apply(new PubsubUnboundedSink<T>(
-                FACTORY,
-                NestedValueProvider.of(topic, new TopicPathTranslator()),
-                coder,
-                timestampLabel,
-                idLabel,
-                formatFn,
-                100 /* numShards */));
+        // NOTE: The record id is always null.
+        OutgoingMessage message =
+            new OutgoingMessage(payload, attributes, c.timestamp().getMillis(), null);
+        output.add(message);
+
+        if (output.size() >= MAX_PUBLISH_BATCH_SIZE) {
+          publish();
         }
-        throw new RuntimeException(); // cases are exhaustive.
+      }
+
+      @FinishBundle
+      public void finishBundle(Context c) throws IOException {
+        if (!output.isEmpty()) {
+          publish();
+        }
+        output = null;
+        pubsubClient.close();
+        pubsubClient = null;
+      }
+
+      private void publish() throws IOException {
+        int n = pubsubClient.publish(
+            PubsubClient.topicPathFromName(getTopic().project, getTopic().topic),
+            output);
+        checkState(n == output.size());
+        output.clear();
       }
 
       @Override
       public void populateDisplayData(DisplayData.Builder builder) {
         super.populateDisplayData(builder);
-        populateCommonDisplayData(builder, timestampLabel, idLabel, topic);
-      }
-
-      @Override
-      protected Coder<Void> getDefaultOutputCoder() {
-        return VoidCoder.of();
-      }
-
-      public PubsubTopic getTopic() {
-        return topic.get();
-      }
-
-      public ValueProvider<PubsubTopic> getTopicProvider() {
-        return topic;
-      }
-
-      public String getTimestampLabel() {
-        return timestampLabel;
-      }
-
-      public String getIdLabel() {
-        return idLabel;
-      }
-
-      public Coder<T> getCoder() {
-        return coder;
-      }
-
-      public SimpleFunction<T, PubsubMessage> getFormatFn() {
-          return formatFn;
-      }
-
-      /**
-       * Writer to Pubsub which batches messages from bounded collections.
-       *
-       * <p>NOTE: This is not the implementation used when running on the Google Cloud Dataflow
-       * service in streaming mode.
-       *
-       * <p>Public so can be suppressed by runners.
-       */
-      public class PubsubBoundedWriter extends DoFn<T, Void> {
-        private static final int MAX_PUBLISH_BATCH_SIZE = 100;
-        private transient List<OutgoingMessage> output;
-        private transient PubsubClient pubsubClient;
-
-        @StartBundle
-        public void startBundle(Context c) throws IOException {
-          this.output = new ArrayList<>();
-          // NOTE: idLabel is ignored.
-          this.pubsubClient =
-              FACTORY.newClient(timestampLabel, null,
-                                c.getPipelineOptions().as(PubsubOptions.class));
-        }
-
-        @ProcessElement
-        public void processElement(ProcessContext c) throws IOException {
-          byte[] payload = null;
-          Map<String, String> attributes = null;
-          if (formatFn != null) {
-            PubsubMessage message = formatFn.apply(c.element());
-            payload = message.getMessage();
-            attributes = message.getAttributeMap();
-          } else {
-            payload = CoderUtils.encodeToByteArray(getCoder(), c.element());
-          }
-          // NOTE: The record id is always null.
-          OutgoingMessage message =
-              new OutgoingMessage(payload, attributes, c.timestamp().getMillis(), null);
-          output.add(message);
-
-          if (output.size() >= MAX_PUBLISH_BATCH_SIZE) {
-            publish();
-          }
-        }
-
-        @FinishBundle
-        public void finishBundle(Context c) throws IOException {
-          if (!output.isEmpty()) {
-            publish();
-          }
-          output = null;
-          pubsubClient.close();
-          pubsubClient = null;
-        }
-
-        private void publish() throws IOException {
-          int n = pubsubClient.publish(
-              PubsubClient.topicPathFromName(getTopic().project, getTopic().topic),
-              output);
-          checkState(n == output.size());
-          output.clear();
-        }
-
-        @Override
-        public void populateDisplayData(DisplayData.Builder builder) {
-          super.populateDisplayData(builder);
-          builder.delegate(Bound.this);
-        }
+        builder.delegate(Write.this);
       }
     }
-
-    /** Disallow construction of utility class. */
-    private Write() {}
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -590,7 +590,8 @@ public class PubsubIO {
        * </ul>
        *
        * <p>If {@code timestampLabel} is not provided, the system will generate record timestamps
-       * the first time it sees each record. All windowing will be done relative to these timestamps.
+       * the first time it sees each record. All windowing will be done relative to these
+       * timestamps.
        *
        * <p>By default, windows are emitted based on an estimate of when this source is likely
        * done producing data for a given timestamp (referred to as the Watermark; see
@@ -1049,14 +1050,14 @@ public class PubsubIO {
     }
 
     /**
-     * Returns the PubSub topic.
+     * Returns the PubSub topic being read from.
      */
     public PubsubTopic getTopic() {
       return topic.get();
     }
 
     /**
-     * Returns the topic @link{ValueProvider}
+     * Returns the {@linkValueProvider} for the topic being read from.
      */
     public ValueProvider<PubsubTopic> getTopicProvider() {
       return topic;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -468,8 +468,8 @@ public class PubsubIO {
    *
    * <p>When running with a {@link PipelineRunner} that only supports bounded
    * {@link PCollection PCollections}, only a bounded portion of the input Pub/Sub stream
-   * can be processed. As such, either {@link #Read#maxNumRecords(int)} or
-   * {@link #Read#maxReadTime(Duration)} must be set.
+   * can be processed. As such, either {@link PubsubIO#Read#maxNumRecords(int)} or
+   * {@link PubsubIO#Read#maxReadTime(Duration)} must be set.
    */
    public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
       /** The Cloud Pub/Sub topic to read from. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -571,7 +571,7 @@ public class PubsubIO {
      * Causes the source to return a PubsubMessage that includes Pubsub attributes.
      * The user must supply a parsing function to transform the PubsubMessage into an output type.
      * A Coder for the output type T must be registered or set on the output via
-     * {@link PCollection.setCoder}.
+     * {@link PCollection#setCoder(Coder)}.
      */
     public <T> Bound<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
       return new Bound<T>(null).withAttributes(parseFn);
@@ -748,7 +748,7 @@ public class PubsubIO {
        * Causes the source to return a PubsubMessage that includes Pubsub attributes.
        * The user must supply a parsing function to transform the PubsubMessage into an output type.
        * A Coder for the output type T must be registered or set on the output via
-       * {@link PCollection.setCoder(Coder<T>)}.
+       * {@link PCollection#setCoder(Coder)}.
        */
       public <T> Bound<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
         return new Bound<T>(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -733,42 +733,73 @@ public class PubsubIO {
         return coder;
       }
 
+     /**
+      * Get the topic being read from.
+      */
       public PubsubTopic getTopic() {
         return topic == null ? null : topic.get();
       }
 
+     /**
+      * Get the {@link ValueProvider} for the topic being read from.
+      */
       public ValueProvider<PubsubTopic> getTopicProvider() {
         return topic;
       }
 
+     /**
+      * Get the subscription being read from.
+      */
       public PubsubSubscription getSubscription() {
         return subscription == null ? null : subscription.get();
       }
 
+     /**
+      * Get the {@link ValueProvider} for the subscription being read from.
+      */
       public ValueProvider<PubsubSubscription> getSubscriptionProvider() {
         return subscription;
       }
 
+     /**
+      * Get the timestamp label.
+      */
       public String getTimestampLabel() {
         return timestampLabel;
       }
 
-      public Coder<T> getCoder() {
-        return coder;
-      }
-
+     /**
+      * Get the id label.
+      */
       public String getIdLabel() {
         return idLabel;
       }
 
+
+     /**
+      * Get the {@link Coder} used for the transform's output.
+      */
+      public Coder<T> getCoder() {
+      return coder;
+    }
+
+     /**
+      * Get the maximum number of records to read.
+      */
       public int getMaxNumRecords() {
         return maxNumRecords;
       }
 
+     /**
+      * Get the maximum read time.
+      */
       public Duration getMaxReadTime() {
         return maxReadTime;
       }
 
+      /**
+       * Get the parse function used for PubSub attributes.
+       */
       public SimpleFunction<PubsubMessage, T> getPubSubMessageParseFn() {
           return parseFn;
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -159,7 +159,7 @@ public class PubsubIO {
    * Class representing a Pub/Sub message. Each message contains a single message payload and
    * a map of attached attributes.
    */
-  public static class PubsubMessage implements Serializable {
+  public static class PubsubMessage {
     private byte[] message;
     private Map<String, String> attributes;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -1059,7 +1059,7 @@ public class PubsubIO {
     /**
      * Used to write a PubSub message together with PubSub attributes. The user-supplied format
      * function translates the input type T to a PubsubMessage object, which is used by the sink
-     * to separately set the PubSub message's payload and attributes.
+     * to publish a message to PubSub with payload and attributes set separately.
      */
     public static <T> Bound<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
         return new Bound<T>(null).withAttributes(formatFn);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
@@ -434,29 +434,47 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
          formatFn, RecordIdMethod.RANDOM);
   }
 
+  /**
+   * Get the topic being written to.
+   */
   public TopicPath getTopic() {
     return topic.get();
   }
 
+  /**
+   * Get the {@link ValueProvider} for the topic being written to.
+   */
   public ValueProvider<TopicPath> getTopicProvider() {
     return topic;
   }
 
+  /**
+   * Get the timestamp label.
+   */
   @Nullable
   public String getTimestampLabel() {
     return timestampLabel;
   }
 
+  /**
+   * Get the id label.
+   */
   @Nullable
   public String getIdLabel() {
     return idLabel;
   }
 
+  /**
+   * Get the format function used for PubSub attributes.
+   */
   @Nullable
   public SimpleFunction<T, PubsubIO.PubsubMessage> getFormatFn() {
     return formatFn;
   }
 
+  /**
+   * Get the Coder used to encode output elements.
+   */
   public Coder<T> getElementCoder() {
     return elementCoder;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
@@ -33,7 +33,16 @@ import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
-import org.apache.beam.sdk.coders.*;
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.BigEndianLongCoder;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.PubsubIO.PubsubMessage;
 import org.apache.beam.sdk.options.PubsubOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -161,8 +170,8 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
     private final RecordIdMethod recordIdMethod;
     private final SimpleFunction<T, PubsubMessage> formatFn;
 
-    ShardFn(Coder<T> elementCoder, int numShards, SimpleFunction<T, PubsubIO.PubsubMessage> formatFn,
-            RecordIdMethod recordIdMethod) {
+    ShardFn(Coder<T> elementCoder, int numShards,
+            SimpleFunction<T, PubsubIO.PubsubMessage> formatFn, RecordIdMethod recordIdMethod) {
       this.elementCoder = elementCoder;
       this.numShards = numShards;
       this.formatFn = formatFn;
@@ -199,7 +208,8 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
           break;
       }
       c.output(KV.of(ThreadLocalRandom.current().nextInt(numShards),
-                     new OutgoingMessage(elementBytes, attributes, timestampMsSinceEpoch, recordId)));
+                     new OutgoingMessage(elementBytes, attributes, timestampMsSinceEpoch,
+                             recordId)));
     }
 
     @Override
@@ -442,7 +452,9 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
   }
 
   @Nullable
-  public SimpleFunction<T, PubsubIO.PubsubMessage> getFormatFn() { return formatFn; }
+  public SimpleFunction<T, PubsubIO.PubsubMessage> getFormatFn() {
+    return formatFn;
+  }
 
   public Coder<T> getElementCoder() {
     return elementCoder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
@@ -22,23 +22,19 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.coders.AtomicCoder;
-import org.apache.beam.sdk.coders.BigEndianLongCoder;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.NullableCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.coders.VarIntCoder;
+
+import org.apache.beam.sdk.coders.*;
+import org.apache.beam.sdk.io.PubsubIO.PubsubMessage;
 import org.apache.beam.sdk.options.PubsubOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.Aggregator;
@@ -46,6 +42,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
@@ -105,23 +102,27 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
   private static class OutgoingMessageCoder extends AtomicCoder<OutgoingMessage> {
     private static final NullableCoder<String> RECORD_ID_CODER =
         NullableCoder.of(StringUtf8Coder.of());
+    private static final MapCoder<String, String> ATTRIBUTES_CODER =
+            MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
 
     @Override
     public void encode(
         OutgoingMessage value, OutputStream outStream, Context context)
         throws CoderException, IOException {
       ByteArrayCoder.of().encode(value.elementBytes, outStream, context.nested());
+      ATTRIBUTES_CODER.encode(value.attributes, outStream, context.nested());
       BigEndianLongCoder.of().encode(value.timestampMsSinceEpoch, outStream, context.nested());
-      RECORD_ID_CODER.encode(value.recordId, outStream, context);
+      RECORD_ID_CODER.encode(value.recordId, outStream, context.nested());
     }
 
     @Override
     public OutgoingMessage decode(
         InputStream inStream, Context context) throws CoderException, IOException {
       byte[] elementBytes = ByteArrayCoder.of().decode(inStream, context.nested());
+      Map<String, String> attributes = ATTRIBUTES_CODER.decode(inStream, context.nested());
       long timestampMsSinceEpoch = BigEndianLongCoder.of().decode(inStream, context.nested());
-      @Nullable String recordId = RECORD_ID_CODER.decode(inStream, context);
-      return new OutgoingMessage(elementBytes, timestampMsSinceEpoch, recordId);
+      @Nullable String recordId = RECORD_ID_CODER.decode(inStream, context.nested());
+      return new OutgoingMessage(elementBytes, attributes, timestampMsSinceEpoch, recordId);
     }
   }
 
@@ -158,17 +159,29 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
     private final Coder<T> elementCoder;
     private final int numShards;
     private final RecordIdMethod recordIdMethod;
+    private final SimpleFunction<T, PubsubMessage> formatFn;
 
-    ShardFn(Coder<T> elementCoder, int numShards, RecordIdMethod recordIdMethod) {
+    ShardFn(Coder<T> elementCoder, int numShards, SimpleFunction<T, PubsubIO.PubsubMessage> formatFn,
+            RecordIdMethod recordIdMethod) {
       this.elementCoder = elementCoder;
       this.numShards = numShards;
+      this.formatFn = formatFn;
       this.recordIdMethod = recordIdMethod;
     }
 
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
       elementCounter.addValue(1L);
-      byte[] elementBytes = CoderUtils.encodeToByteArray(elementCoder, c.element());
+      byte[] elementBytes = null;
+      Map<String, String> attributes = null;
+      if (formatFn != null) {
+        PubsubIO.PubsubMessage message = formatFn.apply(c.element());
+        elementBytes = message.getMessage();
+        attributes = message.getAttributeMap();
+      } else {
+        elementBytes = CoderUtils.encodeToByteArray(elementCoder, c.element());
+      }
+
       long timestampMsSinceEpoch = c.timestamp().getMillis();
       @Nullable String recordId = null;
       switch (recordIdMethod) {
@@ -186,7 +199,7 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
           break;
       }
       c.output(KV.of(ThreadLocalRandom.current().nextInt(numShards),
-                     new OutgoingMessage(elementBytes, timestampMsSinceEpoch, recordId)));
+                     new OutgoingMessage(elementBytes, attributes, timestampMsSinceEpoch, recordId)));
     }
 
     @Override
@@ -365,6 +378,12 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
    */
   private final RecordIdMethod recordIdMethod;
 
+  /**
+   * In order to publish attributes, a formatting function is used to format the output into
+   * a {@link PubsubIO.PubsubMessage}.
+   */
+  private final SimpleFunction<T, PubsubIO.PubsubMessage> formatFn;
+
   @VisibleForTesting
   PubsubUnboundedSink(
       PubsubClientFactory pubsubFactory,
@@ -376,6 +395,7 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
       int publishBatchSize,
       int publishBatchBytes,
       Duration maxLatency,
+      SimpleFunction<T, PubsubIO.PubsubMessage> formatFn,
       RecordIdMethod recordIdMethod) {
     this.pubsubFactory = pubsubFactory;
     this.topic = topic;
@@ -386,6 +406,7 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
     this.publishBatchSize = publishBatchSize;
     this.publishBatchBytes = publishBatchBytes;
     this.maxLatency = maxLatency;
+    this.formatFn = formatFn;
     this.recordIdMethod = idLabel == null ? RecordIdMethod.NONE : recordIdMethod;
   }
 
@@ -395,10 +416,11 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
       Coder<T> elementCoder,
       String timestampLabel,
       String idLabel,
+      SimpleFunction<T, PubsubIO.PubsubMessage> formatFn,
       int numShards) {
     this(pubsubFactory, topic, elementCoder, timestampLabel, idLabel, numShards,
          DEFAULT_PUBLISH_BATCH_SIZE, DEFAULT_PUBLISH_BATCH_BYTES, DEFAULT_MAX_LATENCY,
-         RecordIdMethod.RANDOM);
+         formatFn, RecordIdMethod.RANDOM);
   }
 
   public TopicPath getTopic() {
@@ -419,6 +441,9 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
     return idLabel;
   }
 
+  @Nullable
+  public SimpleFunction<T, PubsubIO.PubsubMessage> getFormatFn() { return formatFn; }
+
   public Coder<T> getElementCoder() {
     return elementCoder;
   }
@@ -433,7 +458,7 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
                     .plusDelayOf(maxLatency))))
             .discardingFiredPanes())
          .apply("PubsubUnboundedSink.Shard",
-             ParDo.of(new ShardFn<T>(elementCoder, numShards, recordIdMethod)))
+             ParDo.of(new ShardFn<T>(elementCoder, numShards, formatFn, recordIdMethod)))
          .setCoder(KvCoder.of(VarIntCoder.of(), CODER))
          .apply(GroupByKey.<Integer, OutgoingMessage>create())
          .apply("PubsubUnboundedSink.Writer",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSink.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.io;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
@@ -111,8 +113,8 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
   private static class OutgoingMessageCoder extends AtomicCoder<OutgoingMessage> {
     private static final NullableCoder<String> RECORD_ID_CODER =
         NullableCoder.of(StringUtf8Coder.of());
-    private static final MapCoder<String, String> ATTRIBUTES_CODER =
-            MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+    private static final NullableCoder<Map<String, String>> ATTRIBUTES_CODER =
+            NullableCoder.of(MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 
     @Override
     public void encode(
@@ -182,7 +184,7 @@ public class PubsubUnboundedSink<T> extends PTransform<PCollection<T>, PDone> {
     public void processElement(ProcessContext c) throws Exception {
       elementCounter.addValue(1L);
       byte[] elementBytes = null;
-      Map<String, String> attributes = null;
+      Map<String, String> attributes = ImmutableMap.<String, String>of();
       if (formatFn != null) {
         PubsubIO.PubsubMessage message = formatFn.apply(c.element());
         elementBytes = message.getMessage();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.PubsubIO.PubsubMessage;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PubsubOptions;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -58,6 +59,7 @@ import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
@@ -394,6 +396,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
     @VisibleForTesting
     final SubscriptionPath subscription;
 
+    private final SimpleFunction<PubsubIO.PubsubMessage, T> parseFn;
+
     /**
      * Client on which to talk to Pubsub. Null if closed.
      */
@@ -580,10 +584,12 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
     /**
      * Construct a reader.
      */
-    public PubsubReader(PubsubOptions options, PubsubSource<T> outer, SubscriptionPath subscription)
+    public PubsubReader(PubsubOptions options, PubsubSource<T> outer, SubscriptionPath subscription,
+                        SimpleFunction<PubsubIO.PubsubMessage, T> parseFn)
         throws IOException, GeneralSecurityException {
       this.outer = outer;
       this.subscription = subscription;
+      this.parseFn = parseFn;
       pubsubClient =
           outer.outer.pubsubFactory.newClient(outer.outer.timestampLabel, outer.outer.idLabel,
                                               options);
@@ -959,7 +965,11 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
         throw new NoSuchElementException();
       }
       try {
-        return CoderUtils.decodeFromByteArray(outer.outer.elementCoder, current.elementBytes);
+        if (parseFn != null) {
+          return parseFn.apply(new PubsubIO.PubsubMessage(current.elementBytes, current.attributes));
+        } else {
+          return CoderUtils.decodeFromByteArray(outer.outer.elementCoder, current.elementBytes);
+        }
       } catch (CoderException e) {
         throw new RuntimeException("Unable to decode element from Pubsub message: ", e);
       }
@@ -1110,7 +1120,7 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
         }
       }
       try {
-        reader = new PubsubReader<>(options.as(PubsubOptions.class), this, subscription);
+        reader = new PubsubReader<>(options.as(PubsubOptions.class), this, subscription, outer.parseFn);
       } catch (GeneralSecurityException | IOException e) {
         throw new RuntimeException("Unable to subscribe to " + subscriptionPath + ": ", e);
       }
@@ -1260,6 +1270,13 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
   @Nullable
   private final String idLabel;
 
+  /**
+   * If not {@literal null}, the user is asking for PubSub attributes. This parse function will be used
+   * to parse {@link PubsubIO.PubsubMessage}s containing a payload and attributes.
+   */
+  @Nullable
+  SimpleFunction<PubsubMessage, T> parseFn;
+
   @VisibleForTesting
   PubsubUnboundedSource(
       Clock clock,
@@ -1269,7 +1286,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
       @Nullable ValueProvider<SubscriptionPath> subscription,
       Coder<T> elementCoder,
       @Nullable String timestampLabel,
-      @Nullable String idLabel) {
+      @Nullable String idLabel,
+      @Nullable SimpleFunction<PubsubIO.PubsubMessage, T> parseFn) {
     checkArgument((topic == null) != (subscription == null),
                   "Exactly one of topic and subscription must be given");
     checkArgument((topic == null) == (project == null),
@@ -1282,6 +1300,7 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
     this.elementCoder = checkNotNull(elementCoder);
     this.timestampLabel = timestampLabel;
     this.idLabel = idLabel;
+    this.parseFn = parseFn;
   }
 
   /**
@@ -1294,8 +1313,10 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
       @Nullable ValueProvider<SubscriptionPath> subscription,
       Coder<T> elementCoder,
       @Nullable String timestampLabel,
-      @Nullable String idLabel) {
-    this(null, pubsubFactory, project, topic, subscription, elementCoder, timestampLabel, idLabel);
+      @Nullable String idLabel,
+      @Nullable SimpleFunction<PubsubIO.PubsubMessage, T> parseFn) {
+    this(null, pubsubFactory, project, topic, subscription, elementCoder, timestampLabel, idLabel,
+        parseFn);
   }
 
   public Coder<T> getElementCoder() {
@@ -1336,6 +1357,9 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
   public String getIdLabel() {
     return idLabel;
   }
+
+  @Nullable
+  public SimpleFunction<PubsubIO.PubsubMessage, T> getWithAttributesParseFn() { return parseFn; }
 
   @Override
   public PCollection<T> expand(PBegin input) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
@@ -966,7 +966,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
       }
       try {
         if (parseFn != null) {
-          return parseFn.apply(new PubsubIO.PubsubMessage(current.elementBytes, current.attributes));
+          return parseFn.apply(new PubsubIO.PubsubMessage(
+                  current.elementBytes, current.attributes));
         } else {
           return CoderUtils.decodeFromByteArray(outer.outer.elementCoder, current.elementBytes);
         }
@@ -1120,7 +1121,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
         }
       }
       try {
-        reader = new PubsubReader<>(options.as(PubsubOptions.class), this, subscription, outer.parseFn);
+        reader = new PubsubReader<>(options.as(PubsubOptions.class), this, subscription,
+                outer.parseFn);
       } catch (GeneralSecurityException | IOException e) {
         throw new RuntimeException("Unable to subscribe to " + subscriptionPath + ": ", e);
       }
@@ -1271,8 +1273,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
   private final String idLabel;
 
   /**
-   * If not {@literal null}, the user is asking for PubSub attributes. This parse function will be used
-   * to parse {@link PubsubIO.PubsubMessage}s containing a payload and attributes.
+   * If not {@literal null}, the user is asking for PubSub attributes. This parse function will be
+   * used to parse {@link PubsubIO.PubsubMessage}s containing a payload and attributes.
    */
   @Nullable
   SimpleFunction<PubsubMessage, T> parseFn;
@@ -1359,7 +1361,9 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
   }
 
   @Nullable
-  public SimpleFunction<PubsubIO.PubsubMessage, T> getWithAttributesParseFn() { return parseFn; }
+  public SimpleFunction<PubsubIO.PubsubMessage, T> getWithAttributesParseFn() {
+    return parseFn;
+  }
 
   @Override
   public PCollection<T> expand(PBegin input) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubUnboundedSource.java
@@ -1321,45 +1321,72 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
         parseFn);
   }
 
+  /**
+   * Get the coder used for elements.
+   */
   public Coder<T> getElementCoder() {
     return elementCoder;
   }
 
+  /**
+   * Get the project path.
+   */
   @Nullable
   public ProjectPath getProject() {
     return project == null ? null : project.get();
   }
 
+  /**
+   * Get the topic being read from.
+   */
   @Nullable
   public TopicPath getTopic() {
     return topic == null ? null : topic.get();
   }
 
+  /**
+   * Get the {@link ValueProvider} for the topic being read from.
+   */
   @Nullable
   public ValueProvider<TopicPath> getTopicProvider() {
     return topic;
   }
 
+  /**
+   * Get the subscription being read from.
+   */
   @Nullable
   public SubscriptionPath getSubscription() {
     return subscription == null ? null : subscription.get();
   }
 
+  /**
+   * Get the {@link ValueProvider} for the subscription being read from.
+   */
   @Nullable
   public ValueProvider<SubscriptionPath> getSubscriptionProvider() {
     return subscription;
   }
 
+  /**
+   * Get the timestamp label.
+   */
   @Nullable
   public String getTimestampLabel() {
     return timestampLabel;
   }
 
+  /**
+   * Get the id label.
+   */
   @Nullable
   public String getIdLabel() {
     return idLabel;
   }
 
+  /**
+   * Get the parsing function for PubSub attributes.
+   */
   @Nullable
   public SimpleFunction<PubsubIO.PubsubMessage, T> getWithAttributesParseFn() {
     return parseFn;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
@@ -102,7 +102,7 @@ import org.apache.beam.sdk.values.PCollection.IsBounded;
  * as the input.
  *
  * <p>If the input {@code PCollection} contains late data (see
- * {@link org.apache.beam.sdk.io.PubsubIO.Read.Bound#timestampLabel}
+ * {@link org.apache.beam.sdk.io.PubsubIO.Read#timestampLabel}
  * for an example of how this can occur) or the
  * {@link Window#triggering requested TriggerFn} can fire before
  * the watermark, then there may be multiple elements

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PropertyNames.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PropertyNames.java
@@ -83,6 +83,7 @@ public class PropertyNames {
   public static final String PARALLEL_INPUT = "parallel_input";
   public static final String PHASE = "phase";
   public static final String PUBSUB_ID_LABEL = "pubsub_id_label";
+  public static final String PUBSUB_SERIALIZED_ATTRIBUTES_FN = "pubsub_serialized_attributes_fn";
   public static final String PUBSUB_SUBSCRIPTION = "pubsub_subscription";
   public static final String PUBSUB_SUBSCRIPTION_OVERRIDE = "pubsub_subscription_runtime_override";
   public static final String PUBSUB_TIMESTAMP_LABEL = "pubsub_timestamp_label";

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubClient.java
@@ -324,8 +324,8 @@ public abstract class PubsubClient implements Closeable {
     @Nullable
     public final String recordId;
 
-    public OutgoingMessage(
-        byte[] elementBytes, Map<String, String> attributes, long timestampMsSinceEpoch, @Nullable String recordId) {
+    public OutgoingMessage(byte[] elementBytes, Map<String, String> attributes,
+                           long timestampMsSinceEpoch, @Nullable String recordId) {
       this.elementBytes = elementBytes;
       this.attributes = attributes;
       this.timestampMsSinceEpoch = timestampMsSinceEpoch;
@@ -357,7 +357,8 @@ public abstract class PubsubClient implements Closeable {
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(Arrays.hashCode(elementBytes), attributes, timestampMsSinceEpoch, recordId);
+      return Objects.hashCode(Arrays.hashCode(elementBytes), attributes, timestampMsSinceEpoch,
+              recordId);
     }
   }
 
@@ -412,8 +413,8 @@ public abstract class PubsubClient implements Closeable {
     }
 
     public IncomingMessage withRequestTime(long requestTimeMsSinceEpoch) {
-      return new IncomingMessage(elementBytes, attributes, timestampMsSinceEpoch, requestTimeMsSinceEpoch,
-                                 ackId, recordId);
+      return new IncomingMessage(elementBytes, attributes, timestampMsSinceEpoch,
+              requestTimeMsSinceEpoch, ackId, recordId);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubClient.java
@@ -310,6 +310,8 @@ public abstract class PubsubClient implements Closeable {
      */
     public final byte[] elementBytes;
 
+    public final Map<String, String> attributes;
+
     /**
      * Timestamp for element (ms since epoch).
      */
@@ -323,8 +325,9 @@ public abstract class PubsubClient implements Closeable {
     public final String recordId;
 
     public OutgoingMessage(
-        byte[] elementBytes, long timestampMsSinceEpoch, @Nullable String recordId) {
+        byte[] elementBytes, Map<String, String> attributes, long timestampMsSinceEpoch, @Nullable String recordId) {
       this.elementBytes = elementBytes;
+      this.attributes = attributes;
       this.timestampMsSinceEpoch = timestampMsSinceEpoch;
       this.recordId = recordId;
     }
@@ -347,13 +350,14 @@ public abstract class PubsubClient implements Closeable {
       OutgoingMessage that = (OutgoingMessage) o;
 
       return timestampMsSinceEpoch == that.timestampMsSinceEpoch
-             && Arrays.equals(elementBytes, that.elementBytes)
-             && Objects.equal(recordId, that.recordId);
+              && Arrays.equals(elementBytes, that.elementBytes)
+              && Objects.equal(attributes, that.attributes)
+              && Objects.equal(recordId, that.recordId);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(Arrays.hashCode(elementBytes), timestampMsSinceEpoch, recordId);
+      return Objects.hashCode(Arrays.hashCode(elementBytes), attributes, timestampMsSinceEpoch, recordId);
     }
   }
 
@@ -368,6 +372,8 @@ public abstract class PubsubClient implements Closeable {
      * Underlying (encoded) element.
      */
     public final byte[] elementBytes;
+
+    public Map<String, String> attributes;
 
     /**
      * Timestamp for element (ms since epoch). Either Pubsub's processing time,
@@ -392,11 +398,13 @@ public abstract class PubsubClient implements Closeable {
 
     public IncomingMessage(
         byte[] elementBytes,
+        Map<String, String> attributes,
         long timestampMsSinceEpoch,
         long requestTimeMsSinceEpoch,
         String ackId,
         String recordId) {
       this.elementBytes = elementBytes;
+      this.attributes = attributes;
       this.timestampMsSinceEpoch = timestampMsSinceEpoch;
       this.requestTimeMsSinceEpoch = requestTimeMsSinceEpoch;
       this.ackId = ackId;
@@ -404,7 +412,7 @@ public abstract class PubsubClient implements Closeable {
     }
 
     public IncomingMessage withRequestTime(long requestTimeMsSinceEpoch) {
-      return new IncomingMessage(elementBytes, timestampMsSinceEpoch, requestTimeMsSinceEpoch,
+      return new IncomingMessage(elementBytes, attributes, timestampMsSinceEpoch, requestTimeMsSinceEpoch,
                                  ackId, recordId);
     }
 
@@ -429,12 +437,13 @@ public abstract class PubsubClient implements Closeable {
              && requestTimeMsSinceEpoch == that.requestTimeMsSinceEpoch
              && ackId.equals(that.ackId)
              && recordId.equals(that.recordId)
-             && Arrays.equals(elementBytes, that.elementBytes);
+             && Arrays.equals(elementBytes, that.elementBytes)
+              && Objects.equal(attributes, that.attributes);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(Arrays.hashCode(elementBytes), timestampMsSinceEpoch,
+      return Objects.hashCode(Arrays.hashCode(elementBytes), attributes, timestampMsSinceEpoch,
                               requestTimeMsSinceEpoch,
                               ackId, recordId);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubGrpcClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubGrpcClient.java
@@ -223,6 +223,10 @@ public class PubsubGrpcClient extends PubsubClient {
           PubsubMessage.newBuilder()
                        .setData(ByteString.copyFrom(outgoingMessage.elementBytes));
 
+      if (outgoingMessage.attributes != null) {
+        message.putAllAttributes(outgoingMessage.attributes);
+      }
+
       if (timestampLabel != null) {
         message.getMutableAttributes()
                .put(timestampLabel, String.valueOf(outgoingMessage.timestampMsSinceEpoch));
@@ -286,7 +290,7 @@ public class PubsubGrpcClient extends PubsubClient {
         recordId = pubsubMessage.getMessageId();
       }
 
-      incomingMessages.add(new IncomingMessage(elementBytes, timestampMsSinceEpoch,
+      incomingMessages.add(new IncomingMessage(elementBytes, attributes, timestampMsSinceEpoch,
                                                requestTimeMsSinceEpoch, ackId, recordId));
     }
     return incomingMessages;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubJsonClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubJsonClient.java
@@ -138,6 +138,8 @@ public class PubsubJsonClient extends PubsubClient {
       Map<String, String> attributes = pubsubMessage.getAttributes();
       if ((timestampLabel != null || idLabel != null) && attributes == null) {
         attributes = new TreeMap<>();
+      }
+      if (attributes != null) {
         pubsubMessage.setAttributes(attributes);
       }
 
@@ -201,7 +203,7 @@ public class PubsubJsonClient extends PubsubClient {
         recordId = pubsubMessage.getMessageId();
       }
 
-      incomingMessages.add(new IncomingMessage(elementBytes, timestampMsSinceEpoch,
+      incomingMessages.add(new IncomingMessage(elementBytes, attributes, timestampMsSinceEpoch,
                                                requestTimeMsSinceEpoch, ackId, recordId));
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubTestClient.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PubsubTestClient.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -39,7 +40,7 @@ import org.apache.beam.sdk.options.PubsubOptions;
  * testing {@link #publish}, {@link #pull}, {@link #acknowledge} and {@link #modifyAckDeadline}
  * methods. Relies on statics to mimic the Pubsub service, though we try to hide that.
  */
-public class PubsubTestClient extends PubsubClient {
+public class PubsubTestClient extends PubsubClient implements Serializable {
   /**
    * Mimic the state of the simulated Pubsub 'service'.
    *
@@ -113,7 +114,8 @@ public class PubsubTestClient extends PubsubClient {
   private static final State STATE = new State();
 
   /** Closing the factory will validate all expected messages were processed. */
-  public interface PubsubTestClientFactory extends PubsubClientFactory, Closeable {
+  public interface PubsubTestClientFactory
+          extends PubsubClientFactory, Closeable, Serializable {
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
@@ -76,7 +76,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
   }
 
   @Rule
-  public TestPipeline p = TestPipeline.create();
+  public transient TestPipeline p = TestPipeline.create();
 
   @Test
   public void saneCoder() throws Exception {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
@@ -57,7 +57,7 @@ public class PubsubUnboundedSinkTest {
   private static final TopicPath TOPIC = PubsubClient.topicPathFromName("testProject", "testTopic");
   private static final String DATA = "testData";
   private static final Map<String, String> ATTRIBUTES =
-          ImmutableMap.<String, String>builder().put("a","b").put("c", "d").build();
+          ImmutableMap.<String, String>builder().put("a", "b").put("c", "d").build();
   private static final long TIMESTAMP = 1234L;
   private static final String TIMESTAMP_LABEL = "timestamp";
   private static final String ID_LABEL = "id";
@@ -79,7 +79,8 @@ public class PubsubUnboundedSinkTest {
 
   @Test
   public void saneCoder() throws Exception {
-    OutgoingMessage message = new OutgoingMessage(DATA.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(DATA));
+    OutgoingMessage message = new OutgoingMessage(
+            DATA.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(DATA));
     CoderProperties.coderDecodeEncodeEqual(PubsubUnboundedSink.CODER, message);
     CoderProperties.coderSerializable(PubsubUnboundedSink.CODER);
   }
@@ -126,7 +127,8 @@ public class PubsubUnboundedSinkTest {
     int batchBytes = 1000;
     for (int i = 0; i < batchSize * 10; i++) {
       String str = String.valueOf(i);
-      outgoing.add(new OutgoingMessage(str.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(str)));
+      outgoing.add(new OutgoingMessage(
+              str.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(str)));
       data.add(str);
     }
     try (PubsubTestClientFactory factory =
@@ -159,7 +161,8 @@ public class PubsubUnboundedSinkTest {
         sb.append(String.valueOf(n));
       }
       String str = sb.toString();
-      outgoing.add(new OutgoingMessage(str.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(str)));
+      outgoing.add(new OutgoingMessage(
+              str.getBytes(), ImmutableMap.<String, String>of(), TIMESTAMP, getRecordId(str)));
       data.add(str);
       n += str.length();
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSinkTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hashing;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ import org.junit.runners.JUnit4;
  * Test PubsubUnboundedSink.
  */
 @RunWith(JUnit4.class)
-public class PubsubUnboundedSinkTest {
+public class PubsubUnboundedSinkTest implements Serializable {
   private static final TopicPath TOPIC = PubsubClient.topicPathFromName("testProject", "testTopic");
   private static final String DATA = "testData";
   private static final Map<String, String> ATTRIBUTES =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubUnboundedSourceTest.java
@@ -98,13 +98,13 @@ public class PubsubUnboundedSourceTest {
     PubsubUnboundedSource<String> source =
         new PubsubUnboundedSource<>(
             clock, factory, null, null, StaticValueProvider.of(SUBSCRIPTION),
-            StringUtf8Coder.of(), TIMESTAMP_LABEL, ID_LABEL);
+            StringUtf8Coder.of(), TIMESTAMP_LABEL, ID_LABEL, null);
     primSource = new PubsubSource<>(source);
   }
 
   private void setupOneMessage() {
     setupOneMessage(ImmutableList.of(
-        new IncomingMessage(DATA.getBytes(), TIMESTAMP, 0, ACK_ID, RECORD_ID)));
+        new IncomingMessage(DATA.getBytes(), null, TIMESTAMP, 0, ACK_ID, RECORD_ID)));
   }
 
   @After
@@ -217,7 +217,7 @@ public class PubsubUnboundedSourceTest {
     for (int i = 0; i < 2; i++) {
       String data = String.format("data_%d", i);
       String ackid = String.format("ackid_%d", i);
-      incoming.add(new IncomingMessage(data.getBytes(), TIMESTAMP, 0, ackid, RECORD_ID));
+      incoming.add(new IncomingMessage(data.getBytes(), null, TIMESTAMP, 0, ackid, RECORD_ID));
     }
     setupOneMessage(incoming);
     PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
@@ -275,7 +275,7 @@ public class PubsubUnboundedSourceTest {
       dataToMessageNum.put(data, messageNum);
       String recid = String.format("recordid_%d", messageNum);
       String ackId = String.format("ackid_%d", messageNum);
-      incoming.add(new IncomingMessage(data.getBytes(), messageNumToTimestamp(messageNum), 0,
+      incoming.add(new IncomingMessage(data.getBytes(), null, messageNumToTimestamp(messageNum), 0,
                                        ackId, recid));
     }
     setupOneMessage(incoming);
@@ -337,6 +337,7 @@ public class PubsubUnboundedSourceTest {
             null,
             StringUtf8Coder.of(),
             null,
+            null,
             null);
     assertThat(source.getSubscription(), nullValue());
 
@@ -366,6 +367,7 @@ public class PubsubUnboundedSourceTest {
             StaticValueProvider.of(topicPath),
             null,
             StringUtf8Coder.of(),
+            null,
             null,
             null);
     assertThat(source.getSubscription(), nullValue());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
@@ -196,7 +196,7 @@ public class PubsubGrpcClientTest {
         .start();
     try {
       OutgoingMessage actualMessage = new OutgoingMessage(
-              DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
+              DATA.getBytes(), ATTRIBUTES, MESSAGE_TIME, RECORD_ID);
       int n = client.publish(TOPIC, ImmutableList.of(actualMessage));
       assertEquals(1, n);
       assertEquals(expectedRequest, Iterables.getOnlyElement(requestsReceived));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
@@ -195,7 +195,8 @@ public class PubsubGrpcClientTest {
         .build()
         .start();
     try {
-      OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
+      OutgoingMessage actualMessage = new OutgoingMessage(
+              DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
       int n = client.publish(TOPIC, ImmutableList.of(actualMessage));
       assertEquals(1, n);
       assertEquals(expectedRequest, Iterables.getOnlyElement(requestsReceived));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubGrpcClientTest.java
@@ -42,6 +42,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.util.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.util.PubsubClient.OutgoingMessage;
@@ -76,6 +77,8 @@ public class PubsubGrpcClientTest {
   private static final String DATA = "testData";
   private static final String RECORD_ID = "testRecordId";
   private static final String ACK_ID = "testAckId";
+  private static final Map<String, String> ATTRIBUTES =
+          ImmutableMap.<String, String>builder().put("a", "b").put("c", "d").build();
 
   @Before
   public void setup() {
@@ -111,6 +114,7 @@ public class PubsubGrpcClientTest {
                      .setData(
                          ByteString.copyFrom(DATA.getBytes()))
                      .setPublishTime(timestamp)
+                     .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
                          ImmutableMap.of(TIMESTAMP_LABEL,
                                          String.valueOf(MESSAGE_TIME),
@@ -160,6 +164,7 @@ public class PubsubGrpcClientTest {
     PubsubMessage expectedPubsubMessage =
         PubsubMessage.newBuilder()
                      .setData(ByteString.copyFrom(DATA.getBytes()))
+                     .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
                          ImmutableMap.of(TIMESTAMP_LABEL, String.valueOf(MESSAGE_TIME),
                                          ID_LABEL, RECORD_ID))
@@ -190,7 +195,7 @@ public class PubsubGrpcClientTest {
         .build()
         .start();
     try {
-      OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), MESSAGE_TIME, RECORD_ID);
+      OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
       int n = client.publish(TOPIC, ImmutableList.of(actualMessage));
       assertEquals(1, n);
       assertEquals(expectedRequest, Iterables.getOnlyElement(requestsReceived));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubJsonClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubJsonClientTest.java
@@ -125,7 +125,7 @@ public class PubsubJsonClientTest {
                                 .publish(expectedTopic, expectedRequest)
                                 .execute()))
            .thenReturn(expectedResponse);
-    OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), MESSAGE_TIME, RECORD_ID);
+    OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
     int n = client.publish(TOPIC, ImmutableList.of(actualMessage));
     assertEquals(1, n);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubJsonClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubJsonClientTest.java
@@ -125,7 +125,8 @@ public class PubsubJsonClientTest {
                                 .publish(expectedTopic, expectedRequest)
                                 .execute()))
            .thenReturn(expectedResponse);
-    OutgoingMessage actualMessage = new OutgoingMessage(DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
+    OutgoingMessage actualMessage = new OutgoingMessage(
+            DATA.getBytes(), null, MESSAGE_TIME, RECORD_ID);
     int n = client.publish(TOPIC, ImmutableList.of(actualMessage));
     assertEquals(1, n);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubTestClientTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/PubsubTestClientTest.java
@@ -61,7 +61,7 @@ public class PubsubTestClientTest {
       }
     };
     IncomingMessage expectedIncomingMessage =
-        new IncomingMessage(DATA.getBytes(), MESSAGE_TIME, REQ_TIME, ACK_ID, MESSAGE_ID);
+        new IncomingMessage(DATA.getBytes(), null, MESSAGE_TIME, REQ_TIME, ACK_ID, MESSAGE_ID);
     try (PubsubTestClientFactory factory =
              PubsubTestClient.createFactoryForPull(clock, SUBSCRIPTION, ACK_TIMEOUT_S,
                                                    Lists.newArrayList(expectedIncomingMessage))) {
@@ -100,7 +100,7 @@ public class PubsubTestClientTest {
   @Test
   public void publishOneMessage() throws IOException {
     OutgoingMessage expectedOutgoingMessage =
-        new OutgoingMessage(DATA.getBytes(), MESSAGE_TIME, MESSAGE_ID);
+        new OutgoingMessage(DATA.getBytes(), null, MESSAGE_TIME, MESSAGE_ID);
     try (PubsubTestClientFactory factory =
              PubsubTestClient.createFactoryForPublish(
                  TOPIC,


### PR DESCRIPTION
Introduces a new PubsubMessage class, that allows separate management of payload and attributes from PubSub. Allows the user to register functions on PubsubIO to parse  and format these objects in order to interact with attributes.
