### PR TITLE
[BEAM-646] Construct Pipeline Nodes after Pipeline#run

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -105,7 +105,7 @@ public class TestPipeline extends Pipeline implements TestRule {
       enableAutoRunIfMissing = enable;
     }
 
-    protected void beforePipelineExecution() {
+    protected void afterPipelineExecution() {
       runInvoked = true;
     }
 
@@ -179,9 +179,9 @@ public class TestPipeline extends Pipeline implements TestRule {
     }
 
     @Override
-    protected void beforePipelineExecution() {
-      super.beforePipelineExecution();
+    protected void afterPipelineExecution() {
       runVisitedNodes = recordPipelineNodes(pipeline);
+      super.afterPipelineExecution();
     }
 
     @Override
@@ -253,7 +253,6 @@ public class TestPipeline extends Pipeline implements TestRule {
    */
   @Override
   public PipelineResult run() {
-    enforcement.beforePipelineExecution();
     try {
       return super.run();
     } catch (RuntimeException exc) {
@@ -263,6 +262,8 @@ public class TestPipeline extends Pipeline implements TestRule {
       } else {
         throw exc;
       }
+    } finally {
+      enforcement.afterPipelineExecution();
     }
   }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Before-run is not compatible with Pipeline Surgery

Specifically, before-execution fails because the snapshot that is taken of the Pipeline is before the PipelineRunner replaces all the nodes, and as a result the final graph (after run() and the test complete successfully) has different nodes, even though it is (in terms of pipeline behavior) the same graph. Neither of the TestPipeline Enforcements require a pre-run traversal, so this should not have observable effects outside of surgery.