### PR TITLE
[BEAM-646] Explicitly pass Pipeline in AppliedPTransform

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/PTransformMatchersTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/PTransformMatchersTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.beam.runners.core.runnerapi;
+package org.apache.beam.runners.core;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -24,7 +24,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
-import org.apache.beam.runners.core.PTransformMatchers;
 import org.apache.beam.sdk.runners.PTransformMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
@@ -60,7 +59,11 @@ public class PTransformMatchersTest implements Serializable {
     });
     PCollection<Integer> output = input.apply(pardo);
 
-    AppliedPTransform<?, ?, ?> application = AppliedPTransform.of("DoStuff", input, output, pardo);
+    AppliedPTransform<?, ?, ?> application =
+        AppliedPTransform
+            .<PCollection<Integer>, PCollection<Integer>,
+                PTransform<? super PCollection<Integer>, PCollection<Integer>>>
+                of("DoStuff", input.expand(), output.expand(), pardo, p);
 
     assertThat(matcher.matches(application), is(true));
   }
@@ -82,7 +85,10 @@ public class PTransformMatchersTest implements Serializable {
     PCollection<Integer> output = input.apply(subclass);
 
     AppliedPTransform<?, ?, ?> application =
-        AppliedPTransform.of("DoStuff", input, output, subclass);
+        AppliedPTransform
+            .<PCollection<Integer>, PCollection<Integer>,
+                PTransform<PCollection<Integer>, PCollection<Integer>>>
+                of("DoStuff", input.expand(), output.expand(), subclass, p);
 
     assertThat(matcher.matches(application), is(false));
   }
@@ -94,7 +100,11 @@ public class PTransformMatchersTest implements Serializable {
     Window.Bound<Integer> window = Window.into(new GlobalWindows());
     PCollection<Integer> output = input.apply(window);
 
-    AppliedPTransform<?, ?, ?> application = AppliedPTransform.of("DoStuff", input, output, window);
+    AppliedPTransform<?, ?, ?> application =
+        AppliedPTransform
+            .<PCollection<Integer>, PCollection<Integer>,
+                PTransform<PCollection<Integer>, PCollection<Integer>>>
+                of("DoStuff", input.expand(), output.expand(), window, p);
 
     assertThat(matcher.matches(application), is(false));
   }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
@@ -54,12 +54,17 @@ public class CommittedResultTest implements Serializable {
 
   private transient PCollection<Integer> created = p.apply(Create.of(1, 2));
   private transient AppliedPTransform<?, ?, ?> transform =
-      AppliedPTransform.of("foo", p.begin(), PDone.in(p), new PTransform<PBegin, PDone>() {
-        @Override
-        public PDone expand(PBegin begin) {
-          throw new IllegalArgumentException("Should never be applied");
-        }
-      });
+      AppliedPTransform.<PBegin, PDone, PTransform<PBegin, PDone>>of(
+          "foo",
+          p.begin().expand(),
+          PDone.in(p).expand(),
+          new PTransform<PBegin, PDone>() {
+            @Override
+            public PDone expand(PBegin begin) {
+              throw new IllegalArgumentException("Should never be applied");
+            }
+          },
+          p);
   private transient BundleFactory bundleFactory = ImmutableListBundleFactory.create();
 
   @Test

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.AfterPane;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -311,7 +312,11 @@ public class WindowEvaluatorFactoryTest {
       throws Exception {
     TransformEvaluator<Long> evaluator =
         factory.forApplication(
-            AppliedPTransform.of("Window", input, windowed, windowTransform), inputBundle);
+            AppliedPTransform
+                .<PCollection<Long>, PCollection<Long>,
+                    PTransform<PCollection<Long>, PCollection<Long>>>
+                    of("Window", input.expand(), windowed.expand(), windowTransform, p),
+            inputBundle);
 
     evaluator.processElement(valueInGlobalWindow);
     evaluator.processElement(valueInGlobalAndTwoIntervalWindows);

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
@@ -52,6 +52,7 @@ import com.google.common.collect.ImmutableSetMultimap;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.SocketTimeoutException;
+import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.runners.dataflow.testing.TestDataflowPipelineOptions;
@@ -71,6 +72,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.TaggedPValue;
 import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
@@ -671,7 +673,12 @@ public class DataflowPipelineJobTest {
       String fullName, PTransform<PInput, POutput> transform, Pipeline p) {
     PInput input = mock(PInput.class);
     when(input.getPipeline()).thenReturn(p);
-    return AppliedPTransform.of(fullName, input, mock(POutput.class), transform);
+    return AppliedPTransform.of(
+        fullName,
+        Collections.<TaggedPValue>emptyList(),
+        Collections.<TaggedPValue>emptyList(),
+        transform,
+        p);
   }
 
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
@@ -323,7 +323,12 @@ public class TransformHierarchy {
      * Returns the {@link AppliedPTransform} representing this {@link Node}.
      */
     public AppliedPTransform<?, ?, ?> toAppliedPTransform() {
-      return AppliedPTransform.of(getFullName(), input, output, (PTransform) getTransform());
+      return AppliedPTransform.of(
+          getFullName(),
+          input.expand(),
+          output.expand(),
+          (PTransform) getTransform(),
+          input.getPipeline());
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/AppliedPTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/AppliedPTransform.java
@@ -30,23 +30,25 @@ import org.apache.beam.sdk.values.TaggedPValue;
  *
  * <p>For internal use.
  *
- * @param <InputT> transform input type
- * @param <OutputT> transform output type
+ * @param <InputT>     transform input type
+ * @param <OutputT>    transform output type
  * @param <TransformT> transform type
  */
 @AutoValue
-public abstract class AppliedPTransform
-    <InputT extends PInput, OutputT extends POutput,
-     TransformT extends PTransform<? super InputT, OutputT>> {
+public abstract class AppliedPTransform<
+    InputT extends PInput, OutputT extends POutput,
+    TransformT extends PTransform<? super InputT, OutputT>> {
 
-  public static <
-          InputT extends PInput,
-          OutputT extends POutput,
+  public static <InputT extends PInput, OutputT extends POutput,
           TransformT extends PTransform<? super InputT, OutputT>>
       AppliedPTransform<InputT, OutputT, TransformT> of(
-          String fullName, InputT input, OutputT output, TransformT transform) {
+          String fullName,
+          List<TaggedPValue> input,
+          List<TaggedPValue> output,
+          TransformT transform,
+          Pipeline p) {
     return new AutoValue_AppliedPTransform<InputT, OutputT, TransformT>(
-        fullName, input.expand(), output.expand(), transform, input.getPipeline());
+        fullName, input, output, transform, p);
   }
 
   public abstract String getFullName();


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
This changes the signature to only use expanded PInputs and POutputs.
This also requires passing the Pipeline object directly, as a root input
(PBegin) expands to no PValues, so the Pipeline cannot be reobtained
from the expansion.