### PR TITLE
[BEAM-1432] Inject number of Shards as a Side Input to Write

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
@@ -54,7 +54,7 @@ class WriteWithShardingFactory<InputT>
   @Override
   public PTransform<PCollection<InputT>, PDone> getReplacementTransform(
       Bound<InputT> transform) {
-    if (transform.getNumShards() == 0) {
+    if (transform.getSharding() == null) {
       return new DynamicallyReshardedWrite<>(transform);
     }
     return transform;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Write.java
@@ -97,18 +97,20 @@ public class Write {
    */
   public static class Bound<T> extends PTransform<PCollection<T>, PDone> {
     private final Sink<T> sink;
+    @Nullable
     private final PTransform<PCollection<T>, PCollectionView<Integer>> computeNumShards;
 
     private Bound(
         Sink<T> sink,
         @Nullable PTransform<PCollection<T>, PCollectionView<Integer>> computeNumShards) {
       this.sink = sink;
-        this.computeNumShards = computeNumShards;
+      this.computeNumShards = computeNumShards;
     }
 
     @Override
     public PDone expand(PCollection<T> input) {
-      checkArgument(IsBounded.BOUNDED == input.isBounded(),
+      checkArgument(
+          IsBounded.BOUNDED == input.isBounded(),
           "%s can only be applied to a Bounded PCollection",
           Write.class.getSimpleName());
       PipelineOptions options = input.getPipeline().getOptions();
@@ -134,6 +136,13 @@ public class Write {
       return sink;
     }
 
+    /**
+     * Gets the {@link PTransform} that will be used to determine sharding. This can be either a
+     * static number of shards (as following a call to {@link #withNumShards(int)}), dynamic (by
+     * {@link #withSharding(PTransform)}), or runner-determined (by {@link
+     * #withRunnerDeterminedSharding()}.
+     */
+    @Nullable
     public PTransform<PCollection<T>, PCollectionView<Integer>> getSharding() {
       return computeNumShards;
     }
@@ -485,7 +494,7 @@ public class Write {
 
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
-      builder.add(DisplayData.item("numShards", numShards));
+      builder.add(DisplayData.item("numShards", numShards).withLabel("ConstantShards"));
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -254,14 +254,11 @@ public class WriteTest {
   public void testBuildWrite() {
     Sink<String> sink = new TestSink() {};
     Write.Bound<String> write = Write.to(sink).withNumShards(3);
-    assertEquals(3, write.getNumShards());
     assertThat(write.getSink(), is(sink));
 
     Write.Bound<String> write2 = write.withNumShards(7);
-    assertEquals(7, write2.getNumShards());
     assertThat(write2.getSink(), is(sink));
     // original unchanged
-    assertEquals(3, write.getNumShards());
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -356,6 +356,34 @@ public class WriteTest {
   }
 
   @Test
+  public void testCustomShardStrategyDisplayData() {
+    TestSink sink = new TestSink() {
+      @Override
+      public void populateDisplayData(DisplayData.Builder builder) {
+        builder.add(DisplayData.item("foo", "bar"));
+      }
+    };
+    Write.Bound<String> write =
+        Write.to(sink)
+            .withSharding(
+                new PTransform<PCollection<String>, PCollectionView<Integer>>() {
+                  @Override
+                  public PCollectionView<Integer> expand(PCollection<String> input) {
+                    return null;
+                  }
+
+                  @Override
+                  public void populateDisplayData(DisplayData.Builder builder) {
+                    builder.add(DisplayData.item("spam", "ham"));
+                  }
+                });
+    DisplayData displayData = DisplayData.from(write);
+    assertThat(displayData, hasDisplayItem("sink", sink.getClass()));
+    assertThat(displayData, includesDisplayDataFor("sink", sink));
+    assertThat(displayData, hasDisplayItem("spam", "ham"));
+  }
+
+  @Test
   public void testWriteUnbounded() {
     PCollection<String> unbounded = p.apply(CountingInput.unbounded())
         .apply(ToString.of());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -23,7 +23,9 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -47,6 +49,7 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.Sink.WriteOperation;
 import org.apache.beam.sdk.io.Sink.Writer;
+import org.apache.beam.sdk.io.Write.ConstantShards;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactoryTest.TestPipelineOptions;
@@ -54,18 +57,22 @@ import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.ToString;
+import org.apache.beam.sdk.transforms.Top;
+import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.junit.Rule;
@@ -93,12 +100,22 @@ public class WriteTest {
   @SuppressWarnings("unchecked") // covariant cast
   private static final PTransform<PCollection<String>, PCollection<String>> IDENTITY_MAP =
       (PTransform)
-      MapElements.via(new SimpleFunction<String, String>() {
-        @Override
-        public String apply(String input) {
-          return input;
-        }
-      });
+          MapElements.via(
+              new SimpleFunction<String, String>() {
+                @Override
+                public String apply(String input) {
+                  return input;
+                }
+              });
+
+  private static final PTransform<PCollection<String>, PCollectionView<Integer>>
+      SHARDING_TRANSFORM =
+          new PTransform<PCollection<String>, PCollectionView<Integer>>() {
+            @Override
+            public PCollectionView<Integer> expand(PCollection<String> input) {
+              return null;
+            }
+          };
 
   private static class WindowAndReshuffle<T> extends PTransform<PCollection<T>, PCollection<T>> {
     private final Window.Bound<T> window;
@@ -167,6 +184,43 @@ public class WriteTest {
         Arrays.asList("one", "two", "three", "four", "five", "six"),
         IDENTITY_MAP,
         Optional.of(1));
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testCustomShardedWrite() {
+    // Flag to validate that the pipeline options are passed to the Sink
+    WriteOptions options = TestPipeline.testingPipelineOptions().as(WriteOptions.class);
+    options.setTestFlag("test_value");
+    Pipeline p = TestPipeline.create(options);
+
+    // Clear the sink's contents.
+    sinkContents.clear();
+    // Reset the number of shards produced.
+    numShards.set(0);
+    // Reset the number of records in each shard.
+    recordsPerShard.clear();
+
+    List<String> inputs = new ArrayList<>();
+    // Prepare timestamps for the elements.
+    List<Long> timestamps = new ArrayList<>();
+    for (long i = 0; i < 1000; i++) {
+      inputs.add(Integer.toString(3));
+      timestamps.add(i + 1);
+    }
+
+    TestSink sink = new TestSink();
+    Write.Bound<String> write = Write.to(sink).withSharding(new LargestInt());
+    p.apply(Create.timestamped(inputs, timestamps).withCoder(StringUtf8Coder.of()))
+        .apply(IDENTITY_MAP)
+        .apply(write);
+
+    p.run();
+    assertThat(sinkContents, containsInAnyOrder(inputs.toArray()));
+    assertTrue(sink.hasCorrectState());
+    // The PCollection has values all equal to three, which should be fed as the sharding strategy
+    assertEquals(3, numShards.intValue());
+    assertEquals(3, recordsPerShard.size());
   }
 
   /**
@@ -255,10 +309,20 @@ public class WriteTest {
     Sink<String> sink = new TestSink() {};
     Write.Bound<String> write = Write.to(sink).withNumShards(3);
     assertThat(write.getSink(), is(sink));
+    PTransform<PCollection<String>, PCollectionView<Integer>> originalSharding =
+        write.getSharding();
+    assertThat(write.getSharding(), instanceOf(ConstantShards.class));
+    assertThat(((ConstantShards) write.getSharding()).getNumShards(), equalTo(3));
+    assertThat(write.getSharding(), equalTo(originalSharding));
 
-    Write.Bound<String> write2 = write.withNumShards(7);
+    Write.Bound<String> write2 = write.withSharding(SHARDING_TRANSFORM);
     assertThat(write2.getSink(), is(sink));
+    assertThat(write2.getSharding(), equalTo(SHARDING_TRANSFORM));
     // original unchanged
+
+    Write.Bound<String> writeUnsharded = write2.withRunnerDeterminedSharding();
+    assertThat(writeUnsharded.getSharding(), nullValue());
+    assertThat(write.getSharding(), equalTo(originalSharding));
   }
 
   @Test
@@ -319,7 +383,8 @@ public class WriteTest {
    * verifies that the output number of shards is correct.
    */
   private static void runShardedWrite(
-      List<String> inputs, PTransform<PCollection<String>, PCollection<String>> transform,
+      List<String> inputs,
+      PTransform<PCollection<String>, PCollection<String>> transform,
       Optional<Integer> numConfiguredShards) {
     // Flag to validate that the pipeline options are passed to the Sink
     WriteOptions options = TestPipeline.testingPipelineOptions().as(WriteOptions.class);
@@ -570,4 +635,28 @@ public class WriteTest {
     String getTestFlag();
     void setTestFlag(String value);
   }
+
+  /**
+   * Outputs the largest integer in a {@link PCollection} into a {@link PCollectionView}. The input
+   * {@link PCollection} must be convertible to integers via {@link Integer#valueOf(String)}
+   */
+  private static class LargestInt
+      extends PTransform<PCollection<String>, PCollectionView<Integer>> {
+    @Override
+    public PCollectionView<Integer> expand(PCollection<String> input) {
+      return input
+          .apply(
+              ParDo.of(
+                  new DoFn<String, Integer>() {
+                    @ProcessElement
+                    public void toInteger(ProcessContext ctxt) {
+                      ctxt.output(Integer.valueOf(ctxt.element()));
+                    }
+                  }))
+          .apply(Top.<Integer>largest(1))
+          .apply(Flatten.<Integer>iterables())
+          .apply(View.<Integer>asSingleton());
+    }
+  }
+
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -312,7 +312,7 @@ public class WriteTest {
     PTransform<PCollection<String>, PCollectionView<Integer>> originalSharding =
         write.getSharding();
     assertThat(write.getSharding(), instanceOf(ConstantShards.class));
-    assertThat(((ConstantShards) write.getSharding()).getNumShards(), equalTo(3));
+    assertThat(((ConstantShards<String>) write.getSharding()).getNumShards().get(), equalTo(3));
     assertThat(write.getSharding(), equalTo(originalSharding));
 
     Write.Bound<String> write2 = write.withSharding(SHARDING_TRANSFORM);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -352,7 +352,7 @@ public class WriteTest {
     DisplayData displayData = DisplayData.from(write);
     assertThat(displayData, hasDisplayItem("sink", sink.getClass()));
     assertThat(displayData, includesDisplayDataFor("sink", sink));
-    assertThat(displayData, hasDisplayItem("numShards", 1));
+    assertThat(displayData, hasDisplayItem("Fixed Number of Shards", 1));
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
This permits users to pass a PTransform from the input elements to the
number of shards instead of requiring a constant amount. This enables
sharding to be determined based on the input data rather than a constant
value.

This can also convert the DirectRunner to inject a custom sharding
strategy in its override, rather than relying on bundling behavior.