### PR TITLE
[BEAM-1590] DataflowRunner: experimental support for issuing FnAPI based jobs

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -34,7 +34,8 @@
 
   <properties>
     <dataflow.container_version>beam-master-20170228</dataflow.container_version>
-    <dataflow.environment_major_version>6</dataflow.environment_major_version>
+    <dataflow.fnapi_environment_major_version>1</dataflow.fnapi_environment_major_version>
+    <dataflow.legacy_environment_major_version>6</dataflow.legacy_environment_major_version>
   </properties>
 
   <build>

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -327,7 +327,7 @@ public class DataflowPipelineTranslator {
       workerPool.setNumWorkers(options.getNumWorkers());
 
       if (options.isStreaming()
-          && DataflowRunner.hasExperiment(options, "enable_windmill_service")) {
+          && !DataflowRunner.hasExperiment(options, "enable_windmill_service")) {
         // Use separate data disk for streaming.
         Disk disk = new Disk();
         disk.setDiskType(options.getWorkerDiskType());

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -327,8 +327,7 @@ public class DataflowPipelineTranslator {
       workerPool.setNumWorkers(options.getNumWorkers());
 
       if (options.isStreaming()
-          && (options.getExperiments() == null
-              || !options.getExperiments().contains("enable_windmill_service"))) {
+          && DataflowRunner.hasExperiment(options, "enable_windmill_service")) {
         // Use separate data disk for streaming.
         Disk disk = new Disk();
         disk.setDiskType(options.getWorkerDiskType());

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -306,12 +306,12 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             PTransformMatchers.parDoWithFnType(unsupported),
             UnsupportedOverrideFactory.withMessage(getUnsupportedMessage(unsupported, true)));
       }
-      if (hasExperiment(options, "enable_custom_pubsub_source")) {
+      if (!hasExperiment(options, "enable_custom_pubsub_source")) {
         ptoverrides.put(
             PTransformMatchers.classEqualTo(PubsubUnboundedSource.class),
             new ReflectiveRootOverrideFactory(StreamingPubsubIORead.class, this));
       }
-      if (hasExperiment(options, "enable_custom_pubsub_sink")) {
+      if (!hasExperiment(options, "enable_custom_pubsub_sink")) {
         ptoverrides.put(
             PTransformMatchers.classEqualTo(PubsubUnboundedSink.class),
             new StreamingPubsubIOWriteOverrideFactory(this));

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -51,7 +51,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -307,14 +306,12 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             PTransformMatchers.parDoWithFnType(unsupported),
             UnsupportedOverrideFactory.withMessage(getUnsupportedMessage(unsupported, true)));
       }
-      if (options.getExperiments() == null
-          || !options.getExperiments().contains("enable_custom_pubsub_source")) {
+      if (hasExperiment(options, "enable_custom_pubsub_source")) {
         ptoverrides.put(
             PTransformMatchers.classEqualTo(PubsubUnboundedSource.class),
             new ReflectiveRootOverrideFactory(StreamingPubsubIORead.class, this));
       }
-      if (options.getExperiments() == null
-          || !options.getExperiments().contains("enable_custom_pubsub_sink")) {
+      if (hasExperiment(options, "enable_custom_pubsub_sink")) {
         ptoverrides.put(
             PTransformMatchers.classEqualTo(PubsubUnboundedSink.class),
             new StreamingPubsubIOWriteOverrideFactory(this));
@@ -559,20 +556,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       workerPool.setWorkerHarnessContainerImage(workerHarnessContainerImage);
     }
 
-    // Requirements about the service.
-    Map<String, Object> environmentVersion = new HashMap<>();
-    environmentVersion.put(
-        PropertyNames.ENVIRONMENT_VERSION_MAJOR_KEY,
-        DataflowRunnerInfo.getDataflowRunnerInfo().getEnvironmentMajorVersion());
-    newJob.getEnvironment().setVersion(environmentVersion);
-    // Default jobType is JAVA_BATCH_AUTOSCALING: A Java job with workers that the job can
-    // autoscale if specified.
-    String jobType = "JAVA_BATCH_AUTOSCALING";
-
-    if (options.isStreaming()) {
-      jobType = "STREAMING";
-    }
-    environmentVersion.put(PropertyNames.ENVIRONMENT_VERSION_JOB_TYPE_KEY, jobType);
+    newJob.getEnvironment().setVersion(getEnvironmentVersion(options));
 
     if (hooks != null) {
       hooks.modifyEnvironmentBeforeSubmission(newJob.getEnvironment());
@@ -678,6 +662,30 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         MonitoringUtil.getGcloudCancelCommand(options, jobResult.getId()));
 
     return dataflowPipelineJob;
+  }
+
+  /** Returns true if the specified experiment is enabled, handling null experiments. */
+  public static boolean hasExperiment(DataflowPipelineDebugOptions options, String experiment) {
+    List<String> experiments =
+        firstNonNull(options.getExperiments(), Collections.<String>emptyList());
+    return experiments.contains(experiment);
+  }
+
+  /** Helper to configure the Dataflow Job Environment based on the user's job options. */
+  private static Map<String, Object> getEnvironmentVersion(DataflowPipelineOptions options) {
+    DataflowRunnerInfo runnerInfo = DataflowRunnerInfo.getDataflowRunnerInfo();
+    String majorVersion;
+    String jobType;
+    if (hasExperiment(options, "beam_fn_api")) {
+      majorVersion = runnerInfo.getFnApiEnvironmentMajorVersion();
+      jobType = options.isStreaming() ? "FNAPI_STREAMING" : "FNAPI_BATCH";
+    } else {
+      majorVersion = runnerInfo.getLegacyEnvironmentMajorVersion();
+      jobType = options.isStreaming() ? "STREAMING" : "JAVA_BATCH_AUTOSCALING";
+    }
+    return ImmutableMap.<String, Object>of(
+        PropertyNames.ENVIRONMENT_VERSION_MAJOR_KEY, majorVersion,
+        PropertyNames.ENVIRONMENT_VERSION_JOB_TYPE_KEY, jobType);
   }
 
   @VisibleForTesting

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunnerInfo.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunnerInfo.java
@@ -29,14 +29,12 @@ import org.slf4j.LoggerFactory;
  * Populates versioning and other information for {@link DataflowRunner}.
  */
 public final class DataflowRunnerInfo {
-
   private static final Logger LOG = LoggerFactory.getLogger(DataflowRunnerInfo.class);
 
   private static final String PROPERTIES_PATH =
       "/org/apache/beam/runners/dataflow/dataflow.properties";
 
   private static class LazyInit {
-
     private static final DataflowRunnerInfo INSTANCE = new DataflowRunnerInfo(PROPERTIES_PATH);
   }
 
@@ -67,11 +65,11 @@ public final class DataflowRunnerInfo {
   public String getFnApiEnvironmentMajorVersion() {
     checkState(
         properties.containsKey(FNAPI_ENVIRONMENT_MAJOR_VERSION_KEY),
-        "Unknown FbAPI environment major version");
+        "Unknown FnAPI environment major version");
     return properties.getProperty(FNAPI_ENVIRONMENT_MAJOR_VERSION_KEY);
   }
 
-  /** Provides the batch worker harness container image name. */
+  /** Provides the container version that will be used for constructing harness image paths. */
   public String getContainerVersion() {
     checkState(
         properties.containsKey(CONTAINER_VERSION_KEY),

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunnerInfo.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunnerInfo.java
@@ -29,12 +29,14 @@ import org.slf4j.LoggerFactory;
  * Populates versioning and other information for {@link DataflowRunner}.
  */
 public final class DataflowRunnerInfo {
+
   private static final Logger LOG = LoggerFactory.getLogger(DataflowRunnerInfo.class);
 
   private static final String PROPERTIES_PATH =
       "/org/apache/beam/runners/dataflow/dataflow.properties";
 
   private static class LazyInit {
+
     private static final DataflowRunnerInfo INSTANCE = new DataflowRunnerInfo(PROPERTIES_PATH);
   }
 
@@ -47,32 +49,34 @@ public final class DataflowRunnerInfo {
 
   private Properties properties;
 
-  private static final String ENVIRONMENT_MAJOR_VERSION_KEY = "environment.major.version";
-  private static final String BATCH_WORKER_HARNESS_CONTAINER_IMAGE_KEY = "worker.image.batch";
-  private static final String STREAMING_WORKER_HARNESS_CONTAINER_IMAGE_KEY =
-      "worker.image.streaming";
+  private static final String FNAPI_ENVIRONMENT_MAJOR_VERSION_KEY =
+      "fnapi.environment.major.version";
+  private static final String LEGACY_ENVIRONMENT_MAJOR_VERSION_KEY =
+      "legacy.environment.major.version";
+  private static final String CONTAINER_VERSION_KEY = "container.version";
 
-  /** Provides the environment's major version number. */
-  public String getEnvironmentMajorVersion() {
+  /** Provides the legacy environment's major version number. */
+  public String getLegacyEnvironmentMajorVersion() {
     checkState(
-        properties.containsKey(ENVIRONMENT_MAJOR_VERSION_KEY), "Unknown environment major version");
-    return properties.getProperty(ENVIRONMENT_MAJOR_VERSION_KEY);
+        properties.containsKey(LEGACY_ENVIRONMENT_MAJOR_VERSION_KEY),
+        "Unknown legacy environment major version");
+    return properties.getProperty(LEGACY_ENVIRONMENT_MAJOR_VERSION_KEY);
+  }
+
+  /** Provides the FnAPI environment's major version number. */
+  public String getFnApiEnvironmentMajorVersion() {
+    checkState(
+        properties.containsKey(FNAPI_ENVIRONMENT_MAJOR_VERSION_KEY),
+        "Unknown FbAPI environment major version");
+    return properties.getProperty(FNAPI_ENVIRONMENT_MAJOR_VERSION_KEY);
   }
 
   /** Provides the batch worker harness container image name. */
-  public String getBatchWorkerHarnessContainerImage() {
+  public String getContainerVersion() {
     checkState(
-        properties.containsKey(BATCH_WORKER_HARNESS_CONTAINER_IMAGE_KEY),
-        "Unknown batch worker harness container image");
-    return properties.getProperty(BATCH_WORKER_HARNESS_CONTAINER_IMAGE_KEY);
-  }
-
-  /** Provides the streaming worker harness container image name. */
-  public String getStreamingWorkerHarnessContainerImage() {
-    checkState(
-        properties.containsKey(STREAMING_WORKER_HARNESS_CONTAINER_IMAGE_KEY),
-        "Unknown streaming worker harness container image");
-    return properties.getProperty(STREAMING_WORKER_HARNESS_CONTAINER_IMAGE_KEY);
+        properties.containsKey(CONTAINER_VERSION_KEY),
+        "Unknown container version");
+    return properties.getProperty(CONTAINER_VERSION_KEY);
   }
 
   private DataflowRunnerInfo(String resourcePath) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.api.services.dataflow.Dataflow;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.util.DataflowTransport;
 import org.apache.beam.runners.dataflow.util.GcsStager;
 import org.apache.beam.runners.dataflow.util.Stager;
@@ -53,6 +54,7 @@ public interface DataflowPipelineDebugOptions extends PipelineOptions {
       + "be enabled with this flag. Please sync with the Dataflow team before enabling any "
       + "experiments.")
   @Experimental
+  @Nullable
   List<String> getExperiments();
   void setExperiments(List<String> value);
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.dataflow.options;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.DataflowRunnerInfo;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.options.Default;
@@ -129,11 +130,14 @@ public interface DataflowPipelineWorkerPoolOptions extends PipelineOptions {
     @Override
     public String create(PipelineOptions options) {
       DataflowPipelineOptions dataflowOptions = options.as(DataflowPipelineOptions.class);
-      if (dataflowOptions.isStreaming()) {
-        return DataflowRunnerInfo.getDataflowRunnerInfo().getStreamingWorkerHarnessContainerImage();
+      String containerVersion = DataflowRunnerInfo.getDataflowRunnerInfo().getContainerVersion();
+      String containerType;
+      if (DataflowRunner.hasExperiment(dataflowOptions, "beam_fn_api")) {
+        containerType = "java";
       } else {
-        return DataflowRunnerInfo.getDataflowRunnerInfo().getBatchWorkerHarnessContainerImage();
+        containerType = dataflowOptions.isStreaming() ? "beam-java-streaming" : "beam-java-batch";
       }
+      return String.format("dataflow.gcr.io/v1beta3/%s:%s", containerType, containerVersion);
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/resources/org/apache/beam/runners/dataflow/dataflow.properties
+++ b/runners/google-cloud-dataflow-java/src/main/resources/org/apache/beam/runners/dataflow/dataflow.properties
@@ -16,8 +16,6 @@
 #
 # Dataflow runtime properties
 
-environment.major.version=${dataflow.environment_major_version}
-
-worker.image.batch=dataflow.gcr.io/v1beta3/beam-java-batch:${dataflow.container_version}
-
-worker.image.streaming=dataflow.gcr.io/v1beta3/beam-java-streaming:${dataflow.container_version}
+legacy.environment.major.version=${dataflow.legacy_environment_major_version}
+fnapi.environment.major.version=${dataflow.fnapi_environment_major_version}
+container.version=${dataflow.container_version}

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerInfoTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerInfoTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -32,20 +33,22 @@ public class DataflowRunnerInfoTest {
   public void getDataflowRunnerInfo() throws Exception {
     DataflowRunnerInfo info = DataflowRunnerInfo.getDataflowRunnerInfo();
 
-    String version = info.getEnvironmentMajorVersion();
+    String version = info.getLegacyEnvironmentMajorVersion();
     // Validate major version is a number
     assertTrue(
-        String.format("Environment major version number %s is not a number", version),
+        String.format("Legacy environment major version number %s is not a number", version),
         version.matches("\\d+"));
 
-    // Validate container images contain gcr.io
+    version = info.getFnApiEnvironmentMajorVersion();
+    // Validate major version is a number
+    assertTrue(
+        String.format("FnAPI environment major version number %s is not a number", version),
+        version.matches("\\d+"));
+
+    // Validate container version does not contain a $ (indicating it was not filled in).
     assertThat(
-        "batch worker harness container image invalid",
-        info.getBatchWorkerHarnessContainerImage(),
-        containsString("gcr.io"));
-    assertThat(
-        "streaming worker harness container image invalid",
-        info.getStreamingWorkerHarnessContainerImage(),
-        containsString("gcr.io"));
+        "container version invalid",
+        info.getContainerVersion(),
+        not(containsString("$")));
   }
 }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -1117,5 +1118,21 @@ public class DataflowRunnerTest {
     thrown.expectMessage("Cannot create output file at");
     thrown.expect(RuntimeException.class);
     p.run();
+  }
+
+  @Test
+  public void testHasExperiment() {
+    DataflowPipelineDebugOptions options =
+        PipelineOptionsFactory.as(DataflowPipelineDebugOptions.class);
+
+    options.setExperiments(null);
+    assertFalse(DataflowRunner.hasExperiment(options, "foo"));
+
+    options.setExperiments(ImmutableList.of("foo", "bar"));
+    assertTrue(DataflowRunner.hasExperiment(options, "foo"));
+    assertTrue(DataflowRunner.hasExperiment(options, "bar"));
+    assertFalse(DataflowRunner.hasExperiment(options, "baz"));
+    assertFalse(DataflowRunner.hasExperiment(options, "ba"));
+    assertFalse(DataflowRunner.hasExperiment(options, "BAR"));
   }
 }


### PR DESCRIPTION
R: @kennknowles 
CC: @herohde @lukecwik @vikkyrk @robertwb 

Includes:

* Mark `getExperiments` as `@Nullable`, for clarity and IDE inference.
* Add utility for testing experiment presence.
* Adaptations to the `dataflow.properties` to streamline and simplify their configuration.