### PR TITLE
[BEAM-1844] Increase the memory threshold for the direct runner test

### DIFF
--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -253,7 +253,7 @@ class PipelineTest(unittest.TestCase):
 
     # Consumed memory should not be proportional to the number of maps.
     memory_threshold = (
-        get_memory_usage_in_bytes() + (3 * len_elements * num_elements))
+        get_memory_usage_in_bytes() + (5 * len_elements * num_elements))
 
     # Plus small additional slack for memory fluctuations during the test.
     memory_threshold += 10 * (2 ** 20)


### PR DESCRIPTION
It seems like overtime the memory usage increased, this is to prevent test failures.