### PR TITLE
[BEAM-1687] Parallel Python ValidatesRunner Tests

### DIFF
--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -45,6 +45,8 @@ from apache_beam.utils.pipeline_options import TypeOptions
 
 
 class PTransformTest(unittest.TestCase):
+  # Enable ValidatesRunner tests running in parallel
+  _multiprocess_can_split_ = True
 
   def assertStartswith(self, msg, prefix):
     self.assertTrue(msg.startswith(prefix),

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -45,7 +45,7 @@ from apache_beam.utils.pipeline_options import TypeOptions
 
 
 class PTransformTest(unittest.TestCase):
-  # Enable ValidatesRunner tests running in parallel
+  # Enable nose tests running in parallel
   _multiprocess_can_split_ = True
 
   def assertStartswith(self, msg, prefix):

--- a/sdks/python/apache_beam/transforms/sideinputs_test.py
+++ b/sdks/python/apache_beam/transforms/sideinputs_test.py
@@ -29,6 +29,8 @@ from apache_beam.transforms.util import assert_that, equal_to
 
 
 class SideInputsTest(unittest.TestCase):
+  # Enable ValidatesRunner tests running in parallel
+  _multiprocess_can_split_ = True
 
   def create_pipeline(self):
     return TestPipeline()

--- a/sdks/python/apache_beam/transforms/sideinputs_test.py
+++ b/sdks/python/apache_beam/transforms/sideinputs_test.py
@@ -29,7 +29,7 @@ from apache_beam.transforms.util import assert_that, equal_to
 
 
 class SideInputsTest(unittest.TestCase):
-  # Enable ValidatesRunner tests running in parallel
+  # Enable nose tests running in parallel
   _multiprocess_can_split_ = True
 
   def create_pipeline(self):

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -61,7 +61,6 @@ GCS_LOCATION=gs://temp-storage-for-end-to-end-tests
 
 # Job name needs to be unique
 JOBNAME_E2E_WC=py-wordcount-`date +%s`
-JOBNAME_VR_TEST=py-validatesrunner-`date +%s`
 
 PROJECT=apache-beam-testing
 
@@ -86,7 +85,6 @@ python setup.py nosetests \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
     --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
     --sdk_location=$SDK_LOCATION \
-    --job_name=$JOBNAME_VR_TEST \
     --requirements_file=postcommit_requirements.txt \
     --num_workers=1"
 

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -77,7 +77,10 @@ echo "mock" >> postcommit_requirements.txt
 # Run ValidatesRunner tests on Google Cloud Dataflow service
 echo ">>> RUNNING DATAFLOW RUNNER VALIDATESRUNNER TESTS"
 python setup.py nosetests \
-  -a ValidatesRunner --test-pipeline-options=" \
+  -a ValidatesRunner \
+  --processes=4 \
+  --process-timeout=600 \
+  --test-pipeline-options=" \
     --runner=TestDataflowRunner \
     --project=$PROJECT \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
@@ -91,7 +94,8 @@ python setup.py nosetests \
 # and validate job that finishes successfully.
 echo ">>> RUNNING TEST DATAFLOW RUNNER py-wordcount"
 python setup.py nosetests \
-  -a IT --test-pipeline-options=" \
+  -a IT \
+  --test-pipeline-options=" \
     --runner=TestDataflowRunner \
     --project=$PROJECT \
     --staging_location=$GCS_LOCATION/staging-wordcount \


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

Parallel ValidatesRunner tests to reduce total time of Python postcommit.

Config process=4 since Jenkins build machine has 4 cores.

Python postcommit time reduce to 37mins with this change. [see](https://builds.apache.org/job/beam_PostCommit_Python_Verify/1474/)