### PR TITLE
[BEAM-1738] Do not reify timestamps in Reshuffle in Dataflow

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -369,6 +369,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
                   BatchViewOverrides.BatchViewAsIterable.class, this));
     }
     ptoverrides
+        .put(PTransformMatchers.classEqualTo(Reshuffle.class), new ReshuffleOverrideFactory())
         // Order is important. Streaming views almost all use Combine internally.
         .put(
             PTransformMatchers.classEqualTo(Combine.GroupedValues.class),

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ReshuffleOverrideFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ReshuffleOverrideFactory.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.dataflow;
+
+import org.apache.beam.runners.core.construction.SingleInputOutputOverrideFactory;
+import org.apache.beam.sdk.runners.PTransformOverrideFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.util.IdentityWindowFn;
+import org.apache.beam.sdk.util.Reshuffle;
+import org.apache.beam.sdk.util.ReshuffleTrigger;
+import org.apache.beam.sdk.util.WindowingStrategy;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+
+/**
+ * A {@link PTransformOverrideFactory} that overrides {@link Reshuffle} with a version that does not
+ * reify timestamps. Dataflow has special handling of the {@link ReshuffleTrigger} which never
+ * buffers elements and outputs elements with their original timestamp.
+ */
+class ReshuffleOverrideFactory<K, V>
+    extends SingleInputOutputOverrideFactory<
+        PCollection<KV<K, V>>, PCollection<KV<K, V>>, Reshuffle<K, V>> {
+  @Override
+  public PTransform<PCollection<KV<K, V>>, PCollection<KV<K, V>>> getReplacementTransform(
+      Reshuffle<K, V> transform) {
+    return new ReshuffleWithOnlyTrigger<>();
+  }
+
+  private static class ReshuffleWithOnlyTrigger<K, V>
+      extends PTransform<PCollection<KV<K, V>>, PCollection<KV<K, V>>> {
+    @Override
+    public PCollection<KV<K, V>> expand(PCollection<KV<K, V>> input) {
+      WindowingStrategy<?, ?> originalStrategy = input.getWindowingStrategy();
+      // If the input has already had its windows merged, then the GBK that performed the merge
+      // will have set originalStrategy.getWindowFn() to InvalidWindows, causing the GBK contained
+      // here to fail. Instead, we install a valid WindowFn that leaves all windows unchanged.
+      Window.Bound<KV<K, V>> rewindow =
+          Window.<KV<K, V>>into(
+              new IdentityWindowFn<>(
+                  originalStrategy.getWindowFn().windowCoder()))
+              .triggering(new ReshuffleTrigger<>())
+              .discardingFiredPanes()
+              .withAllowedLateness(Duration.millis(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()));
+
+      return input.apply(rewindow)
+          .apply(GroupByKey.<K, V>create())
+          // Set the windowing strategy directly, so that it doesn't get counted as the user having
+          // set allowed lateness.
+          .setWindowingStrategyInternal(originalStrategy)
+          .apply("ExpandIterable", ParDo.of(
+              new DoFn<KV<K, Iterable<V>>, KV<K, V>>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  K key = c.element().getKey();
+                  for (V value : c.element().getValue()) {
+                    c.output(KV.of(key, value));
+                  }
+                }
+              }));
+    }
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
Dataflow has special handling of the ReshuffleTrigger that outputs
elements with their original timestamps.