### PR TITLE
[BEAM-1291] KafkaIO: don't log warnig in offset fetcher while closing.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1058,7 +1058,9 @@ public class KafkaIO {
           long offset = offsetConsumer.position(p.topicPartition);
           p.setLatestOffset(offset);
         } catch (Exception e) {
-          LOG.warn("{}: exception while fetching latest offsets. ignored.",  this, e);
+          if (!closed.get()) {
+            LOG.warn("{}: exception while fetching latest offsets. will retry.", this, e);
+          }
           p.setLatestOffset(UNINITIALIZED_OFFSET); // reset
         }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1058,9 +1058,11 @@ public class KafkaIO {
           long offset = offsetConsumer.position(p.topicPartition);
           p.setLatestOffset(offset);
         } catch (Exception e) {
-          if (!closed.get()) {
-            LOG.warn("{}: exception while fetching latest offsets. will retry.", this, e);
+          if (closed.get()) {
+            break;
           }
+          LOG.warn("{}: exception while fetching latest offset for partition {}. will be retried.",
+                   this, p.topicPartition, e);
           p.setLatestOffset(UNINITIALIZED_OFFSET); // reset
         }
 


### PR DESCRIPTION
Don't log a warning in offset fetcher thread if the reader is already closed. This avoids misleading warning in logs (especially with spark runner where the reader is closed after each micro-batch).