### PR TITLE
[BEAM-1425] Window should comply with PTransform style guide

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/WindowAssignTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/WindowAssignTranslator.java
@@ -35,7 +35,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 
 /**
- * {@link Window.Bound} is translated to {link ApexParDoOperator} that wraps an {@link
+ * {@link Window} is translated to {link ApexParDoOperator} that wraps an {@link
  * AssignWindowsDoFn}.
  */
 class WindowAssignTranslator<T> implements TransformTranslator<Window.Assign<T>> {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiOverrideFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiOverrideFactory.java
@@ -135,8 +135,8 @@ class ParDoMultiOverrideFactory<InputT, OutputT>
               //  - ensure this GBK holds to the minimum of those timestamps (via OutputTimeFn)
               //  - discard past panes as it is "just a stream" of elements
               .apply(
-                  Window.<KV<K, WindowedValue<KV<K, InputT>>>>triggering(
-                          Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+                  Window.<KV<K, WindowedValue<KV<K, InputT>>>>configure()
+                      .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
                       .discardingFiredPanes()
                       .withAllowedLateness(inputWindowingStrategy.getAllowedLateness())
                       .withOutputTimeFn(OutputTimeFns.outputAtEarliestInputTimestamp()))

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WindowEvaluatorFactoryTest.java
@@ -43,7 +43,6 @@ import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing;
 import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.Window.Bound;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -113,7 +112,7 @@ public class WindowEvaluatorFactoryTest {
   @Test
   public void singleWindowFnSucceeds() throws Exception {
     Duration windowDuration = Duration.standardDays(7);
-    Bound<Long> transform = Window.<Long>into(FixedWindows.of(windowDuration));
+    Window<Long> transform = Window.<Long>into(FixedWindows.of(windowDuration));
     PCollection<Long> windowed = input.apply(transform);
 
     CommittedBundle<Long> inputBundle = createInputBundle();
@@ -152,7 +151,7 @@ public class WindowEvaluatorFactoryTest {
   public void multipleWindowsWindowFnSucceeds() throws Exception {
     Duration windowDuration = Duration.standardDays(6);
     Duration slidingBy = Duration.standardDays(3);
-    Bound<Long> transform = Window.into(SlidingWindows.of(windowDuration).every(slidingBy));
+    Window<Long> transform = Window.into(SlidingWindows.of(windowDuration).every(slidingBy));
     PCollection<Long> windowed = input.apply(transform);
 
     CommittedBundle<Long> inputBundle = createInputBundle();
@@ -209,7 +208,7 @@ public class WindowEvaluatorFactoryTest {
 
   @Test
   public void referencesEarlierWindowsSucceeds() throws Exception {
-    Bound<Long> transform = Window.into(new EvaluatorTestWindowFn());
+    Window<Long> transform = Window.into(new EvaluatorTestWindowFn());
     PCollection<Long> windowed = input.apply(transform);
 
     CommittedBundle<Long> inputBundle = createInputBundle();

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/AssignWindows.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/AssignWindows.java
@@ -42,13 +42,13 @@ import org.apache.beam.sdk.values.PCollection;
  * @param <T> the type of input element
  */
 class AssignWindows<T> extends PTransform<PCollection<T>, PCollection<T>> {
-  private final Window.Bound<T> transform;
+  private final Window<T> transform;
 
   /**
    * Builds an instance of this class from the overriden transform.
    */
   @SuppressWarnings("unused") // Used via reflection
-  public AssignWindows(Window.Bound<T> transform) {
+  public AssignWindows(Window<T> transform) {
     this.transform = transform;
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ReshuffleOverrideFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ReshuffleOverrideFactory.java
@@ -56,7 +56,7 @@ class ReshuffleOverrideFactory<K, V>
       // If the input has already had its windows merged, then the GBK that performed the merge
       // will have set originalStrategy.getWindowFn() to InvalidWindows, causing the GBK contained
       // here to fail. Instead, we install a valid WindowFn that leaves all windows unchanged.
-      Window.Bound<KV<K, V>> rewindow =
+      Window<KV<K, V>> rewindow =
           Window.<KV<K, V>>into(
               new IdentityWindowFn<>(
                   originalStrategy.getWindowFn().windowCoder()))

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/CreateStreamTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/CreateStreamTest.java
@@ -275,7 +275,7 @@ public class CreateStreamTest implements Serializable {
     PCollection<String> createStrings =
         p.apply("CreateStrings", source)
             .apply("WindowStrings",
-                Window.<String>triggering(AfterPane.elementCountAtLeast(2))
+                Window.<String>configure().triggering(AfterPane.elementCountAtLeast(2))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
     PAssert.that(createStrings).containsInAnyOrder("foo", "bar");
@@ -283,7 +283,7 @@ public class CreateStreamTest implements Serializable {
     PCollection<Integer> createInts =
         p.apply("CreateInts", other)
             .apply("WindowInts",
-                Window.<Integer>triggering(AfterPane.elementCountAtLeast(4))
+                Window.<Integer>configure().triggering(AfterPane.elementCountAtLeast(4))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
     PAssert.that(createInts).containsInAnyOrder(1, 2, 3, 4);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -145,7 +145,7 @@ public class PAssert {
      * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
      * may be executed over an empty input even if the trigger has fired previously. To ensure that
      * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
-     * (via {@link Window.Bound#withAllowedLateness(Duration, ClosingBehavior)} setting
+     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
      * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
      *
      * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
@@ -233,7 +233,7 @@ public class PAssert {
      * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
      * may be executed over an empty input even if the trigger has fired previously. To ensure that
      * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
-     * (via {@link Window.Bound#withAllowedLateness(Duration, ClosingBehavior)} setting
+     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
      * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
      *
      * @return a new {@link SingletonAssert} like this one but with the assertion only applied to

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -939,7 +939,8 @@ public class PAssert {
               PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>,
               PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>>
           removeTriggering =
-              Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>triggering(Never.ever())
+              Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
+                  .triggering(Never.ever())
                   .discardingFiredPanes()
                   .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness());
       // Group the contents by key. If it is empty, this PCollection will be empty, too.
@@ -983,7 +984,8 @@ public class PAssert {
                   Flatten.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>pCollections())
               .apply(
                   "NeverTrigger",
-                  Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>triggering(Never.ever())
+                  Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
+                      .triggering(Never.ever())
                       .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness())
                       .discardingFiredPanes())
               .apply(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -279,8 +279,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
     /**
      * Returns the timestamp of the input element.
      *
-     * <p>See {@link org.apache.beam.sdk.transforms.windowing.Window}
-     * for more information.
+     * <p>See {@link Window} for more information.
      */
     public abstract Instant timestamp();
 
@@ -290,8 +289,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
      *
      * <p>Generally all data is in a single, uninteresting pane unless custom
      * triggering and/or late data has been explicitly requested.
-     * See {@link org.apache.beam.sdk.transforms.windowing.Window}
-     * for more information.
+     * See {@link Window} for more information.
      */
     public abstract PaneInfo pane();
   }
@@ -326,7 +324,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *
    * @deprecated This method permits a {@link DoFn} to emit elements behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -324,7 +324,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *
    * @deprecated This method permits a {@link DoFn} to emit elements behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
@@ -39,7 +39,7 @@ import org.apache.beam.sdk.values.PCollection.IsBounded;
  * each distinct key and window of the input {@code PCollection} to an
  * {@code Iterable} over all the values associated with that key in
  * the input per window.  Absent repeatedly-firing
- * {@link Window.Bound#triggering triggering}, each key in the output
+ * {@link Window#triggering triggering}, each key in the output
  * {@code PCollection} is unique within each window.
  *
  * <p>{@code GroupByKey} is analogous to converting a multi-map into
@@ -97,14 +97,14 @@ import org.apache.beam.sdk.values.PCollection.IsBounded;
  * for details on the estimation.
  *
  * <p>The timestamp for each emitted pane is determined by the
- * {@link Window.Bound#withOutputTimeFn windowing operation}.
+ * {@link Window#withOutputTimeFn windowing operation}.
  * The output {@code PCollection} will have the same {@link WindowFn}
  * as the input.
  *
  * <p>If the input {@code PCollection} contains late data (see
  * {@link org.apache.beam.sdk.io.PubsubIO.Read#timestampLabel}
  * for an example of how this can occur) or the
- * {@link Window.Bound#triggering requested TriggerFn} can fire before
+ * {@link Window#triggering requested TriggerFn} can fire before
  * the watermark, then there may be multiple elements
  * output by a {@code GroupByKey} that correspond to the same key and window.
  *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupByKey.java
@@ -39,7 +39,7 @@ import org.apache.beam.sdk.values.PCollection.IsBounded;
  * each distinct key and window of the input {@code PCollection} to an
  * {@code Iterable} over all the values associated with that key in
  * the input per window.  Absent repeatedly-firing
- * {@link Window#triggering triggering}, each key in the output
+ * {@link Window.Bound#triggering triggering}, each key in the output
  * {@code PCollection} is unique within each window.
  *
  * <p>{@code GroupByKey} is analogous to converting a multi-map into
@@ -104,7 +104,7 @@ import org.apache.beam.sdk.values.PCollection.IsBounded;
  * <p>If the input {@code PCollection} contains late data (see
  * {@link org.apache.beam.sdk.io.PubsubIO.Read#timestampLabel}
  * for an example of how this can occur) or the
- * {@link Window#triggering requested TriggerFn} can fire before
+ * {@link Window.Bound#triggering requested TriggerFn} can fire before
  * the watermark, then there may be multiple elements
  * output by a {@code GroupByKey} that correspond to the same key and window.
  *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -52,7 +52,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    *
    * <p>CAUTION: Use of {@link #withAllowedTimestampSkew(Duration)} permits elements to be emitted
    * behind the watermark. These elements are considered late, and if behind the {@link
-   * Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
+   * Window#withAllowedLateness(Duration) allowed lateness} of a downstream
    * {@link PCollection} may be silently dropped. See https://issues.apache.org/jira/browse/BEAM-644
    * for details on a replacement.
    *
@@ -90,7 +90,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    * future. For infinite skew, use {@code new Duration(Long.MAX_VALUE)}.
    * @deprecated This method permits a to elements to be emitted behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    */
@@ -106,7 +106,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    * @see DoFn#getAllowedTimestampSkew()
    * @deprecated This method permits a to elements to be emitted behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -52,9 +52,9 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    *
    * <p>CAUTION: Use of {@link #withAllowedTimestampSkew(Duration)} permits elements to be emitted
    * behind the watermark. These elements are considered late, and if behind the {@link
-   * Window#withAllowedLateness(Duration) allowed lateness} of a downstream {@link PCollection} may
-   * be silently dropped. See https://issues.apache.org/jira/browse/BEAM-644 for details on a
-   * replacement.
+   * Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
+   * {@link PCollection} may be silently dropped. See https://issues.apache.org/jira/browse/BEAM-644
+   * for details on a replacement.
    *
    * <p>Each output element will be in the same windows as the input element. If a new window based
    * on the new output timestamp is desired, apply a new instance of {@link Window#into(WindowFn)}.
@@ -90,7 +90,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    * future. For infinite skew, use {@code new Duration(Long.MAX_VALUE)}.
    * @deprecated This method permits a to elements to be emitted behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    */
@@ -106,7 +106,7 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
    * @see DoFn#getAllowedTimestampSkew()
    * @deprecated This method permits a to elements to be emitted behind the watermark. These
    *     elements are considered late, and if behind the
-   *     {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
+   *     {@link Window.Bound#withAllowedLateness(Duration) allowed lateness} of a downstream
    *     {@link PCollection} may be silently dropped. See
    *     https://issues.apache.org/jira/browse/BEAM-644 for details on a replacement.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
@@ -26,7 +26,7 @@ import org.joda.time.Instant;
  * A trigger which never fires.
  *
  * <p>Using this trigger will only produce output when the watermark passes the end of the
- * {@link BoundedWindow window} plus the {@link Window#withAllowedLateness allowed
+ * {@link BoundedWindow window} plus the {@link Window.Bound#withAllowedLateness allowed
  * lateness}.
  */
 public final class Never {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Never.java
@@ -26,7 +26,7 @@ import org.joda.time.Instant;
  * A trigger which never fires.
  *
  * <p>Using this trigger will only produce output when the watermark passes the end of the
- * {@link BoundedWindow window} plus the {@link Window.Bound#withAllowedLateness allowed
+ * {@link BoundedWindow window} plus the {@link Window#withAllowedLateness allowed
  * lateness}.
  */
 public final class Never {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PaneInfo.java
@@ -72,7 +72,7 @@ public final class PaneInfo {
    * <li>We'll call a pipeline 'simple' if it does not use
    * {@link DoFn.Context#outputWithTimestamp} in
    * any {@link DoFn}, and it uses the same
-   * {@link org.apache.beam.sdk.transforms.windowing.Window.Bound#withAllowedLateness}
+   * {@link org.apache.beam.sdk.transforms.windowing.Window#withAllowedLateness}
    * argument value on all windows (or uses the default of {@link org.joda.time.Duration#ZERO}).
    * <li>We'll call an element 'locally late', from the point of view of a computation on a
    * worker, if the element's timestamp is before the input watermark for that computation

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
@@ -169,7 +169,7 @@ public class Window {
    * properties can be set on it first.
    */
   public static <T> Bound<T> into(WindowFn<? super T, ?> fn) {
-    return new Bound(null).into(fn);
+    return new Bound().into(fn);
   }
 
   /**
@@ -182,7 +182,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> triggering(Trigger trigger) {
-    return new Bound(null).triggering(trigger);
+    return new Bound().triggering(trigger);
   }
 
   /**
@@ -194,7 +194,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> discardingFiredPanes() {
-    return new Bound(null).discardingFiredPanes();
+    return new Bound().discardingFiredPanes();
   }
 
   /**
@@ -206,7 +206,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> accumulatingFiredPanes() {
-    return new Bound(null).accumulatingFiredPanes();
+    return new Bound().accumulatingFiredPanes();
   }
 
   /**
@@ -222,7 +222,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> withAllowedLateness(Duration allowedLateness) {
-    return new Bound(null).withAllowedLateness(allowedLateness);
+    return new Bound().withAllowedLateness(allowedLateness);
   }
 
   /**
@@ -231,7 +231,7 @@ public class Window {
    */
   @Experimental(Kind.OUTPUT_TIME)
   public static <T> Bound<T> withOutputTimeFn(OutputTimeFn<?> outputTimeFn) {
-    return new Bound(null).withOutputTimeFn(outputTimeFn);
+    return new Bound().withOutputTimeFn(outputTimeFn);
   }
 
   /**
@@ -251,14 +251,12 @@ public class Window {
     @Nullable private final OutputTimeFn<?> outputTimeFn;
 
     private Bound(
-        String name,
         @Nullable WindowFn<? super T, ?> windowFn,
         @Nullable Trigger trigger,
         @Nullable AccumulationMode mode,
         @Nullable Duration allowedLateness,
         ClosingBehavior behavior,
         @Nullable OutputTimeFn<?> outputTimeFn) {
-      super(name);
       this.windowFn = windowFn;
       this.trigger = trigger;
       this.mode = mode;
@@ -267,8 +265,8 @@ public class Window {
       this.outputTimeFn = outputTimeFn;
     }
 
-    private Bound(String name) {
-      this(name, null, null, null, null, null, null);
+    private Bound() {
+      this(null, null, null, null, null, null);
     }
 
     /**
@@ -286,7 +284,7 @@ public class Window {
       }
 
       return new Bound<>(
-          name, windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
+          windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
     }
 
     /**
@@ -303,7 +301,6 @@ public class Window {
     @Experimental(Kind.TRIGGER)
     public Bound<T> triggering(Trigger trigger) {
       return new Bound<T>(
-          name,
           windowFn,
           trigger,
           mode,
@@ -322,7 +319,6 @@ public class Window {
     @Experimental(Kind.TRIGGER)
    public Bound<T> discardingFiredPanes() {
      return new Bound<T>(
-         name,
          windowFn,
          trigger,
          AccumulationMode.DISCARDING_FIRED_PANES,
@@ -341,7 +337,6 @@ public class Window {
    @Experimental(Kind.TRIGGER)
    public Bound<T> accumulatingFiredPanes() {
      return new Bound<T>(
-         name,
          windowFn,
          trigger,
          AccumulationMode.ACCUMULATING_FIRED_PANES,
@@ -366,7 +361,7 @@ public class Window {
     @Experimental(Kind.TRIGGER)
     public Bound<T> withAllowedLateness(Duration allowedLateness) {
       return new Bound<T>(
-          name, windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
+          windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
     }
 
     /**
@@ -376,7 +371,7 @@ public class Window {
     @Experimental(Kind.OUTPUT_TIME)
     public Bound<T> withOutputTimeFn(OutputTimeFn<?> outputTimeFn) {
       return new Bound<T>(
-          name, windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
+          windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
     }
 
     /**
@@ -391,7 +386,7 @@ public class Window {
      */
     @Experimental(Kind.TRIGGER)
     public Bound<T> withAllowedLateness(Duration allowedLateness, ClosingBehavior behavior) {
-      return new Bound<T>(name, windowFn, trigger, mode, allowedLateness, behavior, outputTimeFn);
+      return new Bound<T>(windowFn, trigger, mode, allowedLateness, behavior, outputTimeFn);
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Window.java
@@ -169,7 +169,7 @@ public class Window {
    * properties can be set on it first.
    */
   public static <T> Bound<T> into(WindowFn<? super T, ?> fn) {
-    return new Bound().into(fn);
+    return new Bound<T>().into(fn);
   }
 
   /**
@@ -182,7 +182,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> triggering(Trigger trigger) {
-    return new Bound().triggering(trigger);
+    return new Bound<T>().triggering(trigger);
   }
 
   /**
@@ -194,7 +194,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> discardingFiredPanes() {
-    return new Bound().discardingFiredPanes();
+    return new Bound<T>().discardingFiredPanes();
   }
 
   /**
@@ -206,7 +206,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> accumulatingFiredPanes() {
-    return new Bound().accumulatingFiredPanes();
+    return new Bound<T>().accumulatingFiredPanes();
   }
 
   /**
@@ -222,7 +222,7 @@ public class Window {
    */
   @Experimental(Kind.TRIGGER)
   public static <T> Bound<T> withAllowedLateness(Duration allowedLateness) {
-    return new Bound().withAllowedLateness(allowedLateness);
+    return new Bound<T>().withAllowedLateness(allowedLateness);
   }
 
   /**
@@ -231,7 +231,7 @@ public class Window {
    */
   @Experimental(Kind.OUTPUT_TIME)
   public static <T> Bound<T> withOutputTimeFn(OutputTimeFn<?> outputTimeFn) {
-    return new Bound().withOutputTimeFn(outputTimeFn);
+    return new Bound<T>().withOutputTimeFn(outputTimeFn);
   }
 
   /**
@@ -300,7 +300,7 @@ public class Window {
      */
     @Experimental(Kind.TRIGGER)
     public Bound<T> triggering(Trigger trigger) {
-      return new Bound<T>(
+      return new Bound<>(
           windowFn,
           trigger,
           mode,
@@ -318,7 +318,7 @@ public class Window {
     */
     @Experimental(Kind.TRIGGER)
    public Bound<T> discardingFiredPanes() {
-     return new Bound<T>(
+     return new Bound<>(
          windowFn,
          trigger,
          AccumulationMode.DISCARDING_FIRED_PANES,
@@ -336,7 +336,7 @@ public class Window {
     */
    @Experimental(Kind.TRIGGER)
    public Bound<T> accumulatingFiredPanes() {
-     return new Bound<T>(
+     return new Bound<>(
          windowFn,
          trigger,
          AccumulationMode.ACCUMULATING_FIRED_PANES,
@@ -360,7 +360,7 @@ public class Window {
      */
     @Experimental(Kind.TRIGGER)
     public Bound<T> withAllowedLateness(Duration allowedLateness) {
-      return new Bound<T>(
+      return new Bound<>(
           windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
     }
 
@@ -370,7 +370,7 @@ public class Window {
      */
     @Experimental(Kind.OUTPUT_TIME)
     public Bound<T> withOutputTimeFn(OutputTimeFn<?> outputTimeFn) {
-      return new Bound<T>(
+      return new Bound<>(
           windowFn, trigger, mode, allowedLateness, closingBehavior, outputTimeFn);
     }
 
@@ -386,7 +386,7 @@ public class Window {
      */
     @Experimental(Kind.TRIGGER)
     public Bound<T> withAllowedLateness(Duration allowedLateness, ClosingBehavior behavior) {
-      return new Bound<T>(windowFn, trigger, mode, allowedLateness, behavior, outputTimeFn);
+      return new Bound<>(windowFn, trigger, mode, allowedLateness, behavior, outputTimeFn);
     }
 
     /**
@@ -422,6 +422,7 @@ public class Window {
     /**
      * Get the {@link WindowFn} of this {@link Window.Bound Window PTransform}.
      */
+    @Nullable
     public WindowFn<? super T, ?> getWindowFn() {
       return windowFn;
     }
@@ -568,7 +569,7 @@ public class Window {
    * {@link org.apache.beam.sdk.transforms.GroupByKey}.
    */
   public static <T> Remerge<T> remerge() {
-    return new Remerge<T>();
+    return new Remerge<>();
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Reshuffle.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/Reshuffle.java
@@ -59,7 +59,7 @@ public class Reshuffle<K, V> extends PTransform<PCollection<KV<K, V>>, PCollecti
     // here to fail. Instead, we install a valid WindowFn that leaves all windows unchanged.
     // The OutputTimeFn is set to ensure the GroupByKey does not shift elements forwards in time.
     // Because this outputs as fast as possible, this should not hold the watermark.
-    Window.Bound<KV<K, V>> rewindow =
+    Window<KV<K, V>> rewindow =
         Window.<KV<K, V>>into(new IdentityWindowFn<>(originalStrategy.getWindowFn().windowCoder()))
             .triggering(new ReshuffleTrigger<>())
             .discardingFiredPanes()

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteTest.java
@@ -118,8 +118,8 @@ public class WriteTest {
           };
 
   private static class WindowAndReshuffle<T> extends PTransform<PCollection<T>, PCollection<T>> {
-    private final Window.Bound<T> window;
-    public WindowAndReshuffle(Window.Bound<T> window) {
+    private final Window<T> window;
+    public WindowAndReshuffle(Window<T> window) {
       this.window = window;
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -146,7 +146,7 @@ public class TestStreamTest implements Serializable {
         .advanceWatermarkToInfinity();
 
     PCollection<Long> sum = p.apply(source)
-        .apply(Window.<Long>triggering(AfterWatermark.pastEndOfWindow()
+        .apply(Window.<Long>configure().triggering(AfterWatermark.pastEndOfWindow()
             .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
                 .plusDelayOf(Duration.standardMinutes(5)))).accumulatingFiredPanes()
             .withAllowedLateness(Duration.ZERO))
@@ -272,14 +272,14 @@ public class TestStreamTest implements Serializable {
     PCollection<String> createStrings =
         p.apply("CreateStrings", stream)
             .apply("WindowStrings",
-                Window.<String>triggering(AfterPane.elementCountAtLeast(2))
+                Window.<String>configure().triggering(AfterPane.elementCountAtLeast(2))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
     PAssert.that(createStrings).containsInAnyOrder("foo", "bar");
     PCollection<Integer> createInts =
         p.apply("CreateInts", other)
             .apply("WindowInts",
-                Window.<Integer>triggering(AfterPane.elementCountAtLeast(4))
+                Window.<Integer>configure().triggering(AfterPane.elementCountAtLeast(4))
                     .withAllowedLateness(Duration.ZERO)
                     .accumulatingFiredPanes());
     PAssert.that(createInts).containsInAnyOrder(1, 2, 3, 4);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/TopTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/TopTest.java
@@ -35,7 +35,6 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.Window.Bound;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.hamcrest.Matchers;
@@ -153,7 +152,7 @@ public class TopTest {
   public void testTopEmptyWithIncompatibleWindows() {
     p.enableAbandonedNodeEnforcement(false);
 
-    Bound<String> windowingFn = Window.<String>into(FixedWindows.of(Duration.standardDays(10L)));
+    Window<String> windowingFn = Window.<String>into(FixedWindows.of(Duration.standardDays(10L)));
     PCollection<String> input = p.apply(Create.empty(StringUtf8Coder.of())).apply(windowingFn);
 
     expectedEx.expect(IllegalStateException.class);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowTest.java
@@ -52,7 +52,6 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayDataEvaluator;
-import org.apache.beam.sdk.transforms.windowing.Window.Bound;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.util.WindowingStrategy.AccumulationMode;
 import org.apache.beam.sdk.values.KV;
@@ -168,7 +167,7 @@ public class WindowTest implements Serializable {
 
   /**
    * With {@link #testWindowIntoNullWindowFnNoAssign()}, demonstrates that the expansions of the
-   * {@link Window.Bound} transform depends on if it actually assigns elements to windows.
+   * {@link Window} transform depends on if it actually assigns elements to windows.
    */
   @Test
   public void testWindowIntoWindowFnAssign() {
@@ -192,7 +191,7 @@ public class WindowTest implements Serializable {
 
   /**
    * With {@link #testWindowIntoWindowFnAssign()}, demonstrates that the expansions of the
-   * {@link Window.Bound} transform depends on if it actually assigns elements to windows.
+   * {@link Window} transform depends on if it actually assigns elements to windows.
    */
   @Test
   public void testWindowIntoNullWindowFnNoAssign() {
@@ -429,7 +428,7 @@ public class WindowTest implements Serializable {
     Window.ClosingBehavior closingBehavior = Window.ClosingBehavior.FIRE_IF_NON_EMPTY;
     OutputTimeFn<BoundedWindow> outputTimeFn = OutputTimeFns.outputAtEndOfWindow();
 
-    Window.Bound<?> window = Window
+    Window<?> window = Window
         .into(windowFn)
         .triggering(triggerBuilder)
         .accumulatingFiredPanes()
@@ -459,7 +458,7 @@ public class WindowTest implements Serializable {
     Window.ClosingBehavior closingBehavior = Window.ClosingBehavior.FIRE_IF_NON_EMPTY;
     OutputTimeFn<BoundedWindow> outputTimeFn = OutputTimeFns.outputAtEndOfWindow();
 
-    Window.Bound<?> window = Window
+    Window<?> window = Window
         .into(windowFn)
         .triggering(triggerBuilder)
         .accumulatingFiredPanes()
@@ -486,7 +485,7 @@ public class WindowTest implements Serializable {
   public void testAssignDisplayDataUnchanged() {
     FixedWindows windowFn = FixedWindows.of(Duration.standardHours(5));
 
-    Bound<Object> original = Window.into(windowFn);
+    Window<Object> original = Window.into(windowFn);
     WindowingStrategy<?, ?> updated = WindowingStrategy.globalDefault().withWindowFn(windowFn);
 
     DisplayData displayData = DisplayData.from(new Window.Assign<>(original, updated));
@@ -503,7 +502,7 @@ public class WindowTest implements Serializable {
 
   @Test
   public void testDisplayDataExcludesUnspecifiedProperties() {
-    Window.Bound<?> onlyHasAccumulationMode = Window.<Object>configure().discardingFiredPanes();
+    Window<?> onlyHasAccumulationMode = Window.<Object>configure().discardingFiredPanes();
     assertThat(DisplayData.from(onlyHasAccumulationMode), not(hasDisplayItem(hasKey(isOneOf(
         "windowFn",
         "trigger",
@@ -511,14 +510,14 @@ public class WindowTest implements Serializable {
         "allowedLateness",
         "closingBehavior")))));
 
-    Window.Bound<?> noAccumulationMode = Window.into(new GlobalWindows());
+    Window<?> noAccumulationMode = Window.into(new GlobalWindows());
     assertThat(DisplayData.from(noAccumulationMode),
         not(hasDisplayItem(hasKey("accumulationMode"))));
   }
 
   @Test
   public void testDisplayDataExcludesDefaults() {
-    Window.Bound<?> window = Window.into(new GlobalWindows())
+    Window<?> window = Window.into(new GlobalWindows())
         .triggering(DefaultTrigger.of())
         .withAllowedLateness(Duration.millis(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()));
 


### PR DESCRIPTION
Incompatible changes:

- Window.Bound class is now simply Window: matters for users that were extracting the transform into a variable.
- Static methods such as Window.triggering(), Window.withAllowedLateness() etc. are now available via Window.configure() - e.g. Window.<String>configure().withAllowedLateness(...). The method Window.into() is left intact as it is the primary entry point for windowing a collection, whereas the other methods are for adjusting the parameters of the windowing function.

R: @tgroh 