### PR TITLE
[BEAM-1310] Jdbc IO module now can run ITs against spark & dataflow runners

### DIFF
--- a/sdks/java/io/jdbc/pom.xml
+++ b/sdks/java/io/jdbc/pom.xml
@@ -30,6 +30,56 @@
   <name>Apache Beam :: SDKs :: Java :: IO :: JDBC</name>
   <description>IO to read and write on JDBC datasource.</description>
 
+  <!--
+      The dataflow-runner and spark-runner profiles support using those runners during an integration test. These are
+      not the long-term way we want to support using runners in ITs (e.g. it is annoying to add to all IO modules.)
+      We cannot create a dependency IO -> Runners since the runners depend on IO (e.g. kafka depends on spark.)
+  -->
+
+  <profiles>
+    <!-- Include the Apache Spark runner -P spark-runner -->
+    <profile>
+      <id>spark-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-spark</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming_2.10</artifactId>
+          <version>${spark.version}</version>
+          <scope>runtime</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-core_2.10</artifactId>
+          <version>${spark.version}</version>
+          <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>jul-to-slf4j</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Include the Google Cloud Dataflow runner -P dataflow-runner -->
+    <profile>
+      <id>dataflow-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOIT.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOIT.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,16 +51,19 @@ import org.postgresql.ds.PGSimpleDataSource;
  * <p>This test requires a running instance of Postgres, and the test dataset must exist in the
  * database. `JdbcTestDataSet` will create the read table.
  *
- * <p>You can run just this test by doing the following:
+ * <p>You can run this test by doing the following:
  * <pre>
- * mvn test-compile compile failsafe:integration-test -D beamTestPipelineOptions='[
- * "--postgresServerName=1.2.3.4",
- * "--postgresUsername=postgres",
- * "--postgresDatabaseName=myfancydb",
- * "--postgresPassword=yourpassword",
- * "--postgresSsl=false"
- * ]' -DskipITs=false -Dit.test=org.apache.beam.sdk.io.jdbc.JdbcIOIT -DfailIfNoTests=false
+ *  mvn -e -Pio-it verify -pl sdks/java/io/jdbc -DintegrationTestPipelineOptions='[
+ *  "--postgresServerName=1.2.3.4",
+ *  "--postgresUsername=postgres",
+ *  "--postgresDatabaseName=myfancydb",
+ *  "--postgresPassword=mypass",
+ *  "--postgresSsl=false" ]'
  * </pre>
+ *
+ * <p>If you want to run this with a runner besides directrunner, there are profiles for dataflow
+ * and spark in the jdbc pom. You'll want to activate those in addition to the normal test runner
+ * invocation pipeline options.
  */
 @RunWith(JUnit4.class)
 public class JdbcIOIT {
@@ -103,6 +107,9 @@ public class JdbcIOIT {
     }
   }
 
+  @Rule
+  public TestPipeline pipeline = TestPipeline.create();
+
   /**
    * Does a test read of a few rows from a postgres database.
    *
@@ -112,8 +119,6 @@ public class JdbcIOIT {
   @Test
   public void testRead() throws SQLException {
     String tableName = JdbcTestDataSet.READ_TABLE_NAME;
-
-    TestPipeline pipeline = TestPipeline.create();
 
     PCollection<KV<String, Integer>> output = pipeline.apply(JdbcIO.<KV<String, Integer>>read()
             .withDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create(dataSource))
@@ -147,8 +152,6 @@ public class JdbcIOIT {
   @Test
   public void testWrite() throws SQLException {
     writeTableName = JdbcTestDataSet.createWriteDataTable(dataSource);
-
-    TestPipeline pipeline = TestPipeline.create();
 
     ArrayList<KV<Integer, String>> data = new ArrayList<>();
     for (int i = 0; i < 1000; i++) {

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -45,4 +45,41 @@
     <module>mqtt</module>
   </modules>
 
+  <profiles>
+    <profile>
+      <id>io-it</id>
+      <activation>
+      <property><name>io-it</name></property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <useManifestOnlyJar>false</useManifestOnlyJar>
+                  <skip>${skipDefaultIT}</skip>
+                  <parallel>all</parallel>
+                  <threadCount>4</threadCount>
+                  <systemPropertyVariables>
+                    <beamTestPipelineOptions>${integrationTestPipelineOptions}</beamTestPipelineOptions>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+      <properties>
+        <skipITs>false</skipITs>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

I have added some changes that will allow us to start running the JdbcIO ITs with spark & dataflow.

These 2 commits are deliberately separate since they're doing different things. I don't think it's worth separating out into different commits since both are moving towards the same goal of enabling JdbcIOIT to actually run in jenkins, and can be logically reviewed together.