### PR TITLE
[BEAM-1656] Stop Double-finalizing checkpoints in the DirectRunner

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -170,9 +170,6 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
       UnboundedReader<OutputT> existing = shard.getExistingReader();
       if (existing == null) {
         CheckpointMarkT checkpoint = shard.getCheckpoint();
-        if (checkpoint != null) {
-          checkpoint.finalizeCheckpoint();
-        }
         return shard
             .getSource()
             .createReader(evaluationContext.getPipelineOptions(), checkpoint);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Checkpoints don't need to be finalized before we restore from them.

This cleans up some interactions with `PubSubIO`. I think that this shouldn't
be a requirement, and I'm going to be sending out a tighter specification with
how a Runner can interact with a CheckpointMark soon.