### PR TITLE
Ignores errorprone annotations in enforcer config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1390,6 +1390,8 @@
                       version. Is not shaded, so safe to ignore.
                     -->
                     <exclude>jdk.tools:jdk.tools</exclude>
+                    <!-- Compile-time annotations, safe to ignore -->
+                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
                   </excludes>
                 </enforceBytecodeVersion>
                 <requireJavaVersion>


### PR DESCRIPTION
They use Java 8 classes.
(discovered while building Dataflow worker against Beam at HEAD)

R: @dhalperi 