### PR TITLE
[BEAM-1188] Accept Multiple Verifiers in One IT

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_it_test.py
@@ -31,7 +31,7 @@ class WordCountIT(unittest.TestCase):
   @attr('IT')
   def test_wordcount_it(self):
     # Set extra options to the pipeline for test purpose
-    extra_opts = {'on_success_matcher': PipelineStateMatcher()}
+    extra_opts = {'on_success_matchers': [PipelineStateMatcher()]}
 
     # Get pipeline options from command argument: --test-pipeline-options,
     # and start pipeline job by calling pipeline main function.

--- a/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/test/test_dataflow_runner.py
@@ -32,7 +32,8 @@ class TestDataflowRunner(DataflowRunner):
     self.result = super(TestDataflowRunner, self).run(pipeline)
 
     options = pipeline.options.view_as(TestOptions)
-    if options.on_success_matcher:
-      from hamcrest import assert_that as hc_assert_that
-      hc_assert_that(self.result, pickler.loads(options.on_success_matcher))
+    if options.on_success_matchers:
+      for verifier in pickler.loads(options.on_success_matchers):
+        from hamcrest import assert_that as hc_assert_that
+        hc_assert_that(self.result, verifier)
     return self.result

--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -483,16 +483,17 @@ class TestOptions(PipelineOptions):
   def _add_argparse_args(cls, parser):
     # Options for e2e test pipeline.
     parser.add_argument(
-        '--on_success_matcher',
+        '--on_success_matchers',
         default=None,
         help=('Verify state/output of e2e test pipeline. This is pickled '
-              'version of the matcher which should extends '
+              'version of iterable matchers which should extend '
               'hamcrest.core.base_matcher.BaseMatcher.'))
 
   def validate(self, validator):
     errors = []
-    if self.view_as(TestOptions).on_success_matcher:
-      errors.extend(validator.validate_test_matcher(self, 'on_success_matcher'))
+    if self.view_as(TestOptions).on_success_matchers:
+      errors.extend(
+          validator.validate_test_matcher(self, 'on_success_matchers'))
     return errors
 
 # TODO(silviuc): Add --files_to_stage option.


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Each integration test can set multiple verifiers instead of one. This can help users to verify different aspects of pipeline result in one integration test when more verifiers will be provided in `apache_beam.tests.pipeline_verifiers.py`. User can also build own verifiers to meet their needs.

TODO:
More verifiers are on their way.