### PR TITLE
[BEAM-1467] Add cross-SDK implementations and tests of IntervalWindowCoder

### DIFF
--- a/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
+++ b/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
@@ -96,3 +96,13 @@ nested: true
 examples:
   "\u0003abc\u0003def": {key: abc, value: def}
   "\u0004ab\0c\u0004de\0f": {key: "ab\0c", value: "de\0f"}
+
+---
+
+coder:
+  urn: "urn:beam:coders:intervalwindow:0.1"
+examples:
+  "\x80\x00\x01\x52\x9a\xa4\x9b\x68\x80\xdd\xdb\x01" : {end: 1454293425000, span: 3600000}
+  "\x80\x00\x01\x53\x34\xec\x74\xe8\x80\x90\xfb\xd3\x09" : {end: 1456881825000, span: 2592000000}
+  "\x7f\xdf\x3b\x64\x5a\x1c\xad\x76\xed\x02" : {end: -9223372036854410, span: 365}
+  "\x80\x20\xc4\x9b\xa5\xe3\x53\xf7\x00" : {end: 9223372036854775, span: 0}

--- a/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
+++ b/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
@@ -102,7 +102,7 @@ examples:
 coder:
   urn: "urn:beam:coders:intervalwindow:0.1"
 examples:
-  "\x80\x00\x01\x52\x9a\xa4\x9b\x68\x80\xdd\xdb\x01" : {end: 1454293425000, span: 3600000}
-  "\x80\x00\x01\x53\x34\xec\x74\xe8\x80\x90\xfb\xd3\x09" : {end: 1456881825000, span: 2592000000}
-  "\x7f\xdf\x3b\x64\x5a\x1c\xad\x76\xed\x02" : {end: -9223372036854410, span: 365}
-  "\x80\x20\xc4\x9b\xa5\xe3\x53\xf7\x00" : {end: 9223372036854775, span: 0}
+  "\u0080\u0000\u0001\u0052\u009a\u00a4\u009b\u0068\u0080\u00dd\u00db\u0001" : {end: 1454293425000, span: 3600000}
+  "\u0080\u0000\u0001\u0053\u0034\u00ec\u0074\u00e8\u0080\u0090\u00fb\u00d3\u0009" : {end: 1456881825000, span: 2592000000}
+  "\u007f\u00df\u003b\u0064\u005a\u001c\u00ad\u0076\u00ed\u0002" : {end: -9223372036854410, span: 365}
+  "\u0080\u0020\u00c4\u009b\u00a5\u00e3\u0053\u00f7\u0000" : {end: 9223372036854775, span: 0}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/IntervalWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/IntervalWindow.java
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.DurationCoder;
 import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.util.CloudObject;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.joda.time.ReadableDuration;
@@ -166,10 +167,9 @@ public class IntervalWindow extends BoundedWindow
   /**
    * Encodes an {@link IntervalWindow} as a pair of its upper bound and duration.
    */
-  private static class IntervalWindowCoder extends AtomicCoder<IntervalWindow> {
+  public static class IntervalWindowCoder extends AtomicCoder<IntervalWindow> {
 
-    private static final IntervalWindowCoder INSTANCE =
-        new IntervalWindowCoder();
+    private static final IntervalWindowCoder INSTANCE = new IntervalWindowCoder();
 
     private static final Coder<Instant> instantCoder = InstantCoder.of();
     private static final Coder<ReadableDuration> durationCoder = DurationCoder.of();
@@ -180,9 +180,7 @@ public class IntervalWindow extends BoundedWindow
     }
 
     @Override
-    public void encode(IntervalWindow window,
-                       OutputStream outStream,
-                       Context context)
+    public void encode(IntervalWindow window, OutputStream outStream, Context context)
         throws IOException, CoderException {
       instantCoder.encode(window.end, outStream, context.nested());
       durationCoder.encode(new Duration(window.start, window.end), outStream, context);
@@ -194,6 +192,11 @@ public class IntervalWindow extends BoundedWindow
       Instant end = instantCoder.decode(inStream, context.nested());
       ReadableDuration duration = durationCoder.decode(inStream, context);
       return new IntervalWindow(end.minus(duration), end);
+    }
+
+    @Override
+    protected CloudObject initializeCloudObject() {
+      return CloudObject.forClassName("kind:interval_window");
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CoderUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/CoderUtils.java
@@ -47,6 +47,7 @@ import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.LengthPrefixCoder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
@@ -61,6 +62,7 @@ public final class CoderUtils {
       .put("kind:pair", KvCoder.class)
       .put("kind:stream", IterableCoder.class)
       .put("kind:global_window", GlobalWindow.Coder.class)
+      .put("kind:interval_window", IntervalWindow.IntervalWindowCoder.class)
       .put("kind:length_prefix", LengthPrefixCoder.class)
       .put("kind:windowed_value", WindowedValue.FullWindowedValueCoder.class)
       .build();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CommonCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CommonCoderTest.java
@@ -43,8 +43,12 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder.Context;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow.IntervalWindowCoder;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.KV;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -63,6 +67,7 @@ public class CommonCoderTest {
       .put("urn:beam:coders:bytes:0.1", ByteCoder.class)
       .put("urn:beam:coders:kv:0.1", KvCoder.class)
       .put("urn:beam:coders:varint:0.1", VarLongCoder.class)
+      .put("urn:beam:coders:intervalwindow:0.1", IntervalWindowCoder.class)
       .build();
 
   @AutoValue
@@ -185,6 +190,12 @@ public class CommonCoderTest {
       }
       case "urn:beam:coders:varint:0.1":
         return ((Number) value).longValue();
+      case "urn:beam:coders:intervalwindow:0.1": {
+        Map<String, Object> kvMap = (Map<String, Object>) value;
+        Instant end = new Instant(((Number) kvMap.get("end")).longValue());
+        Duration span = Duration.millis(((Number) kvMap.get("span")).longValue());
+        return new IntervalWindow(end.minus(span), span);
+      }
       default:
         throw new IllegalStateException("Unknown coder URN: " + coderSpec.getUrn());
     }
@@ -202,6 +213,8 @@ public class CommonCoderTest {
         return KvCoder.of(components.get(0), components.get(1));
       case "urn:beam:coders:varint:0.1":
         return VarLongCoder.of();
+      case "urn:beam:coders:intervalwindow:0.1":
+        return IntervalWindowCoder.of();
       default:
         throw new IllegalStateException("Unknown coder URN: " + coder.getUrn());
     }
@@ -215,5 +228,19 @@ public class CommonCoderTest {
     Context context = testSpec.getNested() ? Context.NESTED : Context.OUTER;
     byte[] encoded = CoderUtils.encodeToByteArray(coder, testValue, context);
     assertThat(testSpec.toString(), encoded, equalTo(testSpec.getSerialized()));
+  }
+
+  /**
+   * Utility for adding new entries to the common coder spec -- prints the serialized bytes of
+   * the given value in the given context using JSON-escaped strings.
+   */
+  private static <T> String jsonByteString(Coder<T> coder, T value, Context context)
+      throws CoderException {
+    byte[] bytes = CoderUtils.encodeToByteArray(coder, value, context);
+    StringBuilder sb = new StringBuilder();
+    for (byte b : bytes) {
+      sb.append(String.format("\\x%02x", b & 0xff));
+    }
+    return sb.toString();
   }
 }

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -352,11 +352,11 @@ class IntervalWindowCoderImpl(StreamCoderImpl):
   # TODO: Fn Harness only supports millis. Is this important enough to fix?
   def _to_normal_time(self, value):
     """Convert "lexicographically ordered unsigned" to signed."""
-    return value - 0x8000000000000000
+    return value - (1 << 63)
 
   def _from_normal_time(self, value):
     """Convert signed to "lexicographically ordered unsigned"."""
-    return value + 0x8000000000000000
+    return value + (1 << 63)
 
   def encode_to_stream(self, value, out, nested):
     span_micros = value.end.micros - value.start.micros

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -629,6 +629,21 @@ class GlobalWindowCoder(SingletonCoder):
     }
 
 
+class IntervalWindowCoder(FastCoder):
+  """Coder for an window defined by a start timestamp and a duration."""
+
+  def _create_impl(self):
+    return coder_impl.IntervalWindowCoderImpl()
+
+  def is_deterministic(self):
+    return True
+
+  def as_cloud_object(self):
+    return {
+        '@type': 'kind:interval_window',
+    }
+
+
 class WindowedValueCoder(FastCoder):
   """Coder for windowed values."""
 

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -62,7 +62,8 @@ class CodersTest(unittest.TestCase):
                      coders.FastCoder,
                      coders.ProtoCoder,
                      coders.ToStringCoder,
-                     coders.WindowCoder])
+                     coders.WindowCoder,
+                     coders.IntervalWindowCoder])
     assert not standard - cls.seen, standard - cls.seen
     assert not standard - cls.seen_nested, standard - cls.seen_nested
 
@@ -165,6 +166,12 @@ class CodersTest(unittest.TestCase):
     self.check_coder(coders.SingletonCoder(b), b)
     self.check_coder(coders.TupleCoder((coders.SingletonCoder(a),
                                         coders.SingletonCoder(b))), (a, b))
+
+  def test_interval_window_coder(self):
+    self.check_coder(coders.IntervalWindowCoder(),
+                     *[window.IntervalWindow(x, y)
+                       for x in [-2**52, 0, 2**52]
+                       for y in range(-100, 100)])
 
   def test_timestamp_coder(self):
     self.check_coder(coders.TimestampCoder(),

--- a/sdks/python/apache_beam/coders/slow_stream.py
+++ b/sdks/python/apache_beam/coders/slow_stream.py
@@ -52,6 +52,9 @@ class OutputStream(object):
   def write_bigendian_int64(self, v):
     self.write(struct.pack('>q', v))
 
+  def write_bigendian_uint64(self, v):
+    self.write(struct.pack('>Q', v))
+
   def write_bigendian_int32(self, v):
     self.write(struct.pack('>i', v))
 
@@ -131,6 +134,9 @@ class InputStream(object):
 
   def read_bigendian_int64(self):
     return struct.unpack('>q', self.read(8))[0]
+
+  def read_bigendian_uint64(self):
+    return struct.unpack('>Q', self.read(8))[0]
 
   def read_bigendian_int32(self):
     return struct.unpack('>i', self.read(4))[0]

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -27,6 +27,8 @@ import yaml
 
 from apache_beam import coders
 from apache_beam.coders import coder_impl
+from apache_beam.utils.timestamp import Timestamp
+from apache_beam.transforms.window import IntervalWindow
 
 
 class StandardCodersTest(unittest.TestCase):
@@ -34,7 +36,8 @@ class StandardCodersTest(unittest.TestCase):
   _urn_to_coder_class = {
       'urn:beam:coders:bytes:0.1': coders.BytesCoder,
       'urn:beam:coders:varint:0.1': coders.VarIntCoder,
-      'urn:beam:coders:kv:0.1': lambda k, v: coders.TupleCoder((k, v))
+      'urn:beam:coders:kv:0.1': lambda k, v: coders.TupleCoder((k, v)),
+      'urn:beam:coders:intervalwindow:0.1': coders.IntervalWindowCoder,
   }
 
   _urn_to_json_value_parser = {
@@ -42,7 +45,11 @@ class StandardCodersTest(unittest.TestCase):
       'urn:beam:coders:varint:0.1': lambda x: x,
       'urn:beam:coders:kv:0.1':
           lambda x, key_parser, value_parser: (key_parser(x['key']),
-                                               value_parser(x['value']))
+                                               value_parser(x['value'])),
+      'urn:beam:coders:intervalwindow:0.1':
+          lambda x: IntervalWindow(
+              start=Timestamp(micros=(x['end'] - x['span']) * 1000),
+              end=Timestamp(micros=x['end'] * 1000)),
   }
 
   # We must prepend an underscore to this name so that the open-source unittest

--- a/sdks/python/apache_beam/tests/data/standard_coders.yaml
+++ b/sdks/python/apache_beam/tests/data/standard_coders.yaml
@@ -96,3 +96,13 @@ nested: true
 examples:
   "\u0003abc\u0003def": {key: abc, value: def}
   "\u0004ab\0c\u0004de\0f": {key: "ab\0c", value: "de\0f"}
+
+---
+
+coder:
+  urn: "urn:beam:coders:intervalwindow:0.1"
+examples:
+  "\x80\x00\x01\x52\x9a\xa4\x9b\x68\x80\xdd\xdb\x01" : {end: 1454293425000, span: 3600000}
+  "\x80\x00\x01\x53\x34\xec\x74\xe8\x80\x90\xfb\xd3\x09" : {end: 1456881825000, span: 2592000000}
+  "\x7f\xdf\x3b\x64\x5a\x1c\xad\x76\xed\x02" : {end: -9223372036854410, span: 365}
+  "\x80\x20\xc4\x9b\xa5\xe3\x53\xf7\x00" : {end: 9223372036854775, span: 0}

--- a/sdks/python/apache_beam/tests/data/standard_coders.yaml
+++ b/sdks/python/apache_beam/tests/data/standard_coders.yaml
@@ -102,7 +102,7 @@ examples:
 coder:
   urn: "urn:beam:coders:intervalwindow:0.1"
 examples:
-  "\x80\x00\x01\x52\x9a\xa4\x9b\x68\x80\xdd\xdb\x01" : {end: 1454293425000, span: 3600000}
-  "\x80\x00\x01\x53\x34\xec\x74\xe8\x80\x90\xfb\xd3\x09" : {end: 1456881825000, span: 2592000000}
-  "\x7f\xdf\x3b\x64\x5a\x1c\xad\x76\xed\x02" : {end: -9223372036854410, span: 365}
-  "\x80\x20\xc4\x9b\xa5\xe3\x53\xf7\x00" : {end: 9223372036854775, span: 0}
+  "\u0080\u0000\u0001\u0052\u009a\u00a4\u009b\u0068\u0080\u00dd\u00db\u0001" : {end: 1454293425000, span: 3600000}
+  "\u0080\u0000\u0001\u0053\u0034\u00ec\u0074\u00e8\u0080\u0090\u00fb\u00d3\u0009" : {end: 1456881825000, span: 2592000000}
+  "\u007f\u00df\u003b\u0064\u005a\u001c\u00ad\u0076\u00ed\u0002" : {end: -9223372036854410, span: 365}
+  "\u0080\u0020\u00c4\u009b\u00a5\u00e3\u0053\u00f7\u0000" : {end: 9223372036854775, span: 0}


### PR DESCRIPTION
- Implement an `IntervalWindowCoder` for Python SDK and test it
- Add test data for `IntervalWindow` to `standard_coders.yaml` and test both SDKs
- Add utilities to Java SDK's `CommonCoderTest` to enable more easy generation of test data in future.