### PR TITLE
[BEAM-1856]HDFSFileSink class do not use the same configuration in master thread and slave thread.

### DIFF
--- a/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
+++ b/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
@@ -74,7 +74,7 @@ public class SerializableConfiguration implements Externalizable {
     if (conf == null) {
       return Job.getInstance();
     } else {
-      Job job = Job.getInstance();
+      Job job = Job.getInstance(new Configuration(false));
       for (Map.Entry<String, String> entry : conf.get()) {
         job.getConfiguration().set(entry.getKey(), entry.getValue());
       }

--- a/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
+++ b/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
@@ -74,6 +74,7 @@ public class SerializableConfiguration implements Externalizable {
     if (conf == null) {
       return Job.getInstance();
     } else {
+      // Don't reading configuration from slave thread, but only from master thread.
       Job job = Job.getInstance(new Configuration(false));
       for (Map.Entry<String, String> entry : conf.get()) {
         job.getConfiguration().set(entry.getKey(), entry.getValue());


### PR DESCRIPTION
As described in [BEAM-1856](https://issues.apache.org/jira/browse/BEAM-1856)  `HDFSFileSink` class do not use the same configuration in master thread and slave thread.