### PR TITLE
[BEAM-1387] DatastoreV1: use batch-datastore.googleapis.com endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,8 +109,8 @@
     <clouddebugger.version>v2-rev8-1.22.0</clouddebugger.version>
     <dataflow.version>v1b3-rev43-1.22.0</dataflow.version>
     <dataflow.proto.version>0.5.160222</dataflow.proto.version>
-    <datastore.client.version>1.2.0</datastore.client.version>
-    <datastore.proto.version>1.2.0</datastore.proto.version>
+    <datastore.client.version>1.4.0</datastore.client.version>
+    <datastore.proto.version>1.3.0</datastore.proto.version>
     <google-auto-service.version>1.0-rc2</google-auto-service.version>
     <google-auto-value.version>1.3</google-auto-value.version>
     <google-auth.version>0.6.0</google-auth.version>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -1067,6 +1067,8 @@ public class DatastoreV1 {
 
       if (localhost != null) {
         builder.localHost(localhost);
+      } else {
+        builder.host("batch-datastore.googleapis.com");
       }
 
       return DatastoreFactory.get().create(builder.build());


### PR DESCRIPTION
If localhost is not set.

Note this requires an upgrade to Datastore proto client 1.4, but there ought (fingers crossed) to be no proto conflicts, or so I'm promised.

R: @vikkyrk 
cc: @eddavisson