### PR TITLE
BEAM-1151 Add failure handling to BigQueryIO.Write

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -249,7 +249,8 @@ class BatchLoads<DestinationT>
     // This transform will look at the set of files written for each table, and if any table has
     // too many files or bytes, will partition that table's files into multiple partitions for
     // loading.
-    PCollection<Void> singleton = p.apply(Create.of((Void) null).withCoder(VoidCoder.of()));
+    PCollection<Void> singleton = p.apply("singleton",
+        Create.of((Void) null).withCoder(VoidCoder.of()));
     PCollectionTuple partitions =
         singleton.apply(
             "WritePartition",
@@ -334,7 +335,8 @@ class BatchLoads<DestinationT>
                         dynamicDestinations))
                 .withSideInputs(writeTablesSideInputs));
 
-    PCollection<TableRow> empty = p.apply(Create.empty(TypeDescriptor.of(TableRow.class)));
+    PCollection<TableRow> empty = p.apply("CreateEmptyFailedInserts",
+        Create.empty(TypeDescriptor.of(TableRow.class)));
     return WriteResult.in(input.getPipeline(), empty);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -59,6 +59,7 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /** PTransform that uses BigQuery batch-load jobs to write a PCollection to BigQuery. */
 class BatchLoads<DestinationT>
@@ -333,6 +334,7 @@ class BatchLoads<DestinationT>
                         dynamicDestinations))
                 .withSideInputs(writeTablesSideInputs));
 
-    return WriteResult.in(input.getPipeline());
+    PCollection<TableRow> empty = p.apply(Create.empty(TypeDescriptor.of(TableRow.class)));
+    return WriteResult.in(input.getPipeline(), empty);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -993,7 +993,7 @@ public class BigQueryIO {
         streamingInserts.setTestServices(getBigQueryServices());
         return rowsWithDestination.apply(streamingInserts);
       } else {
-        checkArgument(getFailedInsertRetryPolicy() != null,
+        checkArgument(getFailedInsertRetryPolicy() == null,
             "Record-insert retry policies are not supported when using BigQuery load jobs.");
 
         BatchLoads<DestinationT> batchLoads = new BatchLoads<>(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -988,8 +988,8 @@ public class BigQueryIO {
             "WriteDisposition.WRITE_TRUNCATE is not supported for an unbounded"
                 + " PCollection.");
         StreamingInserts<DestinationT> streamingInserts =
-            new StreamingInserts<>(getCreateDisposition(), dynamicDestinations);
-        streamingInserts.setInsertRetryPolicy(getFailedInsertRetryPolicy());
+            new StreamingInserts<>(getCreateDisposition(), dynamicDestinations)
+            .withInsertRetryPolicy(getFailedInsertRetryPolicy());
         streamingInserts.setTestServices(getBigQueryServices());
         return rowsWithDestination.apply(streamingInserts);
       } else {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -863,6 +863,13 @@ public class BigQueryIO {
       return toBuilder().setTableDescription(tableDescription).build();
     }
 
+    /** Specfies a policy for handling failed inserts.
+     *
+     * <p>Currently this only is allowed when writing an unbounded collection to BigQuery. Bounded
+     * collections are written using batch load jobs, so we don't get per-element failures.
+     * Unbounded collections are written using streaming inserts, so we have access to per-element
+     * insert results.
+     */
     public Write<T> withFailedInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
       return toBuilder().setFailedInsertRetryPolicy(retryPolicy).build();
     }
@@ -989,8 +996,8 @@ public class BigQueryIO {
                 + " PCollection.");
         StreamingInserts<DestinationT> streamingInserts =
             new StreamingInserts<>(getCreateDisposition(), dynamicDestinations)
-            .withInsertRetryPolicy(getFailedInsertRetryPolicy());
-        streamingInserts.setTestServices(getBigQueryServices());
+                .withInsertRetryPolicy(getFailedInsertRetryPolicy())
+                .withTestServices((getBigQueryServices()));
         return rowsWithDestination.apply(streamingInserts);
       } else {
         checkArgument(getFailedInsertRetryPolicy() == null,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -33,6 +33,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.NoSuchElementException;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
 
 /** An interface for real, mock, or fake implementations of Cloud BigQuery services. */
 interface BigQueryServices extends Serializable {
@@ -161,10 +162,14 @@ interface BigQueryServices extends Serializable {
     /**
      * Inserts {@link TableRow TableRows} with the specified insertIds if not null.
      *
+     * <p>If any insert fail permanently according to the retry policy, those indices are added
+     * to failedInserts.
+     *
      * <p>Returns the total bytes count of {@link TableRow TableRows}.
      */
-    long insertAll(TableReference ref, List<TableRow> rowList, @Nullable List<String> insertIdList,
-                   InsertRetryPolicy retryPolicy, List<TableRow> failedInserts)
+    long insertAll(TableReference ref, List<ValueInSingleWindow<TableRow>> rowList,
+                   @Nullable List<String> insertIdList, InsertRetryPolicy retryPolicy,
+                   List<ValueInSingleWindow<TableRow>> failedInserts)
         throws IOException, InterruptedException;
 
     /** Patch BigQuery {@link Table} description. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -163,7 +163,8 @@ interface BigQueryServices extends Serializable {
      *
      * <p>Returns the total bytes count of {@link TableRow TableRows}.
      */
-    long insertAll(TableReference ref, List<TableRow> rowList, @Nullable List<String> insertIdList)
+    long insertAll(TableReference ref, List<TableRow> rowList, @Nullable List<String> insertIdList,
+                   InsertRetryPolicy retryPolicy, List<TableRow> failedInserts)
         throws IOException, InterruptedException;
 
     /** Patch BigQuery {@link Table} description. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -162,7 +162,7 @@ interface BigQueryServices extends Serializable {
     /**
      * Inserts {@link TableRow TableRows} with the specified insertIds if not null.
      *
-     * <p>If any insert fail permanently according to the retry policy, those indices are added
+     * <p>If any insert fail permanently according to the retry policy, those rows are added
      * to failedInserts.
      *
      * <p>Returns the total bytes count of {@link TableRow TableRows}.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -754,15 +754,14 @@ class BigQueryServicesImpl implements BigQueryServices {
                 }
 
                 int errorIndex = error.getIndex().intValue() + strideIndices.get(i);
-                boolean skipRetry = !retryPolicy.shouldRetry(new InsertRetryPolicy.Context(error));
-                if (skipRetry) {
-                  failedInserts.add(rowsToPublish.get(errorIndex));
-                } else {
+                if (retryPolicy.shouldRetry(new InsertRetryPolicy.Context(error))) {
                   allErrors.add(error);
                   retryRows.add(rowsToPublish.get(errorIndex));
                   if (retryIds != null) {
                     retryIds.add(idsToPublish.get(errorIndex));
                   }
+                } else {
+                  failedInserts.add(rowsToPublish.get(errorIndex));
                 }
               }
             }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
@@ -78,7 +78,7 @@ public abstract class InsertRetryPolicy implements Serializable {
   /**
    * Retry all failures except for known persistent errors.
    */
-  public static InsertRetryPolicy dontRetryPersistentErrors() {
+  public static InsertRetryPolicy retryTransientErrors() {
     return new InsertRetryPolicy() {
       @Override
       public boolean shouldRetry(Context context) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import com.google.api.services.bigquery.model.ErrorProto;
+import com.google.api.services.bigquery.model.TableDataInsertAllResponse;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+
+/**
+ * A retry policy for streaming BigQuery inserts.
+ */
+public abstract class InsertRetryPolicy {
+  /**
+   * Contains information about a failed insert.
+   *
+   * <p>Currently only the list of errors returned from BigQuery. In the future this may contain
+   * more information - e.g. how many times this insert has been retried, and for how long.
+   */
+  public static class Context {
+    // A list of all errors corresponding to an attempted insert of a single record.
+    TableDataInsertAllResponse.InsertErrors errors;
+
+    public Context(TableDataInsertAllResponse.InsertErrors errors) {
+      this.errors = errors;
+    }
+  }
+
+  // A list of known persistent errors for which retrying never helps.
+  static final Set<String> PERSISTENT_ERRORS =
+      ImmutableSet.of("invalid", "invalidQuery", "notImplemented");
+
+  /**
+   * Return true if this failure should be retried.
+   */
+  public abstract boolean shouldRetry(Context context);
+
+  /**
+   * Never retry any failures.
+   */
+  public static InsertRetryPolicy neverRetry() {
+    return new InsertRetryPolicy() {
+      @Override
+      public boolean shouldRetry(Context context) {
+        return false;
+      }
+    };
+  }
+
+  /**
+   * Always retry all failures.
+   */
+  public static InsertRetryPolicy alwaysRetry() {
+    return new InsertRetryPolicy() {
+      @Override
+      public boolean shouldRetry(Context context) {
+        return true;
+      }
+    };
+  }
+
+  /**
+   * Retry all failures except for known persistent errors.
+   */
+  public static InsertRetryPolicy dontRetryPersistentErrors() {
+    return new InsertRetryPolicy() {
+      @Override
+      public boolean shouldRetry(Context context) {
+        if (context.errors.getErrors() != null) {
+          for (ErrorProto error : context.errors.getErrors()) {
+            if (error.getReason() != null && PERSISTENT_ERRORS.contains(error.getReason())) {
+              return false;
+            }
+          }
+        }
+        return true;
+      }
+    };
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicy.java
@@ -20,12 +20,13 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import com.google.api.services.bigquery.model.ErrorProto;
 import com.google.api.services.bigquery.model.TableDataInsertAllResponse;
 import com.google.common.collect.ImmutableSet;
+import java.io.Serializable;
 import java.util.Set;
 
 /**
  * A retry policy for streaming BigQuery inserts.
  */
-public abstract class InsertRetryPolicy {
+public abstract class InsertRetryPolicy implements Serializable {
   /**
    * Contains information about a failed insert.
    *

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInserts.java
@@ -38,20 +38,39 @@ public class StreamingInserts<DestinationT>
   private InsertRetryPolicy retryPolicy;
 
   /** Constructor. */
-  StreamingInserts(CreateDisposition createDisposition,
+  public StreamingInserts(CreateDisposition createDisposition,
                    DynamicDestinations<?, DestinationT> dynamicDestinations) {
+    this(createDisposition, dynamicDestinations, InsertRetryPolicy.alwaysRetry());
+  }
+
+  /** Constructor. */
+  public StreamingInserts(CreateDisposition createDisposition,
+                          DynamicDestinations<?, DestinationT> dynamicDestinations,
+                          InsertRetryPolicy retryPolicy) {
     this.createDisposition = createDisposition;
     this.dynamicDestinations = dynamicDestinations;
     this.bigQueryServices = new BigQueryServicesImpl();
-    this.retryPolicy = InsertRetryPolicy.alwaysRetry();
+    this.retryPolicy = retryPolicy;
+  }
+
+  /** Constructor. */
+  private StreamingInserts(CreateDisposition createDisposition,
+                          DynamicDestinations<?, DestinationT> dynamicDestinations,
+                          BigQueryServices bigQueryServices,
+                          InsertRetryPolicy retryPolicy) {
+    this.createDisposition = createDisposition;
+    this.dynamicDestinations = dynamicDestinations;
+    this.bigQueryServices = bigQueryServices;
+    this.retryPolicy = retryPolicy;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
     this.bigQueryServices = bigQueryServices;
   }
 
-  void setInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
-    this.retryPolicy = retryPolicy;
+  StreamingInserts<DestinationT> withInsertRetryPolicy(InsertRetryPolicy retryPolicy) {
+    return new StreamingInserts<>(
+        createDisposition, dynamicDestinations, bigQueryServices, retryPolicy);
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -86,8 +86,8 @@ public class StreamingWriteTables extends PTransform<
     // different unique ids, this implementation relies on "checkpointing", which is
     // achieved as a side effect of having StreamingWriteFn immediately follow a GBK,
     // performed by Reshuffle.
-    TupleTag<Void> mainOutput = new TupleTag<Void>("mainOutput") {};
-    TupleTag<TableRow> failedOutput = new TupleTag<TableRow>("failedOutput") {};
+    TupleTag<Void> mainOutput = new TupleTag<>("mainOutput");
+    TupleTag<TableRow> failedOutput = new TupleTag<>("failedOutput");
     PCollectionTuple tuple = tagged
         .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()))
         .apply(Reshuffle.<ShardedKey<String>, TableRowInfo>of())
@@ -100,6 +100,7 @@ public class StreamingWriteTables extends PTransform<
             ParDo.of(
                 new StreamingWriteFn(bigQueryServices, retryPolicy, failedOutput))
             .withOutputTags(mainOutput, TupleTagList.of(failedOutput)));
-    return WriteResult.in(input.getPipeline(), tuple.get(failedOutput));
+    return WriteResult.in(input.getPipeline(),
+        tuple.get(failedOutput).setCoder(TableRowJsonCoder.of()));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -86,8 +86,8 @@ public class StreamingWriteTables extends PTransform<
     // different unique ids, this implementation relies on "checkpointing", which is
     // achieved as a side effect of having StreamingWriteFn immediately follow a GBK,
     // performed by Reshuffle.
-    TupleTag<Void> mainOutput = new TupleTag<Void>() {};
-    TupleTag<TableRow> failedOutput = new TupleTag<TableRow>() {};
+    TupleTag<Void> mainOutput = new TupleTag<Void>("mainOutput") {};
+    TupleTag<TableRow> failedOutput = new TupleTag<TableRow>("failedOutput") {};
     PCollectionTuple tuple = tagged
         .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()))
         .apply(Reshuffle.<ShardedKey<String>, TableRowInfo>of())

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -17,10 +17,12 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import java.util.Collections;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.PValue;
@@ -30,23 +32,29 @@ import org.apache.beam.sdk.values.TupleTag;
  * The result of a {@link BigQueryIO.Write} transform.
  */
 public final class WriteResult implements POutput {
-
   private final Pipeline pipeline;
+  private final TupleTag<TableRow> failedInsertsTag = new TupleTag<>();
+  private final PCollection<TableRow> failedInserts;
 
   /**
    * Creates a {@link WriteResult} in the given {@link Pipeline}.
    */
-  static WriteResult in(Pipeline pipeline) {
-    return new WriteResult(pipeline);
+  static WriteResult in(Pipeline pipeline, PCollection<TableRow> failedInserts) {
+    return new WriteResult(pipeline, failedInserts);
   }
 
   @Override
   public Map<TupleTag<?>, PValue> expand() {
-    return Collections.emptyMap();
+    return ImmutableMap.<TupleTag<?>, PValue>of(failedInsertsTag, failedInserts);
   }
 
-  private WriteResult(Pipeline pipeline) {
+  private WriteResult(Pipeline pipeline, PCollection<TableRow> failedInserts) {
     this.pipeline = pipeline;
+    this.failedInserts = failedInserts;
+  }
+
+  public PCollection<TableRow> getFailedInserts() {
+    return failedInserts;
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -642,7 +642,7 @@ public class BigQueryIOTest implements Serializable {
                 ImmutableList.of(
                     new TableFieldSchema().setName("name").setType("STRING"),
                     new TableFieldSchema().setName("number").setType("INTEGER"))))
-            .withFailedInsertRetryPolicy(InsertRetryPolicy.dontRetryPersistentErrors())
+            .withFailedInsertRetryPolicy(InsertRetryPolicy.retryTransientErrors())
             .withTestServices(fakeBqServices)
             .withoutValidation()).getFailedInserts();
     // row2 finally fails with a non-retryable error, so we expect to see it in the collection of

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -321,8 +321,7 @@ public class BigQueryIOTest implements Serializable {
         new TableRow().set("name", "d").set("number", 4L),
         new TableRow().set("name", "e").set("number", 5L),
         new TableRow().set("name", "f").set("number", 6L));
-    fakeDatasetService.insertAll(tableReference, expected, null,
-        InsertRetryPolicy.alwaysRetry(), null);
+    fakeDatasetService.insertAll(tableReference, expected, null);
 
     Pipeline p = TestPipeline.create(bqOptions);
 
@@ -435,8 +434,7 @@ public class BigQueryIOTest implements Serializable {
         new TableRow().set("name", "a").set("number", 1L),
         new TableRow().set("name", "b").set("number", 2L),
         new TableRow().set("name", "c").set("number", 3L));
-    fakeDatasetService.insertAll(sometable.getTableReference(), records, null,
-        InsertRetryPolicy.alwaysRetry(), null);
+    fakeDatasetService.insertAll(sometable.getTableReference(), records, null);
 
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
         .withJobService(new FakeJobService())
@@ -1414,8 +1412,7 @@ public class BigQueryIOTest implements Serializable {
     TableReference table = BigQueryHelpers.parseTableSpec("project:data_set.table_name");
     datasetService.createDataset(table.getProjectId(), table.getDatasetId(), "", "");
     datasetService.createTable(new Table().setTableReference(table));
-    datasetService.insertAll(table, expected, null, InsertRetryPolicy.alwaysRetry(),
-        null);
+    datasetService.insertAll(table, expected, null);
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryTableSourceThroughJsonAPI");
     String stepUuid = "testStepUuid";
@@ -1455,8 +1452,7 @@ public class BigQueryIOTest implements Serializable {
                 ImmutableList.of(
                     new TableFieldSchema().setName("name").setType("STRING"),
                     new TableFieldSchema().setName("number").setType("INTEGER")))));
-    fakeDatasetService.insertAll(table, expected, null, InsertRetryPolicy.alwaysRetry(),
-        null);
+    fakeDatasetService.insertAll(table, expected, null);
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryTableSourceInitSplit");
 
@@ -2051,8 +2047,7 @@ public class BigQueryIOTest implements Serializable {
         for (int k = 0; k < numRecordsPerTempTable; ++k) {
           rows.add(new TableRow().set("number", j * numTempTablesPerFinalTable + k));
         }
-        datasetService.insertAll(tempTable, rows, null, InsertRetryPolicy.alwaysRetry(),
-            null);
+        datasetService.insertAll(tempTable, rows, null);
         expectedRows.addAll(rows);
         tables.add(BigQueryHelpers.toJsonString(tempTable));
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -603,6 +603,20 @@ public class BigQueryIOTest implements Serializable {
   }
 
   @Test
+  public void testRetryPolicy() throws Exception {
+    BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
+    bqOptions.setProject("project-id");
+    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+
+    FakeDatasetService datasetService = new FakeDatasetService();
+    FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
+        .withJobService(new FakeJobService())
+        .withDatasetService(datasetService);
+
+    datasetService.createDataset("project-id", "dataset-id", "", "");
+  }
+
+  @Test
   public void testWrite() throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -318,7 +318,8 @@ public class BigQueryIOTest implements Serializable {
         new TableRow().set("name", "d").set("number", 4L),
         new TableRow().set("name", "e").set("number", 5L),
         new TableRow().set("name", "f").set("number", 6L));
-    fakeDatasetService.insertAll(tableReference, expected, null);
+    fakeDatasetService.insertAll(tableReference, expected, null,
+        InsertRetryPolicy.alwaysRetry(), null);
 
     Pipeline p = TestPipeline.create(bqOptions);
 
@@ -431,7 +432,8 @@ public class BigQueryIOTest implements Serializable {
         new TableRow().set("name", "a").set("number", 1L),
         new TableRow().set("name", "b").set("number", 2L),
         new TableRow().set("name", "c").set("number", 3L));
-    fakeDatasetService.insertAll(sometable.getTableReference(), records, null);
+    fakeDatasetService.insertAll(sometable.getTableReference(), records, null,
+        InsertRetryPolicy.alwaysRetry(), null);
 
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
         .withJobService(new FakeJobService())
@@ -1356,7 +1358,8 @@ public class BigQueryIOTest implements Serializable {
     TableReference table = BigQueryHelpers.parseTableSpec("project:data_set.table_name");
     datasetService.createDataset(table.getProjectId(), table.getDatasetId(), "", "");
     datasetService.createTable(new Table().setTableReference(table));
-    datasetService.insertAll(table, expected, null);
+    datasetService.insertAll(table, expected, null, InsertRetryPolicy.alwaysRetry(),
+        null);
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryTableSourceThroughJsonAPI");
     String stepUuid = "testStepUuid";
@@ -1396,7 +1399,8 @@ public class BigQueryIOTest implements Serializable {
                 ImmutableList.of(
                     new TableFieldSchema().setName("name").setType("STRING"),
                     new TableFieldSchema().setName("number").setType("INTEGER")))));
-    fakeDatasetService.insertAll(table, expected, null);
+    fakeDatasetService.insertAll(table, expected, null, InsertRetryPolicy.alwaysRetry(),
+        null);
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryTableSourceInitSplit");
 
@@ -1991,7 +1995,8 @@ public class BigQueryIOTest implements Serializable {
         for (int k = 0; k < numRecordsPerTempTable; ++k) {
           rows.add(new TableRow().set("number", j * numTempTablesPerFinalTable + k));
         }
-        datasetService.insertAll(tempTable, rows, null);
+        datasetService.insertAll(tempTable, rows, null, InsertRetryPolicy.alwaysRetry(),
+            null);
         expectedRows.addAll(rows);
         tables.add(BigQueryHelpers.toJsonString(tempTable));
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -505,7 +505,8 @@ public class BigQueryServicesImplTest {
     DatasetServiceImpl dataService =
         new DatasetServiceImpl(bigquery, PipelineOptionsFactory.create());
     dataService.insertAll(ref, rows, null,
-        BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper());
+        BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper(),
+        InsertRetryPolicy.alwaysRetry(), null);
     verify(response, times(2)).getStatusCode();
     verify(response, times(2)).getContent();
     verify(response, times(2)).getContentType();
@@ -542,7 +543,8 @@ public class BigQueryServicesImplTest {
     DatasetServiceImpl dataService =
         new DatasetServiceImpl(bigquery, PipelineOptionsFactory.create());
     dataService.insertAll(ref, rows, insertIds,
-        BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper());
+        BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper(),
+        InsertRetryPolicy.alwaysRetry(), null);
     verify(response, times(2)).getStatusCode();
     verify(response, times(2)).getContent();
     verify(response, times(2)).getContentType();
@@ -584,7 +586,8 @@ public class BigQueryServicesImplTest {
     // Expect it to fail.
     try {
       dataService.insertAll(ref, rows, null,
-          BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper());
+          BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper(),
+          InsertRetryPolicy.alwaysRetry(), null);
       fail();
     } catch (IOException e) {
       assertThat(e, instanceOf(IOException.class));
@@ -625,7 +628,8 @@ public class BigQueryServicesImplTest {
 
     try {
       dataService.insertAll(ref, rows, null,
-          BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper());
+          BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper(),
+          InsertRetryPolicy.alwaysRetry(), null);
       fail();
     } catch (RuntimeException e) {
       verify(response, times(1)).getStatusCode();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -694,7 +694,7 @@ public class BigQueryServicesImplTest {
     List<ValueInSingleWindow<TableRow>> failedInserts = Lists.newArrayList();
     dataService.insertAll(ref, rows, null,
         BackOffAdapter.toGcpBackOff(TEST_BACKOFF.backoff()), new MockSleeper(),
-        InsertRetryPolicy.dontRetryPersistentErrors(), failedInserts);
+        InsertRetryPolicy.retryTransientErrors(), failedInserts);
     assertEquals(1, failedInserts.size());
     expectedLogs.verifyInfo("Retrying 1 failed inserts to BigQuery");
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
@@ -49,6 +49,9 @@ import java.util.List;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServicesImpl.DatasetServiceImpl;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -391,10 +394,11 @@ public class BigQueryUtilTest {
         .parseTableSpec("project:dataset.table");
     DatasetServiceImpl datasetService = new DatasetServiceImpl(mockClient, options, 5);
 
-    List<TableRow> rows = new ArrayList<>();
+    List<ValueInSingleWindow<TableRow>> rows = new ArrayList<>();
     List<String> ids = new ArrayList<>();
     for (int i = 0; i < 25; ++i) {
-      rows.add(rawRow("foo", 1234));
+      rows.add(ValueInSingleWindow.of(rawRow("foo", 1234), GlobalWindow.TIMESTAMP_MAX_VALUE,
+          GlobalWindow.INSTANCE, PaneInfo.ON_TIME_AND_ONLY_FIRING));
       ids.add(new String());
     }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilTest.java
@@ -400,7 +400,8 @@ public class BigQueryUtilTest {
 
     long totalBytes = 0;
     try {
-      totalBytes = datasetService.insertAll(ref, rows, ids);
+      totalBytes = datasetService.insertAll(ref, rows, ids, InsertRetryPolicy.alwaysRetry(),
+          null);
     } finally {
       verifyInsertAll(5);
       // Each of the 25 rows is 23 bytes: "{f=[{v=foo}, {v=1234}]}"

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeDatasetService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeDatasetService.java
@@ -166,7 +166,8 @@ class FakeDatasetService implements DatasetService, Serializable {
 
   @Override
   public long insertAll(
-      TableReference ref, List<TableRow> rowList, @Nullable List<String> insertIdList)
+      TableReference ref, List<TableRow> rowList, @Nullable List<String> insertIdList,
+      InsertRetryPolicy retryPolicy, List<TableRow> failedInserts)
       throws IOException, InterruptedException {
     synchronized (BigQueryIOTest.tables) {
       if (insertIdList != null) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeDatasetService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeDatasetService.java
@@ -200,6 +200,7 @@ class FakeDatasetService implements DatasetService, Serializable {
       return tableContainer.getTable();
     }
   }
+  public void
 
   void throwNotFound(String format, Object... args) throws IOException {
     throw new IOException(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -308,8 +308,7 @@ class FakeJobService implements JobService, Serializable {
     for (ResourceId filename : sourceFiles) {
       rows.addAll(readRows(filename.toString()));
     }
-    datasetService.insertAll(destination, rows, null, InsertRetryPolicy.alwaysRetry(),
-        null);
+    datasetService.insertAll(destination, rows, null);
     return new JobStatus().setState("DONE");
   }
 
@@ -330,8 +329,7 @@ class FakeJobService implements JobService, Serializable {
           source.getProjectId(), source.getDatasetId(), source.getTableId()));
     }
     datasetService.createTable(new Table().setTableReference(destination));
-    datasetService.insertAll(destination, allRows, null, InsertRetryPolicy.alwaysRetry(),
-        null);
+    datasetService.insertAll(destination, allRows, null);
     return new JobStatus().setState("DONE");
   }
 
@@ -355,8 +353,7 @@ class FakeJobService implements JobService, Serializable {
       throws IOException, InterruptedException  {
     List<TableRow> rows = FakeBigQueryServices.rowsFromEncodedQuery(query.getQuery());
     datasetService.createTable(new Table().setTableReference(query.getDestinationTable()));
-    datasetService.insertAll(query.getDestinationTable(), rows, null,
-        InsertRetryPolicy.alwaysRetry(), null);
+    datasetService.insertAll(query.getDestinationTable(), rows, null);
     return new JobStatus().setState("DONE");
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -308,7 +308,8 @@ class FakeJobService implements JobService, Serializable {
     for (ResourceId filename : sourceFiles) {
       rows.addAll(readRows(filename.toString()));
     }
-    datasetService.insertAll(destination, rows, null);
+    datasetService.insertAll(destination, rows, null, InsertRetryPolicy.alwaysRetry(),
+        null);
     return new JobStatus().setState("DONE");
   }
 
@@ -329,7 +330,8 @@ class FakeJobService implements JobService, Serializable {
           source.getProjectId(), source.getDatasetId(), source.getTableId()));
     }
     datasetService.createTable(new Table().setTableReference(destination));
-    datasetService.insertAll(destination, allRows, null);
+    datasetService.insertAll(destination, allRows, null, InsertRetryPolicy.alwaysRetry(),
+        null);
     return new JobStatus().setState("DONE");
   }
 
@@ -353,7 +355,8 @@ class FakeJobService implements JobService, Serializable {
       throws IOException, InterruptedException  {
     List<TableRow> rows = FakeBigQueryServices.rowsFromEncodedQuery(query.getQuery());
     datasetService.createTable(new Table().setTableReference(query.getDestinationTable()));
-    datasetService.insertAll(query.getDestinationTable(), rows, null);
+    datasetService.insertAll(query.getDestinationTable(), rows, null,
+        InsertRetryPolicy.alwaysRetry(), null);
     return new JobStatus().setState("DONE");
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicyTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.api.services.bigquery.model.ErrorProto;
+import com.google.api.services.bigquery.model.TableDataInsertAllResponse;
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.beam.sdk.io.gcp.bigquery.InsertRetryPolicy.Context;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link InsertRetryPolicy}.
+ */
+@RunWith(JUnit4.class)
+public class InsertRetryPolicyTest {
+  @Test
+  public void testNeverRetry() {
+    assertFalse(InsertRetryPolicy.neverRetry().shouldRetry(
+        new Context(new TableDataInsertAllResponse.InsertErrors())));
+  }
+
+  @Test
+  public void testAlwaysRetry() {
+    assertTrue(InsertRetryPolicy.alwaysRetry().shouldRetry(
+        new Context(new TableDataInsertAllResponse.InsertErrors())));
+  }
+
+  @Test
+  public void testDontRetryPersistentErrors() {
+    InsertRetryPolicy policy = InsertRetryPolicy.dontRetryPersistentErrors();
+    assertTrue(policy.shouldRetry(new Context(generateErrorAmongMany(
+        5, "timeout", "unavailable"))));
+    assertFalse(policy.shouldRetry(new Context(generateErrorAmongMany(
+        5, "timeout", "invalid"))));
+    assertFalse(policy.shouldRetry(new Context(generateErrorAmongMany(
+        5, "timeout", "invalidQuery"))));
+    assertFalse(policy.shouldRetry(new Context(generateErrorAmongMany(
+        5, "timeout", "notImplemented"))));
+  }
+
+  private TableDataInsertAllResponse.InsertErrors generateErrorAmongMany(
+      int numErrors, String baseReason, String exceptionalReason) {
+    // The retry policies are expected to search through the entire list of ErrorProtos to determine
+    // whether to retry. Stick the exceptionalReason in a random position to exercise this.
+    List<ErrorProto> errorProtos = Lists.newArrayListWithExpectedSize(numErrors);
+    int exceptionalPosition = ThreadLocalRandom.current().nextInt(numErrors);
+    for (int i = 0; i < numErrors; ++i) {
+      ErrorProto error = new ErrorProto();
+      error.setReason((i == exceptionalPosition) ? exceptionalReason : baseReason);
+      errorProtos.add(error);
+    }
+    TableDataInsertAllResponse.InsertErrors errors = new TableDataInsertAllResponse.InsertErrors();
+    errors.setErrors(errorProtos);
+    return errors;
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicyTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/InsertRetryPolicyTest.java
@@ -50,7 +50,7 @@ public class InsertRetryPolicyTest {
 
   @Test
   public void testDontRetryPersistentErrors() {
-    InsertRetryPolicy policy = InsertRetryPolicy.dontRetryPersistentErrors();
+    InsertRetryPolicy policy = InsertRetryPolicy.retryTransientErrors();
     assertTrue(policy.shouldRetry(new Context(generateErrorAmongMany(
         5, "timeout", "unavailable"))));
     assertFalse(policy.shouldRetry(new Context(generateErrorAmongMany(


### PR DESCRIPTION
Allow a pipeline to handle streaming insert failures when using BigQueryIO.Write in streaming mode. TableRow objects that fail to insert are returned to the user as a PCollection.

R: @jkff 