### PR TITLE
[BEAM-1422] ParDo should comply with PTransform style guide

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/TfIdf.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/TfIdf.java
@@ -323,7 +323,6 @@ public class TfIdf {
       // presented to each invocation of the DoFn.
       PCollection<KV<String, Double>> wordToDf = wordToDocCount
           .apply("ComputeDocFrequencies", ParDo
-              .withSideInputs(totalDocuments)
               .of(new DoFn<KV<String, Long>, KV<String, Double>>() {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
@@ -335,7 +334,7 @@ public class TfIdf {
 
                   c.output(KV.of(word, documentFrequency));
                 }
-              }));
+              }).withSideInputs(totalDocuments));
 
       // Join the term frequency and document frequency
       // collections, each keyed on the word.

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java
@@ -175,7 +175,6 @@ public class FilterExamples {
       // We'll only output readings with temperatures below this mean.
       PCollection<TableRow> filteredRows = monthFilteredRows
           .apply("ParseAndFilter", ParDo
-              .withSideInputs(globalMeanTemp)
               .of(new DoFn<TableRow, TableRow>() {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
@@ -185,7 +184,7 @@ public class FilterExamples {
                     c.output(c.element());
                   }
                 }
-              }));
+              }).withSideInputs(globalMeanTemp));
 
       return filteredRows;
     }

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -125,7 +125,6 @@ public class GameStats extends LeaderBoard {
       PCollection<KV<String, Integer>> filtered = sumScores
           .apply("ProcessAndFilter", ParDo
               // use the derived mean total score as a side input
-              .withSideInputs(globalMeanScore)
               .of(new DoFn<KV<String, Integer>, KV<String, Integer>>() {
                 private final Aggregator<Long, Long> numSpammerUsers =
                   createAggregator("SpammerUsers", Sum.ofLongs());
@@ -140,7 +139,7 @@ public class GameStats extends LeaderBoard {
                     c.output(c.element());
                   }
                 }
-              }));
+              }).withSideInputs(globalMeanScore));
       return filtered;
     }
   }
@@ -288,7 +287,6 @@ public class GameStats extends LeaderBoard {
           FixedWindows.of(Duration.standardMinutes(options.getFixedWindowDuration()))))
       // Filter out the detected spammer users, using the side input derived above.
       .apply("FilterOutSpammers", ParDo
-              .withSideInputs(spammersView)
               .of(new DoFn<GameActionInfo, GameActionInfo>() {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
@@ -297,8 +295,8 @@ public class GameStats extends LeaderBoard {
                     c.output(c.element());
                   }
                 }
-              }))
-      // Extract and sum teamname/score pairs from the event data.
+              }).withSideInputs(spammersView))
+        // Extract and sum teamname/score pairs from the event data.
       .apply("ExtractTeamScore", new ExtractAndSumScore("team"))
       // [END DocInclude_FilterAndCalc]
       // Write the result to BigQuery

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ApexPipelineTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ApexPipelineTranslator.java
@@ -59,7 +59,7 @@ public class ApexPipelineTranslator implements Pipeline.PipelineVisitor {
 
   static {
     // register TransformTranslators
-    registerTransformTranslator(ParDo.BoundMulti.class, new ParDoTranslator<>());
+    registerTransformTranslator(ParDo.MultiOutput.class, new ParDoTranslator<>());
     registerTransformTranslator(Read.Unbounded.class, new ReadUnboundedTranslator());
     registerTransformTranslator(Read.Bounded.class, new ReadBoundedTranslator());
     registerTransformTranslator(GroupByKey.class, new GroupByKeyTranslator());

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
@@ -44,15 +44,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@link ParDo.BoundMulti} is translated to {@link ApexParDoOperator} that wraps the {@link DoFn}.
+ * {@link ParDo.MultiOutput} is translated to {@link ApexParDoOperator} that wraps the {@link DoFn}.
  */
 class ParDoTranslator<InputT, OutputT>
-    implements TransformTranslator<ParDo.BoundMulti<InputT, OutputT>> {
+    implements TransformTranslator<ParDo.MultiOutput<InputT, OutputT>> {
   private static final long serialVersionUID = 1L;
   private static final Logger LOG = LoggerFactory.getLogger(ParDoTranslator.class);
 
   @Override
-  public void translate(ParDo.BoundMulti<InputT, OutputT> transform, TranslationContext context) {
+  public void translate(ParDo.MultiOutput<InputT, OutputT> transform, TranslationContext context) {
     DoFn<InputT, OutputT> doFn = transform.getFn();
     DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
 
@@ -105,7 +105,7 @@ class ParDoTranslator<InputT, OutputT>
       checkArgument(
           output.getValue() instanceof PCollection,
           "%s %s outputs non-PCollection %s of type %s",
-          ParDo.BoundMulti.class.getSimpleName(),
+          ParDo.MultiOutput.class.getSimpleName(),
           context.getFullName(),
           output.getValue(),
           output.getValue().getClass().getSimpleName());

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoTranslatorTest.java
@@ -281,13 +281,14 @@ public class ParDoTranslatorTest {
 
     PCollectionTuple outputs = pipeline
         .apply(Create.of(inputs))
-        .apply(ParDo.withSideInputs(sideInput1)
-            .withSideInputs(sideInputUnread)
-            .withSideInputs(sideInput2)
-            .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag))
+        .apply(ParDo
             .of(new TestMultiOutputWithSideInputsFn(
                 Arrays.asList(sideInput1, sideInput2),
-                Arrays.<TupleTag<String>>asList())));
+                Arrays.<TupleTag<String>>asList()))
+            .withSideInputs(sideInput1)
+            .withSideInputs(sideInputUnread)
+            .withSideInputs(sideInput2)
+            .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag)));
 
     outputs.get(mainOutputTag).apply(ParDo.of(new EmbeddedCollector()));
     outputs.get(sideOutputTag).setCoder(VoidCoder.of());

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -109,7 +109,7 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.BoundMulti} containing a {@link DoFn}
+   * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutput} containing a {@link DoFn}
    * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */
   public static PTransformMatcher splittableParDoMulti() {
@@ -117,8 +117,8 @@ public class PTransformMatchers {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.BoundMulti) {
-          DoFn<?, ?> fn = ((ParDo.BoundMulti<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.MultiOutput) {
+          DoFn<?, ?> fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.processElement().isSplittable();
         }
@@ -128,7 +128,7 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.BoundMulti} containing a {@link DoFn}
+   * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutput} containing a {@link DoFn}
    * that uses state or timers, as specified by {@link DoFnSignature#usesState()} and
    * {@link DoFnSignature#usesTimers()}.
    */
@@ -137,8 +137,8 @@ public class PTransformMatchers {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.BoundMulti) {
-          DoFn<?, ?> fn = ((ParDo.BoundMulti<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.MultiOutput) {
+          DoFn<?, ?> fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.usesState() || signature.usesTimers();
         }
@@ -148,8 +148,8 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} which matches a {@link ParDo.SingleOutput} or {@link ParDo.BoundMulti}
-   * where the {@link DoFn} is of the provided type.
+   * A {@link PTransformMatcher} which matches a {@link ParDo.SingleOutput} or {@link
+   * ParDo.MultiOutput} where the {@link DoFn} is of the provided type.
    */
   public static PTransformMatcher parDoWithFnType(final Class<? extends DoFn> fnType) {
     return new PTransformMatcher() {
@@ -158,8 +158,8 @@ public class PTransformMatchers {
         DoFn<?, ?> fn;
         if (application.getTransform() instanceof ParDo.SingleOutput) {
           fn = ((ParDo.SingleOutput) application.getTransform()).getFn();
-        } else if (application.getTransform() instanceof ParDo.BoundMulti) {
-          fn = ((ParDo.BoundMulti) application.getTransform()).getFn();
+        } else if (application.getTransform() instanceof ParDo.MultiOutput) {
+          fn = ((ParDo.MultiOutput) application.getTransform()).getFn();
         } else {
           return false;
         }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -70,16 +70,16 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.Bound} containing a {@link DoFn} that
-   * is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
+   * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} containing a {@link DoFn}
+   * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */
   public static PTransformMatcher splittableParDoSingle() {
     return new PTransformMatcher() {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.Bound) {
-          DoFn<?, ?> fn = ((ParDo.Bound<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.SingleOutput) {
+          DoFn<?, ?> fn = ((ParDo.SingleOutput<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.processElement().isSplittable();
         }
@@ -89,17 +89,17 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.Bound} containing a {@link DoFn} that
-   * uses state or timers, as specified by {@link DoFnSignature#usesState()} and
-   * {@link DoFnSignature#usesTimers()}.
+   * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} containing a {@link DoFn}
+   * that uses state or timers, as specified by {@link DoFnSignature#usesState()} and {@link
+   * DoFnSignature#usesTimers()}.
    */
   public static PTransformMatcher stateOrTimerParDoSingle() {
     return new PTransformMatcher() {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.Bound) {
-          DoFn<?, ?> fn = ((ParDo.Bound<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.SingleOutput) {
+          DoFn<?, ?> fn = ((ParDo.SingleOutput<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.usesState() || signature.usesTimers();
         }
@@ -148,7 +148,7 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} which matches a {@link ParDo.Bound} or {@link ParDo.BoundMulti}
+   * A {@link PTransformMatcher} which matches a {@link ParDo.SingleOutput} or {@link ParDo.BoundMulti}
    * where the {@link DoFn} is of the provided type.
    */
   public static PTransformMatcher parDoWithFnType(final Class<? extends DoFn> fnType) {
@@ -156,8 +156,8 @@ public class PTransformMatchers {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         DoFn<?, ?> fn;
-        if (application.getTransform() instanceof ParDo.Bound) {
-          fn = ((ParDo.Bound) application.getTransform()).getFn();
+        if (application.getTransform() instanceof ParDo.SingleOutput) {
+          fn = ((ParDo.SingleOutput) application.getTransform()).getFn();
         } else if (application.getTransform() instanceof ParDo.BoundMulti) {
           fn = ((ParDo.BoundMulti) application.getTransform()).getFn();
         } else {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -92,7 +92,7 @@ public class PTransformMatchersTest implements Serializable {
 
   @Test
   public void classEqualToMatchesSameClass() {
-    PTransformMatcher matcher = PTransformMatchers.classEqualTo(ParDo.Bound.class);
+    PTransformMatcher matcher = PTransformMatchers.classEqualTo(ParDo.SingleOutput.class);
     AppliedPTransform<?, ?, ?> application =
         getAppliedTransform(
             ParDo.of(
@@ -127,7 +127,7 @@ public class PTransformMatchersTest implements Serializable {
 
   @Test
   public void classEqualToDoesNotMatchUnrelatedClass() {
-    PTransformMatcher matcher = PTransformMatchers.classEqualTo(ParDo.Bound.class);
+    PTransformMatcher matcher = PTransformMatchers.classEqualTo(ParDo.SingleOutput.class);
     AppliedPTransform<?, ?, ?> application =
         getAppliedTransform(Window.<KV<String, Integer>>into(new GlobalWindows()));
 
@@ -192,7 +192,7 @@ public class PTransformMatchersTest implements Serializable {
       };
 
   /**
-   * Demonstrates that a {@link ParDo.Bound} does not match any ParDo matcher.
+   * Demonstrates that a {@link ParDo.SingleOutput} does not match any ParDo matcher.
    */
   @Test
   public void parDoSingle() {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OldDoFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OldDoFn.java
@@ -141,8 +141,8 @@ public abstract class OldDoFn<InputT, OutputT> implements Serializable, HasDispl
      * <p>Once passed to {@code sideOutput} the element should not be modified
      * in any way.
      *
-     * <p>The caller of {@code ParDo} uses {@link ParDo#withOutputTags withOutputTags} to
-     * specify the tags of side outputs that it consumes. Non-consumed side
+     * <p>The caller of {@code ParDo} uses {@link ParDo.SingleOutput#withOutputTags withOutputTags}
+     * to specify the tags of side outputs that it consumes. Non-consumed side
      * outputs, e.g., outputs for monitoring purposes only, don't necessarily
      * need to be specified.
      *
@@ -157,7 +157,7 @@ public abstract class OldDoFn<InputT, OutputT> implements Serializable, HasDispl
      * to access any information about the input element. The output element
      * will have a timestamp of negative infinity.
      *
-     * @see ParDo#withOutputTags
+     * @see ParDo.SingleOutput#withOutputTags
      */
     public abstract <T> void sideOutput(TupleTag<T> tag, T output);
 
@@ -181,7 +181,7 @@ public abstract class OldDoFn<InputT, OutputT> implements Serializable, HasDispl
      * to access any information about the input element except for the
      * timestamp.
      *
-     * @see ParDo#withOutputTags
+     * @see ParDo.SingleOutput#withOutputTags
      */
     public abstract <T> void sideOutputWithTimestamp(
         TupleTag<T> tag, T output, Instant timestamp);
@@ -251,7 +251,7 @@ public abstract class OldDoFn<InputT, OutputT> implements Serializable, HasDispl
      * for how this corresponding window is determined.
      *
      * @throws IllegalArgumentException if this is not a side input
-     * @see ParDo#withSideInputs
+     * @see ParDo.SingleOutput#withSideInputs
      */
     public abstract <T> T sideInput(PCollectionView<T> view);
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDo.java
@@ -82,14 +82,14 @@ import org.joda.time.Instant;
 @Experimental(Experimental.Kind.SPLITTABLE_DO_FN)
 public class SplittableParDo<InputT, OutputT, RestrictionT>
     extends PTransform<PCollection<InputT>, PCollectionTuple> {
-  private final ParDo.BoundMulti<InputT, OutputT> parDo;
+  private final ParDo.MultiOutput<InputT, OutputT> parDo;
 
   /**
    * Creates the transform for the given original multi-output {@link ParDo}.
    *
    * @param parDo The splittable {@link ParDo} transform.
    */
-  public SplittableParDo(ParDo.BoundMulti<InputT, OutputT> parDo) {
+  public SplittableParDo(ParDo.MultiOutput<InputT, OutputT> parDo) {
     checkNotNull(parDo, "parDo must not be null");
     this.parDo = parDo;
     checkArgument(
@@ -248,7 +248,7 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
               windowingStrategy,
               input.isBounded().and(signature.isBoundedPerElement()));
 
-      // Set output type descriptor similarly to how ParDo.BoundMulti does it.
+      // Set output type descriptor similarly to how ParDo.MultiOutput does it.
       outputs.get(mainOutputTag).setTypeDescriptor(fn.getOutputTypeDescriptor());
 
       return outputs;
@@ -260,7 +260,7 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
             input,
         TypedPValue<T> output)
         throws CannotProvideCoderException {
-      // Similar logic to ParDo.BoundMulti.getDefaultOutputCoder.
+      // Similar logic to ParDo.MultiOutput.getDefaultOutputCoder.
       @SuppressWarnings("unchecked")
       KeyedWorkItemCoder<String, ElementAndRestriction<InputT, RestrictionT>> kwiCoder =
           (KeyedWorkItemCoder) input.getCoder();

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoTest.java
@@ -135,7 +135,7 @@ public class SplittableParDoTest {
 
   private static final TupleTag<String> MAIN_OUTPUT_TAG = new TupleTag<String>() {};
 
-  private ParDo.BoundMulti<Integer, String> makeParDo(DoFn<Integer, String> fn) {
+  private ParDo.MultiOutput<Integer, String> makeParDo(DoFn<Integer, String> fn) {
     return ParDo.of(fn).withOutputTags(MAIN_OUTPUT_TAG, TupleTagList.empty());
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -168,7 +168,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   /** The set of {@link PTransform PTransforms} that execute a UDF. Useful for some enforcements. */
   private static final Set<Class<? extends PTransform>> CONTAINS_UDF =
       ImmutableSet.of(
-          Read.Bounded.class, Read.Unbounded.class, ParDo.Bound.class, ParDo.BoundMulti.class);
+          Read.Bounded.class, Read.Unbounded.class, ParDo.SingleOutput.class, ParDo.BoundMulti.class);
 
   enum Enforcement {
     ENCODABILITY {
@@ -221,7 +221,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
         enabledParDoEnforcements.add(ImmutabilityEnforcementFactory.create());
       }
       Collection<ModelEnforcementFactory> parDoEnforcements = enabledParDoEnforcements.build();
-      enforcements.put(ParDo.Bound.class, parDoEnforcements);
+      enforcements.put(ParDo.SingleOutput.class, parDoEnforcements);
       enforcements.put(ParDo.BoundMulti.class, parDoEnforcements);
       return enforcements.build();
     }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -53,6 +53,7 @@ import org.apache.beam.sdk.transforms.AppliedPTransform;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.MultiOutput;
 import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -168,7 +169,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   /** The set of {@link PTransform PTransforms} that execute a UDF. Useful for some enforcements. */
   private static final Set<Class<? extends PTransform>> CONTAINS_UDF =
       ImmutableSet.of(
-          Read.Bounded.class, Read.Unbounded.class, ParDo.SingleOutput.class, ParDo.BoundMulti.class);
+          Read.Bounded.class, Read.Unbounded.class, ParDo.SingleOutput.class, MultiOutput.class);
 
   enum Enforcement {
     ENCODABILITY {
@@ -222,7 +223,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
       }
       Collection<ModelEnforcementFactory> parDoEnforcements = enabledParDoEnforcements.build();
       enforcements.put(ParDo.SingleOutput.class, parDoEnforcements);
-      enforcements.put(ParDo.BoundMulti.class, parDoEnforcements);
+      enforcements.put(MultiOutput.class, parDoEnforcements);
       return enforcements.build();
     }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
@@ -116,8 +116,8 @@ class KeyedPValueTrackingVisitor implements PipelineVisitor {
     // The most obvious alternative would be a package-private marker interface, but
     // better to make this obviously hacky so it is less likely to proliferate. Meanwhile
     // we intend to allow explicit expression of key-preserving DoFn in the model.
-    if (transform instanceof ParDo.BoundMulti) {
-      ParDo.BoundMulti<?, ?> parDo = (ParDo.BoundMulti<?, ?>) transform;
+    if (transform instanceof ParDo.MultiOutput) {
+      ParDo.MultiOutput<?, ?> parDo = (ParDo.MultiOutput<?, ?>) transform;
       return parDo.getFn() instanceof ParDoMultiOverrideFactory.ToKeyedWorkItem;
     } else {
       return false;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
@@ -37,7 +37,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A {@link TransformEvaluatorFactory} for {@link ParDo.BoundMulti}. */
+/** A {@link TransformEvaluatorFactory} for {@link ParDo.MultiOutput}. */
 final class ParDoEvaluatorFactory<InputT, OutputT> implements TransformEvaluatorFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(ParDoEvaluatorFactory.class);
@@ -62,13 +62,13 @@ final class ParDoEvaluatorFactory<InputT, OutputT> implements TransformEvaluator
       AppliedPTransform<?, ?, ?> application, CommittedBundle<?> inputBundle) throws Exception {
 
     @SuppressWarnings("unchecked")
-    AppliedPTransform<PCollection<InputT>, PCollectionTuple, ParDo.BoundMulti<InputT, OutputT>>
+    AppliedPTransform<PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>>
         parDoApplication =
             (AppliedPTransform<
-                    PCollection<InputT>, PCollectionTuple, ParDo.BoundMulti<InputT, OutputT>>)
+                    PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>>)
                 application;
 
-    ParDo.BoundMulti<InputT, OutputT> transform = parDoApplication.getTransform();
+    ParDo.MultiOutput<InputT, OutputT> transform = parDoApplication.getTransform();
     final DoFn<InputT, OutputT> doFn = transform.getFn();
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
@@ -51,7 +51,7 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
         ImmutableMap.<Class<? extends PTransform>, TransformEvaluatorFactory>builder()
             .put(Read.Bounded.class, new BoundedReadEvaluatorFactory(ctxt))
             .put(Read.Unbounded.class, new UnboundedReadEvaluatorFactory(ctxt))
-            .put(ParDo.BoundMulti.class, new ParDoEvaluatorFactory<>(ctxt))
+            .put(ParDo.MultiOutput.class, new ParDoEvaluatorFactory<>(ctxt))
             .put(StatefulParDo.class, new StatefulParDoEvaluatorFactory<>(ctxt))
             .put(PCollections.class, new FlattenEvaluatorFactory(ctxt))
             .put(ViewEvaluatorFactory.WriteView.class, new ViewEvaluatorFactory(ctxt))

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactoryTest.java
@@ -243,7 +243,7 @@ public class StatefulParDoEvaluatorFactoryTest implements Serializable {
         mainInput
             .apply(
                 new ParDoMultiOverrideFactory.GbkThenStatefulParDo<>(
-                    ParDo.withSideInputs(sideInput)
+                    ParDo
                         .of(
                             new DoFn<KV<String, Integer>, Integer>() {
                               @StateId(stateId)
@@ -253,6 +253,7 @@ public class StatefulParDoEvaluatorFactoryTest implements Serializable {
                               @ProcessElement
                               public void process(ProcessContext c) {}
                             })
+                        .withSideInputs(sideInput)
                         .withOutputTags(mainOutput, TupleTagList.empty())))
             .get(mainOutput)
             .setCoder(VarIntCoder.of());

--- a/runners/flink/examples/src/main/java/org/apache/beam/runners/flink/examples/TFIDF.java
+++ b/runners/flink/examples/src/main/java/org/apache/beam/runners/flink/examples/TFIDF.java
@@ -347,7 +347,6 @@ public class TFIDF {
       // presented to each invocation of the DoFn.
       PCollection<KV<String, Double>> wordToDf = wordToDocCount
           .apply("ComputeDocFrequencies", ParDo
-              .withSideInputs(totalDocuments)
               .of(new DoFn<KV<String, Long>, KV<String, Double>>() {
                 private static final long serialVersionUID = 0;
 
@@ -361,7 +360,7 @@ public class TFIDF {
 
                   c.output(KV.of(word, documentFrequency));
                 }
-              }));
+              }).withSideInputs(totalDocuments));
 
       // Join the term frequency and document frequency
       // collections, each keyed on the word.

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
@@ -112,7 +112,7 @@ class FlinkBatchTransformTranslators {
 
     TRANSLATORS.put(Window.Assign.class, new WindowAssignTranslatorBatch());
 
-    TRANSLATORS.put(ParDo.BoundMulti.class, new ParDoTranslatorBatch());
+    TRANSLATORS.put(ParDo.MultiOutput.class, new ParDoTranslatorBatch());
 
     TRANSLATORS.put(Read.Bounded.class, new ReadSourceTranslatorBatch());
   }
@@ -499,12 +499,12 @@ class FlinkBatchTransformTranslators {
 
   private static class ParDoTranslatorBatch<InputT, OutputT>
       implements FlinkBatchPipelineTranslator.BatchTransformTranslator<
-          ParDo.BoundMulti<InputT, OutputT>> {
+      ParDo.MultiOutput<InputT, OutputT>> {
 
     @Override
     @SuppressWarnings("unchecked")
     public void translateNode(
-        ParDo.BoundMulti<InputT, OutputT> transform,
+        ParDo.MultiOutput<InputT, OutputT> transform,
         FlinkBatchTranslationContext context) {
       DoFn<InputT, OutputT> doFn = transform.getFn();
       rejectSplittable(doFn);

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -121,7 +121,7 @@ class FlinkStreamingTransformTranslators {
     TRANSLATORS.put(Write.class, new WriteSinkStreamingTranslator());
     TRANSLATORS.put(TextIO.Write.Bound.class, new TextIOWriteBoundStreamingTranslator());
 
-    TRANSLATORS.put(ParDo.BoundMulti.class, new ParDoStreamingTranslator());
+    TRANSLATORS.put(ParDo.MultiOutput.class, new ParDoStreamingTranslator());
 
     TRANSLATORS.put(Window.Assign.class, new WindowAssignTranslator());
     TRANSLATORS.put(Flatten.PCollections.class, new FlattenPCollectionTranslator());
@@ -398,11 +398,11 @@ class FlinkStreamingTransformTranslators {
 
   private static class ParDoStreamingTranslator<InputT, OutputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-      ParDo.BoundMulti<InputT, OutputT>> {
+      ParDo.MultiOutput<InputT, OutputT>> {
 
     @Override
     public void translateNode(
-        ParDo.BoundMulti<InputT, OutputT> transform,
+        ParDo.MultiOutput<InputT, OutputT> transform,
         FlinkStreamingTranslationContext context) {
 
       DoFn<InputT, OutputT> doFn = transform.getFn();

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
@@ -33,7 +33,6 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -76,7 +75,7 @@ public class BatchStatefulParDoOverrides {
   public static <K, InputT, OutputT>
       PTransformOverrideFactory<
               PCollection<KV<K, InputT>>, PCollectionTuple,
-              ParDo.BoundMulti<KV<K, InputT>, OutputT>>
+              ParDo.MultiOutput<KV<K, InputT>, OutputT>>
           multiOutputOverrideFactory() {
     return new MultiOutputOverrideFactory<>();
   }
@@ -107,12 +106,12 @@ public class BatchStatefulParDoOverrides {
 
   private static class MultiOutputOverrideFactory<K, InputT, OutputT>
       implements PTransformOverrideFactory<
-          PCollection<KV<K, InputT>>, PCollectionTuple, ParDo.BoundMulti<KV<K, InputT>, OutputT>> {
+          PCollection<KV<K, InputT>>, PCollectionTuple, ParDo.MultiOutput<KV<K, InputT>, OutputT>> {
 
     @Override
     @SuppressWarnings("unchecked")
     public PTransform<PCollection<KV<K, InputT>>, PCollectionTuple> getReplacementTransform(
-        BoundMulti<KV<K, InputT>, OutputT> originalParDo) {
+        ParDo.MultiOutput<KV<K, InputT>, OutputT> originalParDo) {
       return new StatefulMultiOutputParDo<>(originalParDo);
     }
 
@@ -159,9 +158,9 @@ public class BatchStatefulParDoOverrides {
   static class StatefulMultiOutputParDo<K, InputT, OutputT>
       extends PTransform<PCollection<KV<K, InputT>>, PCollectionTuple> {
 
-    private final BoundMulti<KV<K, InputT>, OutputT> originalParDo;
+    private final ParDo.MultiOutput<KV<K, InputT>, OutputT> originalParDo;
 
-    StatefulMultiOutputParDo(ParDo.BoundMulti<KV<K, InputT>, OutputT> originalParDo) {
+    StatefulMultiOutputParDo(ParDo.MultiOutput<KV<K, InputT>, OutputT> originalParDo) {
       this.originalParDo = originalParDo;
     }
 
@@ -182,7 +181,7 @@ public class BatchStatefulParDoOverrides {
       return input.apply(new GbkBeforeStatefulParDo<K, InputT>()).apply(statefulParDo);
     }
 
-    public BoundMulti<KV<K, InputT>, OutputT> getOriginalParDo() {
+    public ParDo.MultiOutput<KV<K, InputT>, OutputT> getOriginalParDo() {
       return originalParDo;
     }
   }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
@@ -58,12 +58,13 @@ import org.joda.time.Instant;
 public class BatchStatefulParDoOverrides {
 
   /**
-   * Returns a {@link PTransformOverrideFactory} that replaces a single-output
-   * {@link ParDo} with a composite transform specialized for the {@link DataflowRunner}.
+   * Returns a {@link PTransformOverrideFactory} that replaces a single-output {@link ParDo} with a
+   * composite transform specialized for the {@link DataflowRunner}.
    */
   public static <K, InputT, OutputT>
       PTransformOverrideFactory<
-              PCollection<KV<K, InputT>>, PCollection<OutputT>, ParDo.Bound<KV<K, InputT>, OutputT>>
+              PCollection<KV<K, InputT>>, PCollection<OutputT>,
+              ParDo.SingleOutput<KV<K, InputT>, OutputT>>
           singleOutputOverrideFactory() {
     return new SingleOutputOverrideFactory<>();
   }
@@ -82,12 +83,13 @@ public class BatchStatefulParDoOverrides {
 
   private static class SingleOutputOverrideFactory<K, InputT, OutputT>
       implements PTransformOverrideFactory<
-          PCollection<KV<K, InputT>>, PCollection<OutputT>, ParDo.Bound<KV<K, InputT>, OutputT>> {
+          PCollection<KV<K, InputT>>, PCollection<OutputT>,
+          ParDo.SingleOutput<KV<K, InputT>, OutputT>> {
 
     @Override
     @SuppressWarnings("unchecked")
     public PTransform<PCollection<KV<K, InputT>>, PCollection<OutputT>> getReplacementTransform(
-        ParDo.Bound<KV<K, InputT>, OutputT> originalParDo) {
+        ParDo.SingleOutput<KV<K, InputT>, OutputT> originalParDo) {
       return new StatefulSingleOutputParDo<>(originalParDo);
     }
 
@@ -129,13 +131,13 @@ public class BatchStatefulParDoOverrides {
   static class StatefulSingleOutputParDo<K, InputT, OutputT>
       extends PTransform<PCollection<KV<K, InputT>>, PCollection<OutputT>> {
 
-    private final ParDo.Bound<KV<K, InputT>, OutputT> originalParDo;
+    private final ParDo.SingleOutput<KV<K, InputT>, OutputT> originalParDo;
 
-    StatefulSingleOutputParDo(ParDo.Bound<KV<K, InputT>, OutputT> originalParDo) {
+    StatefulSingleOutputParDo(ParDo.SingleOutput<KV<K, InputT>, OutputT> originalParDo) {
       this.originalParDo = originalParDo;
     }
 
-    ParDo.Bound<KV<K, InputT>, OutputT> getOriginalParDo() {
+    ParDo.SingleOutput<KV<K, InputT>, OutputT> getOriginalParDo() {
       return originalParDo;
     }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -821,15 +821,15 @@ public class DataflowPipelineTranslator {
         });
 
     registerTransformTranslator(
-        ParDo.BoundMulti.class,
-        new TransformTranslator<ParDo.BoundMulti>() {
+        ParDo.MultiOutput.class,
+        new TransformTranslator<ParDo.MultiOutput>() {
           @Override
-          public void translate(ParDo.BoundMulti transform, TranslationContext context) {
+          public void translate(ParDo.MultiOutput transform, TranslationContext context) {
             translateMultiHelper(transform, context);
           }
 
           private <InputT, OutputT> void translateMultiHelper(
-              ParDo.BoundMulti<InputT, OutputT> transform, TranslationContext context) {
+              ParDo.MultiOutput<InputT, OutputT> transform, TranslationContext context) {
 
             StepTranslationContext stepContext = context.addStep(transform, "ParallelDo");
             translateInputs(

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -371,7 +371,9 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         .put(
             PTransformMatchers.classEqualTo(Combine.GroupedValues.class),
             new PrimitiveCombineGroupedValuesOverrideFactory())
-        .put(PTransformMatchers.classEqualTo(ParDo.Bound.class), new PrimitiveParDoSingleFactory());
+        .put(
+            PTransformMatchers.classEqualTo(ParDo.SingleOutput.class),
+            new PrimitiveParDoSingleFactory());
     return ptoverrides.build();
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
@@ -26,21 +26,20 @@ import org.apache.beam.sdk.runners.PTransformOverrideFactory;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.ParDo.Bound;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 
 /**
- * A {@link PTransformOverrideFactory} that produces {@link ParDoSingle} instances from
- * {@link ParDo.Bound} instances. {@link ParDoSingle} is a primitive {@link PTransform}, to ensure
+ * A {@link PTransformOverrideFactory} that produces {@link ParDoSingle} instances from {@link
+ * ParDo.SingleOutput} instances. {@link ParDoSingle} is a primitive {@link PTransform}, to ensure
  * that {@link DisplayData} appears on all {@link ParDo ParDos} in the {@link DataflowRunner}.
  */
 public class PrimitiveParDoSingleFactory<InputT, OutputT>
     extends SingleInputOutputOverrideFactory<
-        PCollection<? extends InputT>, PCollection<OutputT>, ParDo.Bound<InputT, OutputT>> {
+        PCollection<? extends InputT>, PCollection<OutputT>, ParDo.SingleOutput<InputT, OutputT>> {
   @Override
   public PTransform<PCollection<? extends InputT>, PCollection<OutputT>> getReplacementTransform(
-      ParDo.Bound<InputT, OutputT> transform) {
+      ParDo.SingleOutput<InputT, OutputT> transform) {
     return new ParDoSingle<>(transform);
   }
 
@@ -49,9 +48,9 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
    */
   public static class ParDoSingle<InputT, OutputT>
       extends ForwardingPTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
-    private final ParDo.Bound<InputT, OutputT> original;
+    private final ParDo.SingleOutput<InputT, OutputT> original;
 
-    private ParDoSingle(Bound<InputT, OutputT> original) {
+    private ParDoSingle(ParDo.SingleOutput<InputT, OutputT> original) {
       this.original = original;
     }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverridesTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverridesTest.java
@@ -87,7 +87,7 @@ public class BatchStatefulParDoOverridesTest implements Serializable {
     DummyStatefulDoFn fn = new DummyStatefulDoFn();
     pipeline
         .apply(Create.of(KV.of(1, 2)))
-        .apply(ParDo.withOutputTags(mainOutputTag, TupleTagList.empty()).of(fn));
+        .apply(ParDo.of(fn).withOutputTags(mainOutputTag, TupleTagList.empty()));
 
     DataflowRunner runner = DataflowRunner.fromOptions(options);
     runner.replaceTransforms(pipeline);

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -1001,8 +1001,8 @@ public class DataflowPipelineTranslatorTest implements Serializable {
       }
     };
 
-    ParDo.Bound<Integer, Integer> parDo1 = ParDo.of(fn1);
-    ParDo.Bound<Integer, Integer> parDo2 = ParDo.of(fn2);
+    ParDo.SingleOutput<Integer, Integer> parDo1 = ParDo.of(fn1);
+    ParDo.SingleOutput<Integer, Integer> parDo2 = ParDo.of(fn2);
     pipeline
       .apply(Create.of(1, 2, 3))
       .apply(parDo1)

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -851,7 +851,7 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     pipeline
         .apply(Create.of(KV.of(1, 1)))
         .apply(
-            ParDo.withOutputTags(mainOutputTag, TupleTagList.empty()).of(
+            ParDo.of(
                 new DoFn<KV<Integer, Integer>, Integer>() {
                   @StateId("unused")
                   final StateSpec<Object, ValueState<Integer>> stateSpec =
@@ -861,7 +861,7 @@ public class DataflowPipelineTranslatorTest implements Serializable {
                   public void process(ProcessContext c) {
                     // noop
                   }
-                }));
+                }).withOutputTags(mainOutputTag, TupleTagList.empty()));
 
     runner.replaceTransforms(pipeline);
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactoryTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactoryTest.java
@@ -58,11 +58,11 @@ public class PrimitiveParDoSingleFactoryTest implements Serializable {
 
   /**
    * A test that demonstrates that the replacement transform has the Display Data of the
-   * {@link ParDo.Bound} it replaces.
+   * {@link ParDo.SingleOutput} it replaces.
    */
   @Test
   public void getReplacementTransformPopulateDisplayData() {
-    ParDo.Bound<Integer, Long> originalTransform = ParDo.of(new ToLongFn());
+    ParDo.SingleOutput<Integer, Long> originalTransform = ParDo.of(new ToLongFn());
     DisplayData originalDisplayData = DisplayData.from(originalTransform);
 
     PTransform<PCollection<? extends Integer>, PCollection<Long>> replacement =
@@ -88,7 +88,7 @@ public class PrimitiveParDoSingleFactoryTest implements Serializable {
         pipeline
             .apply("StringSideInputVals", Create.of("foo", "bar", "baz"))
             .apply("SideStringsView", View.<String>asList());
-    ParDo.Bound<Integer, Long> originalTransform =
+    ParDo.SingleOutput<Integer, Long> originalTransform =
         ParDo.of(new ToLongFn()).withSideInputs(sideLong, sideStrings);
 
     PTransform<PCollection<? extends Integer>, PCollection<Long>> replacementTransform =
@@ -100,7 +100,7 @@ public class PrimitiveParDoSingleFactoryTest implements Serializable {
   @Test
   public void getReplacementTransformGetFn() {
     DoFn<Integer, Long> originalFn = new ToLongFn();
-    ParDo.Bound<Integer, Long> originalTransform = ParDo.of(originalFn);
+    ParDo.SingleOutput<Integer, Long> originalTransform = ParDo.of(originalFn);
     PTransform<PCollection<? extends Integer>, PCollection<Long>> replacementTransform =
         factory.getReplacementTransform(originalTransform);
     ParDoSingle<Integer, Long> parDoSingle = (ParDoSingle<Integer, Long>) replacementTransform;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -355,11 +355,12 @@ public final class TransformTranslator {
     };
   }
 
-  private static <InputT, OutputT> TransformEvaluator<ParDo.BoundMulti<InputT, OutputT>>
+  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>
   parDo() {
-    return new TransformEvaluator<ParDo.BoundMulti<InputT, OutputT>>() {
+    return new TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>() {
       @Override
-      public void evaluate(ParDo.BoundMulti<InputT, OutputT> transform, EvaluationContext context) {
+      public void evaluate(
+          ParDo.MultiOutput<InputT, OutputT> transform, EvaluationContext context) {
         String stepName = context.getCurrentTransform().getFullName();
         DoFn<InputT, OutputT> doFn = transform.getFn();
         rejectSplittable(doFn);
@@ -847,7 +848,7 @@ public final class TransformTranslator {
     EVALUATORS.put(Read.Bounded.class, readBounded());
     EVALUATORS.put(HadoopIO.Read.Bound.class, readHadoop());
     EVALUATORS.put(HadoopIO.Write.Bound.class, writeHadoop());
-    EVALUATORS.put(ParDo.BoundMulti.class, parDo());
+    EVALUATORS.put(ParDo.MultiOutput.class, parDo());
     EVALUATORS.put(GroupByKey.class, groupByKey());
     EVALUATORS.put(Combine.GroupedValues.class, combineGrouped());
     EVALUATORS.put(Combine.Globally.class, combineGlobally());

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -366,11 +366,11 @@ public final class StreamingTransformTranslator {
     };
   }
 
-  private static <InputT, OutputT> TransformEvaluator<ParDo.BoundMulti<InputT, OutputT>>
+  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>
   multiDo() {
-    return new TransformEvaluator<ParDo.BoundMulti<InputT, OutputT>>() {
+    return new TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>() {
       public void evaluate(
-          final ParDo.BoundMulti<InputT, OutputT> transform, final EvaluationContext context) {
+          final ParDo.MultiOutput<InputT, OutputT> transform, final EvaluationContext context) {
         final DoFn<InputT, OutputT> doFn = transform.getFn();
         rejectSplittable(doFn);
         rejectStateAndTimers(doFn);
@@ -523,7 +523,7 @@ public final class StreamingTransformTranslator {
     EVALUATORS.put(Read.Unbounded.class, readUnbounded());
     EVALUATORS.put(GroupByKey.class, groupByKey());
     EVALUATORS.put(Combine.GroupedValues.class, combineGrouped());
-    EVALUATORS.put(ParDo.BoundMulti.class, multiDo());
+    EVALUATORS.put(ParDo.MultiOutput.class, multiDo());
     EVALUATORS.put(ConsoleIO.Write.Unbound.class, print());
     EVALUATORS.put(CreateStream.class, createFromQueue());
     EVALUATORS.put(Window.Assign.class, window());

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkPipelineStateTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkPipelineStateTest.java
@@ -62,7 +62,7 @@ public class SparkPipelineStateTest implements Serializable {
 
   private static final String FAILED_THE_BATCH_INTENTIONALLY = "Failed the batch intentionally";
 
-  private ParDo.Bound<String, String> printParDo(final String prefix) {
+  private ParDo.SingleOutput<String, String> printParDo(final String prefix) {
     return ParDo.of(new DoFn<String, String>() {
 
       @ProcessElement

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/TrackStreamingSourcesTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/TrackStreamingSourcesTest.java
@@ -83,7 +83,7 @@ public class TrackStreamingSourcesTest {
 
     p.apply(emptyStream).apply(ParDo.of(new PassthroughFn<>()));
 
-    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.BoundMulti.class,  0));
+    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutput.class,  0));
     assertThat(StreamingSourceTracker.numAssertions, equalTo(1));
   }
 
@@ -111,7 +111,7 @@ public class TrackStreamingSourcesTest {
         PCollectionList.of(pcol1).and(pcol2).apply(Flatten.<Integer>pCollections());
     flattened.apply(ParDo.of(new PassthroughFn<>()));
 
-    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.BoundMulti.class, 0, 1));
+    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutput.class, 0, 1));
     assertThat(StreamingSourceTracker.numAssertions, equalTo(1));
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/AggregatorPipelineExtractor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/AggregatorPipelineExtractor.java
@@ -71,9 +71,9 @@ class AggregatorPipelineExtractor {
       if (transform != null) {
         if (transform instanceof ParDo.SingleOutput) {
           return AggregatorRetriever.getAggregators(((ParDo.SingleOutput<?, ?>) transform).getFn());
-        } else if (transform instanceof ParDo.BoundMulti) {
+        } else if (transform instanceof ParDo.MultiOutput) {
           return AggregatorRetriever.getAggregators(
-              ((ParDo.BoundMulti<?, ?>) transform).getFn());
+              ((ParDo.MultiOutput<?, ?>) transform).getFn());
         }
       }
       return Collections.emptyList();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/AggregatorPipelineExtractor.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/AggregatorPipelineExtractor.java
@@ -69,8 +69,8 @@ class AggregatorPipelineExtractor {
 
     private Collection<Aggregator<?, ?>> getAggregators(PTransform<?, ?> transform) {
       if (transform != null) {
-        if (transform instanceof ParDo.Bound) {
-          return AggregatorRetriever.getAggregators(((ParDo.Bound<?, ?>) transform).getFn());
+        if (transform instanceof ParDo.SingleOutput) {
+          return AggregatorRetriever.getAggregators(((ParDo.SingleOutput<?, ?>) transform).getFn());
         } else if (transform instanceof ParDo.BoundMulti) {
           return AggregatorRetriever.getAggregators(
               ((ParDo.BoundMulti<?, ?>) transform).getFn());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -1110,7 +1110,7 @@ public class PAssert {
           .apply("WindowToken", windowToken)
           .apply(
               "RunChecks",
-              ParDo.withSideInputs(actual).of(new SideInputCheckerDoFn<>(checkerFn, actual, site)));
+              ParDo.of(new SideInputCheckerDoFn<>(checkerFn, actual, site)).withSideInputs(actual));
 
       return PDone.in(input.getPipeline());
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -1484,7 +1484,7 @@ public class Combine {
       final OutputT defaultValue = fn.defaultValue();
       PCollection<OutputT> defaultIfEmpty = maybeEmpty.getPipeline()
           .apply("CreateVoid", Create.of((Void) null).withCoder(VoidCoder.of()))
-          .apply("ProduceDefault", ParDo.withSideInputs(maybeEmptyView).of(
+          .apply("ProduceDefault", ParDo.of(
               new DoFn<Void, OutputT>() {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
@@ -1493,7 +1493,7 @@ public class Combine {
                     c.output(defaultValue);
                   }
                 }
-              }))
+              }).withSideInputs(maybeEmptyView))
           .setCoder(maybeEmpty.getCoder())
           .setWindowingStrategyInternal(maybeEmpty.getWindowingStrategy());
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -160,7 +160,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
      * <p>Once passed to {@code sideOutput} the element should not be modified
      * in any way.
      *
-     * <p>The caller of {@code ParDo} uses {@link ParDo#withOutputTags} to
+     * <p>The caller of {@code ParDo} uses {@link ParDo.SingleOutput#withOutputTags} to
      * specify the tags of side outputs that it consumes. Non-consumed side
      * outputs, e.g., outputs for monitoring purposes only, don't necessarily
      * need to be specified.
@@ -179,7 +179,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
      * <p><i>Note:</i> A splittable {@link DoFn} is not allowed to output from
      * {@link StartBundle} or {@link FinishBundle} methods.
      *
-     * @see ParDo#withOutputTags
+     * @see ParDo.SingleOutput#withOutputTags
      */
     public abstract <T> void sideOutput(TupleTag<T> tag, T output);
 
@@ -206,7 +206,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
      * <p><i>Note:</i> A splittable {@link DoFn} is not allowed to output from
      * {@link StartBundle} or {@link FinishBundle} methods.
      *
-     * @see ParDo#withOutputTags
+     * @see ParDo.SingleOutput#withOutputTags
      */
     public abstract <T> void sideOutputWithTimestamp(
         TupleTag<T> tag, T output, Instant timestamp);
@@ -272,7 +272,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
      * Returns the value of the side input.
      *
      * @throws IllegalArgumentException if this is not a side input
-     * @see ParDo#withSideInputs
+     * @see ParDo.SingleOutput#withSideInputs
      */
     public abstract <T> T sideInput(PCollectionView<T> view);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -151,7 +151,7 @@ import org.apache.beam.sdk.values.TypedPValue;
  * {@link PCollectionView PCollectionViews} express styles of accessing
  * {@link PCollection PCollections} computed by earlier pipeline operations,
  * passed in to the {@link ParDo} transform using
- * {@link ParDo.Bound#withSideInputs}, and their contents accessible to each of
+ * {@link SingleOutput#withSideInputs}, and their contents accessible to each of
  * the {@link DoFn} operations via {@link DoFn.ProcessContext#sideInput sideInput}.
  * For example:
  *
@@ -181,7 +181,7 @@ import org.apache.beam.sdk.values.TypedPValue;
  * {@link PCollection PCollections}, each keyed by a distinct {@link TupleTag},
  * and bundled in a {@link PCollectionTuple}. The {@link TupleTag TupleTags}
  * to be used for the output {@link PCollectionTuple} are specified by
- * invoking {@link ParDo.Bound#withOutputTags}. Unconsumed side outputs do not
+ * invoking {@link SingleOutput#withOutputTags}. Unconsumed side outputs do not
  * necessarily need to be explicitly specified, even if the {@link DoFn}
  * generates them. Within the {@link DoFn}, an element is added to the
  * main output {@link PCollection} as normal, using
@@ -421,9 +421,9 @@ public class ParDo {
    * <p>The resulting {@link PTransform PTransform} is ready to be applied, or further
    * properties can be set on it first.
    */
-  public static <InputT, OutputT> Bound<InputT, OutputT> of(DoFn<InputT, OutputT> fn) {
+  public static <InputT, OutputT> SingleOutput<InputT, OutputT> of(DoFn<InputT, OutputT> fn) {
     validate(fn);
-    return new Bound<InputT, OutputT>(
+    return new SingleOutput<InputT, OutputT>(
         fn, Collections.<PCollectionView<?>>emptyList(), displayDataForFn(fn));
   }
 
@@ -491,18 +491,18 @@ public class ParDo {
    * {@code PCollection<OutputT>}.
    *
    * <p>A multi-output form of this transform can be created with
-   * {@link ParDo.Bound#withOutputTags}.
+   * {@link SingleOutput#withOutputTags}.
    *
    * @param <InputT> the type of the (main) input {@link PCollection} elements
    * @param <OutputT> the type of the (main) output {@link PCollection} elements
    */
-  public static class Bound<InputT, OutputT>
+  public static class SingleOutput<InputT, OutputT>
       extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
     private final List<PCollectionView<?>> sideInputs;
     private final DoFn<InputT, OutputT> fn;
     private final DisplayData.ItemSpec<? extends Class<?>> fnDisplayData;
 
-    Bound(
+    SingleOutput(
         DoFn<InputT, OutputT> fn,
         List<PCollectionView<?>> sideInputs,
         DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
@@ -518,7 +518,7 @@ public class ParDo {
      *
      * <p>See the discussion of Side Inputs above for more explanation.
      */
-    public Bound<InputT, OutputT> withSideInputs(PCollectionView<?>... sideInputs) {
+    public SingleOutput<InputT, OutputT> withSideInputs(PCollectionView<?>... sideInputs) {
       return withSideInputs(Arrays.asList(sideInputs));
     }
 
@@ -529,9 +529,9 @@ public class ParDo {
      *
      * <p>See the discussion of Side Inputs above for more explanation.
      */
-    public Bound<InputT, OutputT> withSideInputs(
+    public SingleOutput<InputT, OutputT> withSideInputs(
         Iterable<? extends PCollectionView<?>> sideInputs) {
-      return new Bound<>(
+      return new SingleOutput<>(
           fn,
           ImmutableList.<PCollectionView<?>>builder()
               .addAll(this.sideInputs)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -547,9 +547,9 @@ public class ParDo {
      *
      * <p>See the discussion of Side Outputs above for more explanation.
      */
-    public BoundMulti<InputT, OutputT> withOutputTags(
+    public MultiOutput<InputT, OutputT> withOutputTags(
         TupleTag<OutputT> mainOutputTag, TupleTagList sideOutputTags) {
-      return new BoundMulti<>(fn, sideInputs, mainOutputTag, sideOutputTags, fnDisplayData);
+      return new MultiOutput<>(fn, sideInputs, mainOutputTag, sideOutputTags, fnDisplayData);
     }
 
     @Override
@@ -606,7 +606,7 @@ public class ParDo {
    * @param <InputT> the type of the (main) input {@code PCollection} elements
    * @param <OutputT> the type of the main output {@code PCollection} elements
    */
-  public static class BoundMulti<InputT, OutputT>
+  public static class MultiOutput<InputT, OutputT>
       extends PTransform<PCollection<? extends InputT>, PCollectionTuple> {
     private final List<PCollectionView<?>> sideInputs;
     private final TupleTag<OutputT> mainOutputTag;
@@ -614,7 +614,7 @@ public class ParDo {
     private final DisplayData.ItemSpec<? extends Class<?>> fnDisplayData;
     private final DoFn<InputT, OutputT> fn;
 
-    BoundMulti(
+    MultiOutput(
         DoFn<InputT, OutputT> fn,
         List<PCollectionView<?>> sideInputs,
         TupleTag<OutputT> mainOutputTag,
@@ -634,7 +634,7 @@ public class ParDo {
      *
      * <p>See the discussion of Side Inputs above for more explanation.
      */
-    public BoundMulti<InputT, OutputT> withSideInputs(
+    public MultiOutput<InputT, OutputT> withSideInputs(
         PCollectionView<?>... sideInputs) {
       return withSideInputs(Arrays.asList(sideInputs));
     }
@@ -646,9 +646,9 @@ public class ParDo {
      *
      * <p>See the discussion of Side Inputs above for more explanation.
      */
-    public BoundMulti<InputT, OutputT> withSideInputs(
+    public MultiOutput<InputT, OutputT> withSideInputs(
         Iterable<? extends PCollectionView<?>> sideInputs) {
-      return new BoundMulti<>(
+      return new MultiOutput<>(
           fn,
           ImmutableList.<PCollectionView<?>>builder()
               .addAll(this.sideInputs)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
@@ -150,7 +151,7 @@ import org.apache.beam.sdk.values.TypedPValue;
  * {@link PCollectionView PCollectionViews} express styles of accessing
  * {@link PCollection PCollections} computed by earlier pipeline operations,
  * passed in to the {@link ParDo} transform using
- * {@link #withSideInputs}, and their contents accessible to each of
+ * {@link ParDo.Bound#withSideInputs}, and their contents accessible to each of
  * the {@link DoFn} operations via {@link DoFn.ProcessContext#sideInput sideInput}.
  * For example:
  *
@@ -180,7 +181,7 @@ import org.apache.beam.sdk.values.TypedPValue;
  * {@link PCollection PCollections}, each keyed by a distinct {@link TupleTag},
  * and bundled in a {@link PCollectionTuple}. The {@link TupleTag TupleTags}
  * to be used for the output {@link PCollectionTuple} are specified by
- * invoking {@link #withOutputTags}. Unconsumed side outputs do not
+ * invoking {@link ParDo.Bound#withOutputTags}. Unconsumed side outputs do not
  * necessarily need to be explicitly specified, even if the {@link DoFn}
  * generates them. Within the {@link DoFn}, an element is added to the
  * main output {@link PCollection} as normal, using
@@ -203,11 +204,6 @@ import org.apache.beam.sdk.values.TypedPValue;
  * PCollectionTuple results =
  *     words.apply(
  *         ParDo
- *         // Specify the main and consumed side output tags of the
- *         // PCollectionTuple result:
- *         .withOutputTags(wordsBelowCutOffTag,
- *                         TupleTagList.of(wordLengthsAboveCutOffTag)
- *                                     .and(markedWordsTag))
  *         .of(new DoFn<String, String>() {
  *             // Create a tag for the unconsumed side output.
  *             final TupleTag<String> specialWordsTag =
@@ -230,7 +226,12 @@ import org.apache.beam.sdk.values.TypedPValue;
  *                 // Emit this word to the unconsumed side output.
  *                 c.sideOutput(specialWordsTag, word);
  *               }
- *             }}));
+ *             }})
+ *             // Specify the main and consumed side output tags of the
+ *             // PCollectionTuple result:
+ *         .withOutputTags(wordsBelowCutOffTag,
+ *             TupleTagList.of(wordLengthsAboveCutOffTag)
+ *                         .and(markedWordsTag)));
  * // Extract the PCollection results, by tag.
  * PCollection<String> wordsBelowCutOff =
  *     results.get(wordsBelowCutOffTag);
@@ -239,35 +240,6 @@ import org.apache.beam.sdk.values.TypedPValue;
  * PCollection<String> markedWords =
  *     results.get(markedWordsTag);
  * }</pre>
- *
- * <h2>Properties May Be Specified In Any Order</h2>
- *
- * <p>Several properties can be specified for a {@link ParDo}
- * {@link PTransform}, including side inputs, side output tags,
- * and {@link DoFn} to invoke. Only the {@link DoFn} is required; side inputs and side
- * output tags are only specified when they're needed. These
- * properties can be specified in any order, as long as they're
- * specified before the {@link ParDo} {@link PTransform} is applied.
- *
- * <p>The approach used to allow these properties to be specified in
- * any order, with some properties omitted, is to have each of the
- * property "setter" methods defined as static factory methods on
- * {@link ParDo} itself, which return an instance of either
- * {@link ParDo.Unbound} or
- * {@link ParDo.Bound} nested classes, each of which offer
- * property setter instance methods to enable setting additional
- * properties. {@link ParDo.Bound} is used for {@link ParDo}
- * transforms whose {@link DoFn} is specified and whose input and
- * output static types have been bound. {@link ParDo.Unbound ParDo.Unbound} is used
- * for {@link ParDo} transforms that have not yet had their
- * {@link DoFn} specified. Only {@link ParDo.Bound} instances can be
- * applied.
- *
- * <p>Another benefit of this approach is that it reduces the number
- * of type parameters that need to be specified manually. In
- * particular, the input and output types of the {@link ParDo}
- * {@link PTransform} are inferred automatically from the type
- * parameters of the {@link DoFn} argument passed to {@link ParDo#of}.
  *
  * <h2>Output Coders</h2>
  *
@@ -443,91 +415,16 @@ import org.apache.beam.sdk.values.TypedPValue;
 public class ParDo {
 
   /**
-   * Creates a {@link ParDo} {@link PTransform} with the given
-   * side inputs.
-   *
-   * <p>Side inputs are {@link PCollectionView PCollectionViews}, whose contents are
-   * computed during pipeline execution and then made accessible to
-   * {@link DoFn} code via {@link DoFn.ProcessContext#sideInput sideInput}. Each
-   * invocation of the {@link DoFn} receives the same values for these
-   * side inputs.
-   *
-   * <p>See the discussion of Side Inputs above for more explanation.
-   *
-   * <p>The resulting {@link PTransform} is incomplete, and its
-   * input/output types are not yet bound. Use
-   * {@link ParDo.Unbound#of} to specify the {@link DoFn} to
-   * invoke, which will also bind the input/output types of this
-   * {@link PTransform}.
-   */
-  public static Unbound withSideInputs(PCollectionView<?>... sideInputs) {
-    return new Unbound().withSideInputs(sideInputs);
-  }
-
-  /**
-    * Creates a {@link ParDo} with the given side inputs.
-    *
-   * <p>Side inputs are {@link PCollectionView}s, whose contents are
-   * computed during pipeline execution and then made accessible to
-   * {@link DoFn} code via {@link DoFn.ProcessContext#sideInput sideInput}.
-   *
-   * <p>See the discussion of Side Inputs above for more explanation.
-   *
-   * <p>The resulting {@link PTransform} is incomplete, and its
-   * input/output types are not yet bound. Use
-   * {@link ParDo.Unbound#of} to specify the {@link DoFn} to
-   * invoke, which will also bind the input/output types of this
-   * {@link PTransform}.
-   */
-  public static Unbound withSideInputs(
-      Iterable<? extends PCollectionView<?>> sideInputs) {
-    return new Unbound().withSideInputs(sideInputs);
-  }
-
-  /**
-   * Creates a multi-output {@link ParDo} {@link PTransform} whose
-   * output {@link PCollection}s will be referenced using the given main
-   * output and side output tags.
-   *
-   * <p>{@link TupleTag TupleTags} are used to name (with its static element
-   * type {@code T}) each main and side output {@code PCollection<T>}.
-   * This {@link PTransform PTransform's} {@link DoFn} emits elements to the main
-   * output {@link PCollection} as normal, using
-   * {@link DoFn.Context#output}. The {@link DoFn} emits elements to
-   * a side output {@code PCollection} using
-   * {@link DoFn.Context#sideOutput}, passing that side output's tag
-   * as an argument. The result of invoking this {@link PTransform}
-   * will be a {@link PCollectionTuple}, and any of the the main and
-   * side output {@code PCollection}s can be retrieved from it via
-   * {@link PCollectionTuple#get}, passing the output's tag as an
-   * argument.
-   *
-   * <p>See the discussion of Side Outputs above for more explanation.
-   *
-   * <p>The resulting {@link PTransform} is incomplete, and its input
-   * type is not yet bound. Use {@link ParDo.UnboundMulti#of}
-   * to specify the {@link DoFn} to invoke, which will also bind the
-   * input type of this {@link PTransform}.
-   */
-  public static <OutputT> UnboundMulti<OutputT> withOutputTags(
-      TupleTag<OutputT> mainOutputTag,
-      TupleTagList sideOutputTags) {
-    return new Unbound().withOutputTags(mainOutputTag, sideOutputTags);
-  }
-
-  /**
    * Creates a {@link ParDo} {@link PTransform} that will invoke the
    * given {@link DoFn} function.
    *
-   * <p>The resulting {@link PTransform PTransform's} types have been bound, with the
-   * input being a {@code PCollection<InputT>} and the output a
-   * {@code PCollection<OutputT>}, inferred from the types of the argument
-   * {@code DoFn<InputT, OutputT>}. It is ready to be applied, or further
+   * <p>The resulting {@link PTransform PTransform} is ready to be applied, or further
    * properties can be set on it first.
    */
   public static <InputT, OutputT> Bound<InputT, OutputT> of(DoFn<InputT, OutputT> fn) {
     validate(fn);
-    return new Unbound().of(fn, displayDataForFn(fn));
+    return new Bound<InputT, OutputT>(
+        fn, Collections.<PCollectionView<?>>emptyList(), displayDataForFn(fn));
   }
 
   private static <T> DisplayData.ItemSpec<? extends Class<?>> displayDataForFn(T fn) {
@@ -588,85 +485,6 @@ public class ParDo {
   }
 
   /**
-   * An incomplete {@link ParDo} transform, with unbound input/output types.
-   *
-   * <p>Before being applied, {@link ParDo.Unbound#of} must be
-   * invoked to specify the {@link DoFn} to invoke, which will also
-   * bind the input/output types of this {@link PTransform}.
-   */
-  public static class Unbound {
-    private final List<PCollectionView<?>> sideInputs;
-
-    Unbound() {
-      this(ImmutableList.<PCollectionView<?>>of());
-    }
-
-    Unbound(List<PCollectionView<?>> sideInputs) {
-      this.sideInputs = sideInputs;
-    }
-
-    /**
-     * Returns a new {@link ParDo} transform that's like this
-     * transform but with the specified additional side inputs.
-     * Does not modify this transform. The resulting transform is
-     * still incomplete.
-     *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
-     */
-    public Unbound withSideInputs(PCollectionView<?>... sideInputs) {
-      return withSideInputs(Arrays.asList(sideInputs));
-    }
-
-    /**
-     * Returns a new {@link ParDo} transform that is like this
-     * transform but with the specified additional side inputs. Does not modify
-     * this transform. The resulting transform is still incomplete.
-     *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
-     */
-    public Unbound withSideInputs(
-        Iterable<? extends PCollectionView<?>> sideInputs) {
-      ImmutableList.Builder<PCollectionView<?>> builder = ImmutableList.builder();
-      builder.addAll(this.sideInputs);
-      builder.addAll(sideInputs);
-      return new Unbound(builder.build());
-    }
-
-    /**
-     * Returns a new {@link ParDo} {@link PTransform} that's like this
-     * transform but which will invoke the given {@link DoFn}
-     * function, and which has its input and output types bound. Does
-     * not modify this transform. The resulting {@link PTransform} is
-     * sufficiently specified to be applied, but more properties can
-     * still be specified.
-     */
-    public <InputT, OutputT> Bound<InputT, OutputT> of(DoFn<InputT, OutputT> fn) {
-      validate(fn);
-      return of(fn, displayDataForFn(fn));
-    }
-
-    /**
-     * Returns a new multi-output {@link ParDo} transform that's like this transform but with the
-     * specified main and side output tags. Does not modify this transform. The resulting transform
-     * is still incomplete.
-     *
-     * <p>See the discussion of Side Outputs above and on {@link ParDo#withOutputTags} for more
-     * explanation.
-     */
-    public <OutputT> UnboundMulti<OutputT> withOutputTags(
-        TupleTag<OutputT> mainOutputTag, TupleTagList sideOutputTags) {
-      return new UnboundMulti<>(sideInputs, mainOutputTag, sideOutputTags);
-    }
-
-    private <InputT, OutputT> Bound<InputT, OutputT> of(
-        DoFn<InputT, OutputT> doFn, DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
-      return new Bound<>(doFn, sideInputs, fnDisplayData);
-    }
-  }
-
-  /**
    * A {@link PTransform} that, when applied to a {@code PCollection<InputT>},
    * invokes a user-specified {@code DoFn<InputT, OutputT>} on all its elements,
    * with all its outputs collected into an output
@@ -698,8 +516,7 @@ public class ParDo {
      * {@link PTransform} but with the specified additional side inputs. Does not
      * modify this {@link PTransform}.
      *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
+     * <p>See the discussion of Side Inputs above for more explanation.
      */
     public Bound<InputT, OutputT> withSideInputs(PCollectionView<?>... sideInputs) {
       return withSideInputs(Arrays.asList(sideInputs));
@@ -710,8 +527,7 @@ public class ParDo {
      * {@link PTransform} but with the specified additional side inputs. Does not
      * modify this {@link PTransform}.
      *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
+     * <p>See the discussion of Side Inputs above for more explanation.
      */
     public Bound<InputT, OutputT> withSideInputs(
         Iterable<? extends PCollectionView<?>> sideInputs) {
@@ -729,8 +545,7 @@ public class ParDo {
      * PTransform} but with the specified main and side output tags. Does not modify this {@link
      * PTransform}.
      *
-     * <p>See the discussion of Side Outputs above and on {@link ParDo#withOutputTags} for more
-     * explanation.
+     * <p>See the discussion of Side Outputs above for more explanation.
      */
     public BoundMulti<InputT, OutputT> withOutputTags(
         TupleTag<OutputT> mainOutputTag, TupleTagList sideOutputTags) {
@@ -781,82 +596,6 @@ public class ParDo {
   }
 
   /**
-   * An incomplete multi-output {@link ParDo} transform, with unbound
-   * input type.
-   *
-   * <p>Before being applied, {@link ParDo.UnboundMulti#of} must be
-   * invoked to specify the {@link DoFn} to invoke, which will also
-   * bind the input type of this {@link PTransform}.
-   *
-   * @param <OutputT> the type of the main output {@code PCollection} elements
-   */
-  public static class UnboundMulti<OutputT> {
-    private final List<PCollectionView<?>> sideInputs;
-    private final TupleTag<OutputT> mainOutputTag;
-    private final TupleTagList sideOutputTags;
-
-    UnboundMulti(List<PCollectionView<?>> sideInputs,
-                 TupleTag<OutputT> mainOutputTag,
-                 TupleTagList sideOutputTags) {
-      this.sideInputs = sideInputs;
-      this.mainOutputTag = mainOutputTag;
-      this.sideOutputTags = sideOutputTags;
-    }
-
-    /**
-     * Returns a new multi-output {@link ParDo} transform that's like
-     * this transform but with the specified side inputs. Does not
-     * modify this transform. The resulting transform is still
-     * incomplete.
-     *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
-     */
-    public UnboundMulti<OutputT> withSideInputs(
-        PCollectionView<?>... sideInputs) {
-      return withSideInputs(Arrays.asList(sideInputs));
-    }
-
-    /**
-     * Returns a new multi-output {@link ParDo} transform that's like
-     * this transform but with the specified additional side inputs. Does not
-     * modify this transform. The resulting transform is still
-     * incomplete.
-     *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
-     */
-    public UnboundMulti<OutputT> withSideInputs(
-        Iterable<? extends PCollectionView<?>> sideInputs) {
-      return new UnboundMulti<>(
-          ImmutableList.<PCollectionView<?>>builder()
-              .addAll(this.sideInputs)
-              .addAll(sideInputs)
-              .build(),
-          mainOutputTag,
-          sideOutputTags);
-    }
-
-    /**
-     * Returns a new multi-output {@link ParDo} {@link PTransform}
-     * that's like this transform but which will invoke the given
-     * {@link DoFn} function, and which has its input type bound.
-     * Does not modify this transform. The resulting
-     * {@link PTransform} is sufficiently specified to be applied, but
-     * more properties can still be specified.
-     */
-    public <InputT> BoundMulti<InputT, OutputT> of(DoFn<InputT, OutputT> fn) {
-      validate(fn);
-      return of(fn, displayDataForFn(fn));
-    }
-
-    private <InputT> BoundMulti<InputT, OutputT> of(
-        DoFn<InputT, OutputT> fn, DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
-      return new BoundMulti<>(fn, sideInputs, mainOutputTag, sideOutputTags, fnDisplayData);
-    }
-  }
-
-  /**
    * A {@link PTransform} that, when applied to a
    * {@code PCollection<InputT>}, invokes a user-specified
    * {@code DoFn<InputT, OutputT>} on all its elements, which can emit elements
@@ -893,8 +632,7 @@ public class ParDo {
      * that's like this {@link PTransform} but with the specified additional side
      * inputs. Does not modify this {@link PTransform}.
      *
-     * <p>See the discussion of Side Inputs above and on
-     * {@link ParDo#withSideInputs} for more explanation.
+     * <p>See the discussion of Side Inputs above for more explanation.
      */
     public BoundMulti<InputT, OutputT> withSideInputs(
         PCollectionView<?>... sideInputs) {
@@ -906,8 +644,7 @@ public class ParDo {
      * PTransform} but with the specified additional side inputs. Does not modify this {@link
      * PTransform}.
      *
-     * <p>See the discussion of Side Inputs above and on {@link ParDo#withSideInputs} for more
-     * explanation.
+     * <p>See the discussion of Side Inputs above for more explanation.
      */
     public BoundMulti<InputT, OutputT> withSideInputs(
         Iterable<? extends PCollectionView<?>> sideInputs) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
@@ -105,8 +105,8 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
 
     PCollectionTuple outputs = in.apply(
         ParDo
-        .withOutputTags(new TupleTag<Void>(){}, outputTags)
-        .of(partitionDoFn));
+        .of(partitionDoFn)
+        .withOutputTags(new TupleTag<Void>(){}, outputTags));
 
     PCollectionList<T> pcs = PCollectionList.empty(in.getPipeline());
     Coder<T> coder = in.getCoder();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sample.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Sample.java
@@ -146,12 +146,9 @@ public class Sample {
     @Override
     public PCollection<T> expand(PCollection<T> in) {
       PCollectionView<Iterable<T>> iterableView = in.apply(View.<T>asIterable());
-      return
-          in.getPipeline()
+      return in.getPipeline()
           .apply(Create.of((Void) null).withCoder(VoidCoder.of()))
-          .apply(ParDo
-                 .withSideInputs(iterableView)
-                 .of(new SampleAnyDoFn<>(limit, iterableView)))
+          .apply(ParDo.of(new SampleAnyDoFn<>(limit, iterableView)).withSideInputs(iterableView))
           .setCoder(in.getCoder());
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -129,7 +129,7 @@ import org.apache.beam.sdk.values.PCollectionView;
  * }
  * </pre>
  *
- * <p>See {@link ParDo#withSideInputs} for details on how to access
+ * <p>See {@link ParDo.SingleOutput#withSideInputs} for details on how to access
  * this variable inside a {@link ParDo} over another {@link PCollection}.
  */
 public class View {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
@@ -19,14 +19,14 @@
 package org.apache.beam.sdk.transforms.windowing;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
+import org.apache.beam.sdk.transforms.ParDo.MultiOutput;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.joda.time.Duration;
 
 /**
  * A function that takes the windows of elements in a main input and maps them to the appropriate
  * window in a {@link PCollectionView} consumed as a
- * {@link BoundMulti#withSideInputs(PCollectionView[]) side input}.
+ * {@link MultiOutput#withSideInputs(PCollectionView[]) side input}.
  */
 public abstract class WindowMappingFn<TargetWindowT extends BoundedWindow> implements Serializable {
   private final Duration maximumLookback;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypedPValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypedPValue.java
@@ -152,7 +152,7 @@ public abstract class TypedPValue<T> extends PValueBase implements PValue {
         // and provide a better error message if so. Unfortunately, this information is not
         // directly available from the TypeDescriptor, so infer based on the type of the PTransform
         // and the error message itself.
-        if (transform instanceof ParDo.BoundMulti
+        if (transform instanceof ParDo.MultiOutput
             && exc.getReason() == ReasonCode.TYPE_ERASURE) {
           inferFromTokenException = new CannotProvideCoderException(exc.getMessage()
               + " If this error occurs for a side output of the producing ParDo, verify that the "

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/AggregatorPipelineExtractorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/AggregatorPipelineExtractorTest.java
@@ -64,17 +64,17 @@ public class AggregatorPipelineExtractorTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testGetAggregatorStepsWithParDoBoundExtractsSteps() {
+  public void testGetAggregatorStepsWithParDoSingleOutputExtractsSteps() {
     @SuppressWarnings("rawtypes")
-    ParDo.Bound bound = mock(ParDo.Bound.class, "Bound");
+    ParDo.SingleOutput parDo = mock(ParDo.SingleOutput.class, "parDo");
     AggregatorProvidingDoFn<ThreadGroup, StrictMath> fn = new AggregatorProvidingDoFn<>();
-    when(bound.getFn()).thenReturn(fn);
+    when(parDo.getFn()).thenReturn(fn);
 
     Aggregator<Long, Long> aggregatorOne = fn.addAggregator(Sum.ofLongs());
     Aggregator<Integer, Integer> aggregatorTwo = fn.addAggregator(Min.ofIntegers());
 
     TransformHierarchy.Node transformNode = mock(TransformHierarchy.Node.class);
-    when(transformNode.getTransform()).thenReturn(bound);
+    when(transformNode.getTransform()).thenReturn(parDo);
 
     doAnswer(new VisitNodesAnswer(ImmutableList.of(transformNode)))
         .when(p)
@@ -85,8 +85,8 @@ public class AggregatorPipelineExtractorTest {
     Map<Aggregator<?, ?>, Collection<PTransform<?, ?>>> aggregatorSteps =
         extractor.getAggregatorSteps();
 
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(bound), aggregatorSteps.get(aggregatorOne));
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(bound), aggregatorSteps.get(aggregatorTwo));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(parDo), aggregatorSteps.get(aggregatorOne));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(parDo), aggregatorSteps.get(aggregatorTwo));
     assertEquals(aggregatorSteps.size(), 2);
   }
 
@@ -94,15 +94,15 @@ public class AggregatorPipelineExtractorTest {
   @Test
   public void testGetAggregatorStepsWithParDoBoundMultiExtractsSteps() {
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti bound = mock(ParDo.BoundMulti.class, "BoundMulti");
+    ParDo.BoundMulti parDo = mock(ParDo.BoundMulti.class, "parDo");
     AggregatorProvidingDoFn<Object, Void> fn = new AggregatorProvidingDoFn<>();
-    when(bound.getFn()).thenReturn(fn);
+    when(parDo.getFn()).thenReturn(fn);
 
     Aggregator<Long, Long> aggregatorOne = fn.addAggregator(Max.ofLongs());
     Aggregator<Double, Double> aggregatorTwo = fn.addAggregator(Min.ofDoubles());
 
     TransformHierarchy.Node transformNode = mock(TransformHierarchy.Node.class);
-    when(transformNode.getTransform()).thenReturn(bound);
+    when(transformNode.getTransform()).thenReturn(parDo);
 
     doAnswer(new VisitNodesAnswer(ImmutableList.of(transformNode)))
         .when(p)
@@ -113,8 +113,8 @@ public class AggregatorPipelineExtractorTest {
     Map<Aggregator<?, ?>, Collection<PTransform<?, ?>>> aggregatorSteps =
         extractor.getAggregatorSteps();
 
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(bound), aggregatorSteps.get(aggregatorOne));
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(bound), aggregatorSteps.get(aggregatorTwo));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(parDo), aggregatorSteps.get(aggregatorOne));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(parDo), aggregatorSteps.get(aggregatorTwo));
     assertEquals(2, aggregatorSteps.size());
   }
 
@@ -122,20 +122,20 @@ public class AggregatorPipelineExtractorTest {
   @Test
   public void testGetAggregatorStepsWithOneAggregatorInMultipleStepsAddsSteps() {
     @SuppressWarnings("rawtypes")
-    ParDo.Bound bound = mock(ParDo.Bound.class, "Bound");
+    ParDo.SingleOutput parDo = mock(ParDo.SingleOutput.class, "parDo");
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti otherBound = mock(ParDo.BoundMulti.class, "otherBound");
+    ParDo.BoundMulti otherParDo = mock(ParDo.BoundMulti.class, "otherParDo");
     AggregatorProvidingDoFn<String, Math> fn = new AggregatorProvidingDoFn<>();
-    when(bound.getFn()).thenReturn(fn);
-    when(otherBound.getFn()).thenReturn(fn);
+    when(parDo.getFn()).thenReturn(fn);
+    when(otherParDo.getFn()).thenReturn(fn);
 
     Aggregator<Long, Long> aggregatorOne = fn.addAggregator(Sum.ofLongs());
     Aggregator<Double, Double> aggregatorTwo = fn.addAggregator(Min.ofDoubles());
 
     TransformHierarchy.Node transformNode = mock(TransformHierarchy.Node.class);
-    when(transformNode.getTransform()).thenReturn(bound);
+    when(transformNode.getTransform()).thenReturn(parDo);
     TransformHierarchy.Node otherTransformNode = mock(TransformHierarchy.Node.class);
-    when(otherTransformNode.getTransform()).thenReturn(otherBound);
+    when(otherTransformNode.getTransform()).thenReturn(otherParDo);
 
     doAnswer(new VisitNodesAnswer(ImmutableList.of(transformNode, otherTransformNode)))
         .when(p)
@@ -147,9 +147,9 @@ public class AggregatorPipelineExtractorTest {
         extractor.getAggregatorSteps();
 
     assertEquals(
-        ImmutableSet.<PTransform<?, ?>>of(bound, otherBound), aggregatorSteps.get(aggregatorOne));
+        ImmutableSet.<PTransform<?, ?>>of(parDo, otherParDo), aggregatorSteps.get(aggregatorOne));
     assertEquals(
-        ImmutableSet.<PTransform<?, ?>>of(bound, otherBound), aggregatorSteps.get(aggregatorTwo));
+        ImmutableSet.<PTransform<?, ?>>of(parDo, otherParDo), aggregatorSteps.get(aggregatorTwo));
     assertEquals(2, aggregatorSteps.size());
   }
 
@@ -157,25 +157,25 @@ public class AggregatorPipelineExtractorTest {
   @Test
   public void testGetAggregatorStepsWithDifferentStepsAddsSteps() {
     @SuppressWarnings("rawtypes")
-    ParDo.Bound bound = mock(ParDo.Bound.class, "Bound");
+    ParDo.SingleOutput parDo = mock(ParDo.SingleOutput.class, "parDo");
 
     AggregatorProvidingDoFn<ThreadGroup, Void> fn = new AggregatorProvidingDoFn<>();
     Aggregator<Long, Long> aggregatorOne = fn.addAggregator(Sum.ofLongs());
 
-    when(bound.getFn()).thenReturn(fn);
+    when(parDo.getFn()).thenReturn(fn);
 
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti otherBound = mock(ParDo.BoundMulti.class, "otherBound");
+    ParDo.BoundMulti otherParDo = mock(ParDo.BoundMulti.class, "otherParDo");
 
     AggregatorProvidingDoFn<Long, Long> otherFn = new AggregatorProvidingDoFn<>();
     Aggregator<Double, Double> aggregatorTwo = otherFn.addAggregator(Sum.ofDoubles());
 
-    when(otherBound.getFn()).thenReturn(otherFn);
+    when(otherParDo.getFn()).thenReturn(otherFn);
 
     TransformHierarchy.Node transformNode = mock(TransformHierarchy.Node.class);
-    when(transformNode.getTransform()).thenReturn(bound);
+    when(transformNode.getTransform()).thenReturn(parDo);
     TransformHierarchy.Node otherTransformNode = mock(TransformHierarchy.Node.class);
-    when(otherTransformNode.getTransform()).thenReturn(otherBound);
+    when(otherTransformNode.getTransform()).thenReturn(otherParDo);
 
     doAnswer(new VisitNodesAnswer(ImmutableList.of(transformNode, otherTransformNode)))
         .when(p)
@@ -186,8 +186,8 @@ public class AggregatorPipelineExtractorTest {
     Map<Aggregator<?, ?>, Collection<PTransform<?, ?>>> aggregatorSteps =
         extractor.getAggregatorSteps();
 
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(bound), aggregatorSteps.get(aggregatorOne));
-    assertEquals(ImmutableSet.<PTransform<?, ?>>of(otherBound), aggregatorSteps.get(aggregatorTwo));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(parDo), aggregatorSteps.get(aggregatorOne));
+    assertEquals(ImmutableSet.<PTransform<?, ?>>of(otherParDo), aggregatorSteps.get(aggregatorTwo));
     assertEquals(2, aggregatorSteps.size());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/AggregatorPipelineExtractorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/AggregatorPipelineExtractorTest.java
@@ -92,9 +92,9 @@ public class AggregatorPipelineExtractorTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void testGetAggregatorStepsWithParDoBoundMultiExtractsSteps() {
+  public void testGetAggregatorStepsWithParDoMultiOutputExtractsSteps() {
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti parDo = mock(ParDo.BoundMulti.class, "parDo");
+    ParDo.MultiOutput parDo = mock(ParDo.MultiOutput.class, "parDo");
     AggregatorProvidingDoFn<Object, Void> fn = new AggregatorProvidingDoFn<>();
     when(parDo.getFn()).thenReturn(fn);
 
@@ -124,7 +124,7 @@ public class AggregatorPipelineExtractorTest {
     @SuppressWarnings("rawtypes")
     ParDo.SingleOutput parDo = mock(ParDo.SingleOutput.class, "parDo");
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti otherParDo = mock(ParDo.BoundMulti.class, "otherParDo");
+    ParDo.MultiOutput otherParDo = mock(ParDo.MultiOutput.class, "otherParDo");
     AggregatorProvidingDoFn<String, Math> fn = new AggregatorProvidingDoFn<>();
     when(parDo.getFn()).thenReturn(fn);
     when(otherParDo.getFn()).thenReturn(fn);
@@ -165,7 +165,7 @@ public class AggregatorPipelineExtractorTest {
     when(parDo.getFn()).thenReturn(fn);
 
     @SuppressWarnings("rawtypes")
-    ParDo.BoundMulti otherParDo = mock(ParDo.BoundMulti.class, "otherParDo");
+    ParDo.MultiOutput otherParDo = mock(ParDo.MultiOutput.class, "otherParDo");
 
     AggregatorProvidingDoFn<Long, Long> otherFn = new AggregatorProvidingDoFn<>();
     Aggregator<Double, Double> aggregatorTwo = otherFn.addAggregator(Sum.ofDoubles());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
@@ -207,7 +207,7 @@ public class MetricsTest implements Serializable {
             bundleDist.update(40L);
           }
         }))
-        .apply("MyStep2", ParDo.withOutputTags(output1, TupleTagList.of(output2))
+        .apply("MyStep2", ParDo
             .of(new DoFn<Integer, Integer>() {
               @SuppressWarnings("unused")
               @ProcessElement
@@ -221,7 +221,8 @@ public class MetricsTest implements Serializable {
                 c.output(element);
                 c.sideOutput(output2, element);
               }
-            }));
+            })
+            .withOutputTags(output1, TupleTagList.of(output2)));
     PipelineResult result = pipeline.run();
 
     result.waitUntilFinish();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
@@ -46,7 +46,7 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.ParDo.Bound;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.PBegin;
@@ -245,7 +245,7 @@ public class TransformHierarchyTest implements Serializable {
 
   @Test
   public void replaceWithCompositeSucceeds() {
-    final ParDo.Bound<Long, Long> originalParDo =
+    final SingleOutput<Long, Long> originalParDo =
         ParDo.of(
             new DoFn<Long, Long>() {
               @ProcessElement
@@ -324,7 +324,7 @@ public class TransformHierarchyTest implements Serializable {
         PCollection.createPrimitiveOutputInternal(
             pipeline, WindowingStrategy.globalDefault(), IsBounded.BOUNDED);
 
-    ParDo.Bound<Long, Long> pardo =
+    SingleOutput<Long, Long> pardo =
         ParDo.of(
             new DoFn<Long, Long>() {
               @ProcessElement
@@ -408,7 +408,7 @@ public class TransformHierarchyTest implements Serializable {
   @Test
   public void visitAfterReplace() {
     Node root = hierarchy.getCurrent();
-    final Bound<Long, Long> originalParDo =
+    final SingleOutput<Long, Long> originalParDo =
         ParDo.of(
             new DoFn<Long, Long>() {
               @ProcessElement

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformHierarchyTest.java
@@ -46,8 +46,8 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.MultiOutput;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
-import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -268,7 +268,7 @@ public class TransformHierarchyTest implements Serializable {
     hierarchy.popNode();
 
     final TupleTag<Long> longs = new TupleTag<>();
-    final ParDo.BoundMulti<Long, Long> replacementParDo =
+    final MultiOutput<Long, Long> replacementParDo =
         ParDo.of(
                 new DoFn<Long, Long>() {
                   @ProcessElement
@@ -431,7 +431,7 @@ public class TransformHierarchyTest implements Serializable {
     hierarchy.popNode();
 
     final TupleTag<Long> longs = new TupleTag<>();
-    final BoundMulti<Long, Long> replacementParDo =
+    final MultiOutput<Long, Long> replacementParDo =
         ParDo.of(
                 new DoFn<Long, Long>() {
                   @ProcessElement

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FlattenTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FlattenTest.java
@@ -198,14 +198,14 @@ public class FlattenTest implements Serializable {
 
     PCollection<String> output = p
         .apply(Create.of((Void) null).withCoder(VoidCoder.of()))
-        .apply(ParDo.withSideInputs(view).of(new DoFn<Void, String>() {
+        .apply(ParDo.of(new DoFn<Void, String>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (String side : c.sideInput(view)) {
                       c.output(side);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).empty();
     p.run();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -898,7 +898,7 @@ public class ParDoTest implements Serializable {
           }
         };
 
-    ParDo.BoundMulti<Long, Long> parDo =
+    ParDo.MultiOutput<Long, Long> parDo =
         ParDo.of(fn).withOutputTags(mainOut, TupleTagList.of(sideOutOne).and(sideOutTwo));
     PCollectionTuple firstApplication = longs.apply("first", parDo);
     PCollectionTuple secondApplication = longs.apply("second", parDo);
@@ -1161,7 +1161,7 @@ public class ParDoTest implements Serializable {
 
     final TupleTag<Integer> mainOutputTag = new TupleTag<Integer>("main");
     final TupleTag<TestDummy> sideOutputTag = new TupleTag<TestDummy>("unregisteredSide");
-    ParDo.BoundMulti<Integer, Integer> pardo = ParDo.of(new SideOutputDummyFn(sideOutputTag))
+    ParDo.MultiOutput<Integer, Integer> pardo = ParDo.of(new SideOutputDummyFn(sideOutputTag))
         .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag));
     PCollectionTuple outputTuple = input.apply(pardo);
 
@@ -2301,7 +2301,7 @@ public class ParDoTest implements Serializable {
       }
     };
 
-    ParDo.BoundMulti<String, String> parDo = ParDo
+    ParDo.MultiOutput<String, String> parDo = ParDo
             .of(fn)
             .withOutputTags(new TupleTag<String>(), TupleTagList.empty());
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -72,11 +72,10 @@ import org.apache.beam.sdk.testing.UsesTimersInParDo;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.DoFn.OnTimer;
 import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
-import org.apache.beam.sdk.transforms.ParDo.Bound;
+import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.display.DisplayDataMatchers;
-import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -1511,7 +1510,7 @@ public class ParDoTest implements Serializable {
       }
     };
 
-    Bound<String, String> parDo = ParDo.of(fn);
+    SingleOutput<String, String> parDo = ParDo.of(fn);
 
     DisplayData displayData = DisplayData.from(parDo);
     assertThat(displayData, hasDisplayItem(allOf(
@@ -1534,7 +1533,7 @@ public class ParDoTest implements Serializable {
       }
     };
 
-    Bound<String, String> parDo = ParDo.of(fn);
+    SingleOutput<String, String> parDo = ParDo.of(fn);
 
     DisplayData displayData = DisplayData.from(parDo);
     assertThat(displayData, includesDisplayDataFor("fn", fn));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2311,22 +2311,6 @@ public class ParDoTest implements Serializable {
     assertThat(displayData, hasDisplayItem("fn", fn.getClass()));
   }
 
-  private abstract static class SomeTracker implements RestrictionTracker<Object> {}
-  private static class TestSplittableDoFn extends DoFn<Integer, String> {
-    @ProcessElement
-    public void processElement(ProcessContext context, SomeTracker tracker) {}
-
-    @GetInitialRestriction
-    public Object getInitialRestriction(Integer element) {
-      return null;
-    }
-
-    @NewTracker
-    public SomeTracker newTracker(Object restriction) {
-      return null;
-    }
-  }
-
   @Test
   public void testRejectsWrongWindowType() {
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
@@ -99,12 +99,12 @@ public class ViewTest implements Serializable {
     PCollection<Integer> output =
         pipeline.apply("Create123", Create.of(1, 2, 3))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(c.sideInput(view));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(47, 47, 47);
 
@@ -129,12 +129,12 @@ public class ViewTest implements Serializable {
             TimestampedValue.of(3, new Instant(12))))
             .apply("MainWindowInto", Window.<Integer>into(FixedWindows.of(Duration.millis(10))))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(c.sideInput(view));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(47, 47, 48);
 
@@ -150,12 +150,12 @@ public class ViewTest implements Serializable {
             .apply(View.<Integer>asSingleton());
 
     pipeline.apply("Create123", Create.of(1, 2, 3))
-        .apply("OutputSideInputs", ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+        .apply("OutputSideInputs", ParDo.of(new DoFn<Integer, Integer>() {
           @ProcessElement
           public void processElement(ProcessContext c) {
             c.output(c.sideInput(view));
           }
-        }));
+        }).withSideInputs(view));
 
     thrown.expect(PipelineExecutionException.class);
     thrown.expectCause(isA(NoSuchElementException.class));
@@ -174,12 +174,12 @@ public class ViewTest implements Serializable {
     final PCollectionView<Integer> view = oneTwoThree.apply(View.<Integer>asSingleton());
 
     oneTwoThree.apply(
-        "OutputSideInputs", ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+        "OutputSideInputs", ParDo.of(new DoFn<Integer, Integer>() {
           @ProcessElement
           public void processElement(ProcessContext c) {
             c.output(c.sideInput(view));
           }
-        }));
+        }).withSideInputs(view));
 
     thrown.expect(PipelineExecutionException.class);
     thrown.expectCause(isA(IllegalArgumentException.class));
@@ -200,7 +200,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> output =
         pipeline.apply("CreateMainInput", Create.of(29, 31))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     checkArgument(c.sideInput(view).size() == 4);
@@ -209,7 +209,7 @@ public class ViewTest implements Serializable {
                       c.output(i);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(11, 13, 17, 23, 11, 13, 17, 23);
 
@@ -240,7 +240,7 @@ public class ViewTest implements Serializable {
             .apply("MainWindowInto", Window.<Integer>into(FixedWindows.of(Duration.millis(10))))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     checkArgument(c.sideInput(view).size() == 4);
@@ -249,7 +249,7 @@ public class ViewTest implements Serializable {
                       c.output(i);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(11, 13, 17, 23, 31, 33, 37, 43);
 
@@ -267,14 +267,14 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertTrue(c.sideInput(view).isEmpty());
                     assertFalse(c.sideInput(view).iterator().hasNext());
                     c.output(1);
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -292,7 +292,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> output =
         pipeline.apply("CreateMainInput", Create.of(29))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     try {
@@ -319,7 +319,7 @@ public class ViewTest implements Serializable {
                       c.output(i);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(output).containsInAnyOrder(11);
@@ -338,14 +338,14 @@ public class ViewTest implements Serializable {
     PCollection<Integer> output =
         pipeline.apply("CreateMainInput", Create.of(29, 31))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (Integer i : c.sideInput(view)) {
                       c.output(i);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(11, 13, 17, 23, 11, 13, 17, 23);
 
@@ -377,14 +377,14 @@ public class ViewTest implements Serializable {
                     TimestampedValue.of(35, new Instant(11))))
             .apply("MainWindowInto", Window.<Integer>into(FixedWindows.of(Duration.millis(10))))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (Integer i : c.sideInput(view)) {
                       c.output(i);
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(11, 13, 17, 23, 31, 33, 37, 43);
 
@@ -402,13 +402,13 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertFalse(c.sideInput(view).iterator().hasNext());
                     c.output(1);
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -426,7 +426,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> output =
         pipeline.apply("CreateMainInput", Create.of(29))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     Iterator<Integer> iterator = c.sideInput(view).iterator();
@@ -439,7 +439,7 @@ public class ViewTest implements Serializable {
                       c.output(iterator.next());
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(output).containsInAnyOrder(11);
@@ -459,14 +459,14 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (Integer v : c.sideInput(view).get(c.element().substring(0, 1))) {
                       c.output(of(c.element(), v));
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("apple", 2), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -486,7 +486,7 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of(2 /* size */))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, KV<String, Integer>>() {
+                ParDo.of(new DoFn<Integer, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertEquals((int) c.element(), c.sideInput(view).size());
@@ -497,7 +497,7 @@ public class ViewTest implements Serializable {
                       }
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("a", 1), KV.of("a", 2), KV.of("b", 3));
@@ -539,14 +539,14 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (Integer v : c.sideInput(view).get(c.element().substring(0, 1))) {
                       c.output(of(c.element(), v));
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("apple", 2), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -574,7 +574,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of("banana", new Instant(13)),
                                               TimestampedValue.of("blackberry", new Instant(16))))
             .apply("MainWindowInto", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<String, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -584,7 +584,7 @@ public class ViewTest implements Serializable {
                                                  c.output(of(c.element(), v));
                                                }
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("apple", 2), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -611,7 +611,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of(1 /* size */, new Instant(5)),
                                               TimestampedValue.of(1 /* size */, new Instant(16))))
             .apply("MainWindowInto", Window.<Integer>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<Integer, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -626,7 +626,7 @@ public class ViewTest implements Serializable {
                                                  }
                                                }
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("a", 1), KV.of("a", 2), KV.of("b", 3));
@@ -655,7 +655,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of("banana", new Instant(13)),
                                               TimestampedValue.of("blackberry", new Instant(16))))
             .apply("MainWindowInto", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<String, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -665,7 +665,7 @@ public class ViewTest implements Serializable {
                                                  c.output(of(c.element(), v));
                                                }
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("apple", 2), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -685,7 +685,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertTrue(c.sideInput(view).isEmpty());
@@ -693,7 +693,7 @@ public class ViewTest implements Serializable {
                     assertFalse(c.sideInput(view).entrySet().iterator().hasNext());
                     c.output(c.element());
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -715,7 +715,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertTrue(c.sideInput(view).isEmpty());
@@ -723,7 +723,7 @@ public class ViewTest implements Serializable {
                     assertFalse(c.sideInput(view).entrySet().iterator().hasNext());
                     c.output(c.element());
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -743,7 +743,7 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     try {
@@ -770,7 +770,7 @@ public class ViewTest implements Serializable {
                       c.output(KV.of(c.element(), v));
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(output).containsInAnyOrder(KV.of("apple", 1));
@@ -790,13 +790,13 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(
                         of(c.element(), c.sideInput(view).get(c.element().substring(0, 1))));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -816,7 +816,7 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of(2 /* size */))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, KV<String, Integer>>() {
+                ParDo.of(new DoFn<Integer, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertEquals((int) c.element(), c.sideInput(view).size());
@@ -825,7 +825,7 @@ public class ViewTest implements Serializable {
                       c.output(KV.of(entry.getKey(), entry.getValue()));
                     }
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("a", 1), KV.of("b", 3));
@@ -847,13 +847,13 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(
                         of(c.element(), c.sideInput(view).get(c.element().substring(0, 1))));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -881,7 +881,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of("banana", new Instant(4)),
                                               TimestampedValue.of("blackberry", new Instant(16))))
             .apply("MainWindowInto", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<String, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -890,7 +890,7 @@ public class ViewTest implements Serializable {
                                                    c.sideInput(view).get(
                                                        c.element().substring(0, 1))));
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("banana", 2), KV.of("blackberry", 3));
@@ -917,7 +917,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of(2 /* size */, new Instant(5)),
                                               TimestampedValue.of(1 /* size */, new Instant(16))))
             .apply("MainWindowInto", Window.<Integer>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<Integer, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -930,7 +930,7 @@ public class ViewTest implements Serializable {
                                                  c.output(KV.of(entry.getKey(), entry.getValue()));
                                                }
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("a", 1), KV.of("b", 2), KV.of("b", 3));
@@ -961,7 +961,7 @@ public class ViewTest implements Serializable {
                                               TimestampedValue.of("banana", new Instant(4)),
                                               TimestampedValue.of("blackberry", new Instant(16))))
             .apply("MainWindowInto", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputSideInputs", ParDo.of(
                                            new DoFn<String, KV<String, Integer>>() {
                                              @ProcessElement
                                              public void processElement(ProcessContext c) {
@@ -970,7 +970,7 @@ public class ViewTest implements Serializable {
                                                    c.sideInput(view).get(
                                                        c.element().substring(0, 1))));
                                              }
-                                           }));
+                                           }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("banana", 2), KV.of("blackberry", 3));
@@ -991,7 +991,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertTrue(c.sideInput(view).isEmpty());
@@ -999,7 +999,7 @@ public class ViewTest implements Serializable {
                     assertFalse(c.sideInput(view).entrySet().iterator().hasNext());
                     c.output(c.element());
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -1019,7 +1019,7 @@ public class ViewTest implements Serializable {
     PCollection<Integer> results =
         pipeline.apply("Create1", Create.of(1))
             .apply("OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<Integer, Integer>() {
+                ParDo.of(new DoFn<Integer, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     assertTrue(c.sideInput(view).isEmpty());
@@ -1027,7 +1027,7 @@ public class ViewTest implements Serializable {
                     assertFalse(c.sideInput(view).entrySet().iterator().hasNext());
                     c.output(c.element());
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(results).containsInAnyOrder(1);
@@ -1052,13 +1052,13 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(
                         KV.of(c.element(), c.sideInput(view).get(c.element().substring(0, 1))));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 1), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -1082,7 +1082,7 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of("apple"))
             .apply(
                 "OutputSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     try {
@@ -1108,7 +1108,7 @@ public class ViewTest implements Serializable {
                     c.output(
                         KV.of(c.element(), c.sideInput(view).get(c.element().substring(0, 1))));
                   }
-                }));
+                }).withSideInputs(view));
 
     // Pass at least one value through to guarantee that DoFn executes.
     PAssert.that(output).containsInAnyOrder(KV.of("apple", 1));
@@ -1128,13 +1128,13 @@ public class ViewTest implements Serializable {
     PCollection<KV<String, Integer>> output =
         pipeline.apply("CreateMainInput", Create.of("apple", "banana", "blackberry"))
             .apply("Output",
-                ParDo.withSideInputs(view).of(new DoFn<String, KV<String, Integer>>() {
+                ParDo.of(new DoFn<String, KV<String, Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(KV
                         .of(c.element(), c.sideInput(view).get(c.element().substring(0, 1))));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(
         KV.of("apple", 21), KV.of("banana", 3), KV.of("blackberry", 3));
@@ -1161,13 +1161,13 @@ public class ViewTest implements Serializable {
                                        TimestampedValue.of("B", new Instant(15)),
                                        TimestampedValue.of("C", new Instant(7))))
             .apply("WindowMainInput", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputMainAndSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputMainAndSideInputs", ParDo.of(
                                                   new DoFn<String, String>() {
                                                     @ProcessElement
                                                     public void processElement(ProcessContext c) {
                                                       c.output(c.element() + c.sideInput(view));
                                                     }
-                                                  }));
+                                                  }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder("A1", "B5", "C1");
 
@@ -1193,13 +1193,13 @@ public class ViewTest implements Serializable {
                                        TimestampedValue.of("B", new Instant(15)),
                                        TimestampedValue.of("C", new Instant(7))))
             .apply("WindowMainInput", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputMainAndSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputMainAndSideInputs", ParDo.of(
                                                   new DoFn<String, String>() {
                                                     @ProcessElement
                                                     public void processElement(ProcessContext c) {
                                                       c.output(c.element() + c.sideInput(view));
                                                     }
-                                                  }));
+                                                  }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder("A6", "B6", "C6");
 
@@ -1223,13 +1223,13 @@ public class ViewTest implements Serializable {
                                        TimestampedValue.of("B", new Instant(15)),
                                        TimestampedValue.of("C", new Instant(7))))
             .apply("WindowMainInput", Window.<String>into(FixedWindows.of(Duration.millis(10))))
-            .apply("OutputMainAndSideInputs", ParDo.withSideInputs(view).of(
+            .apply("OutputMainAndSideInputs", ParDo.of(
                                                   new DoFn<String, String>() {
                                                     @ProcessElement
                                                     public void processElement(ProcessContext c) {
                                                       c.output(c.element() + c.sideInput(view));
                                                     }
-                                                  }));
+                                                  }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder("A0", "B5", "C0");
 
@@ -1253,12 +1253,12 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateMainInput", Create.of(""))
             .apply(
                 "OutputMainAndSideInputs",
-                ParDo.withSideInputs(view).of(new DoFn<String, String>() {
+                ParDo.of(new DoFn<String, String>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(c.element() + c.sideInput(view));
                   }
-                }));
+                }).withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder("null");
 
@@ -1282,18 +1282,18 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateVoid2", Create.of((Void) null).withCoder(VoidCoder.of()))
             .apply(
                 "OutputSideInput",
-                ParDo.withSideInputs(view1).of(new DoFn<Void, Iterable<Integer>>() {
+                ParDo.of(new DoFn<Void, Iterable<Integer>>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     c.output(c.sideInput(view1));
                   }
-                }))
+                }).withSideInputs(view1))
             .apply("View2", View.<Iterable<Integer>>asIterable());
 
     PCollection<Integer> output =
         pipeline.apply("CreateVoid3", Create.of((Void) null).withCoder(VoidCoder.of()))
             .apply("ReadIterableSideInput",
-                ParDo.withSideInputs(view2).of(new DoFn<Void, Integer>() {
+                ParDo.of(new DoFn<Void, Integer>() {
                   @ProcessElement
                   public void processElement(ProcessContext c) {
                     for (Iterable<Integer> input : c.sideInput(view2)) {
@@ -1302,7 +1302,7 @@ public class ViewTest implements Serializable {
                       }
                     }
                   }
-                }));
+                }).withSideInputs(view2));
 
     PAssert.that(output).containsInAnyOrder(17);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
@@ -59,8 +59,8 @@ public class TypedPValueTest {
     PCollection<Integer> input = p.apply(Create.of(1, 2, 3));
     PCollectionTuple tuple = input.apply(
         ParDo
-        .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag))
-        .of(new IdentityDoFn()));
+        .of(new IdentityDoFn())
+        .withOutputTags(mainOutputTag, TupleTagList.of(sideOutputTag)));
     return tuple;
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/TypedPValueTest.java
@@ -161,7 +161,7 @@ public class TypedPValueTest {
   public void testFinishSpecifyingShouldFailIfNoCoderInferrable() {
     p.enableAbandonedNodeEnforcement(false);
     PCollection<Integer> created = p.apply(Create.of(1, 2, 3));
-    ParDo.Bound<Integer, EmptyClass> uninferrableParDo = ParDo.of(new EmptyClassDoFn());
+    ParDo.SingleOutput<Integer, EmptyClass> uninferrableParDo = ParDo.of(new EmptyClassDoFn());
     PCollection<EmptyClass> unencodable =
         created.apply(uninferrableParDo);
 


### PR DESCRIPTION
Backward-incompatible changes:
* Removes ParDo.Unbound and UnboundMulti (as a result, the only entry point is ParDo.of(DoFn) - you can no longer specify ParDo.withSideInputs(...).of(fn) and such)
* Renames ParDo.Bound to ParDo.SingleOutput and ParDo.BoundMulti to ParDo.MultiOutput

R: @kennknowles 
CC: @davorbonaci @dhalperi 