### PR TITLE
Update python SDK version to the next version.

### DIFF
--- a/sdks/python/apache_beam/version.py
+++ b/sdks/python/apache_beam/version.py
@@ -21,7 +21,7 @@
 import re
 
 
-__version__ = '0.6.0.dev'
+__version__ = '0.7.0.dev'
 
 
 # The following utilities are legacy code from the Maven integration;


### PR DESCRIPTION
This is a gap in the release process. I am making this change manually now.

@sb2nov Could you open a an issue for this.  (Resolving https://issues.apache.org/jira/browse/BEAM-378 would also resolve this issue. And now I am more convinced that the pysdk should just use the version from the pom file.)

R: @davorbonaci 