### PR TITLE
[BEAM-1908] Allow setting CREATE_NEVER when using a tablespec in BigQueryIO

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -954,12 +954,6 @@ public class BigQueryIO {
 
       if (input.isBounded() == PCollection.IsBounded.UNBOUNDED || getTableRefFunction() != null) {
         // We will use BigQuery's streaming write API -- validate supported dispositions.
-        if (getTableRefFunction() != null) {
-          checkArgument(
-              getCreateDisposition() != CreateDisposition.CREATE_NEVER,
-              "CreateDisposition.CREATE_NEVER is not supported when using a tablespec"
-              + " function.");
-        }
         if (getJsonSchema() == null) {
           checkArgument(
               getCreateDisposition() == CreateDisposition.CREATE_NEVER,


### PR DESCRIPTION
Currently, the BigQueryIO.Write transform doesn't allow CreateDisposition.CREATE_NEVER to be set when using a tablespec to determine the BigQuery table name dynamically at runtime.

This check was originally put in because it was assumed that BigQueryIO would need to create a new table every time the tablespec returns a table name that hasn't been seen before. Since then a new BigQuery feature was released which enables date partitioning within a single table, and is now the preferred way to shard data by date (instead of having a table per date). It should therefore be possible to use tablespec to write to a specific partition e.g. `my-project:dataset.my_table$20170407`, while setting CreateDisposition.CREATE_NEVER since we never need to create a new table.

This PR removes the check so that CreateDisposition.CREATE_NEVER can be used with a tablespec.