### PR TITLE
[BEAM-958] Improve desired number of splits in Dataflow.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
@@ -62,12 +62,13 @@ public class CustomSources {
   }
 
   private static int getDesiredNumUnboundedSourceSplits(DataflowPipelineOptions options) {
+    int cores = 4; //TODO: decide at runtime?
     if (options.getMaxNumWorkers() > 0) {
-      return options.getMaxNumWorkers();
+      return options.getMaxNumWorkers() * cores;
     } else if (options.getNumWorkers() > 0) {
-      return options.getNumWorkers() * 3;
+      return options.getNumWorkers() * cores;
     } else {
-      return 20;
+      return 5 * cores;
     }
   }
 


### PR DESCRIPTION
Set desired number of splits for unbounded sources to 4 x (max)workers.
I am not sure of the rationale for previous values, especially 1xMaxWorkers, which implies there could be just core that is utilized on a worker.

This fix is important for supporting autoscaling with sources that respect 'desiredNumSplits' passed to `generateInitialSplits()` (KafkaIO is one such source). 
