### PR TITLE
[BEAM-1410] python-sdk: add stacked WindowedValues in DirectRunner.Bundle.

### DIFF
--- a/sdks/python/apache_beam/runners/direct/bundle_factory.py
+++ b/sdks/python/apache_beam/runners/direct/bundle_factory.py
@@ -28,7 +28,7 @@ class BundleFactory(object):
 
   Args:
     stacked: whether or not to stack the WindowedValues within the bundle
-      in a case consecutive ones share the same timestamp and windows.
+      in case consecutive ones share the same timestamp and windows.
       DirectRunnerOptions.direct_runner_use_stacked_bundle controls this option.
   """
 
@@ -123,7 +123,6 @@ class Bundle(object):
       in the form of iterable if committed and make_copy is not True,
       or as a list of copied WindowedValues.
     """
-
     if not self._stacked:
       if self._committed and not make_copy:
         return self._elements

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -26,12 +26,13 @@ from __future__ import absolute_import
 import collections
 import logging
 
-from apache_beam.runners.direct.bundle_factory import BundleFactory
 from apache_beam.metrics.execution import MetricsEnvironment
+from apache_beam.runners.direct.bundle_factory import BundleFactory
 from apache_beam.runners.runner import PipelineResult
 from apache_beam.runners.runner import PipelineRunner
 from apache_beam.runners.runner import PipelineState
 from apache_beam.runners.runner import PValueCache
+from apache_beam.utils.pipeline_options import DirectOptions
 
 
 class DirectRunner(PipelineRunner):
@@ -71,7 +72,8 @@ class DirectRunner(PipelineRunner):
 
     evaluation_context = EvaluationContext(
         pipeline.options,
-        BundleFactory(),
+        BundleFactory(stacked=pipeline.options.view_as(DirectOptions)
+                      .direct_runner_use_stacked_bundle),
         self.visitor.root_transforms,
         self.visitor.value_to_consumers,
         self.visitor.step_names,

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -201,7 +201,9 @@ class EvaluationContext(object):
           and result.output_bundles[0].pcollection in self.views):
         if committed_bundles:
           assert len(committed_bundles) == 1
-          side_input_result = committed_bundles[0].elements
+          # side_input must be materialized.
+          side_input_result = committed_bundles[0].get_elements_iterable(
+              make_copy=True)
         else:
           side_input_result = []
         tasks = self._side_inputs_container.set_value_and_get_callables(

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -293,7 +293,7 @@ class TransformExecutor(ExecutorService.CallableTask):
           side_input_values, scoped_metrics_container)
 
       if self._input_bundle:
-        for value in self._input_bundle.elements:
+        for value in self._input_bundle.get_elements_iterable():
           evaluator.process_element(value)
 
       with scoped_metrics_container:
@@ -304,7 +304,7 @@ class TransformExecutor(ExecutorService.CallableTask):
         for uncommitted_bundle in result.output_bundles:
           self._evaluation_context.append_to_cache(
               self._applied_transform, uncommitted_bundle.tag,
-              uncommitted_bundle.elements)
+              uncommitted_bundle.get_elements_iterable())
         undeclared_tag_values = result.undeclared_tag_values
         if undeclared_tag_values:
           for tag, value in undeclared_tag_values.iteritems():

--- a/sdks/python/apache_beam/runners/direct/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/direct/watermark_manager.py
@@ -102,7 +102,7 @@ class WatermarkManager(object):
     # Update pending elements. Filter out empty bundles. They do not impact
     # watermarks and should not trigger downstream execution.
     for output in output_committed_bundles:
-      if output.elements:
+      if output.has_elements():
         if output.pcollection in self._value_to_consumers:
           consumers = self._value_to_consumers[output.pcollection]
           for consumer in consumers:
@@ -113,7 +113,7 @@ class WatermarkManager(object):
     completed_tw.update_timers(timer_update)
 
     assert input_committed_bundle or applied_ptransform in self._root_transforms
-    if input_committed_bundle and input_committed_bundle.elements:
+    if input_committed_bundle and input_committed_bundle.has_elements():
       completed_tw.remove_pending(input_committed_bundle)
 
   def _refresh_watermarks(self, applied_ptransform):

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -169,9 +169,9 @@ class RunnerTest(unittest.TestCase):
                  options=PipelineOptions(self.default_properties))
     pcoll = (p | ptransform.Create([1, 2, 3, 4, 5])
              | 'Do' >> beam.ParDo(MyDoFn()))
+    assert_that(pcoll, equal_to([1, 2, 3, 4, 5]))
     result = p.run()
     result.wait_until_finish()
-    assert_that(pcoll, equal_to([1, 2, 3, 4, 5]))
     metrics = result.metrics().query()
     namespace = '{}.{}'.format(MyDoFn.__module__,
                                MyDoFn.__name__)

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -38,6 +38,8 @@ from apache_beam.runners import DirectRunner
 from apache_beam.runners import TestDataflowRunner
 import apache_beam.transforms as ptransform
 from apache_beam.transforms.display import DisplayDataItem
+from apache_beam.transforms.util import assert_that
+from apache_beam.transforms.util import equal_to
 from apache_beam.utils.pipeline_options import PipelineOptions
 
 from apache_beam.metrics.cells import DistributionData
@@ -165,11 +167,11 @@ class RunnerTest(unittest.TestCase):
     runner = DirectRunner()
     p = Pipeline(runner,
                  options=PipelineOptions(self.default_properties))
-    # pylint: disable=expression-not-assigned
-    (p | ptransform.Create([1, 2, 3, 4, 5])
-     | 'Do' >> beam.ParDo(MyDoFn()))
+    pcoll = (p | ptransform.Create([1, 2, 3, 4, 5])
+             | 'Do' >> beam.ParDo(MyDoFn()))
     result = p.run()
     result.wait_until_finish()
+    assert_that(pcoll, equal_to([1, 2, 3, 4, 5]))
     metrics = result.metrics().query()
     namespace = '{}.{}'.format(MyDoFn.__module__,
                                MyDoFn.__name__)

--- a/sdks/python/apache_beam/utils/pipeline_options.py
+++ b/sdks/python/apache_beam/utils/pipeline_options.py
@@ -228,6 +228,20 @@ class TypeOptions(PipelineOptions):
                         'DirectRunner')
 
 
+class DirectOptions(PipelineOptions):
+  """DirectRunner-specific execution options."""
+
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument(
+        '--no_direct_runner_use_stacked_bundle',
+        action='store_false',
+        dest='direct_runner_use_stacked_bundle',
+        help='DirectRunner uses stacked WindowedValues within a Bundle for '
+        'memory optimization. Set --no_direct_runner_use_stacked_bundle to '
+        'avoid it.')
+
+
 class GoogleCloudOptions(PipelineOptions):
   """Google Cloud Dataflow service execution options."""
 


### PR DESCRIPTION
It saves memory for the typical cases that timestamp/window info is shared.

This is on by default, but could be turned off by sending --no_direct_runner_use_stacked_bundle to the pipeline.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
