### PR TITLE
Update Guava version from 19.0 to 20.0 in the example projects

### DIFF
--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -270,7 +270,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0</version>
     </dependency>
 
     <!-- Add slf4j API frontend binding with JUL backend -->

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -316,7 +316,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>20.0</version>
     </dependency>
 
     <!-- Add slf4j API frontend binding with JUL backend -->


### PR DESCRIPTION
The Guava version was updated in the main project on January 19.

Before this change, generated examples would downgrade Guava back to 19.0, possibly causing execution issues if the underlying code actually needs functionality added in Guava 20. In fact, last week Flink runner added such functionality, breaking Quickstart and WordCount on the Flink runner.

R: @francesperry 