### PR TITLE
[BEAM-1343] Fix HDFSFileSource’s split size estimate

### DIFF
--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -237,13 +237,23 @@ public class HDFSFileSource<K, V> extends BoundedSource<KV<K, V>> {
   @Override
   public long getEstimatedSizeBytes(PipelineOptions options) {
     long size = 0;
+
     try {
+      // If this source represents a split from splitIntoBundles, then return the size of the split,
+      // rather then the entire input
+      if (serializableSplit != null) {
+        return serializableSplit.getSplit().getLength();
+      }
+
       Job job = Job.getInstance(); // new instance
       for (FileStatus st : listStatus(createFormat(job), job)) {
         size += st.getLen();
       }
     } catch (IOException | NoSuchMethodException | InvocationTargetException
         | IllegalAccessException | InstantiationException e) {
+      // ignore, and return 0
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       // ignore, and return 0
     }
     return size;


### PR DESCRIPTION
This is a port of this fix:
https://github.com/GoogleCloudPlatform/DataflowJavaSDK/pull/534

HDFSFileSource incorrectly calculates estimated byte size. The source can represent either a top level source or a split from splitIntoBundles. However, getEstimatedSizeBytes always calculates the size of the entire top level source.

This PR detects if the source represents a split and returns its length.
