### PR TITLE
Upgrade dill to 0.2.6 and pin it

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -86,7 +86,7 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.7.7,<2.0.0',
     'crcmod>=1.7,<2.0',
-    'dill>=0.2.5,<0.3',
+    'dill==0.2.6',
     'httplib2>=0.8,<0.10',
     'mock>=1.0.1,<3.0.0',
     'oauth2client>=2.0.1,<4.0.0',


### PR DESCRIPTION
Upgrade dill to the latest version and pin it. There were potential
compatibility issues between 0.2.5 and 0.2.6, and keeping this as a
range requirement is risky going forward.

R: @charlesccychen 