### PR TITLE
[BEAM-1846] Update os-maven-plugin to 1.5.0.final+ for building shade file on RHEL/CentOS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <junit.version>4.12</junit.version>
     <mockito.version>1.9.5</mockito.version>
     <netty.version>4.1.6.Final</netty.version>
-    <os-maven-plugin.version>1.4.0.Final</os-maven-plugin.version>
+    <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
     <protobuf.version>3.1.0</protobuf.version>
     <pubsub.version>v1-rev10-1.22.0</pubsub.version>
     <slf4j.version>1.7.14</slf4j.version>


### PR DESCRIPTION
The current os-maven-plugin may export the profile with quote on certain versions of centos/RHEL, and it introduces the error when building shade file.

  [ERROR]... Error creating shaded jar: The name "os.detected.release.like."centos"" is not legal for JDOM/XML elements: XML names cannot contain the character """. -> [Help 1]

The error is caused by the /etc/os-release which contains some quote. The os-maven-plugin 1.4.1.final+ had fixed it. Therefore, we ought to update the os-maven-plugin to latest verison (1.5.0.fianl) for the user who can’t change the content of the /etc/os-release.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.txt).

---
