### PR TITLE
[BEAM-846] Add WindowMappingFn, WindowMappingFns

### DIFF
--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.Window.Bound;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollection;
 import org.hamcrest.Matchers;
@@ -313,8 +314,8 @@ public class WindowEvaluatorFactoryTest {
     }
 
     @Override
-    public BoundedWindow getSideInputWindow(BoundedWindow window) {
-      return null;
+    public WindowMappingFn<BoundedWindow> getDefaultWindowMappingFn() {
+      throw new UnsupportedOperationException("Cannot be used as a side input");
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms.windowing;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.beam.sdk.coders.Coder;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /**
@@ -46,8 +47,20 @@ public class GlobalWindows extends NonMergingWindowFn<Object, GlobalWindow> {
   }
 
   @Override
-  public GlobalWindow getSideInputWindow(BoundedWindow window) {
-    return GlobalWindow.INSTANCE;
+  public WindowMappingFn<GlobalWindow> getDefaultWindowMappingFn() {
+    return new GlobalWindowMappingFn();
+  }
+
+  static class GlobalWindowMappingFn extends WindowMappingFn<GlobalWindow> {
+    @Override
+    public GlobalWindow getSideInputWindow(BoundedWindow mainWindow) {
+      return GlobalWindow.INSTANCE;
+    }
+
+    @Override
+    public Duration maximumLookback() {
+      return Duration.ZERO;
+    }
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/InvalidWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/InvalidWindows.java
@@ -75,7 +75,7 @@ public class InvalidWindows<W extends BoundedWindow> extends WindowFn<Object, W>
   }
 
   @Override
-  public W getSideInputWindow(BoundedWindow window) {
+  public WindowMappingFn<W> getDefaultWindowMappingFn() {
     throw new UnsupportedOperationException("InvalidWindows is not allowed in side inputs");
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.transforms.windowing;
 
 import java.util.Arrays;
 import java.util.Collection;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /**
@@ -41,12 +42,22 @@ public abstract class PartitioningWindowFn<T, W extends BoundedWindow>
   }
 
   @Override
-  public W getSideInputWindow(final BoundedWindow window) {
-    if (window instanceof GlobalWindow) {
-      throw new IllegalArgumentException(
-          "Attempted to get side input window for GlobalWindow from non-global WindowFn");
-    }
-    return assignWindow(window.maxTimestamp());
+  public WindowMappingFn<W> getDefaultWindowMappingFn() {
+    return new WindowMappingFn<W>() {
+      @Override
+      public W getSideInputWindow(BoundedWindow mainWindow) {
+        if (mainWindow instanceof GlobalWindow) {
+          throw new IllegalArgumentException(
+              "Attempted to get side input window for GlobalWindow from non-global WindowFn");
+        }
+        return assignWindow(mainWindow.maxTimestamp());
+      }
+
+      @Override
+      public Duration maximumLookback() {
+        return Duration.ZERO;
+      }
+    };
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Sessions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Sessions.java
@@ -80,7 +80,7 @@ public class Sessions extends WindowFn<Object, IntervalWindow> {
   }
 
   @Override
-  public IntervalWindow getSideInputWindow(BoundedWindow window) {
+  public WindowMappingFn<IntervalWindow> getDefaultWindowMappingFn() {
     throw new UnsupportedOperationException("Sessions is not allowed in side inputs");
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
@@ -108,9 +108,12 @@ public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
 
   @Override
   public Collection<IntervalWindow> assignWindows(AssignContext c) {
+    return assignWindows(c.timestamp());
+  }
+
+  public Collection<IntervalWindow> assignWindows(Instant timestamp) {
     List<IntervalWindow> windows =
         new ArrayList<>((int) (size.getMillis() / period.getMillis()));
-    Instant timestamp = c.timestamp();
     long lastStart = lastStartFor(timestamp);
     for (long start = lastStart;
          start > timestamp.minus(size).getMillis();
@@ -121,16 +124,27 @@ public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
   }
 
   /**
-   * Return the earliest window that contains the end of the main-input window.
+   * Return a {@link WindowMappingFn} that returns the earliest window that contains the end of the
+   * main-input window.
    */
   @Override
-  public IntervalWindow getSideInputWindow(final BoundedWindow window) {
-    if (window instanceof GlobalWindow) {
-      throw new IllegalArgumentException(
-          "Attempted to get side input window for GlobalWindow from non-global WindowFn");
-    }
-    long lastStart = lastStartFor(window.maxTimestamp().minus(size));
-    return new IntervalWindow(new Instant(lastStart + period.getMillis()), size);
+  public WindowMappingFn<IntervalWindow> getDefaultWindowMappingFn() {
+    return new WindowMappingFn<IntervalWindow>() {
+      @Override
+      public IntervalWindow getSideInputWindow(BoundedWindow mainWindow) {
+        if (mainWindow instanceof GlobalWindow) {
+          throw new IllegalArgumentException(
+              "Attempted to get side input window for GlobalWindow from non-global WindowFn");
+        }
+        long lastStart = lastStartFor(mainWindow.maxTimestamp().minus(size));
+        return new IntervalWindow(new Instant(lastStart + period.getMillis()), size);
+      }
+
+      @Override
+      public Duration maximumLookback() {
+        return Duration.ZERO;
+      }
+    };
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
@@ -125,11 +125,23 @@ public abstract class WindowFn<T, W extends BoundedWindow>
 
   /**
    * Returns the window of the side input corresponding to the given window of
-   * the main input.
+   * the main input. If not overridden, will use the window returned by calling
+   * {@link WindowMappingFn#getSideInputWindow(BoundedWindow)} on the result of
+   * {@link #getDefaultWindowMappingFn()}.
    *
-   * <p>Authors of custom {@code WindowFn}s should override this.
+   * @deprecated see {@link #getDefaultWindowMappingFn()}
    */
-  public abstract W getSideInputWindow(BoundedWindow window);
+  @Deprecated
+  public W getSideInputWindow(BoundedWindow window) {
+    return getDefaultWindowMappingFn().getSideInputWindow(window);
+  }
+
+  /**
+   * Returns the default {@link WindowMappingFn} to use to map main input windows to side input
+   * windows. This should accept arbitrary main input windows, and produce a {@link BoundedWindow}
+   * that can be produced by this {@link WindowFn}.
+   */
+  public abstract WindowMappingFn<W> getDefaultWindowMappingFn();
 
   /**
    * Returns the output timestamp to use for data depending on the given

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.transforms.windowing;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.ParDo.BoundMulti;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.joda.time.Duration;
+
+/**
+ * A function that takes the windows of elements in a main input and maps them to the appropriate
+ * window in a {@link PCollectionView} consumed as a {@link
+ * BoundMulti#withSideInputs(PCollectionView[]) side input}.
+ */
+public abstract class WindowMappingFn<TargetWindowT extends BoundedWindow> implements Serializable {
+  /**
+   * Returns the window of the side input corresponding to the given window of the main input.
+   */
+  public abstract TargetWindowT getSideInputWindow(BoundedWindow mainWindow);
+
+  /**
+   * The maximum distance between the end of any main input window {@code mainWindow}
+   * and the end of the side input window returned by {@link #getSideInputWindow(BoundedWindow)}
+   *
+   * <p>A side input window {@code w} becomes unreachable when the input watermarks for all
+   * consumers surpasses the timestamp:
+   *
+   * <p>(end of side input window) + (maximum lookback) + (main input allowed lateness).
+   *
+   * <p>At this point, every main input window that could map to {@code w} is expired.
+   */
+  public abstract Duration maximumLookback();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowMappingFn.java
@@ -25,8 +25,8 @@ import org.joda.time.Duration;
 
 /**
  * A function that takes the windows of elements in a main input and maps them to the appropriate
- * window in a {@link PCollectionView} consumed as a {@link
- * BoundMulti#withSideInputs(PCollectionView[]) side input}.
+ * window in a {@link PCollectionView} consumed as a
+ * {@link BoundMulti#withSideInputs(PCollectionView[]) side input}.
  */
 public abstract class WindowMappingFn<TargetWindowT extends BoundedWindow> implements Serializable {
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.transforms.windowing.InvalidWindows;
 import org.apache.beam.sdk.transforms.windowing.NonMergingWindowFn;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.values.PCollection;
 import org.joda.time.Instant;
 
@@ -89,7 +90,7 @@ public class IdentityWindowFn<T> extends NonMergingWindowFn<T, BoundedWindow> {
   }
 
   @Override
-  public BoundedWindow getSideInputWindow(BoundedWindow window) {
+  public WindowMappingFn<BoundedWindow> getDefaultWindowMappingFn() {
     throw new UnsupportedOperationException(
         String.format(
             "%s.getSideInputWindow() should never be called."

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SlidingWindowsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SlidingWindowsTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms.windowing;
 import static org.apache.beam.sdk.testing.WindowFnTestUtils.runWindowFn;
 import static org.apache.beam.sdk.testing.WindowFnTestUtils.set;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -152,28 +153,33 @@ public class SlidingWindowsTest {
   }
 
   @Test
-  public void testGetSideInputWindow() {
+  public void testDefaultWindowMappingFn() {
     // [40, 1040), [340, 1340), [640, 1640) ...
     SlidingWindows slidingWindows = SlidingWindows.of(new Duration(1000))
         .every(new Duration(300)).withOffset(new Duration(40));
+    WindowMappingFn<?> mapping =
+        slidingWindows.getDefaultWindowMappingFn();
+
+    assertThat(mapping.maximumLookback(), equalTo(Duration.ZERO));
+
     // Prior
     assertEquals(
         new IntervalWindow(new Instant(340), new Instant(1340)),
-        slidingWindows.getSideInputWindow(
+        mapping.getSideInputWindow(
             new IntervalWindow(new Instant(0), new Instant(1041))));
     assertEquals(
         new IntervalWindow(new Instant(340), new Instant(1340)),
-        slidingWindows.getSideInputWindow(
+        mapping.getSideInputWindow(
             new IntervalWindow(new Instant(0), new Instant(1339))));
     // Align
     assertEquals(
         new IntervalWindow(new Instant(340), new Instant(1340)),
-        slidingWindows.getSideInputWindow(
+        mapping.getSideInputWindow(
             new IntervalWindow(new Instant(0), new Instant(1340))));
     // After
     assertEquals(
         new IntervalWindow(new Instant(640), new Instant(1640)),
-        slidingWindows.getSideInputWindow(
+        mapping.getSideInputWindow(
             new IntervalWindow(new Instant(0), new Instant(1341))));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
@@ -305,7 +305,7 @@ public class WindowTest implements Serializable {
     }
 
     @Override
-    public IntervalWindow getSideInputWindow(BoundedWindow window) {
+    public WindowMappingFn<IntervalWindow> getDefaultWindowMappingFn() {
       throw new UnsupportedOperationException(
           String.format("Can't use %s for side inputs", getClass().getSimpleName()));
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/IdentitySideInputWindowFn.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/IdentitySideInputWindowFn.java
@@ -24,6 +24,8 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.NonMergingWindowFn;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
+import org.joda.time.Duration;
 
 /**
  * A {@link WindowFn} for use during tests that returns the input window for calls to
@@ -48,7 +50,17 @@ public class IdentitySideInputWindowFn extends NonMergingWindowFn<Integer, Bound
   }
 
   @Override
-  public BoundedWindow getSideInputWindow(BoundedWindow window) {
-    return window;
+  public WindowMappingFn<BoundedWindow> getDefaultWindowMappingFn() {
+    return new WindowMappingFn<BoundedWindow>() {
+      @Override
+      public BoundedWindow getSideInputWindow(BoundedWindow window) {
+        return window;
+      }
+
+      @Override
+      public Duration maximumLookback() {
+        return Duration.ZERO;
+      }
+    };
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -147,6 +147,7 @@ import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.NonMergingWindowFn;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.IOChannelFactory;
 import org.apache.beam.sdk.util.IOChannelUtils;
@@ -1048,7 +1049,7 @@ public class BigQueryIOTest implements Serializable {
     }
 
     @Override
-    public PartitionedGlobalWindow getSideInputWindow(BoundedWindow window) {
+    public WindowMappingFn<PartitionedGlobalWindow> getDefaultWindowMappingFn() {
       throw new UnsupportedOperationException(
           "PartitionedGlobalWindows is not allowed in side inputs");
     }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
WindowMappingFn maps from a main input window to a side input window,
and provides a maximum amount of lookback that is possible to generate
using the MappingFn. This separates the logic of assigning windows from
the logic of mapping main and side inputs. Additionally, it permits
pipeline runners to garbage collect side inputs when they are no longer
accessible.

This is currently unused.

See BEAM-846 and BEAM-260 for additional context.

