### PR TITLE
[BEAM-1227] Update archetype pom.xml to non-incubating release

### DIFF
--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>0.4.0-incubating</beam.version>
+    <beam.version>0.4.0</beam.version>
   </properties>
 
   <build>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>0.4.0-incubating</beam.version>
+    <beam.version>0.4.0</beam.version>
   </properties>
 
   <repositories>

--- a/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/main/resources/archetype-resources/pom.xml
@@ -25,7 +25,7 @@
   <version>${version}</version>
 
   <properties>
-    <beam.version>0.4.0-incubating</beam.version>
+    <beam.version>0.4.0</beam.version>
   </properties>
 
   <repositories>

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -25,7 +25,7 @@
   <version>0.1</version>
 
   <properties>
-    <beam.version>0.4.0-incubating</beam.version>
+    <beam.version>0.4.0</beam.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
R: @jbonofre 

Since `mvn versions:set` does not update archetype pom.xml files, and we need to pin the archetype version pre-stable-api, need to do this manually every release.

The new release will be called `0.4.0` with no incubating.