### PR TITLE
[BEAM-41,BEAM-42] Revise MapState and SetState APIs to leverage ReadableState

### DIFF
--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CopyOnAccessInMemoryStateInternalsTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CopyOnAccessInMemoryStateInternalsTest.java
@@ -201,24 +201,24 @@ public class CopyOnAccessInMemoryStateInternalsTest {
     StateTag<Object, MapState<String, Integer>> valueTag =
         StateTags.map("foo", StringUtf8Coder.of(), VarIntCoder.of());
     MapState<String, Integer> underlyingValue = underlying.state(namespace, valueTag);
-    assertThat(underlyingValue.iterate(), emptyIterable());
+    assertThat(underlyingValue.entries().read(), emptyIterable());
 
     underlyingValue.put("hello", 1);
-    assertThat(underlyingValue.get("hello"), equalTo(1));
+    assertThat(underlyingValue.get("hello").read(), equalTo(1));
 
     CopyOnAccessInMemoryStateInternals<String> internals =
         CopyOnAccessInMemoryStateInternals.withUnderlying(key, underlying);
     MapState<String, Integer> copyOnAccessState = internals.state(namespace, valueTag);
-    assertThat(copyOnAccessState.get("hello"), equalTo(1));
+    assertThat(copyOnAccessState.get("hello").read(), equalTo(1));
 
     copyOnAccessState.put("world", 4);
-    assertThat(copyOnAccessState.get("hello"), equalTo(1));
-    assertThat(copyOnAccessState.get("world"), equalTo(4));
-    assertThat(underlyingValue.get("hello"), equalTo(1));
-    assertNull(underlyingValue.get("world"));
+    assertThat(copyOnAccessState.get("hello").read(), equalTo(1));
+    assertThat(copyOnAccessState.get("world").read(), equalTo(4));
+    assertThat(underlyingValue.get("hello").read(), equalTo(1));
+    assertNull(underlyingValue.get("world").read());
 
     MapState<String, Integer> reReadUnderlyingValue = underlying.state(namespace, valueTag);
-    assertThat(underlyingValue.iterate(), equalTo(reReadUnderlyingValue.iterate()));
+    assertThat(underlyingValue.entries().read(), equalTo(reReadUnderlyingValue.entries().read()));
   }
 
   @Test

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/MapState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/MapState.java
@@ -30,21 +30,20 @@ import java.util.Map;
 public interface MapState<K, V> extends State {
 
   /**
-   * Returns the value to which the specified key is mapped in the state.
-   */
-  V get(K key);
-
-  /**
    * Associates the specified value with the specified key in this state.
    */
   void put(K key, V value);
 
   /**
-   * If the specified key is not already associated with a value (or is mapped
-   * to {@code null}) associates it with the given value and returns
-   * {@code null}, else returns the current value.
+   * A deferred read-followed-by-write.
+   *
+   * <p>When {@code read()} is called on the result or state is committed, it forces a read of the
+   * map and reconciliation with any pending modifications.
+   *
+   * <p>If the specified key is not already associated with a value (or is mapped to {@code null})
+   * associates it with the given value and returns {@code null}, else returns the current value.
    */
-  V putIfAbsent(K key, V value);
+  ReadableState<V> putIfAbsent(K key, V value);
 
   /**
    * Removes the mapping for a key from this map if it is present.
@@ -52,42 +51,29 @@ public interface MapState<K, V> extends State {
   void remove(K key);
 
   /**
-   * A bulk get.
-   * @param keys the keys to search for
-   * @return a iterable view of values, maybe some values is null.
-   * The order of values corresponds to the order of the keys.
+   * A deferred lookup.
+   *
+   * <p>A user is encouraged to call {@code get} for all relevant keys and call {@code readLater()}
+   * on the results.
+   *
+   * <p>When {@code read()} is called, a particular state implementation is encouraged to perform
+   * all pending reads in a single batch.
    */
-  Iterable<V> get(Iterable<K> keys);
-
-  /**
-   * Indicate that specified key will be read later.
-   */
-  MapState<K, V> getLater(K k);
-
-  /**
-   * Indicate that specified batch keys will be read later.
-   */
-  MapState<K, V> getLater(Iterable<K> keys);
+  ReadableState<V> get(K key);
 
   /**
    * Returns a iterable view of the keys contained in this map.
    */
-  Iterable<K> keys();
+  ReadableState<Iterable<K>> keys();
 
   /**
    * Returns a iterable view of the values contained in this map.
    */
-  Iterable<V> values();
-
-  /**
-   * Indicate that all key-values will be read later.
-   */
-  MapState<K, V> iterateLater();
+  ReadableState<Iterable<V>> values();
 
   /**
    * Returns a iterable view of all key-values.
    */
-  Iterable<Map.Entry<K, V>> iterate();
-
+  ReadableState<Iterable<Map.Entry<K, V>>> entries();
 }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/ReadableStates.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/state/ReadableStates.java
@@ -17,29 +17,29 @@
  */
 package org.apache.beam.sdk.util.state;
 
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+
 /**
- * State containing no duplicate elements.
- * Items can be added to the set and the contents read out.
- *
- * @param <T> The type of elements in the set.
+ * Utilities for constructing and manipulating {@link ReadableState} instances.
  */
-public interface SetState<T> extends GroupingState<T, Iterable<T>> {
-  /**
-   * Returns true if this set contains the specified element.
-   */
-  ReadableState<Boolean> contains(T t);
+@Experimental(Kind.STATE)
+public class ReadableStates {
 
   /**
-   * Ensures a value is a member of the set, returning {@code true} if it was added and {@code
-   * false} otherwise.
+   * A {@link ReadableState} constructed from a constant value, hence immediately available.
    */
-  ReadableState<Boolean> addIfAbsent(T t);
+  public static <T> ReadableState<T> immediate(final T value) {
+    return new ReadableState<T>() {
+      @Override
+      public T read() {
+        return value;
+      }
 
-  /**
-   * Removes the specified element from this set if it is present.
-   */
-  void remove(T t);
-
-  @Override
-  SetState<T> readLater();
+      @Override
+      public ReadableState<T> readLater() {
+        return this;
+      }
+    };
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2228,7 +2228,7 @@ public class ParDoTest implements Serializable {
             state.put(value.getKey(), value.getValue());
             count.add(1);
             if (count.read() >= 4) {
-              Iterable<Map.Entry<String, Integer>> iterate = state.iterate();
+              Iterable<Map.Entry<String, Integer>> iterate = state.entries().read();
               for (Map.Entry<String, Integer> entry : iterate) {
                 c.output(KV.of(entry.getKey(), entry.getValue()));
               }
@@ -2274,7 +2274,7 @@ public class ParDoTest implements Serializable {
             state.put(value.getKey(), new MyInteger(value.getValue()));
             count.add(1);
             if (count.read() >= 4) {
-              Iterable<Map.Entry<String, MyInteger>> iterate = state.iterate();
+              Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
               for (Map.Entry<String, MyInteger> entry : iterate) {
                 c.output(KV.of(entry.getKey(), entry.getValue()));
               }
@@ -2320,7 +2320,7 @@ public class ParDoTest implements Serializable {
             state.put(value.getKey(), new MyInteger(value.getValue()));
             count.add(1);
             if (count.read() >= 4) {
-              Iterable<Map.Entry<String, MyInteger>> iterate = state.iterate();
+              Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
               for (Map.Entry<String, MyInteger> entry : iterate) {
                 c.output(KV.of(entry.getKey(), entry.getValue()));
               }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---

@JingsongLi and @aljoscha I think you two have the most familiarity with this.

This updates the `MapState` and `SetState` API so the methods return `ReadableState` instead of duplicating the design pattern for every method. This makes it so there is really just one `readLater()` and we use it wherever we need a future-like value.

I have pushed just the API changes to get feedback, and then I will change the in-memory state.