### PR TITLE
[BEAM-1148] Port PAssert away from Aggregators

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -40,6 +40,10 @@ import org.apache.beam.runners.spark.util.GlobalWatermarkHolder;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.BoundedReadFromUnboundedSource;
+import org.apache.beam.sdk.metrics.MetricNameFilter;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
@@ -133,8 +137,14 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
             finishState,
             isOneOf(PipelineResult.State.STOPPED, PipelineResult.State.DONE));
 
-        // validate assertion succeeded (at least once).
-        int successAssertions = result.getAggregatorValue(PAssert.SUCCESS_COUNTER, Integer.class);
+        MetricQueryResults queryResults = result.metrics().queryMetrics(
+            MetricsFilter.builder().addNameFilter(
+                MetricNameFilter.named(PAssert.class, PAssert.SUCCESS_COUNTER)).build());
+        long successAssertions = 0;
+        for (MetricResult<Long> res : queryResults.counters()) {
+          successAssertions += res.attempted().longValue();
+        }
+
         Integer expectedAssertions = testSparkPipelineOptions.getExpectedAssertions() != null
             ? testSparkPipelineOptions.getExpectedAssertions() : expectedNumberOfAssertions;
         assertThat(
@@ -142,13 +152,21 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
                 "Expected %d successful assertions, but found %d.",
                 expectedAssertions, successAssertions),
             successAssertions,
-            is(expectedAssertions));
+            is(expectedAssertions.longValue()));
+
+
         // validate assertion didn't fail.
-        int failedAssertions = result.getAggregatorValue(PAssert.FAILURE_COUNTER, Integer.class);
+        queryResults = result.metrics().queryMetrics(
+            MetricsFilter.builder().addNameFilter(
+                MetricNameFilter.named(PAssert.class, PAssert.FAILURE_COUNTER)).build());
+        long failedAssertions = 0;
+        for (MetricResult<Long> res : queryResults.counters()) {
+          failedAssertions += res.attempted().longValue();
+        }
         assertThat(
             String.format("Found %d failed assertions.", failedAssertions),
             failedAssertions,
-            is(0));
+            is(0L));
 
         LOG.info(
             String.format(

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkMetricResults.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkMetricResults.java
@@ -19,16 +19,13 @@
 package org.apache.beam.runners.spark.metrics;
 
 import com.google.common.base.Function;
-import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
-import java.util.Set;
 import org.apache.beam.sdk.metrics.DistributionData;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.MetricFiltering;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
-import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkMetricResults.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/metrics/SparkMetricResults.java
@@ -25,6 +25,7 @@ import com.google.common.collect.FluentIterable;
 import java.util.Set;
 import org.apache.beam.sdk.metrics.DistributionData;
 import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.MetricFiltering;
 import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
@@ -76,43 +77,9 @@ public class SparkMetricResults extends MetricResults {
       return new Predicate<MetricUpdate<?>>() {
         @Override
         public boolean apply(MetricUpdate<?> metricResult) {
-          return matches(filter, metricResult.getKey());
+          return MetricFiltering.matches(filter, metricResult.getKey());
         }
       };
-    }
-
-    private boolean matches(MetricsFilter filter, MetricKey key) {
-      return matchesName(key.metricName(), filter.names())
-          && matchesScope(key.stepName(), filter.steps());
-    }
-
-    private boolean matchesName(MetricName metricName, Set<MetricNameFilter> nameFilters) {
-      if (nameFilters.isEmpty()) {
-        return true;
-      }
-
-      for (MetricNameFilter nameFilter : nameFilters) {
-        if ((nameFilter.getName() == null || nameFilter.getName().equals(metricName.name()))
-            && Objects.equal(metricName.namespace(), nameFilter.getNamespace())) {
-          return true;
-        }
-      }
-
-      return false;
-    }
-
-    private boolean matchesScope(String actualScope, Set<String> scopes) {
-      if (scopes.isEmpty() || scopes.contains(actualScope)) {
-        return true;
-      }
-
-      for (String scope : scopes) {
-        if (actualScope.startsWith(scope)) {
-          return true;
-        }
-      }
-
-      return false;
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricNameFilter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/MetricNameFilter.java
@@ -54,7 +54,7 @@ public abstract class MetricNameFilter {
   public static MetricNameFilter named(Class<?> namespace, String name) {
     checkNotNull(namespace, "Must specify a inNamespace");
     checkNotNull(name, "Must specify a name");
-    return new AutoValue_MetricNameFilter(namespace.getSimpleName(), name);
+    return new AutoValue_MetricNameFilter(namespace.getName(), name);
   }
 }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -40,9 +40,10 @@ import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
-import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -52,7 +53,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
-import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.WithKeys;
@@ -1125,10 +1125,8 @@ public class PAssert {
    */
   private static class SideInputCheckerDoFn<ActualT> extends DoFn<Integer, Void> {
     private final SerializableFunction<ActualT, Void> checkerFn;
-    private final Aggregator<Integer, Integer> success =
-        createAggregator(SUCCESS_COUNTER, Sum.ofIntegers());
-    private final Aggregator<Integer, Integer> failure =
-        createAggregator(FAILURE_COUNTER, Sum.ofIntegers());
+    private final Counter success = Metrics.counter(PAssert.class, SUCCESS_COUNTER);
+    private final Counter failure = Metrics.counter(PAssert.class, FAILURE_COUNTER);
     private final PCollectionView<ActualT> actual;
     private final PAssertionSite site;
 
@@ -1157,10 +1155,8 @@ public class PAssert {
    */
   private static class GroupedValuesCheckerDoFn<ActualT> extends DoFn<ActualT, Void> {
     private final SerializableFunction<ActualT, Void> checkerFn;
-    private final Aggregator<Integer, Integer> success =
-        createAggregator(SUCCESS_COUNTER, Sum.ofIntegers());
-    private final Aggregator<Integer, Integer> failure =
-        createAggregator(FAILURE_COUNTER, Sum.ofIntegers());
+    private final Counter success = Metrics.counter(PAssert.class, SUCCESS_COUNTER);
+    private final Counter failure = Metrics.counter(PAssert.class, FAILURE_COUNTER);
     private final PAssertionSite site;
 
     private GroupedValuesCheckerDoFn(
@@ -1185,10 +1181,8 @@ public class PAssert {
    */
   private static class SingletonCheckerDoFn<ActualT> extends DoFn<Iterable<ActualT>, Void> {
     private final SerializableFunction<ActualT, Void> checkerFn;
-    private final Aggregator<Integer, Integer> success =
-        createAggregator(SUCCESS_COUNTER, Sum.ofIntegers());
-    private final Aggregator<Integer, Integer> failure =
-        createAggregator(FAILURE_COUNTER, Sum.ofIntegers());
+    private final Counter success = Metrics.counter(PAssert.class, SUCCESS_COUNTER);
+    private final Counter failure = Metrics.counter(PAssert.class, FAILURE_COUNTER);
     private final PAssertionSite site;
 
     private SingletonCheckerDoFn(
@@ -1208,13 +1202,13 @@ public class PAssert {
       PAssertionSite site,
       ActualT actualContents,
       SerializableFunction<ActualT, Void> checkerFn,
-      Aggregator<Integer, Integer> successAggregator,
-      Aggregator<Integer, Integer> failureAggregator) {
+      Counter successCounter,
+      Counter failureCounter) {
     try {
       checkerFn.apply(actualContents);
-      successAggregator.addValue(1);
+      successCounter.inc();
     } catch (Throwable t) {
-      failureAggregator.addValue(1);
+      failureCounter.inc();
       throw site.wrap(t);
     }
   }


### PR DESCRIPTION
This PR contains the following changes:
* Changing `PAssert.java` code to use Metrics instead of Aggregators
* Changing `TestSparkRunner.java` code to use Metrics. The change here also required adding up different Metrics counters because Metrics are per-step; while Aggregators in Spark seem to be adding accross steps.

Additional bug fixes/code improvements:
* Fixing a bug in `MetricFiltering`
* Changing the Spark runner to use `MetricFiltering` instead of its own filtering implementation - if that's okay : )

* I ran `mvn clean verify` successfully.

Are there other places where I should be porting Aggregators checks to Metrics?

@aviemzur @tgroh PTAL