### PR TITLE
[BEAM-1358] Require dependencies to support JDK7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1290,6 +1290,16 @@
             </goals>
             <configuration>
               <rules>
+                <enforceBytecodeVersion>
+                  <maxJdkVersion>1.7</maxJdkVersion>
+                  <excludes>
+                    <!--
+                      Supplied by the user JDK and compiled with matching
+                      version. Is not shaded, so safe to ignore.
+                    -->
+                    <exclude>jdk.tools:jdk.tools</exclude>
+                  </excludes>
+                </enforceBytecodeVersion>
                 <requireJavaVersion>
                   <version>[1.7,)</version>
                 </requireJavaVersion>
@@ -1300,6 +1310,13 @@
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>extra-enforcer-rules</artifactId>
+            <version>1.0-beta-6</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Uses maven-enforcer to do bytecode analysis of transitive dependencies