### PR TITLE
[BEAM-1495] Removes PTransformMatchers for ParDo.Bound

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -66,49 +66,10 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.Bound} containing a {@link DoFn} that
-   * is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
-   */
-  public static PTransformMatcher splittableParDoSingle() {
-    return new PTransformMatcher() {
-      @Override
-      public boolean matches(AppliedPTransform<?, ?, ?> application) {
-        PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.Bound) {
-          DoFn<?, ?> fn = ((ParDo.Bound<?, ?>) transform).getFn();
-          DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
-          return signature.processElement().isSplittable();
-        }
-        return false;
-      }
-    };
-  }
-
-  /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.Bound} containing a {@link DoFn} that
-   * uses state or timers, as specified by {@link DoFnSignature#usesState()} and
-   * {@link DoFnSignature#usesTimers()}.
-   */
-  public static PTransformMatcher stateOrTimerParDoSingle() {
-    return new PTransformMatcher() {
-      @Override
-      public boolean matches(AppliedPTransform<?, ?, ?> application) {
-        PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.Bound) {
-          DoFn<?, ?> fn = ((ParDo.Bound<?, ?>) transform).getFn();
-          DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
-          return signature.usesState() || signature.usesTimers();
-        }
-        return false;
-      }
-    };
-  }
-
-  /**
    * A {@link PTransformMatcher} that matches a {@link ParDo.BoundMulti} containing a {@link DoFn}
    * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */
-  public static PTransformMatcher splittableParDoMulti() {
+  public static PTransformMatcher splittableParDo() {
     return new PTransformMatcher() {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
@@ -128,7 +89,7 @@ public class PTransformMatchers {
    * that uses state or timers, as specified by {@link DoFnSignature#usesState()} and
    * {@link DoFnSignature#usesTimers()}.
    */
-  public static PTransformMatcher stateOrTimerParDoMulti() {
+  public static PTransformMatcher stateOrTimerParDo() {
     return new PTransformMatcher() {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -190,96 +190,44 @@ public class PTransformMatchersTest implements Serializable {
         }
       };
 
-  /**
-   * Demonstrates that a {@link ParDo.Bound} does not match any ParDo matcher.
-   */
   @Test
-  public void parDoSingle() {
-    AppliedPTransform<?, ?, ?> parDoApplication = getAppliedTransform(ParDo.of(doFn));
-
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
-  }
-
-  @Test
-  public void parDoSingleSplittable() {
-    AppliedPTransform<?, ?, ?> parDoApplication = getAppliedTransform(ParDo.of(splittableDoFn));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(true));
-
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
-  }
-
-  @Test
-  public void parDoSingleWithState() {
-    AppliedPTransform<?, ?, ?> parDoApplication = getAppliedTransform(ParDo.of(doFnWithState));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(true));
-
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-  }
-
-  @Test
-  public void parDoSingleWithTimers() {
-    AppliedPTransform<?, ?, ?> parDoApplication =
-        getAppliedTransform(ParDo.of(doFnWithTimers));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(true));
-
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-  }
-
-  @Test
-  public void parDoMulti() {
+  public void parDo() {
     AppliedPTransform<?, ?, ?> parDoApplication =
         getAppliedTransform(
             ParDo.of(doFn).withOutputTags(new TupleTag<Integer>(), TupleTagList.empty()));
 
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
+    assertThat(PTransformMatchers.splittableParDo().matches(parDoApplication), is(false));
+    assertThat(PTransformMatchers.stateOrTimerParDo().matches(parDoApplication), is(false));
   }
 
   @Test
-  public void parDoMultiSplittable() {
+  public void parDoSplittable() {
     AppliedPTransform<?, ?, ?> parDoApplication =
         getAppliedTransform(
             ParDo.of(splittableDoFn).withOutputTags(new TupleTag<Integer>(), TupleTagList.empty()));
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(true));
+    assertThat(PTransformMatchers.splittableParDo().matches(parDoApplication), is(true));
 
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
+    assertThat(PTransformMatchers.stateOrTimerParDo().matches(parDoApplication), is(false));
   }
 
   @Test
-  public void parDoMultiWithState() {
+  public void parDoWithState() {
     AppliedPTransform<?, ?, ?> parDoApplication =
         getAppliedTransform(
             ParDo.of(doFnWithState).withOutputTags(new TupleTag<Integer>(), TupleTagList.empty()));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(true));
+    assertThat(PTransformMatchers.stateOrTimerParDo().matches(parDoApplication), is(true));
 
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
+    assertThat(PTransformMatchers.splittableParDo().matches(parDoApplication), is(false));
   }
 
   @Test
-  public void parDoMultiWithTimers() {
+  public void parDoWithTimers() {
     AppliedPTransform<?, ?, ?> parDoApplication =
         getAppliedTransform(
             ParDo.of(doFnWithTimers).withOutputTags(new TupleTag<Integer>(), TupleTagList.empty()));
-    assertThat(PTransformMatchers.stateOrTimerParDoMulti().matches(parDoApplication), is(true));
+    assertThat(PTransformMatchers.stateOrTimerParDo().matches(parDoApplication), is(true));
 
-    assertThat(PTransformMatchers.splittableParDoMulti().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.splittableParDoSingle().matches(parDoApplication), is(false));
-    assertThat(PTransformMatchers.stateOrTimerParDoSingle().matches(parDoApplication), is(false));
+    assertThat(PTransformMatchers.splittableParDo().matches(parDoApplication), is(false));
   }
 
   @Test
@@ -289,14 +237,12 @@ public class PTransformMatchersTest implements Serializable {
       public void process(ProcessContext ctxt) {
       }
     };
-    AppliedPTransform<?, ?, ?> parDoSingle = getAppliedTransform(ParDo.of(fn));
-    AppliedPTransform<?, ?, ?> parDoMulti =
+    AppliedPTransform<?, ?, ?> parDo =
         getAppliedTransform(
             ParDo.of(fn).withOutputTags(new TupleTag<Object>(), TupleTagList.empty()));
 
     PTransformMatcher matcher = PTransformMatchers.parDoWithFnType(fn.getClass());
-    assertThat(matcher.matches(parDoSingle), is(true));
-    assertThat(matcher.matches(parDoMulti), is(true));
+    assertThat(matcher.matches(parDo), is(true));
   }
 
   @Test
@@ -306,14 +252,12 @@ public class PTransformMatchersTest implements Serializable {
       public void process(ProcessContext ctxt) {
       }
     };
-    AppliedPTransform<?, ?, ?> parDoSingle = getAppliedTransform(ParDo.of(fn));
-    AppliedPTransform<?, ?, ?> parDoMulti =
+    AppliedPTransform<?, ?, ?> parDo =
         getAppliedTransform(
             ParDo.of(fn).withOutputTags(new TupleTag<Object>(), TupleTagList.empty()));
 
     PTransformMatcher matcher = PTransformMatchers.parDoWithFnType(doFnWithState.getClass());
-    assertThat(matcher.matches(parDoSingle), is(false));
-    assertThat(matcher.matches(parDoMulti), is(false));
+    assertThat(matcher.matches(parDo), is(false));
   }
 
   @Test

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -333,9 +333,9 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
             PTransformMatchers.classEqualTo(TestStream.class),
             new DirectTestStreamFactory(this)) /* primitive */
         // SplittableParDo is implemented in terms of GroupByKeys and Primitives
-        .put(PTransformMatchers.splittableParDoMulti(), new ParDoMultiOverrideFactory())
+        .put(PTransformMatchers.splittableParDo(), new ParDoMultiOverrideFactory())
         // state and timer ParDos are implemented in terms of GroupByKeys and Primitives
-        .put(PTransformMatchers.stateOrTimerParDoMulti(), new ParDoMultiOverrideFactory())
+        .put(PTransformMatchers.stateOrTimerParDo(), new ParDoMultiOverrideFactory())
         .put(
             PTransformMatchers.classEqualTo(GBKIntoKeyedWorkItems.class),
             new DirectGBKIntoKeyedWorkItemsOverrideFactory()) /* Returns a GBKO */

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -342,10 +342,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               "The DataflowRunner in batch mode does not support Read.Unbounded"));
       ptoverrides
           // State and timer pardos are implemented by expansion to GBK-then-ParDo
-          .put(PTransformMatchers.stateOrTimerParDoMulti(),
-              BatchStatefulParDoOverrides.multiOutputOverrideFactory())
-          .put(PTransformMatchers.stateOrTimerParDoSingle(),
-              BatchStatefulParDoOverrides.singleOutputOverrideFactory())
+          .put(PTransformMatchers.stateOrTimerParDo(),
+              BatchStatefulParDoOverrides.overrideFactory())
 
           // Write uses views internally
           .put(PTransformMatchers.classEqualTo(Write.class), new BatchWriteFactory(this))


### PR DESCRIPTION
No longer necessary after ParDo.Bound is always translated to BoundMulti.

R: @tgroh 