### PR TITLE
[BEAM-1620] Maven config for streaming ValidatesRunner in Dataflow

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -81,6 +81,52 @@
     </profile>
   </profiles>
 
+  <profiles>
+    <!-- A profile that adds an integration test phase for streaming if and only if
+         the streamingValidatesRunnerPipelineOptions maven property has been set.
+         It should be set to a valid PipelineOptions JSON string. -->
+    <profile>
+      <id>streaming-runnable-on-service-tests</id>
+      <activation>
+        <property><name>streamingValidatesRunnerPipelineOptions</name></property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <executions>
+
+                <!-- Execution in addition to the default runnable-on-service-tests execution -->
+                <execution>
+                  <id>streaming-runnable-on-service-tests</id>
+                  <phase>integration-test</phase>
+                  <goals>
+                    <goal>test</goal>
+                  </goals>
+                  <configuration>
+                    <groups>org.apache.beam.sdk.testing.RunnableOnService</groups>
+                    <parallel>all</parallel>
+                    <threadCount>4</threadCount>
+                    <dependenciesToScan>
+                      <dependency>org.apache.beam:beam-sdks-java-core</dependency>
+                    </dependenciesToScan>
+                    <systemPropertyVariables>
+                      <beamTestPipelineOptions>
+                        ${streamingRunnableOnServicePipelineOptions}
+                      </beamTestPipelineOptions>
+                    </systemPropertyVariables>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <resources>
       <resource>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

@jasonkuster this is essentially an inlining of the configuration for batch. Notes:

 - I'd love to just provide `-D beamTestPipelineOptions=...` and have things automatically just add `--streaming=true` and `--streaming=false` but don't know that you can do that effectively in a POM.
 - Setting `parallel=all` and `threadCount=4` I did manage to get a 429, which surprised me. TBD why that happens; something is not blocking when it should and/or leaking jobs.

CC @davorbonaci in case you have any vision for the right way for this config to get into the project.