### PR TITLE
[BEAM-1782] Updates BigQuery read transform to correctly process empty repeated fields.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1069,8 +1069,17 @@ class BigQueryWrapper(object):
         cell = row['f'][index]
         value = cell['v'] if 'v' in cell else None
       if field.mode == 'REPEATED':
-        result[field.name] = [self._convert_cell_value_to_dict(x['v'], field)
-                              for x in value]
+        if value is None:
+          # We receive 'None' for repeated fields without any values when
+          # 'flatten_results' is 'False'.
+          # When 'flatten_results' is 'True', we receive individual values
+          # instead of a list of values hence we do not hit this condition.
+          # We return an empty list here instead of 'None' to be consistent with
+          # other runners and to be backwards compatible to users.
+          result[field.name] = []
+        else:
+          result[field.name] = [self._convert_cell_value_to_dict(x['v'], field)
+                                for x in value]
       elif value is None:
         if not field.mode == 'NULLABLE':
           raise ValueError('Received \'None\' as the value for the field %s '

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -402,7 +402,8 @@ class TestBigQueryReader(unittest.TestCase):
             bigquery.TableCell(v=None),
             bigquery.TableCell(v=None),
             bigquery.TableCell(v=None),
-            bigquery.TableCell(v=to_json_value([]))])]
+            # REPEATED field without any values.
+            bigquery.TableCell(v=None)])]
     return table_rows, schema, expected_rows
 
   def test_read_from_table(self):


### PR DESCRIPTION
This fixes DirectRunnner. DataflowRunner is already processing these fields correctly.