### PR TITLE
Improve check around accumulation mode

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
@@ -459,10 +459,8 @@ public class Window {
       // an accumulating mode specified
       boolean dataCanArriveLate =
           !(strategy.getWindowFn() instanceof GlobalWindows)
-              && strategy.isAllowedLatenessSpecified()
               && strategy.getAllowedLateness().getMillis() > 0;
-      boolean hasCustomTrigger =
-          strategy.isTriggerSpecified() && !(strategy.getTrigger() instanceof DefaultTrigger);
+      boolean hasCustomTrigger = !(strategy.getTrigger() instanceof DefaultTrigger);
       return dataCanArriveLate || hasCustomTrigger;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
@@ -434,22 +434,36 @@ public class Window {
 
       // Make sure that the windowing strategy is complete & valid.
       if (outputStrategy.isTriggerSpecified()
-          && !(outputStrategy.getTrigger() instanceof DefaultTrigger)) {
-        if (!(outputStrategy.getWindowFn() instanceof GlobalWindows)
-            && !outputStrategy.isAllowedLatenessSpecified()) {
-          throw new IllegalArgumentException("Except when using GlobalWindows,"
-              + " calling .triggering() to specify a trigger requires that the allowed lateness be"
-              + " specified using .withAllowedLateness() to set the upper bound on how late data"
-              + " can arrive before being dropped. See Javadoc for more details.");
-        }
-
-        if (!outputStrategy.isModeSpecified()) {
-          throw new IllegalArgumentException(
-              "Calling .triggering() to specify a trigger requires that the accumulation mode be"
-              + " specified using .discardingFiredPanes() or .accumulatingFiredPanes()."
-              + " See Javadoc for more details.");
-        }
+          && !(outputStrategy.getTrigger() instanceof DefaultTrigger)
+          && !(outputStrategy.getWindowFn() instanceof GlobalWindows)
+          && !outputStrategy.isAllowedLatenessSpecified()) {
+        throw new IllegalArgumentException(
+            "Except when using GlobalWindows,"
+                + " calling .triggering() to specify a trigger requires that the allowed lateness"
+                + " be specified using .withAllowedLateness() to set the upper bound on how late"
+                + " data can arrive before being dropped. See Javadoc for more details.");
       }
+
+      if (!outputStrategy.isModeSpecified() && canProduceMultiplePanes(outputStrategy)) {
+        throw new IllegalArgumentException(
+            "Calling .triggering() to specify a trigger or calling .withAllowedLateness() to"
+                + " specify an allowed lateness greater than zero requires that the accumulation"
+                + " mode be specified using .discardingFiredPanes() or .accumulatingFiredPanes()."
+                + " See Javadoc for more details.");
+      }
+    }
+
+    private boolean canProduceMultiplePanes(WindowingStrategy<?, ?> strategy) {
+      // The default trigger is Repeatedly.forever(AfterWatermark.pastEndOfWindow()); This fires
+      // for every late-arriving element if allowed lateness is nonzero, and thus we must have
+      // an accumulating mode specified
+      boolean dataCanArriveLate =
+          !(strategy.getWindowFn() instanceof GlobalWindows)
+              && strategy.isAllowedLatenessSpecified()
+              && strategy.getAllowedLateness().getMillis() > 0;
+      boolean hasCustomTrigger =
+          strategy.isTriggerSpecified() && !(strategy.getTrigger() instanceof DefaultTrigger);
+      return dataCanArriveLate || hasCustomTrigger;
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
@@ -310,7 +310,8 @@ public class SplittableDoFnTest {
         p.apply(stream)
             .apply(
                 Window.<String>into(FixedWindows.of(Duration.standardMinutes(1)))
-                    .withAllowedLateness(Duration.standardMinutes(1)));
+                    .withAllowedLateness(Duration.standardMinutes(1))
+                    .discardingFiredPanes());
 
     PCollection<KV<String, Integer>> afterSDF =
         input


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
If multiple panes can ever be produced, accumulation mode must be
explicitly set, as there is currently no default accumulation mode. A
pipeline with allowed lateness and the default trigger can produce
multiple panes; as a result, accumulation mode must be set even if there
is no custom trigger if allowed lateness is specified.