### PR TITLE
[BEAM-1160] Add option to disable failures if filePattern resolves to empty

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSourceTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/UnboundedReadFromBoundedSourceTest.java
@@ -292,7 +292,7 @@ public class UnboundedReadFromBoundedSourceTest {
    */
   private static class UnsplittableSource extends FileBasedSource<Byte> {
     public UnsplittableSource(String fileOrPatternSpec, long minBundleSize) {
-      super(fileOrPatternSpec, minBundleSize);
+      super(fileOrPatternSpec, /* TODO */ true, minBundleSize);
     }
 
     public UnsplittableSource(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -280,6 +280,15 @@ public class AvroIO {
         return new Bound<>(name, filepattern, type, schema, false);
       }
 
+      /**
+       * Configures the source to succeed if the specified {@code fileOrPatternSpec} does not match any
+       * files. The default behavior is to fail on empty input.
+       */
+      public Bound<T> withAllowedEmptyInput() {
+        // TODO
+        return this;
+      }
+
       @Override
       public PCollection<T> expand(PBegin input) {
         if (filepattern == null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -229,7 +229,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
 
   private AvroSource(String fileNameOrPattern, long minBundleSize, String schema, Class<T> type,
       String codec, byte[] syncMarker) {
-    super(fileNameOrPattern, minBundleSize);
+    super(fileNameOrPattern, /* TODO */ true, minBundleSize);
     this.readSchemaString = internSchemaString(schema);
     this.codec = codec;
     this.syncMarker = syncMarker;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BlockBasedSource.java
@@ -63,8 +63,8 @@ public abstract class BlockBasedSource<T> extends FileBasedSource<T> {
    * constructor when creating a {@code BlockBasedSource} for a file pattern. See
    * {@link FileBasedSource} for more information.
    */
-  public BlockBasedSource(String fileOrPatternSpec, long minBundleSize) {
-    super(fileOrPatternSpec, minBundleSize);
+  public BlockBasedSource(String fileOrPatternSpec, boolean failOnEmptyInput, long minBundleSize) {
+    super(fileOrPatternSpec, failOnEmptyInput, minBundleSize);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -299,7 +299,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
    */
   private CompressedSource(
       FileBasedSource<T> sourceDelegate, DecompressingChannelFactory channelFactory) {
-    super(sourceDelegate.getFileOrPatternSpecProvider(), Long.MAX_VALUE);
+    super(sourceDelegate.getFileOrPatternSpecProvider(), /* TODO */ true, Long.MAX_VALUE);
     this.sourceDelegate = sourceDelegate;
     this.channelFactory = channelFactory;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -98,21 +98,28 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
    *
    * @param fileOrPatternSpec {@link IOChannelFactory} specification of file or file pattern
    *        represented by the {@link FileBasedSource}.
+   * @param failOnEmptyInput whether to throw if {@code fileOrPatternSpec} does not match any
+   *        files.
    * @param minBundleSize minimum bundle size in bytes.
    */
-  public FileBasedSource(String fileOrPatternSpec, long minBundleSize) {
-    this(StaticValueProvider.of(fileOrPatternSpec), minBundleSize);
+  public FileBasedSource(String fileOrPatternSpec, boolean failOnEmptyInput, long minBundleSize) {
+    this(StaticValueProvider.of(fileOrPatternSpec), failOnEmptyInput, minBundleSize);
   }
 
   /**
    * Create a {@code FileBaseSource} based on a file or a file pattern specification.
    * Same as the {@code String} constructor, but accepting a {@link ValueProvider}
    * to allow for runtime configuration of the source.
+   *
+   * @param failOnEmptyInput whether to throw if {@code fileOrPatternSpec} does not match any
+   *        files.
    */
-  public FileBasedSource(ValueProvider<String> fileOrPatternSpec, long minBundleSize) {
+  public FileBasedSource(ValueProvider<String> fileOrPatternSpec, boolean failOnEmptyInput,
+      long minBundleSize) {
     super(0, Long.MAX_VALUE, minBundleSize);
     mode = Mode.FILEPATTERN;
     this.fileOrPatternSpec = fileOrPatternSpec;
+    // TODO: Implement logic for failOnEmptyInput
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -279,6 +279,15 @@ public class TextIO {
       }
 
       /**
+       * Configures the transform to succeed if the specified {@code filepattern} does not match any
+       * files. The default behaviour is to fail on empty input.
+       */
+      public Bound<T> withAllowedEmptyInput() {
+        // TODO
+        return this;
+      }
+
+      /**
        * Returns a new transform for reading from text files that's like this one but
        * reads from input sources using the specified compression type.
        *
@@ -907,13 +916,13 @@ public class TextIO {
 
     @VisibleForTesting
     TextSource(String fileSpec, Coder<T> coder) {
-      super(fileSpec, 1L);
+      super(fileSpec, /* TODO */ true, 1L);
       this.coder = coder;
     }
 
     @VisibleForTesting
     TextSource(ValueProvider<String> fileSpec, Coder<T> coder) {
-      super(fileSpec, 1L);
+      super(fileSpec, /* TODO */ true, 1L);
       this.coder = coder;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/XmlSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/XmlSource.java
@@ -135,6 +135,15 @@ public class XmlSource<T> extends FileBasedSource<T> {
   }
 
   /**
+   * Configures the source to succeed if the specified {@code fileOrPatternSpec} does not match any
+   * files. The default behavior is to fail on empty input.
+   */
+  public XmlSource<T> withAllowedEmptyInput() {
+    // TODO
+    return this;
+  }
+
+  /**
    * Sets name of the root element of the XML document. This will be used to create a valid starting
    * root element when initiating a bundle of records created from an XML document. This is a
    * required parameter.
@@ -175,7 +184,7 @@ public class XmlSource<T> extends FileBasedSource<T> {
 
   private XmlSource(String fileOrPattern, long minBundleSize, String rootElement,
       String recordElement, Class<T> recordClass) {
-    super(fileOrPattern, minBundleSize);
+    super(fileOrPattern, /* TODO */ true, minBundleSize);
     this.rootElement = rootElement;
     this.recordElement = recordElement;
     this.recordClass = recordClass;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -499,7 +499,7 @@ public class CompressedSourceTest {
    */
   private static class ByteSource extends FileBasedSource<Byte> {
     public ByteSource(String fileOrPatternSpec, long minBundleSize) {
-      super(fileOrPatternSpec, minBundleSize);
+      super(fileOrPatternSpec, /* TODO */ true, minBundleSize);
     }
 
     public ByteSource(String fileName, long minBundleSize, long startOffset, long endOffset) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -89,7 +89,7 @@ public class FileBasedSourceTest {
     final String splitHeader;
 
     public TestFileBasedSource(String fileOrPattern, long minBundleSize, String splitHeader) {
-      super(fileOrPattern, minBundleSize);
+      super(fileOrPattern, /* TODO */ true, minBundleSize);
       this.splitHeader = splitHeader;
     }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Most PTransforms which take a filePattern have construction-time
validation which checks-- among other things-- that the specified
filePattern matches at least one file. This is particularly useful
for catching typos when specifying input files.

Most PTransforms also have an option to disable their
construction-time validation.  This is generally used when
validation cannot be performed at construction time: for example
because the proper credentials aren't available or the input
specification is late-bound in a template. To allow for these
scenarios and still guard against typos, FileBasedSource also
validates that the filePattern matches at least one file at
runtime.

This change adds the ability FileBasedSource to disable this runtime
validation, for cases uses case where empty filePatterns should be
allowed. FileBasedSource gains a new constructor parameter, and
PTransforms which use FileBasedSource have the option exposed in their
respective builder APIs.