### PR TITLE
[BEAM-1429] WindowFn assign should not access the window set

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -306,8 +306,7 @@ class DoFnRunner(Receiver):
         windowed_value = WindowedValue(
             value, timestamp, self.window_fn.assign(assign_context))
       elif isinstance(result, TimestampedValue):
-        assign_context = WindowFn.AssignContext(
-            result.timestamp, result.value, element.windows)
+        assign_context = WindowFn.AssignContext(result.timestamp, result.value)
         windowed_value = WindowedValue(
             result.value, result.timestamp,
             self.window_fn.assign(assign_context))

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1252,10 +1252,8 @@ class WindowInto(ParDo):
     def __init__(self, windowing):
       self.windowing = windowing
 
-    def process(self, element, context=DoFn.ContextParam):
-      context = WindowFn.AssignContext(context.timestamp,
-                                       element=element,
-                                       existing_windows=context.windows)
+    def process(self, element, timestamp=DoFn.TimestampParam):
+      context = WindowFn.AssignContext(timestamp, element=element)
       new_windows = self.windowing.windowfn.assign(context)
       yield WindowedValue(element, context.timestamp, new_windows)
 

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -88,13 +88,12 @@ class WindowFn(object):
   class AssignContext(object):
     """Context passed to WindowFn.assign()."""
 
-    def __init__(self, timestamp, element=None, existing_windows=None):
+    def __init__(self, timestamp, element=None):
       self.timestamp = Timestamp.of(timestamp)
       self.element = element
-      self.existing_windows = existing_windows
 
   def assign(self, assign_context):
-    """Associates a timestamp and set of windows to an element."""
+    """Associates a timestamp to an element."""
     raise NotImplementedError
 
   class MergeContext(object):

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -40,8 +40,8 @@ from apache_beam.transforms.window import WindowedValue
 from apache_beam.transforms.window import WindowFn
 
 
-def context(element, timestamp, windows):
-  return WindowFn.AssignContext(timestamp, element, windows)
+def context(element, timestamp):
+  return WindowFn.AssignContext(timestamp, element)
 
 
 sort_values = Map(lambda (k, vs): (k, sorted(vs)))
@@ -67,40 +67,40 @@ class WindowTest(unittest.TestCase):
     # Test windows with offset: 2, 7, 12, 17, ...
     windowfn = FixedWindows(size=5, offset=2)
     self.assertEqual([IntervalWindow(7, 12)],
-                     windowfn.assign(context('v', 7, [])))
+                     windowfn.assign(context('v', 7)))
     self.assertEqual([IntervalWindow(7, 12)],
-                     windowfn.assign(context('v', 11, [])))
+                     windowfn.assign(context('v', 11)))
     self.assertEqual([IntervalWindow(12, 17)],
-                     windowfn.assign(context('v', 12, [])))
+                     windowfn.assign(context('v', 12)))
 
     # Test windows without offset: 0, 5, 10, 15, ...
     windowfn = FixedWindows(size=5)
     self.assertEqual([IntervalWindow(5, 10)],
-                     windowfn.assign(context('v', 5, [])))
+                     windowfn.assign(context('v', 5)))
     self.assertEqual([IntervalWindow(5, 10)],
-                     windowfn.assign(context('v', 9, [])))
+                     windowfn.assign(context('v', 9)))
     self.assertEqual([IntervalWindow(10, 15)],
-                     windowfn.assign(context('v', 10, [])))
+                     windowfn.assign(context('v', 10)))
 
     # Test windows with offset out of range.
     windowfn = FixedWindows(size=5, offset=12)
     self.assertEqual([IntervalWindow(7, 12)],
-                     windowfn.assign(context('v', 11, [])))
+                     windowfn.assign(context('v', 11)))
 
   def test_sliding_windows_assignment(self):
     windowfn = SlidingWindows(size=15, period=5, offset=2)
     expected = [IntervalWindow(7, 22),
                 IntervalWindow(2, 17),
                 IntervalWindow(-3, 12)]
-    self.assertEqual(expected, windowfn.assign(context('v', 7, [])))
-    self.assertEqual(expected, windowfn.assign(context('v', 8, [])))
-    self.assertEqual(expected, windowfn.assign(context('v', 11, [])))
+    self.assertEqual(expected, windowfn.assign(context('v', 7)))
+    self.assertEqual(expected, windowfn.assign(context('v', 8)))
+    self.assertEqual(expected, windowfn.assign(context('v', 11)))
 
   def test_sessions_merging(self):
     windowfn = Sessions(10)
 
     def merge(*timestamps):
-      windows = [windowfn.assign(context(None, t, [])) for t in timestamps]
+      windows = [windowfn.assign(context(None, t)) for t in timestamps]
       running = set()
 
       class TestMergeContext(WindowFn.MergeContext):


### PR DESCRIPTION
https://github.com/apache/beam/blob/master/sdks/python/apache_beam/transforms/window.py#L97 does not really use access to multiple windows at the same time.

Also as we move to the NewDoFn we have moved away from accessing the windowSet together. Change the function here to only take the element and timestamp as the input.

R: @robertwb @aaltay  PTAL

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
