### PR TITLE
Fix typo of DebuggingWordCount.java

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
@@ -97,7 +97,7 @@ public class DebuggingWordCount {
     private final Aggregator<Long, Long> matchedWords =
         createAggregator("matchedWords", Sum.ofLongs());
     private final Aggregator<Long, Long> unmatchedWords =
-        createAggregator("umatchedWords", Sum.ofLongs());
+        createAggregator("unmatchedWords", Sum.ofLongs());
 
     @ProcessElement
     public void processElement(ProcessContext c) {


### PR DESCRIPTION
Fix typo of DebuggingWordCount.java. Changed `"umatchedWords"` to `"unmatchedWords"`.