### PR TITLE
[BEAM-115] Make distinguished URNs public

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowingStrategies.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowingStrategies.java
@@ -128,11 +128,11 @@ public class WindowingStrategies implements Serializable {
 
   // This URN says that the coder is just a UDF blob the indicated SDK understands
   // TODO: standardize such things
-  private static final String CUSTOM_CODER_URN = "urn:beam:coders:javasdk:0.1";
+  public static final String CUSTOM_CODER_URN = "urn:beam:coders:javasdk:0.1";
 
   // This URN says that the WindowFn is just a UDF blob the indicated SDK understands
   // TODO: standardize such things
-  private static final String CUSTOM_WINDOWFN_URN = "urn:beam:windowfn:javasdk:0.1";
+  public static final String CUSTOM_WINDOWFN_URN = "urn:beam:windowfn:javasdk:0.1";
 
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 


### PR DESCRIPTION
These URNs are in flux and will be relocated to some final good location as the
Runner API and Fn API develop.  For now, this change just makes them public in
the place where they currently are defined.

R: @tgroh 