### PR TITLE
[BEAM-1319] Add conflict resolution to the PipelineOptions internal argparse.

### DIFF
--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -116,9 +116,16 @@ class PipelineOptions(HasDisplayData):
     Returns:
       Dictionary of all args and values.
     """
+
+    # TODO(BEAM-1319): PipelineOption sub-classes in the main session might be
+    # repeated. Pick last unique instance of each subclass to avoid conflicts.
     parser = argparse.ArgumentParser()
+    subset = {}
     for cls in PipelineOptions.__subclasses__():
+      subset[str(cls)] = cls
+    for cls in subset.values():
       cls._add_argparse_args(parser)  # pylint: disable=protected-access
+
     known_args, _ = parser.parse_known_args(self._flags)
     result = vars(known_args)
 


### PR DESCRIPTION
In some instances where a PipelineOptions subclass was defined in the
main session and save_main_session option is enabled, that subclass may
appear multiple times in the PipelineOptions.__subclassess__() list.
This is causing problems with the argparse because options are not
unique any more.

This changes filter the subclasses by name, and pick the last unique
instance of each subclass.

As an alternative option, we could use the conflict_handler='resolve' of
the argparse. However, the drawback of this approach would be that allowing
accidental overriding of the same option name in two different PipelineOptions
subclasses.

Also moves wordcount example to use PipelineOptions. This both serves as an
example of using PipelineOptions, also it is already integrated with
tests and will continue to test this case.