### PR TITLE
[BEAM-1866] DataflowRunner: disable PAssert use of metrics when FnAPI is enabled

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
-import javax.xml.crypto.Data;
 import org.apache.beam.runners.dataflow.DataflowClient;
 import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.apache.beam.runners.dataflow.DataflowRunner;
@@ -187,7 +186,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   void updatePAssertCount(Pipeline pipeline) {
     DataflowPipelineOptions options = pipeline.getOptions().as(DataflowPipelineOptions.class);
     if (DataflowRunner.hasExperiment(options, "beam_fn_api")) {
-      // TODO(BEAM-1866): FnAPI does not support metrics, so expect 0 assertions.
+      // TODO[BEAM-1866]: FnAPI does not support metrics, so expect 0 assertions.
       expectedNumberOfAssertions = 0;
     } else {
       expectedNumberOfAssertions = PAssert.countAsserts(pipeline);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -34,9 +34,11 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
+import javax.xml.crypto.Data;
 import org.apache.beam.runners.dataflow.DataflowClient;
 import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.apache.beam.runners.dataflow.DataflowRunner;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.MonitoringUtil;
 import org.apache.beam.runners.dataflow.util.MonitoringUtil.JobMessagesHandler;
 import org.apache.beam.sdk.Pipeline;
@@ -183,7 +185,13 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
   @VisibleForTesting
   void updatePAssertCount(Pipeline pipeline) {
-    expectedNumberOfAssertions = PAssert.countAsserts(pipeline);
+    DataflowPipelineOptions options = pipeline.getOptions().as(DataflowPipelineOptions.class);
+    if (DataflowRunner.hasExperiment(options, "beam_fn_api")) {
+      // TODO(BEAM-1866): FnAPI does not support metrics, so expect 0 assertions.
+      expectedNumberOfAssertions = 0;
+    } else {
+      expectedNumberOfAssertions = PAssert.countAsserts(pipeline);
+    }
   }
 
   /**


### PR DESCRIPTION
FnApi does not yet support metrics

R: @tgroh 

CC: @pabloem Pablo, I think the work you're doing to improve `PAssert` might be useful here.