### PR TITLE
[BEAM-772] Querying of both structured and unstructured metrics in Dataflow.

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -70,6 +70,13 @@ class DataflowMetrics(MetricResults):
   def _get_metric_key(self, metric):
     """Populate the MetricKey object for a queried metric result."""
     try:
+      # If ValueError is thrown within this try-block, it is because of
+      # one of the following:
+      # 1. Unable to translate the step name. Only happening with improperly
+      #   formatted job graph (unlikely), or step name not bein the internal
+      #   step name (only happens for unstructured-named metrics).
+      # 2. Unable to unpack [step] or [namespace]; which should only happen
+      #   for unstructured names.
       [step] = [prop.value
                 for prop in metric.name.context.additionalProperties
                 if prop.key == 'step']

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -40,7 +40,9 @@ class DataflowMetrics(MetricResults):
       dataflow_client: apiclient.DataflowApplicationClient to interact with the
         dataflow service.
       job_result: DataflowPipelineResult with the state and id information of
-        the job
+        the job.
+      job_graph: apiclient.Job instance to be able to translate between internal
+        step names (e.g. "s2"), and user step names (e.g. "split").
     """
     super(DataflowMetrics, self).__init__()
     self._dataflow_client = dataflow_client
@@ -50,6 +52,7 @@ class DataflowMetrics(MetricResults):
     self._job_graph = job_graph
 
   def _translate_step_name(self, internal_name):
+    """Translate between internal step names (e.g. "s1") and user step names."""
     if not self._job_graph:
       raise ValueError('Could not translate the internal step name.')
 
@@ -65,6 +68,7 @@ class DataflowMetrics(MetricResults):
     return user_step_name
 
   def _get_metric_key(self, metric):
+    """Populate the MetricKey object for a queried metric result."""
     try:
       [step] = [prop.value
                 for prop in metric.name.context.additionalProperties

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -79,6 +79,9 @@ class DataflowMetrics(MetricResults):
                      if prop.key == 'namespace']
       name = metric.name.name
     except ValueError:
+      # An unstructured metric name is "step/namespace/name", but step names
+      # can (and often do) contain slashes. Must only split on the right-most
+      # two slashes, to preserve the full step name.
       [step, namespace, name] = metric.name.name.rsplit('/', 2)
     return MetricKey(step, MetricName(namespace, name))
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -103,13 +103,13 @@ class DataflowMetrics(MetricResults):
              'method. You can see them in the Dataflow User Interface.')
         # Distributions are not yet fully supported in this runner
         continue
-      tentative = [prop
-                   for prop in metric.name.context.additionalProperties
-                   if prop.key == 'tentative' and prop.value == 'true']
-      is_tentative = 'tentative' if tentative else 'committed'
+      is_tentative = [prop
+                      for prop in metric.name.context.additionalProperties
+                      if prop.key == 'tentative' and prop.value == 'true']
+      tentative_or_committed = 'tentative' if is_tentative else 'committed'
 
       metric_key = self._get_metric_key(metric)
-      metrics_by_name[metric_key][is_tentative] = metric
+      metrics_by_name[metric_key][tentative_or_committed] = metric
 
     # Now we create the MetricResult elements.
     result = []

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -79,7 +79,7 @@ class DataflowMetrics(MetricResults):
                      if prop.key == 'namespace']
       name = metric.name.name
     except ValueError:
-      [step, namespace, name] = metric.name.name.split('/')
+      [step, namespace, name] = metric.name.name.rsplit('/', 2)
     return MetricKey(step, MetricName(namespace, name))
 
   def _populate_metric_results(self, response):

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
@@ -103,18 +103,18 @@ class TestDataflowMetrics(unittest.TestCase):
                      "value": "user-split-split/__main__.WordExtractingDoFn/"
                               "words_TentativeAggregateValue"},
                     {"key": "step", "value": "split"}]},
-                "name": "split/__main__.WordExtractingDoFn/words",
+                "name": "longstepname/split/__main__.WordExtractingDoFn/words",
                 "origin": "user"},
        "scalar": {"integer_value": 26181},
        "updateTime": "2017-02-23T01:13:36.659Z"},
       {"name": {"context":
                 {"additionalProperties": [
                     {"key": "original_name",
-                     "value": "user-split-split/__main__.WordExtractingDoFn/"
+                     "value": "user-split-longstepname/split/__main__.WordExtractingDoFn/"
                               "words_TentativeAggregateValue"},
                     {"key": "step", "value": "split"},
                     {"key": "tentative", "value": "true"}]},
-                "name": "split/__main__.WordExtractingDoFn/words",
+                "name": "longstepname/split/__main__.WordExtractingDoFn/words",
                 "origin": "user"},
        "scalar": {"integer_value": 26185},
        "updateTime": "2017-02-23T01:13:36.659Z"},
@@ -185,7 +185,7 @@ class TestDataflowMetrics(unittest.TestCase):
                       MetricName('__main__.WordExtractingDoFn', 'empty_lines')),
             1080, 1080),
         MetricResult(
-            MetricKey('split',
+            MetricKey('longstepname/split',
                       MetricName('__main__.WordExtractingDoFn', 'words')),
             26181, 26185),
         ]

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
@@ -47,31 +47,31 @@ class TestDataflowMetrics(unittest.TestCase):
   STRUCTURED_COUNTER_LIST = {"metrics": [
       {"name": {"context":
                 {"additionalProperties": [
-                      {"key": "namespace",
-                       "value": "__main__.WordExtractingDoFn"},
-                      {"key": "step",
-                       "value": "s2"},
-                      {"key": "tentative",
-                       "value": "true"}]
-                  },
-              "name": "word_lengths",
-              "origin": "user"
-          },
-          "scalar": {"integer_value": 109475},
-          "updateTime": "2017-03-22T18:47:06.402Z"
+                    {"key": "namespace",
+                     "value": "__main__.WordExtractingDoFn"},
+                    {"key": "step",
+                     "value": "s2"},
+                    {"key": "tentative",
+                     "value": "true"}]
+                },
+                "name": "word_lengths",
+                "origin": "user"
+               },
+       "scalar": {"integer_value": 109475},
+       "updateTime": "2017-03-22T18:47:06.402Z"
       },
       {"name": {"context":
-                  {"additionalProperties": [
-                      {"key": "namespace",
-                       "value": "__main__.WordExtractingDoFn"},
-                      {"key": "step",
-                       "value": "s2"}]
-                  },
-              "name": "word_lengths",
-              "origin": "user"
-          },
-          "scalar": {"integer_value": 109475},
-          "updateTime": "2017-03-22T18:47:06.402Z"
+                {"additionalProperties": [
+                    {"key": "namespace",
+                     "value": "__main__.WordExtractingDoFn"},
+                    {"key": "step",
+                     "value": "s2"}]
+                },
+                "name": "word_lengths",
+                "origin": "user"
+               },
+       "scalar": {"integer_value": 109475},
+       "updateTime": "2017-03-22T18:47:06.402Z"
       },
   ]}
 
@@ -132,7 +132,10 @@ class TestDataflowMetrics(unittest.TestCase):
        "updateTime": "2017-02-23T01:13:36.659Z"}
   ]}
 
-  def setup_mock_client_result(self, counter_list=BASIC_COUNTER_LIST):
+  def setup_mock_client_result(self, counter_list=None):
+    if counter_list is None:
+      counter_list = self.BASIC_COUNTER_LIST
+
     mock_client = mock.Mock()
     mock_query_result = DictToObject(counter_list)
     mock_client.get_job_metrics.return_value = mock_query_result
@@ -166,7 +169,8 @@ class TestDataflowMetrics(unittest.TestCase):
     expected_counters = [
         MetricResult(
             MetricKey('split',
-                      MetricName('__main__.WordExtractingDoFn', 'word_lengths')),
+                      MetricName('__main__.WordExtractingDoFn',
+                                 'word_lengths')),
             109475, 109475),
         ]
     self.assertEqual(query_result['counters'], expected_counters)

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
@@ -110,7 +110,8 @@ class TestDataflowMetrics(unittest.TestCase):
       {"name": {"context":
                 {"additionalProperties": [
                     {"key": "original_name",
-                     "value": "user-split-longstepname/split/__main__.WordExtractingDoFn/"
+                     "value": "user-split-longstepname/split/"
+                              "__main__.WordExtractingDoFn/"
                               "words_TentativeAggregateValue"},
                     {"key": "step", "value": "split"},
                     {"key": "tentative", "value": "true"}]},

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -174,7 +174,7 @@ class DataflowRunner(PipelineRunner):
     result = DataflowPipelineResult(
         self.dataflow_client.create_job(self.job), self)
 
-    self._metrics = DataflowMetrics(self.dataflow_client, result)
+    self._metrics = DataflowMetrics(self.dataflow_client, result, self.job)
     result.metric_results = self._metrics
     return result
 


### PR DESCRIPTION
This allows for metrics querying to work with structured names and unstructured names alike. It's been tested in both cases.
R: @charlesccychen 
Question: Do you think that `_translate_step_name` should be part of `DataflowMetrics`? Or should this function be available somewhere else in the `DataflowRunner` or `apiclient.Job` classes, so that other components can use it?