### PR TITLE
BEAM-1760 Potential null dereference in HDFSFileSink#doFinalize

### DIFF
--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSink.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSink.java
@@ -336,6 +336,7 @@ public abstract class HDFSFileSink<T, K, V> extends Sink<T> {
       // rename output shards to Hadoop style, i.e. part-r-00000.txt
       int i = 0;
       for (FileStatus s : statuses) {
+        if (s.getPath().getParent() == null) break;
         String name = s.getPath().getName();
         int pos = name.indexOf('.');
         String ext = pos > 0 ? name.substring(pos) : "";

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSink.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSink.java
@@ -336,7 +336,9 @@ public abstract class HDFSFileSink<T, K, V> extends Sink<T> {
       // rename output shards to Hadoop style, i.e. part-r-00000.txt
       int i = 0;
       for (FileStatus s : statuses) {
-        if (s.getPath().getParent() == null) break;
+        if (s.getPath().getParent() == null) {
+          break;
+        }
         String name = s.getPath().getName();
         int pos = name.indexOf('.');
         String ext = pos > 0 ? name.substring(pos) : "";


### PR DESCRIPTION
Check whether s.getPath().getParent() is null.
If it is null, break out of the loop.