### PR TITLE
[BEAM-545] PipelineOptions: fix parameter name

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -263,7 +263,7 @@ public interface PipelineOptions extends HasDisplayData {
       + "It defaults to ApplicationName-UserName-Date-RandomInteger")
   @Default.InstanceFactory(JobNameFactory.class)
   String getJobName();
-  void setJobName(String numWorkers);
+  void setJobName(String jobName);
 
   /**
    * A {@link DefaultValueFactory} that obtains the class of the {@code DirectRunner} if it exists


### PR DESCRIPTION
Seems like a cut and paste error. R: @peihe