### PR TITLE
[BEAM-115,BEAM-1348] Unify Fn API and Runner API FunctionSpec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,9 +317,16 @@
     <dependencies>
       <dependency>
         <groupId>org.apache.beam</groupId>
+        <artifactId>beam-sdks-common-runner-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-common-fn-api</artifactId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-common-fn-api</artifactId>

--- a/sdks/common/fn-api/pom.xml
+++ b/sdks/common/fn-api/pom.xml
@@ -84,6 +84,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-common-runner-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/sdks/common/fn-api/src/main/proto/beam_fn_api.proto
+++ b/sdks/common/fn-api/src/main/proto/beam_fn_api.proto
@@ -37,6 +37,7 @@ package org.apache.beam.fn.v1;
 option java_package = "org.apache.beam.fn.v1";
 option java_outer_classname = "BeamFnApi";
 
+import "beam_runner_api.proto";
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -82,7 +83,7 @@ message PrimitiveTransform {
 
   // (Required) A function spec that is used by this primitive
   // transform to process data.
-  FunctionSpec function_spec = 2;
+  org.apache.beam.runner_api.v1.FunctionSpec function_spec = 2;
 
   // A map of distinct input names to target definitions.
   // For example, in CoGbk this represents the tag name associated with each
@@ -111,33 +112,6 @@ message PrimitiveTransform {
  * This is still unstable mainly due to how we model the side input.
  */
 
-// Defines the common elements of user-definable functions, to allow the SDK to
-// express the information the runner needs to execute work.
-// Stable
-message FunctionSpec {
-  // (Required) A pipeline level unique id which can be used as a reference to
-  // refer to this.
-  int64 id = 1;
-
-  // (Required) A globally unique name representing this user definable
-  // function.
-  //
-  // User definable functions use the urn encodings registered such that another
-  // may implement the user definable function within another language.
-  //
-  // For example:
-  //    urn:org.apache.beam:coder:kv:1.0
-  string urn = 2;
-
-  // (Required) Reference to specification of execution environment required to
-  // invoke this function.
-  int64 environment_reference = 3;
-
-  // Data used to parameterize this function. Depending on the urn, this may be
-  // optional or required.
-  google.protobuf.Any data = 4;
-}
-
 message SideInput {
   // TODO: Coder?
 
@@ -145,7 +119,7 @@ message SideInput {
   Target input = 1;
 
   // For FnAPI.
-  FunctionSpec view_fn = 2;
+  org.apache.beam.runner_api.v1.FunctionSpec view_fn = 2;
 }
 
 // Defines how to encode values into byte streams and decode values from byte
@@ -161,12 +135,13 @@ message SideInput {
 //    urn:org.apache.beam:coder:iterable:1.0
 // Stable
 message Coder {
-  // TODO: This looks weird when compared to the other function specs
-  // which use URN to differentiate themselves. Should "Coder" be embedded
-  // inside the FunctionSpec data block.
+
+  // (Required) A pipeline level unique id which can be used as a reference to
+  // refer to this.
+  int64 id = 3;
 
   // The data associated with this coder used to reconstruct it.
-  FunctionSpec function_spec = 1;
+  org.apache.beam.runner_api.v1.FunctionSpec function_spec = 1;
 
   // A list of component coder references.
   //
@@ -351,14 +326,14 @@ message PrimitiveTransformSplit {
   //
   // For example, a remote GRPC source will have a specific urn and data
   // block containing an ElementCountRestriction.
-  FunctionSpec completed_restriction = 2;
+  org.apache.beam.runner_api.v1.FunctionSpec completed_restriction = 2;
 
   // (Required) A function specification describing the restriction
   // representing the remainder of work for the primitive transform.
   //
   // FOr example, a remote GRPC source will have a specific urn and data
   // block contain an ElemntCountSkipRestriction.
-  FunctionSpec remaining_restriction = 3;
+  org.apache.beam.runner_api.v1.FunctionSpec remaining_restriction = 3;
 }
 
 message ProcessBundleSplitResponse {

--- a/sdks/common/runner-api/src/main/proto/beam_runner_api.proto
+++ b/sdks/common/runner-api/src/main/proto/beam_runner_api.proto
@@ -25,7 +25,7 @@ syntax = "proto3";
 
 package org.apache.beam.runner_api.v1;
 
-option java_package = "org.apache.beam.sdks.common.runner_api.v1";
+option java_package = "org.apache.beam.sdk.common.runner.v1";
 option java_outer_classname = "RunnerApi";
 
 import "google/protobuf/any.proto";

--- a/sdks/java/harness/pom.xml
+++ b/sdks/java/harness/pom.xml
@@ -77,6 +77,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-common-runner-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/RegisterHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/RegisterHandler.java
@@ -77,9 +77,9 @@ public class RegisterHandler {
       computeIfAbsent(processBundleDescriptor.getId()).complete(processBundleDescriptor);
       for (BeamFnApi.Coder coder : processBundleDescriptor.getCodersList()) {
         LOGGER.debug("Registering {} with type {}",
-            coder.getFunctionSpec().getId(),
+            coder.getId(),
             coder.getClass());
-        computeIfAbsent(coder.getFunctionSpec().getId()).complete(coder);
+        computeIfAbsent(coder.getId()).complete(coder);
       }
     }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/runners/core/BeamFnDataReadRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/runners/core/BeamFnDataReadRunner.java
@@ -31,6 +31,7 @@ import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.fn.ThrowingConsumer;
 import org.apache.beam.fn.v1.BeamFnApi;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.util.Serializer;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
@@ -59,26 +60,37 @@ public class BeamFnDataReadRunner<OutputT> {
   private CompletableFuture<Void> readFuture;
 
   public BeamFnDataReadRunner(
-      BeamFnApi.FunctionSpec functionSpec,
+      RunnerApi.FunctionSpec functionSpec,
       Supplier<Long> processBundleInstructionIdSupplier,
       BeamFnApi.Target inputTarget,
       BeamFnApi.Coder coderSpec,
       BeamFnDataClient beamFnDataClientFactory,
       Map<String, Collection<ThrowingConsumer<WindowedValue<OutputT>>>> outputMap)
           throws IOException {
-    this.apiServiceDescriptor = functionSpec.getData().unpack(BeamFnApi.RemoteGrpcPort.class)
-        .getApiServiceDescriptor();
+    this.apiServiceDescriptor =
+        functionSpec
+            .getSdkFnSpec()
+            .getData()
+            .unpack(BeamFnApi.RemoteGrpcPort.class)
+            .getApiServiceDescriptor();
     this.inputTarget = inputTarget;
     this.processBundleInstructionIdSupplier = processBundleInstructionIdSupplier;
     this.beamFnDataClientFactory = beamFnDataClientFactory;
     this.consumers = ImmutableList.copyOf(FluentIterable.concat(outputMap.values()));
 
     @SuppressWarnings("unchecked")
-    Coder<WindowedValue<OutputT>> coder = Serializer.deserialize(
-        OBJECT_MAPPER.readValue(
-            coderSpec.getFunctionSpec().getData().unpack(BytesValue.class).getValue().newInput(),
-            Map.class),
-        Coder.class);
+    Coder<WindowedValue<OutputT>> coder =
+        Serializer.deserialize(
+            OBJECT_MAPPER.readValue(
+                coderSpec
+                    .getFunctionSpec()
+                    .getSdkFnSpec()
+                    .getData()
+                    .unpack(BytesValue.class)
+                    .getValue()
+                    .newInput(),
+                Map.class),
+            Coder.class);
     this.coder = coder;
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/runners/core/BoundedSourceRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/runners/core/BoundedSourceRunner.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
 import org.apache.beam.fn.harness.fn.ThrowingConsumer;
-import org.apache.beam.fn.v1.BeamFnApi;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.Source.Reader;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -39,12 +39,12 @@ import org.apache.beam.sdk.util.WindowedValue;
  */
 public class BoundedSourceRunner<InputT extends BoundedSource<OutputT>, OutputT> {
   private final PipelineOptions pipelineOptions;
-  private final BeamFnApi.FunctionSpec definition;
+  private final RunnerApi.FunctionSpec definition;
   private final Collection<ThrowingConsumer<WindowedValue<OutputT>>> consumers;
 
   public BoundedSourceRunner(
       PipelineOptions pipelineOptions,
-      BeamFnApi.FunctionSpec definition,
+      RunnerApi.FunctionSpec definition,
       Map<String, Collection<ThrowingConsumer<WindowedValue<OutputT>>>> outputMap) {
     this.pipelineOptions = pipelineOptions;
     this.definition = definition;
@@ -53,23 +53,26 @@ public class BoundedSourceRunner<InputT extends BoundedSource<OutputT>, OutputT>
 
   /**
    * The runner harness is meant to send the source over the Beam Fn Data API which would be
-   * consumed by the {@link #runReadLoop}. Drop this method once the runner harness sends the
-   * source instead of unpacking it from the data block of the function specification.
+   * consumed by the {@link #runReadLoop}. Drop this method once the runner harness sends the source
+   * instead of unpacking it from the data block of the function specification.
    */
   @Deprecated
   public void start() throws Exception {
     try {
       // The representation here is defined as the java serialized representation of the
       // bounded source object packed into a protobuf Any using a protobuf BytesValue wrapper.
-      byte[] bytes = definition.getData().unpack(BytesValue.class).getValue().toByteArray();
+      byte[] bytes =
+          definition.getSdkFnSpec().getData().unpack(BytesValue.class).getValue().toByteArray();
       @SuppressWarnings("unchecked")
       InputT boundedSource =
           (InputT) SerializableUtils.deserializeFromByteArray(bytes, definition.toString());
       runReadLoop(WindowedValue.valueInGlobalWindow(boundedSource));
     } catch (InvalidProtocolBufferException e) {
       throw new IOException(
-          String.format("Failed to decode %s, expected %s",
-              definition.getData().getTypeUrl(), BytesValue.getDescriptor().getFullName()),
+          String.format(
+              "Failed to decode %s, expected %s",
+              definition.getSdkFnSpec().getData().getTypeUrl(),
+              BytesValue.getDescriptor().getFullName()),
           e);
     }
   }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -65,6 +65,7 @@ import org.apache.beam.runners.dataflow.util.DoFnInfo;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -105,18 +106,38 @@ public class ProcessBundleHandlerTest {
   static {
     try {
       STRING_CODER_SPEC =
-          BeamFnApi.Coder.newBuilder().setFunctionSpec(BeamFnApi.FunctionSpec.newBuilder()
-          .setId(STRING_CODER_SPEC_ID)
-          .setData(Any.pack(BytesValue.newBuilder().setValue(ByteString.copyFrom(
-              OBJECT_MAPPER.writeValueAsBytes(STRING_CODER.asCloudObject()))).build())))
-          .build();
+          BeamFnApi.Coder.newBuilder()
+              .setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()
+                      .setSdkFnSpec(
+                          RunnerApi.SdkFunctionSpec.newBuilder()
+                              .setData(
+                                  Any.pack(
+                                      BytesValue.newBuilder()
+                                          .setValue(
+                                              ByteString.copyFrom(
+                                                  OBJECT_MAPPER.writeValueAsBytes(
+                                                      STRING_CODER.asCloudObject())))
+                                          .build()))))
+              .build();
       LONG_CODER_SPEC =
-          BeamFnApi.Coder.newBuilder().setFunctionSpec(BeamFnApi.FunctionSpec.newBuilder()
-          .setId(STRING_CODER_SPEC_ID)
-          .setData(Any.pack(BytesValue.newBuilder().setValue(ByteString.copyFrom(
-              OBJECT_MAPPER.writeValueAsBytes(WindowedValue.getFullCoder(
-                  VarLongCoder.of(), GlobalWindow.Coder.INSTANCE).asCloudObject()))).build())))
-          .build();
+          BeamFnApi.Coder.newBuilder()
+              .setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()
+                      .setSdkFnSpec(
+                          RunnerApi.SdkFunctionSpec.newBuilder()
+                              .setData(
+                                  Any.pack(
+                                      BytesValue.newBuilder()
+                                          .setValue(
+                                              ByteString.copyFrom(
+                                                  OBJECT_MAPPER.writeValueAsBytes(
+                                                      WindowedValue.getFullCoder(
+                                                              VarLongCoder.of(),
+                                                              GlobalWindow.Coder.INSTANCE)
+                                                          .asCloudObject())))
+                                          .build()))))
+              .build();
     } catch (IOException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -339,13 +360,19 @@ public class ProcessBundleHandlerTest {
         ImmutableMap.of(
             mainOutputId, TestDoFn.mainOutput,
             sideOutputId, TestDoFn.sideOutput));
-    BeamFnApi.FunctionSpec functionSpec = BeamFnApi.FunctionSpec.newBuilder()
-        .setId(1L)
-        .setUrn(JAVA_DO_FN_URN)
-        .setData(Any.pack(BytesValue.newBuilder()
-            .setValue(ByteString.copyFrom(SerializableUtils.serializeToByteArray(doFnInfo)))
-            .build()))
-        .build();
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setSpec(RunnerApi.UrnWithParameter.newBuilder().setUrn(JAVA_DO_FN_URN))
+            .setSdkFnSpec(
+                RunnerApi.SdkFunctionSpec.newBuilder()
+                    .setData(
+                        Any.pack(
+                            BytesValue.newBuilder()
+                                .setValue(
+                                    ByteString.copyFrom(
+                                        SerializableUtils.serializeToByteArray(doFnInfo)))
+                                .build())))
+            .build();
     BeamFnApi.Target inputATarget1 = BeamFnApi.Target.newBuilder()
         .setPrimitiveTransformReference(1000L)
         .setName("inputATarget1")
@@ -458,14 +485,20 @@ public class ProcessBundleHandlerTest {
     List<ThrowingRunnable> startFunctions = new ArrayList<>();
     List<ThrowingRunnable> finishFunctions = new ArrayList<>();
 
-    BeamFnApi.FunctionSpec functionSpec = BeamFnApi.FunctionSpec.newBuilder()
-        .setId(1L)
-        .setUrn(JAVA_SOURCE_URN)
-        .setData(Any.pack(BytesValue.newBuilder()
-            .setValue(ByteString.copyFrom(
-                SerializableUtils.serializeToByteArray(CountingSource.upTo(3))))
-            .build()))
-        .build();
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setSpec(RunnerApi.UrnWithParameter.newBuilder().setUrn(JAVA_SOURCE_URN))
+            .setSdkFnSpec(
+                RunnerApi.SdkFunctionSpec.newBuilder()
+                    .setData(
+                        Any.pack(
+                            BytesValue.newBuilder()
+                                .setValue(
+                                    ByteString.copyFrom(
+                                        SerializableUtils.serializeToByteArray(
+                                            CountingSource.upTo(3))))
+                                .build())))
+            .build();
 
     BeamFnApi.PrimitiveTransform primitiveTransform = BeamFnApi.PrimitiveTransform.newBuilder()
         .setId(primitiveTransformId)
@@ -529,11 +562,11 @@ public class ProcessBundleHandlerTest {
     List<ThrowingRunnable> startFunctions = new ArrayList<>();
     List<ThrowingRunnable> finishFunctions = new ArrayList<>();
 
-    BeamFnApi.FunctionSpec functionSpec = BeamFnApi.FunctionSpec.newBuilder()
-        .setId(1L)
-        .setUrn(DATA_INPUT_URN)
-        .setData(Any.pack(REMOTE_PORT))
-        .build();
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setSpec(RunnerApi.UrnWithParameter.newBuilder().setUrn(DATA_INPUT_URN))
+            .setSdkFnSpec(RunnerApi.SdkFunctionSpec.newBuilder().setData(Any.pack(REMOTE_PORT)))
+            .build();
 
     BeamFnApi.PrimitiveTransform primitiveTransform = BeamFnApi.PrimitiveTransform.newBuilder()
         .setId(primitiveTransformId)
@@ -602,10 +635,9 @@ public class ProcessBundleHandlerTest {
     List<ThrowingRunnable> startFunctions = new ArrayList<>();
     List<ThrowingRunnable> finishFunctions = new ArrayList<>();
 
-    BeamFnApi.FunctionSpec functionSpec = BeamFnApi.FunctionSpec.newBuilder()
-        .setId(1L)
-        .setUrn(DATA_OUTPUT_URN)
-        .setData(Any.pack(REMOTE_PORT))
+    RunnerApi.FunctionSpec functionSpec = RunnerApi.FunctionSpec.newBuilder()
+        .setSpec(RunnerApi.UrnWithParameter.newBuilder().setUrn(DATA_OUTPUT_URN))
+        .setSdkFnSpec(RunnerApi.SdkFunctionSpec.newBuilder().setData(Any.pack(REMOTE_PORT)))
         .build();
 
     BeamFnApi.PrimitiveTransform primitiveTransform = BeamFnApi.PrimitiveTransform.newBuilder()

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/RegisterHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/RegisterHandlerTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.fn.harness.test.TestExecutors;
 import org.apache.beam.fn.harness.test.TestExecutors.TestExecutorService;
 import org.apache.beam.fn.v1.BeamFnApi;
 import org.apache.beam.fn.v1.BeamFnApi.RegisterResponse;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,11 +43,11 @@ public class RegisterHandlerTest {
       .setInstructionId(1L)
       .setRegister(BeamFnApi.RegisterRequest.newBuilder()
           .addProcessBundleDescriptor(BeamFnApi.ProcessBundleDescriptor.newBuilder().setId(1L)
-              .addCoders(BeamFnApi.Coder.newBuilder().setFunctionSpec(
-                  BeamFnApi.FunctionSpec.newBuilder().setId(10L)).build()))
+              .addCoders(BeamFnApi.Coder.newBuilder().setId(10L).setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()).build()))
           .addProcessBundleDescriptor(BeamFnApi.ProcessBundleDescriptor.newBuilder().setId(2L)
-              .addCoders(BeamFnApi.Coder.newBuilder().setFunctionSpec(
-                  BeamFnApi.FunctionSpec.newBuilder().setId(20L)).build()))
+              .addCoders(BeamFnApi.Coder.newBuilder().setId(20L).setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()).build()))
           .build())
       .build();
   private static final BeamFnApi.InstructionResponse REGISTER_RESPONSE =

--- a/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BeamFnDataReadRunnerTest.java
@@ -50,6 +50,7 @@ import org.apache.beam.fn.harness.test.TestExecutors.TestExecutorService;
 import org.apache.beam.fn.v1.BeamFnApi;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
@@ -69,17 +70,32 @@ public class BeamFnDataReadRunnerTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final BeamFnApi.RemoteGrpcPort PORT_SPEC = BeamFnApi.RemoteGrpcPort.newBuilder()
       .setApiServiceDescriptor(BeamFnApi.ApiServiceDescriptor.getDefaultInstance()).build();
-  private static final BeamFnApi.FunctionSpec FUNCTION_SPEC = BeamFnApi.FunctionSpec.newBuilder()
-      .setData(Any.pack(PORT_SPEC)).build();
+
+  private static final RunnerApi.FunctionSpec FUNCTION_SPEC =
+      RunnerApi.FunctionSpec.newBuilder()
+          .setSdkFnSpec(RunnerApi.SdkFunctionSpec.newBuilder().setData(Any.pack(PORT_SPEC)))
+          .build();
+
   private static final Coder<WindowedValue<String>> CODER =
       WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE);
   private static final BeamFnApi.Coder CODER_SPEC;
   static {
     try {
-      CODER_SPEC = BeamFnApi.Coder.newBuilder().setFunctionSpec(BeamFnApi.FunctionSpec.newBuilder()
-          .setData(Any.pack(BytesValue.newBuilder().setValue(ByteString.copyFrom(
-              OBJECT_MAPPER.writeValueAsBytes(CODER.asCloudObject()))).build())))
-          .build();
+      CODER_SPEC =
+          BeamFnApi.Coder.newBuilder()
+              .setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()
+                      .setSdkFnSpec(
+                          RunnerApi.SdkFunctionSpec.newBuilder()
+                              .setData(
+                                  Any.pack(
+                                      BytesValue.newBuilder()
+                                          .setValue(
+                                              ByteString.copyFrom(
+                                                  OBJECT_MAPPER.writeValueAsBytes(
+                                                      CODER.asCloudObject())))
+                                          .build()))))
+              .build();
     } catch (IOException e) {
       throw new ExceptionInInitializerError(e);
     }

--- a/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BeamFnDataWriteRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BeamFnDataWriteRunnerTest.java
@@ -40,6 +40,7 @@ import org.apache.beam.fn.harness.fn.CloseableThrowingConsumer;
 import org.apache.beam.fn.v1.BeamFnApi;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
@@ -57,17 +58,30 @@ public class BeamFnDataWriteRunnerTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final BeamFnApi.RemoteGrpcPort PORT_SPEC = BeamFnApi.RemoteGrpcPort.newBuilder()
       .setApiServiceDescriptor(BeamFnApi.ApiServiceDescriptor.getDefaultInstance()).build();
-  private static final BeamFnApi.FunctionSpec FUNCTION_SPEC = BeamFnApi.FunctionSpec.newBuilder()
-      .setData(Any.pack(PORT_SPEC)).build();
+  private static final RunnerApi.FunctionSpec FUNCTION_SPEC =
+      RunnerApi.FunctionSpec.newBuilder()
+          .setSdkFnSpec(RunnerApi.SdkFunctionSpec.newBuilder().setData(Any.pack(PORT_SPEC)))
+          .build();
   private static final Coder<WindowedValue<String>> CODER =
       WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE);
   private static final BeamFnApi.Coder CODER_SPEC;
   static {
     try {
-      CODER_SPEC = BeamFnApi.Coder.newBuilder().setFunctionSpec(BeamFnApi.FunctionSpec.newBuilder()
-      .setData(Any.pack(BytesValue.newBuilder().setValue(ByteString.copyFrom(
-          OBJECT_MAPPER.writeValueAsBytes(CODER.asCloudObject()))).build())))
-      .build();
+      CODER_SPEC =
+          BeamFnApi.Coder.newBuilder()
+              .setFunctionSpec(
+                  RunnerApi.FunctionSpec.newBuilder()
+                      .setSdkFnSpec(
+                          RunnerApi.SdkFunctionSpec.newBuilder()
+                              .setData(
+                                  Any.pack(
+                                      BytesValue.newBuilder()
+                                          .setValue(
+                                              ByteString.copyFrom(
+                                                  OBJECT_MAPPER.writeValueAsBytes(
+                                                      CODER.asCloudObject())))
+                                          .build()))))
+              .build();
     } catch (IOException e) {
       throw new ExceptionInInitializerError(e);
     }

--- a/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BoundedSourceRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/runners/core/BoundedSourceRunnerTest.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.fn.harness.fn.ThrowingConsumer;
-import org.apache.beam.fn.v1.BeamFnApi;
+import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -58,7 +58,7 @@ public class BoundedSourceRunnerTest {
     BoundedSourceRunner<BoundedSource<Long>, Long> runner =
         new BoundedSourceRunner<>(
         PipelineOptionsFactory.create(),
-        BeamFnApi.FunctionSpec.getDefaultInstance(),
+        RunnerApi.FunctionSpec.getDefaultInstance(),
         outputMap);
 
     runner.runReadLoop(valueInGlobalWindow(CountingSource.upTo(2)));
@@ -81,7 +81,7 @@ public class BoundedSourceRunnerTest {
     BoundedSourceRunner<BoundedSource<Long>, Long> runner =
         new BoundedSourceRunner<>(
         PipelineOptionsFactory.create(),
-        BeamFnApi.FunctionSpec.getDefaultInstance(),
+        RunnerApi.FunctionSpec.getDefaultInstance(),
         outputMap);
 
     runner.runReadLoop(valueInGlobalWindow(CountingSource.upTo(0)));
@@ -101,8 +101,9 @@ public class BoundedSourceRunnerTest {
     BoundedSourceRunner<BoundedSource<Long>, Long> runner =
         new BoundedSourceRunner<>(
         PipelineOptionsFactory.create(),
-        BeamFnApi.FunctionSpec.newBuilder().setData(
-            Any.pack(BytesValue.newBuilder().setValue(encodedSource).build())).build(),
+        RunnerApi.FunctionSpec.newBuilder().setSdkFnSpec(
+            RunnerApi.SdkFunctionSpec.newBuilder().setData(
+            Any.pack(BytesValue.newBuilder().setValue(encodedSource).build()))).build(),
         outputMap);
 
     runner.start();


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

This ports the Fn API and the Java SDK's Fn harness to use the `FunctionSpec` from the Runner API, aka the function spec that will be part of the user's submitted pipeline. At some point we might want yet a third `sdks/common/common` :-) library for things that are shared but for now minimizing administrative overhead. (p.s. that is why I like more specific names)

The proto is arranged just slightly differently due to observations by both @tgroh and @robertwb that the "pass the serialized blob" SDK-specific path and the "specify the function via a URN and parameters" path should be starkly separated.

The changes I made to the Java SDK harness are really just one step beyond automated refactor. I think some of the ways that the SDK-specific payload look like measures of expedience prior to this PR; I did not try to improve them.