### PR TITLE
TestDataflowRunner: better error handling

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -326,7 +326,8 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     private final StringBuffer errorMessage;
     private volatile boolean hasSeenError;
 
-    private ErrorMonitorMessagesHandler(DataflowPipelineJob job, JobMessagesHandler messageHandler) {
+    private ErrorMonitorMessagesHandler(
+        DataflowPipelineJob job, JobMessagesHandler messageHandler) {
       this.job = job;
       this.messageHandler = messageHandler;
       this.errorMessage = new StringBuffer();

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -111,8 +111,8 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
     assertThat(job, testPipelineOptions.getOnCreateMatcher());
 
-    CancelWorkflowOnError messageHandler = new CancelWorkflowOnError(
-        job, new MonitoringUtil.LoggingHandler());
+    final ErrorMonitorMessagesHandler messageHandler =
+        new ErrorMonitorMessagesHandler(job, new MonitoringUtil.LoggingHandler());
 
     try {
       final Optional<Boolean> success;
@@ -126,6 +126,10 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               for (;;) {
                 JobMetrics metrics = getJobMetrics(job);
                 Optional<Boolean> success = checkForPAssertSuccess(job, metrics);
+                if (messageHandler.hasSeenError()) {
+                  return Optional.of(false);
+                }
+
                 if (success.isPresent() && (!success.get() || atMaxWatermark(job, metrics))) {
                   // It's possible that the streaming pipeline doesn't use PAssert.
                   // So checkForSuccess() will return true before job is finished.
@@ -312,18 +316,21 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   }
 
   /**
-   * Cancels the workflow on the first error message it sees.
+   * Monitors job log output messages for errors.
    *
    * <p>Creates an error message representing the concatenation of all error messages seen.
    */
-  private static class CancelWorkflowOnError implements JobMessagesHandler {
+  private static class ErrorMonitorMessagesHandler implements JobMessagesHandler {
     private final DataflowPipelineJob job;
     private final JobMessagesHandler messageHandler;
     private final StringBuffer errorMessage;
-    private CancelWorkflowOnError(DataflowPipelineJob job, JobMessagesHandler messageHandler) {
+    private volatile boolean hasSeenError;
+
+    private ErrorMonitorMessagesHandler(DataflowPipelineJob job, JobMessagesHandler messageHandler) {
       this.job = job;
       this.messageHandler = messageHandler;
       this.errorMessage = new StringBuffer();
+      this.hasSeenError = false;
     }
 
     @Override
@@ -335,20 +342,16 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
           LOG.info("Dataflow job {} threw exception. Failure message was: {}",
               job.getJobId(), message.getMessageText());
           errorMessage.append(message.getMessageText());
-        }
-      }
-      if (errorMessage.length() > 0) {
-        LOG.info("Cancelling Dataflow job {}", job.getJobId());
-        try {
-          job.cancel();
-        } catch (Exception ignore) {
-          // The TestDataflowRunner will thrown an AssertionError with the job failure
-          // messages.
+          hasSeenError = true;
         }
       }
     }
 
-    private String getErrorMessage() {
+    boolean hasSeenError() {
+      return hasSeenError;
+    }
+
+    String getErrorMessage() {
       return errorMessage.toString();
     }
   }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -207,7 +208,7 @@ public class TestDataflowRunnerTest {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {
       assertThat(expected.getMessage(), containsString("FooException"));
-      verify(mockJob, atLeastOnce()).cancel();
+      verify(mockJob, never()).cancel();
       return;
     }
     // Note that fail throws an AssertionError which is why it is placed out here


### PR DESCRIPTION
1. There was a race in which pipelines without PAsserts might
   erroneously pass because they would be canceled, which would
   in turn cause the watermarks to reach max infinity, which
   would in turn (because there are no PAsserts) cause the main
   streaming poll loop think the pipeline succeeded.

   Fix this by making the error presence available to the main
   polling loop, and only canceling from there.

2. The fact we were canceling from two places meant we could
   get double-cancelations that led to test failures.

Fix both these issues (I hope).