### PR TITLE
HIFIO Cassandra tests were failing if run twice in a row without a clean

### DIFF
--- a/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithEmbeddedCassandraTest.java
+++ b/sdks/java/io/hadoop/jdk1.8-tests/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithEmbeddedCassandraTest.java
@@ -147,6 +147,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
   }
 
   public static void createCassandraData() throws Exception {
+    session.execute("DROP KEYSPACE IF EXISTS " + CASSANDRA_KEYSPACE);
     session.execute("CREATE KEYSPACE " + CASSANDRA_KEYSPACE
         + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};");
     session.execute("USE " + CASSANDRA_KEYSPACE);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
The embedded cassandra tests work correctly the first time they are run after a mvn clean - on any test phase execution of the jdk1.8-tests directory after that (ie, any time you run this unit tests again), they will fail. Thus, this passes our "mvn clean verify" runs and is not breaking CI, but will likely break any devs running tests in this directory locally without clean-ing. (aka, me)

R @dhalperi 
R @tgroh 
...whoever gets to this first