### PR TITLE
Python Precommit Maven Install

### DIFF
--- a/.jenkins/common_job_properties.groovy
+++ b/.jenkins/common_job_properties.groovy
@@ -81,6 +81,7 @@ class common_job_properties {
 
   // Sets the pull request build trigger.
   static def setPullRequestBuildTrigger(def context,
+                                        def branchWhitelist,
                                         def commitStatusContext,
                                         def successComment = '--none--') {
     context.triggers {
@@ -88,6 +89,7 @@ class common_job_properties {
         admins(['asfbot'])
         useGitHubHooks()
         orgWhitelist(['apache'])
+        whiteListTargetBranches(branchWhitelist)
         allowMembersOfWhitelistedOrgsAsAdmin()
         permitAll()
 
@@ -140,9 +142,9 @@ class common_job_properties {
   }
 
   // Sets common config for PreCommit jobs.
-  static def setPreCommit(def context, comment) {
+  static def setPreCommit(def context, branches, comment) {
     // Set pull request build trigger.
-    setPullRequestBuildTrigger(context, comment)
+    setPullRequestBuildTrigger(context, branches, comment)
   }
 
   // Sets common config for PostCommit jobs.

--- a/.jenkins/job_beam_PreCommit_Python_MavenInstall.groovy
+++ b/.jenkins/job_beam_PreCommit_Python_MavenInstall.groovy
@@ -18,10 +18,9 @@
 
 import common_job_properties
 
-// This is the Java precommit which runs a maven install, and the current set
-// of precommit tests.
-mavenJob('beam_PreCommit_Java_MavenInstall') {
-  description('Runs an install of the current GitHub Pull Request.')
+// This job defines the Python precommit which runs a maven install on python-sdk branch.
+mavenjob('beam_PreCommit_Python_MavenInstall') {
+  description('Runs an maven install on the python-sdk branch.')
 
   previousNames('beam_PreCommit_MavenVerify')
 
@@ -29,14 +28,11 @@ mavenJob('beam_PreCommit_Java_MavenInstall') {
   concurrentBuild()
 
   // Set common parameters.
-  common_job_properties.setTopLevelJobProperties(delegate)
-
-  // Set Maven parameters.
-  common_job_properties.setMavenConfig(delegate)
+  common_job_properties.setTopLevelJobProperties(delegate, 'python-sdk')
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, ['master'], 'Jenkins: Maven clean install')
+  common_job_properties.setPreCommit(delegate, ['python-sdk'], 'Jenkins: Python PreCommit')
 
   // Maven goals for this job.
-  goals('-B -e -Prelease,include-runners,jenkins-precommit,direct-runner,dataflow-runner,spark-runner,flink-runner,apex-runner help:effective-settings clean install')
+  goals('-B -e help:effective-settings clean install')
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

After moving Jenkins config to DSL plugin, python-sdk didn't build in beam_Precommit_Java_MavenInstall in a period of time. Triage the issue was very difficult since both python and java builds are shown in one Jenkins branch and no way to filter them by project.

This PR is to make python precommit build shown in separate Jenkins branch for a more clear view.