### PR TITLE
[BEAM-1523] Remove PValue.getProducingTransformInternal

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -874,7 +874,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(
             overriddenTransform.getElementCoder()));
       }
-      stepContext.addInput(PropertyNames.PARALLEL_INPUT, context.getInput(transform));
+      PCollection<T> input = context.getInput(transform);
+      stepContext.addInput(PropertyNames.PARALLEL_INPUT, input);
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.OutputReference;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
@@ -73,7 +74,12 @@ interface TransformTranslator<TransformT extends PTransform> {
      */
     Step addStep(PTransform<?, ? extends PValue> transform, Step step);
     /** Encode a PValue reference as an output reference. */
-    OutputReference asOutputReference(PValue value);
+    OutputReference asOutputReference(PValue value, AppliedPTransform<?, ?, ?> producer);
+
+    /**
+     * Get the {@link AppliedPTransform} that produced the provided {@link PValue}.
+     */
+    AppliedPTransform<?, ?, ?> getProducer(PValue value);
   }
 
   /** The interface for a {@link TransformTranslator} to build a Dataflow step. */
@@ -93,6 +99,11 @@ interface TransformTranslator<TransformT extends PTransform> {
     /**
      * Adds an input with the given name to this Dataflow step, coming from the specified input
      * PValue.
+     *
+     * <p>The input {@link PValue} must have already been produced by a step earlier in this {@link
+     * Pipeline}. If the input value has not yet been produced yet (either by a call to {@link
+     * StepTranslationContext#addOutput(PValue)} or within a call to {@link
+     * TranslationContext#addStep(PTransform, Step)}), this method will throw an exception.
      */
     void addInput(String name, PInput value);
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -565,8 +565,11 @@ public class DataflowPipelineTranslatorTest implements Serializable {
   private static class EmbeddedTranslator
       implements TransformTranslator<EmbeddedTransform> {
     @Override public void translate(EmbeddedTransform transform, TranslationContext context) {
-      addObject(transform.step.getProperties(), PropertyNames.PARALLEL_INPUT,
-          context.asOutputReference(context.getInput(transform)));
+      PCollection<String> input = context.getInput(transform);
+      addObject(
+          transform.step.getProperties(),
+          PropertyNames.PARALLEL_INPUT,
+          context.asOutputReference(input, context.getProducer(input)));
       context.addStep(transform, transform.step);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PValue.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.values;
 
 import java.util.List;
-import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
 
 /**
@@ -30,14 +29,6 @@ public interface PValue extends POutput, PInput {
    * Returns the name of this {@link PValue}.
    */
   String getName();
-
-  /**
-   * Returns the {@link AppliedPTransform} that this {@link PValue} is an output of.
-   *
-   * <p>For internal use only.
-   */
-  @Deprecated
-  AppliedPTransform<?, ?, ?> getProducingTransformInternal();
 
   /**
    * {@inheritDoc}.


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
This exposes too much information on the structure of the Graph to be
appropriate for non-graph related APIs. It also is not stable, and
subject to change at any point due to Pipeline Surgery APIs.

Update DataflowRunner to use the visited TransformHierarchy to obtain
the producing transforms for PValues, and store these values to
construct the graph.
