### PR TITLE
[BEAM-1151] Add interface for accessing failed BigQuery inserts

### DIFF
--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteToBigQuery.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteToBigQuery.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
-import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteToBigQuery.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteToBigQuery.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.options.GcpOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -119,12 +120,13 @@ public class WriteToBigQuery<InputT>
 
   @Override
   public PDone expand(PCollection<InputT> teamAndScore) {
-    return teamAndScore
+    teamAndScore
       .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
       .apply(BigQueryIO.writeTableRows().to(getTable(teamAndScore.getPipeline(), tableName))
           .withSchema(getSchema())
           .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
           .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+    return PDone.in(teamAndScore.getPipeline());
   }
 
   /** Utility to construct an output table reference. */

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteWindowedToBigQuery.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/utils/WriteWindowedToBigQuery.java
@@ -59,13 +59,14 @@ public class WriteWindowedToBigQuery<T>
 
   @Override
   public PDone expand(PCollection<T> teamAndScore) {
-    return teamAndScore
+    teamAndScore
       .apply("ConvertToRow", ParDo.of(new BuildRowFn()))
       .apply(BigQueryIO.writeTableRows()
                 .to(getTable(teamAndScore.getPipeline(), tableName))
                 .withSchema(getSchema())
                 .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
                 .withWriteDisposition(WriteDisposition.WRITE_APPEND));
+    return PDone.in(teamAndScore.getPipeline());
   }
 
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoadBigQuery.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoadBigQuery.java
@@ -45,7 +45,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -53,7 +52,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 /**
  * PTransform that uses BigQuery batch-load jobs to write a PCollection to BigQuery.
  */
-class BatchLoadBigQuery<T> extends PTransform<PCollection<T>, PDone> {
+class BatchLoadBigQuery<T> extends PTransform<PCollection<T>, WriteResult> {
   BigQueryIO.Write<T> write;
 
   BatchLoadBigQuery(BigQueryIO.Write<T> write) {
@@ -61,7 +60,7 @@ class BatchLoadBigQuery<T> extends PTransform<PCollection<T>, PDone> {
   }
 
   @Override
-  public PDone expand(PCollection<T> input) {
+  public WriteResult expand(PCollection<T> input) {
     Pipeline p = input.getPipeline();
     BigQueryOptions options = p.getOptions().as(BigQueryOptions.class);
     ValueProvider<TableReference> table = write.getTableWithDefaultProject(options);
@@ -177,6 +176,6 @@ class BatchLoadBigQuery<T> extends PTransform<PCollection<T>, PDone> {
             write.getTableDescription()))
             .withSideInputs(jobIdTokenView));
 
-    return PDone.in(input.getPipeline());
+    return WriteResult.in(input.getPipeline());
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -70,7 +70,6 @@ import org.apache.beam.sdk.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
-import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -674,7 +673,7 @@ public class BigQueryIO {
 
   /** Implementation of {@link #write}. */
   @AutoValue
-  public abstract static class Write<T> extends PTransform<PCollection<T>, PDone> {
+  public abstract static class Write<T> extends PTransform<PCollection<T>, WriteResult> {
     @VisibleForTesting
     // Maximum number of files in a single partition.
     static final int MAX_NUM_FILES = 10000;
@@ -984,7 +983,7 @@ public class BigQueryIO {
     }
 
     @Override
-    public PDone expand(PCollection<T> input) {
+    public WriteResult expand(PCollection<T> input) {
       // When writing an Unbounded PCollection, or when a tablespec function is defined, we use
       // StreamWithDeDup and BigQuery's streaming import API.
       if (input.isBounded() == IsBounded.UNBOUNDED || getTableRefFunction() != null) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -17,12 +17,10 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.google.api.services.bigquery.model.TableRow;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutputValueBase;
 import org.apache.beam.sdk.values.TaggedPValue;
 
@@ -40,19 +38,7 @@ public class WriteResult extends POutputValueBase {
 
   @Override
   public List<TaggedPValue> expand() {
-    //
     return Collections.emptyList();
-  }
-
-  /**
-   * Returns a {@link PCollection} of inserts that permanently failed when attempting to insert into
-   * BigQuery. This can be used for example to write these rows out to an alternate sink. This wil
-   * only be set if the user has specified a failed-row policy on {@link BigQueryIO.Write}.
-   *
-   * <p>This functionality is not yet implemented.
-   */
-  public PCollection<TableRow> getFailedRows() {
-    throw new UnsupportedOperationException("Failed row support not yet implemented.");
   }
 
   private WriteResult(Pipeline pipeline) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import com.google.api.services.bigquery.model.TableRow;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.POutputValueBase;
+import org.apache.beam.sdk.values.TaggedPValue;
+
+
+/**
+ * The result of a {@link BigQueryIO.Write} transform.
+ */
+public class WriteResult extends POutputValueBase {
+  /**
+   * Creates a {@link WriteResult} in the given {@link Pipeline}.
+   */
+  public static WriteResult in(Pipeline pipeline) {
+    return new WriteResult(pipeline);
+  }
+
+  @Override
+  public List<TaggedPValue> expand() {
+    //
+    return Collections.emptyList();
+  }
+
+  /**
+   * Returns a {@link PCollection} of inserts that permanently failed when attempting to insert into
+   * BigQuery. This can be used for example to write these rows out to an alternate sink. This wil
+   * only be set if the user has specified a failed-row policy on {@link BigQueryIO.Write}.
+   *
+   * <p>This functionality is not yet implemented.
+   */
+  public PCollection<TableRow> getFailedRows() {
+    throw new UnsupportedOperationException("Failed row support not yet implemented.");
+  }
+
+  private WriteResult(Pipeline pipeline) {
+    super(pipeline);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -28,11 +28,11 @@ import org.apache.beam.sdk.values.TaggedPValue;
 /**
  * The result of a {@link BigQueryIO.Write} transform.
  */
-public class WriteResult extends POutputValueBase {
+final class WriteResult extends POutputValueBase {
   /**
    * Creates a {@link WriteResult} in the given {@link Pipeline}.
    */
-  public static WriteResult in(Pipeline pipeline) {
+  static WriteResult in(Pipeline pipeline) {
     return new WriteResult(pipeline);
   }
 


### PR DESCRIPTION
This PR adds a new return type to BigQueryIO.Write, to replace PDone. This enables future features such as accessing failed inserts as a PCollection. 

R: @dhalperi 