### PR TITLE
[BEAM-564] Updates Python source API to allow reporting consumed and remaining number of split points

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -298,6 +298,8 @@ class RangeTracker(object):
   the current reader and by a reader of the task starting at 43).
   """
 
+  SPLIT_POINTS_UNKNOWN = object()
+
   def start_position(self):
     """Returns the starting position of the current range, inclusive."""
     raise NotImplementedError(type(self))
@@ -315,8 +317,8 @@ class RangeTracker(object):
 
     ** Thread safety **
 
-    This method along with several other methods of this class may be invoked by
-    multiple threads, hence must be made thread-safe, e.g. by using a single
+    Methods of the class ``RangeTracker`` including this method may get invoked
+    by different threads, hence must be made thread-safe, e.g. by using a single
     lock object.
 
     Args:
@@ -350,8 +352,8 @@ class RangeTracker(object):
 
     ** Thread safety **
 
-    This method along with several other methods of this class may be invoked by
-    multiple threads, hence must be made thread-safe, e.g. by using a single
+    Methods of the class ``RangeTracker`` including this method may get invoked
+    by different threads, hence must be made thread-safe, e.g. by using a single
     lock object.
 
     Args:
@@ -385,8 +387,8 @@ class RangeTracker(object):
 
     ** Thread safety **
 
-    This method along with several other methods of this class may be invoked by
-    multiple threads, hence must be made thread-safe, e.g. by using a single
+    Methods of the class ``RangeTracker`` including this method may get invoked
+    by different threads, hence must be made thread-safe, e.g. by using a single
     lock object.
 
     Args:
@@ -403,8 +405,8 @@ class RangeTracker(object):
 
     ** Thread safety **
 
-    This method along with several other methods of this class may be invoked by
-    multiple threads, hence must be made thread-safe, e.g. by using a single
+    Methods of the class ``RangeTracker`` including this method may get invoked
+    by different threads, hence must be made thread-safe, e.g. by using a single
     lock object.
 
     Returns:
@@ -413,6 +415,143 @@ class RangeTracker(object):
       0.0 if no such calls have happened.
     """
     raise NotImplementedError
+
+  def split_points(self):
+    """Gives the number of split points consumed and remaining.
+
+    For a ``RangeTracker`` used by a ``BoundedSource`` (within a
+    ``BoundedSource.read()`` invocation) this method produces a 2-tuple that
+    gives the number of split points consumed by the ``BoundedSource`` and the
+    number of split points remaining within the range of the ``RangeTracker``
+    that has not been consumed by the ``BoundedSource``.
+
+    More specifically, given that the position of the current record being read
+    by ``BoundedSource`` is current_position this method produces a tuple that
+    consists of
+    (1) number of split points in the range [self.start_position(),
+    current_position) without including the split point that is currently being
+    consumed. This represents the total amount of parallelism in the consumed
+    part of the source.
+    (2) number of split points within the range
+    [current_position, self.stop_position()) including the split point that is
+    currently being consumed. This represents the total amount of parallelism in
+    the unconsumed part of the source.
+
+    Methods of the class ``RangeTracker`` including this method may get invoked
+    by different threads, hence must be made thread-safe, e.g. by using a single
+    lock object.
+
+    ** General information about consumed and remaining number of split
+       points returned by this method. **
+
+      * Before a source read (``BoundedSource.read()`` invocation) claims the
+        first split point, number of consumed split points is 0. This condition
+        holds independent of whether the input is "splittable". A splittable
+        source is a source that has more than one split point.
+      * Any source read that has only claimed one split point has 0 consumed
+        split points since the first split point is the current split point and
+        is still being processed. This condition holds independent of whether
+        the input is splittable.
+      * For an empty source read which never invokes
+        ``RangeTracker.try_claim()``, the consumed number of split points is 0.
+        This condition holds independent of whether the input is splittable.
+      * For a source read which has invoked ``RangeTracker.try_claim()`` n
+        times, the consumed number of split points is  n -1.
+      * If a ``BoundedSource`` sets a callback through function
+        ``set_split_points_unclaimed_callback()``, ``RangeTracker`` can use that
+        callback when determining remaining number of split points.
+      * Remaining split points should include the split point that is currently
+        being consumed by the source read. Hence if the above callback returns
+        an integer value n, remaining number of split points should be (n + 1).
+      * After last split point is claimed remaining split points becomes 1,
+        because this unfinished read itself represents an  unfinished split
+        point.
+      * After all records of the source has been consumed, remaining number of
+        split points becomes 0 and consumed number of split points becomes equal
+        to the total number of split points within the range being read by the
+        source. This method does not address this condition and will continue to
+        report number of consumed split points as
+        ("total number of split points" - 1) and number of remaining split
+        points as 1. A runner that performs the reading of the source can
+        detect when all records have been consumed and adjust remaining and
+        consumed number of split points accordingly.
+
+    ** Examples **
+
+    (1) A "perfectly splittable" input which can be read in parallel down to the
+        individual records.
+
+        Consider a perfectly splittable input that consists of 50 split points.
+
+      * Before a source read (``BoundedSource.read()`` invocation) claims the
+        first split point, number of consumed split points is 0 number of
+        remaining split points is 50.
+      * After claiming first split point, consumed number of split points is 0
+        and remaining number of split is 50.
+      * After claiming split point #30, consumed number of split points is 29
+        and remaining number of split points is 21.
+      * After claiming all 50 split points, consumed number of split points is
+        49 and remaining number of split points is 1.
+
+    (2) a "block-compressed" file format such as ``avroio``, in which a block of
+        records has to be read as a whole, but different blocks can be read in
+        parallel.
+
+        Consider a block compressed input that consists of 5 blocks.
+
+      * Before a source read (``BoundedSource.read()`` invocation) claims the
+        first split point (first block), number of consumed split points is 0
+        number of remaining split points is 5.
+      * After claiming first split point, consumed number of split points is 0
+        and remaining number of split is 5.
+      * After claiming split point #3, consumed number of split points is 2
+        and remaining number of split points is 3.
+      * After claiming all 5 split points, consumed number of split points is
+        4 and remaining number of split points is 1.
+
+    (3) an "unsplittable" input such as a cursor in a database or a gzip
+        compressed file.
+
+        Such an input is considered to have only a single split point. Number of
+        consumed split points is always 0 and number of remaining split points
+        is always 1.
+
+    By default ``RangeTracker` returns ``RangeTracker.SPLIT_POINTS_UNKNOWN`` for
+    both consumed and remaining number of split points, which indicates that the
+    number of split points consumed and remaining is unknown.
+
+    Returns:
+      A pair that gives consumed and remaining number of split points. Consumed
+      number of split points should be an integer larger than or equal to zero
+      or ``RangeTracker.SPLIT_POINTS_UNKNOWN``. Remaining number of split points
+      should be an integer larger than zero or
+      ``RangeTracker.SPLIT_POINTS_UNKNOWN``.
+    """
+    return (RangeTracker.SPLIT_POINTS_UNKNOWN,
+            RangeTracker.SPLIT_POINTS_UNKNOWN)
+
+  def set_split_points_unclaimed_callback(self, callback):
+    """Sets a callback for determining the unclaimed number of split points.
+
+    By invoking this function, a ``BoundedSource`` can set a callback function
+    that may get invoked by the ``RangeTracker`` to determine the number of
+    unclaimed split points. A split point is unclaimed if
+    ``RangeTracker.try_claim()`` method has not been successfully invoked for
+    that particular split point. The callback function accepts a single
+    parameter, a stop position for the BoundedSource (stop_position). If the
+    record currently being consumed by the ``BoundedSource`` is at position
+    current_position, callback should return the number of split points within
+    the range (current_position, stop_position). Note that, this should not
+    include the split point that is currently being consumed by the source.
+
+    Args:
+      callback: a function that takes a single parameter, a stop position,
+                and returns unclaimed number of split points for the source read
+                operation that is calling this function. Value returned from
+                callback should be either an integer larger than or equal to
+                zero or ``RangeTracker.SPLIT_POINTS_UNKNOWN``.
+    """
+    pass
 
 
 class Sink(HasDisplayData):

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -55,6 +55,9 @@ class OffsetRangeTracker(iobase.RangeTracker):
     self._offset_of_last_split_point = -1
     self._lock = threading.Lock()
 
+    self._split_points_seen = 0
+    self._split_points_unclaimed_callback = None
+
   def start_position(self):
     return self._start_offset
 
@@ -106,6 +109,7 @@ class OffsetRangeTracker(iobase.RangeTracker):
         return False
       self._offset_of_last_split_point = record_start
       self._last_record_start = record_start
+      self._split_points_seen += 1
       return True
 
   def set_current_position(self, record_start):
@@ -167,6 +171,24 @@ class OffsetRangeTracker(iobase.RangeTracker):
     return int(math.ceil(self.start_position() + fraction * (
         self.stop_position() - self.start_position())))
 
+  def split_points(self):
+    with self._lock:
+      split_points_consumed = (
+          0 if self._split_points_seen == 0 else self._split_points_seen - 1)
+      split_points_unclaimed = (
+          self._split_points_unclaimed_callback(self.stop_position())
+          if self._split_points_unclaimed_callback
+          else iobase.RangeTracker.SPLIT_POINTS_UNKNOWN)
+      split_points_remaining = (
+          iobase.RangeTracker.SPLIT_POINTS_UNKNOWN if
+          split_points_unclaimed == iobase.RangeTracker.SPLIT_POINTS_UNKNOWN
+          else (split_points_unclaimed + 1))
+
+      return (split_points_consumed, split_points_remaining)
+
+  def set_split_points_unclaimed_callback(self, callback):
+    self._split_points_unclaimed_callback = callback
+
 
 class GroupedShuffleRangeTracker(iobase.RangeTracker):
   """A 'RangeTracker' for positions used by'GroupedShuffleReader'.
@@ -184,6 +206,7 @@ class GroupedShuffleRangeTracker(iobase.RangeTracker):
     self._decoded_stop_pos = decoded_stop_pos
     self._decoded_last_group_start = None
     self._last_group_was_at_a_split_point = False
+    self._split_points_seen = 0
     self._lock = threading.Lock()
 
   def start_position(self):
@@ -240,6 +263,7 @@ class GroupedShuffleRangeTracker(iobase.RangeTracker):
 
       self._decoded_last_group_start = decoded_group_start
       self._last_group_was_at_a_split_point = True
+      self._split_points_seen += 1
       return True
 
   def set_current_position(self, decoded_group_start):
@@ -284,6 +308,14 @@ class GroupedShuffleRangeTracker(iobase.RangeTracker):
     raise RuntimeError('GroupedShuffleRangeTracker does not measure fraction'
                        ' consumed due to positions being opaque strings'
                        ' that are interpreted by the service')
+
+  def split_points(self):
+    with self._lock:
+      splits_points_consumed = (
+          0 if self._split_points_seen <= 1 else (self._split_points_seen - 1))
+
+      return (splits_points_consumed,
+              iobase.RangeTracker.SPLIT_POINTS_UNKNOWN)
 
 
 class OrderedPositionRangeTracker(iobase.RangeTracker):
@@ -380,7 +412,7 @@ class UnsplittableRangeTracker(iobase.RangeTracker):
       range_tracker: a ``RangeTracker`` to which all method calls expect calls
       to ``try_split()`` will be delegated.
     """
-    assert range_tracker
+    assert isinstance(range_tracker, iobase.RangeTracker)
     self._range_tracker = range_tracker
 
   def start_position(self):
@@ -403,6 +435,10 @@ class UnsplittableRangeTracker(iobase.RangeTracker):
 
   def fraction_consumed(self):
     return self._range_tracker.fraction_consumed()
+
+  def split_points(self):
+    # An unsplittable range only contains a single split point.
+    return (0, 1)
 
 
 class LexicographicKeyRangeTracker(OrderedPositionRangeTracker):

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -24,6 +24,7 @@ import math
 import unittest
 
 
+from apache_beam.io import iobase
 from apache_beam.io import range_trackers
 
 
@@ -157,6 +158,35 @@ class OffsetRangeTrackerTest(unittest.TestCase):
     self.assertTrue(tracker.try_claim(120))
     with self.assertRaises(Exception):
       tracker.try_claim(110)
+
+  def test_try_split_points(self):
+    tracker = range_trackers.OffsetRangeTracker(100, 400)
+
+    def dummy_callback(stop_position):
+      return int(stop_position / 5)
+
+    tracker.set_split_points_unclaimed_callback(dummy_callback)
+
+    self.assertEqual(tracker.split_points(),
+                     (0, 81))
+    self.assertTrue(tracker.try_claim(120))
+    self.assertEqual(tracker.split_points(),
+                     (0, 81))
+    self.assertTrue(tracker.try_claim(140))
+    self.assertEqual(tracker.split_points(),
+                     (1, 81))
+    tracker.try_split(200)
+    self.assertEqual(tracker.split_points(),
+                     (1, 41))
+    self.assertTrue(tracker.try_claim(150))
+    self.assertEqual(tracker.split_points(),
+                     (2, 41))
+    self.assertTrue(tracker.try_claim(180))
+    self.assertEqual(tracker.split_points(),
+                     (3, 41))
+    self.assertFalse(tracker.try_claim(210))
+    self.assertEqual(tracker.split_points(),
+                     (3, 41))
 
 
 class GroupedShuffleRangeTrackerTest(unittest.TestCase):
@@ -318,6 +348,28 @@ class GroupedShuffleRangeTrackerTest(unittest.TestCase):
         self.bytes_to_position([3, 2, 0])))
     self.assertFalse(tracker.try_claim(
         self.bytes_to_position([3, 2, 1])))
+
+  def test_split_points(self):
+    tracker = range_trackers.GroupedShuffleRangeTracker(
+        self.bytes_to_position([1, 0, 0]),
+        self.bytes_to_position([5, 0, 0]))
+    self.assertEqual(tracker.split_points(),
+                     (0, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
+    self.assertTrue(tracker.try_claim(self.bytes_to_position([1, 2, 3])))
+    self.assertEqual(tracker.split_points(),
+                     (0, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
+    self.assertTrue(tracker.try_claim(self.bytes_to_position([1, 2, 5])))
+    self.assertEqual(tracker.split_points(),
+                     (1, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
+    self.assertTrue(tracker.try_claim(self.bytes_to_position([3, 6, 8])))
+    self.assertEqual(tracker.split_points(),
+                     (2, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
+    self.assertTrue(tracker.try_claim(self.bytes_to_position([4, 255, 255])))
+    self.assertEqual(tracker.split_points(),
+                     (3, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
+    self.assertFalse(tracker.try_claim(self.bytes_to_position([5, 1, 0])))
+    self.assertEqual(tracker.split_points(),
+                     (3, iobase.RangeTracker.SPLIT_POINTS_UNKNOWN))
 
 
 class OrderedPositionRangeTrackerTest(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/dataflow/native_io/iobase.py
+++ b/sdks/python/apache_beam/runners/dataflow/native_io/iobase.py
@@ -136,7 +136,8 @@ class NativeSourceReader(object):
 class ReaderProgress(object):
   """A representation of how far a NativeSourceReader has read."""
 
-  def __init__(self, position=None, percent_complete=None, remaining_time=None):
+  def __init__(self, position=None, percent_complete=None, remaining_time=None,
+               consumed_split_points=None, remaining_split_points=None):
 
     self._position = position
 
@@ -149,6 +150,8 @@ class ReaderProgress(object):
     self._percent_complete = percent_complete
 
     self._remaining_time = remaining_time
+    self._consumed_split_points = consumed_split_points
+    self._remaining_split_points = remaining_split_points
 
   @property
   def position(self):
@@ -171,6 +174,14 @@ class ReaderProgress(object):
   def remaining_time(self):
     """Returns progress, represented as an estimated time remaining."""
     return self._remaining_time
+
+  @property
+  def consumed_split_points(self):
+    return self._consumed_split_points
+
+  @property
+  def remaining_split_points(self):
+    return self._remaining_split_points
 
 
 class ReaderPosition(object):


### PR DESCRIPTION
With this update Python BoundedSource/RangeTracker API can report consumed and remaining number of split points while performing a source read operations. Java SDK source API already supports reporting these signals.

These signals can be used by runner implementations, for example, to perform scaling decisions.

This provides a slightly simplified API compared to previous PR https://github.com/apache/incubator-beam/pull/881.

Main differences compared to https://github.com/apache/incubator-beam/pull/881 are following.

(1) set_done()/done() methods were removed from the RangeTracker interface.

Downside is that RangeTracker will be unable to provide the signal that all records have been consumed. I think this signal is unnecessary since a runner can detect that anyways since the reader loop of the source ends at that point.

(2)
Callback between BoundedSource and RangeTracker was changed from reporting remaining number of split points to reporting unclaimed number of split points. This makes the implementation of the callback simpler for source authors. 
