### PR TITLE
[BEAM-1903, BEAM-1904] Fixes SDF issues re: watermarks and stop/resume

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnAdapters.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnAdapters.java
@@ -286,6 +286,11 @@ public class DoFnAdapters {
     }
 
     @Override
+    public void updateWatermark(Instant watermark) {
+      throw new UnsupportedOperationException("Only splittable DoFn's can use updateWatermark()");
+    }
+
+    @Override
     public BoundedWindow window() {
       return context.window();
     }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -542,6 +542,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
+    public void updateWatermark(Instant watermark) {
+      throw new UnsupportedOperationException("Only splittable DoFn's can use updateWatermark()");
+    }
+
+    @Override
     public void output(OutputT output) {
       context.outputWindowedValue(windowedValue.withValue(output));
     }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
@@ -17,15 +17,11 @@
  */
 package org.apache.beam.runners.core;
 
-import static org.apache.beam.sdk.transforms.DoFn.ProcessContinuation.resume;
-import static org.apache.beam.sdk.transforms.DoFn.ProcessContinuation.stop;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.concurrent.Executors;
@@ -54,17 +50,12 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
     }
 
     @ProcessElement
-    public ProcessContinuation process(ProcessContext context, OffsetRangeTracker tracker)
+    public void process(ProcessContext context, OffsetRangeTracker tracker)
         throws Exception {
-      OffsetRange range = tracker.currentRestriction();
-      for (int i = (int) range.getFrom(); i < range.getTo(); ++i) {
-        if (!tracker.tryClaim(i)) {
-          return resume();
-        }
+      for (long i = tracker.currentRestriction().getFrom(); tracker.tryClaim(i); ++i) {
         Thread.sleep(sleepBeforeEachOutput.getMillis());
         context.output("" + i);
       }
-      return stop();
     }
 
     @GetInitialRestriction
@@ -111,7 +102,6 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
   public void testInvokeProcessElementOutputBounded() throws Exception {
     SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
         runTest(10000, Duration.ZERO);
-    assertTrue(res.getContinuation().shouldResume());
     OffsetRange residualRange = res.getResidualRestriction();
     // Should process the first 100 elements.
     assertEquals(1000, residualRange.getFrom());
@@ -122,7 +112,6 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
   public void testInvokeProcessElementTimeBounded() throws Exception {
     SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
         runTest(10000, Duration.millis(100));
-    assertTrue(res.getContinuation().shouldResume());
     OffsetRange residualRange = res.getResidualRestriction();
     // Should process ideally around 30 elements - but due to timing flakiness, we can't enforce
     // that precisely. Just test that it's not egregiously off.
@@ -135,7 +124,6 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
   public void testInvokeProcessElementVoluntaryReturn() throws Exception {
     SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
         runTest(5, Duration.millis(100));
-    assertFalse(res.getContinuation().shouldResume());
     assertNull(res.getResidualRestriction());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
+import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
@@ -548,10 +549,11 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <ul>
    * <li>It <i>must</i> define a {@link GetInitialRestriction} method.
    * <li>It <i>may</i> define a {@link SplitRestriction} method.
-   * <li>It <i>must</i> define a {@link NewTracker} method returning the same type as the type of
+   * <li>It <i>may</i> define a {@link NewTracker} method returning the same type as the type of
    *     the {@link RestrictionTracker} argument of {@link ProcessElement}, which in turn must be a
    *     subtype of {@code RestrictionTracker<R>} where {@code R} is the restriction type returned
-   *     by {@link GetInitialRestriction}.
+   *     by {@link GetInitialRestriction}. This method is optional in case the restriction type
+   *     returned by {@link GetInitialRestriction} implements {@link HasDefaultTracker}.
    * <li>It <i>may</i> define a {@link GetRestrictionCoder} method.
    * <li>The type of restrictions used by all of these methods must be the same.
    * <li>Its {@link ProcessElement} method <i>may</i> return a {@link ProcessContinuation} to

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -672,6 +672,11 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
     }
 
     @Override
+    public void updateWatermark(Instant watermark) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public PipelineOptions getPipelineOptions() {
       return context.getPipelineOptions();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -50,6 +50,7 @@ import net.bytebuddy.implementation.bytecode.Throw;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.implementation.bytecode.assign.Assigner.Typing;
 import net.bytebuddy.implementation.bytecode.assign.TypeCasting;
+import net.bytebuddy.implementation.bytecode.constant.NullConstant;
 import net.bytebuddy.implementation.bytecode.constant.TextConstant;
 import net.bytebuddy.implementation.bytecode.member.FieldAccess;
 import net.bytebuddy.implementation.bytecode.member.MethodInvocation;
@@ -625,17 +626,6 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
    * {@link ProcessElement} method.
    */
   private static final class ProcessElementDelegation extends DoFnMethodDelegation {
-    private static final MethodDescription PROCESS_CONTINUATION_STOP_METHOD;
-
-    static {
-      try {
-        PROCESS_CONTINUATION_STOP_METHOD =
-            new MethodDescription.ForLoadedMethod(DoFn.ProcessContinuation.class.getMethod("stop"));
-      } catch (NoSuchMethodException e) {
-        throw new RuntimeException("Failed to locate ProcessContinuation.stop()");
-      }
-    }
-
     private final DoFnSignature.ProcessElementMethod signature;
 
     /** Implementation of {@link MethodDelegation} for the {@link ProcessElement} method. */
@@ -672,12 +662,8 @@ public class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
     @Override
     protected StackManipulation afterDelegation(MethodDescription instrumentedMethod) {
-      if (TypeDescription.VOID.equals(targetMethod.getReturnType().asErasure())) {
-        return new StackManipulation.Compound(
-            MethodInvocation.invoke(PROCESS_CONTINUATION_STOP_METHOD), MethodReturn.REFERENCE);
-      } else {
-        return MethodReturn.of(targetMethod.getReturnType().asErasure());
-      }
+      return new StackManipulation.Compound(
+          NullConstant.INSTANCE, MethodReturn.REFERENCE);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -53,8 +53,8 @@ public interface DoFnInvoker<InputT, OutputT> {
    * Invoke the {@link DoFn.ProcessElement} method on the bound {@link DoFn}.
    *
    * @param extra Factory for producing extra parameter objects (such as window), if necessary.
-   * @return The {@link DoFn.ProcessContinuation} returned by the underlying method, or {@link
-   *     DoFn.ProcessContinuation#stop()} if it returns {@code void}.
+   * @return {@code null} - see <a href="https://issues.apache.org/jira/browse/BEAM-1904">JIRA</a>
+   *     tracking the complete removal of {@link DoFn.ProcessContinuation}.
    */
   DoFn.ProcessContinuation invokeProcessElement(ArgumentProvider<InputT, OutputT> extra);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
@@ -397,21 +396,16 @@ public abstract class DoFnSignature {
     @Nullable
     public abstract TypeDescriptor<? extends BoundedWindow> windowT();
 
-    /** Whether this {@link DoFn} returns a {@link ProcessContinuation} or void. */
-    public abstract boolean hasReturnValue();
-
     static ProcessElementMethod create(
         Method targetMethod,
         List<Parameter> extraParameters,
         TypeDescriptor<?> trackerT,
-        @Nullable TypeDescriptor<? extends BoundedWindow> windowT,
-        boolean hasReturnValue) {
+        @Nullable TypeDescriptor<? extends BoundedWindow> windowT) {
       return new AutoValue_DoFnSignature_ProcessElementMethod(
           targetMethod,
           Collections.unmodifiableList(extraParameters),
           trackerT,
-          windowT,
-          hasReturnValue);
+          windowT);
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.transforms.reflect;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
@@ -428,8 +426,6 @@ public class DoFnSignatures {
    * <li>If the {@link DoFn} (or any of its supertypes) is annotated as {@link
    *     DoFn.BoundedPerElement} or {@link DoFn.UnboundedPerElement}, use that. Only one of
    *     these must be specified.
-   * <li>If {@link DoFn.ProcessElement} returns {@link DoFn.ProcessContinuation}, assume it is
-   *     unbounded. Otherwise (if it returns {@code void}), assume it is bounded.
    * <li>If {@link DoFn.ProcessElement} returns {@code void}, but the {@link DoFn} is annotated
    *     {@link DoFn.UnboundedPerElement}, this is an error.
    * </ol>
@@ -455,10 +451,7 @@ public class DoFnSignatures {
     }
     if (processElement.isSplittable()) {
       if (isBounded == null) {
-        isBounded =
-            processElement.hasReturnValue()
-                ? PCollection.IsBounded.UNBOUNDED
-                : PCollection.IsBounded.BOUNDED;
+        isBounded = PCollection.IsBounded.BOUNDED;
       }
     } else {
       errors.checkArgument(
@@ -467,7 +460,6 @@ public class DoFnSignatures {
               + ((isBounded == PCollection.IsBounded.BOUNDED)
                   ? DoFn.BoundedPerElement.class.getSimpleName()
                   : DoFn.UnboundedPerElement.class.getSimpleName()));
-      checkState(!processElement.hasReturnValue(), "Should have been inferred splittable");
       isBounded = PCollection.IsBounded.BOUNDED;
     }
     return isBounded;
@@ -691,10 +683,8 @@ public class DoFnSignatures {
       TypeDescriptor<?> outputT,
       FnAnalysisContext fnContext) {
     errors.checkArgument(
-        void.class.equals(m.getReturnType())
-            || DoFn.ProcessContinuation.class.equals(m.getReturnType()),
-        "Must return void or %s",
-        DoFn.ProcessContinuation.class.getSimpleName());
+        void.class.equals(m.getReturnType()),
+        "Must return void");
 
 
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
@@ -734,11 +724,7 @@ public class DoFnSignatures {
     }
 
     return DoFnSignature.ProcessElementMethod.create(
-        m,
-        methodContext.getExtraParameters(),
-        trackerT,
-        windowT,
-        DoFn.ProcessContinuation.class.equals(m.getReturnType()));
+        m, methodContext.getExtraParameters(), trackerT, windowT);
   }
 
   private static void checkParameterOneOf(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -19,6 +19,9 @@ package org.apache.beam.sdk.transforms.splittabledofn;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.apache.beam.sdk.transforms.DoFn;
 
 /**
  * A {@link RestrictionTracker} for claiming offsets in an {@link OffsetRange} in a monotonically
@@ -27,6 +30,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class OffsetRangeTracker implements RestrictionTracker<OffsetRange> {
   private OffsetRange range;
   private Long lastClaimedOffset = null;
+  private Long lastAttemptedOffset = null;
 
   public OffsetRangeTracker(OffsetRange range) {
     this.range = checkNotNull(range);
@@ -59,17 +63,40 @@ public class OffsetRangeTracker implements RestrictionTracker<OffsetRange> {
    */
   public synchronized boolean tryClaim(long i) {
     checkArgument(
-        lastClaimedOffset == null || i > lastClaimedOffset,
-        "Trying to claim offset %s while last claimed was %s",
+        lastAttemptedOffset == null || i > lastAttemptedOffset,
+        "Trying to claim offset %s while last attempted was %s",
         i,
-        lastClaimedOffset);
+        lastAttemptedOffset);
     checkArgument(
         i >= range.getFrom(), "Trying to claim offset %s before start of the range %s", i, range);
+    lastAttemptedOffset = i;
     // No respective checkArgument for i < range.to() - it's ok to try claiming offsets beyond it.
     if (i >= range.getTo()) {
       return false;
     }
     lastClaimedOffset = i;
     return true;
+  }
+
+  /**
+   * Marks that there are no more offsets to be claimed in the range.
+   *
+   * <p>E.g., a {@link DoFn} reading a file and claiming the offset of each record in the file might
+   * call this if it hits EOF - even though the last attempted claim was before the end of the
+   * range, there are no more offsets to claim.
+   */
+  public synchronized void markDone() {
+    lastAttemptedOffset = Long.MAX_VALUE;
+  }
+
+  @Override
+  public synchronized void checkDone() throws IllegalStateException {
+    checkState(
+        lastAttemptedOffset >= range.getTo() - 1,
+        "Last attempted offset was %s in range %s, claiming work in [%s, %s) was not attempted",
+        lastAttemptedOffset,
+        range,
+        lastAttemptedOffset + 1,
+        range.getTo());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -38,5 +38,13 @@ public interface RestrictionTracker<RestrictionT> {
    */
   RestrictionT checkpoint();
 
+  /**
+   * Called by the runner after {@link DoFn.ProcessElement} returns.
+   *
+   * <p>Must throw an exception with an informative error message, if there is still any unclaimed
+   * work remaining in the restriction.
+   */
+  void checkDone() throws IllegalStateException;
+
   // TODO: Add the more general splitRemainderAfterFraction() and other methods.
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -39,7 +39,6 @@ import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.CustomCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.reflect.DoFnInvoker.FakeArgumentProvider;
 import org.apache.beam.sdk.transforms.reflect.testhelper.DoFnInvokersTestHelper;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
@@ -83,8 +82,8 @@ public class DoFnInvokersTest {
     when(mockArgumentProvider.processContext(Matchers.<DoFn>any())).thenReturn(mockProcessContext);
   }
 
-  private ProcessContinuation invokeProcessElement(DoFn<String, String> fn) {
-    return DoFnInvokers.invokerFor(fn).invokeProcessElement(mockArgumentProvider);
+  private void invokeProcessElement(DoFn<String, String> fn) {
+    DoFnInvokers.invokerFor(fn).invokeProcessElement(mockArgumentProvider);
   }
 
   private void invokeOnTimer(String timerId, DoFn<String, String> fn) {
@@ -113,7 +112,7 @@ public class DoFnInvokersTest {
       public void processElement(ProcessContext c) throws Exception {}
     }
     MockFn mockFn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(mockFn));
+    invokeProcessElement(mockFn);
     verify(mockFn).processElement(mockProcessContext);
   }
 
@@ -134,7 +133,7 @@ public class DoFnInvokersTest {
   public void testDoFnWithProcessElementInterface() throws Exception {
     IdentityUsingInterfaceWithProcessElement fn =
         mock(IdentityUsingInterfaceWithProcessElement.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).processElement(mockProcessContext);
   }
 
@@ -155,14 +154,14 @@ public class DoFnInvokersTest {
   @Test
   public void testDoFnWithMethodInSuperclass() throws Exception {
     IdentityChildWithoutOverride fn = mock(IdentityChildWithoutOverride.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).process(mockProcessContext);
   }
 
   @Test
   public void testDoFnWithMethodInSubclass() throws Exception {
     IdentityChildWithOverride fn = mock(IdentityChildWithOverride.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).process(mockProcessContext);
   }
 
@@ -173,7 +172,7 @@ public class DoFnInvokersTest {
       public void processElement(ProcessContext c, IntervalWindow w) throws Exception {}
     }
     MockFn fn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).processElement(mockProcessContext, mockWindow);
   }
 
@@ -197,7 +196,7 @@ public class DoFnInvokersTest {
           throws Exception {}
     }
     MockFn fn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).processElement(mockProcessContext, mockState);
   }
 
@@ -223,32 +222,8 @@ public class DoFnInvokersTest {
       public void onTimer() {}
     }
     MockFn fn = mock(MockFn.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).processElement(mockProcessContext, mockTimer);
-  }
-
-  @Test
-  public void testDoFnWithReturn() throws Exception {
-    class MockFn extends DoFn<String, String> {
-      @DoFn.ProcessElement
-      public ProcessContinuation processElement(ProcessContext c, SomeRestrictionTracker tracker)
-          throws Exception {
-        return null;
-      }
-
-      @GetInitialRestriction
-      public SomeRestriction getInitialRestriction(String element) {
-        return null;
-      }
-
-      @NewTracker
-      public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
-        return null;
-      }
-    }
-    MockFn fn = mock(MockFn.class);
-    when(fn.processElement(mockProcessContext, null)).thenReturn(ProcessContinuation.resume());
-    assertEquals(ProcessContinuation.resume(), invokeProcessElement(fn));
   }
 
   @Test
@@ -306,9 +281,7 @@ public class DoFnInvokersTest {
   /** Public so Mockito can do "delegatesTo()" in the test below. */
   public static class MockFn extends DoFn<String, String> {
     @ProcessElement
-    public ProcessContinuation processElement(ProcessContext c, SomeRestrictionTracker tracker) {
-      return null;
-    }
+    public void processElement(ProcessContext c, SomeRestrictionTracker tracker) {}
 
     @GetInitialRestriction
     public SomeRestriction getInitialRestriction(String element) {
@@ -360,7 +333,7 @@ public class DoFnInvokersTest {
         .splitRestriction(
             eq("blah"), same(restriction), Mockito.<DoFn.OutputReceiver<SomeRestriction>>any());
     when(fn.newTracker(restriction)).thenReturn(tracker);
-    when(fn.processElement(mockProcessContext, tracker)).thenReturn(ProcessContinuation.resume());
+    fn.processElement(mockProcessContext, tracker);
 
     assertEquals(coder, invoker.invokeGetRestrictionCoder(new CoderRegistry()));
     assertEquals(restriction, invoker.invokeGetInitialRestriction("blah"));
@@ -376,8 +349,6 @@ public class DoFnInvokersTest {
         });
     assertEquals(Arrays.asList(part1, part2, part3), outputs);
     assertEquals(tracker, invoker.invokeNewTracker(restriction));
-    assertEquals(
-        ProcessContinuation.resume(),
         invoker.invokeProcessElement(
             new FakeArgumentProvider<String, String>() {
               @Override
@@ -389,7 +360,7 @@ public class DoFnInvokersTest {
               public RestrictionTracker<?> restrictionTracker() {
                 return tracker;
               }
-            }));
+            });
   }
 
   private static class RestrictionWithDefaultTracker
@@ -410,6 +381,9 @@ public class DoFnInvokersTest {
     public RestrictionWithDefaultTracker checkpoint() {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void checkDone() throws IllegalStateException {}
   }
 
   private static class CoderForDefaultTracker extends CustomCoder<RestrictionWithDefaultTracker> {
@@ -459,8 +433,7 @@ public class DoFnInvokersTest {
             assertEquals("foo", output);
           }
         });
-    assertEquals(
-        ProcessContinuation.stop(), invoker.invokeProcessElement(mockArgumentProvider));
+    invoker.invokeProcessElement(mockArgumentProvider);
     assertThat(
         invoker.invokeNewTracker(new RestrictionWithDefaultTracker()),
         instanceOf(DefaultTracker.class));
@@ -550,14 +523,14 @@ public class DoFnInvokersTest {
   @Test
   public void testLocalPrivateDoFnClass() throws Exception {
     PrivateDoFnClass fn = mock(PrivateDoFnClass.class);
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     verify(fn).processThis(mockProcessContext);
   }
 
   @Test
   public void testStaticPackagePrivateDoFnClass() throws Exception {
     DoFn<String, String> fn = mock(DoFnInvokersTestHelper.newStaticPackagePrivateDoFn().getClass());
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyStaticPackagePrivateDoFn(fn, mockProcessContext);
   }
 
@@ -565,28 +538,28 @@ public class DoFnInvokersTest {
   public void testInnerPackagePrivateDoFnClass() throws Exception {
     DoFn<String, String> fn =
         mock(new DoFnInvokersTestHelper().newInnerPackagePrivateDoFn().getClass());
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyInnerPackagePrivateDoFn(fn, mockProcessContext);
   }
 
   @Test
   public void testStaticPrivateDoFnClass() throws Exception {
     DoFn<String, String> fn = mock(DoFnInvokersTestHelper.newStaticPrivateDoFn().getClass());
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyStaticPrivateDoFn(fn, mockProcessContext);
   }
 
   @Test
   public void testInnerPrivateDoFnClass() throws Exception {
     DoFn<String, String> fn = mock(new DoFnInvokersTestHelper().newInnerPrivateDoFn().getClass());
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyInnerPrivateDoFn(fn, mockProcessContext);
   }
 
   @Test
   public void testAnonymousInnerDoFn() throws Exception {
     DoFn<String, String> fn = mock(new DoFnInvokersTestHelper().newInnerAnonymousDoFn().getClass());
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyInnerAnonymousDoFn(fn, mockProcessContext);
   }
 
@@ -594,7 +567,7 @@ public class DoFnInvokersTest {
   public void testStaticAnonymousDoFnInOtherPackage() throws Exception {
     // Can't use mockito for this one - the anonymous class is final and can't be mocked.
     DoFn<String, String> fn = DoFnInvokersTestHelper.newStaticAnonymousDoFn();
-    assertEquals(ProcessContinuation.stop(), invokeProcessElement(fn));
+    invokeProcessElement(fn);
     DoFnInvokersTestHelper.verifyStaticAnonymousDoFnInvoked(fn, mockProcessContext);
   }
 
@@ -620,32 +593,6 @@ public class DoFnInvokersTest {
         return null;
       }
     });
-  }
-
-  @Test
-  public void testProcessElementExceptionWithReturn() throws Exception {
-    thrown.expect(UserCodeException.class);
-    thrown.expectMessage("bogus");
-    DoFnInvokers
-        .invokerFor(
-            new DoFn<Integer, Integer>() {
-              @ProcessElement
-              public ProcessContinuation processElement(
-                  @SuppressWarnings("unused") ProcessContext c, SomeRestrictionTracker tracker) {
-                throw new IllegalArgumentException("bogus");
-              }
-
-              @GetInitialRestriction
-              public SomeRestriction getInitialRestriction(Integer element) {
-                return null;
-              }
-
-              @NewTracker
-              public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
-                return null;
-              }
-            })
-        .invokeProcessElement(new FakeArgumentProvider<Integer, Integer>());
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
@@ -50,7 +50,7 @@ public class DoFnSignaturesProcessElementTest {
   @Test
   public void testBadReturnType() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Must return void or ProcessContinuation");
+    thrown.expectMessage("Must return void");
 
     analyzeProcessElementMethod(
         new AnonymousMethod() {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -60,20 +60,6 @@ public class DoFnSignaturesSplittableDoFnTest {
   private abstract static class SomeRestrictionCoder implements Coder<SomeRestriction> {}
 
   @Test
-  public void testReturnsProcessContinuation() throws Exception {
-    DoFnSignature.ProcessElementMethod signature =
-        analyzeProcessElementMethod(
-            new AnonymousMethod() {
-              private DoFn.ProcessContinuation method(
-                  DoFn<Integer, String>.ProcessContext context) {
-                return null;
-              }
-            });
-
-    assertTrue(signature.hasReturnValue());
-  }
-
-  @Test
   public void testHasRestrictionTracker() throws Exception {
     DoFnSignature.ProcessElementMethod signature =
         analyzeProcessElementMethod(
@@ -157,54 +143,6 @@ public class DoFnSignaturesSplittableDoFnTest {
             .isBoundedPerElement());
   }
 
-  private static class BaseFnWithContinuation extends DoFn<Integer, String> {
-    @ProcessElement
-    public ProcessContinuation processElement(
-        ProcessContext context, SomeRestrictionTracker tracker) {
-      return null;
-    }
-
-    @GetInitialRestriction
-    public SomeRestriction getInitialRestriction(Integer element) {
-      return null;
-    }
-
-    @NewTracker
-    public SomeRestrictionTracker newTracker(SomeRestriction restriction) {
-      return null;
-    }
-  }
-
-  @Test
-  public void testSplittableIsBoundedByDefault() throws Exception {
-    assertEquals(
-        PCollection.IsBounded.UNBOUNDED,
-        DoFnSignatures
-            .getSignature(BaseFnWithContinuation.class)
-            .isBoundedPerElement());
-  }
-
-  @Test
-  public void testSplittableRespectsBoundednessAnnotation() throws Exception {
-    @BoundedPerElement
-    class BoundedFnWithContinuation extends BaseFnWithContinuation {}
-
-    assertEquals(
-        PCollection.IsBounded.BOUNDED,
-        DoFnSignatures
-            .getSignature(BoundedFnWithContinuation.class)
-            .isBoundedPerElement());
-
-    @UnboundedPerElement
-    class UnboundedFnWithContinuation extends BaseFnWithContinuation {}
-
-    assertEquals(
-        PCollection.IsBounded.UNBOUNDED,
-        DoFnSignatures
-            .getSignature(UnboundedFnWithContinuation.class)
-            .isBoundedPerElement());
-  }
-
   @Test
   public void testUnsplittableButDeclaresBounded() throws Exception {
     @BoundedPerElement
@@ -234,10 +172,8 @@ public class DoFnSignaturesSplittableDoFnTest {
   public void testSplittableWithAllFunctions() throws Exception {
     class GoodSplittableDoFn extends DoFn<Integer, String> {
       @ProcessElement
-      public ProcessContinuation processElement(
-          ProcessContext context, SomeRestrictionTracker tracker) {
-        return null;
-      }
+      public void processElement(
+          ProcessContext context, SomeRestrictionTracker tracker) {}
 
       @GetInitialRestriction
       public SomeRestriction getInitialRestriction(Integer element) {
@@ -262,7 +198,6 @@ public class DoFnSignaturesSplittableDoFnTest {
     DoFnSignature signature = DoFnSignatures.getSignature(GoodSplittableDoFn.class);
     assertEquals(SomeRestrictionTracker.class, signature.processElement().trackerT().getRawType());
     assertTrue(signature.processElement().isSplittable());
-    assertTrue(signature.processElement().hasReturnValue());
     assertEquals(
         SomeRestriction.class, signature.getInitialRestriction().restrictionT().getRawType());
     assertEquals(SomeRestriction.class, signature.splitRestriction().restrictionT().getRawType());
@@ -279,9 +214,7 @@ public class DoFnSignaturesSplittableDoFnTest {
   public void testSplittableWithAllFunctionsGeneric() throws Exception {
     class GoodGenericSplittableDoFn<RestrictionT, TrackerT, CoderT> extends DoFn<Integer, String> {
       @ProcessElement
-      public ProcessContinuation processElement(ProcessContext context, TrackerT tracker) {
-        return null;
-      }
+      public void processElement(ProcessContext context, TrackerT tracker) {}
 
       @GetInitialRestriction
       public RestrictionT getInitialRestriction(Integer element) {
@@ -309,7 +242,6 @@ public class DoFnSignaturesSplittableDoFnTest {
                 SomeRestriction, SomeRestrictionTracker, SomeRestrictionCoder>() {}.getClass());
     assertEquals(SomeRestrictionTracker.class, signature.processElement().trackerT().getRawType());
     assertTrue(signature.processElement().isSplittable());
-    assertTrue(signature.processElement().hasReturnValue());
     assertEquals(
         SomeRestriction.class, signature.getInitialRestriction().restrictionT().getRawType());
     assertEquals(SomeRestriction.class, signature.splitRestriction().restrictionT().getRawType());


### PR DESCRIPTION
See detailed discussion in document:
https://docs.google.com/document/d/1BGc8pM1GOvZhwR9SARSVte-20XEoBUxrGJ5gTWXdv3c/edit

In particular, this PR:
- Removes DoFn.ProcessContinuation and all the code and tests that handled returning resume() - from DoFnSignatures, DoFnInvokers, and SplittableParDo and runner hooks, as well as inference of UnboundedPerElement from the return value.
- Adds ProcessContext.updateWatermark(), currently allowed to be called only from SDF. This has surprisingly little impact - basically just a "throw unsupported" implementation in SimpleDoFnRunner and DoFnTester, and a proper implementation in SDF code
- Adds RestrictionTracker.checkDone() and unit tests

Overall this looks much easier of a change than I thought, and should be pretty easy to review. 90% of the code is for bullet 1; bullet 2 is not really separable from it so it's in the same commit. Bullet 3 could be separated; I can put it in a separate commit if needed, but it's a small amount of code.

R: @tgroh 