### PR TITLE
[BEAM-1369] Reduce test times for two retry based tests

### DIFF
--- a/sdks/python/apache_beam/io/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcsio_test.py
@@ -435,7 +435,7 @@ class TestGCSIO(unittest.TestCase):
     f = self.gcs.open(file_name)
     random.seed(0)
     f.buffer_size = 1024 * 1024
-    f.segment_timeout = 0.1
+    f.segment_timeout = 0.01
     self.assertEqual(f.mode, 'r')
     f._real_get_segment = f._get_segment
 

--- a/sdks/python/apache_beam/utils/retry_test.py
+++ b/sdks/python/apache_beam/utils/retry_test.py
@@ -51,7 +51,7 @@ def test_function(a, b):
   raise NotImplementedError
 
 
-@retry.with_exponential_backoff(initial_delay_secs=1.0, num_retries=1)
+@retry.with_exponential_backoff(initial_delay_secs=0.1, num_retries=1)
 def test_function_with_real_clock(a, b):
   _ = a, b
   raise NotImplementedError


### PR DESCRIPTION
R: @charlesccychen PTAL

- The gcsio test was taking 2s so reducing the segment override makes it faster.
- The retry test now just starts at a lower time to speed it up from 1s -> 0.1s

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
