### PR TITLE
[BEAM-1357] Upgrade error-prone-annotations to restore JDK7 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -755,7 +755,7 @@
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.0.13</version>
+        <version>2.0.15</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
They accidentally released 2 incremental versions, .13 and .14, which do not work with JDK7.
But .15 does.