### PR TITLE
[BEAM-1566] Flink: upgrade apache commons

### DIFF
--- a/runners/flink/runner/pom.xml
+++ b/runners/flink/runner/pom.xml
@@ -186,6 +186,15 @@
       </exclusions>
     </dependency>
 
+    <!--
+    Force an upgrade on the version of Apache Commons from Flink to support DEFLATE compression.
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>[1.9,)</version>
+    </dependency>
+
     <!-- Test scoped -->
 
     <dependency>


### PR DESCRIPTION
R: @aljoscha 

Any concerns about an upgrade here? My understanding is that Apache Commons is good about versioning so this should not be breaking anything.

Prefer an exact version or a range?