### PR TITLE
[BEAM-1365] Fix the big query regex to account for . in dataset name

### DIFF
--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -302,7 +302,7 @@ def _parse_table_reference(table, dataset=None, project=None):
   # table name.
   if dataset is None:
     match = re.match(
-        r'^((?P<project>.+):)?(?P<dataset>\w+)\.(?P<table>[\w\$]+)$', table)
+        r'^((?P<project>.+):)?(?P<dataset>[\w\.]+)\.(?P<table>[\w\$]+)$', table)
     if not match:
       raise ValueError(
           'Expected a table reference (PROJECT:DATASET.TABLE or '


### PR DESCRIPTION
R: @chamikaramj PTAL

Bigquery datasets allow for . inside them but the regex in https://github.com/apache/beam/blob/master/sdks/python/apache_beam/io/bigquery.py#L305 doesn't allow for this.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
