### PR TITLE
[BEAM-1907] PubsubIO: remove support for BoundedReader

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -83,8 +83,6 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.FileBasedSink;
-import org.apache.beam.sdk.io.PubsubIO.Read.PubsubBoundedReader;
-import org.apache.beam.sdk.io.PubsubIO.Write.PubsubBoundedWriter;
 import org.apache.beam.sdk.io.PubsubUnboundedSink;
 import org.apache.beam.sdk.io.PubsubUnboundedSource;
 import org.apache.beam.sdk.io.Read;
@@ -303,15 +301,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             PTransformOverride.of(
                 PTransformMatchers.emptyFlatten(), EmptyFlattenAsCreateFactory.instance()));
     if (streaming) {
-      // In streaming mode must use either the custom Pubsub unbounded source/sink or
-      // defer to Windmill's built-in implementation.
-      for (Class<? extends DoFn> unsupported :
-          ImmutableSet.of(PubsubBoundedReader.class, PubsubBoundedWriter.class)) {
-        overridesBuilder.add(
-            PTransformOverride.of(
-                PTransformMatchers.parDoWithFnType(unsupported),
-                UnsupportedOverrideFactory.withMessage(getUnsupportedMessage(unsupported, true))));
-      }
       if (!hasExperiment(options, "enable_custom_pubsub_source")) {
         overridesBuilder.add(
             PTransformOverride.of(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/PubsubIOTest.java
@@ -95,17 +95,13 @@ public class PubsubIOTest {
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .topic(StaticValueProvider.of(topic))
         .timestampLabel("myTimestamp")
-        .idLabel("myId")
-        .maxNumRecords(1234)
-        .maxReadTime(maxReadTime);
+        .idLabel("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("topic", topic));
     assertThat(displayData, hasDisplayItem("timestampLabel", "myTimestamp"));
     assertThat(displayData, hasDisplayItem("idLabel", "myId"));
-    assertThat(displayData, hasDisplayItem("maxNumRecords", 1234));
-    assertThat(displayData, hasDisplayItem("maxReadTime", maxReadTime));
   }
 
   @Test
@@ -116,17 +112,13 @@ public class PubsubIOTest {
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .subscription(StaticValueProvider.of(subscription))
         .timestampLabel("myTimestamp")
-        .idLabel("myId")
-        .maxNumRecords(1234)
-        .maxReadTime(maxReadTime);
+        .idLabel("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("subscription", subscription));
     assertThat(displayData, hasDisplayItem("timestampLabel", "myTimestamp"));
     assertThat(displayData, hasDisplayItem("idLabel", "myId"));
-    assertThat(displayData, hasDisplayItem("maxNumRecords", 1234));
-    assertThat(displayData, hasDisplayItem("maxReadTime", maxReadTime));
   }
 
   @Test


### PR DESCRIPTION
Google Cloud Pub/Sub is not currently that useful in bounded mode --
it's a streaming source. Years ago, before the DirectRunner supported
unbounded PCollections and sources, however, we were unable to run the
streaming source in any SDK -- so we added a trivial bounded mode for
testing.

That trivial mode is no longer necessary. Additionally, it may confuse
users into thinking it's reliable (it's not), performant (it's not),
or has well defined semantics (it doesn't) -- it's really intended just
for testing.

Now that the DirectRunner supports everything we need -- unbounded
PCollections, non-blocking execution with cancelation, etc. -- we can
delete the bounded mode.