### PR TITLE
[BEAM-1339] Add wrapping of lambda in a SimpleFunction

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SimpleFunctionTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SimpleFunctionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link SimpleFunction}.
+ */
+@RunWith(JUnit4.class)
+public class SimpleFunctionTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testFailureIfNotOverridden() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("must override");
+    thrown.expectMessage("apply");
+
+    SimpleFunction<Integer, Integer> broken = new SimpleFunction<Integer, Integer>() {};
+  }
+}

--- a/sdks/java/java8tests/src/test/java/org/apache/beam/sdk/transforms/MapElementsJava8Test.java
+++ b/sdks/java/java8tests/src/test/java/org/apache/beam/sdk/transforms/MapElementsJava8Test.java
@@ -37,11 +37,11 @@ public class MapElementsJava8Test implements Serializable {
   public final transient TestPipeline pipeline = TestPipeline.create();
 
   /**
-   * Basic test of {@link MapElements} with a lambda (which is instantiated as a
-   * {@link SerializableFunction}).
+   * Basic test of {@link MapElements} with a lambda (which is instantiated as a {@link
+   * SerializableFunction}).
    */
   @Test
-  public void testMapBasic() throws Exception {
+  public void testMapLambda() throws Exception {
 
     PCollection<Integer> output = pipeline
         .apply(Create.of(1, 2, 3))
@@ -49,6 +49,24 @@ public class MapElementsJava8Test implements Serializable {
             // Note that the type annotation is required (for Java, not for Dataflow)
             .via((Integer i) -> i * 2)
             .withOutputType(new TypeDescriptor<Integer>() {}));
+
+    PAssert.that(output).containsInAnyOrder(6, 2, 4);
+    pipeline.run();
+  }
+
+  /**
+   * Basic test of {@link MapElements} with a lambda wrapped into a {@link SimpleFunction} to
+   * remember its type.
+   */
+  @Test
+  public void testMapWrappedLambda() throws Exception {
+
+    PCollection<Integer> output =
+        pipeline
+            .apply(Create.of(1, 2, 3))
+            .apply(
+                MapElements
+                    .via(new SimpleFunction<Integer, Integer>((Integer i) -> i * 2) {}));
 
     PAssert.that(output).containsInAnyOrder(6, 2, 4);
     pipeline.run();

--- a/sdks/java/java8tests/src/test/java/org/apache/beam/sdk/transforms/SimpleFunctionJava8Test.java
+++ b/sdks/java/java8tests/src/test/java/org/apache/beam/sdk/transforms/SimpleFunctionJava8Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Java 8 tests for {@link SimpleFunction}.
+ */
+@RunWith(JUnit4.class)
+public class SimpleFunctionJava8Test implements Serializable {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
+  /**
+   * Basic test of {@link MapElements} with a lambda (which is instantiated as a {@link
+   * SerializableFunction}).
+   */
+  @Test
+  public void testGoodTypeForLambda() throws Exception {
+    SimpleFunction<Integer, String> fn =
+        new SimpleFunction<Integer, String>((Integer i) -> i.toString()) {};
+
+    assertThat(fn.getInputTypeDescriptor(), equalTo(TypeDescriptors.integers()));
+    assertThat(fn.getOutputTypeDescriptor(), equalTo(TypeDescriptors.strings()));
+  }
+
+  /**
+   * Basic test of {@link MapElements} with a lambda wrapped into a {@link SimpleFunction} to
+   * remember its type.
+   */
+  @Test
+  public void testGoodTypeForMethodRef() throws Exception {
+    SimpleFunction<Integer, String> fn =
+        new SimpleFunction<Integer, String>(SimpleFunctionJava8Test::toStringThisThing) {};
+
+    assertThat(fn.getInputTypeDescriptor(), equalTo(TypeDescriptors.integers()));
+    assertThat(fn.getOutputTypeDescriptor(), equalTo(TypeDescriptors.strings()));
+  }
+
+  private static String toStringThisThing(Integer i) {
+    return i.toString();
+  }
+}


### PR DESCRIPTION
Here's a fun trick for getting a type descriptor attached to a lambda that seems nicer than `.withOutputType(...)`. For discussion.