### PR TITLE
[BEAM-1799] Move HashingFn to io/common, switch to better hash

### DIFF
--- a/sdks/java/io/common/pom.xml
+++ b/sdks/java/io/common/pom.xml
@@ -34,5 +34,9 @@
         <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-java-core</artifactId>
       </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+      </dependency>
     </dependencies>
 </project>

--- a/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/HashingFn.java
+++ b/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/HashingFn.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.beam.sdk.io.hadoop.inputformat.hashing;
+package org.apache.beam.sdk.io.common;
 
 import com.google.common.collect.Lists;
 import com.google.common.hash.HashCode;
@@ -62,7 +62,7 @@ public class HashingFn extends CombineFn<String, HashingFn.Accum, String> {
      if (accum.hashCode != null) {
       elementHashes.add(accum.hashCode);
     }
-    HashCode inputHashCode = Hashing.sha1().hashString(input, StandardCharsets.UTF_8);
+    HashCode inputHashCode = Hashing.murmur3_128().hashString(input, StandardCharsets.UTF_8);
     elementHashes.add(inputHashCode);
     accum.hashCode = Hashing.combineUnordered(elementHashes);
     return accum;

--- a/sdks/java/io/hadoop/jdk1.8-tests/pom.xml
+++ b/sdks/java/io/hadoop/jdk1.8-tests/pom.xml
@@ -36,41 +36,6 @@
 
   <build>
     <plugins>
-      <plugin>
-       <!-- Guava shading is required as Cassandra tests require version
-       19 of Guava, by default project wide Guava shading may not suffice as it
-       loads a different version of guava which will not work for Cassandra tests -->
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>com.google.guava:guava:19.0</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>com.google.common</pattern>
-                  <shadedPattern>org.apache.beam.sdk.io.hadoop.jdk1.8-tests.repackaged.com.google.common</shadedPattern>
-                </relocation>
-               <relocation>
-                 <pattern>com.google.thirdparty</pattern>
-                 <shadedPattern>org.apache.beam.sdk.io.hadoop.jdk1.8-tests.repackaged.com.google.thirdparty</shadedPattern>
-                 </relocation>
-               </relocations>
-               <transformers>
-                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-               </transformers>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
       <!-- Overridden enforcer plugin for JDK1.8 for running tests -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -178,11 +143,6 @@
       <artifactId>beam-sdks-java-io-hadoop-input-format</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -206,6 +166,12 @@
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-direct-java</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-common</artifactId>
+      <scope>test</scope>
+      <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithElasticTest.java
+++ b/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithElasticTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.beam.sdk.io.hadoop.inputformat.hashing.HashingFn;
+import org.apache.beam.sdk.io.common.HashingFn;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Combine;
@@ -105,7 +105,7 @@ public class HIFIOWithElasticTest implements Serializable {
   @Test
   public void testHifIOWithElastic() {
     // Expected hashcode is evaluated during insertion time one time and hardcoded here.
-    String expectedHashCode = "e2098f431f90193aa4545e033e6fd2217aafe7b6";
+    String expectedHashCode = "a62a85f5f081e3840baf1028d4d6c6bc";
     Configuration conf = getConfiguration();
     PCollection<KV<Text, LinkedMapWritable>> esData =
         pipeline.apply(HadoopInputFormatIO.<Text, LinkedMapWritable>read().withConfiguration(conf));
@@ -135,7 +135,7 @@ public class HIFIOWithElasticTest implements Serializable {
   @Test
   public void testHifIOWithElasticQuery() {
     long expectedRowCount = 1L;
-    String expectedHashCode = "caa37dbd8258e3a7f98932958c819a57aab044ec";
+    String expectedHashCode = "cfbf3e5c993d44e57535a114e25f782d";
     Configuration conf = getConfiguration();
     String fieldValue = ELASTIC_TYPE_ID_PREFIX + "2";
     String query = "{"

--- a/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/integration/tests/HIFIOCassandraIT.java
+++ b/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/integration/tests/HIFIOCassandraIT.java
@@ -21,9 +21,9 @@ import com.datastax.driver.core.Row;
 
 import java.io.Serializable;
 
+import org.apache.beam.sdk.io.common.HashingFn;
 import org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIO;
 import org.apache.beam.sdk.io.hadoop.inputformat.custom.options.HIFTestOptions;
-import org.apache.beam.sdk.io.hadoop.inputformat.hashing.HashingFn;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;

--- a/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/integration/tests/HIFIOElasticIT.java
+++ b/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/integration/tests/HIFIOElasticIT.java
@@ -17,9 +17,9 @@ package org.apache.beam.sdk.io.hadoop.inputformat.integration.tests;
 import java.io.IOException;
 import java.io.Serializable;
 
+import org.apache.beam.sdk.io.common.HashingFn;
 import org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIO;
 import org.apache.beam.sdk.io.hadoop.inputformat.custom.options.HIFTestOptions;
-import org.apache.beam.sdk.io.hadoop.inputformat.hashing.HashingFn;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
HadoopInputFormatIO has a hashing function that can be used to easily verify reads - this moves it to a common place so other IOs can use it. 

It also switches from SHA1 -> murmur since that's a good, fast hash (which is all we need). That meant I had to update the hashes in the unit tests.

cc @dhalperi please take a look
cc @diptikul this will change some of the code you're working on, wanted to make sure you're aware. Should be an easy merge, but wanted to give you a heads up. Also, I had thought that the Guava 19 dependency in HIFIO was a hard requirement, but I seem to be able to mvn verify & run the HIFIO ITs without it. Is there something I should be doing to cause the problem? (perhaps it was in the removed cassandra-unit dependency?)