### PR TITLE
[BEAM-1842] Add CreateViewWithViewFn PTransformMatcher

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexRunner.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexRunner.java
@@ -242,7 +242,7 @@ public class ApexRunner extends PipelineRunner<ApexRunnerResult> {
           .apply(Combine.globally(transform.getCombineFn())
               .withoutDefaults().withFanout(transform.getFanout()));
 
-      PCollectionView<OutputT> view = PCollectionViews.singletonView(combined.getPipeline(),
+      PCollectionView<OutputT> view = PCollectionViews.singletonView(combined,
           combined.getWindowingStrategy(), transform.getInsertDefault(),
           transform.getInsertDefault() ? transform.getCombineFn().defaultValue() : null,
               combined.getCoder());
@@ -338,8 +338,8 @@ public class ApexRunner extends PipelineRunner<ApexRunnerResult> {
 
     @Override
     public PCollectionView<Iterable<T>> expand(PCollection<T> input) {
-      PCollectionView<Iterable<T>> view = PCollectionViews.iterableView(input.getPipeline(),
-          input.getWindowingStrategy(), input.getCoder());
+      PCollectionView<Iterable<T>> view =
+          PCollectionViews.iterableView(input, input.getWindowingStrategy(), input.getCoder());
 
       return input.apply(Combine.globally(new Concatenate<T>()).withoutDefaults())
           .apply(CreateApexPCollectionView.<T, Iterable<T>> of(view));

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -28,9 +28,12 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
+import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.ProcessElementMethod;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
+import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TaggedPValue;
@@ -164,6 +167,21 @@ public class PTransformMatchers {
           return false;
         }
         return fnType.equals(fn.getClass());
+      }
+    };
+  }
+
+  public static PTransformMatcher createViewWithViewFn(final Class<? extends ViewFn> viewFnType) {
+    return new PTransformMatcher() {
+      @Override
+      public boolean matches(AppliedPTransform<?, ?, ?> application) {
+        if (!(application.getTransform() instanceof CreatePCollectionView)) {
+          return false;
+        }
+        CreatePCollectionView<?, ?> createView =
+            (CreatePCollectionView<?, ?>) application.getTransform();
+        ViewFn<Iterable<WindowedValue<?>>, ?> viewFn = createView.getView().getViewFn();
+        return viewFn.getClass().equals(viewFnType);
       }
     };
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -41,13 +41,18 @@ import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
+import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.util.PCollectionViews;
 import org.apache.beam.sdk.util.TimeDomain;
 import org.apache.beam.sdk.util.Timer;
 import org.apache.beam.sdk.util.TimerSpec;
 import org.apache.beam.sdk.util.TimerSpecs;
+import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.util.state.StateSpec;
 import org.apache.beam.sdk.util.state.StateSpecs;
@@ -56,6 +61,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.TaggedPValue;
 import org.apache.beam.sdk.values.TupleTag;
@@ -322,6 +328,47 @@ public class PTransformMatchersTest implements Serializable {
     AppliedPTransform<?, ?, ?> notParDo = getAppliedTransform(Create.empty(VoidCoder.of()));
     PTransformMatcher matcher = PTransformMatchers.parDoWithFnType(doFnWithState.getClass());
     assertThat(matcher.matches(notParDo), is(false));
+  }
+
+  @Test
+  public void createViewWithViewFn() {
+    PCollection<Integer> input = p.apply(Create.of(1));
+    PCollectionView<Iterable<Integer>> view =
+        PCollectionViews.iterableView(input, input.getWindowingStrategy(), input.getCoder());
+    ViewFn<Iterable<WindowedValue<?>>, Iterable<Integer>> viewFn = view.getViewFn();
+    CreatePCollectionView<?, ?> createView = CreatePCollectionView.of(view);
+
+    PTransformMatcher matcher = PTransformMatchers.createViewWithViewFn(viewFn.getClass());
+    assertThat(matcher.matches(getAppliedTransform(createView)), is(true));
+  }
+
+  @Test
+  public void createViewWithViewFnDifferentViewFn() {
+    PCollection<Integer> input = p.apply(Create.of(1));
+    PCollectionView<Iterable<Integer>> view =
+        PCollectionViews.iterableView(input, input.getWindowingStrategy(), input.getCoder());
+    ViewFn<Iterable<WindowedValue<?>>, Iterable<Integer>> viewFn =
+        new ViewFn<Iterable<WindowedValue<?>>, Iterable<Integer>>() {
+          @Override
+          public Iterable<Integer> apply(Iterable<WindowedValue<?>> contents) {
+            return Collections.emptyList();
+          }
+        };
+    CreatePCollectionView<?, ?> createView = CreatePCollectionView.of(view);
+
+    PTransformMatcher matcher = PTransformMatchers.createViewWithViewFn(viewFn.getClass());
+    assertThat(matcher.matches(getAppliedTransform(createView)), is(false));
+  }
+
+  @Test
+  public void createViewWithViewFnNotCreatePCollectionView() {
+    PCollection<Integer> input = p.apply(Create.of(1));
+    PCollectionView<Iterable<Integer>> view =
+        PCollectionViews.iterableView(input, input.getWindowingStrategy(), input.getCoder());
+
+    PTransformMatcher matcher =
+        PTransformMatchers.createViewWithViewFn(view.getViewFn().getClass());
+    assertThat(matcher.matches(getAppliedTransform(View.asIterable())), is(false));
   }
 
   @Test

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SideInputHandlerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SideInputHandlerTest.java
@@ -51,20 +51,22 @@ public class SideInputHandlerTest {
   private WindowingStrategy<Object, IntervalWindow> windowingStrategy1 =
       WindowingStrategy.of(FixedWindows.of(new Duration(WINDOW_MSECS_1)));
 
-  private PCollectionView<Iterable<String>> view1 = PCollectionViewTesting.testingView(
-      new TupleTag<Iterable<WindowedValue<String>>>() {},
-      new PCollectionViewTesting.IdentityViewFn<String>(),
-      StringUtf8Coder.of(),
-      windowingStrategy1);
+  private PCollectionView<Iterable<String>> view1 =
+      PCollectionViewTesting.testingView(
+          new TupleTag<Iterable<WindowedValue<String>>>() {},
+          new PCollectionViewTesting.IdentityViewFn<String>(),
+          StringUtf8Coder.of(),
+          windowingStrategy1);
 
   private WindowingStrategy<Object, IntervalWindow> windowingStrategy2 =
       WindowingStrategy.of(FixedWindows.of(new Duration(WINDOW_MSECS_2)));
 
-  private PCollectionView<Iterable<String>> view2 = PCollectionViewTesting.testingView(
-      new TupleTag<Iterable<WindowedValue<String>>>() {},
-      new PCollectionViewTesting.IdentityViewFn<String>(),
-      StringUtf8Coder.of(),
-      windowingStrategy2);
+  private PCollectionView<Iterable<String>> view2 =
+      PCollectionViewTesting.testingView(
+          new TupleTag<Iterable<WindowedValue<String>>>() {},
+          new PCollectionViewTesting.IdentityViewFn<String>(),
+          StringUtf8Coder.of(),
+          windowingStrategy2);
 
   @Test
   public void testIsEmpty() {

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
@@ -51,6 +51,7 @@ import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
@@ -204,24 +205,12 @@ public class SideInputContainerTest {
   }
 
   @Test
-  public void withPCollectionViewsErrorsForContainsNotInViews() {
-    PCollectionView<Map<String, Iterable<String>>> newView =
-        PCollectionViews.multimapView(
-            pipeline,
-            WindowingStrategy.globalDefault(),
-            KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("with unknown views " + ImmutableList.of(newView).toString());
-
-    container.createReaderForViews(ImmutableList.<PCollectionView<?>>of(newView));
-  }
-
-  @Test
   public void withViewsForViewNotInContainerFails() {
+    PCollection<KV<String, String>> input =
+        pipeline.apply(Create.empty(new TypeDescriptor<KV<String, String>>() {}));
     PCollectionView<Map<String, Iterable<String>>> newView =
         PCollectionViews.multimapView(
-            pipeline,
+            input,
             WindowingStrategy.globalDefault(),
             KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ViewEvaluatorFactoryTest.java
@@ -63,7 +63,8 @@ public class ViewEvaluatorFactoryTest {
     PCollection<String> input = p.apply(Create.of("foo", "bar"));
     CreatePCollectionView<String, Iterable<String>> createView =
         CreatePCollectionView.of(
-            PCollectionViews.iterableView(p, input.getWindowingStrategy(), StringUtf8Coder.of()));
+            PCollectionViews.iterableView(
+                input, input.getWindowingStrategy(), StringUtf8Coder.of()));
     PCollection<Iterable<String>> concat =
         input.apply(WithKeys.<Void, String>of((Void) null))
             .setCoder(KvCoder.of(VoidCoder.of(), StringUtf8Coder.of()))

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
@@ -170,13 +170,14 @@ public class WriteWithShardingFactoryTest {
 
   @Test
   public void keyBasedOnCountFnFewElementsExtraShards() throws Exception {
+    long countValue = (long) WriteWithShardingFactory.MIN_SHARDS_FOR_LOG + 3;
+    PCollection<Long> inputCount = p.apply(Create.of(countValue));
     PCollectionView<Long> elementCountView =
         PCollectionViews.singletonView(
-            p, WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
+            inputCount, WindowingStrategy.globalDefault(), true, 0L, VarLongCoder.of());
     CalculateShardsFn fn = new CalculateShardsFn(3);
     DoFnTester<Long, Integer> fnTester = DoFnTester.of(fn);
 
-    long countValue = (long) WriteWithShardingFactory.MIN_SHARDS_FOR_LOG + 3;
     fnTester.setSideInput(elementCountView, GlobalWindow.INSTANCE, countValue);
 
     List<Integer> kvs = fnTester.processBundle(10L);

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkStreamingViewOverrides.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/FlinkStreamingViewOverrides.java
@@ -59,7 +59,7 @@ class FlinkStreamingViewOverrides {
     public PCollectionView<Map<K, V>> expand(PCollection<KV<K, V>> input) {
       PCollectionView<Map<K, V>> view =
           PCollectionViews.mapView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder());
 
@@ -104,7 +104,7 @@ class FlinkStreamingViewOverrides {
     public PCollectionView<Map<K, Iterable<V>>> expand(PCollection<KV<K, V>> input) {
       PCollectionView<Map<K, Iterable<V>>> view =
           PCollectionViews.multimapView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder());
 
@@ -144,7 +144,7 @@ class FlinkStreamingViewOverrides {
     public PCollectionView<List<T>> expand(PCollection<T> input) {
       PCollectionView<List<T>> view =
           PCollectionViews.listView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder());
 
@@ -175,7 +175,7 @@ class FlinkStreamingViewOverrides {
     public PCollectionView<Iterable<T>> expand(PCollection<T> input) {
       PCollectionView<Iterable<T>> view =
           PCollectionViews.iterableView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder());
 
@@ -272,7 +272,7 @@ class FlinkStreamingViewOverrides {
               .withFanout(transform.getFanout()));
 
       PCollectionView<OutputT> view = PCollectionViews.singletonView(
-          combined.getPipeline(),
+          combined,
           combined.getWindowingStrategy(),
           transform.getInsertDefault(),
           transform.getInsertDefault()

--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/DoFnOperatorTest.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/DoFnOperatorTest.java
@@ -58,7 +58,6 @@ import org.apache.beam.sdk.util.state.ValueState;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
-
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -85,20 +84,22 @@ public class DoFnOperatorTest {
   private WindowingStrategy<Object, IntervalWindow> windowingStrategy1 =
       WindowingStrategy.of(FixedWindows.of(new Duration(WINDOW_MSECS_1)));
 
-  private PCollectionView<Iterable<String>> view1 = PCollectionViewTesting.testingView(
-      new TupleTag<Iterable<WindowedValue<String>>>() {},
-      new PCollectionViewTesting.IdentityViewFn<String>(),
-      StringUtf8Coder.of(),
-      windowingStrategy1);
+  private PCollectionView<Iterable<String>> view1 =
+      PCollectionViewTesting.testingView(
+          new TupleTag<Iterable<WindowedValue<String>>>() {},
+          new PCollectionViewTesting.IdentityViewFn<String>(),
+          StringUtf8Coder.of(),
+          windowingStrategy1);
 
   private WindowingStrategy<Object, IntervalWindow> windowingStrategy2 =
       WindowingStrategy.of(FixedWindows.of(new Duration(WINDOW_MSECS_2)));
 
-  private PCollectionView<Iterable<String>> view2 = PCollectionViewTesting.testingView(
-      new TupleTag<Iterable<WindowedValue<String>>>() {},
-      new PCollectionViewTesting.IdentityViewFn<String>(),
-      StringUtf8Coder.of(),
-      windowingStrategy2);
+  private PCollectionView<Iterable<String>> view2 =
+      PCollectionViewTesting.testingView(
+          new TupleTag<Iterable<WindowedValue<String>>>() {},
+          new PCollectionViewTesting.IdentityViewFn<String>(),
+          StringUtf8Coder.of(),
+          windowingStrategy2);
 
   @Test
   @SuppressWarnings("unchecked")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchViewOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchViewOverrides.java
@@ -214,7 +214,7 @@ class BatchViewOverrides {
       KvCoder<K, V> inputCoder = (KvCoder) input.getCoder();
       try {
         PCollectionView<Map<K, V>> view = PCollectionViews.mapView(
-            input.getPipeline(), input.getWindowingStrategy(), inputCoder);
+            input, input.getWindowingStrategy(), inputCoder);
         return BatchViewAsMultimap.applyForMapLike(runner, input, view, true /* unique keys */);
       } catch (NonDeterministicException e) {
         runner.recordViewUsesNonDeterministicKeyCoder(this);
@@ -701,7 +701,7 @@ class BatchViewOverrides {
       KvCoder<K, V> inputCoder = (KvCoder) input.getCoder();
       try {
         PCollectionView<Map<K, Iterable<V>>> view = PCollectionViews.multimapView(
-            input.getPipeline(), input.getWindowingStrategy(), inputCoder);
+            input, input.getWindowingStrategy(), inputCoder);
 
         return applyForMapLike(runner, input, view, false /* unique keys not expected */);
       } catch (NonDeterministicException e) {
@@ -959,7 +959,7 @@ class BatchViewOverrides {
       @SuppressWarnings({"rawtypes", "unchecked"})
       PCollectionView<ViewT> view =
           (PCollectionView<ViewT>) PCollectionViews.<FinalT, W>singletonView(
-              input.getPipeline(),
+              (PCollection) input,
               (WindowingStrategy) input.getWindowingStrategy(),
               hasDefault,
               defaultValue,
@@ -1092,7 +1092,7 @@ class BatchViewOverrides {
     @Override
     public PCollectionView<List<T>> expand(PCollection<T> input) {
       PCollectionView<List<T>> view = PCollectionViews.listView(
-          input.getPipeline(), input.getWindowingStrategy(), input.getCoder());
+          input, input.getWindowingStrategy(), input.getCoder());
       return applyForIterableLike(runner, input, view);
     }
 
@@ -1177,7 +1177,7 @@ class BatchViewOverrides {
     @Override
     public PCollectionView<Iterable<T>> expand(PCollection<T> input) {
       PCollectionView<Iterable<T>> view = PCollectionViews.iterableView(
-          input.getPipeline(), input.getWindowingStrategy(), input.getCoder());
+          input, input.getWindowingStrategy(), input.getCoder());
       return BatchViewAsList.applyForIterableLike(runner, input, view);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -1601,7 +1601,7 @@ public class Combine {
       return combined.apply(
           CreatePCollectionView.<OutputT, OutputT>of(
               PCollectionViews.singletonView(
-                  input.getPipeline(),
+                  combined,
                   input.getWindowingStrategy(),
                   insertDefault,
                   insertDefault ? fn.defaultValue() : null,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -257,7 +257,7 @@ public class View {
     @Override
     public PCollectionView<List<T>> expand(PCollection<T> input) {
       return input.apply(CreatePCollectionView.<T, List<T>>of(PCollectionViews.listView(
-          input.getPipeline(), input.getWindowingStrategy(), input.getCoder())));
+          input, input.getWindowingStrategy(), input.getCoder())));
     }
   }
 
@@ -283,7 +283,7 @@ public class View {
     @Override
     public PCollectionView<Iterable<T>> expand(PCollection<T> input) {
       return input.apply(CreatePCollectionView.<T, Iterable<T>>of(PCollectionViews.iterableView(
-          input.getPipeline(), input.getWindowingStrategy(), input.getCoder())));
+          input, input.getWindowingStrategy(), input.getCoder())));
     }
   }
 
@@ -427,7 +427,7 @@ public class View {
     public PCollectionView<Map<K, Iterable<V>>> expand(PCollection<KV<K, V>> input) {
       return input.apply(CreatePCollectionView.<KV<K, V>, Map<K, Iterable<V>>>of(
           PCollectionViews.multimapView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder())));
     }
@@ -464,7 +464,7 @@ public class View {
     public PCollectionView<Map<K, V>> expand(PCollection<KV<K, V>> input) {
       return input.apply(CreatePCollectionView.<KV<K, V>, Map<K, V>>of(
           PCollectionViews.mapView(
-              input.getPipeline(),
+              input,
               input.getWindowingStrategy(),
               input.getCoder())));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionView.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionView.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.values;
 
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.View;
@@ -43,6 +44,14 @@ import org.apache.beam.sdk.util.WindowingStrategy;
  * @param <T> the type of the value(s) accessible via this {@link PCollectionView}
  */
 public interface PCollectionView<T> extends PValue, Serializable {
+  /**
+   * Gets the {@link PCollection} this {@link PCollectionView} was created from.
+   *
+   * <p>The {@link PCollection} may not be available in all contexts.
+   */
+  @Nullable
+  PCollection<?> getPCollection();
+
   /**
    * @deprecated this method will be removed entirely. The {@link PCollection} underlying a side
    *     input, is part of the side input's specification with a {@link ParDo} transform, which will

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.util.PCollectionViews;
 import org.apache.beam.sdk.util.WindowingStrategy;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.hamcrest.Matchers;
@@ -324,9 +325,10 @@ public class DoFnTesterTest {
 
   @Test
   public void fnWithSideInputDefault() throws Exception {
+    PCollection<Integer> pCollection = p.apply(Create.empty(VarIntCoder.of()));
     final PCollectionView<Integer> value =
         PCollectionViews.singletonView(
-            p, WindowingStrategy.globalDefault(), true, 0, VarIntCoder.of());
+            pCollection, WindowingStrategy.globalDefault(), true, 0, VarIntCoder.of());
 
     try (DoFnTester<Integer, Integer> tester = DoFnTester.of(new SideInputDoFn(value))) {
       tester.processElement(1);
@@ -339,9 +341,10 @@ public class DoFnTesterTest {
 
   @Test
   public void fnWithSideInputExplicit() throws Exception {
+    PCollection<Integer> pCollection = p.apply(Create.of(-2));
     final PCollectionView<Integer> value =
         PCollectionViews.singletonView(
-            p, WindowingStrategy.globalDefault(), true, 0, VarIntCoder.of());
+            pCollection, WindowingStrategy.globalDefault(), true, 0, VarIntCoder.of());
 
     try (DoFnTester<Integer, Integer> tester = DoFnTester.of(new SideInputDoFn(value))) {
       tester.setSideInput(value, GlobalWindow.INSTANCE, -2);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---   
This matcher is to stop matching the composite View.asFoo PTransforms,
as a PipelineRunner should support materialization of arbitrary
PTransforms created with the CreatePCollectionView transform.