### PR TITLE
[BEAM-1224] Rename options.py to pipeline_options.py

### DIFF
--- a/sdks/python/apache_beam/examples/complete/autocomplete.py
+++ b/sdks/python/apache_beam/examples/complete/autocomplete.py
@@ -24,8 +24,8 @@ import logging
 import re
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def run(argv=None):

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -36,8 +36,8 @@ import apache_beam as beam
 from apache_beam.typehints import Any
 from apache_beam.typehints import Iterable
 from apache_beam.typehints import Tuple
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 @beam.typehints.with_output_types(Tuple[int, int, int])

--- a/sdks/python/apache_beam/examples/complete/tfidf.py
+++ b/sdks/python/apache_beam/examples/complete/tfidf.py
@@ -30,8 +30,8 @@ import re
 
 import apache_beam as beam
 from apache_beam.pvalue import AsSingleton
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def read_documents(pipeline, uris):

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
@@ -46,8 +46,8 @@ import logging
 import apache_beam as beam
 from apache_beam import combiners
 from apache_beam import window
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 ONE_HOUR_IN_SECONDS = 3600

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
@@ -35,8 +35,8 @@ import apache_beam as beam
 
 from apache_beam.pvalue import AsList
 from apache_beam.pvalue import AsSingleton
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def create_groups(group_ids, corpus, word, ignore_corpus, ignore_word):

--- a/sdks/python/apache_beam/examples/cookbook/bigshuffle.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigshuffle.py
@@ -25,8 +25,8 @@ import logging
 
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def crc32line(line):

--- a/sdks/python/apache_beam/examples/cookbook/coders.py
+++ b/sdks/python/apache_beam/examples/cookbook/coders.py
@@ -35,8 +35,8 @@ import json
 import logging
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 class JsonCoder(object):

--- a/sdks/python/apache_beam/examples/cookbook/custom_ptransform.py
+++ b/sdks/python/apache_beam/examples/cookbook/custom_ptransform.py
@@ -27,7 +27,7 @@ import logging
 
 import apache_beam as beam
 
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 # pylint doesn't understand our pipeline syntax:

--- a/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
+++ b/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
@@ -73,9 +73,9 @@ from googledatastore import helper as datastore_helper, PropertyFilter
 import apache_beam as beam
 from apache_beam.io.datastore.v1.datastoreio import ReadFromDatastore
 from apache_beam.io.datastore.v1.datastoreio import WriteToDatastore
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 empty_line_aggregator = beam.Aggregator('emptyLines')
 average_word_size_aggregator = beam.Aggregator('averageWordLength',

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -35,8 +35,8 @@ import apache_beam as beam
 from apache_beam import coders
 from apache_beam.typehints import typehints
 from apache_beam.typehints.decorators import with_output_types
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 class Player(object):

--- a/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
+++ b/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
@@ -36,8 +36,8 @@ import logging
 import re
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def run(argv=None, assert_results=None):

--- a/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
+++ b/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
@@ -54,8 +54,8 @@ import re
 
 import apache_beam as beam
 from apache_beam import pvalue
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 class SplitLinesToWordsFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -88,7 +88,7 @@ def construct_pipeline(renames):
     return True
 
   # [START pipelines_constructing_creating]
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   p = beam.Pipeline(options=PipelineOptions())
   # [END pipelines_constructing_creating]
@@ -125,7 +125,7 @@ def model_pipelines(argv):
   import re
 
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   class MyOptions(PipelineOptions):
 
@@ -161,7 +161,7 @@ def model_pcollection(argv):
 
   URL: https://cloud.google.com/dataflow/model/pcollection
   """
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   class MyOptions(PipelineOptions):
 
@@ -197,7 +197,7 @@ def pipeline_options_remote(argv):
   """
 
   from apache_beam import Pipeline
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START pipeline_options_create]
   options = PipelineOptions(flags=argv)
@@ -212,8 +212,8 @@ def pipeline_options_remote(argv):
       parser.add_argument('--output')
   # [END pipeline_options_define_custom]
 
-  from apache_beam.utils.options import GoogleCloudOptions
-  from apache_beam.utils.options import StandardOptions
+  from apache_beam.utils.pipeline_options import GoogleCloudOptions
+  from apache_beam.utils.pipeline_options import StandardOptions
 
   # [START pipeline_options_dataflow_service]
   # Create and set your PipelineOptions.
@@ -254,7 +254,7 @@ def pipeline_options_local(argv):
   """
 
   from apache_beam import Pipeline
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   options = PipelineOptions(flags=argv)
 
@@ -320,7 +320,7 @@ def pipeline_logging(lines, output):
 
   import re
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START pipeline_logging]
   # import Python logging module.
@@ -357,7 +357,7 @@ def pipeline_monitoring(renames):
 
   import re
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   class WordCountOptions(PipelineOptions):
 
@@ -425,9 +425,9 @@ def examples_wordcount_minimal(renames):
 
   import apache_beam as beam
 
-  from apache_beam.utils.options import GoogleCloudOptions
-  from apache_beam.utils.options import StandardOptions
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import GoogleCloudOptions
+  from apache_beam.utils.pipeline_options import StandardOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START examples_wordcount_minimal_options]
   options = PipelineOptions()
@@ -485,7 +485,7 @@ def examples_wordcount_wordcount(renames):
   import re
 
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   argv = []
 
@@ -544,7 +544,7 @@ def examples_wordcount_debugging(renames):
   import re
 
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START example_wordcount_debugging_logging]
   # [START example_wordcount_debugging_aggregators]
@@ -635,7 +635,7 @@ def model_custom_source(count):
   from apache_beam.io import iobase
   from apache_beam.io.range_trackers import OffsetRangeTracker
   from apache_beam.transforms.core import PTransform
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # Defining a new source.
   # [START model_custom_source_new_source]
@@ -766,7 +766,7 @@ def model_custom_sink(simplekv, KVs, final_table_name_no_ptransform,
   import apache_beam as beam
   from apache_beam.io import iobase
   from apache_beam.transforms.core import PTransform
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # Defining the new sink.
   # [START model_custom_sink_new_sink]
@@ -867,7 +867,7 @@ def model_textio(renames):
     return re.findall(r'[A-Za-z\']+', x)
 
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START model_textio_read]
   p = beam.Pipeline(options=PipelineOptions())
@@ -902,7 +902,7 @@ def model_datastoreio():
   from google.datastore.v1 import query_pb2
   import googledatastore
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   from apache_beam.io.datastore.v1.datastoreio import ReadFromDatastore
   from apache_beam.io.datastore.v1.datastoreio import WriteToDatastore
 
@@ -938,7 +938,7 @@ def model_bigqueryio():
   URL: https://cloud.google.com/dataflow/model/bigquery-io
   """
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   # [START model_bigqueryio_read]
   p = beam.Pipeline(options=PipelineOptions())
@@ -1009,7 +1009,7 @@ def model_composite_transform_example(contents, output_path):
   # [END composite_ptransform_apply_method]
   # [END composite_transform_example]
 
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   p = beam.Pipeline(options=PipelineOptions())
   (p
    | beam.Create(contents)
@@ -1025,7 +1025,7 @@ def model_multiple_pcollections_flatten(contents, output_path):
   """
   some_hash_fn = lambda s: ord(s[0])
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   p = beam.Pipeline(options=PipelineOptions())
   partition_fn = lambda element, partitions: some_hash_fn(element) % partitions
 
@@ -1066,7 +1066,7 @@ def model_multiple_pcollections_partition(contents, output_path):
     """Assume i in [0,100)."""
     return i
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   p = beam.Pipeline(options=PipelineOptions())
 
   students = p | beam.Create(contents)
@@ -1096,7 +1096,7 @@ def model_group_by_key(contents, output_path):
   import re
 
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   p = beam.Pipeline(options=PipelineOptions())
   words_and_counts = (
       p
@@ -1123,7 +1123,7 @@ def model_co_group_by_key_tuple(email_list, phone_list, output_path):
   URL: https://cloud.google.com/dataflow/model/group-by-key
   """
   import apache_beam as beam
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
   p = beam.Pipeline(options=PipelineOptions())
   # [START model_group_by_key_cogroupbykey_tuple]
   # Each data set is represented by key-value pairs in separate PCollections.
@@ -1161,7 +1161,7 @@ def model_join_using_side_inputs(
 
   import apache_beam as beam
   from apache_beam.pvalue import AsIter
-  from apache_beam.utils.options import PipelineOptions
+  from apache_beam.utils.pipeline_options import PipelineOptions
 
   p = beam.Pipeline(options=PipelineOptions())
   # [START model_join_using_side_inputs]

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -31,7 +31,7 @@ from apache_beam import typehints
 from apache_beam.io import fileio
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
-from apache_beam.utils.options import TypeOptions
+from apache_beam.utils.pipeline_options import TypeOptions
 from apache_beam.examples.snippets import snippets
 
 # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -24,8 +24,8 @@ import logging
 import re
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 empty_line_aggregator = beam.Aggregator('emptyLines')

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -46,8 +46,8 @@ import logging
 import re
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 class FilterTextFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/wordcount_minimal.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal.py
@@ -51,8 +51,8 @@ import logging
 import re
 
 import apache_beam as beam
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 def run(argv=None):

--- a/sdks/python/apache_beam/internal/apiclient.py
+++ b/sdks/python/apache_beam/internal/apiclient.py
@@ -41,10 +41,10 @@ from apache_beam.utils import retry
 from apache_beam.utils.dependency import get_required_container_version
 from apache_beam.utils.dependency import get_sdk_name_and_version
 from apache_beam.utils.names import PropertyNames
-from apache_beam.utils.options import DebugOptions
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import StandardOptions
-from apache_beam.utils.options import WorkerOptions
+from apache_beam.utils.pipeline_options import DebugOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import StandardOptions
+from apache_beam.utils.pipeline_options import WorkerOptions
 from apache_beam.internal.clients import storage
 import apache_beam.internal.clients.dataflow as dataflow
 

--- a/sdks/python/apache_beam/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/internal/apiclient_test.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 from apache_beam.runners.dataflow_runner import DataflowRunner
 from apache_beam.internal import apiclient
 

--- a/sdks/python/apache_beam/internal/auth.py
+++ b/sdks/python/apache_beam/internal/auth.py
@@ -29,8 +29,8 @@ from oauth2client.client import OAuth2Credentials
 
 from apache_beam.utils import processes
 from apache_beam.utils import retry
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 # When we are running in GCE, we can authenticate with VM credentials.

--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -120,7 +120,7 @@ from apache_beam.internal.json_value import to_json_value
 from apache_beam.runners.dataflow.native_io import iobase as dataflow_io
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.utils import retry
-from apache_beam.utils.options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
 
 # Protect against environments where bigquery library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -35,7 +35,7 @@ from apache_beam.io.bigquery import TableRowJsonCoder
 from apache_beam.io.bigquery import parse_table_schema_from_json
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class TestRowAsDictJsonCoder(unittest.TestCase):

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -55,10 +55,10 @@ from apache_beam.runners import create_runner
 from apache_beam.runners import PipelineRunner
 from apache_beam.transforms import ptransform
 from apache_beam.typehints import TypeCheckError
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
-from apache_beam.utils.options import StandardOptions
-from apache_beam.utils.options import TypeOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
+from apache_beam.utils.pipeline_options import StandardOptions
+from apache_beam.utils.pipeline_options import TypeOptions
 from apache_beam.utils.pipeline_options_validator import PipelineOptionsValidator
 
 

--- a/sdks/python/apache_beam/runners/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow_runner.py
@@ -41,7 +41,7 @@ from apache_beam.typehints import typehints
 from apache_beam.utils import names
 from apache_beam.utils.names import PropertyNames
 from apache_beam.utils.names import TransformNames
-from apache_beam.utils.options import StandardOptions
+from apache_beam.utils.pipeline_options import StandardOptions
 from apache_beam.internal.clients import dataflow as dataflow_api
 
 

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -38,7 +38,7 @@ from apache_beam.typehints.typecheck import OutputCheckWrapperDoFn
 from apache_beam.typehints.typecheck import TypeCheckError
 from apache_beam.typehints.typecheck import TypeCheckWrapperDoFn
 from apache_beam.utils import counters
-from apache_beam.utils.options import TypeOptions
+from apache_beam.utils.pipeline_options import TypeOptions
 
 
 class TransformEvaluatorRegistry(object):

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -36,7 +36,7 @@ from apache_beam.runners import DirectRunner
 from apache_beam.runners import TestDataflowRunner
 import apache_beam.transforms as ptransform
 from apache_beam.transforms.display import DisplayDataItem
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class RunnerTest(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/template_runner_test.py
+++ b/sdks/python/apache_beam/runners/template_runner_test.py
@@ -26,7 +26,7 @@ import tempfile
 import apache_beam as beam
 from apache_beam.pipeline import Pipeline
 from apache_beam.runners.dataflow_runner import DataflowRunner
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 from apache_beam.internal import apiclient
 
 

--- a/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
@@ -19,7 +19,7 @@
 
 from apache_beam.internal import pickler
 from apache_beam.runners.dataflow_runner import DataflowRunner
-from apache_beam.utils.options import TestOptions
+from apache_beam.utils.pipeline_options import TestOptions
 
 
 class TestDataflowRunner(DataflowRunner):

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -22,8 +22,8 @@ import shlex
 
 from apache_beam.internal import pickler
 from apache_beam.pipeline import Pipeline
-from nose.plugins.skip import SkipTest
 from apache_beam.utils.pipeline_options import PipelineOptions
+from nose.plugins.skip import SkipTest
 
 
 class TestPipeline(Pipeline):

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -22,8 +22,8 @@ import shlex
 
 from apache_beam.internal import pickler
 from apache_beam.pipeline import Pipeline
-from apache_beam.utils.options import PipelineOptions
 from nose.plugins.skip import SkipTest
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class TestPipeline(Pipeline):

--- a/sdks/python/apache_beam/test_pipeline_test.py
+++ b/sdks/python/apache_beam/test_pipeline_test.py
@@ -20,7 +20,7 @@
 import unittest
 
 from apache_beam.test_pipeline import TestPipeline
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class TestPipelineTest(unittest.TestCase):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -46,7 +46,7 @@ from apache_beam.typehints import TypeCheckError
 from apache_beam.typehints import Union
 from apache_beam.typehints import WithTypeHints
 from apache_beam.typehints.trivial_inference import element_type
-from apache_beam.utils.options import TypeOptions
+from apache_beam.utils.pipeline_options import TypeOptions
 
 # Type variables
 T = typehints.TypeVariable('T')

--- a/sdks/python/apache_beam/transforms/display.py
+++ b/sdks/python/apache_beam/transforms/display.py
@@ -122,7 +122,7 @@ class DisplayData(object):
       ValueError: If the has_display_data argument is not an instance of
         HasDisplayData.
     """
-    from apache_beam.utils.options import PipelineOptions
+    from apache_beam.utils.pipeline_options import PipelineOptions
     if not isinstance(pipeline_options, PipelineOptions):
       raise ValueError(
           'Element of class {}.{} does not subclass PipelineOptions'

--- a/sdks/python/apache_beam/transforms/display_test.py
+++ b/sdks/python/apache_beam/transforms/display_test.py
@@ -29,7 +29,7 @@ import apache_beam as beam
 from apache_beam.transforms.display import HasDisplayData
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display import DisplayDataItem
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class DisplayDataItemMatcher(BaseMatcher):

--- a/sdks/python/apache_beam/transforms/ptransform.py
+++ b/sdks/python/apache_beam/transforms/ptransform.py
@@ -410,7 +410,7 @@ class PTransform(WithTypeHints, HasDisplayData):
       deferred = False
       # pylint: disable=wrong-import-order, wrong-import-position
       from apache_beam import pipeline
-      from apache_beam.utils.options import PipelineOptions
+      from apache_beam.utils.pipeline_options import PipelineOptions
       # pylint: enable=wrong-import-order, wrong-import-position
       p = pipeline.Pipeline(
           'DirectRunner', PipelineOptions(sys.argv))

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -36,8 +36,8 @@ import apache_beam.typehints as typehints
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
 from apache_beam.typehints.typehints_test import TypeHintTestCase
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import TypeOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import TypeOptions
 
 
 # Disable frequent lint warning due to pipe operator for chaining transforms.

--- a/sdks/python/apache_beam/transforms/write_ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/write_ptransform_test.py
@@ -25,7 +25,7 @@ from apache_beam.io import iobase
 from apache_beam.pipeline import Pipeline
 from apache_beam.transforms.ptransform import PTransform
 from apache_beam.transforms.util import assert_that, is_empty
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class _TestSink(iobase.Sink):

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -25,8 +25,8 @@ from apache_beam import pvalue
 from apache_beam import typehints
 from apache_beam.transforms.util import assert_that, equal_to
 from apache_beam.typehints import WithTypeHints
-from apache_beam.utils.options import OptionsContext
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import OptionsContext
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 # These test often construct a pipeline as value | PTransform to test side
 # effects (e.g. errors).

--- a/sdks/python/apache_beam/utils/dependency.py
+++ b/sdks/python/apache_beam/utils/dependency.py
@@ -66,8 +66,8 @@ from apache_beam import version as beam_version
 from apache_beam.internal import pickler
 from apache_beam.utils import names
 from apache_beam.utils import processes
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 # Standard file names used for staging files.

--- a/sdks/python/apache_beam/utils/dependency_test.py
+++ b/sdks/python/apache_beam/utils/dependency_test.py
@@ -26,9 +26,9 @@ import unittest
 from apache_beam import utils
 from apache_beam.utils import dependency
 from apache_beam.utils import names
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import PipelineOptions
-from apache_beam.utils.options import SetupOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import SetupOptions
 
 
 class SetupTest(unittest.TestCase):

--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -15,10 +15,7 @@
 # limitations under the License.
 #
 
-"""Pipeline options obtained from command line parsing.
-
-TODO(silviuc): Should rename this module to pipeline_options.
-"""
+"""Pipeline options obtained from command line parsing."""
 
 import argparse
 

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -23,7 +23,7 @@ import unittest
 import hamcrest as hc
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 
 
 class PipelineOptionsTest(unittest.TestCase):

--- a/sdks/python/apache_beam/utils/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator.py
@@ -20,13 +20,13 @@
 import re
 
 from apache_beam.internal import pickler
-from apache_beam.utils.options import DebugOptions
-from apache_beam.utils.options import GoogleCloudOptions
-from apache_beam.utils.options import SetupOptions
-from apache_beam.utils.options import StandardOptions
-from apache_beam.utils.options import TestOptions
-from apache_beam.utils.options import TypeOptions
-from apache_beam.utils.options import WorkerOptions
+from apache_beam.utils.pipeline_options import DebugOptions
+from apache_beam.utils.pipeline_options import GoogleCloudOptions
+from apache_beam.utils.pipeline_options import SetupOptions
+from apache_beam.utils.pipeline_options import StandardOptions
+from apache_beam.utils.pipeline_options import TestOptions
+from apache_beam.utils.pipeline_options import TypeOptions
+from apache_beam.utils.pipeline_options import WorkerOptions
 
 
 class PipelineOptionsValidator(object):

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -21,7 +21,7 @@ import logging
 import unittest
 
 from apache_beam.internal import pickler
-from apache_beam.utils.options import PipelineOptions
+from apache_beam.utils.pipeline_options import PipelineOptions
 from apache_beam.utils.pipeline_options_validator import PipelineOptionsValidator
 from hamcrest.core.base_matcher import BaseMatcher
 


### PR DESCRIPTION
options.py contains the class PipelineOptions (and other classes derived from it) and should be renamed pipeline_options.py for clarity. Its test file is pipeline_options_test.py.
