### PR TITLE
[BEAM-1184] Add integration tests for ElasticsearchIO

### DIFF
--- a/sdks/java/io/elasticsearch/pom.xml
+++ b/sdks/java/io/elasticsearch/pom.xml
@@ -86,6 +86,11 @@
       <version>4.5.2</version>
     </dependency>
 
+    <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+
     <!-- compile dependencies -->
     <dependency>
       <groupId>com.google.auto.value</groupId>

--- a/sdks/java/io/elasticsearch/src/test/contrib/create_elk_container.sh
+++ b/sdks/java/io/elasticsearch/src/test/contrib/create_elk_container.sh
@@ -22,16 +22,3 @@
 #bind then on host ports, allow shell access to container and mount current directory on /home/$USER inside the container
 
 docker create -p 5601:5601 -p 9200:9200 -p 5044:5044 -p 5000:5000 -p 9300:9300 -it -v $(pwd):/home/$USER/ --name elk-2.4  sebp/elk:es240_l240_k460
-
-
-#Create an ELK (Elasticsearch Logstash Kibana) container for ES v5.0 and compatible Logstash and Kibana versions,
-#bind then on host ports, allow shell access to container and mount current directory on /home/$USER inside the container
-
-docker create -p 5601:5601 -p 9200:9200 -p 5044:5044 -p 5000:5000 -p 9300:9300 -it -v $(pwd):/home/$USER/ --name elk-5.0  sebp/elk:es500_l500_k500
-
-# set system vm.max_map_count to the minimal value acceptable by ES 5.0
-echo "increasing virtual memory for ES 5.0 ..."
-sudo sysctl -w vm.max_map_count=262144
-cp /etc/sysctl.conf /tmp/sysctl.conf
-echo "vm.max_map_count=262144" >> /tmp/sysctl.conf
-sudo cp /tmp/sysctl.conf /etc/sysctl.conf

--- a/sdks/java/io/elasticsearch/src/test/contrib/create_elk_container.sh
+++ b/sdks/java/io/elasticsearch/src/test/contrib/create_elk_container.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#Create an ELK (Elasticsearch Logstash Kibana) container for ES v2.4 and compatible Logstash and Kibana versions,
+#bind then on host ports, allow shell access to container and mount current directory on /home/$USER inside the container
+
+docker create -p 5601:5601 -p 9200:9200 -p 5044:5044 -p 5000:5000 -p 9300:9300 -it -v $(pwd):/home/$USER/ --name elk-2.4  sebp/elk:es240_l240_k460
+
+
+#Create an ELK (Elasticsearch Logstash Kibana) container for ES v5.0 and compatible Logstash and Kibana versions,
+#bind then on host ports, allow shell access to container and mount current directory on /home/$USER inside the container
+
+docker create -p 5601:5601 -p 9200:9200 -p 5044:5044 -p 5000:5000 -p 9300:9300 -it -v $(pwd):/home/$USER/ --name elk-5.0  sebp/elk:es500_l500_k500
+
+# set system vm.max_map_count to the minimal value acceptable by ES 5.0
+echo "increasing virtual memory for ES 5.0 ..."
+sudo sysctl -w vm.max_map_count=262144
+cp /etc/sysctl.conf /tmp/sysctl.conf
+echo "vm.max_map_count=262144" >> /tmp/sysctl.conf
+sudo cp /tmp/sysctl.conf /etc/sysctl.conf

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -40,8 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A test of {@link ElasticsearchIO} on an independent
- * Elasticsearch instance.
+ * A test of {@link ElasticsearchIO} on an independent Elasticsearch instance.
  *
  * <p>This test requires a running instance of Elasticsearch, and the test dataset must exist in the
  * database.
@@ -54,10 +53,8 @@ import org.slf4j.LoggerFactory;
  *  "--elasticsearchHttpPort=9200",
  *  "--elasticsearchTcpPort=9300" ]'
  * </pre>
- *
  */
 public class ElasticsearchIOIT {
-  private static final int AVERAGE_DOC_SIZE = 25;
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchIOIT.class);
   private static TransportClient client;
   private static ElasticsearchTestOptions options;
@@ -106,7 +103,6 @@ public class ElasticsearchIOIT {
   }
 
   @Test
-//  @Category(RunnableOnService.class)
   public void testReadVolume() throws Exception {
     PCollection<String> output =
         pipeline.apply(
@@ -117,7 +113,6 @@ public class ElasticsearchIOIT {
   }
 
   @Test
-//  @Category(RunnableOnService.class)
   public void testWriteVolume() throws Exception {
     ElasticsearchIO.ConnectionConfiguration writeConnectionConfiguration =
         ElasticsearchTestDataSet.getConnectionConfiguration(
@@ -148,8 +143,12 @@ public class ElasticsearchIOIT {
     long estimatedSize = initialSource.getEstimatedSizeBytes(options);
     LOGGER.info("Estimated size: {}", estimatedSize);
     assertThat(
-        "Wrong estimated size",
+        "Wrong estimated size bellow minimum",
         estimatedSize,
-        greaterThan(AVERAGE_DOC_SIZE * ElasticsearchTestDataSet.NUM_DOCS));
+        greaterThan(ElasticsearchTestDataSet.AVERAGE_DOC_SIZE * ElasticsearchTestDataSet.NUM_DOCS));
+    assertThat(
+        "Wrong estimated size beyond maximum",
+        estimatedSize,
+        greaterThan(ElasticsearchTestDataSet.MAX_DOC_SIZE * ElasticsearchTestDataSet.NUM_DOCS));
   }
 }

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
-import org.apache.beam.sdk.testing.RunnableOnService;
 import org.apache.beam.sdk.testing.SourceTestUtils;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
@@ -37,7 +36,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,7 +106,7 @@ public class ElasticsearchIOIT {
   }
 
   @Test
-  @Category(RunnableOnService.class)
+//  @Category(RunnableOnService.class)
   public void testReadVolume() throws Exception {
     PCollection<String> output =
         pipeline.apply(
@@ -119,7 +117,7 @@ public class ElasticsearchIOIT {
   }
 
   @Test
-  @Category(RunnableOnService.class)
+//  @Category(RunnableOnService.class)
   public void testWriteVolume() throws Exception {
     ElasticsearchIO.ConnectionConfiguration writeConnectionConfiguration =
         ElasticsearchTestDataSet.getConnectionConfiguration(

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -88,10 +88,14 @@ public class ElasticsearchIOIT {
         ElasticsearchIO.read().withConnectionConfiguration(readConnectionConfiguration);
     ElasticsearchIO.BoundedElasticsearchSource initialSource =
         new ElasticsearchIO.BoundedElasticsearchSource(read, null);
+    //desiredBundleSize is ignored because in ES 2.x there is no way to split shards. So we get
+    // as many bundles as ES shards and bundle size is shard size
     long desiredBundleSizeBytes = 0;
     List<? extends BoundedSource<String>> splits =
         initialSource.splitIntoBundles(desiredBundleSizeBytes, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
+    //this is the number of ES shards
+    // (By default, each index in Elasticsearch is allocated 5 primary shards)
     long expectedNumSplits = 5;
     assertEquals(expectedNumSplits, splits.size());
     int nonEmptySplits = 0;

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.elasticsearch;
+
+import static org.apache.beam.sdk.testing.SourceTestUtils.readFromSource;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.RunnableOnService;
+import org.apache.beam.sdk.testing.SourceTestUtils;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.elasticsearch.client.transport.TransportClient;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A test of {@link ElasticsearchIO} on an independent
+ * Elasticsearch instance.
+ *
+ * <p>This test requires a running instance of Elasticsearch, and the test dataset must exist in the
+ * database.
+ *
+ * <p>You can run this test by doing the following from the beam parent module directory:
+ *
+ * <pre>
+ *  mvn -e -Pio-it verify -pl sdks/java/io/elasticsearch -DintegrationTestPipelineOptions='[
+ *  "--elasticsearchServer=1.2.3.4",
+ *  "--elasticsearchHttpPort=9200",
+ *  "--elasticsearchTcpPort=9300" ]'
+ * </pre>
+ *
+ */
+public class ElasticsearchIOIT {
+  private static final int AVERAGE_DOC_SIZE = 25;
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchIOIT.class);
+  private static TransportClient client;
+  private static ElasticsearchTestOptions options;
+  private static ElasticsearchIO.ConnectionConfiguration readConnectionConfiguration;
+  @Rule public TestPipeline pipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    PipelineOptionsFactory.register(ElasticsearchTestOptions.class);
+    options = TestPipeline.testingPipelineOptions().as(ElasticsearchTestOptions.class);
+    client = ElasticsearchTestDataSet.getClient(options);
+    readConnectionConfiguration =
+        ElasticsearchTestDataSet.getConnectionConfiguration(
+            options, ElasticsearchTestDataSet.ReadOrWrite.READ);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    ElasticsearchTestDataSet.deleteIndex(client, ElasticsearchTestDataSet.ReadOrWrite.WRITE);
+    client.close();
+  }
+
+  @Test
+  public void testSplitsVolume() throws Exception {
+    ElasticsearchIO.Read read =
+        ElasticsearchIO.read().withConnectionConfiguration(readConnectionConfiguration);
+    ElasticsearchIO.BoundedElasticsearchSource initialSource =
+        new ElasticsearchIO.BoundedElasticsearchSource(read, null);
+    long desiredBundleSizeBytes = 0;
+    List<? extends BoundedSource<String>> splits =
+        initialSource.splitIntoBundles(desiredBundleSizeBytes, options);
+    SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
+    long expectedNumSplits = 5;
+    assertEquals(expectedNumSplits, splits.size());
+    int nonEmptySplits = 0;
+    for (BoundedSource<String> subSource : splits) {
+      if (readFromSource(subSource, options).size() > 0) {
+        nonEmptySplits += 1;
+      }
+    }
+    assertEquals(expectedNumSplits, nonEmptySplits);
+  }
+
+  @Test
+  @Category(RunnableOnService.class)
+  public void testReadVolume() throws Exception {
+    PCollection<String> output =
+        pipeline.apply(
+            ElasticsearchIO.read().withConnectionConfiguration(readConnectionConfiguration));
+    PAssert.thatSingleton(output.apply("Count", Count.<String>globally()))
+        .isEqualTo(ElasticsearchTestDataSet.NUM_DOCS);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(RunnableOnService.class)
+  public void testWriteVolume() throws Exception {
+    ElasticsearchIO.ConnectionConfiguration writeConnectionConfiguration =
+        ElasticsearchTestDataSet.getConnectionConfiguration(
+            options, ElasticsearchTestDataSet.ReadOrWrite.WRITE);
+    List<String> data =
+        ElasticSearchIOTestUtils.createDocuments(
+            ElasticsearchTestDataSet.NUM_DOCS,
+            ElasticSearchIOTestUtils.InjectionMode.DO_NOT_INJECT_INVALID_DOCS);
+    pipeline
+        .apply(Create.of(data))
+        .apply(ElasticsearchIO.write().withConnectionConfiguration(writeConnectionConfiguration));
+    pipeline.run();
+
+    long currentNumDocs =
+        ElasticSearchIOTestUtils.upgradeIndexAndGetCurrentNumDocs(
+            ElasticsearchTestDataSet.ES_INDEX, ElasticsearchTestDataSet.ES_TYPE, client);
+    assertEquals(ElasticsearchTestDataSet.NUM_DOCS, currentNumDocs);
+  }
+
+  @Test
+  public void testEstimatedSizesVolume() throws Exception {
+    ElasticsearchIO.Read read =
+        ElasticsearchIO.read().withConnectionConfiguration(readConnectionConfiguration);
+    ElasticsearchIO.BoundedElasticsearchSource initialSource =
+        new ElasticsearchIO.BoundedElasticsearchSource(read, null);
+    // can't use equal assert as Elasticsearch indexes never have same size
+    // (due to internal Elasticsearch implementation)
+    long estimatedSize = initialSource.getEstimatedSizeBytes(options);
+    LOGGER.info("Estimated size: {}", estimatedSize);
+    assertThat(
+        "Wrong estimated size",
+        estimatedSize,
+        greaterThan(AVERAGE_DOC_SIZE * ElasticsearchTestDataSet.NUM_DOCS));
+  }
+}

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
@@ -35,6 +35,8 @@ public class ElasticsearchTestDataSet {
   public static final String ES_INDEX = "beam";
   public static final String ES_TYPE = "test";
   public static final long NUM_DOCS = 60000;
+  public static final int AVERAGE_DOC_SIZE = 25;
+  public static final int MAX_DOC_SIZE = 35;
   private static String writeIndex = ES_INDEX + org.joda.time.Instant.now().getMillis();
 
   /**

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
@@ -1,0 +1,90 @@
+package org.apache.beam.sdk.io.elasticsearch;
+
+import static java.net.InetAddress.getByName;
+
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+
+/**
+ * Manipulates test data used by the {@link ElasticsearchIO}
+ * integration tests.
+ *
+ * <p>This is independent from the tests so that for read tests it can be run separately after data
+ * store creation rather than every time (which can be more fragile.)
+ */
+public class ElasticsearchTestDataSet {
+
+  public static final String ES_INDEX = "beam";
+  public static final String ES_TYPE = "test";
+  public static final long NUM_DOCS = 60000;
+  private static String writeIndex = ES_INDEX + org.joda.time.Instant.now().getMillis();
+
+  /**
+   * Use this to create the index for reading before IT read tests.
+   *
+   * <p>To invoke this class, you can use this command line from elasticsearch io module directory:
+   *
+   * <pre>
+   * mvn test-compile exec:java \
+   * -Dexec.mainClass=org.apache.beam.sdk.io.elasticsearch.ElasticsearchTestDataSet \
+   *   -Dexec.args="--elasticsearchServer=1.2.3.4 \
+   *  --elasticsearchHttpPort=9200 \
+   *  --elasticsearchTcpPort=9300" \
+   *   -Dexec.classpathScope=test
+   *   </pre>
+   *
+   * @param args Please pass options from ElasticsearchTestOptions used for connection to
+   *     Elasticsearch as shown above.
+   */
+  public static void main(String[] args) throws Exception {
+    PipelineOptionsFactory.register(ElasticsearchTestOptions.class);
+    ElasticsearchTestOptions options =
+        PipelineOptionsFactory.fromArgs(args).as(ElasticsearchTestOptions.class);
+
+    createAndPopulateIndex(getClient(options), ReadOrWrite.READ);
+  }
+
+  private static void createAndPopulateIndex(TransportClient client, ReadOrWrite rOw)
+      throws Exception {
+    // automatically creates the index and insert docs
+    ElasticSearchIOTestUtils.insertTestDocuments(
+        (rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex, ES_TYPE, NUM_DOCS, client);
+  }
+
+  public static TransportClient getClient(ElasticsearchTestOptions options) throws Exception {
+    TransportClient client =
+        TransportClient.builder()
+            .build()
+            .addTransportAddress(
+                new InetSocketTransportAddress(
+                    getByName(options.getElasticsearchServer()),
+                    Integer.valueOf(options.getElasticsearchTcpPort())));
+    return client;
+  }
+
+  public static ElasticsearchIO.ConnectionConfiguration getConnectionConfiguration(
+      ElasticsearchTestOptions options, ReadOrWrite rOw) {
+    ElasticsearchIO.ConnectionConfiguration connectionConfiguration =
+        ElasticsearchIO.ConnectionConfiguration.create(
+            new String[] {
+              "http://"
+                  + options.getElasticsearchServer()
+                  + ":"
+                  + options.getElasticsearchHttpPort()
+            },
+            (rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex,
+            ES_TYPE);
+    return connectionConfiguration;
+  };
+
+  public static void deleteIndex(TransportClient client, ReadOrWrite rOw) throws Exception {
+    ElasticSearchIOTestUtils.deleteIndex((rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex, client);
+  }
+
+  /** Enum that tells whether we use the index for reading or for writing. */
+  public enum ReadOrWrite {
+    READ,
+    WRITE
+  }
+}

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io.elasticsearch;
 
 import static java.net.InetAddress.getByName;

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestOptions.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestOptions.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.elasticsearch;
+
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+
+/**
+ * These options can be used by a test connecting to an Elasticsearch instance to configure their
+ * connection.
+ */
+
+public interface ElasticsearchTestOptions extends TestPipelineOptions {
+    @Description("Server name for Elasticsearch server (host name/ip address)")
+    @Default.String("elasticsearch-server-name")
+    String getElasticsearchServer();
+    void setElasticsearchServer(String value);
+
+
+    @Description("Http port for elasticsearch server")
+    @Default.Integer(9200)
+    Integer getElasticsearchHttpPort();
+    void setElasticsearchHttpPort(Integer value);
+
+    @Description("Tcp port for elasticsearch server")
+    @Default.Integer(9300)
+    Integer getElasticsearchTcpPort();
+    void setElasticsearchTcpPort(Integer value);
+
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
R: @ssisk 
R: @jbonofre 

These are integration tests for ElasticsearchIO. They are conform to integration tests architecture discussed in the ML and in JDBCIO IT: 
- they do not insert test dataset during the test, they insert it in java standalone
- they use  pipelineOptions
- they read and write test in different indexes
- they clean after test case and not before each test
- they introduce ElasticsearchTestDataset