### PR TITLE
[BEAM-1260] Captures assertion site and message in PAssert

### DIFF
--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.fail;
 import com.datatorrent.api.DAG;
 import com.datatorrent.api.Sink;
 import com.datatorrent.lib.util.KryoCloneUtils;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
@@ -183,7 +182,7 @@ public class ParDoBoundTranslatorTest {
             + " but the message was \""
             + exc.getMessage()
             + "\"",
-        expectedPattern.matcher(Throwables.getStackTraceAsString(exc)).find());
+        expectedPattern.matcher(exc.getMessage()).find());
   }
 
   @Test

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslatorTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import com.datatorrent.api.DAG;
 import com.datatorrent.api.Sink;
 import com.datatorrent.lib.util.KryoCloneUtils;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
@@ -182,7 +183,7 @@ public class ParDoBoundTranslatorTest {
             + " but the message was \""
             + exc.getMessage()
             + "\"",
-        expectedPattern.matcher(exc.getMessage()).find());
+        expectedPattern.matcher(Throwables.getStackTraceAsString(exc)).find());
   }
 
   @Test

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -391,7 +391,8 @@ public class PAssert {
 
     public AssertionError wrap(Throwable t) {
       AssertionError res =
-          new AssertionError(message.isEmpty() ? "PAssert assertion failed" : message, t);
+          new AssertionError(
+              message.isEmpty() ? t.getMessage() : (message + ": " + t.getMessage()), t);
       res.setStackTrace(creationStackTrace);
       return res;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.InputStream;
@@ -378,7 +379,7 @@ public class PAssertTest implements Serializable {
             + " but the message was \""
             + exc.getMessage()
             + "\"",
-        expectedPattern.matcher(exc.getMessage()).find());
+        expectedPattern.matcher(Throwables.getStackTraceAsString(exc)).find());
   }
 
   @Test
@@ -389,7 +390,29 @@ public class PAssertTest implements Serializable {
 
     Throwable thrown = runExpectingAssertionFailure(pipeline);
 
-    assertThat(thrown.getMessage(), containsString("Expected: iterable over [] in any order"));
+    assertThat(
+        Throwables.getStackTraceAsString(thrown),
+        containsString("Expected: iterable over [] in any order"));
+  }
+
+  @Test
+  @Category(RunnableOnService.class)
+  public void testAssertionSiteAndMessageIsCaptured() throws Exception {
+    PCollection<Long> vals = pipeline.apply(CountingInput.upTo(5L));
+    assertThatCollectionIsEmpty(vals);
+
+    Throwable thrown = runExpectingAssertionFailure(pipeline);
+
+    String str = Throwables.getStackTraceAsString(thrown);
+    assertThat(
+        str,
+        containsString("Expected: iterable over [] in any order"));
+    assertThat(str, containsString("testAssertionSiteAndMessageIsCaptured"));
+    assertThat(str, containsString("assertThatCollectionIsEmpty"));
+  }
+
+  private static void assertThatCollectionIsEmpty(PCollection<Long> vals) {
+    PAssert.that("Should be empty", vals).empty();
   }
 
   private static Throwable runExpectingAssertionFailure(Pipeline pipeline) {


### PR DESCRIPTION
This makes PAssert failures quite a bit easier to debug.
Example message after this commit:

```
java.lang.AssertionError: Some message

	at org.apache.beam.sdk.testing.PAssert$PAssertionSite.capture(PAssert.java:384)
	at org.apache.beam.sdk.testing.PAssert.that(PAssert.java:279)
	at org.apache.beam.sdk.transforms.SplittableDoFnTest.testPairWithIndexWindowedTimestamped(SplittableDoFnTest.java:234)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        ...
Caused by: java.lang.AssertionError:
Expected: iterable over [<TimestampedValue(KV{z, 0}, 2017-01-10T00:38:28.000Z)>, <TimestampedValue(KV{bb, 0}, 2017-01-10T00:38:29.000Z)>, <TimestampedValue(KV{bb, 1}, 2017-01-10T00:38:29.000Z)>, <TimestampedValue(KV{ccccc, 0}, 2017-01-10T00:38:30.000Z)>, <TimestampedValue(KV{ccccc, 1}, 2017-01-10T00:38:30.000Z)>, <TimestampedValue(KV{ccccc, 2}, 2017-01-10T00:38:30.000Z)>, <TimestampedValue(KV{ccccc, 3}, 2017-01-10T00:38:30.000Z)>, <TimestampedValue(KV{ccccc, 4}, 2017-01-10T00:38:30.000Z)>] in any order
     but: Not matched: <TimestampedValue(KV{a, 0}, 2017-01-10T00:38:28.000Z)>
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.apache.beam.sdk.testing.PAssert$AssertContainsInAnyOrder.apply(PAssert.java:1270)
	at org.apache.beam.sdk.testing.PAssert$AssertContainsInAnyOrder.apply(PAssert.java:1)
        ...
```

(as opposed to, basically, just the "Caused by" part)

Inspiration for this CL was when this test failed while working on something else, but didn't tell me which of the assertions was wrong. https://github.com/apache/beam/blob/master/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java#L157-L159

R: @kennknowles 