### PR TITLE
[BEAM-551] Cache value in NVP.get()

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -108,6 +108,7 @@ public interface ValueProvider<T> extends Serializable {
 
     private final ValueProvider<X> value;
     private final SerializableFunction<X, T> translator;
+    private transient X cachedValue;
 
     NestedValueProvider(ValueProvider<X> value, SerializableFunction<X, T> translator) {
       this.value = checkNotNull(value);
@@ -125,7 +126,10 @@ public interface ValueProvider<T> extends Serializable {
 
     @Override
     public T get() {
-      return translator.apply(value.get());
+      if (cachedValue == null) {
+        cachedValue = translator.apply(value.get());
+      }
+      return cachedValue;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -108,7 +108,7 @@ public interface ValueProvider<T> extends Serializable {
 
     private final ValueProvider<X> value;
     private final SerializableFunction<X, T> translator;
-    private transient T cachedValue;
+    private transient volatile T cachedValue;
 
     NestedValueProvider(ValueProvider<X> value, SerializableFunction<X, T> translator) {
       this.value = checkNotNull(value);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -108,7 +108,7 @@ public interface ValueProvider<T> extends Serializable {
 
     private final ValueProvider<X> value;
     private final SerializableFunction<X, T> translator;
-    private transient X cachedValue;
+    private transient T cachedValue;
 
     NestedValueProvider(ValueProvider<X> value, SerializableFunction<X, T> translator) {
       this.value = checkNotNull(value);


### PR DESCRIPTION
My understanding is that since assignment is atomic, further concurrency handling is not needed, but I am inexpert in Java's handling of such.

R: @dhalperi