### PR TITLE
[BEAM-1467] Add cross-SDK implementations and tests of WindowedValueCoder

### DIFF
--- a/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
+++ b/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
@@ -144,12 +144,19 @@ examples:
 
 ---
 
+# All windowed values consist of pane infos that represent NO_FIRING until full support is added
+# in the Python SDK (BEAM-1522).
 coder:
   urn: "urn:beam:coders:windowed_value:0.1"
   components: [{urn: "urn:beam:coders:varint:0.1"},
                {urn: "urn:beam:coders:global_window:0.1"}]
 examples:
-  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {value: 2, timestamp: 1454293425000, windows: ["global"]}
+  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {
+    value: 2,
+    timestamp: 1454293425000,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: ["global"]
+  }
 
 ---
 
@@ -158,5 +165,16 @@ coder:
   components: [{urn: "urn:beam:coders:varint:0.1"},
                {urn: "urn:beam:coders:interval_window:0.1"}]
 examples:
-  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {value: 4, timestamp: -400000, windows: [{end: 1454293425000, span: 280000}]}
-  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {value: 2, timestamp: -100, windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]}
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {
+    value: 4,
+    timestamp: -400000,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: [{end: 1454293425000, span: 280000}]
+  }
+
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {
+    value: 2,
+    timestamp: -100,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]
+  }

--- a/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
+++ b/sdks/common/fn-api/src/test/resources/org/apache/beam/fn/v1/standard_coders.yaml
@@ -100,7 +100,7 @@ examples:
 ---
 
 coder:
-  urn: "urn:beam:coders:intervalwindow:0.1"
+  urn: "urn:beam:coders:interval_window:0.1"
 examples:
   "\u0080\u0000\u0001\u0052\u009a\u00a4\u009b\u0068\u0080\u00dd\u00db\u0001" : {end: 1454293425000, span: 3600000}
   "\u0080\u0000\u0001\u0053\u0034\u00ec\u0074\u00e8\u0080\u0090\u00fb\u00d3\u0009" : {end: 1456881825000, span: 2592000000}
@@ -126,3 +126,37 @@ examples:
   "\0\0\0\u0001\u0003abc": ["abc"]
   "\0\0\0\u0002\u0004ab\0c\u0004de\0f": ["ab\0c", "de\0f"]
   "\0\0\0\0": []
+
+---
+
+coder:
+  urn: "urn:beam:coders:stream:0.1"
+  components: [{urn: "urn:beam:coders:global_window:0.1"}]
+examples:
+  "\0\0\0\u0001": [""]
+
+---
+
+coder:
+  urn: "urn:beam:coders:global_window:0.1"
+examples:
+  "": ""
+
+---
+
+coder:
+  urn: "urn:beam:coders:windowed_value:0.1"
+  components: [{urn: "urn:beam:coders:varint:0.1"},
+               {urn: "urn:beam:coders:global_window:0.1"}]
+examples:
+  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {value: 2, timestamp: 1454293425000, windows: ["global"]}
+
+---
+
+coder:
+  urn: "urn:beam:coders:windowed_value:0.1"
+  components: [{urn: "urn:beam:coders:varint:0.1"},
+               {urn: "urn:beam:coders:interval_window:0.1"}]
+examples:
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {value: 4, timestamp: -400000, windows: [{end: 1454293425000, span: 280000}]}
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {value: 2, timestamp: -100, windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CommonCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CommonCoderTest.java
@@ -220,16 +220,16 @@ public class CommonCoderTest {
         Map<String, Object> kvMap = (Map<String, Object>) value;
         Coder valueCoder = ((WindowedValue.FullWindowedValueCoder) coder).getValueCoder();
         Coder windowCoder = ((WindowedValue.FullWindowedValueCoder) coder).getWindowCoder();
-        Object window_value = convertValue(
+        Object windowValue = convertValue(
             kvMap.get("value"), coderSpec.getComponents().get(0), valueCoder);
         Instant timestamp = new Instant(((Number) kvMap.get("timestamp")).longValue());
         List<BoundedWindow> windows = new LinkedList<>();
-        for(Object window: ((List<Object>) kvMap.get("windows"))) {
+        for (Object window: ((List<Object>) kvMap.get("windows"))) {
           windows.add((BoundedWindow) convertValue(window, coderSpec.getComponents().get(1),
               windowCoder));
         }
         // Note: Until Python SDK supports PaneInfo, we default to PaneInfo.NO_FIRING.
-        return WindowedValue.of(window_value, timestamp, windows, PaneInfo.NO_FIRING);
+        return WindowedValue.of(windowValue, timestamp, windows, PaneInfo.NO_FIRING);
       default:
         throw new IllegalStateException("Unknown coder URN: " + coderSpec.getUrn());
     }

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -589,13 +589,12 @@ class WindowedValueCoderImpl(StreamCoderImpl):
   def encode_to_stream(self, value, out, nested):
     wv = value  # type cast
     # Avoid creation of Timestamp object.
-    restore_sign = -1 if wv.timestamp_micros < 0 else 1
     out.write_bigendian_uint64(
-        # Convert to postive number and divide, since python rounds off to the
-        # lower negative number. For ex: -3 / 2 = -2, but we expect it to be -1,
-        # to be consistent across SDKs.
-        self._from_normal_time(
-            restore_sign * (abs(wv.timestamp_micros) / 1000)))
+        # Since python integer division rounds off to the lower negative number,
+        # we used float division and converting back to int.
+        # For ex: -3 / 2 = -2, but we expect it to be -1, to be consistent
+        # across SDKs.
+        self._from_normal_time(int(wv.timestamp_micros / 1000.0)))
     self._windows_coder.encode_to_stream(wv.windows, out, True)
     # Default PaneInfo encoded byte representing NO_FIRING.
     # TODO(vikasrk): Remove the hard coding here once PaneInfo is supported.
@@ -610,9 +609,9 @@ class WindowedValueCoderImpl(StreamCoderImpl):
     # were indeed MIN/MAX timestamps.
     # TODO(vikasrk): Clean this up once we have a BEAM wide consensus on
     # precision of timestamps.
-    if timestamp == -(abs(MIN_TIMESTAMP.micros) / 1000):
+    if timestamp == int(MIN_TIMESTAMP.micros / 1000.0):
       timestamp = MIN_TIMESTAMP.micros
-    elif timestamp == (MAX_TIMESTAMP.micros / 1000):
+    elif timestamp == int(MAX_TIMESTAMP.micros / 1000.0):
       timestamp = MAX_TIMESTAMP.micros
     else:
       timestamp *= 1000

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -24,11 +24,12 @@ encode many elements with minimal overhead.
 This module may be optionally compiled with Cython, using the corresponding
 coder_impl.pxd file for type hints.
 """
-
 from types import NoneType
 
 from apache_beam.coders import observable
 from apache_beam.utils.timestamp import Timestamp
+from apache_beam.utils.timestamp import MAX_TIMESTAMP
+from apache_beam.utils.timestamp import MIN_TIMESTAMP
 from apache_beam.utils import windowed_value
 
 # pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
@@ -570,6 +571,15 @@ class IterableCoderImpl(SequenceCoderImpl):
 class WindowedValueCoderImpl(StreamCoderImpl):
   """A coder for windowed values."""
 
+  # TODO: Fn Harness only supports millis. Is this important enough to fix?
+  def _to_normal_time(self, value):
+    """Convert "lexicographically ordered unsigned" to signed."""
+    return value - (1 << 63)
+
+  def _from_normal_time(self, value):
+    """Convert signed to "lexicographically ordered unsigned"."""
+    return value + (1 << 63)
+
   def __init__(self, value_coder, timestamp_coder, window_coder):
     # TODO(lcwik): Remove the timestamp coder field
     self._value_coder = value_coder
@@ -578,17 +588,39 @@ class WindowedValueCoderImpl(StreamCoderImpl):
 
   def encode_to_stream(self, value, out, nested):
     wv = value  # type cast
-    self._value_coder.encode_to_stream(wv.value, out, True)
     # Avoid creation of Timestamp object.
-    out.write_bigendian_int64(wv.timestamp_micros)
+    out.write_bigendian_uint64(
+        # Convert to postive number and divide since python rounds off the lower
+        # negative number. For ex: -3 / 2 = -2, but we expect it to be -1, to be
+        # consistent across SDKs.
+        self._from_normal_time(-(-wv.timestamp_micros / 1000)))
     self._windows_coder.encode_to_stream(wv.windows, out, True)
+    # Default PaneInfo encoded byte representing NO_FIRING.
+    # TODO(vikasrk): Remove the hard coding here and add support for PaneInfo.
+    out.write_byte(0xF)
+    self._value_coder.encode_to_stream(wv.value, out, nested)
+
 
   def decode_from_stream(self, in_stream, nested):
+    timestamp = self._to_normal_time(in_stream.read_bigendian_uint64())
+    # Restore MIN/MAX timestamps manually as encoding incurs loss
+    # of precision while converting to millis.
+    if timestamp == -(-MIN_TIMESTAMP.micros / 1000):
+      timestamp = MIN_TIMESTAMP.micros
+    elif timestamp == -(- MAX_TIMESTAMP.micros / 1000):
+      timestamp = MAX_TIMESTAMP.micros
+    else:
+      timestamp *= 1000
+
+    windows = self._windows_coder.decode_from_stream(in_stream, True)
+    # Read and discard PaneInfo.
+    in_stream.read_byte()
+    value = self._value_coder.decode_from_stream(in_stream, nested)
     return windowed_value.create(
-        self._value_coder.decode_from_stream(in_stream, True),
+        value,
         # Avoid creation of Timestamp object.
-        in_stream.read_bigendian_int64(),
-        self._windows_coder.decode_from_stream(in_stream, True))
+        timestamp,
+        windows)
 
   def get_estimated_size_and_observables(self, value, nested=False):
     """Returns estimated size of value along with any nested observables."""
@@ -600,13 +632,15 @@ class WindowedValueCoderImpl(StreamCoderImpl):
     observables = []
     value_estimated_size, value_observables = (
         self._value_coder.get_estimated_size_and_observables(
-            value.value, nested=True))
+            value.value, nested=nested))
     estimated_size += value_estimated_size
     observables += value_observables
     estimated_size += (
         self._timestamp_coder.estimate_size(value.timestamp, nested=True))
     estimated_size += (
         self._windows_coder.estimate_size(value.windows, nested=True))
+    # for pane info
+    estimated_size += 1
     return estimated_size, observables
 
 

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -589,11 +589,13 @@ class WindowedValueCoderImpl(StreamCoderImpl):
   def encode_to_stream(self, value, out, nested):
     wv = value  # type cast
     # Avoid creation of Timestamp object.
+    restore_sign = -1 if wv.timestamp_micros < 0 else 1
     out.write_bigendian_uint64(
         # Convert to postive number and divide, since python rounds off to the
         # lower negative number. For ex: -3 / 2 = -2, but we expect it to be -1,
         # to be consistent across SDKs.
-        self._from_normal_time(-(-wv.timestamp_micros / 1000)))
+        self._from_normal_time(
+            restore_sign * (abs(wv.timestamp_micros) / 1000)))
     self._windows_coder.encode_to_stream(wv.windows, out, True)
     # Default PaneInfo encoded byte representing NO_FIRING.
     # TODO(vikasrk): Remove the hard coding here once PaneInfo is supported.
@@ -608,9 +610,9 @@ class WindowedValueCoderImpl(StreamCoderImpl):
     # were indeed MIN/MAX timestamps.
     # TODO(vikasrk): Clean this up once we have a BEAM wide consensus on
     # precision of timestamps.
-    if timestamp == -(-MIN_TIMESTAMP.micros / 1000):
+    if timestamp == -(abs(MIN_TIMESTAMP.micros) / 1000):
       timestamp = MIN_TIMESTAMP.micros
-    elif timestamp == -(-MAX_TIMESTAMP.micros / 1000):
+    elif timestamp == (MAX_TIMESTAMP.micros / 1000):
       timestamp = MAX_TIMESTAMP.micros
     else:
       timestamp *= 1000

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -264,7 +264,7 @@ class CodersTest(unittest.TestCase):
         },
         coder.as_cloud_object())
     # Test binary representation
-    self.assertEqual('\x7f\xdf;dZ\x1c\xac\t\x0f\x00\x00\x00\x01\x01',
+    self.assertEqual('\x7f\xdf;dZ\x1c\xac\t\x00\x00\x00\x01\x0f\x01',
                      coder.encode(window.GlobalWindows.windowed_value(1)))
     # Test unnested
     self.check_coder(

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -264,13 +264,20 @@ class CodersTest(unittest.TestCase):
         },
         coder.as_cloud_object())
     # Test binary representation
-    self.assertEqual('\x01\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01',
+    self.assertEqual('\x7f\xdf;dZ\x1c\xac\t\x0f\x00\x00\x00\x01\x01',
                      coder.encode(window.GlobalWindows.windowed_value(1)))
     # Test unnested
     self.check_coder(
         coders.WindowedValueCoder(coders.VarIntCoder()),
         windowed_value.WindowedValue(3, -100, ()),
         windowed_value.WindowedValue(-1, 100, (1, 2, 3)))
+
+    # Test Global Window
+    self.check_coder(
+        coders.WindowedValueCoder(coders.VarIntCoder(),
+                                  coders.GlobalWindowCoder()),
+        window.GlobalWindows.windowed_value(1))
+
     # Test nested
     self.check_coder(
         coders.TupleCoder((

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -32,7 +32,6 @@ from apache_beam.utils.timestamp import Timestamp
 from apache_beam.transforms.window import IntervalWindow
 from apache_beam.transforms import window
 
-
 from nose_parameterized import parameterized
 
 STANDARD_CODERS_YAML = os.path.join(

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -27,8 +27,11 @@ import yaml
 
 from apache_beam import coders
 from apache_beam.coders import coder_impl
+from apache_beam.utils import windowed_value
 from apache_beam.utils.timestamp import Timestamp
 from apache_beam.transforms.window import IntervalWindow
+from apache_beam.transforms import window
+
 
 from nose_parameterized import parameterized
 
@@ -55,8 +58,11 @@ class StandardCodersTest(unittest.TestCase):
       'urn:beam:coders:bytes:0.1': coders.BytesCoder,
       'urn:beam:coders:varint:0.1': coders.VarIntCoder,
       'urn:beam:coders:kv:0.1': lambda k, v: coders.TupleCoder((k, v)),
-      'urn:beam:coders:intervalwindow:0.1': coders.IntervalWindowCoder,
+      'urn:beam:coders:interval_window:0.1': coders.IntervalWindowCoder,
       'urn:beam:coders:stream:0.1': lambda t: coders.IterableCoder(t),
+      'urn:beam:coders:global_window:0.1': coders.GlobalWindowCoder,
+      'urn:beam:coders:windowed_value:0.1':
+          lambda v, w: coders.WindowedValueCoder(v, w)
   }
 
   _urn_to_json_value_parser = {
@@ -65,11 +71,16 @@ class StandardCodersTest(unittest.TestCase):
       'urn:beam:coders:kv:0.1':
           lambda x, key_parser, value_parser: (key_parser(x['key']),
                                                value_parser(x['value'])),
-      'urn:beam:coders:intervalwindow:0.1':
+      'urn:beam:coders:interval_window:0.1':
           lambda x: IntervalWindow(
               start=Timestamp(micros=(x['end'] - x['span']) * 1000),
               end=Timestamp(micros=x['end'] * 1000)),
-      'urn:beam:coders:stream:0.1': lambda x, parser: map(parser, x)
+      'urn:beam:coders:stream:0.1': lambda x, parser: map(parser, x),
+      'urn:beam:coders:global_window:0.1': lambda x: window.GlobalWindow(),
+      'urn:beam:coders:windowed_value:0.1':
+          lambda x, value_parser, window_parser: windowed_value.create(
+              value_parser(x['value']), x['timestamp'] * 1000,
+              tuple([window_parser(w) for w in x['windows']]))
   }
 
   @parameterized.expand(_load_test_cases(STANDARD_CODERS_YAML))

--- a/sdks/python/apache_beam/tests/data/standard_coders.yaml
+++ b/sdks/python/apache_beam/tests/data/standard_coders.yaml
@@ -144,12 +144,19 @@ examples:
 
 ---
 
+# All windowed values consist of pane infos that represent NO_FIRING until full support is added
+# in the Python SDK (BEAM-1522).
 coder:
   urn: "urn:beam:coders:windowed_value:0.1"
   components: [{urn: "urn:beam:coders:varint:0.1"},
                {urn: "urn:beam:coders:global_window:0.1"}]
 examples:
-  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {value: 2, timestamp: 1454293425000, windows: ["global"]}
+  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {
+    value: 2,
+    timestamp: 1454293425000,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: ["global"]
+  }
 
 ---
 
@@ -158,5 +165,16 @@ coder:
   components: [{urn: "urn:beam:coders:varint:0.1"},
                {urn: "urn:beam:coders:interval_window:0.1"}]
 examples:
-  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {value: 4, timestamp: -400000, windows: [{end: 1454293425000, span: 280000}]}
-  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {value: 2, timestamp: -100, windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]}
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {
+    value: 4,
+    timestamp: -400000,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: [{end: 1454293425000, span: 280000}]
+  }
+
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {
+    value: 2,
+    timestamp: -100,
+    pane: {is_first: True, is_last: True, timing: UNKNOWN, index: 0, on_time_index: 0},
+    windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]
+  }

--- a/sdks/python/apache_beam/tests/data/standard_coders.yaml
+++ b/sdks/python/apache_beam/tests/data/standard_coders.yaml
@@ -100,7 +100,7 @@ examples:
 ---
 
 coder:
-  urn: "urn:beam:coders:intervalwindow:0.1"
+  urn: "urn:beam:coders:interval_window:0.1"
 examples:
   "\u0080\u0000\u0001\u0052\u009a\u00a4\u009b\u0068\u0080\u00dd\u00db\u0001" : {end: 1454293425000, span: 3600000}
   "\u0080\u0000\u0001\u0053\u0034\u00ec\u0074\u00e8\u0080\u0090\u00fb\u00d3\u0009" : {end: 1456881825000, span: 2592000000}
@@ -126,3 +126,37 @@ examples:
   "\0\0\0\u0001\u0003abc": ["abc"]
   "\0\0\0\u0002\u0004ab\0c\u0004de\0f": ["ab\0c", "de\0f"]
   "\0\0\0\0": []
+
+---
+
+coder:
+  urn: "urn:beam:coders:stream:0.1"
+  components: [{urn: "urn:beam:coders:global_window:0.1"}]
+examples:
+  "\0\0\0\u0001": [""]
+
+---
+
+coder:
+  urn: "urn:beam:coders:global_window:0.1"
+examples:
+  "": ""
+
+---
+
+coder:
+  urn: "urn:beam:coders:windowed_value:0.1"
+  components: [{urn: "urn:beam:coders:varint:0.1"},
+               {urn: "urn:beam:coders:global_window:0.1"}]
+examples:
+  "\u0080\0\u0001R\u009a\u00a4\u009bh\0\0\0\u0001\u000f\u0002": {value: 2, timestamp: 1454293425000, windows: ["global"]}
+
+---
+
+coder:
+  urn: "urn:beam:coders:windowed_value:0.1"
+  components: [{urn: "urn:beam:coders:varint:0.1"},
+               {urn: "urn:beam:coders:interval_window:0.1"}]
+examples:
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00f9\u00e5\u0080\0\0\0\u0001\u0080\0\u0001R\u009a\u00a4\u009bh\u00c0\u008b\u0011\u000f\u0004": {value: 4, timestamp: -400000, windows: [{end: 1454293425000, span: 280000}]}
+  "\u007f\u00ff\u00ff\u00ff\u00ff\u00ff\u00ff\u009c\0\0\0\u0002\u0080\0\u0001R\u009a\u00a4\u009bh\u0080\u00dd\u00db\u0001\u007f\u00df;dZ\u001c\u00adv\u00ed\u0002\u000f\u0002": {value: 2, timestamp: -100, windows: [{end: 1454293425000, span: 3600000}, {end: -9223372036854410, span: 365}]}

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -230,7 +230,7 @@ class GlobalWindows(WindowFn):
 
   @classmethod
   def windowed_value(cls, value, timestamp=MIN_TIMESTAMP):
-    return WindowedValue(value, timestamp, [GlobalWindow()])
+    return WindowedValue(value, timestamp, (GlobalWindow(),))
 
   def assign(self, assign_context):
     return [GlobalWindow()]


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

- Tests for GlobalWindowCoder
- Cross-sdk implementation / tests for WindowedValueCoder
- Note: PaneInfo isn't supported in python SDK yet, so we hard code the value to 0x0F which represents PaneInfo.NO_FIRING

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
