### PR TITLE
[BEAM-597] Added a new method on Coder which returns a TypeDescriptor.

### DIFF
--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSink.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSink.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 
 /**
@@ -127,6 +128,11 @@ public class UnboundedFlinkSink<T> extends Sink<T> {
           @Override
           public Collection<String> getAllowedEncodings() {
             return null;
+          }
+
+          @Override
+          public TypeDescriptor<Object> getEncodedTypeDescriptor() {
+            return TypeDescriptor.of(Object.class);
           }
         };
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/Experimental.java
@@ -88,6 +88,9 @@ public @interface Experimental {
     METRICS,
 
     /** Experimental runner APIs. Should not be used by pipeline authors. */
-    CORE_RUNNERS_ONLY
+    CORE_RUNNERS_ONLY,
+
+    /** Experimental feature related to making the encoded element type available from a Coder. */
+    CODER_TYPE_ENCODING
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -167,6 +167,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
 
   private final Class<T> type;
   private final SerializableSchemaSupplier schemaSupplier;
+  private final TypeDescriptor<T> typeDescriptor;
 
   private final List<String> nonDeterministicReasons;
 
@@ -239,6 +240,7 @@ public class AvroCoder<T> extends StandardCoder<T> {
   protected AvroCoder(Class<T> type, Schema schema) {
     this.type = type;
     this.schemaSupplier = new SerializableSchemaSupplier(schema);
+    typeDescriptor = TypeDescriptor.of(type);
     nonDeterministicReasons = new AvroDeterminismChecker().check(TypeDescriptor.of(type), schema);
 
     // Decoder and Encoder start off null for each thread. They are allocated and potentially
@@ -382,6 +384,11 @@ public class AvroCoder<T> extends StandardCoder<T> {
    */
   public Schema getSchema() {
     return schemaSupplier.get();
+  }
+
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return typeDescriptor;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianIntegerCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianIntegerCoder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link BigEndianIntegerCoder} encodes {@link Integer Integers} in 4 bytes, big-endian.
@@ -39,6 +40,7 @@ public class BigEndianIntegerCoder extends AtomicCoder<Integer> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final BigEndianIntegerCoder INSTANCE = new BigEndianIntegerCoder();
+  private static final TypeDescriptor<Integer> TYPE_DESCRIPTOR = new TypeDescriptor<Integer>() {};
 
   private BigEndianIntegerCoder() {}
 
@@ -81,6 +83,11 @@ public class BigEndianIntegerCoder extends AtomicCoder<Integer> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Integer value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Integer> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianLongCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianLongCoder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link BigEndianLongCoder} encodes {@link Long}s in 8 bytes, big-endian.
@@ -39,6 +40,7 @@ public class BigEndianLongCoder extends AtomicCoder<Long> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final BigEndianLongCoder INSTANCE = new BigEndianLongCoder();
+  private static final TypeDescriptor<Long> TYPE_DESCRIPTOR = new TypeDescriptor<Long>() {};
 
   private BigEndianLongCoder() {}
 
@@ -81,6 +83,11 @@ public class BigEndianLongCoder extends AtomicCoder<Long> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Long value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Long> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteArrayCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteArrayCoder.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import org.apache.beam.sdk.util.ExposedByteArrayOutputStream;
 import org.apache.beam.sdk.util.StreamUtils;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} for {@code byte[]}.
@@ -48,6 +49,7 @@ public class ByteArrayCoder extends AtomicCoder<byte[]> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final ByteArrayCoder INSTANCE = new ByteArrayCoder();
+  private static final TypeDescriptor<byte[]> TYPE_DESCRIPTOR = new TypeDescriptor<byte[]>() {};
 
   private ByteArrayCoder() {}
 
@@ -120,6 +122,11 @@ public class ByteArrayCoder extends AtomicCoder<byte[]> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(byte[] value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<byte[]> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteCoder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link ByteCoder} encodes {@link Byte} values in 1 byte using Java serialization.
@@ -37,6 +38,7 @@ public class ByteCoder extends AtomicCoder<Byte> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final ByteCoder INSTANCE = new ByteCoder();
+  private static final TypeDescriptor<Byte> TYPE_DESCRIPTOR = new TypeDescriptor<Byte>() {};
 
   private ByteCoder() {}
 
@@ -93,6 +95,11 @@ public class ByteCoder extends AtomicCoder<Byte> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Byte value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Byte> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteStringCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteStringCoder.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} for {@link ByteString} objects based on their encoded Protocol Buffer form.
@@ -41,6 +42,8 @@ public class ByteStringCoder extends AtomicCoder<ByteString> {
   /***************************/
 
   private static final ByteStringCoder INSTANCE = new ByteStringCoder();
+  private static final TypeDescriptor<ByteString> TYPE_DESCRIPTOR =
+      new TypeDescriptor<ByteString>() {};
 
   private ByteStringCoder() {}
 
@@ -101,5 +104,10 @@ public class ByteStringCoder extends AtomicCoder<ByteString> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(ByteString value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<ByteString> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder Coder&lt;T&gt;} defines how to encode and decode values of type {@code T} into
@@ -252,6 +253,12 @@ public interface Coder<T> extends Serializable {
    */
   @Experimental(Kind.CODER_ENCODING_ID)
   Collection<String> getAllowedEncodings();
+
+  /**
+   * Returns the {@link TypeDescriptor} for the type encoded.
+   */
+  @Experimental(Kind.CODER_TYPE_ENCODING)
+  TypeDescriptor<T> getEncodedTypeDescriptor();
 
   /**
    * Exception thrown by {@link Coder#verifyDeterministic()} if the encoding is

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CollectionCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CollectionCoder.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.util.PropertyNames;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * A {@link CollectionCoder} encodes {@link Collection Collections} in the format
@@ -68,5 +70,11 @@ public class CollectionCoder<T> extends IterableLikeCoder<T, Collection<T>> {
 
   protected CollectionCoder(Coder<T> elemCoder) {
     super(elemCoder, "Collection");
+  }
+
+  @Override
+  public TypeDescriptor<Collection<T>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<Collection<T>>() {}.where(
+        new TypeParameter<T>() {}, getElemCoder().getEncodedTypeDescriptor());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@code DelegateCoder<T, IntermediateT>} wraps a {@link Coder} for {@code IntermediateT} and
@@ -55,7 +56,15 @@ public final class DelegateCoder<T, IntermediateT> extends CustomCoder<T> {
   public static <T, IntermediateT> DelegateCoder<T, IntermediateT> of(Coder<IntermediateT> coder,
       CodingFunction<T, IntermediateT> toFn,
       CodingFunction<IntermediateT, T> fromFn) {
-    return new DelegateCoder<T, IntermediateT>(coder, toFn, fromFn);
+    return of(coder, toFn, fromFn, null);
+  }
+
+  public static <T, IntermediateT> DelegateCoder<T, IntermediateT> of(
+      Coder<IntermediateT> coder,
+      CodingFunction<T, IntermediateT> toFn,
+      CodingFunction<IntermediateT, T> fromFn,
+      TypeDescriptor<T> typeDescriptor) {
+    return new DelegateCoder<T, IntermediateT>(coder, toFn, fromFn, typeDescriptor);
   }
 
   @Override
@@ -154,6 +163,14 @@ public final class DelegateCoder<T, IntermediateT> extends CustomCoder<T> {
     return allowedEncodings;
   }
 
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    if (typeDescriptor == null) {
+      return super.getEncodedTypeDescriptor();
+    }
+    return typeDescriptor;
+  }
+
   private String delegateEncodingId(Class<?> delegateClass, String encodingId) {
     return String.format("%s:%s", delegateClass.getName(), encodingId);
   }
@@ -175,12 +192,15 @@ public final class DelegateCoder<T, IntermediateT> extends CustomCoder<T> {
   private final Coder<IntermediateT> coder;
   private final CodingFunction<T, IntermediateT> toFn;
   private final CodingFunction<IntermediateT, T> fromFn;
+  private final TypeDescriptor<T> typeDescriptor;
 
   protected DelegateCoder(Coder<IntermediateT> coder,
       CodingFunction<T, IntermediateT> toFn,
-      CodingFunction<IntermediateT, T> fromFn) {
+      CodingFunction<IntermediateT, T> fromFn,
+      TypeDescriptor<T> typeDescriptor) {
     this.coder = coder;
     this.fromFn = fromFn;
     this.toFn = toFn;
+    this.typeDescriptor = typeDescriptor;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DoubleCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DoubleCoder.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link DoubleCoder} encodes {@link Double} values in 8 bytes using Java serialization.
@@ -39,6 +40,7 @@ public class DoubleCoder extends AtomicCoder<Double> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final DoubleCoder INSTANCE = new DoubleCoder();
+  private static final TypeDescriptor<Double> TYPE_DESCRIPTOR = new TypeDescriptor<Double>() {};
 
   private DoubleCoder() {}
 
@@ -95,6 +97,11 @@ public class DoubleCoder extends AtomicCoder<Double> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Double value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Double> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DurationCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DurationCoder.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDuration;
 
@@ -39,6 +40,8 @@ public class DurationCoder extends AtomicCoder<ReadableDuration> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final DurationCoder INSTANCE = new DurationCoder();
+  private static final TypeDescriptor<ReadableDuration> TYPE_DESCRIPTOR =
+      new TypeDescriptor<ReadableDuration>() {};
 
   private final VarLongCoder longCoder = VarLongCoder.of();
 
@@ -91,5 +94,10 @@ public class DurationCoder extends AtomicCoder<ReadableDuration> {
   public void registerByteSizeObserver(
       ReadableDuration value, ElementByteSizeObserver observer, Context context) throws Exception {
     longCoder.registerByteSizeObserver(toLong(value), observer, context);
+  }
+
+  @Override
+  public TypeDescriptor<ReadableDuration> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Instant;
 
 /**
@@ -39,6 +40,7 @@ public class InstantCoder extends AtomicCoder<Instant> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final InstantCoder INSTANCE = new InstantCoder();
+  private static final TypeDescriptor<Instant> TYPE_DESCRIPTOR = new TypeDescriptor<Instant>() {};
 
   private final BigEndianLongCoder longCoder = BigEndianLongCoder.of();
 
@@ -109,5 +111,10 @@ public class InstantCoder extends AtomicCoder<Instant> {
       Instant value, ElementByteSizeObserver observer, Context context) throws Exception {
     longCoder.registerByteSizeObserver(
         ORDER_PRESERVING_CONVERTER.convert(value), observer, context);
+  }
+
+  @Override
+  public TypeDescriptor<Instant> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableCoder.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.PropertyNames;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * An {@link IterableCoder} encodes any {@link Iterable} in the format
@@ -72,5 +74,11 @@ public class IterableCoder<T> extends IterableLikeCoder<T, Iterable<T>> {
     CloudObject result = CloudObject.forClassName("kind:stream");
     addBoolean(result, PropertyNames.IS_STREAM_LIKE, true);
     return result;
+  }
+
+  @Override
+  public TypeDescriptor<Iterable<T>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<Iterable<T>>() {}.where(
+        new TypeParameter<T>() {}, getElemCoder().getEncodedTypeDescriptor());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/JAXBCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/JAXBCoder.java
@@ -32,6 +32,7 @@ import javax.xml.bind.Unmarshaller;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.Structs;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A coder for JAXB annotated objects. This coder uses JAXB marshalling/unmarshalling mechanisms
@@ -42,6 +43,7 @@ import org.apache.beam.sdk.util.VarInt;
 public class JAXBCoder<T> extends AtomicCoder<T> {
 
   private final Class<T> jaxbClass;
+  private final TypeDescriptor<T> typeDescriptor;
   private transient volatile JAXBContext jaxbContext;
 
   public Class<T> getJAXBClass() {
@@ -50,6 +52,7 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
 
   private JAXBCoder(Class<T> jaxbClass) {
     this.jaxbClass = jaxbClass;
+    this.typeDescriptor = TypeDescriptor.of(jaxbClass);
   }
 
   /**
@@ -120,6 +123,11 @@ public class JAXBCoder<T> extends AtomicCoder<T> {
   @Override
   public String getEncodingId() {
     return getJAXBClass().getName();
+  }
+
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return typeDescriptor;
   }
 
   private static class CloseIgnoringInputStream extends FilterInputStream {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/KvCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/KvCoder.java
@@ -31,6 +31,8 @@ import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * A {@code KvCoder} encodes {@link KV}s.
@@ -150,5 +152,12 @@ public class KvCoder<K, V> extends StandardCoder<KV<K, V>> {
     }
     keyCoder.registerByteSizeObserver(kv.getKey(), observer, context.nested());
     valueCoder.registerByteSizeObserver(kv.getValue(), observer, context);
+  }
+
+  @Override
+  public TypeDescriptor<KV<K, V>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<KV<K, V>>() {}.where(
+            new TypeParameter<K>() {}, keyCoder.getEncodedTypeDescriptor())
+        .where(new TypeParameter<V>() {}, valueCoder.getEncodedTypeDescriptor());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ListCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ListCoder.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import org.apache.beam.sdk.util.PropertyNames;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * A {@link Coder} for {@link List}, using the format of {@link IterableLikeCoder}.
@@ -73,4 +75,9 @@ public class ListCoder<T> extends IterableLikeCoder<T, List<T>> {
         "ListCoder.elemCoder must be deterministic", getElemCoder());
   }
 
+  @Override
+  public TypeDescriptor<List<T>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<List<T>>(getClass()) {}.where(
+        new TypeParameter<T>() {}, getElemCoder().getEncodedTypeDescriptor());
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/MapCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/MapCoder.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * A {@link Coder} for {@link Map Maps} that encodes them according to provided
@@ -184,5 +186,12 @@ public class MapCoder<K, V> extends StandardCoder<Map<K, V>> {
     }
     keyCoder.registerByteSizeObserver(entry.getKey(), observer, context.nested());
     valueCoder.registerByteSizeObserver(entry.getValue(), observer, context);
+  }
+
+  @Override
+  public TypeDescriptor<Map<K, V>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<Map<K, V>>() {}.where(
+            new TypeParameter<K>() {}, keyCoder.getEncodedTypeDescriptor())
+        .where(new TypeParameter<V>() {}, valueCoder.getEncodedTypeDescriptor());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
@@ -30,6 +30,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link NullableCoder} encodes nullable values of type {@code T} using a nested
@@ -182,5 +183,10 @@ public class NullableCoder<T> extends StandardCoder<T> {
       return true;
     }
     return valueCoder.isRegisterByteSizeObserverCheap(value, context);
+  }
+
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return valueCoder.getEncodedTypeDescriptor();
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -55,7 +55,7 @@ public class SerializableCoder<T extends Serializable> extends AtomicCoder<T> {
   public static <T extends Serializable> SerializableCoder<T> of(TypeDescriptor<T> type) {
     @SuppressWarnings("unchecked")
     Class<T> clazz = (Class<T>) type.getRawType();
-    return of(clazz);
+    return new SerializableCoder<>(clazz, type);
   }
 
   /**
@@ -63,7 +63,7 @@ public class SerializableCoder<T extends Serializable> extends AtomicCoder<T> {
    * @param <T> the element type
    */
   public static <T extends Serializable> SerializableCoder<T> of(Class<T> clazz) {
-    return new SerializableCoder<>(clazz);
+    return new SerializableCoder<>(clazz, TypeDescriptor.of(clazz));
   }
 
   @JsonCreator
@@ -104,9 +104,11 @@ public class SerializableCoder<T extends Serializable> extends AtomicCoder<T> {
 
 
   private final Class<T> type;
+  private final TypeDescriptor<T> typeDescriptor;
 
-  protected SerializableCoder(Class<T> type) {
+  protected SerializableCoder(Class<T> type, TypeDescriptor<T> typeDescriptor) {
     this.type = type;
+    this.typeDescriptor = typeDescriptor;
   }
 
   public Class<T> getRecordType() {
@@ -171,6 +173,11 @@ public class SerializableCoder<T extends Serializable> extends AtomicCoder<T> {
   @Override
   public int hashCode() {
     return type.hashCode();
+  }
+
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return typeDescriptor;
   }
 
   // This coder inherits isRegisterByteSizeObserverCheap,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SetCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SetCoder.java
@@ -25,6 +25,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.beam.sdk.util.PropertyNames;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 
 /**
  * A {@link SetCoder} encodes any {@link Set} using the format of {@link IterableLikeCoder}. The
@@ -62,6 +64,12 @@ public class SetCoder<T> extends IterableLikeCoder<T, Set<T>> {
   public void verifyDeterministic() throws NonDeterministicException {
     throw new NonDeterministicException(this,
         "Ordering of elements in a set may be non-deterministic.");
+  }
+
+  @Override
+  public TypeDescriptor<Set<T>> getEncodedTypeDescriptor() {
+    return new TypeDescriptor<Set<T>>() {}.where(
+        new TypeParameter<T>() {}, getElemCoder().getEncodedTypeDescriptor());
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StandardCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StandardCoder.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * An abstract base class to implement a {@link Coder} that defines equality, hashing, and printing
@@ -254,5 +255,12 @@ public abstract class StandardCoder<T> implements Coder<T> {
             "Unable to encode element '" + value + "' with coder '" + this + "'.", exn);
       }
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return (TypeDescriptor<T>)
+        TypeDescriptor.of(getClass()).resolveType(new TypeDescriptor<T>() {}.getType());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringDelegateCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringDelegateCoder.java
@@ -24,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import org.apache.beam.sdk.coders.DelegateCoder.CodingFunction;
 import org.apache.beam.sdk.coders.protobuf.ProtoCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that wraps a {@code Coder<String>}
@@ -49,7 +50,11 @@ import org.apache.beam.sdk.coders.protobuf.ProtoCoder;
  */
 public final class StringDelegateCoder<T> extends CustomCoder<T> {
   public static <T> StringDelegateCoder<T> of(Class<T> clazz) {
-    return new StringDelegateCoder<T>(clazz);
+    return StringDelegateCoder.<T>of(clazz, TypeDescriptor.of(clazz));
+  }
+
+  public static <T> StringDelegateCoder<T> of(Class<T> clazz, TypeDescriptor<T> typeDescriptor) {
+    return new StringDelegateCoder<T>(clazz, typeDescriptor);
   }
 
   @Override
@@ -60,7 +65,7 @@ public final class StringDelegateCoder<T> extends CustomCoder<T> {
   private final DelegateCoder<T, String> delegateCoder;
   private final Class<T> clazz;
 
-  protected StringDelegateCoder(final Class<T> clazz) {
+  protected StringDelegateCoder(final Class<T> clazz, TypeDescriptor<T> typeDescriptor) {
     delegateCoder = DelegateCoder.of(StringUtf8Coder.of(),
       new CodingFunction<T, String>() {
         @Override
@@ -77,7 +82,7 @@ public final class StringDelegateCoder<T> extends CustomCoder<T> {
             InvocationTargetException {
           return clazz.getConstructor(String.class).newInstance(input);
         }
-      });
+      }, typeDescriptor);
 
     this.clazz = clazz;
   }
@@ -128,6 +133,11 @@ public final class StringDelegateCoder<T> extends CustomCoder<T> {
   @Override
   public Collection<String> getAllowedEncodings() {
     return delegateCoder.getAllowedEncodings();
+  }
+
+  @Override
+  public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    return delegateCoder.getEncodedTypeDescriptor();
   }
 }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringUtf8Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StringUtf8Coder.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.util.ExposedByteArrayOutputStream;
 import org.apache.beam.sdk.util.StreamUtils;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that encodes {@link String Strings} in UTF-8 encoding.
@@ -48,6 +49,7 @@ public class StringUtf8Coder extends AtomicCoder<String> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final StringUtf8Coder INSTANCE = new StringUtf8Coder();
+  private static final TypeDescriptor<String> TYPE_DESCRIPTOR = new TypeDescriptor<String>() {};
 
   private static void writeString(String value, DataOutputStream dos)
       throws IOException {
@@ -111,6 +113,11 @@ public class StringUtf8Coder extends AtomicCoder<String> {
   @Override
   public boolean consistentWithEquals() {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<String> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/TableRowJsonCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/TableRowJsonCoder.java
@@ -24,6 +24,7 @@ import com.google.api.services.bigquery.model.TableRow;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that encodes BigQuery {@link TableRow} objects in their native JSON format.
@@ -64,6 +65,7 @@ public class TableRowJsonCoder extends AtomicCoder<TableRow> {
       new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
 
   private static final TableRowJsonCoder INSTANCE = new TableRowJsonCoder();
+  private static final TypeDescriptor<TableRow> TYPE_DESCRIPTOR = new TypeDescriptor<TableRow>() {};
 
   private TableRowJsonCoder() { }
 
@@ -77,5 +79,10 @@ public class TableRowJsonCoder extends AtomicCoder<TableRow> {
   public void verifyDeterministic() throws NonDeterministicException {
     throw new NonDeterministicException(this,
         "TableCell can hold arbitrary instances, which may be non-deterministic.");
+  }
+
+  @Override
+  public TypeDescriptor<TableRow> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/TextualIntegerCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/TextualIntegerCoder.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that encodes {@code Integer Integers} as the ASCII bytes of
@@ -34,6 +35,8 @@ public class TextualIntegerCoder extends AtomicCoder<Integer> {
   }
 
   /////////////////////////////////////////////////////////////////////////////
+
+  private static final TypeDescriptor<Integer> TYPE_DESCRIPTOR = new TypeDescriptor<Integer>() {};
 
   protected TextualIntegerCoder() {}
 
@@ -56,6 +59,11 @@ public class TextualIntegerCoder extends AtomicCoder<Integer> {
     } catch (NumberFormatException exn) {
       throw new CoderException("error when decoding a textual integer", exn);
     }
+  }
+
+  @Override
+  public TypeDescriptor<Integer> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarIntCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarIntCoder.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that encodes {@link Integer Integers} using between 1 and 5 bytes. Negative
@@ -39,8 +40,8 @@ public class VarIntCoder extends AtomicCoder<Integer> {
 
   /////////////////////////////////////////////////////////////////////////////
 
-  private static final VarIntCoder INSTANCE =
-      new VarIntCoder();
+  private static final VarIntCoder INSTANCE = new VarIntCoder();
+  private static final TypeDescriptor<Integer> TYPE_DESCRIPTOR = new TypeDescriptor<Integer>() {};
 
   private VarIntCoder() {}
 
@@ -83,6 +84,11 @@ public class VarIntCoder extends AtomicCoder<Integer> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Integer value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Integer> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarLongCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarLongCoder.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UTFDataFormatException;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} that encodes {@link Long Longs} using between 1 and 10 bytes. Negative
@@ -40,6 +41,7 @@ public class VarLongCoder extends AtomicCoder<Long> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final VarLongCoder INSTANCE = new VarLongCoder();
+  private static final TypeDescriptor<Long> TYPE_DESCRIPTOR = new TypeDescriptor<Long>() {};
 
   private VarLongCoder() {}
 
@@ -82,6 +84,11 @@ public class VarLongCoder extends AtomicCoder<Long> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Long value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Long> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.coders;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.InputStream;
 import java.io.OutputStream;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * A {@link Coder} for {@link Void}. Uses zero bytes per {@link Void}.
@@ -34,6 +35,7 @@ public class VoidCoder extends AtomicCoder<Void> {
   /////////////////////////////////////////////////////////////////////////////
 
   private static final VoidCoder INSTANCE = new VoidCoder();
+  private static final TypeDescriptor<Void> TYPE_DESCRIPTOR = new TypeDescriptor<Void>() {};
 
   private VoidCoder() {}
 
@@ -66,6 +68,11 @@ public class VoidCoder extends AtomicCoder<Void> {
   @Override
   public boolean isRegisterByteSizeObserverCheap(Void value, Context context) {
     return true;
+  }
+
+  @Override
+  public TypeDescriptor<Void> getEncodedTypeDescriptor() {
+    return TYPE_DESCRIPTOR;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestStream.java
@@ -46,6 +46,8 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TimestampedValue.TimestampedValueCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeParameter;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.joda.time.ReadableDuration;
@@ -363,6 +365,12 @@ public final class TestStream<T> extends PTransform<PBegin, PCollection<T>> {
       elementCoder.verifyDeterministic();
       DURATION_CODER.verifyDeterministic();
       INSTANT_CODER.verifyDeterministic();
+    }
+
+    @Override
+    public TypeDescriptor<Event<T>> getEncodedTypeDescriptor() {
+      return new TypeDescriptor<Event<T>>() {}.where(
+          new TypeParameter<T>() {}, valueCoder.getEncodedTypeDescriptor());
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TimestampedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TimestampedValue.java
@@ -151,6 +151,12 @@ public class TimestampedValue<V> {
     public static <T> List<Object> getInstanceComponents(TimestampedValue<T> exampleValue) {
       return Arrays.<Object>asList(exampleValue.getValue());
     }
+
+    @Override
+    public TypeDescriptor<TimestampedValue<T>> getEncodedTypeDescriptor() {
+      return new TypeDescriptor<TimestampedValue<T>>() {}.where(
+          new TypeParameter<T>() {}, valueCoder.getEncodedTypeDescriptor());
+    }
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/AvroCoderTest.java
@@ -67,6 +67,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -844,6 +845,12 @@ public class AvroCoderTest {
 
     assertNonDeterministic(coder,
         reasonField(SomeGeneric.class, "foo", "erasure"));
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    AvroCoder<Pojo> coder = AvroCoder.of(Pojo.class);
+    assertThat(coder.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Pojo.class)));
   }
 
   private static class SomeGeneric<T> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/BigEndianIntegerCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/BigEndianIntegerCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -85,5 +89,10 @@ public class BigEndianIntegerCoderTest {
     thrown.expectMessage("cannot encode a null Integer");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Integer.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/BigEndianLongCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/BigEndianLongCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -89,5 +93,10 @@ public class BigEndianLongCoderTest {
     thrown.expectMessage("cannot encode a null Long");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Long.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteArrayCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteArrayCoderTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -138,5 +139,10 @@ public class ByteArrayCoderTest {
     thrown.expectMessage("cannot encode a null byte[]");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(byte[].class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -86,5 +90,10 @@ public class ByteCoderTest {
     thrown.expectMessage("cannot encode a null Byte");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Byte.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteStringCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ByteStringCoderTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -27,6 +29,7 @@ import java.util.List;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -116,5 +119,10 @@ public class ByteStringCoderTest {
         assertEquals(encoded.length, TEST_CODER.getEncodedElementByteSize(value, context));
       }
     }
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(ByteString.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CoderRegistryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CoderRegistryTest.java
@@ -459,6 +459,7 @@ public class CoderRegistryTest {
   private static class MyValueCoder implements Coder<MyValue> {
 
     private static final MyValueCoder INSTANCE = new MyValueCoder();
+    private static final TypeDescriptor<MyValue> TYPE_DESCRIPTOR = TypeDescriptor.of(MyValue.class);
 
     public static MyValueCoder of() {
       return INSTANCE;
@@ -524,6 +525,11 @@ public class CoderRegistryTest {
     @Override
     public Collection<String> getAllowedEncodings() {
       return Collections.singletonList(getEncodingId());
+    }
+
+    @Override
+    public TypeDescriptor<MyValue> getEncodedTypeDescriptor() {
+      return TYPE_DESCRIPTOR;
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CoderTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.coders;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
@@ -26,6 +27,7 @@ import static org.junit.Assert.assertThat;
 import java.util.Collections;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -73,5 +75,11 @@ public class CoderTest {
     assertThat(exception.getReasons(), contains("Problem"));
     assertThat(exception.toString(), containsString("Problem"));
     assertThat(exception.toString(), containsString("is not deterministic"));
+  }
+
+  @Test
+  public void testTypeIsPreserved() throws Exception {
+    assertThat(VoidCoder.of().getEncodedTypeDescriptor(),
+        equalTo(TypeDescriptor.of(Void.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CollectionCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CollectionCoderTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,6 +29,7 @@ import java.util.TreeSet;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -94,5 +98,11 @@ public class CollectionCoderTest {
   @Test
   public void testCoderIsSerializableWithWellKnownCoderType() throws Exception {
     CoderProperties.coderSerializable(CollectionCoder.of(GlobalWindow.Coder.INSTANCE));
+  }
+
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<Collection<Integer>> expectedTypeDescriptor =
+        new TypeDescriptor<Collection<Integer>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(expectedTypeDescriptor));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DefaultCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DefaultCoderTest.java
@@ -79,7 +79,7 @@ public class DefaultCoderTest {
     }
 
     protected CustomSerializableCoder() {
-      super(CustomRecord.class);
+      super(CustomRecord.class, TypeDescriptor.of(CustomRecord.class));
     }
   }
 
@@ -93,7 +93,7 @@ public class DefaultCoderTest {
     }
 
     protected OldCustomSerializableCoder() {
-      super(OldCustomRecord.class);
+      super(OldCustomRecord.class, TypeDescriptor.of(OldCustomRecord.class));
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DoubleCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DoubleCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -91,5 +95,10 @@ public class DoubleCoderTest {
     thrown.expectMessage("cannot encode a null Double");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Double.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DurationCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/DurationCoderTest.java
@@ -17,11 +17,15 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.collect.Lists;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Duration;
 import org.joda.time.ReadableDuration;
 import org.junit.Rule;
@@ -81,5 +85,11 @@ public class DurationCoderTest {
     thrown.expectMessage("cannot encode a null ReadableDuration");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(
+        TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(ReadableDuration.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/InstantCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/InstantCoderTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.common.collect.Lists;
 import com.google.common.primitives.UnsignedBytes;
 import java.util.ArrayList;
@@ -25,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Instant;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -111,5 +115,10 @@ public class InstantCoderTest {
     thrown.expectMessage("cannot encode a null Instant");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Instant.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/IterableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/IterableCoderTest.java
@@ -17,8 +17,10 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -30,6 +32,7 @@ import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.Structs;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -120,5 +123,11 @@ public class IterableCoderTest {
     thrown.expectMessage("cannot encode a null Iterable");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<Iterable<Integer>> typeDescriptor = new TypeDescriptor<Iterable<Integer>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(typeDescriptor));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/JAXBCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/JAXBCoderTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -32,6 +34,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -209,5 +212,12 @@ public class JAXBCoderTest {
     Coder<TestType> coder = JAXBCoder.of(TestType.class);
     CoderProperties.coderHasEncodingId(
         coder, TestType.class.getName());
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(
+        JAXBCoder.of(TestType.class).getEncodedTypeDescriptor(),
+        equalTo(TypeDescriptor.of(TestType.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/KvCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/KvCoderTest.java
@@ -17,7 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -29,6 +31,7 @@ import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.Structs;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -137,5 +140,12 @@ public class KvCoderTest {
     thrown.expectMessage("cannot encode a null KV");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<KV<String, Integer>> typeDescriptor =
+        new TypeDescriptor<KV<String, Integer>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(typeDescriptor));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ListCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ListCoderTest.java
@@ -17,8 +17,10 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -136,4 +139,9 @@ public class ListCoderTest {
     CoderProperties.<List<Integer>>coderDecodeEncodeEqual(coder, list);
   }
 
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<List<Integer>> typeDescriptor = new TypeDescriptor<List<Integer>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(typeDescriptor));
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/MapCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/MapCoderTest.java
@@ -17,8 +17,10 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
@@ -30,6 +32,7 @@ import java.util.TreeMap;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -108,5 +111,12 @@ public class MapCoderTest {
     thrown.expectMessage("cannot encode a null Map");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<Map<Integer, String>> typeDescriptor =
+        new TypeDescriptor<Map<Integer, String>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(typeDescriptor));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/NullableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/NullableCoderTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import org.apache.beam.sdk.coders.Coder.Context;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -169,6 +170,11 @@ public class NullableCoderTest {
   public void testNestedNullableCoder() {
     NullableCoder<Double> coder = NullableCoder.of(DoubleCoder.of());
     assertThat(NullableCoder.of(coder), theInstance(coder));
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(String.class)));
   }
 
   private static class EntireStreamExpectingCoder extends DeterministicStandardCoder<String> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.coders;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -37,6 +38,7 @@ import org.apache.beam.sdk.util.CloudObject;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.Serializer;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -231,5 +233,12 @@ public class SerializableCoderTest implements Serializable {
     CoderProperties.coderHasEncodingId(
         coder,
         String.format("%s:%s", MyRecord.class.getName(), MyRecord.serialVersionUID));
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(
+        SerializableCoder.of(MyRecord.class).getEncodedTypeDescriptor(),
+        Matchers.equalTo(TypeDescriptor.of(MyRecord.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SetCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SetCoderTest.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +28,7 @@ import java.util.TreeSet;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -87,5 +91,11 @@ public class SetCoderTest {
     thrown.expectMessage("cannot encode a null Set");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    TypeDescriptor<Set<Integer>> typeDescriptor = new TypeDescriptor<Set<Integer>>() {};
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(typeDescriptor));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StandardCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StandardCoderTest.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
@@ -194,5 +195,44 @@ public class StandardCoderTest {
 
     Assert.assertThat(coderWithArgs.toString(),
         CoreMatchers.equalTo("StandardCoderTest$1(BigDecimalCoder,BigIntegerCoder)"));
+  }
+
+  @Test
+  public void testGenericStandardCoderFallsBackToT() throws Exception {
+    Assert.assertThat(
+        new Foo<String>().getEncodedTypeDescriptor().getType(),
+        CoreMatchers.not(TypeDescriptor.of(String.class).getType()));
+  }
+
+  @Test
+  public void testGenericStandardCoder() throws Exception {
+    Assert.assertThat(new FooTwo().getEncodedTypeDescriptor(),
+        CoreMatchers.equalTo(TypeDescriptor.of(String.class)));
+  }
+
+  private static class Foo<T> extends StandardCoder<T> {
+
+    @Override
+    public void encode(T value, OutputStream outStream, Coder.Context context)
+        throws CoderException, IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T decode(InputStream inStream, Coder.Context context)
+        throws CoderException, IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void verifyDeterministic() throws Coder.NonDeterministicException {}
+  }
+
+  private static class FooTwo extends Foo<String> {
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StringDelegateCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StringDelegateCoderTest.java
@@ -17,11 +17,15 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -67,5 +71,12 @@ public class StringDelegateCoderTest {
   public void testEncodingId() throws Exception {
     StringDelegateCoder<URI> coder = StringDelegateCoder.of(URI.class);
     CoderProperties.coderHasEncodingId(coder, URI.class.getName());
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(
+        StringDelegateCoder.of(URI.class).getEncodedTypeDescriptor(),
+        equalTo(TypeDescriptor.of(URI.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StringUtf8CoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StringUtf8CoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -75,5 +79,10 @@ public class StringUtf8CoderTest {
     thrown.expectMessage("cannot encode a null String");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(String.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TableRowJsonCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TableRowJsonCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import com.google.api.services.bigquery.model.TableRow;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -81,5 +85,10 @@ public class TableRowJsonCoderTest {
   @Test
   public void testWireFormatEncode() throws Exception {
     CoderProperties.coderEncodesBase64(TEST_CODER, TEST_VALUES, TEST_ENCODINGS);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(TableRow.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TextualIntegerCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/TextualIntegerCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -85,5 +89,10 @@ public class TextualIntegerCoderTest {
     thrown.expectMessage("cannot encode a null Integer");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Integer.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/VarIntCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/VarIntCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -85,5 +89,10 @@ public class VarIntCoderTest {
     thrown.expectMessage("cannot encode a null Integer");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Integer.class)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/VarLongCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/VarLongCoderTest.java
@@ -17,10 +17,14 @@
  */
 package org.apache.beam.sdk.coders;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -89,5 +93,10 @@ public class VarLongCoderTest {
     thrown.expectMessage("cannot encode a null Long");
 
     CoderUtils.encodeToBase64(TEST_CODER, null);
+  }
+
+  @Test
+  public void testEncodedTypeDescriptor() throws Exception {
+    assertThat(TEST_CODER.getEncodedTypeDescriptor(), equalTo(TypeDescriptor.of(Long.class)));
   }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

The new method allows returning type information about the data being
encoded and decoded by a Coder.
Added a default implementation to StandardCoder which returns the
TypeDescriptor for Object to ease the transition and avoid breaking
implementations relying on StandardCoder or AtomicCoder.

This will break classes implementing the Coder interface directly.