### PR TITLE
[BEAM-1188] Python File Verifier For E2E Tests

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_it_test.py
@@ -33,7 +33,7 @@ class WordCountIT(unittest.TestCase):
 
   # The default checksum is a SHA-1 hash generated from a sorted list of
   # lines read from expected output.
-  DEFAULT_CHECKSUM = 'c780e9466b8635af1d11b74bbd35233a82908a02'
+  DEFAULT_CHECKSUM = '33535a832b7db6d78389759577d4ff495980b9c0'
 
   @attr('IT')
   def test_wordcount_it(self):

--- a/sdks/python/apache_beam/examples/wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_it_test.py
@@ -20,7 +20,6 @@
 import logging
 import unittest
 
-from datetime import datetime as dt
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr
 
@@ -32,6 +31,8 @@ from apache_beam.tests.pipeline_verifiers import FileChecksumMatcher
 
 class WordCountIT(unittest.TestCase):
 
+  # The default checksum is a SHA-1 hash generated from a sorted list of
+  # lines read from expected output.
   DEFAULT_CHECKSUM = 'c780e9466b8635af1d11b74bbd35233a82908a02'
 
   @attr('IT')
@@ -40,7 +41,7 @@ class WordCountIT(unittest.TestCase):
 
     # Set extra options to the pipeline for test purpose
     output = '/'.join([test_pipeline.get_option('output'),
-                       dt.now().strftime('py-wordcount-%Y-%m-%d-%H-%M-%S'),
+                       test_pipeline.get_option('job_name'),
                        'results'])
     pipeline_verifiers = [PipelineStateMatcher(),
                           FileChecksumMatcher(output + '*-of-*',

--- a/sdks/python/apache_beam/test_pipeline.py
+++ b/sdks/python/apache_beam/test_pipeline.py
@@ -117,7 +117,7 @@ class TestPipeline(Pipeline):
 
     Append extra pipeline options to existing option list if provided.
     Test verifier (if contains in extra options) should be pickled before
-    append, and will be unpickled later in TestRunner.
+    appending, and will be unpickled later in the TestRunner.
     """
     options = list(self.options_list)
     for k, v in extra_opts.items():

--- a/sdks/python/apache_beam/test_pipeline_test.py
+++ b/sdks/python/apache_beam/test_pipeline_test.py
@@ -19,7 +19,6 @@
 
 import logging
 import unittest
-import mock
 
 from hamcrest.core.base_matcher import BaseMatcher
 from hamcrest.core.assert_that import assert_that as hc_assert_that
@@ -76,7 +75,9 @@ class TestPipelineTest(unittest.TestCase):
       {'options': {'student': True},
        'expected': ['--student']},
       {'options': {'student': False},
-       'expected': []}
+       'expected': []},
+      {'options': {'name': 'Mark', 'student': True},
+       'expected': ['--name=Mark', '--student']}
   ]
 
   def test_append_extra_options(self):
@@ -90,7 +91,7 @@ class TestPipelineTest(unittest.TestCase):
     opt_list = TestPipeline().get_full_options_as_args(**extra_opt)
     matcher = pickler.loads(opt_list[0].split('=')[1])
     self.assertTrue(isinstance(matcher, BaseMatcher))
-    hc_assert_that(mock.Mock(), matcher)
+    hc_assert_that(None, matcher)
 
   def test_get_option(self):
     name, value = ('job', 'mockJob')

--- a/sdks/python/apache_beam/test_pipeline_test.py
+++ b/sdks/python/apache_beam/test_pipeline_test.py
@@ -17,10 +17,22 @@
 
 """Unit test for the TestPipeline class"""
 
+import logging
 import unittest
+import mock
 
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.assert_that import assert_that as hc_assert_that
+
+from apache_beam.internal import pickler
 from apache_beam.test_pipeline import TestPipeline
 from apache_beam.utils.pipeline_options import PipelineOptions
+
+
+# A simple matcher that is ued for testing extra options appending.
+class SimpleMatcher(BaseMatcher):
+  def _matches(self, item):
+    return True
 
 
 class TestPipelineTest(unittest.TestCase):
@@ -32,9 +44,6 @@ class TestPipelineTest(unittest.TestCase):
                                  'male': True,
                                  'age': 1}}
 
-  def setUp(self):
-    self.pipeline = TestPipeline()
-
   # Used for testing pipeline option creation.
   class TestParsingOptions(PipelineOptions):
 
@@ -45,19 +54,57 @@ class TestPipelineTest(unittest.TestCase):
       parser.add_argument('--age', action='store', type=int, help='mock age')
 
   def test_option_args_parsing(self):
+    test_pipeline = TestPipeline(argv=self.TEST_CASE['options'])
     self.assertListEqual(
-        self.pipeline.get_test_option_args(argv=self.TEST_CASE['options']),
+        test_pipeline.get_full_options_as_args(),
         self.TEST_CASE['expected_list'])
 
+  def test_empty_option_args_parsing(self):
+    test_pipeline = TestPipeline()
+    self.assertListEqual([],
+                         test_pipeline.get_full_options_as_args())
+
   def test_create_test_pipeline_options(self):
-    test_options = PipelineOptions(
-        self.pipeline.get_test_option_args(self.TEST_CASE['options']))
-    self.assertDictContainsSubset(
-        self.TEST_CASE['expected_dict'], test_options.get_all_options())
+    test_pipeline = TestPipeline(argv=self.TEST_CASE['options'])
+    test_options = PipelineOptions(test_pipeline.get_full_options_as_args())
+    self.assertDictContainsSubset(self.TEST_CASE['expected_dict'],
+                                  test_options.get_all_options())
+
+  EXTRA_OPT_CASES = [
+      {'options': {'name': 'Mark'},
+       'expected': ['--name=Mark']},
+      {'options': {'student': True},
+       'expected': ['--student']},
+      {'options': {'student': False},
+       'expected': []}
+  ]
 
   def test_append_extra_options(self):
-    extra_opt = {'name': 'Mark'}
-    options_list = self.pipeline.get_test_option_args(
-        argv=self.TEST_CASE['options'], **extra_opt)
-    expected_list = self.TEST_CASE['expected_list'] + ['--name=Mark']
-    self.assertListEqual(expected_list, options_list)
+    test_pipeline = TestPipeline()
+    for case in self.EXTRA_OPT_CASES:
+      opt_list = test_pipeline.get_full_options_as_args(**case['options'])
+      self.assertListEqual(opt_list, case['expected'])
+
+  def test_append_verifier_in_extra_opt(self):
+    extra_opt = {'matcher': SimpleMatcher()}
+    opt_list = TestPipeline().get_full_options_as_args(**extra_opt)
+    matcher = pickler.loads(opt_list[0].split('=')[1])
+    self.assertTrue(isinstance(matcher, BaseMatcher))
+    hc_assert_that(mock.Mock(), matcher)
+
+  def test_get_option(self):
+    name, value = ('job', 'mockJob')
+    test_pipeline = TestPipeline()
+    test_pipeline.options_list = ['--%s=%s' % (name, value)]
+    self.assertEqual(test_pipeline.get_option(name), value)
+
+  def test_skip_IT(self):
+    test_pipeline = TestPipeline(is_integration_test=True)
+    test_pipeline.run()
+    # Note that this will never be reached since it should be skipped above.
+    self.fail()
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/tests/pipeline_verifiers_test.py
+++ b/sdks/python/apache_beam/tests/pipeline_verifiers_test.py
@@ -18,27 +18,37 @@
 """Unit tests for the test pipeline verifiers"""
 
 import logging
+import tempfile
 import unittest
 
+from hamcrest import assert_that as hc_assert_that
+from mock import Mock, patch
+
+from apache_beam.io.fileio import TextFileSource
 from apache_beam.runners.runner import PipelineState
 from apache_beam.runners.runner import PipelineResult
-from apache_beam.tests.pipeline_verifiers import PipelineStateMatcher
-from hamcrest import assert_that as hc_assert_that
+from apache_beam.tests import pipeline_verifiers as verifiers
+from apache_beam.tests.test_utils import patch_retry
 
 
 class PipelineVerifiersTest(unittest.TestCase):
+
+  def setUp(self):
+    self._mock_result = Mock()
+    patch_retry(self, verifiers)
 
   def test_pipeline_state_matcher_success(self):
     """Test PipelineStateMatcher successes when using default expected state
     and job actually finished in DONE
     """
     pipeline_result = PipelineResult(PipelineState.DONE)
-    hc_assert_that(pipeline_result, PipelineStateMatcher())
+    hc_assert_that(pipeline_result, verifiers.PipelineStateMatcher())
 
   def test_pipeline_state_matcher_given_state(self):
     """Test PipelineStateMatcher successes when matches given state"""
     pipeline_result = PipelineResult(PipelineState.FAILED)
-    hc_assert_that(pipeline_result, PipelineStateMatcher(PipelineState.FAILED))
+    hc_assert_that(pipeline_result,
+                   verifiers.PipelineStateMatcher(PipelineState.FAILED))
 
   def test_pipeline_state_matcher_fails(self):
     """Test PipelineStateMatcher fails when using default expected state
@@ -53,7 +63,52 @@ class PipelineVerifiersTest(unittest.TestCase):
     for state in failed_state:
       pipeline_result = PipelineResult(state)
       with self.assertRaises(AssertionError):
-        hc_assert_that(pipeline_result, PipelineStateMatcher())
+        hc_assert_that(pipeline_result, verifiers.PipelineStateMatcher())
+
+  test_cases = [
+      {'content': 'Test FileChecksumMatcher with single file',
+       'num_files': 1,
+       'expected_checksum': 'ebe16840cc1d0b4fe1cf71743e9d772fa31683b8'},
+      {'content': 'Test FileChecksumMatcher with multiple files',
+       'num_files': 3,
+       'expected_checksum': '58b3d3636de3891ac61afb8ace3b5025c3c37d44'},
+      {'content': '',
+       'num_files': 1,
+       'expected_checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709'},
+  ]
+
+  def create_temp_file(self, content, directory=None):
+    with tempfile.NamedTemporaryFile(delete=False, dir=directory) as f:
+      f.write(content)
+      return f.name
+
+  def test_file_checksum_matcher_success(self):
+    for case in self.test_cases:
+      temp_dir = tempfile.mkdtemp()
+      for _ in range(case['num_files']):
+        self.create_temp_file(case['content'], temp_dir)
+      matcher = verifiers.FileChecksumMatcher(temp_dir + '/*',
+                                              case['expected_checksum'])
+      hc_assert_that(self._mock_result, matcher)
+
+  @patch.object(TextFileSource, 'reader')
+  def test_file_checksum_matcher_read_failed(self, mock_reader):
+    mock_reader.side_effect = IOError('No file found.')
+    matcher = verifiers.FileChecksumMatcher('dummy/path', Mock())
+    with self.assertRaises(IOError):
+      hc_assert_that(self._mock_result, matcher)
+    self.assertTrue(mock_reader.called)
+    self.assertEqual(verifiers.MAX_RETRIES + 1, mock_reader.call_count)
+
+  @patch.object(TextFileSource, 'reader')
+  def test_file_checksum_matcher_service_error(self, mock_reader):
+    mock_reader.side_effect = RuntimeError('GCS service failed.')
+    matcher = verifiers.FileChecksumMatcher('dummy/path', Mock())
+    with self.assertRaises(RuntimeError):
+      hc_assert_that(self._mock_result, matcher)
+    self.assertTrue(mock_reader.called)
+    self.assertEqual(verifiers.MAX_RETRIES + 1, mock_reader.call_count)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/tests/test_utils.py
+++ b/sdks/python/apache_beam/tests/test_utils.py
@@ -23,8 +23,17 @@ from mock import Mock, patch
 from apache_beam.utils import retry
 
 
-def patch_retry(cls, module):
-  """A function to patch retry module to use mock clock and logger."""
+def patch_retry(testcase, module):
+  """A function to patch retry module to use mock clock and logger.
+
+  Clock and logger that defined in retry decorator will be replaced in test
+  in order to skip sleep phase when retry happens.
+
+  Args:
+    testcase: A test class that calls this function to patch retry module.
+    module: The module that uses retry and need to be replaced with mock
+      clock and logger in test.
+  """
   real_retry_with_exponential_backoff = retry.with_exponential_backoff
 
   def patched_retry_with_exponential_backoff(num_retries, retry_filter):
@@ -44,4 +53,4 @@ def patch_retry(cls, module):
     # Reload module again after removing patch.
     imp.reload(module)
 
-  cls.addCleanup(kill_patches)
+  testcase.addCleanup(kill_patches)

--- a/sdks/python/apache_beam/tests/test_utils.py
+++ b/sdks/python/apache_beam/tests/test_utils.py
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Utility methods for testing"""
+
+import imp
+from mock import Mock, patch
+
+from apache_beam.utils import retry
+
+
+def patch_retry(cls, module):
+  """A function to patch retry module to use mock clock and logger."""
+  real_retry_with_exponential_backoff = retry.with_exponential_backoff
+
+  def patched_retry_with_exponential_backoff(num_retries, retry_filter):
+    """A patch for retry decorator to use a mock dummy clock and logger."""
+    return real_retry_with_exponential_backoff(
+        num_retries=num_retries, retry_filter=retry_filter, logger=Mock(),
+        clock=Mock())
+
+  patch.object(retry, 'with_exponential_backoff',
+               side_effect=patched_retry_with_exponential_backoff).start()
+
+  # Reload module after patching.
+  imp.reload(module)
+
+  def kill_patches():
+    patch.stopall()
+    # Reload module again after removing patch.
+    imp.reload(module)
+
+  cls.addCleanup(kill_patches)

--- a/sdks/python/apache_beam/tests/test_utils.py
+++ b/sdks/python/apache_beam/tests/test_utils.py
@@ -30,7 +30,8 @@ def patch_retry(testcase, module):
   in order to skip sleep phase when retry happens.
 
   Args:
-    testcase: A test class that calls this function to patch retry module.
+    testcase: An instance of unittest.TestCase that calls this function to
+      patch retry module.
     module: The module that uses retry and need to be replaced with mock
       clock and logger in test.
   """
@@ -48,9 +49,9 @@ def patch_retry(testcase, module):
   # Reload module after patching.
   imp.reload(module)
 
-  def kill_patches():
+  def remove_patches():
     patch.stopall()
     # Reload module again after removing patch.
     imp.reload(module)
 
-  testcase.addCleanup(kill_patches)
+  testcase.addCleanup(remove_patches)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Add FileChecksumVerifier to verify E2E test output file(s) after pipeline job finished:
 - Refactor TestPipeline to be clean and able to get option value by name
 - Create FileChecksumVerifier with retry when IO failed.
 - Add FileChecksumVerifier to wordcount e2e test which is running in postcommit.
 - Create test_utils to hold utility method for testing.

Test is done by running wordcount_it against Dataflow service.