### PR TITLE
[BEAM-886] Implement annotation based NewDoFn in Python SDK

### DIFF
--- a/sdks/python/apache_beam/dataflow_test.py
+++ b/sdks/python/apache_beam/dataflow_test.py
@@ -32,7 +32,7 @@ from apache_beam.pvalue import EmptySideInput
 from apache_beam.pvalue import SideOutputValue
 from apache_beam.test_pipeline import TestPipeline
 from apache_beam.transforms import Create
-from apache_beam.transforms import DoFn
+from apache_beam.transforms import NewDoFn
 from apache_beam.transforms import FlatMap
 from apache_beam.transforms import GroupByKey
 from apache_beam.transforms import Map
@@ -109,11 +109,11 @@ class DataflowTest(unittest.TestCase):
 
   @attr('ValidatesRunner')
   def test_par_do_with_do_fn_object(self):
-    class SomeDoFn(DoFn):
+    class SomeDoFn(NewDoFn):
       """A custom DoFn for a FlatMap transform."""
 
-      def process(self, context, prefix, suffix):
-        return ['%s-%s-%s' % (prefix, context.element, suffix)]
+      def process(self, element, prefix, suffix):
+        return ['%s-%s-%s' % (prefix, element, suffix)]
 
     pipeline = TestPipeline()
     words_list = ['aa', 'bb', 'cc']
@@ -127,15 +127,15 @@ class DataflowTest(unittest.TestCase):
 
   @attr('ValidatesRunner')
   def test_par_do_with_multiple_outputs_and_using_yield(self):
-    class SomeDoFn(DoFn):
+    class SomeDoFn(NewDoFn):
       """A custom DoFn using yield."""
 
-      def process(self, context):
-        yield context.element
-        if context.element % 2 == 0:
-          yield SideOutputValue('even', context.element)
+      def process(self, element):
+        yield element
+        if element % 2 == 0:
+          yield SideOutputValue('even', element)
         else:
-          yield SideOutputValue('odd', context.element)
+          yield SideOutputValue('odd', element)
 
     pipeline = TestPipeline()
     nums = pipeline | 'Some Numbers' >> Create([1, 2, 3, 4])

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions.py
@@ -104,20 +104,18 @@ class TopPerMonth(beam.PTransform):
 class SessionsToStringsDoFn(beam.NewDoFn):
   """Adds the session information to be part of the key."""
 
-  def process(self, element, windows=beam.NewDoFn.WindowsParam):
-    yield (element[0] + ' : ' +
-           ', '.join([str(w) for w in windows]), element[1])
+  def process(self, element, w=beam.NewDoFn.WindowParam):
+    yield (element[0] + ' : ' + str(w), element[1])
 
 
 class FormatOutputDoFn(beam.NewDoFn):
   """Formats a string containing the user, count, and session."""
 
-  def process(self, element, windows=beam.NewDoFn.WindowsParam):
+  def process(self, element, w=beam.NewDoFn.WindowParam):
     for kv in element:
       session = kv[0]
       count = kv[1]
-      yield (session + ' : ' + str(count) + ' : '
-             + ', '.join([str(w) for w in windows]))
+      yield session + ' : ' + str(count) + ' : ' + str(w)
 
 
 class ComputeTopSessions(beam.PTransform):

--- a/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
+++ b/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
@@ -71,6 +71,7 @@ from google.datastore.v1 import query_pb2
 from googledatastore import helper as datastore_helper, PropertyFilter
 
 import apache_beam as beam
+from apache_beam import NewDoFn
 from apache_beam.io import ReadFromText
 from apache_beam.io.datastore.v1.datastoreio import ReadFromDatastore
 from apache_beam.io.datastore.v1.datastoreio import WriteToDatastore
@@ -84,10 +85,10 @@ average_word_size_aggregator = beam.Aggregator('averageWordLength',
                                                float)
 
 
-class WordExtractingDoFn(beam.DoFn):
+class WordExtractingDoFn(NewDoFn):
   """Parse each line of input text into words."""
 
-  def process(self, context):
+  def process(self, element, context=NewDoFn.ContextParam):
     """Returns an iterator over words in contents of Cloud Datastore entity.
     The element is a line of text.  If the line is blank, note that, too.
     Args:
@@ -95,7 +96,7 @@ class WordExtractingDoFn(beam.DoFn):
     Returns:
       The processed element.
     """
-    content_value = context.element.properties.get('content', None)
+    content_value = element.properties.get('content', None)
     text_line = ''
     if content_value:
       text_line = content_value.string_value

--- a/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
+++ b/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo.py
@@ -60,7 +60,7 @@ from apache_beam.utils.pipeline_options import PipelineOptions
 from apache_beam.utils.pipeline_options import SetupOptions
 
 
-class SplitLinesToWordsFn(beam.DoFn):
+class SplitLinesToWordsFn(beam.NewDoFn):
   """A transform to split a line of text into individual words.
 
   This transform will have 3 outputs:
@@ -73,7 +73,7 @@ class SplitLinesToWordsFn(beam.DoFn):
   SIDE_OUTPUT_TAG_SHORT_WORDS = 'tag_short_words'
   SIDE_OUTPUT_TAG_CHARACTER_COUNT = 'tag_character_count'
 
-  def process(self, context):
+  def process(self, element):
     """Receives a single element (a line) and produces words and side outputs.
 
     Important things to note here:
@@ -94,9 +94,9 @@ class SplitLinesToWordsFn(beam.DoFn):
     # yield a count (integer) to the SIDE_OUTPUT_TAG_CHARACTER_COUNT tagged
     # collection.
     yield pvalue.SideOutputValue(self.SIDE_OUTPUT_TAG_CHARACTER_COUNT,
-                                 len(context.element))
+                                 len(element))
 
-    words = re.findall(r'[A-Za-z\']+', context.element)
+    words = re.findall(r'[A-Za-z\']+', element)
     for word in words:
       if len(word) <= 3:
         # yield word as a side output to the SIDE_OUTPUT_TAG_SHORT_WORDS tagged

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -304,10 +304,10 @@ def pipeline_logging(lines, output):
   # import Python logging module.
   import logging
 
-  class ExtractWordsFn(beam.DoFn):
+  class ExtractWordsFn(beam.NewDoFn):
 
-    def process(self, context):
-      words = re.findall(r'[A-Za-z\']+', context.element)
+    def process(self, element):
+      words = re.findall(r'[A-Za-z\']+', element)
       for word in words:
         yield word
 
@@ -345,17 +345,17 @@ def pipeline_monitoring(renames):
                           help='output for the pipeline',
                           default='gs://my-bucket/output')
 
-  class ExtractWordsFn(beam.DoFn):
+  class ExtractWordsFn(beam.NewDoFn):
 
-    def process(self, context):
-      words = re.findall(r'[A-Za-z\']+', context.element)
+    def process(self, element):
+      words = re.findall(r'[A-Za-z\']+', element)
       for word in words:
         yield word
 
-  class FormatCountsFn(beam.DoFn):
+  class FormatCountsFn(beam.NewDoFn):
 
-    def process(self, context):
-      word, count = context.element
+    def process(self, element):
+      word, count = element
       yield '%s: %s' % (word, count)
 
   # [START pipeline_monitoring_composite]
@@ -489,10 +489,10 @@ def examples_wordcount_wordcount(renames):
   # [END examples_wordcount_wordcount_composite]
 
   # [START examples_wordcount_wordcount_dofn]
-  class FormatAsTextFn(beam.DoFn):
+  class FormatAsTextFn(beam.NewDoFn):
 
-    def process(self, context):
-      word, count = context.element
+    def process(self, element):
+      word, count = element
       yield '%s: %s' % (word, count)
 
   formatted = counts | beam.ParDo(FormatAsTextFn())
@@ -513,7 +513,7 @@ def examples_wordcount_debugging(renames):
   # [START example_wordcount_debugging_aggregators]
   import logging
 
-  class FilterTextFn(beam.DoFn):
+  class FilterTextFn(beam.NewDoFn):
     """A DoFn that filters for a specific key based on a regular expression."""
 
     # A custom aggregator can track values in your pipeline as it runs. Create
@@ -524,8 +524,8 @@ def examples_wordcount_debugging(renames):
     def __init__(self, pattern):
       self.pattern = pattern
 
-    def process(self, context):
-      word, _ = context.element
+    def process(self, element, context=beam.NewDoFn.ContextParam):
+      word, _ = element
       if re.match(self.pattern, word):
         # Log at INFO level each element we match. When executing this pipeline
         # using the Dataflow service, these log lines will appear in the Cloud
@@ -534,7 +534,7 @@ def examples_wordcount_debugging(renames):
 
         # Add 1 to the custom aggregator matched_words
         context.aggregate_to(self.matched_words, 1)
-        yield context.element
+        yield element
       else:
         # Log at the "DEBUG" level each element that is not matched. Different
         # log levels can be used to control the verbosity of logging providing

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -36,10 +36,10 @@ average_word_size_aggregator = beam.Aggregator('averageWordLength',
                                                float)
 
 
-class WordExtractingDoFn(beam.DoFn):
+class WordExtractingDoFn(beam.NewDoFn):
   """Parse each line of input text into words."""
 
-  def process(self, context):
+  def process(self, element, context=beam.NewDoFn.ContextParam):
     """Returns an iterator over the words of this element.
 
     The element is a line of text.  If the line is blank, note that, too.
@@ -50,7 +50,7 @@ class WordExtractingDoFn(beam.DoFn):
     Returns:
       The processed element.
     """
-    text_line = context.element.strip()
+    text_line = element.strip()
     if not text_line:
       context.aggregate_to(empty_line_aggregator, 1)
     words = re.findall(r'[A-Za-z\']+', text_line)

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -46,13 +46,14 @@ import logging
 import re
 
 import apache_beam as beam
+from apache_beam import NewDoFn
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
 from apache_beam.utils.pipeline_options import PipelineOptions
 from apache_beam.utils.pipeline_options import SetupOptions
 
 
-class FilterTextFn(beam.DoFn):
+class FilterTextFn(NewDoFn):
   """A DoFn that filters for a specific key based on a regular expression."""
 
   # A custom aggregator can track values in your pipeline as it runs. Those
@@ -68,15 +69,15 @@ class FilterTextFn(beam.DoFn):
     super(FilterTextFn, self).__init__()
     self.pattern = pattern
 
-  def process(self, context):
-    word, _ = context.element
+  def process(self, element, context=NewDoFn.ContextParam):
+    word, _ = element
     if re.match(self.pattern, word):
       # Log at INFO level each element we match. When executing this pipeline
       # using the Dataflow service, these log lines will appear in the Cloud
       # Logging UI.
       logging.info('Matched %s', word)
       context.aggregate_to(self.matched_words, 1)
-      yield context.element
+      yield element
     else:
       # Log at the "DEBUG" level each element that is not matched. Different log
       # levels can be used to control the verbosity of logging providing an

--- a/sdks/python/apache_beam/io/datastore/v1/datastoreio.py
+++ b/sdks/python/apache_beam/io/datastore/v1/datastoreio.py
@@ -25,7 +25,7 @@ from googledatastore import helper as datastore_helper
 from apache_beam.io.datastore.v1 import helper
 from apache_beam.io.datastore.v1 import query_splitter
 from apache_beam.transforms import Create
-from apache_beam.transforms import DoFn
+from apache_beam.transforms import NewDoFn
 from apache_beam.transforms import FlatMap
 from apache_beam.transforms import GroupByKey
 from apache_beam.transforms import Map
@@ -143,7 +143,7 @@ class ReadFromDatastore(PTransform):
 
     return disp_data
 
-  class SplitQueryFn(DoFn):
+  class SplitQueryFn(NewDoFn):
     """A `DoFn` that splits a given query into multiple sub-queries."""
     def __init__(self, project, query, namespace, num_splits):
       super(ReadFromDatastore.SplitQueryFn, self).__init__()
@@ -153,13 +153,12 @@ class ReadFromDatastore(PTransform):
       self._query = query
       self._num_splits = num_splits
 
-    def start_bundle(self, context):
+    def start_bundle(self):
       self._datastore = helper.get_datastore(self._project)
 
-    def process(self, p_context, *args, **kwargs):
+    def process(self, query, *args, **kwargs):
       # distinct key to be used to group query splits.
       key = 1
-      query = p_context.element
 
       # If query has a user set limit, then the query cannot be split.
       if query.HasField('limit'):
@@ -200,7 +199,7 @@ class ReadFromDatastore(PTransform):
 
       return disp_data
 
-  class ReadFn(DoFn):
+  class ReadFn(NewDoFn):
     """A DoFn that reads entities from Cloud Datastore, for a given query."""
     def __init__(self, project, namespace=None):
       super(ReadFromDatastore.ReadFn, self).__init__()
@@ -208,11 +207,10 @@ class ReadFromDatastore(PTransform):
       self._datastore_namespace = namespace
       self._datastore = None
 
-    def start_bundle(self, context):
+    def start_bundle(self):
       self._datastore = helper.get_datastore(self._project)
 
-    def process(self, p_context, *args, **kwargs):
-      query = p_context.element
+    def process(self, query, *args, **kwargs):
       # Returns an iterator of entities that reads in batches.
       entities = helper.fetch_entities(self._project, self._datastore_namespace,
                                        query, self._datastore)
@@ -322,7 +320,7 @@ class _Mutate(PTransform):
     return {'project': self._project,
             'mutation_fn': self._mutation_fn.__class__.__name__}
 
-  class DatastoreWriteFn(DoFn):
+  class DatastoreWriteFn(NewDoFn):
     """A ``DoFn`` that write mutations to Datastore.
 
     Mutations are written in batches, where the maximum batch size is
@@ -338,16 +336,16 @@ class _Mutate(PTransform):
       self._datastore = None
       self._mutations = []
 
-    def start_bundle(self, context):
+    def start_bundle(self):
       self._mutations = []
       self._datastore = helper.get_datastore(self._project)
 
-    def process(self, context):
-      self._mutations.append(context.element)
+    def process(self, element):
+      self._mutations.append(element)
       if len(self._mutations) >= _Mutate._WRITE_BATCH_SIZE:
         self._flush_batch()
 
-    def finish_bundle(self, context):
+    def finish_bundle(self):
       if self._mutations:
         self._flush_batch()
       self._mutations = []

--- a/sdks/python/apache_beam/io/datastore/v1/datastoreio_test.py
+++ b/sdks/python/apache_beam/io/datastore/v1/datastoreio_test.py
@@ -64,11 +64,9 @@ class DatastoreioTest(unittest.TestCase):
 
         split_query_fn = ReadFromDatastore.SplitQueryFn(
             self._PROJECT, self._query, None, num_splits)
-        mock_context = MagicMock()
-        mock_context.element = self._query
-        split_query_fn.start_bundle(mock_context)
+        split_query_fn.start_bundle()
         returned_split_queries = []
-        for split_query in split_query_fn.process(mock_context):
+        for split_query in split_query_fn.process(self._query):
           returned_split_queries.append(split_query)
 
         self.assertEqual(len(returned_split_queries), num_splits)
@@ -93,11 +91,9 @@ class DatastoreioTest(unittest.TestCase):
                           side_effect=fake_get_splits):
           split_query_fn = ReadFromDatastore.SplitQueryFn(
               self._PROJECT, self._query, None, num_splits)
-          mock_context = MagicMock()
-          mock_context.element = self._query
-          split_query_fn.start_bundle(mock_context)
+          split_query_fn.start_bundle()
           returned_split_queries = []
-          for split_query in split_query_fn.process(mock_context):
+          for split_query in split_query_fn.process(self._query):
             returned_split_queries.append(split_query)
 
           self.assertEqual(len(returned_split_queries), expected_num_splits)
@@ -112,11 +108,9 @@ class DatastoreioTest(unittest.TestCase):
       self._query.limit.value = 3
       split_query_fn = ReadFromDatastore.SplitQueryFn(
           self._PROJECT, self._query, None, 4)
-      mock_context = MagicMock()
-      mock_context.element = self._query
-      split_query_fn.start_bundle(mock_context)
+      split_query_fn.start_bundle()
       returned_split_queries = []
-      for split_query in split_query_fn.process(mock_context):
+      for split_query in split_query_fn.process(self._query):
         returned_split_queries.append(split_query)
 
       self.assertEqual(1, len(returned_split_queries))
@@ -138,11 +132,9 @@ class DatastoreioTest(unittest.TestCase):
                           side_effect=ValueError("Testing query split error")):
           split_query_fn = ReadFromDatastore.SplitQueryFn(
               self._PROJECT, self._query, None, num_splits)
-          mock_context = MagicMock()
-          mock_context.element = self._query
-          split_query_fn.start_bundle(mock_context)
+          split_query_fn.start_bundle()
           returned_split_queries = []
-          for split_query in split_query_fn.process(mock_context):
+          for split_query in split_query_fn.process(self._query):
             returned_split_queries.append(split_query)
 
           self.assertEqual(len(returned_split_queries), expected_num_splits)
@@ -182,12 +174,10 @@ class DatastoreioTest(unittest.TestCase):
 
       datastore_write_fn = _Mutate.DatastoreWriteFn(self._PROJECT)
 
-      mock_context = MagicMock()
-      datastore_write_fn.start_bundle(mock_context)
+      datastore_write_fn.start_bundle()
       for mutation in expected_mutations:
-        mock_context.element = mutation
-        datastore_write_fn.process(mock_context)
-      datastore_write_fn.finish_bundle(mock_context)
+        datastore_write_fn.process(mutation)
+      datastore_write_fn.finish_bundle()
 
       self.assertEqual(actual_mutations, expected_mutations)
       self.assertEqual((num_entities - 1) / _Mutate._WRITE_BATCH_SIZE + 1,

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -105,6 +105,22 @@ class PipelineTest(unittest.TestCase):
     assert_that(pcoll3, equal_to([14, 15, 16]), label='pcoll3')
     pipeline.run()
 
+  def test_flatmap_builtin(self):
+    pipeline = TestPipeline(runner=self.runner_name)
+    pcoll = pipeline | 'label1' >> Create([1, 2, 3])
+    assert_that(pcoll, equal_to([1, 2, 3]))
+
+    pcoll2 = pcoll | 'do' >> FlatMap(lambda x: [x + 10])
+    assert_that(pcoll2, equal_to([11, 12, 13]), label='pcoll2')
+
+    pcoll3 = pcoll2 | 'm1' >> Map(lambda x: [x, 12])
+    assert_that(pcoll3,
+                equal_to([[11, 12], [12, 12], [13, 12]]), label='pcoll3')
+
+    pcoll4 = pcoll3 | 'do2' >> FlatMap(set)
+    assert_that(pcoll4, equal_to([11, 12, 12, 12, 13]), label='pcoll4')
+    pipeline.run()
+
   def test_create_singleton_pcollection(self):
     pipeline = TestPipeline(runner=self.runner_name)
     pcoll = pipeline | 'label' >> Create([[1, 2, 3]])

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -36,6 +36,10 @@ cdef class DoFnRunner(Receiver):
   cdef object tagged_receivers
   cdef LoggingContext logging_context
   cdef object step_name
+  cdef object is_new_dofn
+  cdef object args
+  cdef object kwargs
+  cdef object side_inputs
   cdef bint has_windowed_side_inputs
 
   cdef Receiver main_receivers

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -20,7 +20,6 @@
 """Worker operations executor."""
 
 import sys
-import types
 
 from apache_beam.internal import util
 from apache_beam.pvalue import SideOutputValue
@@ -151,7 +150,6 @@ class DoFnRunner(Receiver):
 
         self.dofn = CurriedFn()
 
-
   def receive(self, windowed_value):
     self.process(windowed_value)
 
@@ -170,9 +168,7 @@ class DoFnRunner(Receiver):
     arguments, _, _, defaults = self.dofn.get_function_arguments('process')
     defaults = defaults if defaults else []
 
-    self_in_args = int(isinstance(self.dofn.process, types.MethodType) and \
-        self.dofn.process.im_self is not None and \
-        'self' in arguments)
+    self_in_args = int(self.dofn.is_process_bounded())
 
     # Call for the process function for each window if has windowed side inputs
     # otherwise we can optimize the runner by calling process for entire window

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -29,7 +29,7 @@ from apache_beam.runners.direct import DirectRunner
 from apache_beam.runners.direct.consumer_tracking_pipeline_visitor import ConsumerTrackingPipelineVisitor
 from apache_beam.transforms import CoGroupByKey
 from apache_beam.transforms import Create
-from apache_beam.transforms import DoFn
+from apache_beam.transforms import NewDoFn
 from apache_beam.transforms import FlatMap
 from apache_beam.transforms import Flatten
 from apache_beam.transforms import ParDo
@@ -74,18 +74,18 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
   def test_side_inputs(self):
 
-    class SplitNumbersFn(DoFn):
+    class SplitNumbersFn(NewDoFn):
 
-      def process(self, context):
-        if context.element < 0:
-          yield pvalue.SideOutputValue('tag_negative', context.element)
+      def process(self, element):
+        if element < 0:
+          yield pvalue.SideOutputValue('tag_negative', element)
         else:
-          yield context.element
+          yield element
 
-    class ProcessNumbersFn(DoFn):
+    class ProcessNumbersFn(NewDoFn):
 
-      def process(self, context, negatives):
-        yield context.element
+      def process(self, element, negatives):
+        yield element
 
     root_create = Create('create', [[-1, 2, 3]])
 

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -35,8 +35,10 @@ from apache_beam.transforms import sideinputs
 from apache_beam.transforms.window import GlobalWindows
 from apache_beam.transforms.window import WindowedValue
 from apache_beam.typehints.typecheck import OutputCheckWrapperDoFn
+from apache_beam.typehints.typecheck import OutputCheckWrapperNewDoFn
 from apache_beam.typehints.typecheck import TypeCheckError
 from apache_beam.typehints.typecheck import TypeCheckWrapperDoFn
+from apache_beam.typehints.typecheck import TypeCheckWrapperNewDoFn
 from apache_beam.utils import counters
 from apache_beam.utils.pipeline_options import TypeOptions
 
@@ -344,9 +346,18 @@ class _ParDoEvaluator(_TransformEvaluator):
     pipeline_options = self._evaluation_context.pipeline_options
     if (pipeline_options is not None
         and pipeline_options.view_as(TypeOptions).runtime_type_check):
-      dofn = TypeCheckWrapperDoFn(dofn, transform.get_type_hints())
+      # TODO(sourabhbajaj): Remove this if-else
+      if isinstance(dofn, core.NewDoFn):
+        dofn = TypeCheckWrapperNewDoFn(dofn, transform.get_type_hints())
+      else:
+        dofn = TypeCheckWrapperDoFn(dofn, transform.get_type_hints())
 
-    dofn = OutputCheckWrapperDoFn(dofn, self._applied_ptransform.full_label)
+    # TODO(sourabhbajaj): Remove this if-else
+    if isinstance(dofn, core.NewDoFn):
+      dofn = OutputCheckWrapperNewDoFn(
+          dofn, self._applied_ptransform.full_label)
+    else:
+      dofn = OutputCheckWrapperDoFn(dofn, self._applied_ptransform.full_label)
     self.runner = DoFnRunner(dofn, transform.args, transform.kwargs,
                              self._side_inputs,
                              self._applied_ptransform.inputs[0].windowing,

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -109,11 +109,11 @@ class RunnerTest(unittest.TestCase):
                 'a_class': SpecialParDo,
                 'a_time': self.now}
 
-    class SpecialDoFn(beam.DoFn):
+    class SpecialDoFn(beam.NewDoFn):
       def display_data(self):
         return {'dofn_value': 42}
 
-      def process(self, context):
+      def process(self):
         pass
 
     now = datetime.now()
@@ -146,21 +146,21 @@ class RunnerTest(unittest.TestCase):
   def test_direct_runner_metrics(self):
     from apache_beam.metrics.metric import Metrics
 
-    class MyDoFn(beam.DoFn):
-      def start_bundle(self, context):
+    class MyDoFn(beam.NewDoFn):
+      def start_bundle(self):
         count = Metrics.counter(self.__class__, 'bundles')
         count.inc()
 
-      def finish_bundle(self, context):
+      def finish_bundle(self):
         count = Metrics.counter(self.__class__, 'finished_bundles')
         count.inc()
 
-      def process(self, context):
+      def process(self, element):
         count = Metrics.counter(self.__class__, 'elements')
         count.inc()
         distro = Metrics.distribution(self.__class__, 'element_dist')
-        distro.update(context.element)
-        return [context.element]
+        distro.update(element)
+        return [element]
 
     runner = DirectRunner()
     p = Pipeline(runner,

--- a/sdks/python/apache_beam/transforms/aggregator_test.py
+++ b/sdks/python/apache_beam/transforms/aggregator_test.py
@@ -59,10 +59,10 @@ class AggregatorTest(unittest.TestCase):
     aggregators = [Aggregator('%s_%s' % (f.__name__, t.__name__), f, t)
                    for f, t, _ in counter_types]
 
-    class UpdateAggregators(beam.DoFn):
-      def process(self, context):
+    class UpdateAggregators(beam.NewDoFn):
+      def process(self, element, context=beam.NewDoFn.ContextParam):
         for a in aggregators:
-          context.aggregate_to(a, context.element)
+          context.aggregate_to(a, element)
 
     p = TestPipeline()
     p | beam.Create([0, 1, 2, 3]) | beam.ParDo(UpdateAggregators())  # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -323,10 +323,7 @@ class CallableWrapperDoFn(NewDoFn):
       raise TypeError('Expected a callable object instead of: %r' % fn)
 
     self._fn = fn
-    if _fn_takes_side_inputs(fn):
-      self.process = fn
-    else:
-      self.process = lambda e: fn(e)
+    self.process = fn
 
     super(CallableWrapperDoFn, self).__init__()
 
@@ -672,7 +669,7 @@ class ParDo(PTransformWithSideInputs):
   def __init__(self, fn_or_label, *args, **kwargs):
     super(ParDo, self).__init__(fn_or_label, *args, **kwargs)
 
-    if not (isinstance(self.fn, DoFn) or isinstance(self.fn, NewDoFn)):
+    if not isinstance(self.fn, (DoFn, NewDoFn)):
       raise TypeError('ParDo must be called with a DoFn instance.')
 
   def default_type_hints(self):
@@ -683,7 +680,7 @@ class ParDo(PTransformWithSideInputs):
         self.fn.infer_output_type(input_type))
 
   def make_fn(self, fn):
-    if isinstance(fn, DoFn) or isinstance(fn, NewDoFn):
+    if isinstance(fn, (DoFn, NewDoFn)):
       return fn
     return CallableWrapperDoFn(fn)
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -109,6 +109,7 @@ class DoFnProcessContext(DoFnContext):
       self.timestamp = windowed_value.timestamp
       self.windows = windowed_value.windows
 
+  # TODO(sourabhbajaj): Move as we're trying to deprecate the use of context
   def aggregate_to(self, aggregator, input_value):
     """Provide a new input value for the aggregator.
 
@@ -119,6 +120,101 @@ class DoFnProcessContext(DoFnContext):
     self.state.counter_for(aggregator).update(input_value)
 
 
+class NewDoFn(WithTypeHints, HasDisplayData):
+  """A function object used by a transform with custom processing.
+
+  The ParDo transform is such a transform. The ParDo.apply
+  method will take an object of type DoFn and apply it to all elements of a
+  PCollection object.
+
+  In order to have concrete DoFn objects one has to subclass from DoFn and
+  define the desired behavior (start_bundle/finish_bundle and process) or wrap a
+  callable object using the CallableWrapperDoFn class.
+  """
+
+  ElementParam = 'ElementParam'
+  ContextParam = 'ContextParam'
+  SideInputParam = 'SideInputParam'
+  TimestampParam = 'TimestampParam'
+  WindowsParam = 'WindowsParam'
+
+  @staticmethod
+  def from_callable(fn):
+    return CallableWrapperDoFn(fn)
+
+  def default_label(self):
+    return self.__class__.__name__
+
+  def process(self, element, *args, **kwargs):
+    """Called for each element of a pipeline. The default arguments are needed
+    for the DoFnRunner to be able to pass the parameters correctly.
+
+    Args:
+      element: The element to be processed
+      context: a DoFnProcessContext object containing. See the
+        DoFnProcessContext documentation for details.
+      *args: side inputs
+      **kwargs: keyword side inputs
+    """
+    raise NotImplementedError
+
+  def start_bundle(self):
+    """Called before a bundle of elements is processed on a worker.
+
+    Elements to be processed are split into bundles and distributed
+    to workers. Before a worker calls process() on the first element
+    of its bundle, it calls this method.
+    """
+    pass
+
+  def finish_bundle(self):
+    """Called after a bundle of elements is processed on a worker.
+    """
+    pass
+
+  def get_function_arguments(self, func):
+    """Return the function arguments based on the name provided. If they have
+    a _inspect_function attached to the class then use that otherwise default
+    to the python inspect library.
+    """
+    func_name = '_inspect_%s' % func
+    if hasattr(self, func_name):
+      f = getattr(self, func_name)
+      return f()
+    else:
+      f = getattr(self, func)
+      return inspect.getargspec(f)
+
+  # TODO(sourabhbajaj): Do we want to remove the responsiblity of these from
+  # the DoFn or maybe the runner
+  def infer_output_type(self, input_type):
+    # TODO(robertwb): Side inputs types.
+    # TODO(robertwb): Assert compatibility with input type hint?
+    return self._strip_output_annotations(
+        trivial_inference.infer_return_type(self.process, [input_type]))
+
+  def _strip_output_annotations(self, type_hint):
+    annotations = (window.TimestampedValue, window.WindowedValue,
+                   pvalue.SideOutputValue)
+    # TODO(robertwb): These should be parameterized types that the
+    # type inferencer understands.
+    if (type_hint in annotations
+        or trivial_inference.element_type(type_hint) in annotations):
+      return Any
+    else:
+      return type_hint
+
+  def process_argspec_fn(self):
+    """Returns the Python callable that will eventually be invoked.
+
+    This should ideally be the user-level function that is called with
+    the main and (if any) side inputs, and is used to relate the type
+    hint parameters with the input parameters (e.g., by argument name).
+    """
+    return self.process
+
+
+# TODO(Sourabh): Remove after migration to NewDoFn
 class DoFn(WithTypeHints, HasDisplayData):
   """A function object used by a transform with custom processing.
 
@@ -207,7 +303,7 @@ def _fn_takes_side_inputs(fn):
   return len(argspec.args) > 1 + is_bound or argspec.varargs or argspec.keywords
 
 
-class CallableWrapperDoFn(DoFn):
+class CallableWrapperDoFn(NewDoFn):
   """A DoFn (function) object wrapping a callable object.
 
   The purpose of this class is to conveniently wrap simple functions and use
@@ -228,10 +324,9 @@ class CallableWrapperDoFn(DoFn):
 
     self._fn = fn
     if _fn_takes_side_inputs(fn):
-      self.process = lambda context, *args, **kwargs: fn(
-          context.element, *args, **kwargs)
+      self.process = fn
     else:
-      self.process = lambda context: fn(context.element)
+      self.process = lambda e: fn(e)
 
     super(CallableWrapperDoFn, self).__init__()
 
@@ -577,7 +672,7 @@ class ParDo(PTransformWithSideInputs):
   def __init__(self, fn_or_label, *args, **kwargs):
     super(ParDo, self).__init__(fn_or_label, *args, **kwargs)
 
-    if not isinstance(self.fn, DoFn):
+    if not (isinstance(self.fn, DoFn) or isinstance(self.fn, NewDoFn)):
       raise TypeError('ParDo must be called with a DoFn instance.')
 
   def default_type_hints(self):
@@ -588,7 +683,9 @@ class ParDo(PTransformWithSideInputs):
         self.fn.infer_output_type(input_type))
 
   def make_fn(self, fn):
-    return fn if isinstance(fn, DoFn) else CallableWrapperDoFn(fn)
+    if isinstance(fn, DoFn) or isinstance(fn, NewDoFn):
+      return fn
+    return CallableWrapperDoFn(fn)
 
   def process_argspec_fn(self):
     return self.fn.process_argspec_fn()
@@ -968,7 +1065,7 @@ class CombineValues(PTransformWithSideInputs):
         *args, **kwargs)
 
 
-class CombineValuesDoFn(DoFn):
+class CombineValuesDoFn(NewDoFn):
   """DoFn for performing per-key Combine transforms."""
 
   def __init__(self, input_pcoll_type, combinefn, runtime_type_check):
@@ -976,7 +1073,7 @@ class CombineValuesDoFn(DoFn):
     self.combinefn = combinefn
     self.runtime_type_check = runtime_type_check
 
-  def process(self, p_context, *args, **kwargs):
+  def process(self, element, *args, **kwargs):
     # Expected elements input to this DoFn are 2-tuples of the form
     # (key, iter), with iter an iterable of all the values associated with key
     # in the input PCollection.
@@ -985,11 +1082,11 @@ class CombineValuesDoFn(DoFn):
       # breaking it up so that output type violations manifest as TypeCheck
       # errors rather than type errors.
       return [
-          (p_context.element[0],
-           self.combinefn.apply(p_context.element[1], *args, **kwargs))]
+          (element[0],
+           self.combinefn.apply(element[1], *args, **kwargs))]
     else:
       # Add the elements into three accumulators (for testing of merge).
-      elements = p_context.element[1]
+      elements = element[1]
       accumulators = []
       for k in range(3):
         if len(elements) <= k:
@@ -1003,7 +1100,7 @@ class CombineValuesDoFn(DoFn):
       accumulator = self.combinefn.merge_accumulators(
           accumulators, *args, **kwargs)
       # Convert accumulator to the final result.
-      return [(p_context.element[0],
+      return [(element[0],
                self.combinefn.extract_output(accumulator, *args, **kwargs))]
 
   def default_type_hints(self):
@@ -1034,22 +1131,23 @@ class GroupByKey(PTransform):
   The implementation here is used only when run on the local direct runner.
   """
 
-  class ReifyWindows(DoFn):
+  class ReifyWindows(NewDoFn):
 
-    def process(self, context):
+    def process(self, element, windows=NewDoFn.WindowsParam,
+                timestamp=NewDoFn.TimestampParam):
       try:
-        k, v = context.element
+        k, v = element
       except TypeError:
         raise TypeCheckError('Input to GroupByKey must be a PCollection with '
                              'elements compatible with KV[A, B]')
 
-      return [(k, window.WindowedValue(v, context.timestamp, context.windows))]
+      return [(k, window.WindowedValue(v, timestamp, windows))]
 
     def infer_output_type(self, input_type):
       key_type, value_type = trivial_inference.key_value_types(input_type)
       return Iterable[KV[key_type, typehints.WindowedValue[value_type]]]
 
-  class GroupAlsoByWindow(DoFn):
+  class GroupAlsoByWindow(NewDoFn):
     # TODO(robertwb): Support combiner lifting.
 
     def __init__(self, windowing):
@@ -1062,7 +1160,7 @@ class GroupByKey(PTransform):
       value_type = windowed_value_iter_type.inner_type.inner_type
       return Iterable[KV[key_type, Iterable[value_type]]]
 
-    def start_bundle(self, context):
+    def start_bundle(self):
       # pylint: disable=wrong-import-order, wrong-import-position
       from apache_beam.transforms.trigger import InMemoryUnmergedState
       from apache_beam.transforms.trigger import create_trigger_driver
@@ -1070,8 +1168,8 @@ class GroupByKey(PTransform):
       self.driver = create_trigger_driver(self.windowing, True)
       self.state_type = InMemoryUnmergedState
 
-    def process(self, context):
-      k, vs = context.element
+    def process(self, element):
+      k, vs = element
       state = self.state_type()
       # TODO(robertwb): Conditionally process in smaller chunks.
       for wvalue in self.driver.process_elements(state, vs, MIN_TIMESTAMP):
@@ -1154,10 +1252,11 @@ class Partition(PTransformWithSideInputs):
   representing each of n partitions, in order.
   """
 
-  class ApplyPartitionFnFn(DoFn):
+  class ApplyPartitionFnFn(NewDoFn):
     """A DoFn that applies a PartitionFn."""
 
-    def process(self, context, partitionfn, n, *args, **kwargs):
+    def process(self, element, partitionfn, n, context=NewDoFn.ContextParam,
+                *args, **kwargs):
       partition = partitionfn.partition_for(context, n, *args, **kwargs)
       if not 0 <= partition < n:
         raise ValueError(
@@ -1165,7 +1264,7 @@ class Partition(PTransformWithSideInputs):
             '%d not in [0, %d)' % (partition, n))
       # Each input is directed into the side output that corresponds to the
       # selected partition.
-      yield pvalue.SideOutputValue(str(partition), context.element)
+      yield pvalue.SideOutputValue(str(partition), element)
 
   def make_fn(self, fn):
     return fn if isinstance(fn, PartitionFn) else CallableWrapperPartitionFn(fn)
@@ -1223,16 +1322,17 @@ class WindowInto(ParDo):
   determined by the windowing function.
   """
 
-  class WindowIntoFn(DoFn):
+  class WindowIntoFn(NewDoFn):
     """A DoFn that applies a WindowInto operation."""
 
     def __init__(self, windowing):
       self.windowing = windowing
 
-    def process(self, context):
-      context = WindowFn.AssignContext(context.timestamp,
-                                       element=context.element,
-                                       existing_windows=context.windows)
+    def process(self, element, windows=NewDoFn.WindowsParam,
+                timestamp=NewDoFn.TimestampParam):
+      context = WindowFn.AssignContext(timestamp,
+                                       element=element,
+                                       existing_windows=windows)
       new_windows = self.windowing.windowfn.assign(context)
       yield WindowedValue(context.element, context.timestamp, new_windows)
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -334,7 +334,12 @@ class CallableWrapperDoFn(NewDoFn):
       raise TypeError('Expected a callable object instead of: %r' % fn)
 
     self._fn = fn
-    self.process = fn
+    if isinstance(fn, (
+        types.BuiltinFunctionType, types.MethodType, types.FunctionType)):
+      self.process = fn
+    else:
+      # For cases such as set / list where fn is callable but not a function
+      self.process = lambda e: fn(e)
 
     super(CallableWrapperDoFn, self).__init__()
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -213,6 +213,17 @@ class NewDoFn(WithTypeHints, HasDisplayData):
     """
     return self.process
 
+  def is_process_bounded(self):
+    """Checks if an object is a bound method on an instance."""
+    if not isinstance(self.process, types.MethodType):
+      return False # Not a method
+    if self.process.im_self is None:
+      return False # Method is not bound
+    if issubclass(self.process.im_class, type) or \
+        self.process.im_class is types.ClassType:
+      return False # Method is a classmethod
+    return True
+
 
 # TODO(Sourabh): Remove after migration to NewDoFn
 class DoFn(WithTypeHints, HasDisplayData):

--- a/sdks/python/apache_beam/transforms/display_test.py
+++ b/sdks/python/apache_beam/transforms/display_test.py
@@ -99,7 +99,7 @@ class DisplayDataTest(unittest.TestCase):
     self.assertEqual(display_pt.display_data(), {})
 
   def test_inheritance_dofn(self):
-    class MyDoFn(beam.DoFn):
+    class MyDoFn(beam.NewDoFn):
       pass
 
     display_dofn = MyDoFn()
@@ -126,12 +126,12 @@ class DisplayDataTest(unittest.TestCase):
     """ Tests basic display data cases (key:value, key:dict)
     It does not test subcomponent inclusion
     """
-    class MyDoFn(beam.DoFn):
+    class MyDoFn(beam.NewDoFn):
       def __init__(self, my_display_data=None):
         self.my_display_data = my_display_data
 
-      def process(self, context):
-        yield context.element + 1
+      def process(self, element):
+        yield element + 1
 
       def display_data(self):
         return {'static_integer': 120,
@@ -168,7 +168,7 @@ class DisplayDataTest(unittest.TestCase):
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_drop_if_none(self):
-    class MyDoFn(beam.DoFn):
+    class MyDoFn(beam.NewDoFn):
       def display_data(self):
         return {'some_val': DisplayDataItem('something').drop_if_none(),
                 'non_val': DisplayDataItem(None).drop_if_none(),
@@ -183,7 +183,7 @@ class DisplayDataTest(unittest.TestCase):
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
 
   def test_subcomponent(self):
-    class SpecialDoFn(beam.DoFn):
+    class SpecialDoFn(beam.NewDoFn):
       def display_data(self):
         return {'dofn_value': 42}
 

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -752,7 +752,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
        | 'T' >> beam.Create([1, 2, 3]).with_output_types(int)
        | 'Upper' >> beam.ParDo(ToUpperCaseWithPrefix(), 'hello'))
 
-    self.assertEqual("Type hint violation for 'upper': "
+    self.assertEqual("Type hint violation for 'Upper': "
                      "requires <type 'str'> but got <type 'int'> for element",
                      e.exception.message)
 
@@ -787,7 +787,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
        | 'Add' >> beam.ParDo(AddWithNum(), 5))
       self.p.run()
 
-    self.assertEqual("Type hint violation for 'add': "
+    self.assertEqual("Type hint violation for 'Add': "
                      "requires <type 'int'> but got <type 'str'> for element",
                      e.exception.message)
 

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -105,10 +105,10 @@ class PTransformTest(unittest.TestCase):
         'instead of args=(0,), kwargs={\'name\': \'value\'}')
 
   def test_do_with_do_fn(self):
-    class AddNDoFn(beam.DoFn):
+    class AddNDoFn(beam.NewDoFn):
 
-      def process(self, context, addon):
-        return [context.element + addon]
+      def process(self, element, addon):
+        return [element + addon]
 
     pipeline = TestPipeline()
     pcoll = pipeline | 'Start' >> beam.Create([1, 2, 3])
@@ -117,9 +117,9 @@ class PTransformTest(unittest.TestCase):
     pipeline.run()
 
   def test_do_with_unconstructed_do_fn(self):
-    class MyDoFn(beam.DoFn):
+    class MyDoFn(beam.NewDoFn):
 
-      def process(self, context):
+      def process(self):
         pass
 
     pipeline = TestPipeline()
@@ -206,15 +206,16 @@ class PTransformTest(unittest.TestCase):
     self.assertStartswith(cm.exception.message, expected_error_prefix)
 
   def test_do_fn_with_start_finish(self):
-    class MyDoFn(beam.DoFn):
-      def start_bundle(self, c):
+    class MyDoFn(beam.NewDoFn):
+      def start_bundle(self):
         yield 'start'
 
-      def process(self, c):
+      def process(self):
         pass
 
-      def finish_bundle(self, c):
+      def finish_bundle(self):
         yield 'finish'
+
     pipeline = TestPipeline()
     pcoll = pipeline | 'Start' >> beam.Create([1, 2, 3])
     result = pcoll | 'Do' >> beam.ParDo(MyDoFn())
@@ -653,8 +654,8 @@ class PTransformLabelsTest(unittest.TestCase):
     self.check_label(beam.CombineGlobally(sum), r'CombineGlobally(sum)')
     self.check_label(beam.CombinePerKey(sum), r'CombinePerKey(sum)')
 
-    class MyDoFn(beam.DoFn):
-      def process(self, context):
+    class MyDoFn(beam.NewDoFn):
+      def process(self):
         pass
 
     self.check_label(beam.ParDo(MyDoFn()), r'ParDo(MyDoFn)')
@@ -728,9 +729,9 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_do_fn_pipeline_pipeline_type_check_satisfied(self):
     @with_input_types(int, int)
     @with_output_types(typehints.List[int])
-    class AddWithFive(beam.DoFn):
-      def process(self, context, five):
-        return [context.element + five]
+    class AddWithFive(beam.NewDoFn):
+      def process(self, element, five):
+        return [element + five]
 
     d = (self.p
          | 'T' >> beam.Create([1, 2, 3]).with_output_types(int)
@@ -742,17 +743,17 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_do_fn_pipeline_pipeline_type_check_violated(self):
     @with_input_types(str, str)
     @with_output_types(typehints.List[str])
-    class ToUpperCaseWithPrefix(beam.DoFn):
-      def process(self, context, prefix):
-        return [prefix + context.element.upper()]
+    class ToUpperCaseWithPrefix(beam.NewDoFn):
+      def process(self, element, prefix):
+        return [prefix + element.upper()]
 
     with self.assertRaises(typehints.TypeCheckError) as e:
       (self.p
        | 'T' >> beam.Create([1, 2, 3]).with_output_types(int)
        | 'Upper' >> beam.ParDo(ToUpperCaseWithPrefix(), 'hello'))
 
-    self.assertEqual("Type hint violation for 'Upper': "
-                     "requires <type 'str'> but got <type 'int'> for context",
+    self.assertEqual("Type hint violation for 'upper': "
+                     "requires <type 'str'> but got <type 'int'> for element",
                      e.exception.message)
 
   def test_do_fn_pipeline_runtime_type_check_satisfied(self):
@@ -760,9 +761,9 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     @with_input_types(int, int)
     @with_output_types(int)
-    class AddWithNum(beam.DoFn):
-      def process(self, context, num):
-        return [context.element + num]
+    class AddWithNum(beam.NewDoFn):
+      def process(self, element, num):
+        return [element + num]
 
     d = (self.p
          | 'T' >> beam.Create([1, 2, 3]).with_output_types(int)
@@ -776,9 +777,9 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     @with_input_types(int, int)
     @with_output_types(typehints.List[int])
-    class AddWithNum(beam.DoFn):
-      def process(self, context, num):
-        return [context.element + num]
+    class AddWithNum(beam.NewDoFn):
+      def process(self, element, num):
+        return [element + num]
 
     with self.assertRaises(typehints.TypeCheckError) as e:
       (self.p
@@ -786,8 +787,8 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
        | 'Add' >> beam.ParDo(AddWithNum(), 5))
       self.p.run()
 
-    self.assertEqual("Type hint violation for 'Add': "
-                     "requires <type 'int'> but got <type 'str'> for context",
+    self.assertEqual("Type hint violation for 'add': "
+                     "requires <type 'int'> but got <type 'str'> for element",
                      e.exception.message)
 
   def test_pardo_does_not_type_check_using_type_hint_decorators(self):
@@ -1445,7 +1446,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual("Type hint violation for 'ParDo(CombineValuesDoFn)': "
                      "requires Tuple[TypeVariable[K], "
                      "Iterable[Union[float, int, long]]] "
-                     "but got Tuple[None, Iterable[str]] for p_context",
+                     "but got Tuple[None, Iterable[str]] for element",
                      e.exception.message)
 
   def test_mean_globally_runtime_checking_satisfied(self):
@@ -1502,7 +1503,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual("Type hint violation for 'ParDo(CombineValuesDoFn)': "
                      "requires Tuple[TypeVariable[K], "
                      "Iterable[Union[float, int, long]]] "
-                     "but got Tuple[str, Iterable[str]] for p_context",
+                     "but got Tuple[str, Iterable[str]] for element",
                      e.exception.message)
 
   def test_mean_per_key_runtime_checking_satisfied(self):
@@ -1535,7 +1536,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Runtime type violation detected within "
         "ParDo(OddMean/CombinePerKey(MeanCombineFn)/"
         "Combine/ParDo(CombineValuesDoFn)): "
-        "Type-hint for argument: 'p_context' violated: "
+        "Type-hint for argument: 'element' violated: "
         "Tuple[TypeVariable[K], Iterable[Union[float, int, long]]]"
         " hint type-constraint violated. "
         "The type of element #1 in the passed tuple is incorrect. "
@@ -1799,7 +1800,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual("Type hint violation for 'ParDo(CombineValuesDoFn)': "
                      "requires Tuple[TypeVariable[K], "
                      "Iterable[Tuple[TypeVariable[K], TypeVariable[V]]]] "
-                     "but got Tuple[None, Iterable[int]] for p_context",
+                     "but got Tuple[None, Iterable[int]] for element",
                      e.exception.message)
 
   def test_to_dict_pipeline_check_satisfied(self):

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -47,11 +47,11 @@ def context(element, timestamp, windows):
 sort_values = Map(lambda (k, vs): (k, sorted(vs)))
 
 
-class ReifyWindowsFn(core.DoFn):
-  def process(self, context):
-    key, values = context.element
-    for window in context.windows:
-      yield "%s @ %s" % (key, window), values
+class ReifyWindowsFn(core.NewDoFn):
+  def process(self, element, windows=core.NewDoFn.WindowsParam):
+    key, values = element
+    for w in windows:
+      yield "%s @ %s" % (key, w), values
 reify_windows = core.ParDo(ReifyWindowsFn())
 
 

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -48,10 +48,9 @@ sort_values = Map(lambda (k, vs): (k, sorted(vs)))
 
 
 class ReifyWindowsFn(core.NewDoFn):
-  def process(self, element, windows=core.NewDoFn.WindowsParam):
+  def process(self, element, w=core.NewDoFn.WindowParam):
     key, values = element
-    for w in windows:
-      yield "%s @ %s" % (key, w), values
+    yield "%s @ %s" % (key, w), values
 reify_windows = core.ParDo(ReifyWindowsFn())
 
 

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -263,7 +263,7 @@ def getcallargs_forhints(func, *typeargs, **typekwargs):
     for k, var in enumerate(reversed(argspec.args)):
       if k >= len(argspec.defaults):
         break
-      if callargs.get(var, None) is argspec.defaults[-k]:
+      if callargs.get(var, None) is argspec.defaults[-k-1]:
         callargs[var] = typehints.Any
   # Patch up varargs and keywords
   if argspec.varargs:

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -24,6 +24,7 @@ import types
 
 from apache_beam.pvalue import SideOutputValue
 from apache_beam.transforms.core import DoFn
+from apache_beam.transforms.core import NewDoFn
 from apache_beam.transforms.window import WindowedValue
 from apache_beam.typehints import check_constraint
 from apache_beam.typehints import CompositeTypeHintError
@@ -162,3 +163,144 @@ class OutputCheckWrapperDoFn(DoFn):
                            'iterable. %s was returned instead.'
                            % type(output))
     return output
+
+
+class AbstractDoFnWrapper(NewDoFn):
+  """An abstract class to create wrapper around NewDoFn"""
+
+  def __init__(self, dofn):
+    super(AbstractDoFnWrapper, self).__init__()
+    self.dofn = dofn
+
+  def _inspect_start_bundle(self):
+    return self.dofn.get_function_arguments('start_bundle')
+
+  def _inspect_process(self):
+    return self.dofn.get_function_arguments('process')
+
+  def _inspect_finish_bundle(self):
+    return self.dofn.get_function_arguments('finish_bundle')
+
+  def wrapper(self, method, args, kwargs):
+    return method(*args, **kwargs)
+
+  def start_bundle(self, *args, **kwargs):
+    return self.wrapper(self.dofn.start_bundle, args, kwargs)
+
+  def process(self, *args, **kwargs):
+    return self.wrapper(self.dofn.process, args, kwargs)
+
+  def finish_bundle(self, *args, **kwargs):
+    return self.wrapper(self.dofn.finish_bundle, args, kwargs)
+
+
+class OutputCheckWrapperNewDoFn(AbstractDoFnWrapper):
+  """A DoFn that verifies against common errors in the output type."""
+
+  def __init__(self, dofn, full_label):
+    super(OutputCheckWrapperNewDoFn, self).__init__(dofn)
+    self.full_label = full_label
+
+  def wrapper(self, method, args, kwargs):
+    try:
+      result = method(*args, **kwargs)
+    except TypeCheckError as e:
+      error_msg = ('Runtime type violation detected within ParDo(%s): '
+                   '%s' % (self.full_label, e))
+      raise TypeCheckError, error_msg, sys.exc_info()[2]
+    else:
+      return self._check_type(result)
+
+  def _check_type(self, output):
+    if output is None:
+      return output
+    elif isinstance(output, (dict, basestring)):
+      object_type = type(output).__name__
+      raise TypeCheckError('Returning a %s from a ParDo or FlatMap is '
+                           'discouraged. Please use list("%s") if you really '
+                           'want this behavior.' %
+                           (object_type, output))
+    elif not isinstance(output, collections.Iterable):
+      raise TypeCheckError('FlatMap and ParDo must return an '
+                           'iterable. %s was returned instead.'
+                           % type(output))
+    return output
+
+
+class TypeCheckWrapperNewDoFn(AbstractDoFnWrapper):
+  """A wrapper around a DoFn which performs type-checking of input and output.
+  """
+
+  def __init__(self, dofn, type_hints, label=None):
+    super(TypeCheckWrapperNewDoFn, self).__init__(dofn)
+    self.dofn = dofn
+    self._process_fn = self.dofn.process_argspec_fn()
+    if type_hints.input_types:
+      input_args, input_kwargs = type_hints.input_types
+      self._input_hints = getcallargs_forhints(
+          self._process_fn, *input_args, **input_kwargs)
+    else:
+      self._input_hints = None
+    # TODO(robertwb): Multi-output.
+    self._output_type_hint = type_hints.simple_output_type(label)
+
+  def wrapper(self, method, args, kwargs):
+    result = method(*args, **kwargs)
+    return self._type_check_result(result)
+
+  def process(self, *args, **kwargs):
+    if self._input_hints:
+      actual_inputs = inspect.getcallargs(self._process_fn, *args, **kwargs)
+      for var, hint in self._input_hints.items():
+        if hint is actual_inputs[var]:
+          # self parameter
+          continue
+        _check_instance_type(hint, actual_inputs[var], var, True)
+    return self._type_check_result(self.dofn.process(*args, **kwargs))
+
+  def _type_check_result(self, transform_results):
+    if self._output_type_hint is None or transform_results is None:
+      return transform_results
+
+    def type_check_output(o):
+      # TODO(robertwb): Multi-output.
+      x = o.value if isinstance(o, (SideOutputValue, WindowedValue)) else o
+      self._type_check(self._output_type_hint, x, is_input=False)
+
+    # If the return type is a generator, then we will need to interleave our
+    # type-checking with its normal iteration so we don't deplete the
+    # generator initially just by type-checking its yielded contents.
+    if isinstance(transform_results, types.GeneratorType):
+      return GeneratorWrapper(transform_results, type_check_output)
+    else:
+      for o in transform_results:
+        type_check_output(o)
+      return transform_results
+
+  def _type_check(self, type_constraint, datum, is_input):
+    """Typecheck a PTransform related datum according to a type constraint.
+
+    This function is used to optionally type-check either an input or an output
+    to a PTransform.
+
+    Args:
+        type_constraint: An instance of a typehints.TypeContraint, one of the
+          white-listed builtin Python types, or a custom user class.
+        datum: An instance of a Python object.
+        is_input: True if 'datum' is an input to a PTransform's DoFn. False
+          otherwise.
+
+    Raises:
+      TypeError: If 'datum' fails to type-check according to 'type_constraint'.
+    """
+    datum_type = 'input' if is_input else 'output'
+
+    try:
+      check_constraint(type_constraint, datum)
+    except CompositeTypeHintError as e:
+      raise TypeCheckError, e.message, sys.exc_info()[2]
+    except SimpleTypeHintError:
+      error_msg = ("According to type-hint expected %s should be of type %s. "
+                   "Instead, received '%s', an instance of type %s."
+                   % (datum_type, type_constraint, datum, type(datum)))
+      raise TypeCheckError, error_msg, sys.exc_info()[2]

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -193,6 +193,9 @@ class AbstractDoFnWrapper(NewDoFn):
   def finish_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.finish_bundle, args, kwargs)
 
+  def is_process_bounded(self):
+    return self.dofn.is_process_bounded()
+
 
 class OutputCheckWrapperNewDoFn(AbstractDoFnWrapper):
   """A DoFn that verifies against common errors in the output type."""

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -69,9 +69,9 @@ class MainInputTest(unittest.TestCase):
   def test_typed_dofn_class(self):
     @typehints.with_input_types(int)
     @typehints.with_output_types(str)
-    class MyDoFn(beam.DoFn):
-      def process(self, context):
-        return [str(context.element)]
+    class MyDoFn(beam.NewDoFn):
+      def process(self, element):
+        return [str(element)]
 
     result = [1, 2, 3] | beam.ParDo(MyDoFn())
     self.assertEqual(['1', '2', '3'], sorted(result))
@@ -83,9 +83,9 @@ class MainInputTest(unittest.TestCase):
       [1, 2, 3] | (beam.ParDo(MyDoFn()) | 'again' >> beam.ParDo(MyDoFn()))
 
   def test_typed_dofn_instance(self):
-    class MyDoFn(beam.DoFn):
-      def process(self, context):
-        return [str(context.element)]
+    class MyDoFn(beam.NewDoFn):
+      def process(self, element):
+        return [str(element)]
     my_do_fn = MyDoFn().with_input_types(int).with_output_types(str)
 
     result = [1, 2, 3] | beam.ParDo(my_do_fn)


### PR DESCRIPTION
- Implement the new annotation based DoFn in python see https://s.apache.org/a-new-dofn 
- Migrate all the cases of DoFn to NewDoFn
- CallableWrapperDoFn now extends NewDoFn
- Typechecking is also handled using the NewDoFn
- All unittests pass locally

Future Work:
- Remove OldDoFn completely from the code
- Deprecate the use of Context and pass state directly to the process method

R: @robertwb PTAL

---

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
