### PR TITLE
[BEAM-1492] Upgrade bytebuddy to 1.6.8 to jump past asm 5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -871,7 +871,7 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.5.5</version>
+        <version>1.6.8</version>
       </dependency>
 
       <!-- Testing -->

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -427,7 +427,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
                   // Push "this" (DoFnInvoker on top of the stack)
                   MethodVariableAccess.REFERENCE.loadFrom(0),
                   // Access this.delegate (DoFn on top of the stack)
-                  FieldAccess.forField(delegateField).getter(),
+                  FieldAccess.forField(delegateField).read(),
                   // Cast it to the more precise type
                   TypeCasting.to(doFnType),
                   // Run the beforeDelegation manipulations.
@@ -637,7 +637,7 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       StackManipulation pushDelegate =
           new StackManipulation.Compound(
               MethodVariableAccess.REFERENCE.loadFrom(0),
-              FieldAccess.forField(delegateField).getter());
+              FieldAccess.forField(delegateField).read());
 
       StackManipulation pushExtraContextFactory = MethodVariableAccess.REFERENCE.loadFrom(1);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyOnTimerInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyOnTimerInvokerFactory.java
@@ -239,7 +239,7 @@ class ByteBuddyOnTimerInvokerFactory implements OnTimerInvokerFactory {
       StackManipulation pushDelegate =
           new StackManipulation.Compound(
               MethodVariableAccess.REFERENCE.loadFrom(0),
-              FieldAccess.forField(delegateField).getter());
+              FieldAccess.forField(delegateField).read());
 
       StackManipulation pushExtraContextFactory = MethodVariableAccess.REFERENCE.loadFrom(1);
 
@@ -295,7 +295,7 @@ class ByteBuddyOnTimerInvokerFactory implements OnTimerInvokerFactory {
                                   .getDeclaredFields()
                                   .filter(ElementMatchers.named(FN_DELEGATE_FIELD_NAME))
                                   .getOnly())
-                          .putter(),
+                          .write(),
                       // Return void.
                       MethodReturn.VOID)
                   .apply(methodVisitor, implementationContext);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

There is a suspected bug in asm 5.0 that is considered the likely root cause of a bug sbt/sbt-assembly#205 (see [this comment](https://github.com/sbt/sbt-assembly/issues/205#issuecomment-279964607)) that carried over to [Gearpump](https://issues.apache.org/jira/browse/GEARPUMP-236). This commit upgrades us to depend on bytebuddy 1.6.8 that uses asm 5.2 in which those derivative bugs have cleared up.

I have not found a direct reference to what the issue is, precisely, but the dependency effect is nil because bytebuddy is fully shaded (no deps) so we might as well jump past any problematic version eagerly.