### PR TITLE
Fixes two checkstyle violations

### DIFF
--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core;
 
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MutationDetector.java
@@ -28,5 +28,5 @@ public interface MutationDetector extends AutoCloseable {
   /**
    * @throws IllegalMutationException if illegal mutations are detected.
    */
-  void verifyUnmodified();
+  void verifyUnmodified() throws IllegalMutationException;
 }


### PR DESCRIPTION
One snuck in via https://github.com/apache/beam/pull/2264, the other one
(in MutationDetector) I'm not sure - it's been around for long. I'm also
pretty sure it's a checkstyle bug, but the throws declaration doesn't
hurt and makes checkstyle stop complaining.

R: @tgroh OR @kennknowles 