### PR TITLE
Ignore results from the tox clean up phase

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -51,11 +51,11 @@ commands =
   pip install -e .[test]
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py test
-  # Clean up all cython generated files.
-  find apache_beam -type f -name '*.c' -delete
-  find apache_beam -type f -name '*.so' -delete
-  find target/build -type f -name '*.c' -delete
-  find target/build -type f -name '*.so' -delete
+  # Clean up all cython generated files. Ignore if deletion fails.
+  - find apache_beam -type f -name '*.c' -delete
+  - find apache_beam -type f -name '*.so' -delete
+  - find target/build -type f -name '*.c' -delete
+  - find target/build -type f -name '*.so' -delete
 passenv = TRAVIS*
 
 [testenv:py27gcp]


### PR DESCRIPTION
Some temporary files are generated only under certain conditions and
this should not fail tox.

R: @sb2nov 