### PR TITLE
[BEAM-1430] PartitionFn should not access context and just the element

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -525,8 +525,7 @@ class PartitionFn(WithTypeHints):
     """Specify which partition will receive this element.
 
     Args:
-      context: A DoFnProcessContext containing an element of the
-        input PCollection.
+      element: An element of the input PCollection.
       num_partitions: Number of partitions, i.e., output PCollections.
       *args: optional parameters and side inputs.
       **kwargs: optional parameters and side inputs.
@@ -559,8 +558,8 @@ class CallableWrapperPartitionFn(PartitionFn):
       raise TypeError('Expected a callable object instead of: %r' % fn)
     self._fn = fn
 
-  def partition_for(self, context, num_partitions, *args, **kwargs):
-    return self._fn(context.element, num_partitions, *args, **kwargs)
+  def partition_for(self, element, num_partitions, *args, **kwargs):
+    return self._fn(element, num_partitions, *args, **kwargs)
 
 
 class ParDo(PTransformWithSideInputs):
@@ -1179,9 +1178,8 @@ class Partition(PTransformWithSideInputs):
   class ApplyPartitionFnFn(DoFn):
     """A DoFn that applies a PartitionFn."""
 
-    def process(self, element, partitionfn, n, context=DoFn.ContextParam,
-                *args, **kwargs):
-      partition = partitionfn.partition_for(context, n, *args, **kwargs)
+    def process(self, element, partitionfn, n, *args, **kwargs):
+      partition = partitionfn.partition_for(element, n, *args, **kwargs)
       if not 0 <= partition < n:
         raise ValueError(
             'PartitionFn specified out-of-bounds partition index: '

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -398,8 +398,8 @@ class PTransformTest(unittest.TestCase):
 
     class SomePartitionFn(beam.PartitionFn):
 
-      def partition_for(self, context, num_partitions, offset):
-        return (context.element % 3) + offset
+      def partition_for(self, element, num_partitions, offset):
+        return (element % 3) + offset
 
     pipeline = TestPipeline()
     pcoll = pipeline | 'Start' >> beam.Create([0, 1, 2, 3, 4, 5, 6, 7, 8])


### PR DESCRIPTION
PartitionFn currently has access to the complete process context. We should limit the access to just the element to make it more NewDoFn like. This also removes the last uses on ContextParam after #1942 

R: @robertwb @aaltay PTAL

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
