### PR TITLE
[BEAM-1369] Reduce test sizes to improve unit test speeds

### DIFF
--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -90,11 +90,14 @@ class JsonCoder(object):
 
 class EstimatePiTransform(beam.PTransform):
   """Runs 10M trials, and combine the results to estimate pi."""
+  def __init__(self, tries_per_work_item=100000):
+    self.tries_per_work_item = tries_per_work_item
 
   def expand(self, pcoll):
     # A hundred work items of a hundred thousand tries each.
     return (pcoll
-            | 'Initialize' >> beam.Create([100000] * 100).with_output_types(int)
+            | 'Initialize' >> beam.Create(
+                [self.tries_per_work_item] * 100).with_output_types(int)
             | 'Run trials' >> beam.Map(run_trials)
             | 'Sum' >> beam.CombineGlobally(combine_results).without_defaults())
 

--- a/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
@@ -39,7 +39,7 @@ class EstimatePiTest(unittest.TestCase):
 
   def test_basics(self):
     p = TestPipeline()
-    result = p | 'Estimate' >> estimate_pi.EstimatePiTransform()
+    result = p | 'Estimate' >> estimate_pi.EstimatePiTransform(5000)
 
     # Note: Probabilistically speaking this test can fail with a probability
     # that is very small (VERY) given that we run at least 10 million trials.

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -284,8 +284,8 @@ class TestAvro(unittest.TestCase):
     # work rebalancing test that completes within an acceptable amount of time.
     old_sync_interval = avro.datafile.SYNC_INTERVAL
     try:
-      avro.datafile.SYNC_INTERVAL = 5
-      file_name = self._write_data(count=20)
+      avro.datafile.SYNC_INTERVAL = 2
+      file_name = self._write_data(count=5)
       source = AvroSource(file_name)
       splits = [split
                 for split in source.split(desired_bundle_size=float('inf'))]

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -486,7 +486,8 @@ class TestBigQueryReader(unittest.TestCase):
     self.assertEqual(actual_rows, table_rows)
     self.assertEqual(schema, reader.schema)
 
-  def test_read_from_table_and_job_complete_retry(self):
+  @mock.patch('time.sleep', return_value=None)
+  def test_read_from_table_and_job_complete_retry(self, patched_time_sleep):
     client = mock.Mock()
     client.jobs.Insert.return_value = bigquery.Job(
         jobReference=bigquery.JobReference(

--- a/sdks/python/apache_beam/io/source_test_utils_test.py
+++ b/sdks/python/apache_beam/io/source_test_utils_test.py
@@ -113,9 +113,8 @@ class SourceTestUtilsTest(unittest.TestCase):
     self.assertTrue(stats.non_trivial_fractions)
 
   def test_split_at_fraction_exhaustive(self):
-    data = self._create_data(20)
+    data = self._create_data(10)
     source = self._create_source(data)
-
     source_test_utils.assertSplitAtFractionExhaustive(source)
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -258,8 +258,8 @@ class TextSourceTest(unittest.TestCase):
         (splits[0].source, splits[0].start_position, splits[0].stop_position))
 
   def test_dynamic_work_rebalancing(self):
-    file_name, expected_data = write_data(15)
-    assert len(expected_data) == 15
+    file_name, expected_data = write_data(5)
+    assert len(expected_data) == 5
     source = TextSource(file_name, 0, CompressionTypes.UNCOMPRESSED, True,
                         coders.StrUtf8Coder())
     splits = [split for split in source.split(desired_bundle_size=100000)]
@@ -279,8 +279,8 @@ class TextSourceTest(unittest.TestCase):
         perform_multi_threaded_test=False)
 
   def test_dynamic_work_rebalancing_mixed_eol(self):
-    file_name, expected_data = write_data(15, eol=EOL.MIXED)
-    assert len(expected_data) == 15
+    file_name, expected_data = write_data(5, eol=EOL.MIXED)
+    assert len(expected_data) == 5
     source = TextSource(file_name, 0, CompressionTypes.UNCOMPRESSED, True,
                         coders.StrUtf8Coder())
     splits = [split for split in source.split(desired_bundle_size=100000)]
@@ -374,7 +374,7 @@ class TextSourceTest(unittest.TestCase):
     pipeline.run()
 
   def test_read_gzip_large(self):
-    _, lines = write_data(10000)
+    _, lines = write_data(1000)
     file_name = tempfile.NamedTemporaryFile(
         delete=False, prefix=tempfile.template).name
     with gzip.GzipFile(file_name, 'wb') as f:
@@ -389,7 +389,7 @@ class TextSourceTest(unittest.TestCase):
     pipeline.run()
 
   def test_read_gzip_large_after_splitting(self):
-    _, lines = write_data(10000)
+    _, lines = write_data(1000)
     file_name = tempfile.NamedTemporaryFile(
         delete=False, prefix=tempfile.template).name
     with gzip.GzipFile(file_name, 'wb') as f:

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -219,14 +219,13 @@ class CombineTest(unittest.TestCase):
     pipeline.run()
 
   def test_global_sample(self):
-
     def is_good_sample(actual):
       assert len(actual) == 1
       assert sorted(actual[0]) in [[1, 1, 2], [1, 2, 2]], actual
 
     with TestPipeline() as pipeline:
       pcoll = pipeline | 'start' >> Create([1, 1, 2, 2])
-      for ix in xrange(30):
+      for ix in xrange(9):
         assert_that(
             pcoll | combine.Sample.FixedSizeGlobally('sample-%d' % ix, 3),
             is_good_sample,
@@ -235,7 +234,7 @@ class CombineTest(unittest.TestCase):
   def test_per_key_sample(self):
     pipeline = TestPipeline()
     pcoll = pipeline | 'start-perkey' >> Create(
-        sum(([(i, 1), (i, 1), (i, 2), (i, 2)] for i in xrange(300)), []))
+        sum(([(i, 1), (i, 1), (i, 2), (i, 2)] for i in xrange(9)), []))
     result = pcoll | 'sample' >> combine.Sample.FixedSizePerKey(3)
 
     def matcher():


### PR DESCRIPTION
R: @aaltay PTAL

These changes reduce the time taken by python unittests from 85 to 36 seconds.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
