### PR TITLE
[BEAM-1648] Replace gsutil with storage API calls

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -754,7 +754,6 @@ class GcsBufferedWriter(object):
     self.path = path
     self.mode = mode
     self.bucket, self.name = parse_gcs_path(path)
-    self.mode = mode
 
     self.closed = False
     self.position = 0


### PR DESCRIPTION
This PR replaces the `gsutil cp` call with a GCS API call when staging resources.

I was unsure how to unit test this feature, and given that the existing functionality was not under test already, I just tested this with the following script:

```python
from apache_beam.runners.dataflow.internal import dependency
dependency._dependency_file_copy('/home/david/myfile.txt', 'gs://mybucket/myfile.txt')
dependency._dependency_file_copy('gs://mybucket/myfile.txt', 'gs://mybucket/myfile2.txt')
dependency._dependency_file_copy('gs://mybucket/myfile2.txt', '/home/david/myfile2.txt')
```
All three operations are successful.

I've set up travis-ci for the build, and it is successful for the python tests but not the Java tests (it looks like this is a general issue at the moment).

---

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
