### PR TITLE
[BEAM-1530] Support record-determined output tables

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -152,13 +152,12 @@ public class PubsubIO {
           .withLabel("Pubsub Topic"));
     }
   }
-
+  
   /**
    * Class representing a Pub/Sub message. Each message contains a single message payload and
    * a map of attached attributes.
    */
   public static class PubsubMessage {
-
     private byte[] message;
     private Map<String, String> attributes;
 
@@ -177,9 +176,7 @@ public class PubsubIO {
     /**
      * Returns the given attribute value. If not such attribute exists, returns null.
      */
-    @Nullable
     public String getAttribute(String attribute) {
-      checkNotNull(attribute, "attribute");
       return attributes.get(attribute);
     }
 
@@ -1066,6 +1063,7 @@ public class PubsubIO {
               idLabel,
               formatFn,
               100 /* numShards */));
+
       }
       throw new RuntimeException(); // cases are exhaustive.
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/PubsubIO.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Strings;
@@ -152,7 +151,7 @@ public class PubsubIO {
           .withLabel("Pubsub Topic"));
     }
   }
-  
+
   /**
    * Class representing a Pub/Sub message. Each message contains a single message payload and
    * a map of attached attributes.


### PR DESCRIPTION
Changes the existing tableRefFunction: BoundedWindow -> String, to a policy that takes a Context object. This allows us to add further items to the policy without breaking compatibility. This PR puts the window and the element in the Context.
