### PR TITLE
[BEAM-59] Beam FileSystem: match() and its local implementation.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -45,7 +45,7 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    * <ol>
    * <li>{@code spec} could be a glob or a uri. {@link #match} should be able to tell and
    * choose efficient implementations.
-   * <li>The user-provided {@code spec} might refer to files or a directories. It is common that
+   * <li>The user-provided {@code spec} might refer to files or directories. It is common that
    * users that wish to indicate a directory will omit the trailing {@code /}, such as in a spec of
    * {@code "/tmp/dir"}. The {@link FileSystem} should be able to recognize a directory with
    * the trailing {@code /} omitted, but should always return a correct {@link ResourceIdT}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -42,13 +42,15 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    * calling other methods.
    *
    * <p>Implementation should handle the following ambiguities of a user-provided spec:
-   * <ul>
-   * <li>1). spec could be a glob or a uri. {@link #match} should be able to tell and
+   * <ol>
+   * <li>{@code spec} could be a glob or a uri. {@link #match} should be able to tell and
    * choose efficient implementations.
-   * <li>2). spec does not end with a path delimiter may refer to files or directories:
-   * For example, local directory "/home/dir/" should be returned for spec “/home/dir”.
-   * (However, spec ends with a path delimiter always refers to directories.)
-   * </ul>
+   * <li>The user-provided {@code spec} might refer to files or a directories. It is common that
+   * users that wish to indicate a directory will omit the trailing {@code /}, such as in a spec of
+   * {@code "/tmp/dir"}. The {@link FileSystem} should be able to recognize a directory with
+   * the trailing {@code /} omitted, but should always return a correct {@link ResourceIdT}
+   * (e.g., {@code "/tmp/dir/"} inside the returned {@link MatchResult}.
+   * </ol>
    *
    * <p>All {@link FileSystem} implementations should support glob in the final hierarchical path
    * component of {@link ResourceIdT}. This allows SDK libraries to construct file system agnostic

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -37,18 +37,22 @@ import org.apache.beam.sdk.io.fs.ResourceId;
  */
 public abstract class FileSystem<ResourceIdT extends ResourceId> {
   /**
-   * This is the entry point to convert users provided specs to {@link ResourceIdT ResourceIds}.
+   * This is the entry point to convert user-provided specs to {@link ResourceIdT ResourceIds}.
    * Callers should use {@link #match} to resolve users specs ambiguities before
    * calling other methods.
    *
-   * <p>Implementation should handle the following ambiguities of a user provided spec:
-   * 1). spec could be a glob or a uri. {@link #match} should be able to tell and
-   *     choose efficient implementations.
-   * 2). spec does not end with a path delimiter, such as ‘/’, may refer to files or directories:
-   *     For example, directory "file:/home/dir/" should be returned for spec “file:/home/dir”.
-   *     (However, spec ends with a path delimiter always refers to directories.)
-   * Note: File systems glob support is different. However, it is required to
-   * support glob in the final component of a path (eg file:/foo/bar/*.txt).
+   * <p>Implementation should handle the following ambiguities of a user-provided spec:
+   * <ul>
+   * <li>1). spec could be a glob or a uri. {@link #match} should be able to tell and
+   * choose efficient implementations.
+   * <li>2). spec does not end with a path delimiter may refer to files or directories:
+   * For example, local directory "/home/dir/" should be returned for spec “/home/dir”.
+   * (However, spec ends with a path delimiter always refers to directories.)
+   * </ul>
+   *
+   * <p>All {@link FileSystem} implementations should support glob in the final hierarchical path
+   * component of {@link ResourceIdT}. This allows SDK libraries to construct file system agnostic
+   * spec. {@link FileSystem FileSystems} can support additional patterns for user-provided specs.
    *
    * @return {@code List<MatchResult>} in the same order of the input specs.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
@@ -62,7 +62,7 @@ public abstract class MatchResult {
   }
 
   /**
-   * Returns a {@link MatchResult} with UNKNOWN {@link Status}.
+   * Returns a {@link MatchResult} with {@link Status#UNKNOWN}.
    */
   public static MatchResult unknown() {
     return new MatchResult() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/MatchResult.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.fs;
+
+import com.google.auto.value.AutoValue;
+import java.io.IOException;
+
+/**
+ * The result of {@link org.apache.beam.sdk.io.FileSystem#match}.
+ */
+public abstract class MatchResult {
+
+  private MatchResult() {}
+
+  /**
+   * Returns a {@link MatchResult} given the {@link Status} and {@link Metadata}.
+   */
+  public static MatchResult create(final Status status, final Metadata[] metadata) {
+    return new MatchResult() {
+      @Override
+      public Status status() {
+        return status;
+      }
+
+      @Override
+      public Metadata[] metadata() throws IOException {
+        return metadata;
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link MatchResult} given the {@link Status} and {@link IOException}.
+   */
+  public static MatchResult create(final Status status, final IOException e) {
+    return new MatchResult() {
+      @Override
+      public Status status() {
+        return status;
+      }
+
+      @Override
+      public Metadata[] metadata() throws IOException {
+        throw e;
+      }
+    };
+  }
+
+  /**
+   * Returns a {@link MatchResult} with UNKNOWN {@link Status}.
+   */
+  public static MatchResult unknown() {
+    return new MatchResult() {
+      @Override
+      public Status status() {
+        return Status.UNKNOWN;
+      }
+
+      @Override
+      public Metadata[] metadata() throws IOException {
+        throw new IOException("MatchResult status is UNKNOWN, and metadata is not available.");
+      }
+    };
+  }
+
+  /**
+   * Status of the {@link MatchResult}.
+   */
+  public abstract Status status();
+
+  /**
+   * {@link Metadata} of matched files.
+   */
+  public abstract Metadata[] metadata() throws IOException;
+
+  /**
+   * {@link Metadata} of a matched file.
+   */
+  @AutoValue
+  public abstract static class Metadata {
+    public abstract ResourceId resourceId();
+    public abstract long sizeBytes();
+    public abstract boolean isReadSeekEfficient();
+
+    public static Builder builder() {
+      return new AutoValue_MatchResult_Metadata.Builder();
+    }
+
+    /**
+     * Builder class for {@link Metadata}.
+     */
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setResourceId(ResourceId value);
+      public abstract Builder setSizeBytes(long value);
+      public abstract Builder setIsReadSeekEfficient(boolean value);
+      public abstract Metadata build();
+    }
+  }
+
+  /**
+   * Status of a {@link MatchResult}.
+   */
+  public enum Status {
+    UNKNOWN,
+    OK,
+    NOT_FOUND,
+    ERROR,
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemTest.java
@@ -30,15 +30,21 @@ import com.google.common.io.Files;
 import com.google.common.io.LineReader;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.io.fs.CreateOptions.StandardCreateOptions;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -147,6 +153,122 @@ public class LocalFileSystemTest {
     }
   }
 
+  @Test
+  public void testMatchExact() throws Exception {
+    List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
+    temporaryFolder.newFile("aa");
+    temporaryFolder.newFile("ab");
+
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a").toString()));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchNone() throws Exception {
+    List<String> expected = ImmutableList.of();
+    temporaryFolder.newFile("a");
+    temporaryFolder.newFile("aa");
+    temporaryFolder.newFile("ab");
+
+    // Windows doesn't like resolving paths with * in them, so the * is appended after resolve.
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("b") + "*"));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchUsingExplicitPath() throws Exception {
+    List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
+    temporaryFolder.newFile("aa");
+
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a").toString()));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchUsingExplicitPathForNonExistentFile() throws Exception {
+    List<String> expected = ImmutableList.of();
+    temporaryFolder.newFile("aa");
+
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a").toString()));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchMultipleWithoutSubdirectoryExpansion() throws Exception {
+    File unmatchedSubDir = temporaryFolder.newFolder("aaa");
+    File unmatchedSubDirFile = File.createTempFile("sub-dir-file", "", unmatchedSubDir);
+    unmatchedSubDirFile.deleteOnExit();
+    List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString(),
+        temporaryFolder.newFile("aa").toString(), temporaryFolder.newFile("ab").toString());
+    temporaryFolder.newFile("ba");
+    temporaryFolder.newFile("bb");
+
+    // Windows doesn't like resolving paths with * in them, so the * is appended after resolve.
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a") + "*"));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchMultipleWithSubdirectoryExpansion() throws Exception {
+    File matchedSubDir = temporaryFolder.newFolder("a");
+    File matchedSubDirFile = File.createTempFile("sub-dir-file", "", matchedSubDir);
+    matchedSubDirFile.deleteOnExit();
+    File unmatchedSubDir = temporaryFolder.newFolder("b");
+    File unmatchedSubDirFile = File.createTempFile("sub-dir-file", "", unmatchedSubDir);
+    unmatchedSubDirFile.deleteOnExit();
+
+    List<String> expected = ImmutableList.of(matchedSubDirFile.toString(),
+        temporaryFolder.newFile("aa").toString(), temporaryFolder.newFile("ab").toString());
+    temporaryFolder.newFile("ba");
+    temporaryFolder.newFile("bb");
+
+    // Windows doesn't like resolving paths with * in them, so the ** is appended after resolve.
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a") + "**"));
+    assertThat(
+        toFilenames(matchResults),
+        Matchers.hasItems(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchWithDirectoryFiltersOutDirectory() throws Exception {
+    List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
+    temporaryFolder.newFolder("a_dir_that_should_not_be_matched");
+
+    // Windows doesn't like resolving paths with * in them, so the * is appended after resolve.
+    List<MatchResult> matchResults = localFileSystem.match(
+        ImmutableList.of(temporaryFolder.getRoot().toPath().resolve("a") + "*"));
+    assertThat(
+        toFilenames(matchResults),
+        containsInAnyOrder(expected.toArray(new String[expected.size()])));
+  }
+
+  @Test
+  public void testMatchWithoutParentDirectory() throws Exception {
+    Path pattern = LocalResourceId
+        .fromPath(temporaryFolder.getRoot().toPath(), true /* isDirectory */)
+        .resolve("non_existing_dir", StandardResolveOptions.RESOLVE_DIRECTORY)
+        .resolve("*", StandardResolveOptions.RESOLVE_FILE)
+        .getPath();
+    assertTrue(
+        toFilenames(localFileSystem.match(ImmutableList.of(pattern.toString()))).isEmpty());
+  }
+
   private void createFileWithContent(Path path, String content) throws Exception {
     try (Writer writer = Channels.newWriter(
         localFileSystem.create(
@@ -164,6 +286,26 @@ public class LocalFileSystemTest {
           @Override
           public LocalResourceId apply(Path path) {
             return LocalResourceId.fromPath(path, isDirectory);
+          }})
+        .toList();
+  }
+
+  private List<String> toFilenames(List<MatchResult> matchResults) {
+    return FluentIterable
+        .from(matchResults)
+        .transformAndConcat(new Function<MatchResult, Iterable<Metadata>>() {
+          @Override
+          public Iterable<Metadata> apply(MatchResult matchResult) {
+            try {
+              return Arrays.asList(matchResult.metadata());
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          }})
+        .transform(new Function<Metadata, String>() {
+          @Override
+          public String apply(Metadata metadata) {
+            return ((LocalResourceId) metadata.resourceId()).getPath().toString();
           }})
         .toList();
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/FileIOChannelFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/FileIOChannelFactoryTest.java
@@ -130,7 +130,7 @@ public class FileIOChannelFactoryTest {
   }
 
   @Test
-  public void testMatchNone() throws Exception {
+  public void testMatchPatternNone() throws Exception {
     List<String> expected = ImmutableList.of();
     temporaryFolder.newFile("a");
     temporaryFolder.newFile("aa");
@@ -142,16 +142,7 @@ public class FileIOChannelFactoryTest {
   }
 
   @Test
-  public void testMatchUsingExplicitPath() throws Exception {
-    List<String> expected = ImmutableList.of(temporaryFolder.newFile("a").toString());
-    temporaryFolder.newFile("aa");
-
-    assertThat(factory.match(factory.resolve(temporaryFolder.getRoot().getPath(), "a")),
-        containsInAnyOrder(expected.toArray(new String[expected.size()])));
-  }
-
-  @Test
-  public void testMatchUsingExplicitPathForNonExistentFile() throws Exception {
+  public void testMatchForNonExistentFile() throws Exception {
     List<String> expected = ImmutableList.of();
     temporaryFolder.newFile("aa");
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystem.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystem.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.fs.CreateOptions;
+import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.options.GcsOptions;
 
 /**
@@ -38,6 +39,11 @@ class GcsFileSystem extends FileSystem<GcsResourceId> {
 
   GcsFileSystem(GcsOptions options) {
     this.options = checkNotNull(options, "options");
+  }
+
+  @Override
+  protected List<MatchResult> match(List<String> specs) throws IOException {
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.fs.CreateOptions;
+import org.apache.beam.sdk.io.fs.MatchResult;
 
 /**
  * Adapts {@link org.apache.hadoop.fs.FileSystem} connectors to be used as
@@ -32,6 +33,11 @@ import org.apache.beam.sdk.io.fs.CreateOptions;
 class HadoopFileSystem extends FileSystem<HadoopResourceId> {
 
   HadoopFileSystem() {}
+
+  @Override
+  protected List<MatchResult> match(List<String> specs) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 
   @Override
   protected WritableByteChannel create(HadoopResourceId resourceId, CreateOptions createOptions)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This PR added FileSystem.match() and MatchResult. It also ported the implementation from FileIOChannelFactory and its tests over.

Gcs FileSystem implementation requires some code refactoring, and will be sent as a separate PR.