### PR TITLE
[BEAM-1388] Updates default values used by retry decorator.

### DIFF
--- a/sdks/python/apache_beam/utils/retry.py
+++ b/sdks/python/apache_beam/utils/retry.py
@@ -54,11 +54,11 @@ class FuzzedExponentialIntervals(object):
       [(1 - fuzz) * d, d].
     max_delay_sec: Maximum delay (in seconds). After this limit is reached,
       further tries use max_delay_sec instead of exponentially increasing
-      the time. Defaults to 4 hours.
+      the time. Defaults to 1 hour.
   """
 
   def __init__(self, initial_delay_secs, num_retries, factor=2, fuzz=0.5,
-               max_delay_secs=60 * 60 * 4):
+               max_delay_secs=60 * 60 * 1):
     self._initial_delay_secs = initial_delay_secs
     self._num_retries = num_retries
     self._factor = factor

--- a/sdks/python/apache_beam/utils/retry.py
+++ b/sdks/python/apache_beam/utils/retry.py
@@ -115,9 +115,9 @@ def no_retries(fun):
 
 
 def with_exponential_backoff(
-    num_retries=16, initial_delay_secs=5.0, logger=logging.warning,
+    num_retries=7, initial_delay_secs=5.0, logger=logging.warning,
     retry_filter=retry_on_server_errors_filter,
-    clock=Clock(), fuzz=True, factor=2, max_delay_secs=60 * 60 * 4):
+    clock=Clock(), fuzz=True, factor=2, max_delay_secs=60 * 60):
   """Decorator with arguments that control the retry logic.
 
   Args:

--- a/sdks/python/apache_beam/utils/retry_test.py
+++ b/sdks/python/apache_beam/utils/retry_test.py
@@ -75,7 +75,7 @@ class RetryTest(unittest.TestCase):
 
   def transient_failure(self, a, b):
     self.calls += 1
-    if self.calls > 8:
+    if self.calls > 4:
       return a + b
     raise NotImplementedError
 
@@ -99,7 +99,7 @@ class RetryTest(unittest.TestCase):
                       retry.with_exponential_backoff(clock=self.clock)(
                           self.permanent_failure),
                       10, b=20)
-    self.assertEqual(len(self.clock.calls), 16)
+    self.assertEqual(len(self.clock.calls), 7)
 
   def test_with_explicit_number_of_retries(self):
     self.assertRaises(NotImplementedError,
@@ -133,7 +133,7 @@ class RetryTest(unittest.TestCase):
                           fuzz=False)(
                               self.permanent_failure),
                       10, b=20)
-    self.assertEqual(len(self.clock.calls), 16)
+    self.assertEqual(len(self.clock.calls), 7)
     self.assertEqual(self.clock.calls[0], 10.0)
 
   def test_log_calls_for_permanent_failure(self):
@@ -142,7 +142,7 @@ class RetryTest(unittest.TestCase):
                           clock=self.clock, logger=self.logger.log)(
                               self.permanent_failure),
                       10, b=20)
-    self.assertEqual(len(self.logger.calls), 16)
+    self.assertEqual(len(self.logger.calls), 7)
     for message, func_name, exn_name  in self.logger.calls:
       self.assertTrue(message.startswith('Retry with exponential backoff:'))
       self.assertEqual(exn_name, 'NotImplementedError\n')
@@ -153,11 +153,10 @@ class RetryTest(unittest.TestCase):
         clock=self.clock, logger=self.logger.log, fuzz=False)(
             self.transient_failure)(10, b=20)
     self.assertEqual(result, 30)
-    self.assertEqual(len(self.clock.calls), 8)
+    self.assertEqual(len(self.clock.calls), 4)
     self.assertEqual(self.clock.calls,
-                     [5.0 * 1, 5.0 * 2, 5.0 * 4, 5.0 * 8,
-                      5.0 * 16, 5.0 * 32, 5.0 * 64, 5.0 * 128])
-    self.assertEqual(len(self.logger.calls), 8)
+                     [5.0 * 1, 5.0 * 2, 5.0 * 4, 5.0 * 8,])
+    self.assertEqual(len(self.logger.calls), 4)
     for message, func_name, exn_name  in self.logger.calls:
       self.assertTrue(message.startswith('Retry with exponential backoff:'))
       self.assertEqual(exn_name, 'NotImplementedError\n')


### PR DESCRIPTION
Updates following defaults so that total wait time by default is more practical.

num_retries from 16 to 7.
max_delay_secs from 4 hours to 1 hour.

With this update, for maximum number of retries, system will wait for 635 sec while wait before last retry being 320 sec.
