### PR TITLE
[BEAM-1340] Removes inputProvider() and outputReceiver()

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnAdapters.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnAdapters.java
@@ -204,16 +204,6 @@ public class DoFnAdapters {
     }
 
     @Override
-    public DoFn.InputProvider<InputT> inputProvider() {
-      throw new UnsupportedOperationException("inputProvider() exists only for testing");
-    }
-
-    @Override
-    public DoFn.OutputReceiver<OutputT> outputReceiver() {
-      throw new UnsupportedOperationException("outputReceiver() exists only for testing");
-    }
-
-    @Override
     public <RestrictionT> RestrictionTracker<RestrictionT> restrictionTracker() {
       throw new UnsupportedOperationException("This is a non-splittable DoFn");
     }
@@ -313,16 +303,6 @@ public class DoFnAdapters {
     @Override
     public OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn) {
       throw new UnsupportedOperationException("Timers are not supported for OldDoFn");
-    }
-
-    @Override
-    public DoFn.InputProvider<InputT> inputProvider() {
-      throw new UnsupportedOperationException("inputProvider() exists only for testing");
-    }
-
-    @Override
-    public DoFn.OutputReceiver<OutputT> outputReceiver() {
-      throw new UnsupportedOperationException("outputReceiver() exists only for testing");
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -34,9 +34,7 @@ import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.Context;
-import org.apache.beam.sdk.transforms.DoFn.InputProvider;
 import org.apache.beam.sdk.transforms.DoFn.OnTimerContext;
-import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
@@ -439,16 +437,6 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public InputProvider<InputT> inputProvider() {
-      throw new UnsupportedOperationException("InputProvider is for testing only.");
-    }
-
-    @Override
-    public OutputReceiver<OutputT> outputReceiver() {
-      throw new UnsupportedOperationException("OutputReceiver is for testing only.");
-    }
-
-    @Override
     public <RestrictionT> RestrictionTracker<RestrictionT> restrictionTracker() {
       throw new UnsupportedOperationException(
           "Cannot access RestrictionTracker outside of @ProcessElement method.");
@@ -626,16 +614,6 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public InputProvider<InputT> inputProvider() {
-      throw new UnsupportedOperationException("InputProvider parameters are not supported.");
-    }
-
-    @Override
-    public OutputReceiver<OutputT> outputReceiver() {
-      throw new UnsupportedOperationException("OutputReceiver parameters are not supported.");
-    }
-
-    @Override
     public <RestrictionT> RestrictionTracker<RestrictionT> restrictionTracker() {
       throw new UnsupportedOperationException("RestrictionTracker parameters are not supported.");
     }
@@ -741,16 +719,6 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     @Override
     public OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn) {
       return this;
-    }
-
-    @Override
-    public InputProvider<InputT> inputProvider() {
-      throw new UnsupportedOperationException("InputProvider parameters are not supported.");
-    }
-
-    @Override
-    public OutputReceiver<OutputT> outputReceiver() {
-      throw new UnsupportedOperationException("OutputReceiver parameters are not supported.");
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
@@ -672,18 +672,6 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
       }
 
       @Override
-      public DoFn.InputProvider<InputT> inputProvider() {
-        // DoFnSignatures should have verified that this DoFn doesn't access extra context.
-        throw new IllegalStateException("Unexpected extra context access on a splittable DoFn");
-      }
-
-      @Override
-      public DoFn.OutputReceiver<OutputT> outputReceiver() {
-        // DoFnSignatures should have verified that this DoFn doesn't access extra context.
-        throw new IllegalStateException("Unexpected extra context access on a splittable DoFn");
-      }
-
-      @Override
       public TrackerT restrictionTracker() {
         return tracker;
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -372,12 +372,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   public interface OutputReceiver<T> {
     void output(T output);
   }
-
-  /** Provides a single value of the given type. */
-  public interface InputProvider<T> {
-    T get();
-  }
-
   /////////////////////////////////////////////////////////////////////////////
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -315,18 +315,6 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
             }
 
             @Override
-            public DoFn.InputProvider<InputT> inputProvider() {
-              throw new UnsupportedOperationException(
-                  "Not expected to access InputProvider from DoFnTester");
-            }
-
-            @Override
-            public DoFn.OutputReceiver<OutputT> outputReceiver() {
-              throw new UnsupportedOperationException(
-                  "Not expected to access OutputReceiver from DoFnTester");
-            }
-
-            @Override
             public <RestrictionT> RestrictionTracker<RestrictionT> restrictionTracker() {
               throw new UnsupportedOperationException(
                   "Not expected to access RestrictionTracker from a regular DoFn in DoFnTester");

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -68,9 +68,7 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.OnTimerMethod;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.Cases;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.ContextParameter;
-import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.InputProviderParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OnTimerContextParameter;
-import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OutputReceiverParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.ProcessContextParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.StateParameter;
@@ -569,16 +567,6 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
             return new StackManipulation.Compound(
                 simpleExtraContextParameter(WINDOW_PARAMETER_METHOD),
                 TypeCasting.to(new TypeDescription.ForLoadedType(p.windowT().getRawType())));
-          }
-
-          @Override
-          public StackManipulation dispatch(InputProviderParameter p) {
-            return simpleExtraContextParameter(INPUT_PROVIDER_PARAMETER_METHOD);
-          }
-
-          @Override
-          public StackManipulation dispatch(OutputReceiverParameter p) {
-            return simpleExtraContextParameter(OUTPUT_RECEIVER_PARAMETER_METHOD);
           }
 
           @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -21,8 +21,6 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFn.FinishBundle;
-import org.apache.beam.sdk.transforms.DoFn.InputProvider;
-import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
 import org.apache.beam.sdk.transforms.DoFn.StartBundle;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
@@ -113,12 +111,6 @@ public interface DoFnInvoker<InputT, OutputT> {
     /** Provide a {@link DoFn.OnTimerContext} to use with the given {@link DoFn}. */
     DoFn<InputT, OutputT>.OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn);
 
-    /** A placeholder for testing purposes. */
-    InputProvider<InputT> inputProvider();
-
-    /** A placeholder for testing purposes. */
-    OutputReceiver<OutputT> outputReceiver();
-
     /**
      * If this is a splittable {@link DoFn}, returns the {@link RestrictionTracker} associated with
      * the current {@link ProcessElement} call.
@@ -151,16 +143,6 @@ public interface DoFnInvoker<InputT, OutputT> {
 
     @Override
     public DoFn<InputT, OutputT>.OnTimerContext onTimerContext(DoFn<InputT, OutputT> doFn) {
-      return null;
-    }
-
-    @Override
-    public InputProvider<InputT> inputProvider() {
-      return null;
-    }
-
-    @Override
-    public OutputReceiver<OutputT> outputReceiver() {
       return null;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.InputProvider;
-import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
@@ -190,10 +188,6 @@ public abstract class DoFnSignature {
         return cases.dispatch((WindowParameter) this);
       } else if (this instanceof RestrictionTrackerParameter) {
         return cases.dispatch((RestrictionTrackerParameter) this);
-      } else if (this instanceof InputProviderParameter) {
-        return cases.dispatch((InputProviderParameter) this);
-      } else if (this instanceof OutputReceiverParameter) {
-        return cases.dispatch((OutputReceiverParameter) this);
       } else if (this instanceof StateParameter) {
         return cases.dispatch((StateParameter) this);
       } else if (this instanceof TimerParameter) {
@@ -213,8 +207,6 @@ public abstract class DoFnSignature {
       ResultT dispatch(ProcessContextParameter p);
       ResultT dispatch(OnTimerContextParameter p);
       ResultT dispatch(WindowParameter p);
-      ResultT dispatch(InputProviderParameter p);
-      ResultT dispatch(OutputReceiverParameter p);
       ResultT dispatch(RestrictionTrackerParameter p);
       ResultT dispatch(StateParameter p);
       ResultT dispatch(TimerParameter p);
@@ -247,16 +239,6 @@ public abstract class DoFnSignature {
         }
 
         @Override
-        public ResultT dispatch(InputProviderParameter p) {
-          return dispatchDefault(p);
-        }
-
-        @Override
-        public ResultT dispatch(OutputReceiverParameter p) {
-          return dispatchDefault(p);
-        }
-
-        @Override
         public ResultT dispatch(RestrictionTrackerParameter p) {
           return dispatchDefault(p);
         }
@@ -280,10 +262,6 @@ public abstract class DoFnSignature {
           new AutoValue_DoFnSignature_Parameter_ProcessContextParameter();
     private static final OnTimerContextParameter ON_TIMER_CONTEXT_PARAMETER =
         new AutoValue_DoFnSignature_Parameter_OnTimerContextParameter();
-    private static final InputProviderParameter INPUT_PROVIDER_PARAMETER =
-        new AutoValue_DoFnSignature_Parameter_InputProviderParameter();
-    private static final OutputReceiverParameter OUTPUT_RECEIVER_PARAMETER =
-        new AutoValue_DoFnSignature_Parameter_OutputReceiverParameter();
 
     /** Returns a {@link ContextParameter}. */
     public static ContextParameter context() {
@@ -303,20 +281,6 @@ public abstract class DoFnSignature {
     /** Returns a {@link WindowParameter}. */
     public static WindowParameter boundedWindow(TypeDescriptor<? extends BoundedWindow> windowT) {
       return new AutoValue_DoFnSignature_Parameter_WindowParameter(windowT);
-    }
-
-    /**
-     * Returns an {@link InputProviderParameter}.
-     */
-    public static InputProviderParameter inputProvider() {
-      return INPUT_PROVIDER_PARAMETER;
-    }
-
-    /**
-     * Returns an {@link OutputReceiverParameter}.
-     */
-    public static OutputReceiverParameter outputReceiver() {
-      return OUTPUT_RECEIVER_PARAMETER;
     }
 
     /**
@@ -375,26 +339,6 @@ public abstract class DoFnSignature {
     public abstract static class WindowParameter extends Parameter {
       WindowParameter() {}
       public abstract TypeDescriptor<? extends BoundedWindow> windowT();
-    }
-
-    /**
-     * Descriptor for a {@link Parameter} of type {@link InputProvider}.
-     *
-     * <p>All such descriptors are equal.
-     */
-    @AutoValue
-    public abstract static class InputProviderParameter extends Parameter {
-      InputProviderParameter() {}
-    }
-
-    /**
-     * Descriptor for a {@link Parameter} of type {@link OutputReceiver}.
-     *
-     * <p>All such descriptors are equal.
-     */
-    @AutoValue
-    public abstract static class OutputReceiverParameter extends Parameter {
-      OutputReceiverParameter() {}
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
@@ -155,12 +155,18 @@ public class ReflectHelpers {
     }
 
     private void formatParameterizedType(StringBuilder builder, ParameterizedType t) {
+      if (t.getOwnerType() != null) {
+        format(builder, t.getOwnerType());
+        builder.append('.');
+      }
       format(builder, t.getRawType());
-      builder.append('<');
-      COMMA_SEPARATOR.appendTo(builder,
-          FluentIterable.from(asList(t.getActualTypeArguments()))
-          .transform(TYPE_SIMPLE_DESCRIPTION));
-      builder.append('>');
+      if (t.getActualTypeArguments().length > 0) {
+        builder.append('<');
+        COMMA_SEPARATOR.appendTo(builder,
+            FluentIterable.from(asList(t.getActualTypeArguments()))
+                .transform(TYPE_SIMPLE_DESCRIPTION));
+        builder.append('>');
+      }
     }
 
     private void formatGenericArrayType(StringBuilder builder, GenericArrayType t) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -73,16 +73,12 @@ public class DoFnInvokersTest {
 
   @Mock private DoFn<String, String>.ProcessContext mockProcessContext;
   @Mock private IntervalWindow mockWindow;
-  @Mock private DoFn.InputProvider<String> mockInputProvider;
-  @Mock private DoFn.OutputReceiver<String> mockOutputReceiver;
   @Mock private DoFnInvoker.ArgumentProvider<String, String> mockArgumentProvider;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(mockArgumentProvider.window()).thenReturn(mockWindow);
-    when(mockArgumentProvider.inputProvider()).thenReturn(mockInputProvider);
-    when(mockArgumentProvider.outputReceiver()).thenReturn(mockOutputReceiver);
     when(mockArgumentProvider.processContext(Matchers.<DoFn>any())).thenReturn(mockProcessContext);
   }
 
@@ -228,28 +224,6 @@ public class DoFnInvokersTest {
     MockFn fn = mock(MockFn.class);
     assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
     verify(fn).processElement(mockProcessContext, mockTimer);
-  }
-
-  @Test
-  public void testDoFnWithOutputReceiver() throws Exception {
-    class MockFn extends DoFn<String, String> {
-      @DoFn.ProcessElement
-      public void processElement(ProcessContext c, OutputReceiver<String> o) throws Exception {}
-    }
-    MockFn fn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
-    verify(fn).processElement(mockProcessContext, mockOutputReceiver);
-  }
-
-  @Test
-  public void testDoFnWithInputProvider() throws Exception {
-    class MockFn extends DoFn<String, String> {
-      @DoFn.ProcessElement
-      public void processElement(ProcessContext c, InputProvider<String> o) throws Exception {}
-    }
-    MockFn fn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
-    verify(fn).processElement(mockProcessContext, mockInputProvider);
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
@@ -65,41 +65,35 @@ public class DoFnSignaturesProcessElementTest {
     analyzeProcessElementMethod(
         new AnonymousMethod() {
           private void method(
-              DoFn<Integer, String>.ProcessContext c,
-              DoFn.InputProvider<Integer> input,
-              DoFn.OutputReceiver<String> output) {}
+              DoFn<Integer, String>.ProcessContext c) {}
         });
   }
 
   @Test
   public void testBadGenericsTwoArgs() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("OutputReceiver<Integer>");
-    thrown.expectMessage("should be");
-    thrown.expectMessage("OutputReceiver<String>");
+    thrown.expectMessage("DoFn<Integer, Integer>.ProcessContext");
+    thrown.expectMessage("must have type");
+    thrown.expectMessage("DoFn<Integer, String>.ProcessContext");
 
     analyzeProcessElementMethod(
         new AnonymousMethod() {
           private void method(
-              DoFn<Integer, String>.ProcessContext c,
-              DoFn.InputProvider<Integer> input,
-              DoFn.OutputReceiver<Integer> output) {}
+              DoFn<Integer, Integer>.ProcessContext c) {}
         });
   }
 
   @Test
   public void testBadGenericWildCards() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("OutputReceiver<? super Integer>");
-    thrown.expectMessage("should be");
-    thrown.expectMessage("OutputReceiver<String>");
+    thrown.expectMessage("DoFn<Integer, ? super Integer>.ProcessContext");
+    thrown.expectMessage("must have type");
+    thrown.expectMessage("DoFn<Integer, String>.ProcessContext");
 
     analyzeProcessElementMethod(
         new AnonymousMethod() {
           private void method(
-              DoFn<Integer, String>.ProcessContext c,
-              DoFn.InputProvider<Integer> input,
-              DoFn.OutputReceiver<? super Integer> output) {}
+              DoFn<Integer, ? super Integer>.ProcessContext c) {}
         });
   }
 
@@ -107,17 +101,15 @@ public class DoFnSignaturesProcessElementTest {
     @ProcessElement
     @SuppressWarnings("unused")
     public void badTypeVariables(
-        DoFn<InputT, OutputT>.ProcessContext c,
-        DoFn.InputProvider<InputT> input,
-        DoFn.OutputReceiver<InputT> output) {}
+        DoFn<InputT, InputT>.ProcessContext c) {}
   }
 
   @Test
   public void testBadTypeVariables() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("OutputReceiver<InputT>");
-    thrown.expectMessage("should be");
-    thrown.expectMessage("OutputReceiver<OutputT>");
+    thrown.expectMessage("DoFn<InputT, InputT>.ProcessContext");
+    thrown.expectMessage("must have type");
+    thrown.expectMessage("DoFn<InputT, OutputT>.ProcessContext");
 
     DoFnSignatures.getSignature(BadTypeVariables.class);
   }
@@ -164,9 +156,7 @@ public class DoFnSignaturesProcessElementTest {
     @ProcessElement
     @SuppressWarnings("unused")
     public void goodTypeVariables(
-        DoFn<InputT, OutputT>.ProcessContext c,
-        DoFn.InputProvider<InputT> input,
-        DoFn.OutputReceiver<OutputT> output) {}
+        DoFn<InputT, OutputT>.ProcessContext c) {}
   }
 
   @Test
@@ -177,7 +167,7 @@ public class DoFnSignaturesProcessElementTest {
   private static class IdentityFn<T> extends DoFn<T, T> {
     @ProcessElement
     @SuppressWarnings("unused")
-    public void processElement(ProcessContext c, InputProvider<T> input, OutputReceiver<T> output) {
+    public void processElement(ProcessContext c) {
       c.output(c.element());
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -403,7 +403,8 @@ public class DoFnSignaturesSplittableDoFnTest {
   @Test
   public void testSplitRestrictionReturnsWrongType() throws Exception {
     thrown.expectMessage(
-        "Third argument must be OutputReceiver<SomeRestriction>, but is OutputReceiver<String>");
+        "Third argument must be DoFn.OutputReceiver<SomeRestriction>, "
+            + "but is DoFn.OutputReceiver<String>");
     DoFnSignatures.analyzeSplitRestrictionMethod(
         errors(),
         TypeDescriptor.of(FakeDoFn.class),

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -76,7 +76,7 @@ public class DoFnSignaturesTest {
   @Test
   public void testBadExtraContext() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Must take a single argument of type Context");
+    thrown.expectMessage("Must take a single argument of type DoFn<Integer, String>.Context");
 
     DoFnSignatures.analyzeBundleMethod(
         errors(),
@@ -656,10 +656,10 @@ public class DoFnSignaturesTest {
   @Test
   public void testStateParameterWrongGenericType() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("ValueState<java.lang.String>");
+    thrown.expectMessage("ValueState<String>");
     thrown.expectMessage("reference to");
     thrown.expectMessage("different type");
-    thrown.expectMessage("ValueState<java.lang.Integer>");
+    thrown.expectMessage("ValueState<Integer>");
     thrown.expectMessage("my-id");
     thrown.expectMessage("myProcessElement");
     thrown.expectMessage("index 1");


### PR DESCRIPTION
Removes InputProvider itself too.
Does not remove OutputReceiver because it's used in @SplitRestriction method.
Cleans up tests that looked at InputProvider/OutputReceiver parameters - instead now they look at DoFn.ProcessContext parameter, and I improved the formatting of parameter types too.

R: @kennknowles 