### PR TITLE
[BEAM-1558] add cloudera repository for flink runner deps

### DIFF
--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -54,6 +54,16 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>cloudera-releases</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 
   <build>


### PR DESCRIPTION
When building beam from source with a fresh local repository, the org.mortbay.jetty:jetty-util:jar:6.1.26.cloudera.4 dependency is not available in the repository list (the dependency is transitive via org.apache.flink:flink-java:jar:1.2.0).

This PR adds the cloudera repo matching the repo listed in flink 1.2.0 pom.xml, to follow convention of listing repositories containing the artifacts required for the build.