### PR TITLE
[BEAM-646] Get the #apply out of the DirectRunner

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundMultiTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundMultiTranslator.java
@@ -58,7 +58,8 @@ class ParDoBoundMultiTranslator<InputT, OutputT>
 
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("ApexRunner does not support Splittable DoFn: %s", doFn));
+          String.format(
+              "%s does not support splittable DoFn: %s", ApexRunner.class.getSimpleName(), doFn));
     }
     if (signature.stateDeclarations().size() > 0) {
       throw new UnsupportedOperationException(

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundMultiTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundMultiTranslator.java
@@ -56,6 +56,10 @@ class ParDoBoundMultiTranslator<InputT, OutputT>
     DoFn<InputT, OutputT> doFn = transform.getFn();
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
 
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("ApexRunner does not support Splittable DoFn: %s", doFn));
+    }
     if (signature.stateDeclarations().size() > 0) {
       throw new UnsupportedOperationException(
           String.format(

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslator.java
@@ -43,6 +43,10 @@ class ParDoBoundTranslator<InputT, OutputT>
     DoFn<InputT, OutputT> doFn = transform.getFn();
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
 
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("ApexRunner does not support Splittable DoFn: %s", doFn));
+    }
     if (signature.stateDeclarations().size() > 0) {
       throw new UnsupportedOperationException(
           String.format(

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoBoundTranslator.java
@@ -45,7 +45,8 @@ class ParDoBoundTranslator<InputT, OutputT>
 
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("ApexRunner does not support Splittable DoFn: %s", doFn));
+          String.format(
+              "%s does not support splittable DoFn: %s", ApexRunner.class.getSimpleName(), doFn));
     }
     if (signature.stateDeclarations().size() > 0) {
       throw new UnsupportedOperationException(

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -30,8 +30,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.beam.runners.core.SplittableParDo;
+import org.apache.beam.runners.core.SplittableParDo.GBKIntoKeyedWorkItems;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
+import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.direct.DirectRunner.DirectPipelineResult;
 import org.apache.beam.runners.direct.TestStreamEvaluatorFactory.DirectTestStreamFactory;
 import org.apache.beam.runners.direct.ViewEvaluatorFactory.ViewOverrideFactory;
@@ -41,10 +42,11 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.Read;
-import org.apache.beam.sdk.io.Write;
+import org.apache.beam.sdk.io.Write.Bound;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.runners.PTransformMatcher;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.testing.TestStream;
@@ -53,14 +55,13 @@ import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
 import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.beam.sdk.values.PInput;
-import org.apache.beam.sdk.values.POutput;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -72,23 +73,49 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   /**
    * The default set of transform overrides to use in the {@link DirectRunner}.
    *
-   * <p>A transform override must have a single-argument constructor that takes an instance of the
-   * type of transform it is overriding.
+   * <p>The order in which overrides is applied is important, as some overrides are expanded into a
+   * composite. If the composite contains {@link PTransform PTransforms} which are also overridden,
+   * these PTransforms must occur later in the iteration order. {@link ImmutableMap} has an
+   * iteration order based on the order at which elements are added to it.
    */
   @SuppressWarnings("rawtypes")
-  private static Map<Class<? extends PTransform>, PTransformOverrideFactory>
-      defaultTransformOverrides =
-          ImmutableMap.<Class<? extends PTransform>, PTransformOverrideFactory>builder()
-              .put(CreatePCollectionView.class, new ViewOverrideFactory())
-              .put(GroupByKey.class, new DirectGroupByKeyOverrideFactory())
-              .put(TestStream.class, new DirectTestStreamFactory())
-              .put(Write.Bound.class, new WriteWithShardingFactory())
-              .put(ParDo.Bound.class, new ParDoSingleViaMultiOverrideFactory())
-              .put(ParDo.BoundMulti.class, new ParDoMultiOverrideFactory())
-              .put(
-                  SplittableParDo.GBKIntoKeyedWorkItems.class,
-                  new DirectGBKIntoKeyedWorkItemsOverrideFactory())
-              .build();
+  private static Map<PTransformMatcher, PTransformOverrideFactory> defaultTransformOverrides =
+      ImmutableMap.<PTransformMatcher, PTransformOverrideFactory>builder()
+          .put(
+              PTransformMatchers.classEqualTo(Bound.class),
+              new WriteWithShardingFactory()) /* Uses a view internally. */
+          .put(
+              PTransformMatchers.classEqualTo(CreatePCollectionView.class),
+              new ViewOverrideFactory()) /* Uses pardos and GBKs */
+          .put(
+              PTransformMatchers.classEqualTo(TestStream.class),
+              new DirectTestStreamFactory()) /* primitive */
+          /* Single-output ParDos are implemented in terms of Multi-output ParDos. Any override
+          that is applied to a multi-output ParDo must first have all matching Single-output ParDos
+          converted to match.
+           */
+          .put(PTransformMatchers.splittableParDoSingle(), new ParDoSingleViaMultiOverrideFactory())
+          .put(
+              PTransformMatchers.stateOrTimerParDoSingle(),
+              new ParDoSingleViaMultiOverrideFactory())
+          // SplittableParMultiDo is implemented in terms of nonsplittable single ParDos
+          .put(PTransformMatchers.splittableParDoMulti(), new ParDoMultiOverrideFactory())
+          // state and timer pardos are implemented in terms of nonsplittable single ParDos
+          .put(PTransformMatchers.stateOrTimerParDoMulti(), new ParDoMultiOverrideFactory())
+          .put(
+              PTransformMatchers.classEqualTo(ParDo.Bound.class),
+              new ParDoSingleViaMultiOverrideFactory()) /* returns a BoundMulti */
+          .put(
+              PTransformMatchers.classEqualTo(BoundMulti.class),
+              /* returns one of two primitives; SplittableParDos are replaced above. */
+              new ParDoMultiOverrideFactory())
+          .put(
+              PTransformMatchers.classEqualTo(GBKIntoKeyedWorkItems.class),
+              new DirectGBKIntoKeyedWorkItemsOverrideFactory()) /* Returns a GBKO */
+          .put(
+              PTransformMatchers.classEqualTo(GroupByKey.class),
+              new DirectGroupByKeyOverrideFactory()) /* returns two chained primitives. */
+          .build();
 
   /**
    * Part of a {@link PCollection}. Elements are output to a bundle, which will cause them to be
@@ -281,23 +308,11 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   }
 
   @Override
-  public <OutputT extends POutput, InputT extends PInput> OutputT apply(
-      PTransform<InputT, OutputT> transform, InputT input) {
-    PTransformOverrideFactory<InputT, OutputT, PTransform<InputT, OutputT>> overrideFactory =
-        defaultTransformOverrides.get(transform.getClass());
-    if (overrideFactory != null) {
-      PTransform<InputT, OutputT> customTransform =
-          overrideFactory.getReplacementTransform(transform);
-      if (customTransform != transform) {
-        return Pipeline.applyTransform(transform.getName(), input, customTransform);
-      }
-    }
-    // If there is no override, or we should not apply the override, apply the original transform
-    return super.apply(transform, input);
-  }
-
-  @Override
   public DirectPipelineResult run(Pipeline pipeline) {
+    for (Map.Entry<PTransformMatcher, PTransformOverrideFactory> override :
+        defaultTransformOverrides.entrySet()) {
+      pipeline.replace(override.getKey(), override.getValue());
+    }
     MetricsEnvironment.setMetricsSupported(true);
     DirectGraphVisitor graphVisitor = new DirectGraphVisitor();
     pipeline.traverseTopologically(graphVisitor);
@@ -463,5 +478,8 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
     public Clock get() {
       return NanosOffsetClock.create();
     }
+  }
+
+  private static class ComplexParDoMatcher {
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
@@ -229,7 +229,8 @@ class EvaluationContext {
 
   private void fireAvailableCallbacks(AppliedPTransform<?, ?, ?> producingTransform) {
     TransformWatermarks watermarks = watermarkManager.getWatermarks(producingTransform);
-    callbackExecutor.fireForWatermark(producingTransform, watermarks.getOutputWatermark());
+    Instant outputWatermark = watermarks.getOutputWatermark();
+    callbackExecutor.fireForWatermark(producingTransform, outputWatermark);
   }
 
   /**

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TestStreamEvaluatorFactory.java
@@ -187,7 +187,8 @@ class TestStreamEvaluatorFactory implements TransformEvaluatorFactory {
     static class DirectTestStream<T> extends PTransform<PBegin, PCollection<T>> {
       private final TestStream<T> original;
 
-      private DirectTestStream(TestStream<T> transform) {
+      @VisibleForTesting
+      DirectTestStream(TestStream<T> transform) {
         this.original = transform;
       }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -83,8 +83,7 @@ public class DirectRunnerTest implements Serializable {
     PipelineOptions opts = PipelineOptionsFactory.create();
     opts.setRunner(DirectRunner.class);
 
-    Pipeline p = Pipeline.create(opts);
-    return p;
+    return Pipeline.create(opts);
   }
 
   @Test

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
@@ -60,7 +60,6 @@ public class ViewEvaluatorFactoryTest {
 
   @Test
   public void testInMemoryEvaluator() throws Exception {
-
     PCollection<String> input = p.apply(Create.of("foo", "bar"));
     CreatePCollectionView<String, Iterable<String>> createView =
         CreatePCollectionView.of(
@@ -77,8 +76,7 @@ public class ViewEvaluatorFactoryTest {
     TestViewWriter<String, Iterable<String>> viewWriter = new TestViewWriter<>();
     when(context.createPCollectionViewWriter(concat, view)).thenReturn(viewWriter);
 
-    CommittedBundle<String> inputBundle =
-        bundleFactory.createBundle(input).commit(Instant.now());
+    CommittedBundle<String> inputBundle = bundleFactory.createBundle(input).commit(Instant.now());
     AppliedPTransform<?, ?, ?> producer = DirectGraphs.getProducer(view);
     TransformEvaluator<Iterable<String>> evaluator =
         new ViewEvaluatorFactory(context)

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchTransformTranslators.java
@@ -489,6 +489,14 @@ class FlinkBatchTransformTranslators {
     }
   }
 
+  private static void rejectSplittable(DoFn<?, ?> doFn) {
+    DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("FlinkRunner does not currently support Splittable DoFn: %s", doFn));
+    }
+  }
+
   private static void rejectStateAndTimers(DoFn<?, ?> doFn) {
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
 
@@ -523,6 +531,7 @@ class FlinkBatchTransformTranslators {
 
         FlinkBatchTranslationContext context) {
       DoFn<InputT, OutputT> doFn = transform.getFn();
+      rejectSplittable(doFn);
       rejectStateAndTimers(doFn);
 
       DataSet<WindowedValue<InputT>> inputDataSet =
@@ -569,6 +578,7 @@ class FlinkBatchTransformTranslators {
         ParDo.BoundMulti<InputT, OutputT> transform,
         FlinkBatchTranslationContext context) {
       DoFn<InputT, OutputT> doFn = transform.getFn();
+      rejectSplittable(doFn);
       rejectStateAndTimers(doFn);
       DataSet<WindowedValue<InputT>> inputDataSet =
           context.getInputDataSet(context.getInput(transform));

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkBatchTransformTranslators.java
@@ -493,7 +493,9 @@ class FlinkBatchTransformTranslators {
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("FlinkRunner does not currently support Splittable DoFn: %s", doFn));
+          String.format(
+              "%s does not currently support splittable DoFn: %s",
+              FlinkRunner.class.getSimpleName(), doFn));
     }
   }
 

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
@@ -314,7 +314,9 @@ public class FlinkStreamingTransformTranslators {
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("FlinkRunner does not currently support Splittable DoFn: %s", doFn));
+          String.format(
+              "%s does not currently support splittable DoFn: %s",
+              FlinkRunner.class.getSimpleName(), doFn));
     }
   }
 

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/FlinkStreamingTransformTranslators.java
@@ -310,6 +310,14 @@ public class FlinkStreamingTransformTranslators {
     }
   }
 
+  private static void rejectSplittable(DoFn<?, ?> doFn) {
+    DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("FlinkRunner does not currently support Splittable DoFn: %s", doFn));
+    }
+  }
+
   private static void rejectTimers(DoFn<?, ?> doFn) {
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
 
@@ -334,6 +342,7 @@ public class FlinkStreamingTransformTranslators {
         FlinkStreamingTranslationContext context) {
 
       DoFn<InputT, OutputT> doFn = transform.getFn();
+      rejectSplittable(doFn);
       rejectTimers(doFn);
 
       WindowingStrategy<?, ?> windowingStrategy =
@@ -519,6 +528,7 @@ public class FlinkStreamingTransformTranslators {
         FlinkStreamingTranslationContext context) {
 
       DoFn<InputT, OutputT> doFn = transform.getFn();
+      rejectSplittable(doFn);
       rejectTimers(doFn);
 
       // we assume that the transformation does not change the windowing strategy.

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -946,6 +946,10 @@ public class DataflowPipelineTranslator {
       Map<Long, TupleTag<?>> outputMap) {
 
     DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("FlinkRunner does not currently support splittable DoFn: %s", fn));
+    }
 
     stepContext.addInput(PropertyNames.USER_FN, fn.getClass().getName());
     stepContext.addInput(

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -948,7 +948,10 @@ public class DataflowPipelineTranslator {
     DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("FlinkRunner does not currently support splittable DoFn: %s", fn));
+          String.format(
+              "%s does not currently support splittable DoFn: %s",
+              DataflowRunner.class.getSimpleName(),
+              fn));
     }
 
     stepContext.addInput(PropertyNames.USER_FN, fn.getClass().getName());

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -24,6 +24,7 @@ import static org.apache.beam.runners.spark.io.hadoop.ShardNameBuilder.getOutput
 import static org.apache.beam.runners.spark.io.hadoop.ShardNameBuilder.getOutputFilePrefix;
 import static org.apache.beam.runners.spark.io.hadoop.ShardNameBuilder.getOutputFileTemplate;
 import static org.apache.beam.runners.spark.io.hadoop.ShardNameBuilder.replaceShardCount;
+import static org.apache.beam.runners.spark.translation.TranslationUtils.rejectSplittable;
 import static org.apache.beam.runners.spark.translation.TranslationUtils.rejectStateAndTimers;
 
 import com.google.common.collect.Maps;
@@ -244,6 +245,7 @@ public final class TransformTranslator {
       public void evaluate(ParDo.Bound<InputT, OutputT> transform, EvaluationContext context) {
         String stepName = context.getCurrentTransform().getFullName();
         DoFn<InputT, OutputT> doFn = transform.getFn();
+        rejectSplittable(doFn);
         rejectStateAndTimers(doFn);
         @SuppressWarnings("unchecked")
         JavaRDD<WindowedValue<InputT>> inRDD =
@@ -271,6 +273,7 @@ public final class TransformTranslator {
       public void evaluate(ParDo.BoundMulti<InputT, OutputT> transform, EvaluationContext context) {
         String stepName = context.getCurrentTransform().getFullName();
         DoFn<InputT, OutputT> doFn = transform.getFn();
+        rejectSplittable(doFn);
         rejectStateAndTimers(doFn);
         @SuppressWarnings("unchecked")
         JavaRDD<WindowedValue<InputT>> inRDD =

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -223,6 +223,14 @@ public final class TranslationUtils {
     }
   }
 
+  public static void rejectSplittable(DoFn<?, ?> doFn) {
+    DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
+
+    if (signature.processElement().isSplittable()) {
+      throw new UnsupportedOperationException(
+          String.format("SparkRunner does not support SplittableDoFn: %s", doFn));
+    }
+  }
   /**
    * Reject state and timers {@link DoFn}.
    *

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -228,7 +228,8 @@ public final class TranslationUtils {
 
     if (signature.processElement().isSplittable()) {
       throw new UnsupportedOperationException(
-          String.format("SparkRunner does not support SplittableDoFn: %s", doFn));
+          String.format(
+              "%s does not support splittable DoFn: %s", SparkRunner.class.getSimpleName(), doFn));
     }
   }
   /**

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.spark.translation.streaming;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.runners.spark.translation.TranslationUtils.rejectSplittable;
 import static org.apache.beam.runners.spark.translation.TranslationUtils.rejectStateAndTimers;
 
 import com.google.common.collect.Maps;
@@ -377,6 +378,7 @@ final class StreamingTransformTranslator {
       public void evaluate(final ParDo.Bound<InputT, OutputT> transform,
                            final EvaluationContext context) {
         final DoFn<InputT, OutputT> doFn = transform.getFn();
+        rejectSplittable(doFn);
         rejectStateAndTimers(doFn);
         final SparkRuntimeContext runtimeContext = context.getRuntimeContext();
         final WindowingStrategy<?, ?> windowingStrategy =
@@ -419,6 +421,7 @@ final class StreamingTransformTranslator {
       public void evaluate(final ParDo.BoundMulti<InputT, OutputT> transform,
                            final EvaluationContext context) {
         final DoFn<InputT, OutputT> doFn = transform.getFn();
+        rejectSplittable(doFn);
         rejectStateAndTimers(doFn);
         final SparkRuntimeContext runtimeContext = context.getRuntimeContext();
         final SparkPCollectionView pviews = context.getPViews();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestStream.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestStream.java
@@ -42,8 +42,10 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TimestampedValue.TimestampedValueCoder;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -255,11 +257,9 @@ public final class TestStream<T> extends PTransform<PBegin, PCollection<T>> {
 
   @Override
   public PCollection<T> expand(PBegin input) {
-    throw new IllegalStateException(
-        String.format(
-            "Pipeline Runner %s does not provide a required override for %s",
-            input.getPipeline().getRunner().getClass().getSimpleName(),
-            getClass().getSimpleName()));
+    return PCollection.<T>createPrimitiveOutputInternal(
+            input.getPipeline(), WindowingStrategy.globalDefault(), IsBounded.UNBOUNDED)
+        .setCoder(coder);
   }
 
   public Coder<T> getValueCoder() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -738,10 +738,6 @@ public class ParDo {
 
     @Override
     public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
-      checkArgument(
-          !isSplittable(getFn()),
-          "%s does not support Splittable DoFn",
-          input.getPipeline().getOptions().getRunner().getName());
       validateWindowType(input, fn);
       return PCollection.<OutputT>createPrimitiveOutputInternal(
               input.getPipeline(),
@@ -932,10 +928,7 @@ public class ParDo {
 
     @Override
     public PCollectionTuple expand(PCollection<? extends InputT> input) {
-      checkArgument(
-          !isSplittable(getFn()),
-          "%s does not support Splittable DoFn",
-          input.getPipeline().getOptions().getRunner().getName());
+      // SplittableDoFn should be forbidden on the runner-side.
       validateWindowType(input, fn);
       PCollectionTuple outputs = PCollectionTuple.ofPrimitiveOutputsInternal(
           input.getPipeline(),

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -24,12 +24,9 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.TestStream.Builder;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -313,20 +310,6 @@ public class TestStreamTest implements Serializable {
             .advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE.minus(1L));
     thrown.expect(IllegalArgumentException.class);
     stream.advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE);
-  }
-
-  @Test
-  public void testUnsupportedRunnerThrows() {
-    PipelineOptions opts = PipelineOptionsFactory.create();
-    opts.setRunner(CrashingRunner.class);
-
-    Pipeline p = Pipeline.create(opts);
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("does not provide a required override");
-    thrown.expectMessage(TestStream.class.getSimpleName());
-    thrown.expectMessage(CrashingRunner.class.getSimpleName());
-    p.apply(TestStream.create(VarIntCoder.of()).advanceWatermarkToInfinity());
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2152,34 +2152,4 @@ public class ParDoTest implements Serializable {
 
     // If it doesn't crash, we made it!
   }
-
-  @Test
-  public void testRejectsSplittableDoFnByDefault() {
-    // ParDo with a splittable DoFn must be overridden by the runner.
-    // Without an override, applying it directly must fail.
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(pipeline.getRunner().getClass().getName());
-    thrown.expectMessage("does not support Splittable DoFn");
-
-    pipeline.apply(Create.of(1, 2, 3)).apply(ParDo.of(new TestSplittableDoFn()));
-  }
-
-  @Test
-  public void testMultiRejectsSplittableDoFnByDefault() {
-    // ParDo with a splittable DoFn must be overridden by the runner.
-    // Without an override, applying it directly must fail.
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(pipeline.getRunner().getClass().getName());
-    thrown.expectMessage("does not support Splittable DoFn");
-
-    pipeline
-        .apply(Create.of(1, 2, 3))
-        .apply(
-            ParDo.of(new TestSplittableDoFn())
-                .withOutputTags(
-                    new TupleTag<String>("main") {},
-                    TupleTagList.of(new TupleTag<String>("side1") {})));
-  }
 }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Use the Graph Surgery API in the DirectRunner.

The Forwarding View is currently required to ensure that the `WriteView` transform
is marked as the producer of the View proper. It is then replaced by the original view,
so the Pipeline writes the view to the correct location.

I'm going to revisit the producer-marking code soon, but this is safe to review.

I also missed invariant maintenance within TransformHierarchy within #1998,
so that's added here as well.