### PR TITLE
[BEAM-1089] Replace "--none--" with a message in Jenkins comments

### DIFF
--- a/.jenkins/common_job_properties.groovy
+++ b/.jenkins/common_job_properties.groovy
@@ -121,11 +121,11 @@ class common_job_properties {
         result('SUCCESS')
       }
       messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
-        message('--none--')
+        message('Error')
         result('ERROR')
       }
       messages << 'org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildResultMessage' {
-        message('--none--')
+        message('Failure')
         result('FAILURE')
       }
     }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @jasonkuster (I'll grab a committer later)

I believe there was some expectation that the magic value "--none--" would disable comments. Instead, though, Jenkins is writing that exact string to our pull requests. Until we figure out how to actually disable comments, we may as well leave informative messages.