### PR TITLE
[BEAM-1784] Makes DataflowPipelineJob.cancel() idempotent

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineJob.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineJob.java
@@ -364,8 +364,8 @@ public class DataflowPipelineJob implements PipelineResult {
         content.setId(jobId);
         content.setRequestedState("JOB_STATE_CANCELLED");
         try {
-          dataflowClient.updateJob(jobId, content);
-          return State.CANCELLED;
+          Job job = dataflowClient.updateJob(jobId, content);
+          return MonitoringUtil.toState(job.getCurrentState());
         } catch (IOException e) {
           State state = getState();
           if (state.isTerminal()) {
@@ -384,7 +384,8 @@ public class DataflowPipelineJob implements PipelineResult {
       }
     });
     if (cancelState.compareAndSet(null, tentativeCancelTask)) {
-      // This is the thread that requested cancel first.
+      // This thread should perform cancellation, while others will
+      // only wait for the result.
       cancelState.get().run();
     }
     try {

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
@@ -723,7 +723,7 @@ public class DataflowPipelineJobTest {
         mock(Dataflow.Projects.Locations.Jobs.Update.class);
     when(mockJobs.update(eq(PROJECT_ID), eq(REGION_ID), eq(JOB_ID), any(Job.class)))
         .thenReturn(update);
-    when(update.execute()).thenReturn(new Job());
+    when(update.execute()).thenReturn(new Job().setCurrentState("JOB_STATE_CANCELLED"));
 
     DataflowPipelineJob job = new DataflowPipelineJob(JOB_ID, options, null);
 


### PR DESCRIPTION
R: @tgroh 