### PR TITLE
Add TestStream to Python SDK

### DIFF
--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -246,6 +246,11 @@ class TimestampedValue(object):
     self.value = value
     self.timestamp = Timestamp.of(timestamp)
 
+  def __cmp__(self, other):
+    if type(self) is not type(other):
+      return cmp(type(self), type(other))
+    return cmp((self.value, self.timestamp), (other.value, other.timestamp))
+
 
 class GlobalWindow(BoundedWindow):
   """The default window into which all data is placed (via GlobalWindows)."""

--- a/sdks/python/apache_beam/transforms/window_test.py
+++ b/sdks/python/apache_beam/transforms/window_test.py
@@ -62,6 +62,12 @@ reify_windows = core.ParDo(ReifyWindowsFn())
 
 class WindowTest(unittest.TestCase):
 
+  def test_timestamped_value_cmp(self):
+    self.assertEqual(TimestampedValue('a', 2), TimestampedValue('a', 2))
+    self.assertEqual(TimestampedValue('a', 2), TimestampedValue('a', 2.0))
+    self.assertNotEqual(TimestampedValue('a', 2), TimestampedValue('a', 2.1))
+    self.assertNotEqual(TimestampedValue('a', 2), TimestampedValue('b', 2))
+
   def test_global_window(self):
     self.assertEqual(GlobalWindow(), GlobalWindow())
     self.assertNotEqual(GlobalWindow(),

--- a/sdks/python/apache_beam/utils/test_stream.py
+++ b/sdks/python/apache_beam/utils/test_stream.py
@@ -1,0 +1,131 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Provides TestStream for verifying streaming runner semantics."""
+
+from apache_beam import coders
+from apache_beam import pvalue
+from apache_beam.transforms import PTransform
+from apache_beam.transforms.window import TimestampedValue
+from apache_beam.utils import timestamp
+from apache_beam.utils.windowed_value import WindowedValue
+
+
+class Event(object):
+  """Test stream event."""
+
+  def __cmp__(self, other):
+    if type(self) is not type(other):
+      return cmp(type(self), type(other))
+    return self._typed_cmp(other)
+
+
+class ElementEvent(Event):
+  """Element-producing test stream event."""
+
+  def __init__(self, timestamped_values):
+    self.timestamped_values = timestamped_values
+
+  def _typed_cmp(self, other):
+    return cmp(self.timestamped_values, other.timestamped_values)
+
+
+class WatermarkEvent(Event):
+  """Watermark-advancing test stream event."""
+
+  def __init__(self, new_watermark):
+    self.new_watermark = timestamp.Timestamp.of(new_watermark)
+
+  def _typed_cmp(self, other):
+    return cmp(self.new_watermark, other.new_watermark)
+
+
+class ProcessingTimeEvent(Event):
+  """Processing time-advancing test stream event."""
+
+  def __init__(self, advance_by):
+    self.advance_by = timestamp.Duration.of(advance_by)
+
+  def _typed_cmp(self, other):
+    return cmp(self.advance_by, other.advance_by)
+
+
+class TestStream(PTransform):
+  """Test stream that generates events on an unbounded PCollection of elements.
+
+  Each event emits elements, advances the watermark or advances the processing
+  time.  After all of the specified elements are emitted, ceases to produce
+  output.
+  """
+
+  def __init__(self, coder=coders.FastPrimitivesCoder):
+    assert coder is not None
+    self.coder = coder
+    self.current_watermark = timestamp.MIN_TIMESTAMP
+    self.events = []
+
+  def expand(self, pbegin):
+    assert isinstance(pbegin, pvalue.PBegin)
+    self.pipeline = pbegin.pipeline
+    return pvalue.PCollection(self.pipeline)
+
+  def _infer_output_coder(self, input_type=None, input_coder=None):
+    return self.coder
+
+  def _add(self, event):
+    if isinstance(event, ElementEvent):
+      for tv in event.timestamped_values:
+        assert tv.timestamp < timestamp.MAX_TIMESTAMP, (
+            'Element timestamp must be before timestamp.MAX_TIMESTAMP.')
+    elif isinstance(event, WatermarkEvent):
+      assert event.new_watermark > self.current_watermark, (
+          'Watermark must strictly-monotonically advance.')
+      self.current_watermark = event.new_watermark
+    elif isinstance(event, ProcessingTimeEvent):
+      assert event.advance_by > 0, (
+          'Must advance processing time by positive amount.')
+    else:
+      raise ValueError('Unknown event: %s' % event)
+    self.events.append(event)
+
+  def add_elements(self, elements):
+    timestamped_values = []
+    for element in elements:
+      if isinstance(element, TimestampedValue):
+        timestamped_values.append(element)
+      elif isinstance(element, WindowedValue):
+        # Drop windows for elements in test stream.
+        timestamped_values.append(
+            TimestampedValue(element.value, element.timestamp))
+      else:
+        # Add elements with timestamp equal to current watermark.
+        timestamped_values.append(
+            TimestampedValue(element, self.current_watermark))
+    self._add(ElementEvent(timestamped_values))
+    return self
+
+  def advance_watermark_to(self, new_watermark):
+    self._add(WatermarkEvent(new_watermark))
+    return self
+
+  def advance_watermark_to_infinity(self):
+    self.advance_watermark_to(timestamp.MAX_TIMESTAMP)
+    return self
+
+  def advance_processing_time(self, advance_by):
+    self._add(ProcessingTimeEvent(advance_by))
+    return self

--- a/sdks/python/apache_beam/utils/test_stream_test.py
+++ b/sdks/python/apache_beam/utils/test_stream_test.py
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the test_stream module."""
+
+import unittest
+
+from apache_beam.transforms.window import TimestampedValue
+from apache_beam.utils import timestamp
+from apache_beam.utils.test_stream import ElementEvent
+from apache_beam.utils.test_stream import ProcessingTimeEvent
+from apache_beam.utils.test_stream import TestStream
+from apache_beam.utils.test_stream import WatermarkEvent
+from apache_beam.utils.windowed_value import WindowedValue
+
+
+class TestStreamTest(unittest.TestCase):
+
+  def test_basic_test_stream(self):
+    test_stream = (TestStream()
+                   .advance_watermark_to(0)
+                   .add_elements([
+                       'a',
+                       WindowedValue('b', 3, []),
+                       TimestampedValue('c', 6)])
+                   .advance_processing_time(10)
+                   .advance_watermark_to(8)
+                   .add_elements(['d'])
+                   .advance_watermark_to_infinity())
+    self.assertEqual(
+        test_stream.events,
+        [
+            WatermarkEvent(0),
+            ElementEvent([
+                TimestampedValue('a', 0),
+                TimestampedValue('b', 3),
+                TimestampedValue('c', 6),
+            ]),
+            ProcessingTimeEvent(10),
+            WatermarkEvent(8),
+            ElementEvent([
+                TimestampedValue('d', 8),
+            ]),
+            WatermarkEvent(timestamp.MAX_TIMESTAMP),
+        ]
+    )
+
+  def test_test_stream_errors(self):
+    with self.assertRaises(AssertionError, msg=(
+        'Watermark must strictly-monotonically advance.')):
+      _ = (TestStream()
+           .advance_watermark_to(5)
+           .advance_watermark_to(4))
+
+    with self.assertRaises(AssertionError, msg=(
+        'Must advance processing time by positive amount.')):
+      _ = (TestStream()
+           .advance_processing_time(-1))
+
+    with self.assertRaises(AssertionError, msg=(
+        'Element timestamp must be before timestamp.MAX_TIMESTAMP.')):
+      _ = (TestStream()
+           .add_elements([
+               TimestampedValue('a', timestamp.MAX_TIMESTAMP + 1)
+           ]))
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/utils/test_stream_test.py
+++ b/sdks/python/apache_beam/utils/test_stream_test.py
@@ -75,7 +75,7 @@ class TestStreamTest(unittest.TestCase):
         'Element timestamp must be before timestamp.MAX_TIMESTAMP.')):
       _ = (TestStream()
            .add_elements([
-               TimestampedValue('a', timestamp.MAX_TIMESTAMP + 1)
+               TimestampedValue('a', timestamp.MAX_TIMESTAMP)
            ]))
 
 if __name__ == '__main__':


### PR DESCRIPTION
The TestStream will be used for verifying streaming runner semantics.
