### PR TITLE
Improves logging of FileBasedSource size estimates

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -222,6 +222,11 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
             fileOrPatternSpec,
             System.currentTimeMillis() - startTime);
       }
+      LOG.info(
+          "Filepattern {} matched {} files with total size {}",
+          fileOrPatternSpec.get(),
+          inputs.size(),
+          totalSize);
       return totalSize;
     } else {
       long start = getStartOffset();
@@ -286,8 +291,18 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
     Collections.shuffle(selectedFiles);
     selectedFiles = selectedFiles.subList(0, sampleSize);
 
-    return files.size() * getExactTotalSizeOfFiles(selectedFiles, ioChannelFactory)
-        / selectedFiles.size();
+    long exactTotalSampleSize = getExactTotalSizeOfFiles(selectedFiles, ioChannelFactory);
+    double avgSize = 1.0 * exactTotalSampleSize / selectedFiles.size();
+    long totalSize = Math.round(files.size() * avgSize);
+    LOG.info(
+        "Sampling {} files gave {} total bytes ({} average per file), "
+            + "inferring total size of {} files to be {}",
+        selectedFiles.size(),
+        exactTotalSampleSize,
+        avgSize,
+        files.size(),
+        totalSize);
+    return totalSize;
   }
 
   @Override


### PR DESCRIPTION
Motivated by debugging a customer job that produced a weird file size estimate.

R: @dhalperi 