### PR TITLE
[BEAM-1260] Revert "Captures assertion site and message in PAssert"

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.InputStream;
@@ -391,49 +390,6 @@ public class PAssertTest implements Serializable {
     Throwable thrown = runExpectingAssertionFailure(pipeline);
 
     assertThat(thrown.getMessage(), containsString("Expected: iterable over [] in any order"));
-  }
-
-  @Test
-  @Category(RunnableOnService.class)
-  public void testAssertionSiteIsCapturedWithMessage() throws Exception {
-    PCollection<Long> vals = pipeline.apply(CountingInput.upTo(5L));
-    assertThatCollectionIsEmptyWithMessage(vals);
-
-    Throwable thrown = runExpectingAssertionFailure(pipeline);
-
-    assertThat(
-        thrown.getMessage(),
-        containsString("Should be empty"));
-    assertThat(
-        thrown.getMessage(),
-        containsString("Expected: iterable over [] in any order"));
-    String stacktrace = Throwables.getStackTraceAsString(thrown);
-    assertThat(stacktrace, containsString("testAssertionSiteIsCapturedWithMessage"));
-    assertThat(stacktrace, containsString("assertThatCollectionIsEmptyWithMessage"));
-  }
-
-  @Test
-  @Category(RunnableOnService.class)
-  public void testAssertionSiteIsCapturedWithoutMessage() throws Exception {
-    PCollection<Long> vals = pipeline.apply(CountingInput.upTo(5L));
-    assertThatCollectionIsEmptyWithoutMessage(vals);
-
-    Throwable thrown = runExpectingAssertionFailure(pipeline);
-
-    assertThat(
-        thrown.getMessage(),
-        containsString("Expected: iterable over [] in any order"));
-    String stacktrace = Throwables.getStackTraceAsString(thrown);
-    assertThat(stacktrace, containsString("testAssertionSiteIsCapturedWithoutMessage"));
-    assertThat(stacktrace, containsString("assertThatCollectionIsEmptyWithoutMessage"));
-  }
-
-  private static void assertThatCollectionIsEmptyWithMessage(PCollection<Long> vals) {
-    PAssert.that("Should be empty", vals).empty();
-  }
-
-  private static void assertThatCollectionIsEmptyWithoutMessage(PCollection<Long> vals) {
-    PAssert.that(vals).empty();
   }
 
   private static Throwable runExpectingAssertionFailure(Pipeline pipeline) {


### PR DESCRIPTION
This reverts commit c62611c73ab0f9a5769f3ee9b28b11e917628f78.

It breaks post-commit Dataflow and Flink runners, e.g. https://builds.apache.org/job/beam_PostCommit_Java_RunnableOnService_Dataflow/2010/org.apache.beam$beam-runners-google-cloud-dataflow-java/consoleFull

R: @kennknowles 