### PR TITLE
[BEAM-1406] Removes deprecated fileio.TextFileSink

### DIFF
--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -53,8 +53,8 @@ After this import statement
 
 * transform classes are available as beam.FlatMap, beam.GroupByKey, etc.
 * Pipeline class is available as beam.Pipeline
-* text source/sink classes are available as beam.io.TextFileSource,
-  beam.io.TextFileSink
+* text source/sink transforms are available as beam.io.RedfromText,
+  beam.io.WriteToText
 
 Examples
 --------

--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -53,7 +53,7 @@ After this import statement
 
 * transform classes are available as beam.FlatMap, beam.GroupByKey, etc.
 * Pipeline class is available as beam.Pipeline
-* text source/sink transforms are available as beam.io.RedfromText,
+* text read/write transforms are available as beam.io.ReadfromText,
   beam.io.WriteToText
 
 Examples

--- a/sdks/python/apache_beam/io/fileio.py
+++ b/sdks/python/apache_beam/io/fileio.py
@@ -28,14 +28,11 @@ import shutil
 import time
 import zlib
 
-from apache_beam import coders
 from apache_beam.internal import util
 from apache_beam.io import gcsio
 from apache_beam.io import iobase
 from apache_beam.transforms.display import DisplayDataItem
 
-
-__all__ = ['TextFileSink']
 
 DEFAULT_SHARD_NAME_TEMPLATE = '-SSSSS-of-NNNNN'
 
@@ -721,77 +718,3 @@ class FileSinkWriter(iobase.Writer):
   def close(self):
     self.sink.close(self.temp_handle)
     return self.temp_shard_path
-
-
-class TextFileSink(FileSink):
-  """A sink to a GCS or local text file or files."""
-
-  def __init__(self,
-               file_path_prefix,
-               file_name_suffix='',
-               append_trailing_newlines=True,
-               num_shards=0,
-               shard_name_template=None,
-               coder=coders.ToStringCoder(),
-               compression_type=CompressionTypes.AUTO):
-    """Initialize a TextFileSink.
-
-    Args:
-      file_path_prefix: The file path to write to. The files written will begin
-        with this prefix, followed by a shard identifier (see num_shards), and
-        end in a common extension, if given by file_name_suffix. In most cases,
-        only this argument is specified and num_shards, shard_name_template, and
-        file_name_suffix use default values.
-      file_name_suffix: Suffix for the files written.
-      append_trailing_newlines: indicate whether this sink should write an
-        additional newline char after writing each element.
-      num_shards: The number of files (shards) used for output. If not set, the
-        service will decide on the optimal number of shards.
-        Constraining the number of shards is likely to reduce
-        the performance of a pipeline.  Setting this value is not recommended
-        unless you require a specific number of output files.
-      shard_name_template: A template string containing placeholders for
-        the shard number and shard count. Currently only '' and
-        '-SSSSS-of-NNNNN' are patterns accepted by the service.
-        When constructing a filename for a particular shard number, the
-        upper-case letters 'S' and 'N' are replaced with the 0-padded shard
-        number and shard count respectively.  This argument can be '' in which
-        case it behaves as if num_shards was set to 1 and only one file will be
-        generated. The default pattern used is '-SSSSS-of-NNNNN'.
-      coder: Coder used to encode each line.
-      compression_type: Used to handle compressed output files. Typical value
-          is CompressionTypes.AUTO, in which case the final file path's
-          extension (as determined by file_path_prefix, file_name_suffix,
-          num_shards and shard_name_template) will be used to detect the
-          compression.
-
-    Returns:
-      A TextFileSink object usable for writing.
-    """
-    super(TextFileSink, self).__init__(
-        file_path_prefix,
-        file_name_suffix=file_name_suffix,
-        num_shards=num_shards,
-        shard_name_template=shard_name_template,
-        coder=coder,
-        mime_type='text/plain',
-        compression_type=compression_type)
-    self.append_trailing_newlines = append_trailing_newlines
-
-    if type(self) is TextFileSink:
-      logging.warning('Direct usage of TextFileSink is deprecated. Please use '
-                      '\'textio.WriteToText()\' instead of directly '
-                      'instantiating a TextFileSink object.')
-
-  def display_data(self):
-    dd_parent = super(TextFileSink, self).display_data()
-    dd_parent['append_newline'] = DisplayDataItem(
-        self.append_trailing_newlines,
-        label='Append Trailing New Lines')
-    return dd_parent
-
-  def write_encoded_record(self, file_handle, encoded_value):
-    """Writes a single encoded record."""
-    file_handle.write(encoded_value)
-    if self.append_trailing_newlines:
-      file_handle.write('\n')

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -225,7 +225,7 @@ class _TextSink(fileio.FileSink):
                shard_name_template=None,
                coder=coders.ToStringCoder(),
                compression_type=fileio.CompressionTypes.AUTO):
-    """Initialize a TextFileSink.
+    """Initialize a _TextSink.
 
     Args:
       file_path_prefix: The file path to write to. The files written will begin
@@ -257,7 +257,7 @@ class _TextSink(fileio.FileSink):
           compression.
 
     Returns:
-      A TextFileSink object usable for writing.
+      A _TextSink object usable for writing.
     """
     super(_TextSink, self).__init__(
         file_path_prefix,

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -214,9 +214,73 @@ class _TextSource(filebasedsource.FileBasedSource):
               sep_bounds[1] - record_start_position_in_buffer)
 
 
-class _TextSink(fileio.TextFileSink):
-  # TODO: Move code from 'fileio.TextFileSink' to here.
-  pass
+class _TextSink(fileio.FileSink):
+  """A sink to a GCS or local text file or files."""
+
+  def __init__(self,
+               file_path_prefix,
+               file_name_suffix='',
+               append_trailing_newlines=True,
+               num_shards=0,
+               shard_name_template=None,
+               coder=coders.ToStringCoder(),
+               compression_type=fileio.CompressionTypes.AUTO):
+    """Initialize a TextFileSink.
+
+    Args:
+      file_path_prefix: The file path to write to. The files written will begin
+        with this prefix, followed by a shard identifier (see num_shards), and
+        end in a common extension, if given by file_name_suffix. In most cases,
+        only this argument is specified and num_shards, shard_name_template, and
+        file_name_suffix use default values.
+      file_name_suffix: Suffix for the files written.
+      append_trailing_newlines: indicate whether this sink should write an
+        additional newline char after writing each element.
+      num_shards: The number of files (shards) used for output. If not set, the
+        service will decide on the optimal number of shards.
+        Constraining the number of shards is likely to reduce
+        the performance of a pipeline.  Setting this value is not recommended
+        unless you require a specific number of output files.
+      shard_name_template: A template string containing placeholders for
+        the shard number and shard count. Currently only '' and
+        '-SSSSS-of-NNNNN' are patterns accepted by the service.
+        When constructing a filename for a particular shard number, the
+        upper-case letters 'S' and 'N' are replaced with the 0-padded shard
+        number and shard count respectively.  This argument can be '' in which
+        case it behaves as if num_shards was set to 1 and only one file will be
+        generated. The default pattern used is '-SSSSS-of-NNNNN'.
+      coder: Coder used to encode each line.
+      compression_type: Used to handle compressed output files. Typical value
+          is CompressionTypes.AUTO, in which case the final file path's
+          extension (as determined by file_path_prefix, file_name_suffix,
+          num_shards and shard_name_template) will be used to detect the
+          compression.
+
+    Returns:
+      A TextFileSink object usable for writing.
+    """
+    super(_TextSink, self).__init__(
+        file_path_prefix,
+        file_name_suffix=file_name_suffix,
+        num_shards=num_shards,
+        shard_name_template=shard_name_template,
+        coder=coder,
+        mime_type='text/plain',
+        compression_type=compression_type)
+    self.append_trailing_newlines = append_trailing_newlines
+
+  def display_data(self):
+    dd_parent = super(_TextSink, self).display_data()
+    dd_parent['append_newline'] = DisplayDataItem(
+        self.append_trailing_newlines,
+        label='Append Trailing New Lines')
+    return dd_parent
+
+  def write_encoded_record(self, file_handle, encoded_value):
+    """Writes a single encoded record."""
+    file_handle.write(encoded_value)
+    if self.append_trailing_newlines:
+      file_handle.write('\n')
 
 
 class ReadFromText(PTransform):


### PR DESCRIPTION
Users should be using textio.WriteToText() transform instead of
fileio.TextFileSink.
