### PR TITLE
[BEAM-1882] Update postgres k8 scripts & add scripts for running local dev test

### DIFF
--- a/sdks/java/io/jdbc/src/test/resources/kubernetes/postgres-service-for-local-dev.yml
+++ b/sdks/java/io/jdbc/src/test/resources/kubernetes/postgres-service-for-local-dev.yml
@@ -13,20 +13,16 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+
 apiVersion: v1
-kind: Pod
+kind: Service
 metadata:
-  name: postgres-no-pv
+  name: postgres-for-dev
   labels:
-    name: postgres-no-pv
+    name: postgres
 spec:
-  containers:
-    - name: postgres
-      image: postgres
-      env:
-        - name: POSTGRES_PASSWORD
-          value: uuinkks
-        - name: PGDATA
-          value: /var/lib/postgresql/data/pgdata
-      ports:
-        - containerPort: 5432
+  ports:
+    - port: 5432
+  selector:
+    name: postgres
+  type: LoadBalancer

--- a/sdks/java/io/jdbc/src/test/resources/kubernetes/postgres.yml
+++ b/sdks/java/io/jdbc/src/test/resources/kubernetes/postgres.yml
@@ -13,16 +13,44 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: postgres-no-pv
+  name: postgres
   labels:
-    name: postgres-no-pv
+    name: postgres
 spec:
   ports:
     - port: 5432
       nodePort: 31234
   selector:
-    name: postgres-no-pv
+    name: postgres
   type: NodePort
+
+---
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    name: postgres
+  template:
+    metadata:
+      name: postgres
+      labels:
+        name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres
+          env:
+            - name: POSTGRES_PASSWORD
+              value: uuinkks
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432

--- a/sdks/java/io/jdbc/src/test/resources/kubernetes/setup.sh
+++ b/sdks/java/io/jdbc/src/test/resources/kubernetes/setup.sh
@@ -16,5 +16,4 @@
 #    limitations under the License.
 #
 
-kubectl create -f postgres-pod-no-vol.yml
-kubectl create -f postgres-service-public.yml
+kubectl create -f ./sdks/java/io/jdbc/src/test/resources/kubernetes/postgres.yml

--- a/sdks/java/io/jdbc/src/test/resources/kubernetes/teardown.sh
+++ b/sdks/java/io/jdbc/src/test/resources/kubernetes/teardown.sh
@@ -16,5 +16,4 @@
 #    limitations under the License.
 #
 
-kubectl delete service postgres-no-pv
-kubectl delete pod postgres-no-pv
+kubectl delete -f ./sdks/java/io/jdbc/src/test/resources/kubernetes/postgres.yml


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Currently, the postgres instance created is a pod - that means that if crashes/anything happens to it, it won't be re-created. We should should switch to ReplicaController, which will ensure that it will be automatically created again.

This change:
* consolidates the normal pod creation + service down to one file
* switches from pods -> replica controllers
* adds a k8s script that exposes a public IP - this can be used when doing local development.

cc @jbonofre @jasonkuster 