### PR TITLE
[BEAM-1573] Use Kafka serializers instead of coders in KafkaIO

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
@@ -44,6 +44,8 @@ import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.junit.Rule;
@@ -118,14 +120,14 @@ public class SparkRunnerDebuggerTest {
     KafkaIO.Read<String, String> read = KafkaIO.<String, String>read()
         .withBootstrapServers("mykafka:9092")
         .withTopics(Collections.singletonList("my_input_topic"))
-        .withKeyCoder(StringUtf8Coder.of())
-        .withValueCoder(StringUtf8Coder.of());
+        .withKeyDeserializer(StringDeserializer.class)
+        .withValueDeserializer(StringDeserializer.class);
 
     KafkaIO.Write<String, String> write = KafkaIO.<String, String>write()
         .withBootstrapServers("myotherkafka:9092")
         .withTopic("my_output_topic")
-        .withKeyCoder(StringUtf8Coder.of())
-        .withValueCoder(StringUtf8Coder.of());
+        .withKeySerializer(StringSerializer.class)
+        .withValueSerializer(StringSerializer.class);
 
     KvCoder<String, String> stringKvCoder = KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -34,6 +34,8 @@ import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -56,14 +58,17 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.io.Read.Unbounded;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
 import org.apache.beam.sdk.io.UnboundedSource.UnboundedReader;
 import org.apache.beam.sdk.io.kafka.KafkaCheckpointMark.PartitionMark;
+import org.apache.beam.sdk.io.kafka.serialization.CoderBasedKafkaDeserializer;
+import org.apache.beam.sdk.io.kafka.serialization.CoderBasedKafkaSerializer;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -73,8 +78,6 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.util.CoderUtils;
-import org.apache.beam.sdk.util.ExposedByteArrayInputStream;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -94,6 +97,7 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serializer;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -118,7 +122,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>To configure a Kafka source, you must specify at the minimum Kafka <tt>bootstrapServers</tt>
  * and one or more topics to consume. The following example illustrates various options for
- * configuring the source :
+ * configuring the source:
  *
  * <pre>{@code
  *
@@ -126,9 +130,9 @@ import org.slf4j.LoggerFactory;
  *    .apply(KafkaIO.<Long, String>read()
  *       .withBootstrapServers("broker_1:9092,broker_2:9092")
  *       .withTopic("my_topic")  // use withTopics(List<String>) to read from multiple topics.
- *       // set a Coder for Key and Value
- *       .withKeyCoder(BigEndianLongCoder.of())
- *       .withValueCoder(StringUtf8Coder.of())
+ *       .withKeyDeserializer(LongDeserializer.class)
+ *       .withValueDeserializer(StringDeserializer.class)
+ *
  *       // above four are required configuration. returns PCollection<KafkaRecord<Long, String>>
  *
  *       // rest of the settings are optional :
@@ -149,6 +153,49 @@ import org.slf4j.LoggerFactory;
  *    .apply(Values.<String>create()) // PCollection<String>
  *     ...
  * }</pre>
+ *
+ * <p>Kafka provides deserializers for common types in
+ * {@link org.apache.kafka.common.serialization}. Alternatively, to use Kafka deserializers
+ * based on wrapping Beam {@link Coder}s, use {@code readWithCoders} instead of {@code read}:
+ *
+ * <pre>{@code
+ *
+ *  pipeline
+ *    .apply(KafkaIO.<MyKey, MyValue>readWithCoders(MyKeyCoder.of(), MyValueCoder.of())
+ *       .withBootstrapServers("broker_1:9092,broker_2:9092")
+ *       .withTopic("my_topic")
+ *    )
+ *    ...
+ * }</pre>
+ *
+ * <p>The key and value {@link Coder}s for the resulting collection are inferred from the
+ * deserializer types through the {@link Coder} registry. When the registry cannot infer the
+ * coder types, either register custom {@link Coder}s in the registry, or use
+ * {@code readWithCoders} as demonstrated above.
+ *
+ *
+ * <pre>{@code
+ *
+ *  pipeline
+ *    .apply(KafkaIO.<Long, String>read()
+ *       .withBootstrapServers("broker_1:9092,broker_2:9092")
+ *       .withTopic("my_topic")
+ *
+ *      // explicitly specify coder
+ *       .withKeyDeserializer(LongDeserializer.class)
+ *       .withKeyCoder(BigEndianLongCoder.of())
+ *
+ *      // infer coder from deserializer
+ *       .withValueCoder(StringUtf8Coder.of())
+ *     )
+ *     ...
+ * }</pre>
+ *
+ * <p>Note that {@link Deserializer}s are used to specify how to deserialize objects from Kafka,
+ * while {@link Coder}s are used to set up properties of the resulting transformation.
+ *
+ * <p>To read Avro data, {@code fromAvro} can be used. This does not require manually specifying
+ * a {@link Coder} or {@link Deserializer}.
  *
  * <h3>Partition Assignment and Checkpointing</h3>
  * The Kafka partitions are evenly distributed among splits (workers).
@@ -175,9 +222,8 @@ import org.slf4j.LoggerFactory;
  *       .withBootstrapServers("broker_1:9092,broker_2:9092")
  *       .withTopic("results")
  *
- *       // set Coder for Key and Value
- *       .withKeyCoder(BigEndianLongCoder.of())
- *       .withValueCoder(StringUtf8Coder.of())
+ *       .withKeySerializer(new LongSerializer())
+ *       .withValueSerializer(new StringSerializer())
  *
  *       // you can further customize KafkaProducer used to write the records by adding more
  *       // settings for ProducerConfig. e.g, to enable compression :
@@ -193,10 +239,13 @@ import org.slf4j.LoggerFactory;
  *  strings.apply(KafkaIO.<Void, String>write()
  *      .withBootstrapServers("broker_1:9092,broker_2:9092")
  *      .withTopic("results")
- *      .withValueCoder(StringUtf8Coder.of()) // just need coder for value
+ *      .withValueSerializer(new StringSerializer()) // just need serializer for value
  *      .values()
  *    );
  * }</pre>
+ *
+ * <p>To write Avro data, {@code toAvro} can be used. This does not require specifying a
+ * serializer.
  *
  * <h3>Advanced Kafka Configuration</h3>
  * KafakIO allows setting most of the properties in {@link ConsumerConfig} for source or in
@@ -214,11 +263,48 @@ import org.slf4j.LoggerFactory;
  */
 @Experimental
 public class KafkaIO {
+
+  /**
+   * Attempt to infer a {@link Coder} by extracting the type of the deserialized-class
+   * from the deserializer argument using the {@link Coder} registry.
+   */
+  public static <T> Coder<T> inferCoder(CoderRegistry coderRegistry,
+                                        Class<? extends Deserializer<T>> deserializer) {
+
+    checkNotNull(deserializer);
+
+    for (Type type :  deserializer.getGenericInterfaces()) {
+      if (!(type instanceof ParameterizedType)) {
+        continue;
+      }
+
+      // This does not recurse: we will not infer from a class that extends
+      // a class that extends Deserializer<T>.
+      ParameterizedType parameterizedType = (ParameterizedType) type;
+      Class enclosingClass = (Class) parameterizedType.getRawType();
+
+      if (enclosingClass == (Class) Deserializer.class) {
+        Type actualType = parameterizedType.getActualTypeArguments()[0];
+
+        try {
+          @SuppressWarnings("unchecked")
+          Class<T> clazz = (Class<T>) actualType;
+          return coderRegistry.getDefaultCoder(clazz);
+        } catch (CannotProvideCoderException e) {
+          LOG.warn("Could not infer coder from deserializer type", e);
+        }
+      }
+    }
+
+    throw new RuntimeException("Could not extract deserializer type from "
+            + deserializer.toString());
+  }
+
   /**
    * Creates an uninitialized {@link Read} {@link PTransform}. Before use, basic Kafka
    * configuration should set with {@link Read#withBootstrapServers(String)} and
-   * {@link Read#withTopics(List)}. Other optional settings include key and value coders,
-   * custom timestamp and watermark functions.
+   * {@link Read#withTopics(List)}. Other optional settings include key and value
+   * {@link Deserializer}s, custom timestamp and watermark functions.
    */
   public static Read<byte[], byte[]> readBytes() {
     return new AutoValue_KafkaIO_Read.Builder<byte[], byte[]>()
@@ -226,6 +312,8 @@ public class KafkaIO {
         .setTopicPartitions(new ArrayList<TopicPartition>())
         .setKeyCoder(ByteArrayCoder.of())
         .setValueCoder(ByteArrayCoder.of())
+        .setKeyDeserializer(ByteArrayDeserializer.class)
+        .setValueDeserializer(ByteArrayDeserializer.class)
         .setConsumerFactoryFn(Read.KAFKA_CONSUMER_FACTORY_FN)
         .setConsumerConfig(Read.DEFAULT_CONSUMER_PROPERTIES)
         .setMaxNumRecords(Long.MAX_VALUE)
@@ -235,8 +323,8 @@ public class KafkaIO {
   /**
    * Creates an uninitialized {@link Read} {@link PTransform}. Before use, basic Kafka
    * configuration should set with {@link Read#withBootstrapServers(String)} and
-   * {@link Read#withTopics(List)}. Other optional settings include key and value coders,
-   * custom timestamp and watermark functions.
+   * {@link Read#withTopics(List)}. Other optional settings include key and value
+   * {@link Deserializer}s, custom timestamp and watermark functions.
    */
   public static <K, V> Read<K, V> read() {
     return new AutoValue_KafkaIO_Read.Builder<K, V>()
@@ -249,14 +337,89 @@ public class KafkaIO {
   }
 
   /**
+   * Creates an uninitialized {@link Read} {@link PTransform}, using Kafka {@link Deserializer}s
+   * based on {@link Coder} instances.
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> Read<K, V> readWithCoders(Coder<K> keyCoder, Coder<V> valueCoder) {
+    // Kafka constructs deserializers directly. Pass coder through consumer
+    // configuration.
+    ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+    Map<String, Object> config = builder
+            .putAll(Read.DEFAULT_CONSUMER_PROPERTIES)
+            .put(CoderBasedKafkaDeserializer.configForKeyDeserializer(), keyCoder)
+            .put(CoderBasedKafkaDeserializer.configForValueDeserializer(), valueCoder)
+            .build();
+
+    CoderBasedKafkaDeserializer<K> keyDeserializer = new CoderBasedKafkaDeserializer<K>();
+    CoderBasedKafkaDeserializer<V> valueDeserializer = new CoderBasedKafkaDeserializer<V>();
+
+    return new AutoValue_KafkaIO_Read.Builder<K, V>()
+            .setTopics(new ArrayList<String>())
+            .setTopicPartitions(new ArrayList<TopicPartition>())
+            .setKeyCoder(keyCoder)
+            .setValueCoder(valueCoder)
+            .setKeyDeserializer((Class<Deserializer<K>>) (Class<?>) keyDeserializer.getClass())
+            .setValueDeserializer((Class<Deserializer<V>>) (Class<?>) valueDeserializer.getClass())
+            .setConsumerFactoryFn(Read.KAFKA_CONSUMER_FACTORY_FN)
+            .setConsumerConfig(config)
+            .setMaxNumRecords(Long.MAX_VALUE)
+            .build();
+  }
+
+  /**
+   * Creates an uninitialized {@link Read} {@link PTransform}, using Kafka {@link Deserializer}s
+   * based on {@link AvroCoder}. This reads data in the Avro binary format directly without using
+   * an Avro object container.
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> Read<K, V> fromAvro(Class<K> keyClass, Class<V> valueClass) {
+    return readWithCoders(AvroCoder.of(keyClass), AvroCoder.of(valueClass));
+  }
+
+  /**
    * Creates an uninitialized {@link Write} {@link PTransform}. Before use, Kafka configuration
    * should be set with {@link Write#withBootstrapServers(String)} and {@link Write#withTopic}
-   * along with {@link Coder}s for (optional) key and values.
+   * along with {@link Deserializer}s for (optional) key and values.
    */
   public static <K, V> Write<K, V> write() {
     return new AutoValue_KafkaIO_Write.Builder<K, V>()
         .setProducerConfig(Write.DEFAULT_PRODUCER_PROPERTIES)
         .build();
+  }
+  /**
+   * Creates an uninitialized {@link Write} {@link PTransform}, using Kafka {@link Serializer}s
+   * based on {@link Coder} instances.
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> Write<K, V> writeWithCoders(Coder<K> keyCoder, Coder<V> valueCoder) {
+    // Kafka constructs serializers directly. Pass coder through consumer
+    // configuration.
+    ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder<>();
+    Map<String, Object> config = builder
+            .putAll(Write.DEFAULT_PRODUCER_PROPERTIES)
+            .put(CoderBasedKafkaSerializer.configForKeySerializer(), keyCoder)
+            .put(CoderBasedKafkaSerializer.configForValueSerializer(), valueCoder)
+            .build();
+
+    CoderBasedKafkaSerializer<K> keySerializer = new CoderBasedKafkaSerializer<K>();
+    CoderBasedKafkaSerializer<V> valueSerializer = new CoderBasedKafkaSerializer<V>();
+
+    return new AutoValue_KafkaIO_Write.Builder<K, V>()
+            .setProducerConfig(config)
+            .setKeySerializer((Class<Serializer<K>>) (Class<?>) keySerializer.getClass())
+            .setValueSerializer((Class<Serializer<V>>) (Class<?>) valueSerializer.getClass())
+            .build();
+  }
+
+  /**
+   * Creates an uninitialized {@link Write} {@link PTransform}, using Kafka {@link Serializer}s
+   * based on {@link AvroCoder}. The coder writes Avro data directly without using an Avro object
+   * container.
+   */
+  @SuppressWarnings("unchecked")
+  public static <K, V> Write<K, V> toAvro(Class<K> keyClass, Class<V> valueClass) {
+    return writeWithCoders(AvroCoder.of(keyClass), AvroCoder.of(valueClass));
   }
 
   ///////////////////////// Read Support \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
@@ -273,6 +436,8 @@ public class KafkaIO {
     abstract List<TopicPartition> getTopicPartitions();
     @Nullable abstract Coder<K> getKeyCoder();
     @Nullable abstract Coder<V> getValueCoder();
+    @Nullable abstract Class<? extends Deserializer<K>> getKeyDeserializer();
+    @Nullable abstract Class<? extends Deserializer<V>> getValueDeserializer();
     abstract SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>
         getConsumerFactoryFn();
     @Nullable abstract SerializableFunction<KafkaRecord<K, V>, Instant> getTimestampFn();
@@ -290,6 +455,9 @@ public class KafkaIO {
       abstract Builder<K, V> setTopicPartitions(List<TopicPartition> topicPartitions);
       abstract Builder<K, V> setKeyCoder(Coder<K> keyCoder);
       abstract Builder<K, V> setValueCoder(Coder<V> valueCoder);
+      abstract Builder<K, V> setKeyDeserializer(Class<? extends Deserializer<K>> keyDeserializer);
+      abstract Builder<K, V> setValueDeserializer(
+          Class<? extends Deserializer<V>> valueDeserializer);
       abstract Builder<K, V> setConsumerFactoryFn(
           SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> consumerFactoryFn);
       abstract Builder<K, V> setTimestampFn(SerializableFunction<KafkaRecord<K, V>, Instant> fn);
@@ -342,14 +510,28 @@ public class KafkaIO {
     }
 
     /**
-     * Returns a new {@link Read} with {@link Coder} for key bytes.
+     * Returns a new {@link Read} with a Kafka {@link Deserializer} for key bytes.
+     */
+    public Read<K, V> withKeyDeserializer(Class<? extends Deserializer<K>> keyDeserializer) {
+      return toBuilder().setKeyDeserializer(keyDeserializer).build();
+    }
+
+    /**
+     * Returns a new {@link Read} with a {@link Coder} for the key.
      */
     public Read<K, V> withKeyCoder(Coder<K> keyCoder) {
       return toBuilder().setKeyCoder(keyCoder).build();
     }
 
     /**
-     * Returns a new {@link Read} with {@link Coder} for value bytes.
+     * Returns a new {@link Read} with a Kafka {@link Deserializer} for value bytes.
+     */
+    public Read<K, V> withValueDeserializer(Class<? extends Deserializer<V>> valueDeserializer) {
+      return toBuilder().setValueDeserializer(valueDeserializer).build();
+    }
+
+    /**
+     * Returns a new {@link Read} with a {@link Coder} for values.
      */
     public Read<K, V> withValueCoder(Coder<V> valueCoder) {
       return toBuilder().setValueCoder(valueCoder).build();
@@ -436,20 +618,51 @@ public class KafkaIO {
     }
 
     @Override
-    public void validate(PBegin input) {
+    public void validate(PBegin input)  {
       checkNotNull(getConsumerConfig().get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG),
           "Kafka bootstrap servers should be set");
       checkArgument(getTopics().size() > 0 || getTopicPartitions().size() > 0,
           "Kafka topics or topic_partitions are required");
-      checkNotNull(getKeyCoder(), "Key coder must be set");
-      checkNotNull(getValueCoder(), "Value coder must be set");
+      checkNotNull(getKeyDeserializer(), "Key deserializer must be set");
+      checkNotNull(getValueDeserializer(), "Value deserializer must be set");
+
+      if (input != null) {
+        CoderRegistry registry = input.getPipeline().getCoderRegistry();
+
+        checkNotNull(getKeyCoder() != null
+                        ? getKeyCoder()
+                        : inferCoder(registry, getKeyDeserializer()),
+                "Key coder must be set");
+
+        checkNotNull(getValueCoder() != null
+                        ? getValueCoder()
+                        : inferCoder(registry, getValueDeserializer()),
+                "Value coder must be set");
+      } else {
+        checkNotNull(getKeyCoder(), "Key coder must be set");
+        checkNotNull(getValueCoder(), "Value coder must be set");
+      }
     }
 
     @Override
     public PCollection<KafkaRecord<K, V>> expand(PBegin input) {
-     // Handles unbounded source to bounded conversion if maxNumRecords or maxReadTime is set.
+      // Infer key/value coders if not specified explicitly
+      CoderRegistry registry = input.getPipeline().getCoderRegistry();
+
+      Coder<K> keyCoder = getKeyCoder() != null
+              ? getKeyCoder()
+              : inferCoder(registry, getKeyDeserializer());
+
+      Coder<V> valueCoder = getValueCoder() != null
+              ? getValueCoder()
+              : inferCoder(registry, getValueDeserializer());
+
+      // Handles unbounded source to bounded conversion if maxNumRecords or maxReadTime is set.
       Unbounded<KafkaRecord<K, V>> unbounded =
-          org.apache.beam.sdk.io.Read.from(makeSource());
+          org.apache.beam.sdk.io.Read.from(this
+                  .withKeyCoder(keyCoder)
+                  .withValueCoder(valueCoder)
+                  .makeSource());
 
       PTransform<PBegin, PCollection<KafkaRecord<K, V>>> transform = unbounded;
 
@@ -488,8 +701,8 @@ public class KafkaIO {
      * A set of properties that are not required or don't make sense for our consumer.
      */
     private static final Map<String, String> IGNORED_CONSUMER_PROPERTIES = ImmutableMap.of(
-        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "Set keyCoder instead",
-        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "Set valueCoder instead"
+        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, "Set keyDeserializer instead",
+        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, "Set valueDeserializer instead"
         // "group.id", "enable.auto.commit", "auto.commit.interval.ms" :
         //     lets allow these, applications can have better resume point for restarts.
         );
@@ -739,6 +952,9 @@ public class KafkaIO {
     private Instant curTimestamp;
     private Iterator<PartitionState> curBatch = Collections.emptyIterator();
 
+    private Deserializer<K> keyDeserializerInstance = null;
+    private Deserializer<V> valueDeserializerInstance = null;
+
     private static final Duration KAFKA_POLL_TIMEOUT = Duration.millis(1000);
     private static final Duration NEW_RECORDS_POLL_TIMEOUT = Duration.millis(10);
 
@@ -912,6 +1128,16 @@ public class KafkaIO {
       consumer = spec.getConsumerFactoryFn().apply(spec.getConsumerConfig());
       consumerSpEL.evaluateAssign(consumer, spec.getTopicPartitions());
 
+      try {
+        keyDeserializerInstance = source.spec.getKeyDeserializer().newInstance();
+        valueDeserializerInstance = source.spec.getValueDeserializer().newInstance();
+      } catch (InstantiationException | IllegalAccessException e) {
+        throw new IOException("Could not instantiate deserializers", e);
+      }
+
+      keyDeserializerInstance.configure(spec.getConsumerConfig(), true);
+      valueDeserializerInstance.configure(spec.getConsumerConfig(), false);
+
       for (PartitionState p : partitionStates) {
         if (p.nextOffset != UNINITIALIZED_OFFSET) {
           consumer.seek(p.topicPartition, p.nextOffset);
@@ -1003,15 +1229,16 @@ public class KafkaIO {
 
           curRecord = null; // user coders below might throw.
 
-          // apply user coders. might want to allow skipping records that fail to decode.
+          // apply user deserializers.
+          // might want to allow skipping records that fail to deserialize.
           // TODO: wrap exceptions from coders to make explicit to users
           KafkaRecord<K, V> record = new KafkaRecord<K, V>(
               rawRecord.topic(),
               rawRecord.partition(),
               rawRecord.offset(),
               consumerSpEL.getRecordTimestamp(rawRecord),
-              decode(rawRecord.key(), source.spec.getKeyCoder()),
-              decode(rawRecord.value(), source.spec.getValueCoder()));
+              keyDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.key()),
+              valueDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.value()));
 
           curTimestamp = (source.spec.getTimestampFn() == null)
               ? Instant.now() : source.spec.getTimestampFn().apply(record);
@@ -1030,16 +1257,6 @@ public class KafkaIO {
           }
         }
       }
-    }
-
-    private static byte[] nullBytes = new byte[0];
-    private static <T> T decode(byte[] bytes, Coder<T> coder) throws IOException {
-      // If 'bytes' is null, use byte[0]. It is common for key in Kakfa record to be null.
-      // This makes it impossible for user to distinguish between zero length byte and null.
-      // Alternately, we could have a ByteArrayCoder that handles nulls, and use that for default
-      // coder.
-      byte[] toDecode = bytes == null ? nullBytes : bytes;
-      return coder.decode(new ExposedByteArrayInputStream(toDecode), Coder.Context.OUTER);
     }
 
     // update latest offset for each partition.
@@ -1153,6 +1370,9 @@ public class KafkaIO {
         }
       }
 
+      Closeables.close(keyDeserializerInstance, true);
+      Closeables.close(valueDeserializerInstance, true);
+
       Closeables.close(offsetConsumer, true);
       Closeables.close(consumer, true);
     }
@@ -1167,22 +1387,23 @@ public class KafkaIO {
   @AutoValue
   public abstract static class Write<K, V> extends PTransform<PCollection<KV<K, V>>, PDone> {
     @Nullable abstract String getTopic();
-    @Nullable abstract Coder<K> getKeyCoder();
-    @Nullable abstract Coder<V> getValueCoder();
     abstract Map<String, Object> getProducerConfig();
     @Nullable
     abstract SerializableFunction<Map<String, Object>, Producer<K, V>> getProducerFactoryFn();
+
+    @Nullable abstract Class<? extends Serializer<K>> getKeySerializer();
+    @Nullable abstract Class<? extends Serializer<V>> getValueSerializer();
 
     abstract Builder<K, V> toBuilder();
 
     @AutoValue.Builder
     abstract static class Builder<K, V> {
       abstract Builder<K, V> setTopic(String topic);
-      abstract Builder<K, V> setKeyCoder(Coder<K> keyCoder);
-      abstract Builder<K, V> setValueCoder(Coder<V> valueCoder);
       abstract Builder<K, V> setProducerConfig(Map<String, Object> producerConfig);
       abstract Builder<K, V> setProducerFactoryFn(
           SerializableFunction<Map<String, Object>, Producer<K, V>> fn);
+      abstract Builder<K, V> setKeySerializer(Class<? extends Serializer<K>> serializer);
+      abstract Builder<K, V> setValueSerializer(Class<? extends Serializer<V>> serializer);
       abstract Write<K, V> build();
     }
 
@@ -1204,19 +1425,19 @@ public class KafkaIO {
     }
 
     /**
-     * Returns a new {@link Write} with {@link Coder} for serializing key (if any) to bytes.
+     * Returns a new {@link Write} with {@link Serializer} for serializing key (if any) to bytes.
      * A key is optional while writing to Kafka. Note when a key is set, its hash is used to
      * determine partition in Kafka (see {@link ProducerRecord} for more details).
      */
-    public Write<K, V> withKeyCoder(Coder<K> keyCoder) {
-      return toBuilder().setKeyCoder(keyCoder).build();
+    public Write<K, V> withKeySerializer(Class<? extends Serializer<K>> keySerializer) {
+      return toBuilder().setKeySerializer(keySerializer).build();
     }
 
     /**
-     * Returns a new {@link Write} with {@link Coder} for serializing value to bytes.
+     * Returns a new {@link Write} with {@link Serializer} for serializing value to bytes.
      */
-    public Write<K, V> withValueCoder(Coder<V> valueCoder) {
-      return toBuilder().setValueCoder(valueCoder).build();
+    public Write<K, V> withValueSerializer(Class<? extends Serializer<V>> valueSerializer) {
+      return toBuilder().setValueSerializer(valueSerializer).build();
     }
 
     public Write<K, V> updateProducerProperties(Map<String, Object> configUpdates) {
@@ -1239,7 +1460,7 @@ public class KafkaIO {
      * collections of values rather thank {@link KV}s.
      */
     public PTransform<PCollection<V>, PDone> values() {
-      return new KafkaValueWrite<>(withKeyCoder(new NullOnlyCoder<K>()).toBuilder().build());
+      return new KafkaValueWrite<>(toBuilder().build());
     }
 
     @Override
@@ -1253,26 +1474,19 @@ public class KafkaIO {
       checkNotNull(getProducerConfig().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
           "Kafka bootstrap servers should be set");
       checkNotNull(getTopic(), "Kafka topic should be set");
-      checkNotNull(getKeyCoder(), "Key coder should be set");
-      checkNotNull(getValueCoder(), "Value coder should be set");
     }
 
     // set config defaults
     private static final Map<String, Object> DEFAULT_PRODUCER_PROPERTIES =
         ImmutableMap.<String, Object>of(
-            ProducerConfig.RETRIES_CONFIG, 3,
-            // See comment about custom serializers in KafkaWriter constructor.
-            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, CoderBasedKafkaSerializer.class,
-            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, CoderBasedKafkaSerializer.class);
+            ProducerConfig.RETRIES_CONFIG, 3);
 
     /**
      * A set of properties that are not required or don't make sense for our producer.
      */
     private static final Map<String, String> IGNORED_PRODUCER_PROPERTIES = ImmutableMap.of(
-        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "Set keyCoder instead",
-        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "Set valueCoder instead",
-        configForKeySerializer(), "Reserved for internal serializer",
-        configForValueSerializer(), "Reserved for internal serializer"
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "Use withKeySerializer instead",
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "Use withValueSerializer instead"
      );
 
     @Override
@@ -1310,7 +1524,7 @@ public class KafkaIO {
               return KV.of(null, element);
             }
           }))
-        .setCoder(KvCoder.of(new NullOnlyCoder<K>(), kvWriteTransform.getValueCoder()))
+        .setCoder(KvCoder.of(new NullOnlyCoder<K>(), input.getCoder()))
         .apply(kvWriteTransform);
     }
 
@@ -1389,8 +1603,11 @@ public class KafkaIO {
       // Use case : write all the events for a single session to same Kafka partition.
 
       this.producerConfig = new HashMap<>(spec.getProducerConfig());
-      this.producerConfig.put(configForKeySerializer(), spec.getKeyCoder());
-      this.producerConfig.put(configForValueSerializer(), spec.getValueCoder());
+
+      this.producerConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                              spec.getKeySerializer());
+      this.producerConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                              spec.getValueSerializer());
     }
 
     private synchronized void checkForFailures() throws IOException {
@@ -1426,49 +1643,5 @@ public class KafkaIO {
         LOG.warn("KafkaWriter send failed : '{}'", exception.getMessage());
       }
     }
-  }
-
-  /**
-   * Implements Kafka's {@link Serializer} with a {@link Coder}. The coder is stored as serialized
-   * value in producer configuration map.
-   */
-  public static class CoderBasedKafkaSerializer<T> implements Serializer<T> {
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-      String configKey = isKey ? configForKeySerializer() : configForValueSerializer();
-      coder = (Coder<T>) configs.get(configKey);
-      checkNotNull(coder, "could not instantiate coder for Kafka serialization");
-    }
-
-    @Override
-    public byte[] serialize(String topic, @Nullable T data) {
-      if (data == null) {
-        return null; // common for keys to be null
-      }
-
-      try {
-        return CoderUtils.encodeToByteArray(coder, data);
-      } catch (CoderException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public void close() {
-    }
-
-    private Coder<T> coder = null;
-    private static final String CONFIG_FORMAT = "beam.coder.based.kafka.%s.serializer";
-  }
-
-
-  private static String configForKeySerializer() {
-    return String.format(CoderBasedKafkaSerializer.CONFIG_FORMAT, "key");
-  }
-
-  private static String configForValueSerializer() {
-    return String.format(CoderBasedKafkaSerializer.CONFIG_FORMAT, "value");
   }
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/CoderBasedKafkaDeserializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/CoderBasedKafkaDeserializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.kafka.serialization;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.kafka.common.serialization.Deserializer;
+
+/**
+ * Implements a Kafka {@link Deserializer} with a {@link Coder}.
+ *
+ * <p>As Kafka instantiates serializers directly, the coder
+ * must be stored as serialized value in the producer configuration map.
+ */
+public class CoderBasedKafkaDeserializer<T> implements Deserializer<T> {
+    @SuppressWarnings("unchecked")
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        String configKey = isKey ? configForKeyDeserializer() : configForValueDeserializer();
+        coder = (Coder<T>) configs.get(configKey);
+        checkNotNull(coder, "could not instantiate coder for Kafka deserialization");
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        if (data == null) {
+            return null;
+        }
+
+        try {
+            return CoderUtils.decodeFromByteArray(coder, data);
+        } catch (CoderException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+    public static String configForKeyDeserializer() {
+        return String.format(CoderBasedKafkaDeserializer.CONFIG_FORMAT, "key");
+    }
+
+    public static String configForValueDeserializer() {
+        return String.format(CoderBasedKafkaDeserializer.CONFIG_FORMAT, "value");
+    }
+
+    private Coder<T> coder = null;
+    private static final String CONFIG_FORMAT = "beam.coder.based.kafka.%s.deserializer";
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/CoderBasedKafkaSerializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/CoderBasedKafkaSerializer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.kafka.serialization;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * Implements Kafka's {@link Serializer} with a {@link Coder}.
+ *
+ * <p>As Kafka instantiates serializers directly, the coder
+ * must be stored as serialized value in the producer configuration map.
+ */
+public class CoderBasedKafkaSerializer<T> implements Serializer<T> {
+  @SuppressWarnings("unchecked")
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    String configKey = isKey ? configForKeySerializer() : configForValueSerializer();
+    coder = (Coder<T>) configs.get(configKey);
+    checkNotNull(coder, "could not instantiate coder for Kafka serialization");
+  }
+
+  @Override
+  public byte[] serialize(String topic, @Nullable T data) {
+    if (data == null) {
+      return null; // common for keys to be null
+    }
+
+    try {
+      return CoderUtils.encodeToByteArray(coder, data);
+    } catch (CoderException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+  }
+
+  public static String configForKeySerializer() {
+    return String.format(CoderBasedKafkaSerializer.CONFIG_FORMAT, "key");
+  }
+
+  public static String configForValueSerializer() {
+    return String.format(CoderBasedKafkaSerializer.CONFIG_FORMAT, "value");
+  }
+
+  private Coder<T> coder = null;
+  private static final String CONFIG_FORMAT = "beam.coder.based.kafka.%s.serializer";
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantDeserializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.kafka.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.joda.time.Instant;
+
+/**
+ * Kafka {@link Deserializer} for {@link Instant}.
+ *
+ * <p>This decodes the number of milliseconds since epoch using {@link LongDeserializer}.
+ */
+public class InstantDeserializer implements Deserializer<Instant> {
+    private LongDeserializer longDeserializer = null;
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (longDeserializer == null) {
+            longDeserializer = new LongDeserializer();
+        }
+    }
+
+    @Override
+    public Instant deserialize(String topic, byte[] bytes) {
+        return new Instant(longDeserializer.deserialize(topic, bytes));
+    }
+
+    @Override
+    public void close() {
+        longDeserializer.close();
+    }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantSerializer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/InstantSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.kafka.serialization;
+
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.joda.time.Instant;
+
+/**
+ * Kafka {@link Serializer} for {@link Instant}.
+ *
+ * <p>This encodes the number of milliseconds since epoch using {@link LongSerializer}.
+ */
+public class InstantSerializer implements Serializer<Instant> {
+    private LongSerializer longSerializer = null;
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+        if (longSerializer == null) {
+            longSerializer = new LongSerializer();
+        }
+    }
+
+    @Override
+    public byte[] serialize(String topic, Instant instant) {
+        return longSerializer.serialize(topic, instant.getMillis());
+    }
+
+    @Override
+    public void close() {
+        longSerializer.close();
+    }
+};

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/package-info.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/serialization/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Kafka serializers and deserializers.
+ */
+package org.apache.beam.sdk.io.kafka.serialization;

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -41,12 +41,15 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
-import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
-import org.apache.beam.sdk.coders.BigEndianLongCoder;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.UnboundedSource.UnboundedReader;
+import org.apache.beam.sdk.io.kafka.serialization.InstantDeserializer;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -74,7 +77,14 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
+import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Utils;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.joda.time.Instant;
@@ -231,8 +241,8 @@ public class KafkaIOTest {
         .withTopics(topics)
         .withConsumerFactoryFn(new ConsumerFactoryFn(
             topics, 10, numElements, OffsetResetStrategy.EARLIEST)) // 20 partitions
-        .withKeyCoder(BigEndianIntegerCoder.of())
-        .withValueCoder(BigEndianLongCoder.of())
+        .withKeyDeserializer(IntegerDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class)
         .withMaxNumRecords(numElements);
 
     if (timestampFn != null) {
@@ -303,9 +313,9 @@ public class KafkaIOTest {
         .withTopic("my_topic")
         .withConsumerFactoryFn(new ConsumerFactoryFn(
             ImmutableList.of(topic), 10, numElements, OffsetResetStrategy.EARLIEST))
-        .withKeyCoder(BigEndianIntegerCoder.of())
-        .withValueCoder(BigEndianLongCoder.of())
-        .withMaxNumRecords(numElements);
+        .withMaxNumRecords(numElements)
+        .withKeyDeserializer(IntegerDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class);
 
     PCollection<Long> input = p
         .apply(reader.withoutMetadata())
@@ -326,8 +336,8 @@ public class KafkaIOTest {
         .withTopicPartitions(ImmutableList.of(new TopicPartition("test", 5)))
         .withConsumerFactoryFn(new ConsumerFactoryFn(
             topics, 10, numElements, OffsetResetStrategy.EARLIEST)) // 10 partitions
-        .withKeyCoder(ByteArrayCoder.of())
-        .withValueCoder(BigEndianLongCoder.of())
+        .withKeyDeserializer(ByteArrayDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class)
         .withMaxNumRecords(numElements / 10);
 
     PCollection<Long> input = p
@@ -386,8 +396,14 @@ public class KafkaIOTest {
     int numElements = 1000;
     int numSplits = 10;
 
+    // Coders must be specified explicitly here due to the way the transform
+    // is used in the test.
     UnboundedSource<KafkaRecord<Integer, Long>, ?> initial =
-        mkKafkaReadTransform(numElements, null).makeSource();
+        mkKafkaReadTransform(numElements, null)
+                .withKeyCoder(VarIntCoder.of())
+                .withValueCoder(VarLongCoder.of())
+                .makeSource();
+
     List<? extends UnboundedSource<KafkaRecord<Integer, Long>, ?>> splits =
         initial.generateInitialSplits(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
@@ -510,8 +526,8 @@ public class KafkaIOTest {
         .withTopics(topics)
         .withConsumerFactoryFn(new ConsumerFactoryFn(
             topics, 10, numElements, OffsetResetStrategy.LATEST))
-        .withKeyCoder(BigEndianIntegerCoder.of())
-        .withValueCoder(BigEndianLongCoder.of())
+        .withKeyDeserializer(IntegerDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class)
         .withMaxNumRecords(numElements)
         .withTimestampFn(new ValueAsTimestampFn())
         .makeSource()
@@ -554,8 +570,8 @@ public class KafkaIOTest {
         .apply(KafkaIO.<Integer, Long>write()
             .withBootstrapServers("none")
             .withTopic(topic)
-            .withKeyCoder(BigEndianIntegerCoder.of())
-            .withValueCoder(BigEndianLongCoder.of())
+            .withKeySerializer(IntegerSerializer.class)
+            .withValueSerializer(LongSerializer.class)
             .withProducerFactoryFn(new ProducerFactoryFn()));
 
       p.run();
@@ -587,7 +603,7 @@ public class KafkaIOTest {
         .apply(KafkaIO.<Integer, Long>write()
             .withBootstrapServers("none")
             .withTopic(topic)
-            .withValueCoder(BigEndianLongCoder.of())
+            .withValueSerializer(LongSerializer.class)
             .withProducerFactoryFn(new ProducerFactoryFn())
             .values());
 
@@ -628,8 +644,8 @@ public class KafkaIOTest {
         .apply(KafkaIO.<Integer, Long>write()
             .withBootstrapServers("none")
             .withTopic(topic)
-            .withKeyCoder(BigEndianIntegerCoder.of())
-            .withValueCoder(BigEndianLongCoder.of())
+            .withKeySerializer(IntegerSerializer.class)
+            .withValueSerializer(LongSerializer.class)
             .withProducerFactoryFn(new ProducerFactoryFn()));
 
       try {
@@ -664,8 +680,8 @@ public class KafkaIOTest {
             new TopicPartition("test", 6)))
         .withConsumerFactoryFn(new ConsumerFactoryFn(
             Lists.newArrayList("test"), 10, 10, OffsetResetStrategy.EARLIEST)) // 10 partitions
-        .withKeyCoder(ByteArrayCoder.of())
-        .withValueCoder(BigEndianLongCoder.of());
+        .withKeyDeserializer(ByteArrayDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class);
 
     DisplayData displayData = DisplayData.from(read);
 
@@ -681,7 +697,7 @@ public class KafkaIOTest {
     KafkaIO.Write<Integer, Long> write = KafkaIO.<Integer, Long>write()
         .withBootstrapServers("myServerA:9092,myServerB:9092")
         .withTopic("myTopic")
-        .withValueCoder(BigEndianLongCoder.of())
+        .withValueSerializer(LongSerializer.class)
         .withProducerFactoryFn(new ProducerFactoryFn());
 
     DisplayData displayData = DisplayData.from(write);
@@ -689,6 +705,52 @@ public class KafkaIOTest {
     assertThat(displayData, hasDisplayItem("topic", "myTopic"));
     assertThat(displayData, hasDisplayItem("bootstrap.servers", "myServerA:9092,myServerB:9092"));
     assertThat(displayData, hasDisplayItem("retries", 3));
+  }
+
+  // interface for testing coder inference
+  private interface DummyInterface<T> {
+  }
+
+  // interface for testing coder inference
+  private interface DummyNonparametricInterface {
+  }
+
+  // class for testing coder inference
+  private static class DeserializerWithInterfaces
+          implements DummyInterface<String>, DummyNonparametricInterface,
+            Deserializer<Long> {
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public Long deserialize(String topic, byte[] bytes) {
+      return 0L;
+    }
+
+    @Override
+    public void close() {
+
+    }
+  }
+
+  @Test
+  public void testInferKeyCoder() {
+    CoderRegistry registry = new CoderRegistry();
+    registry.registerStandardCoders();
+
+    assertTrue(KafkaIO.inferCoder(registry, LongDeserializer.class)
+            instanceof VarLongCoder);
+
+    assertTrue(KafkaIO.inferCoder(registry, StringDeserializer.class)
+            instanceof StringUtf8Coder);
+
+    assertTrue(KafkaIO.inferCoder(registry, InstantDeserializer.class)
+            instanceof InstantCoder);
+
+    assertTrue(KafkaIO.inferCoder(registry, DeserializerWithInterfaces.class)
+            instanceof VarLongCoder);
   }
 
   private static void verifyProducerRecords(String topic, int numElements, boolean keyIsAbsent) {
@@ -724,8 +786,8 @@ public class KafkaIOTest {
   private static final MockProducer<Integer, Long> MOCK_PRODUCER =
     new MockProducer<Integer, Long>(
       false, // disable synchronous completion of send. see ProducerSendCompletionThread below.
-      new KafkaIO.CoderBasedKafkaSerializer<Integer>(),
-      new KafkaIO.CoderBasedKafkaSerializer<Long>()) {
+      new IntegerSerializer(),
+      new LongSerializer()) {
 
       // override flush() so that it does not complete all the waiting sends, giving a chance to
       // ProducerCompletionThread to inject errors.
@@ -754,10 +816,14 @@ public class KafkaIOTest {
     public Producer<Integer, Long> apply(Map<String, Object> config) {
 
       // Make sure the config is correctly set up for serializers.
-      Utils.newInstance(
-          ((Class<?>) config.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
-              .asSubclass(Serializer.class)
-      ).configure(config, true);
+
+      // There may not be a key serializer if we're interested only in values.
+      if (config.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG) != null) {
+        Utils.newInstance(
+                ((Class<?>) config.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG))
+                        .asSubclass(Serializer.class)
+        ).configure(config, true);
+      }
 
       Utils.newInstance(
           ((Class<?>) config.get(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG))


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---



**This is a work in progress, do not merge**.

Modified:
- Use Kafka serializers and deserializers in KafkaIO
- Added helper methods `fromAvro` and `toAvro`, to use serialization based on `AvroCoder`. This is uniform with other IO such as HDFS.
- Moved `CoderBasedKafkaSerializer` out, and added `CoderBaseKafkaDeserializer`. These are used for `toAvro/fromAvro`, and can be useful to port existing code that relies on coder.
- Added `InstantSerializer` and `InstantDeserializer`, as `Instant` is used in some of the tests.
 
Writer lets Kafka handle serialization itself. Reader uses Kafka byte deserializers, and calls the user-provided Kafka deserializer from `advance`. Note that Kafka serializers and deserializers are not themselves `Serializable`. Hence, I've used a `Class<..>` in the `spec` both for read and write.

There is still an issue, though. `Read` still takes **both a deserializer and a coder**. This is because the source must implement `getDefaultOutputCoder`, and I am not sure how to infer it. Having to provide the two is heavy, but I am not sure how to infer the coders in this context. Any thoughts?

cc @rangadi @jkff
