### PR TITLE
[BEAM-802] Add ValueProvider class for FileBasedSource I/O Transforms

### DIFF
--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -29,7 +29,6 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
-from apache_beam.utils.value_provider import StaticValueProvider
 
 
 # Importing following private class for testing purposes.
@@ -166,9 +165,9 @@ class TestAvro(unittest.TestCase):
     # No extra avro parameters for AvroSource.
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern',
-                               str(StaticValueProvider(str, file_name)))]
-
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'StaticValueProvider(type=str, value=\'%s\')' % file_name)]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_read_display_data(self):
@@ -179,8 +178,9 @@ class TestAvro(unittest.TestCase):
     # No extra avro parameters for AvroSource.
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern',
-                               str(StaticValueProvider(str, file_name)))]
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'StaticValueProvider(type=str, value=\'%s\')' % file_name)]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_sink_display_data(self):

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -29,6 +29,8 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
+from apache_beam.utils.value_provider import StaticValueProvider
+
 
 # Importing following private class for testing purposes.
 from apache_beam.io.avroio import _AvroSource as AvroSource
@@ -164,7 +166,9 @@ class TestAvro(unittest.TestCase):
     # No extra avro parameters for AvroSource.
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern', file_name)]
+        DisplayDataItemMatcher('file_pattern',
+                               str(StaticValueProvider(str, file_name)))]
+
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_read_display_data(self):
@@ -175,7 +179,8 @@ class TestAvro(unittest.TestCase):
     # No extra avro parameters for AvroSource.
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern', file_name)]
+        DisplayDataItemMatcher('file_pattern',
+                               str(StaticValueProvider(str, file_name)))]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_sink_display_data(self):

--- a/sdks/python/apache_beam/io/filebasedsource.py
+++ b/sdks/python/apache_beam/io/filebasedsource.py
@@ -114,7 +114,7 @@ class FileBasedSource(iobase.BoundedSource):
   def _get_concat_source(self):
     if self._concat_source is None:
       if not self._pattern.is_accessible():
-        raise RuntimeError('value not accessible')
+        raise RuntimeError('%s not accessible' % self._pattern)
 
       single_file_sources = []
       pattern = self._pattern.get()
@@ -187,7 +187,7 @@ class FileBasedSource(iobase.BoundedSource):
     """Validate if there are actual files in the specified glob pattern
     """
     if not self._pattern.is_accessible():
-      raise RuntimeError('value not accessible')
+      raise RuntimeError('%s not accessible' % self._pattern)
     pattern = self._pattern.get()
 
     # Limit the responses as we only want to check if something exists
@@ -204,7 +204,7 @@ class FileBasedSource(iobase.BoundedSource):
 
   def estimate_size(self):
     if not self._pattern.is_accessible():
-      raise RuntimeError('value not accessible')
+      raise RuntimeError('%s not accessible' % self._pattern)
     pattern = self._pattern.get()
     file_names = [f for f in fileio.ChannelFactory.glob(pattern)]
 

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -42,7 +42,6 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
-from apache_beam.utils.value_provider import StaticValueProvider
 
 
 class LineSource(FileBasedSource):
@@ -254,10 +253,10 @@ class TestFileBasedSource(unittest.TestCase):
     fbs = LineSource(file_name)
     dd = DisplayData.create_from(fbs)
     expected_items = [
-        DisplayDataItemMatcher('file_pattern',
-                               str(StaticValueProvider(str, file_name))),
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'StaticValueProvider(type=str, value=\'%s\')' % file_name),
         DisplayDataItemMatcher('compression', 'auto')]
-    print dd.items
     hc.assert_that(dd.items,
                    hc.contains_inanyorder(*expected_items))
 
@@ -589,8 +588,9 @@ class TestSingleFileSource(unittest.TestCase):
     dd = DisplayData.create_from(fbs)
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern',
-                               str(StaticValueProvider(str, file_name)))]
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'StaticValueProvider(type=str, value=\'%s\')' % file_name)]
     hc.assert_that(dd.items,
                    hc.contains_inanyorder(*expected_items))
 

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -42,6 +42,7 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
+from apache_beam.utils.value_provider import StaticValueProvider
 
 
 class LineSource(FileBasedSource):
@@ -253,8 +254,10 @@ class TestFileBasedSource(unittest.TestCase):
     fbs = LineSource(file_name)
     dd = DisplayData.create_from(fbs)
     expected_items = [
-        DisplayDataItemMatcher('file_pattern', file_name),
+        DisplayDataItemMatcher('file_pattern',
+                               str(StaticValueProvider(str, file_name))),
         DisplayDataItemMatcher('compression', 'auto')]
+    print dd.items
     hc.assert_that(dd.items,
                    hc.contains_inanyorder(*expected_items))
 
@@ -586,7 +589,8 @@ class TestSingleFileSource(unittest.TestCase):
     dd = DisplayData.create_from(fbs)
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern', file_name)]
+        DisplayDataItemMatcher('file_pattern',
+                               str(StaticValueProvider(str, file_name)))]
     hc.assert_that(dd.items,
                    hc.contains_inanyorder(*expected_items))
 

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -49,8 +49,6 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
 
-from apache_beam.utils.value_provider import StaticValueProvider
-
 
 class TextSourceTest(unittest.TestCase):
 
@@ -299,8 +297,9 @@ class TextSourceTest(unittest.TestCase):
     dd = DisplayData.create_from(read)
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern',
-                               str(StaticValueProvider(str, 'prefix'))),
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'StaticValueProvider(type=str, value=\'prefix\')'),
         DisplayDataItemMatcher('strip_newline', True)]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -49,6 +49,8 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.transforms.util import assert_that
 from apache_beam.transforms.util import equal_to
 
+from apache_beam.utils.value_provider import StaticValueProvider
+
 
 class TextSourceTest(unittest.TestCase):
 
@@ -297,7 +299,8 @@ class TextSourceTest(unittest.TestCase):
     dd = DisplayData.create_from(read)
     expected_items = [
         DisplayDataItemMatcher('compression', 'auto'),
-        DisplayDataItemMatcher('file_pattern', 'prefix'),
+        DisplayDataItemMatcher('file_pattern',
+                               str(StaticValueProvider(str, 'prefix'))),
         DisplayDataItemMatcher('strip_newline', True)]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 

--- a/sdks/python/apache_beam/transforms/display_test.py
+++ b/sdks/python/apache_beam/transforms/display_test.py
@@ -30,7 +30,6 @@ from apache_beam.transforms.display import HasDisplayData
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.utils.pipeline_options import PipelineOptions
-from apache_beam.utils.pipeline_options import static_value_provider_of
 
 
 class DisplayDataItemMatcher(BaseMatcher):
@@ -115,21 +114,20 @@ class DisplayDataTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       DisplayData.create_from_options(MyDisplayComponent())
 
-  def test_vp_display_data(self):
+  def test_value_provider_display_data(self):
     class TestOptions(PipelineOptions):
       @classmethod
       def _add_argparse_args(cls, parser):
-        parser.add_argument(
+        parser.add_value_provider_argument(
             '--int_flag',
-            type=static_value_provider_of(int),
+            type=int,
             help='int_flag description')
-        parser.add_argument(
+        parser.add_value_provider_argument(
             '--str_flag',
-            type=static_value_provider_of(str),
+            type=str,
+            default='hello',
             help='str_flag description')
-    options = TestOptions(['--int_flag', '1', '--str_flag', '/dev/null'])
-    # TODO: Make flags be capable of having
-    # the same name for vp and non-vp values.
+    options = TestOptions(['--int_flag', '1'])
     items = DisplayData.create_from_options(options).items
     expected_items = [
         DisplayDataItemMatcher(
@@ -137,7 +135,8 @@ class DisplayDataTest(unittest.TestCase):
             'StaticValueProvider(type=int, value=1)'),
         DisplayDataItemMatcher(
             'str_flag',
-            'StaticValueProvider(type=str, value=\'/dev/null\')'
+            'RuntimeValueProvider(option=str_flag,'
+            ' type=str, default_value=\'hello\', value=None)'
         )
     ]
     hc.assert_that(items, hc.contains_inanyorder(*expected_items))

--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -20,6 +20,20 @@
 import argparse
 
 from apache_beam.transforms.display import HasDisplayData
+from apache_beam.utils.value_provider import StaticValueProvider
+
+
+def static_value_provider_of(type):
+  """"Helper function to plug a ValueProvider into argparse.
+
+  Args:
+    type: the type of the value. Since the type param of argparse's
+          add_argument will always be ValueProvider, we need to
+          preserve the type of the actual value.
+  """
+  def _f(value):
+    return StaticValueProvider(type, value)
+  return _f
 
 
 class PipelineOptions(HasDisplayData):

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -24,8 +24,8 @@ import hamcrest as hc
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.utils.pipeline_options import PipelineOptions
-from apache_beam.utils.pipeline_options import static_value_provider_of
 from apache_beam.utils.value_provider import StaticValueProvider
+from apache_beam.utils.value_provider import RuntimeValueProvider
 
 
 class PipelineOptionsTest(unittest.TestCase):
@@ -172,25 +172,49 @@ class PipelineOptionsTest(unittest.TestCase):
     options = PipelineOptions(flags=[''])
     self.assertEqual(options.get_all_options()['template_location'], None)
 
-  def test_static_value_provider_of(self):
-    class TestOptions(PipelineOptions):
+  def test_value_provider_options(self):
+    class UserOptions(PipelineOptions):
       @classmethod
       def _add_argparse_args(cls, parser):
+        parser.add_value_provider_argument(
+            '--vp_arg',
+            help='This flag is a value provider')
+
+        parser.add_value_provider_argument(
+            '--vp_arg2',
+            default=1,
+            type=int)
+
         parser.add_argument(
-            '--int_flag',
-            type=static_value_provider_of(int),
-            help='--int_flag description')
-        parser.add_argument(
-            '--str_flag',
-            type=static_value_provider_of(str),
-            help='--str_flag descriptions')
-    # TODO: Make flags be capable of having
-    # the same name for vp and non-vp values.
-    options = TestOptions(['--int_flag', '1', '--str_flag', '/dev/null'])
-    assert isinstance(options.int_flag, StaticValueProvider)
-    assert isinstance(options.str_flag, StaticValueProvider)
-    assert options.int_flag.get() == 1
-    assert options.str_flag.get() == '/dev/null'
+            '--non_vp_arg',
+            default=1,
+            type=int
+        )
+
+    # Provide values: if not provided, the option becomes of the type runtime vp
+    options = UserOptions(['--vp_arg', 'hello'])
+    self.assertIsInstance(options.vp_arg, StaticValueProvider)
+    self.assertIsInstance(options.vp_arg2, RuntimeValueProvider)
+    self.assertIsInstance(options.non_vp_arg, int)
+
+    # Values can be overwritten
+    options = UserOptions(vp_arg=5,
+                          vp_arg2=StaticValueProvider(value_type=str,
+                                                      value='bye'),
+                          non_vp_arg=RuntimeValueProvider(
+                              pipeline_options_subclass=UserOptions,
+                              option_name='foo',
+                              value_type=int,
+                              default_value=10,
+                              optionsid='id'))
+    self.assertEqual(options.vp_arg, 5)
+    self.assertTrue(options.vp_arg2.is_accessible(),
+                    '%s is not accessible' % options.vp_arg2)
+    self.assertEqual(options.vp_arg2.get(), 'bye')
+    self.assertEqual(options.non_vp_arg.is_accessible(), False)
+
+    with self.assertRaises(RuntimeError):
+      options.non_vp_arg.get()
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/utils/pipeline_options_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_test.py
@@ -24,6 +24,8 @@ import hamcrest as hc
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 from apache_beam.utils.pipeline_options import PipelineOptions
+from apache_beam.utils.pipeline_options import static_value_provider_of
+from apache_beam.utils.value_provider import StaticValueProvider
 
 
 class PipelineOptionsTest(unittest.TestCase):
@@ -169,6 +171,26 @@ class PipelineOptionsTest(unittest.TestCase):
 
     options = PipelineOptions(flags=[''])
     self.assertEqual(options.get_all_options()['template_location'], None)
+
+  def test_static_value_provider_of(self):
+    class TestOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--int_flag',
+            type=static_value_provider_of(int),
+            help='--int_flag description')
+        parser.add_argument(
+            '--str_flag',
+            type=static_value_provider_of(str),
+            help='--str_flag descriptions')
+    # TODO: Make flags be capable of having
+    # the same name for vp and non-vp values.
+    options = TestOptions(['--int_flag', '1', '--str_flag', '/dev/null'])
+    assert isinstance(options.int_flag, StaticValueProvider)
+    assert isinstance(options.str_flag, StaticValueProvider)
+    assert options.int_flag.get() == 1
+    assert options.str_flag.get() == '/dev/null'
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/utils/value_provider.py
+++ b/sdks/python/apache_beam/utils/value_provider.py
@@ -1,0 +1,50 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A ValueProvider class to implement templates with both hard-coded
+and dynamically provided values.
+"""
+
+
+class ValueProvider(object):
+  def is_accessible(self):
+    raise NotImplementedError(
+        'ValueProvider.is_accessible implemented in derived classes'
+    )
+
+  def get(self):
+    raise NotImplementedError(
+        'ValueProvider.get implemented in derived classes'
+    )
+
+
+class StaticValueProvider(object):
+  def __init__(self, value_class, value):
+    self.value_class = value_class
+    self.data = value_class(value)
+    self.accessible = True
+
+  def is_accessible(self):
+    return self.accessible
+
+  def get(self):
+    return self.data
+
+  def __str__(self):
+    return '%s(type=%s, value=%s)' % (self.__class__.__name__,
+                                      self.value_class.__name__,
+                                      repr(self.data))


### PR DESCRIPTION
- [x] Add ValueProvider class.
- [x] Derive StaticValueProvider and RuntimeValueProvider from ValueProvider.
- [x] Derive ValueProviderArgumentParser from argparse.ArgumentParser as API for the template user.
- [x] Modify FileBasedSource I/O transforms to accept objects of type ValueProvider.
- [x] Modify display_data.
- [ ] Modify other I/O transforms.
- [ ] Handle serialization / deserialization