### PR TITLE
[BEAM-1460] Changed name of ToString.of() to elements()

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ToString.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ToString.java
@@ -42,7 +42,7 @@ public final class ToString {
    * element of the input {@link PCollection} to a {@link String} using the
    * {@link Object#toString} method.
    */
-  public static PTransform<PCollection<?>, PCollection<String>> of() {
+  public static PTransform<PCollection<?>, PCollection<String>> elements() {
     return new SimpleToString();
   }
 
@@ -97,7 +97,7 @@ public final class ToString {
    * <p>Example of use:
    * <pre>{@code
    * PCollection<Long> longs = ...;
-   * PCollection<String> strings = longs.apply(ToString.of());
+   * PCollection<String> strings = longs.apply(ToString.elements());
    * }</pre>
    *
    *

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -297,7 +297,7 @@ public class WriteTest {
   @Test
   public void testWriteUnbounded() {
     PCollection<String> unbounded = p.apply(CountingInput.unbounded())
-        .apply(ToString.of());
+        .apply(ToString.elements());
 
     TestSink sink = new TestSink();
     thrown.expect(IllegalArgumentException.class);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ToStringTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ToStringTest.java
@@ -48,7 +48,7 @@ public class ToStringTest {
     Integer[] ints = {1, 2, 3, 4, 5};
     String[] strings = {"1", "2", "3", "4", "5"};
     PCollection<Integer> input = p.apply(Create.of(Arrays.asList(ints)));
-    PCollection<String> output = input.apply(ToString.of());
+    PCollection<String> output = input.apply(ToString.elements());
     PAssert.that(output).containsInAnyOrder(strings);
     p.run();
   }


### PR DESCRIPTION
 Changed name of ToString.of() to ToString.elements().