### PR TITLE
[BEAM-1413] Fix some DoFn javadoc literals

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -77,15 +77,15 @@ import org.joda.time.Instant;
  *
  * <p>Example usage:
  *
- * <pre>{@code
- * PCollection<String> lines = ... ;
- * PCollection<String> words =
- *     lines.apply(ParDo.of(new DoFn<String, String>() {
- *         {@literal @}ProcessElement
- *         public void processElement(ProcessContext c, BoundedWindow window) {
- *
- *         }}));
- * }</pre>
+ * <pre><code>
+ * {@literal PCollection<String>} lines = ... ;
+ * {@literal PCollection<String>} words =
+ *     {@literal lines.apply(ParDo.of(new DoFn<String, String>())} {
+ *         {@literal @ProcessElement}
+ *          public void processElement(ProcessContext c, BoundedWindow window) {
+ *            ...
+ *          }}));
+ * </code></pre>
  *
  * @param <InputT> the type of the (main) input elements
  * @param <OutputT> the type of the (main) output elements
@@ -385,21 +385,21 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * subclass to your {@link ProcessElement @ProcessElement} or {@link OnTimer @OnTimer} method, and
    * annotate it with {@link StateId}. See the following code for an example:
    *
-   * <pre>{@code
-   * new DoFn<KV<Key, Foo>, Baz>() {
-   *   {@literal @}StateId("my-state-id")
-   *   private final StateSpec<K, ValueState<MyState>> myStateSpec =
+   * <pre><code>{@literal new DoFn<KV<Key, Foo>, Baz>()} {
+   *
+   *  {@literal @StateId("my-state-id")}
+   *  {@literal private final StateSpec<K, ValueState<MyState>>} myStateSpec =
    *       StateSpecs.value(new MyStateCoder());
    *
-   *   {@literal @}ProcessElement
+   *  {@literal @ProcessElement}
    *   public void processElement(
    *       ProcessContext c,
-   *       {@literal @}StateId("my-state-id") ValueState<MyState> myState) {
+   *      {@literal @StateId("my-state-id") ValueState<MyState> myState}) {
    *     myState.read();
    *     myState.write(...);
    *   }
    * }
-   * }</pre>
+   * </code></pre>
    *
    * <p>State is subject to the following validity conditions:
    *
@@ -429,24 +429,22 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * {@link ProcessElement @ProcessElement} or {@link OnTimer @OnTimer} method, and annotate it with
    * {@link TimerId}. See the following code for an example:
    *
-   * <pre>{@code
-   * new DoFn<KV<Key, Foo>, Baz>() {
-   *   {@literal @}TimerId("my-timer-id")
-   *   private final TimerSpec myTimer = TimerSpecs.timerForDomain(TimeDomain.EVENT_TIME);
+   * <pre><code>{@literal new DoFn<KV<Key, Foo>, Baz>()} {
+   *   {@literal @TimerId("my-timer-id")}
+   *    private final TimerSpec myTimer = TimerSpecs.timerForDomain(TimeDomain.EVENT_TIME);
    *
-   *   {@literal @}ProcessElement
-   *   public void processElement(
-   *       ProcessContext c,
-   *       {@literal @}TimerId("my-timer-id") Timer myTimer) {
-   *     myTimer.setForNowPlus(Duration.standardSeconds(...));
-   *   }
+   *   {@literal @ProcessElement}
+   *    public void processElement(
+   *        ProcessContext c,
+   *       {@literal @TimerId("my-timer-id") Timer myTimer}) {
+   *      myTimer.setForNowPlus(Duration.standardSeconds(...));
+   *    }
    *
-   *   {@literal @}OnTimer("my-timer-id")
-   *   public void onMyTimer() {
-   *     ...
-   *   }
-   * }
-   * }</pre>
+   *   {@literal @OnTimer("my-timer-id")}
+   *    public void onMyTimer() {
+   *      ...
+   *    }
+   * }</code></pre>
    *
    * <p>Timers are subject to the following validity conditions:
    *


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

@dhalperi and @davorbonaci are familiar with the pain here... I tried my best to make it legible both in source and in target. The problem is actually mostly related to multi-line use of javadoc tags, which javadoc simply processes incorrectly. This seems like a fairly brain-dead reproducible format for such blocks.