### PR TITLE
[BEAM-1188] Fix Incorrect Value Parsing in Test Pipeline Test

### DIFF
--- a/sdks/python/apache_beam/test_pipeline_test.py
+++ b/sdks/python/apache_beam/test_pipeline_test.py
@@ -89,7 +89,8 @@ class TestPipelineTest(unittest.TestCase):
   def test_append_verifier_in_extra_opt(self):
     extra_opt = {'matcher': SimpleMatcher()}
     opt_list = TestPipeline().get_full_options_as_args(**extra_opt)
-    matcher = pickler.loads(opt_list[0].split('=')[1])
+    _, value = opt_list[0].split('=', 1)
+    matcher = pickler.loads(value)
     self.assertTrue(isinstance(matcher, BaseMatcher))
     hc_assert_that(None, matcher)
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Use `split('=')[1]` to parse value from a key-value string (using `=` as separator) have a potential problem. 

In `test_append_verifier_in_extra_opt`, the value is a pickled string and contains more than one `=`, we should stop parsing at the first `=` to get correct value. 