### PR TITLE
[BEAM-1674] Add unicode type to the typeDict attribute in Python SDK

### DIFF
--- a/sdks/python/apache_beam/transforms/display.py
+++ b/sdks/python/apache_beam/transforms/display.py
@@ -160,6 +160,7 @@ class DisplayDataItem(object):
   display item belongs to.
   """
   typeDict = {str:'STRING',
+              unicode:'STRING',
               int:'INTEGER',
               float:'FLOAT',
               bool: 'BOOLEAN',

--- a/sdks/python/apache_beam/transforms/display_test.py
+++ b/sdks/python/apache_beam/transforms/display_test.py
@@ -122,6 +122,17 @@ class DisplayDataTest(unittest.TestCase):
         DisplayDataItemMatcher('extra_packages',
                                str(['package1', 'package2']))))
 
+  def test_unicode_type_display_data(self):
+    class MyDoFn(beam.DoFn):
+      def display_data(self):
+        return {'unicode_string': unicode('my string'),
+                'unicode_literal_string': u'my literal string'}
+
+    fn = MyDoFn()
+    dd = DisplayData.create_from(fn)
+    for item in dd.items:
+      self.assertEqual(item.type, 'STRING')
+
   def test_base_cases(self):
     """ Tests basic display data cases (key:value, key:dict)
     It does not test subcomponent inclusion


### PR DESCRIPTION
When I executed Biq Query exection on the Google Cloud Dataflow,  the following error occurred.

```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 73-78: ordinal not in range(128)
```

It seems there is a problem when the executed SQL is UTF-8 strings(unicode type).

```python:apache_beam/transforms/display.py
    #TODO: Fix Args: documentation once the Python classes handling has changed
    type_ = cls.typeDict.get(type(value))
    if type_ is None:
      type_ = 'CLASS' if inspect.isclass(value) else None
    if type_ is None and value is None:
      type_ = 'STRING'
    return type_
```
so unicode type is always considered as unexpected type.

the actual error occurrence place is here(if self.type is None).
```python:apache_beam/transforms/display.py
    if self.key is None:
      raise ValueError('Invalid DisplayDataItem. Key must not be None')
    if self.namespace is None:
      raise ValueError('Invalid DisplayDataItem. Namespace must not be None')
    if self.value is None:
      raise ValueError('Invalid DisplayDataItem. Value must not be None')
    if self.type is None:
      raise ValueError(
          'Invalid DisplayDataItem. Value {} is of an unsupported type.'
          .format(self.value)
```
So I fixed the problem the following code.