### PR TITLE
FlinkRunner: also disable the FlattenWithHeterogeneousCoders test in the streaming suite

### DIFF
--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -86,6 +86,7 @@
                 <configuration>
                   <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
                   <excludedGroups>
+                    org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders,
                     org.apache.beam.sdk.testing.UsesStatefulParDo,
                     org.apache.beam.sdk.testing.UsesTimersInParDo,
                     org.apache.beam.sdk.testing.UsesSplittableParDo,


### PR DESCRIPTION
CC: @tgroh 
