### PR TITLE
[BEAM-1504] Parameterized tests for standard coders in Python SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1125,6 +1125,7 @@
               <exclude>**/test/**/.placeholder</exclude>
               <exclude>.repository/**/*</exclude>
               <exclude>**/nose-*.egg/**/*</exclude>
+              <exclude>**/.eggs/**/*</exclude>
               <exclude>**/.tox/**/*</exclude>
 
               <!-- Default eclipse excludes neglect subprojects -->

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -36,7 +36,11 @@ STANDARD_CODERS_YAML = os.path.join(
     os.path.dirname(__file__), '..', 'tests', 'data', 'standard_coders.yaml')
 
 
-def data(test_yaml):
+def _load_test_cases(test_yaml):
+  """Load test data from yaml file and return an iterable of test cases.
+
+  See ``standard_coders.yaml`` for more details.
+  """
   if not os.path.exists(test_yaml):
     raise ValueError('Could not find the test spec: %s' % test_yaml)
   for ix, spec in enumerate(yaml.load_all(open(test_yaml))):
@@ -68,7 +72,7 @@ class StandardCodersTest(unittest.TestCase):
       'urn:beam:coders:stream:0.1': lambda x, parser: map(parser, x)
   }
 
-  @parameterized.expand(data(STANDARD_CODERS_YAML))
+  @parameterized.expand(_load_test_cases(STANDARD_CODERS_YAML))
   def test_standard_coder(self, name, spec):
     coder = self.parse_coder(spec['coder'])
     parse_value = self.json_value_parser(spec['coder'])

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -30,6 +30,20 @@ from apache_beam.coders import coder_impl
 from apache_beam.utils.timestamp import Timestamp
 from apache_beam.transforms.window import IntervalWindow
 
+from nose_parameterized import parameterized
+
+STANDARD_CODERS_YAML = os.path.join(
+    os.path.dirname(__file__), '..', 'tests', 'data', 'standard_coders.yaml')
+
+
+def data(test_yaml):
+  if not os.path.exists(test_yaml):
+    raise ValueError('Could not find the test spec: %s' % test_yaml)
+  for ix, spec in enumerate(yaml.load_all(open(test_yaml))):
+    spec['index'] = ix
+    name = spec.get('name', spec['coder']['urn'].split(':')[-2])
+    yield [name, spec]
+
 
 class StandardCodersTest(unittest.TestCase):
 
@@ -54,30 +68,8 @@ class StandardCodersTest(unittest.TestCase):
       'urn:beam:coders:stream:0.1': lambda x, parser: map(parser, x)
   }
 
-  # We must prepend an underscore to this name so that the open-source unittest
-  # runner does not execute this method directly as a test.
-  @classmethod
-  def _create_test(cls, spec):
-    counter = 0
-    name = spec.get('name', spec['coder']['urn'].split(':')[-2])
-    unique_name = 'test_' + name
-    while hasattr(cls, unique_name):
-      counter += 1
-      unique_name = 'test_%s_%d' % (name, counter)
-    setattr(cls, unique_name, lambda self: self._run_coder_test(spec))
-
-  # We must prepend an underscore to this name so that the open-source unittest
-  # runner does not execute this method directly as a test.
-  @classmethod
-  def _create_tests(cls, coder_test_specs):
-    if not os.path.exists(STANDARD_CODERS_YAML):
-      raise ValueError(
-          "Could not find the test spec: %s" % STANDARD_CODERS_YAML)
-    for ix, spec in enumerate(yaml.load_all(open(coder_test_specs))):
-      spec['index'] = ix
-      cls._create_test(spec)
-
-  def _run_coder_test(self, spec):
+  @parameterized.expand(data(STANDARD_CODERS_YAML))
+  def test_standard_coder(self, name, spec):
     coder = self.parse_coder(spec['coder'])
     parse_value = self.json_value_parser(spec['coder'])
     nested_list = [spec['nested']] if 'nested' in spec else [True, False]
@@ -122,11 +114,6 @@ class StandardCodersTest(unittest.TestCase):
         docs[doc_ix] = docs[doc_ix].replace(
             quote(expected_encoded) + ':', quote(actual_encoded) + ':')
       open(STANDARD_CODERS_YAML, 'w').write(doc_sep.join(docs))
-
-
-STANDARD_CODERS_YAML = os.path.join(
-    os.path.dirname(__file__), '..', 'tests', 'data', 'standard_coders.yaml')
-StandardCodersTest._create_tests(STANDARD_CODERS_YAML)
 
 
 def encode_nested(coder, value, nested=True):

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -100,6 +100,7 @@ REQUIRED_PACKAGES = [
 
 
 REQUIRED_TEST_PACKAGES = [
+    'nose-parameterized>=0.5.0',
     'pyhamcrest>=1.9,<2.0',
     ]
 

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -100,7 +100,7 @@ REQUIRED_PACKAGES = [
 
 
 REQUIRED_TEST_PACKAGES = [
-    'nose-parameterized>=0.5.0, <0.6.0',
+    'nose-parameterized>=0.5.0,<0.6.0',
     'pyhamcrest>=1.9,<2.0',
     ]
 

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -100,7 +100,7 @@ REQUIRED_PACKAGES = [
 
 
 REQUIRED_TEST_PACKAGES = [
-    'nose-parameterized>=0.5.0',
+    'nose-parameterized>=0.5.0, <0.6.0',
     'pyhamcrest>=1.9,<2.0',
     ]
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

`python setup.py test -s apache_beam.coders.standard_coders_test`

...

`test_standard_coder_0_bytes (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_1_bytes (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_2_varint (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_3_kv (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_4_kv (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_5_kv (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_6_intervalwindow (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_7_stream (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
test_standard_coder_8_stream (apache_beam.coders.standard_coders_test.StandardCodersTest) ... ok
`

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
