### PR TITLE
[BEAM-1265] Fail if --streaming option is used

### DIFF
--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -189,6 +189,14 @@ class StandardOptions(PipelineOptions):
                         action='store_true',
                         help='Whether to enable streaming mode.')
 
+  # TODO(BEAM-1265): Remove this error, once at least one runner supports
+  # streaming pipelines.
+  def validate(self, validator):
+    errors = []
+    if self.view_as(StandardOptions).streaming:
+      errors.append('Streaming pipelines are not supported.')
+    return errors
+
 
 class TypeOptions(PipelineOptions):
 

--- a/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/utils/pipeline_options_validator_test.py
@@ -300,6 +300,14 @@ class SetupTest(unittest.TestCase):
     errors = validator.validate()
     self.assertFalse(errors)
 
+  def test_streaming(self):
+    pipeline_options = PipelineOptions(['--streaming'])
+    runner = MockRunners.TestDataflowRunner()
+    validator = PipelineOptionsValidator(pipeline_options, runner)
+    errors = validator.validate()
+
+    self.assertIn('Streaming pipelines are not supported.', errors)
+
   def test_test_matcher(self):
     def get_validator(matcher):
       options = ['--project=example:example',


### PR DESCRIPTION
Currently, none of the runners for Python SDK supports streaming. Fail
at pipeline validation time if '--streaming' option is set. This is to
prevent user confusion, until streaming execution is implemented.

