### PR TITLE
Allow customizing the GCE metadata service URL.

### DIFF
--- a/sdks/python/apache_beam/internal/gcp/auth.py
+++ b/sdks/python/apache_beam/internal/gcp/auth.py
@@ -86,9 +86,11 @@ class GCEMetadataCredentials(OAuth2Credentials):
       retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def _refresh(self, http_request):
     refresh_time = datetime.datetime.now()
-    req = urllib2.Request('http://metadata.google.internal/computeMetadata/v1/'
-                          'instance/service-accounts/default/token',
-                          headers={'Metadata-Flavor': 'Google'})
+    metadata_root = os.environ.get(
+        'GCE_METADATA_ROOT', 'metadata.google.internal')
+    token_url = ('http://{}/computeMetadata/v1/instance/service-accounts/'
+                 'default/token').format(metadata_root)
+    req = urllib2.Request(token_url, headers={'Metadata-Flavor': 'Google'})
     token_data = json.loads(urllib2.urlopen(req).read())
     self.access_token = token_data['access_token']
     self.token_expiry = (refresh_time +


### PR DESCRIPTION
The goal here is to allow a user to customize where a job finds the metadata
service; it would also be possible to do this programmatically (eg expose a
variable), but making it an environment variable allows a caller to do this
without need to do so in-process.

PTAL @robertwb 