### PR TITLE
ElasticsearchIO: Added compatibility check with v2.x

### DIFF
--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -87,9 +87,6 @@ public class ElasticsearchIOTest implements Serializable {
     ServerSocket serverSocket = new ServerSocket(0);
     int esHttpPort = serverSocket.getLocalPort();
     serverSocket.close();
-    connectionConfiguration =
-        ElasticsearchIO.ConnectionConfiguration.create(
-            new String[] {"http://" + ES_IP + ":" + esHttpPort}, ES_INDEX, ES_TYPE);
     LOG.info("Starting embedded Elasticsearch instance ({})", esHttpPort);
     Settings.Builder settingsBuilder =
         Settings.settingsBuilder()
@@ -108,6 +105,9 @@ public class ElasticsearchIOTest implements Serializable {
     node = NodeBuilder.nodeBuilder().settings(settingsBuilder).build();
     LOG.info("Elasticsearch node created");
     node.start();
+    connectionConfiguration =
+      ElasticsearchIO.ConnectionConfiguration.create(
+        new String[] {"http://" + ES_IP + ":" + esHttpPort}, ES_INDEX, ES_TYPE);
   }
 
   @AfterClass

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
@@ -79,7 +79,7 @@ public class ElasticsearchTestDataSet {
             .addTransportAddress(
                 new InetSocketTransportAddress(
                     getByName(options.getElasticsearchServer()),
-                    Integer.valueOf(options.getElasticsearchTcpPort())));
+                    options.getElasticsearchTcpPort()));
     return client;
   }
 

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchTestDataSet.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.elasticsearch;
 
 import static java.net.InetAddress.getByName;
 
+import java.io.IOException;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -83,7 +84,7 @@ public class ElasticsearchTestDataSet {
   }
 
   public static ElasticsearchIO.ConnectionConfiguration getConnectionConfiguration(
-      ElasticsearchTestOptions options, ReadOrWrite rOw) {
+      ElasticsearchTestOptions options, ReadOrWrite rOw) throws IOException {
     ElasticsearchIO.ConnectionConfiguration connectionConfiguration =
         ElasticsearchIO.ConnectionConfiguration.create(
             new String[] {
@@ -95,7 +96,7 @@ public class ElasticsearchTestDataSet {
             (rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex,
             ES_TYPE);
     return connectionConfiguration;
-  };
+  }
 
   public static void deleteIndex(TransportClient client, ReadOrWrite rOw) throws Exception {
     ElasticSearchIOTestUtils.deleteIndex((rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex, client);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Some users of the ElasticsearchIO try to use it with Elasticsearch v5.x which is not supported yet (see https://issues.apache.org/jira/browse/BEAM-1637), this PR just adds a compatibility warning in the IO javadoc. I did not create a jira for it.

R: @jbonofre 