### PR TITLE
[BEAM-1226] Add support for well known coder types to Apache Beam Python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -206,8 +206,7 @@ class DataflowRunner(PipelineRunner):
     if window_coder:
       return coders.WindowedValueCoder(
           coders.registry.get_coder(typehint),
-          coders.TimestampCoder(),
-          window_coder)
+          window_coder=window_coder)
     else:
       return coders.registry.get_coder(typehint)
 

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -111,7 +111,7 @@ class WindowFn(object):
     raise NotImplementedError
 
   def get_window_coder(self):
-    return coders.PickleCoder()
+    return coders.WindowCoder()
 
   def get_transformed_output_time(self, window, input_timestamp):  # pylint: disable=unused-argument
     """Given input time and output window, returns output time for window.
@@ -240,7 +240,7 @@ class GlobalWindows(WindowFn):
     pass  # No merging.
 
   def get_window_coder(self):
-    return coders.SingletonCoder(GlobalWindow())
+    return coders.GlobalWindowCoder()
 
   def __hash__(self):
     return hash(type(self))

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -28,6 +28,8 @@ from apache_beam.transforms import GroupByKey
 from apache_beam.transforms import Map
 from apache_beam.transforms import window
 from apache_beam.transforms import WindowInto
+from apache_beam.transforms.timeutil import MAX_TIMESTAMP
+from apache_beam.transforms.timeutil import MIN_TIMESTAMP
 from apache_beam.transforms.util import assert_that, equal_to
 from apache_beam.transforms.window import FixedWindows
 from apache_beam.transforms.window import IntervalWindow
@@ -54,6 +56,13 @@ reify_windows = core.ParDo(ReifyWindowsFn())
 
 
 class WindowTest(unittest.TestCase):
+
+  def test_global_window(self):
+    self.assertEqual(window.GlobalWindow(), window.GlobalWindow())
+    self.assertNotEqual(window.GlobalWindow(),
+                        window.IntervalWindow(MIN_TIMESTAMP, MAX_TIMESTAMP))
+    self.assertNotEqual(window.IntervalWindow(MIN_TIMESTAMP, MAX_TIMESTAMP),
+                        window.GlobalWindow())
 
   def test_fixed_windows(self):
     # Test windows with offset: 2, 7, 12, 17, ...


### PR DESCRIPTION
This uses specific cloud object representations for the following types:
kind:pair (TupleCoder with two components, previously pickled)
kind:stream (IterableCoder with a single component, previously ignored)
kind:global_window (GlobalWindowCoder, previously SingletonCoder)
kind:length_prefix (A new type of coder which always encodes the length of the value type as a prefix, has a single component)
kind:windowed_value (A wrapper coder with two components (value coder and window coder))

This also drops the ability to configure the timestamp coder on WindowedValueCoder.

These changes are towards having a common binary representation for certain well known coders across multiple languages.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
