### PR TITLE
[BEAM-1368] fixed Python SDK setup in Python 3.x

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -30,8 +30,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 
 def get_version():
   global_names = {}
-  execfile(os.path.normpath('./apache_beam/version.py'),
-           global_names)
+  exec(open(os.path.normpath('./apache_beam/version.py')).read(), global_names)
   return global_names['__version__']
 
 PACKAGE_NAME = 'apache-beam-sdk'


### PR DESCRIPTION
By replacing the usage of `execfile()` by `exec()`, which is the official recommendation for portability.

Further details described at [BEAM-1368](https://issues.apache.org/jira/browse/BEAM-1368).

---

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).


