### PR TITLE
Fixed: small documentation issue in HDFS IO

### DIFF
--- a/sdks/java/io/hdfs/README.md
+++ b/sdks/java/io/hdfs/README.md
@@ -31,13 +31,13 @@ A `HDFSFileSource` can be read from using the
 ```java
 HDFSFileSource<K, V> source = HDFSFileSource.from(path, MyInputFormat.class,
   MyKey.class, MyValue.class);
-PCollection<KV<MyKey, MyValue>> records = Read.from(mySource);
+PCollection<KV<MyKey, MyValue>> records = pipeline.apply(Read.from(mySource));
 ```
 
 Alternatively, the `readFrom` method is a convenience method that returns a read
 transform. For example:
 
 ```java
-PCollection<KV<MyKey, MyValue>> records = HDFSFileSource.readFrom(path,
-  MyInputFormat.class, MyKey.class, MyValue.class);
+PCollection<KV<MyKey, MyValue>> records = pipeline.apply(HDFSFileSource.readFrom(path,
+  MyInputFormat.class, MyKey.class, MyValue.class));
 ```

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -91,7 +91,7 @@ import org.slf4j.LoggerFactory;
  * {@code
  * HDFSFileSource<K, V> source = HDFSFileSource.from(path, MyInputFormat.class,
  *   MyKey.class, MyValue.class);
- * PCollection<KV<MyKey, MyValue>> records = Read.from(mySource);
+ * PCollection<KV<MyKey, MyValue>> records = pipeline.apply(Read.from(mySource));
  * }
  * </pre>
  *


### PR DESCRIPTION
Small cosmetic change: HDFS IO's documentation confuses collection and transform in the examples for `Read`.

As per the contribution guide, I have not filed a JIRA given that this is a minor change.