### PR TITLE
[BEAM-1409] Check that Elements, Timers have permitted Timestamps

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ImmutableListBundleFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ImmutableListBundleFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.direct;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
@@ -94,6 +95,11 @@ class ImmutableListBundleFactory implements BundleFactory {
           "Can't add element %s to committed bundle in PCollection %s",
           element,
           pcollection);
+      checkArgument(
+          element.getTimestamp().isBefore(BoundedWindow.TIMESTAMP_MAX_VALUE),
+          "Can't add an element past the end of time (%s), got timestamp %s",
+          BoundedWindow.TIMESTAMP_MAX_VALUE,
+          element.getTimestamp());
       elements.add(element);
       if (element.getTimestamp().isBefore(minSoFar)) {
         minSoFar = element.getTimestamp();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.direct;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
@@ -1361,6 +1362,11 @@ public class WatermarkManager {
        * it has previously been deleted. Returns this {@link TimerUpdateBuilder}.
        */
       public TimerUpdateBuilder setTimer(TimerData setTimer) {
+        checkArgument(
+            setTimer.getTimestamp().isBefore(BoundedWindow.TIMESTAMP_MAX_VALUE),
+            "Got a timer for after the end of time (%s), got %s",
+            BoundedWindow.TIMESTAMP_MAX_VALUE,
+            setTimer.getTimestamp());
         deletedTimers.remove(setTimer);
         setTimers.add(setTimer);
         return this;

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutableListBundleFactoryTest.java
@@ -44,6 +44,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
@@ -139,6 +140,28 @@ public class ImmutableListBundleFactoryTest {
         WindowedValue.timestampedValueInGlobalWindow(2, new Instant(1000L));
 
     afterCommitGetElementsShouldHaveAddedElements(ImmutableList.of(firstValue, secondValue));
+  }
+
+  @Test
+  public void addElementsAtEndOfTimeThrows() {
+    Instant timestamp = BoundedWindow.TIMESTAMP_MAX_VALUE;
+    WindowedValue<Integer> value = WindowedValue.timestampedValueInGlobalWindow(1, timestamp);
+
+    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle();
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(timestamp.toString());
+    bundle.add(value);
+  }
+
+  @Test
+  public void addElementsPastEndOfTimeThrows() {
+    Instant timestamp = BoundedWindow.TIMESTAMP_MAX_VALUE.plus(Duration.standardMinutes(2));
+    WindowedValue<Integer> value = WindowedValue.timestampedValueInGlobalWindow(1, timestamp);
+
+    UncommittedBundle<Integer> bundle = bundleFactory.createRootBundle();
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(timestamp.toString());
+    bundle.add(value);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Add a checkArgument to ImmutableListBundleFactory that elements must
be timestamped earlier than the maximum representable timestamp.

Add a checkArgument to TimerData that Timers must fire before the
maximum representable timestamp.
