### PR TITLE
[BEAM-1463] Updates BigQuery read transform to handle 'null' fields properly for DirectRunner

### DIFF
--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -1065,17 +1065,16 @@ class BigQueryWrapper(object):
       value = None
       if isinstance(schema, bigquery.TableSchema):
         cell = row.f[index]
-        if cell.v is None:
-          continue  # Field not present in the row.
-        value = from_json_value(cell.v)
+        value = from_json_value(cell.v) if cell.v is not None else None
       elif isinstance(schema, bigquery.TableFieldSchema):
         cell = row['f'][index]
-        if 'v' not in cell:
-          continue  # Field not present in the row.
-        value = cell['v']
+        value = cell['v'] if 'v' in cell else None
       if field.mode == 'REPEATED':
         result[field.name] = [self._convert_cell_value_to_dict(x['v'], field)
                               for x in value]
+      elif value is None:
+        assert field.mode == 'NULLABLE'
+        result[field.name] = None
       else:
         result[field.name] = self._convert_cell_value_to_dict(value, field)
     return result

--- a/sdks/python/apache_beam/io/bigquery.py
+++ b/sdks/python/apache_beam/io/bigquery.py
@@ -1073,7 +1073,9 @@ class BigQueryWrapper(object):
         result[field.name] = [self._convert_cell_value_to_dict(x['v'], field)
                               for x in value]
       elif value is None:
-        assert field.mode == 'NULLABLE'
+        if not field.mode == 'NULLABLE':
+          raise ValueError('Received \'None\' as the value for the field %s '
+                           'but the field is not NULLABLE.', field.name)
         result[field.name] = None
       else:
         result[field.name] = self._convert_cell_value_to_dict(value, field)

--- a/sdks/python/apache_beam/io/bigquery_test.py
+++ b/sdks/python/apache_beam/io/bigquery_test.py
@@ -308,14 +308,19 @@ class TestBigQueryReader(unittest.TestCase):
             'ts': '22:39:12.627498',
             'dt_ts': '2008-12-25T07:30:00',
             'r': {'s2': 'b'},
-            'rpr': [{'s3': 'c', 'rpr2': [{'rs': ['d', 'e'], 's4': 'f'}]}]
+            'rpr': [{'s3': 'c', 'rpr2': [{'rs': ['d', 'e'], 's4': None}]}]
         },
         {
             'i': 10,
             's': 'xyz',
             'f': -3.14,
             'b': False,
-            'rpr': []
+            'rpr': [],
+            't': None,
+            'dt': None,
+            'ts': None,
+            'dt_ts': None,
+            'r': None,
         }]
 
     nested_schema = [
@@ -372,7 +377,7 @@ class TestBigQueryReader(unittest.TestCase):
             # schemas correctly so we have to use this f,v based format
             bigquery.TableCell(v=to_json_value({'f': [{'v': 'b'}]})),
             bigquery.TableCell(v=to_json_value([{'v':{'f':[{'v':'c'}, {'v':[
-                {'v':{'f':[{'v':[{'v':'d'}, {'v':'e'}]}, {'v':'f'}]}}]}]}}]))
+                {'v':{'f':[{'v':[{'v':'d'}, {'v':'e'}]}, {'v':None}]}}]}]}}]))
             ]),
         bigquery.TableRow(f=[
             bigquery.TableCell(v=to_json_value('false')),


### PR DESCRIPTION
Updates BigQuery read transform so that DirectRunner handles 'null' fields properly.

Before this change, for DirectRunner, a record (dictionary) returned by BigQuery  read transform did not contain keys for fields that are 'null'. For DataflowRunner, these fields are available with value 'None'.
I believe, retaining these fields value 'None' to be the proper behavior here.

This change makes these two runners consistent when it comes to handling BigQuery 'null' values.

