### PR TITLE
[BEAM-1113] Re-enable UsesTimersInParDo tests in Dataflow runner

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -126,7 +126,6 @@
                 org.apache.beam.sdk.testing.UsesGaugeMetrics,
                 org.apache.beam.sdk.testing.UsesSetState,
                 org.apache.beam.sdk.testing.UsesMapState,
-                org.apache.beam.sdk.testing.UsesTimersInParDo,
                 org.apache.beam.sdk.testing.UsesSplittableParDo,
                 org.apache.beam.sdk.testing.UsesUnboundedPCollections,
                 org.apache.beam.sdk.testing.UsesTestStream,

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -111,7 +111,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         new ErrorMonitorMessagesHandler(job, new MonitoringUtil.LoggingHandler());
 
     try {
-      Optional<Boolean> result = Optional.absent();
+      Optional<Boolean> assertionResult = Optional.absent();
 
       if (options.isStreaming()) {
         // In streaming, there are infinite retries, so rather than timeout
@@ -148,14 +148,16 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         }
 
         if (messageHandler.hasSeenError()) {
-          result = Optional.of(false);
+          // We know it is a failure, but there are no metrics in streaming
+          // and the message may be a non-assertion failure
+          assertionResult = Optional.absent();
         }
       } else {
         job.waitUntilFinish(Duration.standardSeconds(-1), messageHandler);
-        result = checkForPAssertSuccess(job);
+        assertionResult = checkForPAssertSuccess(job);
       }
 
-      if (!result.isPresent()) {
+      if (!assertionResult.isPresent()) {
         if (options.isStreaming()) {
           LOG.warn(
               "Dataflow job {} did not output a success or failure metric."
@@ -167,7 +169,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               String.format(
                   "Dataflow job %s did not output a success or failure metric.", job.getJobId()));
         }
-      } else if (!result.get()) {
+      } else if (!assertionResult.get()) {
         throw new AssertionError(
             Strings.isNullOrEmpty(messageHandler.getErrorMessage())
                 ? String.format(
@@ -203,19 +205,13 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
    * <p>If the pipeline is not in a failed/cancelled state and no PAsserts were used within the
    * pipeline, then this method will state that all PAsserts succeeded.
    *
-   * @return Optional.of(false) if we are certain a PAssert or some other critical thing has failed,
-   *     Optional.of(true) if we are certain all PAsserts passed, and Optional.absent() if the
-   *     evidence is inconclusive.
+   * @return Optional.of(false) if we are certain a PAssert failed.
+   *     Optional.of(true) if we are certain all PAsserts passed.
+   *     Optional.absent() if the evidence is inconclusive, including when the pipeline may have
+   *     failed for other reasons.
    */
   @VisibleForTesting
   Optional<Boolean> checkForPAssertSuccess(DataflowPipelineJob job) throws IOException {
-
-    // If the job failed, this is a definite failure. We only cancel jobs when they fail.
-    State state = job.getState();
-    if (state == State.FAILED || state == State.CANCELLED) {
-      LOG.info("Dataflow job {} terminated in failure state {}", job.getJobId(), state);
-      return Optional.of(false);
-    }
 
     JobMetrics metrics = getJobMetrics(job);
     if (metrics == null || metrics.getMetrics() == null) {
@@ -253,6 +249,16 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
           failures,
           expectedNumberOfAssertions);
       return Optional.of(true);
+    }
+
+    // If the job failed, this is a definite failure. We only cancel jobs when they fail.
+    State state = job.getState();
+    if (state == State.FAILED || state == State.CANCELLED) {
+      LOG.info(
+          "Dataflow job {} terminated in failure state {} without reporting a failed assertion",
+          job.getJobId(),
+          state);
+      return Optional.absent();
     }
 
     LOG.info(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -54,7 +54,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CustomCoder;
@@ -2766,7 +2765,7 @@ public class ParDoTest implements Serializable {
         };
 
     PCollection<Integer> output = pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    thrown.expect(PipelineExecutionException.class);
+    thrown.expect(RuntimeException.class);
     // Note that runners can reasonably vary their message - this matcher should be flexible
     // and can be evolved.
     thrown.expectMessage("relative timers");
@@ -2796,7 +2795,7 @@ public class ParDoTest implements Serializable {
         };
 
     PCollection<Integer> output = pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    thrown.expect(PipelineExecutionException.class);
+    thrown.expect(RuntimeException.class);
     // Note that runners can reasonably vary their message - this matcher should be flexible
     // and can be evolved.
     thrown.expectMessage("event time timer");


### PR DESCRIPTION
A rather vital commit left out of #1792. Do not review yet; utilizing Jenkins.