### PR TITLE
[BEAM-1690] Revert BigQueryIO bit of 'Make all uses of CountingOutputStream close their resources'

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2272,9 +2272,7 @@ public class BigQueryIO {
 
       public final KV<String, Long> close() throws IOException {
         channel.close();
-        KV<String, Long> record = KV.of(fileName, out.getCount());
-        out.close();
-        return record;
+        return KV.of(fileName, out.getCount());
       }
     }
 


### PR DESCRIPTION
This reverts the portion of commit 3115dbdca1858511e98476b5c79e6cca98782b0b
that touches BigQueryIO, which caused a double close bug, seen here: https://builds.apache.org/job/beam_PostCommit_Java_MavenInstall/org.apache.beam$beam-examples-java/2857/testReport/junit/org.apache.beam.examples.cookbook/BigQueryTornadoesIT/testE2EBigQueryTornadoes/