### PR TITLE
[BEAM-1284] KvSwapTest: enhance validation to catch coder errors

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/KvSwapTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/KvSwapTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms;
 import java.util.Arrays;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.RunnableOnService;
@@ -38,16 +39,17 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class KvSwapTest {
-  static final KV<String, Integer>[] TABLE = new KV[] {
+  private static final KV<String, Integer>[] TABLE = new KV[] {
     KV.of("one", 1),
     KV.of("two", 2),
     KV.of("three", 3),
     KV.of("four", 4),
     KV.of("dup", 4),
-    KV.of("dup", 5)
+    KV.of("dup", 5),
+    KV.of("null", null),
   };
 
-  static final KV<String, Integer>[] EMPTY_TABLE = new KV[] {
+  private static final KV<String, Integer>[] EMPTY_TABLE = new KV[] {
   };
 
   @Rule
@@ -58,7 +60,7 @@ public class KvSwapTest {
   public void testKvSwap() {
     PCollection<KV<String, Integer>> input =
         p.apply(Create.of(Arrays.asList(TABLE)).withCoder(
-            KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
+            KvCoder.of(StringUtf8Coder.of(), NullableCoder.of(BigEndianIntegerCoder.of()))));
 
     PCollection<KV<Integer, String>> output = input.apply(
         KvSwap.<String, Integer>create());
@@ -69,7 +71,8 @@ public class KvSwapTest {
         KV.of(3, "three"),
         KV.of(4, "four"),
         KV.of(4, "dup"),
-        KV.of(5, "dup"));
+        KV.of(5, "dup"),
+        KV.of((Integer) null, "null"));
     p.run();
   }
 


### PR DESCRIPTION
This test ensures that coders are propagated from input to output rather than
re-inferred.