### PR TITLE
Prune branches in Jenkins build

### DIFF
--- a/.jenkins/common_job_properties.groovy
+++ b/.jenkins/common_job_properties.groovy
@@ -53,6 +53,7 @@ class common_job_properties {
         branch('${sha1}')
         extensions {
           cleanAfterCheckout()
+          pruneBranches()
         }
       }
     }


### PR DESCRIPTION
This avoids possible conflicts in evolution of the configuration
of how remote branches are mapped to local branches.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

R: @jasonkuster 

I believe this would have prevented breakage. Since branches are nothing but pointers, having them sit around to potentially be incompatible seems to serve no purpose. In other words, I feel this should be a default configuration, unless someone has a rebuttal.