### PR TITLE
[BEAM-1594] Supports DRAINING and DRAINED states

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/MonitoringUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/MonitoringUtil.java
@@ -60,6 +60,10 @@ public final class MonitoringUtil {
           .put("JOB_STATE_FAILED", State.FAILED)
           .put("JOB_STATE_CANCELLED", State.CANCELLED)
           .put("JOB_STATE_UPDATED", State.UPDATED)
+          // A DRAINING job is still running - the closest mapping is RUNNING.
+          .put("JOB_STATE_DRAINING", State.RUNNING)
+          // A DRAINED job has successfully terminated - the closest mapping is DONE.
+          .put("JOB_STATE_DRAINED", State.DONE)
           .build();
   private static final String JOB_MESSAGE_ERROR = "JOB_MESSAGE_ERROR";
   private static final String JOB_MESSAGE_WARNING = "JOB_MESSAGE_WARNING";

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/MonitoringUtilTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/MonitoringUtilTest.java
@@ -89,30 +89,29 @@ public class MonitoringUtilTest {
   }
 
   @Test
-  public void testToStateCreatesState() {
-    String stateName = "JOB_STATE_DONE";
+  public void testToStateNormal() {
+    // Trivially mapped cases
+    assertEquals(State.UNKNOWN, MonitoringUtil.toState("JOB_STATE_UNKNOWN"));
+    assertEquals(State.STOPPED, MonitoringUtil.toState("JOB_STATE_STOPPED"));
+    assertEquals(State.RUNNING, MonitoringUtil.toState("JOB_STATE_RUNNING"));
+    assertEquals(State.DONE, MonitoringUtil.toState("JOB_STATE_DONE"));
+    assertEquals(State.FAILED, MonitoringUtil.toState("JOB_STATE_FAILED"));
+    assertEquals(State.CANCELLED, MonitoringUtil.toState("JOB_STATE_CANCELLED"));
+    assertEquals(State.UPDATED, MonitoringUtil.toState("JOB_STATE_UPDATED"));
 
-    State result = MonitoringUtil.toState(stateName);
-
-    assertEquals(State.DONE, result);
+    // Non-trivially mapped cases
+    assertEquals(State.RUNNING, MonitoringUtil.toState("JOB_STATE_DRAINING"));
+    assertEquals(State.DONE, MonitoringUtil.toState("JOB_STATE_DRAINED"));
   }
 
   @Test
   public void testToStateWithNullReturnsUnknown() {
-    String stateName = null;
-
-    State result = MonitoringUtil.toState(stateName);
-
-    assertEquals(State.UNKNOWN, result);
+    assertEquals(State.UNKNOWN, MonitoringUtil.toState(null));
   }
 
   @Test
   public void testToStateWithOtherValueReturnsUnknown() {
-    String stateName = "FOO_BAR_BAZ";
-
-    State result = MonitoringUtil.toState(stateName);
-
-    assertEquals(State.UNKNOWN, result);
+    assertEquals(State.UNKNOWN, MonitoringUtil.toState("FOO_BAR_BAZ"));
   }
 
   @Test


### PR DESCRIPTION
Dataflow's DRAINING is treated as RUNNING, and DRAINED as DONE.

R: @tgroh 
CC: @dhalperi 