### PR TITLE
[BEAM-1743] Use CreatePCollectionView explicitly in CombineGloballyAsSingletonView

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -342,9 +342,11 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               "The DataflowRunner in batch mode does not support Read.Unbounded"));
       ptoverrides
           // State and timer pardos are implemented by expansion to GBK-then-ParDo
-          .put(PTransformMatchers.stateOrTimerParDoMulti(),
+          .put(
+              PTransformMatchers.stateOrTimerParDoMulti(),
               BatchStatefulParDoOverrides.multiOutputOverrideFactory())
-          .put(PTransformMatchers.stateOrTimerParDoSingle(),
+          .put(
+              PTransformMatchers.stateOrTimerParDoSingle(),
               BatchStatefulParDoOverrides.singleOutputOverrideFactory())
 
           // Write uses views internally
@@ -356,6 +358,9 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               PTransformMatchers.classEqualTo(View.AsMultimap.class),
               new ReflectiveOneToOneOverrideFactory(
                   BatchViewOverrides.BatchViewAsMultimap.class, this))
+          .put(
+              PTransformMatchers.classEqualTo(Combine.GloballyAsSingletonView.class),
+              new BatchViewOverrides.BatchCombineGloballyAsSingletonViewFactory(this))
           .put(
               PTransformMatchers.classEqualTo(View.AsSingleton.class),
               new ReflectiveOneToOneOverrideFactory(

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -792,12 +792,24 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     assertAllStepOutputsHaveUniqueIds(job);
 
     List<Step> steps = job.getSteps();
-    assertEquals(2, steps.size());
+    assertEquals(6, steps.size());
 
     Step createStep = steps.get(0);
     assertEquals("ParallelRead", createStep.getKind());
 
-    Step collectionToSingletonStep = steps.get(1);
+    Step addNullKeyStep = steps.get(1);
+    assertEquals("ParallelDo", addNullKeyStep.getKind());
+
+    Step groupByKeyStep = steps.get(2);
+    assertEquals("GroupByKey", groupByKeyStep.getKind());
+
+    Step combineGroupedValuesStep = steps.get(3);
+    assertEquals("ParallelDo", combineGroupedValuesStep.getKind());
+
+    Step dropKeysStep = steps.get(4);
+    assertEquals("ParallelDo", dropKeysStep.getKind());
+
+    Step collectionToSingletonStep = steps.get(5);
     assertEquals("CollectionToSingleton", collectionToSingletonStep.getKind());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformTreeTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/TransformTreeTest.java
@@ -64,7 +64,7 @@ public class TransformTreeTest {
   enum TransformsSeen {
     READ,
     WRITE,
-    COMBINE_GLOBALLY
+    SAMPLE
   }
 
   /**
@@ -112,8 +112,6 @@ public class TransformTreeTest {
     }
   }
 
-  // Builds a pipeline containing a composite operation (Pick), then
-  // visits the nodes and verifies that the hierarchy was captured.
   @Test
   public void testCompositeCapture() throws Exception {
     p.enableAbandonedNodeEnforcement(false);
@@ -121,8 +119,10 @@ public class TransformTreeTest {
     File inputFile = tmpFolder.newFile();
     File outputFile = tmpFolder.newFile();
 
+    final PTransform<PCollection<String>, PCollection<Iterable<String>>> sample =
+        Sample.fixedSizeGlobally(10);
     p.apply("ReadMyFile", TextIO.Read.from(inputFile.getPath()))
-        .apply(Combine.globally(Sample.<String>combineFn(10)))
+        .apply(sample)
         .apply(Flatten.<String>iterables())
         .apply("WriteMyFile", TextIO.Write.to(outputFile.getPath()));
 
@@ -131,46 +131,50 @@ public class TransformTreeTest {
     final EnumSet<TransformsSeen> left =
         EnumSet.noneOf(TransformsSeen.class);
 
-    p.traverseTopologically(new Pipeline.PipelineVisitor.Defaults() {
-      @Override
-      public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
-        PTransform<?, ?> transform = node.getTransform();
-        if (transform instanceof Combine.Globally) {
-          assertTrue(visited.add(TransformsSeen.COMBINE_GLOBALLY));
-          assertNotNull(node.getEnclosingNode());
-          assertTrue(node.isCompositeNode());
-        } else if (transform instanceof Write) {
-          assertTrue(visited.add(TransformsSeen.WRITE));
-          assertNotNull(node.getEnclosingNode());
-          assertTrue(node.isCompositeNode());
-        }
-        assertThat(transform, not(instanceOf(Read.Bounded.class)));
-        return CompositeBehavior.ENTER_TRANSFORM;
-      }
+    p.traverseTopologically(
+        new Pipeline.PipelineVisitor.Defaults() {
+          @Override
+          public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
+            if (node.isRootNode()) {
+              return CompositeBehavior.ENTER_TRANSFORM;
+            }
+            PTransform<?, ?> transform = node.getTransform();
+            if (sample.getClass().equals(transform.getClass())) {
+              assertTrue(visited.add(TransformsSeen.SAMPLE));
+              assertNotNull(node.getEnclosingNode());
+              assertTrue(node.isCompositeNode());
+            } else if (transform instanceof Write) {
+              assertTrue(visited.add(TransformsSeen.WRITE));
+              assertNotNull(node.getEnclosingNode());
+              assertTrue(node.isCompositeNode());
+            }
+            assertThat(transform, not(instanceOf(Read.Bounded.class)));
+            return CompositeBehavior.ENTER_TRANSFORM;
+          }
 
-      @Override
-      public void leaveCompositeTransform(TransformHierarchy.Node node) {
-        PTransform<?, ?> transform = node.getTransform();
-        if (transform instanceof Combine.Globally) {
-          assertTrue(left.add(TransformsSeen.COMBINE_GLOBALLY));
-        }
-      }
+          @Override
+          public void leaveCompositeTransform(TransformHierarchy.Node node) {
+            PTransform<?, ?> transform = node.getTransform();
+            if (!node.isRootNode() && transform.getClass().equals(sample.getClass())) {
+              assertTrue(left.add(TransformsSeen.SAMPLE));
+            }
+          }
 
-      @Override
-      public void visitPrimitiveTransform(TransformHierarchy.Node node) {
-        PTransform<?, ?> transform = node.getTransform();
-        // Pick is a composite, should not be visited here.
-        assertThat(transform, not(instanceOf(Combine.Globally.class)));
-        assertThat(transform, not(instanceOf(Write.class)));
-        if (transform instanceof Read.Bounded
-            && node.getEnclosingNode().getTransform() instanceof TextIO.Read.Bound) {
-          assertTrue(visited.add(TransformsSeen.READ));
-        }
-      }
-    });
+          @Override
+          public void visitPrimitiveTransform(TransformHierarchy.Node node) {
+            PTransform<?, ?> transform = node.getTransform();
+            // Pick is a composite, should not be visited here.
+            assertThat(transform, not(instanceOf(Combine.Globally.class)));
+            assertThat(transform, not(instanceOf(Write.class)));
+            if (transform instanceof Read.Bounded
+                && node.getEnclosingNode().getTransform() instanceof TextIO.Read.Bound) {
+              assertTrue(visited.add(TransformsSeen.READ));
+            }
+          }
+        });
 
     assertTrue(visited.equals(EnumSet.allOf(TransformsSeen.class)));
-    assertTrue(left.equals(EnumSet.of(TransformsSeen.COMBINE_GLOBALLY)));
+    assertTrue(left.equals(EnumSet.of(TransformsSeen.SAMPLE)));
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Implement View.asSingleton as a CombineGloballyAsSingletonView.

This stops any writing of a SingletonView that is not actually a
Singleton View. - i.e. the contents (which can never be read) cannot
be provided to the View.CreatePCollectionView transform, as they must
go through a combiner before they arrive.