### PR TITLE
Invoke onMerge in AfterWatermarkEarly

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -129,6 +129,7 @@ public class AfterWatermarkStateMachine {
       // the new merged window, because even if the merged window is "done" some pending elements
       // haven't had a chance to fire.
       if (!earlyContext.trigger().finishedInAllMergingWindows() || !endOfWindowReached(c)) {
+        earlySubtrigger.invokeOnMerge(earlyContext);
         earlyContext.trigger().setFinished(false);
         if (lateTrigger != null) {
           ExecutableTriggerStateMachine lateSubtrigger = c.trigger().subTrigger(LATE_INDEX);

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachineTest.java
@@ -21,8 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnMergeContext;
 import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnceTriggerStateMachine;
 import org.apache.beam.runners.core.triggers.TriggerStateMachineTester.SimpleTriggerStateMachineTester;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -291,6 +293,23 @@ public class AfterWatermarkStateMachineTest {
     assertFalse(tester.shouldFire(mergedWindow));
     tester.injectElements(1);
     assertTrue(tester.shouldFire(mergedWindow));
+  }
+
+  @Test
+  public void testEarlyAndLateOnMergeSubtriggerMerges() throws Exception {
+    tester =
+        TriggerStateMachineTester.forTrigger(
+            AfterWatermarkStateMachine.pastEndOfWindow()
+                .withEarlyFirings(mockEarly)
+                .withLateFirings(mockLate),
+            Sessions.withGapDuration(Duration.millis(10)));
+
+    tester.injectElements(1);
+    tester.injectElements(5);
+
+    // Merging should re-activate the early trigger in the merged window
+    tester.mergeWindows();
+    verify(mockEarly).onMerge(Mockito.any(OnMergeContext.class));
   }
 
   /**


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This ensures that any triggering state manipulations appropriately
notify the early subtrigger before resetting the finished bit. This
ensures that any timers or state is appropriately migrated to the
merged window.

Merged to master in #1907 