### PR TITLE
[BEAM-1272] Align the naming of "generateInitialSplits" and "splitIntoBundles" to better reflect their intention

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/utils/ValuesSource.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/utils/ValuesSource.java
@@ -55,7 +55,7 @@ public class ValuesSource<T> extends UnboundedSource<T, UnboundedSource.Checkpoi
   }
 
   @Override
-  public java.util.List<? extends UnboundedSource<T, CheckpointMark>> generateInitialSplits(
+  public java.util.List<? extends UnboundedSource<T, CheckpointMark>> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.singletonList(this);
   }

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/utils/ValuesSource.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/utils/ValuesSource.java
@@ -55,7 +55,7 @@ public class ValuesSource<T> extends UnboundedSource<T, UnboundedSource.Checkpoi
   }
 
   @Override
-  public java.util.List<? extends UnboundedSource<T, CheckpointMark>> splitIntoSubSources(
+  public java.util.List<? extends UnboundedSource<T, CheckpointMark>> split(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.singletonList(this);
   }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/UnboundedTextSource.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/UnboundedTextSource.java
@@ -39,7 +39,7 @@ public class UnboundedTextSource extends UnboundedSource<String, UnboundedSource
   private static final long serialVersionUID = 1L;
 
   @Override
-  public List<? extends UnboundedSource<String, CheckpointMark>> splitIntoSubSources(
+  public List<? extends UnboundedSource<String, CheckpointMark>> split(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.<UnboundedSource<String, CheckpointMark>>singletonList(this);
   }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/UnboundedTextSource.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/UnboundedTextSource.java
@@ -39,7 +39,7 @@ public class UnboundedTextSource extends UnboundedSource<String, UnboundedSource
   private static final long serialVersionUID = 1L;
 
   @Override
-  public List<? extends UnboundedSource<String, CheckpointMark>> generateInitialSplits(
+  public List<? extends UnboundedSource<String, CheckpointMark>> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.<UnboundedSource<String, CheckpointMark>>singletonList(this);
   }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/GroupByKeyTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/GroupByKeyTranslatorTest.java
@@ -131,7 +131,7 @@ public class GroupByKeyTranslatorTest {
     }
 
     @Override
-    public List<? extends UnboundedSource<String, CheckpointMark>> splitIntoSubSources(
+    public List<? extends UnboundedSource<String, CheckpointMark>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return Collections.<UnboundedSource<String, CheckpointMark>>singletonList(this);
     }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/GroupByKeyTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/GroupByKeyTranslatorTest.java
@@ -131,7 +131,7 @@ public class GroupByKeyTranslatorTest {
     }
 
     @Override
-    public List<? extends UnboundedSource<String, CheckpointMark>> generateInitialSplits(
+    public List<? extends UnboundedSource<String, CheckpointMark>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return Collections.<UnboundedSource<String, CheckpointMark>>singletonList(this);
     }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/utils/CollectionSource.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/utils/CollectionSource.java
@@ -47,7 +47,7 @@ public class CollectionSource<T> extends UnboundedSource<T, UnboundedSource.Chec
   }
 
   @Override
-  public List<? extends UnboundedSource<T, CheckpointMark>> splitIntoSubSources(
+  public List<? extends UnboundedSource<T, CheckpointMark>> split(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.singletonList(this);
   }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/utils/CollectionSource.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/utils/CollectionSource.java
@@ -47,7 +47,7 @@ public class CollectionSource<T> extends UnboundedSource<T, UnboundedSource.Chec
   }
 
   @Override
-  public List<? extends UnboundedSource<T, CheckpointMark>> generateInitialSplits(
+  public List<? extends UnboundedSource<T, CheckpointMark>> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) throws Exception {
     return Collections.singletonList(this);
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
@@ -62,7 +62,7 @@ import org.slf4j.LoggerFactory;
  * {@link PTransform} that converts a {@link BoundedSource} as an {@link UnboundedSource}.
  *
  * <p>{@link BoundedSource} is read directly without calling
- * {@link BoundedSource#splitIntoSubSources},
+ * {@link BoundedSource#split},
  * and element timestamps are propagated. While any elements remain, the watermark is the beginning
  * of time {@link BoundedWindow#TIMESTAMP_MIN_VALUE}, and after all elements have been produced
  * the watermark goes to the end of time {@link BoundedWindow#TIMESTAMP_MAX_VALUE}.
@@ -131,7 +131,7 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
     }
 
     @Override
-    public List<BoundedToUnboundedSourceAdapter<T>> splitIntoSubSources(
+    public List<BoundedToUnboundedSourceAdapter<T>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       try {
         long desiredBundleSize = boundedSource.getEstimatedSizeBytes(options) / desiredNumSplits;
@@ -141,7 +141,7 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
           return ImmutableList.of(this);
         }
         List<? extends BoundedSource<T>> splits =
-            boundedSource.splitIntoSubSources(desiredBundleSize, options);
+            boundedSource.split(desiredBundleSize, options);
         if (splits == null) {
           LOG.warn("BoundedSource cannot split {}, skips the initial splits.", boundedSource);
           return ImmutableList.of(this);

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
@@ -61,7 +61,8 @@ import org.slf4j.LoggerFactory;
 /**
  * {@link PTransform} that converts a {@link BoundedSource} as an {@link UnboundedSource}.
  *
- * <p>{@link BoundedSource} is read directly without calling {@link BoundedSource#splitIntoBundles},
+ * <p>{@link BoundedSource} is read directly without calling
+ * {@link BoundedSource#splitIntoSubSources},
  * and element timestamps are propagated. While any elements remain, the watermark is the beginning
  * of time {@link BoundedWindow#TIMESTAMP_MIN_VALUE}, and after all elements have been produced
  * the watermark goes to the end of time {@link BoundedWindow#TIMESTAMP_MAX_VALUE}.
@@ -130,7 +131,7 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
     }
 
     @Override
-    public List<BoundedToUnboundedSourceAdapter<T>> generateInitialSplits(
+    public List<BoundedToUnboundedSourceAdapter<T>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       try {
         long desiredBundleSize = boundedSource.getEstimatedSizeBytes(options) / desiredNumSplits;
@@ -140,7 +141,7 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
           return ImmutableList.of(this);
         }
         List<? extends BoundedSource<T>> splits =
-            boundedSource.splitIntoBundles(desiredBundleSize, options);
+            boundedSource.splitIntoSubSources(desiredBundleSize, options);
         if (splits == null) {
           LOG.warn("BoundedSource cannot split {}, skips the initial splits.", boundedSource);
           return ImmutableList.of(this);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -196,7 +196,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
       long estimatedBytes = source.getEstimatedSizeBytes(options);
       long bytesPerBundle = estimatedBytes / targetParallelism;
       List<? extends BoundedSource<T>> bundles =
-          source.splitIntoBundles(bytesPerBundle, options);
+          source.splitIntoSubSources(bytesPerBundle, options);
       ImmutableList.Builder<CommittedBundle<BoundedSourceShard<T>>> shards =
           ImmutableList.builder();
       for (BoundedSource<T> bundle : bundles) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -196,7 +196,7 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
       long estimatedBytes = source.getEstimatedSizeBytes(options);
       long bytesPerBundle = estimatedBytes / targetParallelism;
       List<? extends BoundedSource<T>> bundles =
-          source.splitIntoSubSources(bytesPerBundle, options);
+          source.split(bytesPerBundle, options);
       ImmutableList.Builder<CommittedBundle<BoundedSourceShard<T>>> shards =
           ImmutableList.builder();
       for (BoundedSource<T> bundle : bundles) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -301,7 +301,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
         throws Exception {
       UnboundedSource<OutputT, ?> source = transform.getTransform().getSource();
       List<? extends UnboundedSource<OutputT, ?>> splits =
-          source.generateInitialSplits(targetParallelism, evaluationContext.getPipelineOptions());
+          source.splitIntoSubSources(targetParallelism, evaluationContext.getPipelineOptions());
       UnboundedReadDeduplicator deduplicator =
           source.requiresDeduping()
               ? UnboundedReadDeduplicator.CachedIdDeduplicator.create()

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -301,7 +301,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
         throws Exception {
       UnboundedSource<OutputT, ?> source = transform.getTransform().getSource();
       List<? extends UnboundedSource<OutputT, ?>> splits =
-          source.splitIntoSubSources(targetParallelism, evaluationContext.getPipelineOptions());
+          source.split(targetParallelism, evaluationContext.getPipelineOptions());
       UnboundedReadDeduplicator deduplicator =
           source.requiresDeduping()
               ? UnboundedReadDeduplicator.CachedIdDeduplicator.create()

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -265,7 +265,7 @@ public class BoundedReadEvaluatorFactoryTest {
   public void boundedSourceInMemoryTransformEvaluatorShardsOfSource() throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
     List<? extends BoundedSource<Long>> splits =
-        source.splitIntoSubSources(source.getEstimatedSizeBytes(options) / 2, options);
+        source.split(source.getEstimatedSizeBytes(options) / 2, options);
 
     UncommittedBundle<BoundedSourceShard<Long>> rootBundle = bundleFactory.createRootBundle();
     for (BoundedSource<Long> split : splits) {
@@ -365,7 +365,7 @@ public class BoundedReadEvaluatorFactoryTest {
     }
 
     @Override
-    public List<? extends OffsetBasedSource<T>> splitIntoSubSources(
+    public List<? extends OffsetBasedSource<T>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactoryTest.java
@@ -265,7 +265,7 @@ public class BoundedReadEvaluatorFactoryTest {
   public void boundedSourceInMemoryTransformEvaluatorShardsOfSource() throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
     List<? extends BoundedSource<Long>> splits =
-        source.splitIntoBundles(source.getEstimatedSizeBytes(options) / 2, options);
+        source.splitIntoSubSources(source.getEstimatedSizeBytes(options) / 2, options);
 
     UncommittedBundle<BoundedSourceShard<Long>> rootBundle = bundleFactory.createRootBundle();
     for (BoundedSource<Long> split : splits) {
@@ -365,7 +365,7 @@ public class BoundedReadEvaluatorFactoryTest {
     }
 
     @Override
-    public List<? extends OffsetBasedSource<T>> splitIntoBundles(
+    public List<? extends OffsetBasedSource<T>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -549,13 +549,13 @@ public class DirectRunnerTest implements Serializable {
     }
 
     @Override
-    public List<? extends BoundedSource<T>> splitIntoBundles(
+    public List<? extends BoundedSource<T>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       // Must have more than
       checkState(
           desiredBundleSizeBytes < getEstimatedSizeBytes(options),
           "Must split into more than one source");
-      return underlying.splitIntoBundles(desiredBundleSizeBytes, options);
+      return underlying.splitIntoSubSources(desiredBundleSizeBytes, options);
     }
 
     @Override

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -549,13 +549,13 @@ public class DirectRunnerTest implements Serializable {
     }
 
     @Override
-    public List<? extends BoundedSource<T>> splitIntoSubSources(
+    public List<? extends BoundedSource<T>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       // Must have more than
       checkState(
           desiredBundleSizeBytes < getEstimatedSizeBytes(options),
           "Must split into more than one source");
-      return underlying.splitIntoSubSources(desiredBundleSizeBytes, options);
+      return underlying.split(desiredBundleSizeBytes, options);
     }
 
     @Override

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
@@ -450,7 +450,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     }
 
     @Override
-    public List<? extends UnboundedSource<T, TestCheckpointMark>> splitIntoSubSources(
+    public List<? extends UnboundedSource<T, TestCheckpointMark>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactoryTest.java
@@ -450,7 +450,7 @@ public class UnboundedReadEvaluatorFactoryTest {
     }
 
     @Override
-    public List<? extends UnboundedSource<T, TestCheckpointMark>> generateInitialSplits(
+    public List<? extends UnboundedSource<T, TestCheckpointMark>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
@@ -101,7 +101,7 @@ public class SourceInputFormat<T>
     try {
       long desiredSizeBytes = initialSource.getEstimatedSizeBytes(options) / numSplits;
       List<? extends Source<T>> shards =
-          initialSource.splitIntoSubSources(desiredSizeBytes, options);
+          initialSource.split(desiredSizeBytes, options);
       int numShards = shards.size();
       SourceInputSplit<T>[] sourceInputSplits = new SourceInputSplit[numShards];
       for (int i = 0; i < numShards; i++) {

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
@@ -100,7 +100,8 @@ public class SourceInputFormat<T>
   public SourceInputSplit<T>[] createInputSplits(int numSplits) throws IOException {
     try {
       long desiredSizeBytes = initialSource.getEstimatedSizeBytes(options) / numSplits;
-      List<? extends Source<T>> shards = initialSource.splitIntoBundles(desiredSizeBytes, options);
+      List<? extends Source<T>> shards =
+          initialSource.splitIntoSubSources(desiredSizeBytes, options);
       int numShards = shards.size();
       SourceInputSplit<T>[] sourceInputSplits = new SourceInputSplit[numShards];
       for (int i = 0; i < numShards; i++) {

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/BoundedSourceWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/BoundedSourceWrapper.java
@@ -76,7 +76,7 @@ public class BoundedSourceWrapper<OutputT>
     // get the splits early. we assume that the generated splits are stable,
     // this is necessary so that the mapping of state to source is correct
     // when restoring
-    splitSources = source.splitIntoBundles(desiredBundleSize, pipelineOptions);
+    splitSources = source.splitIntoSubSources(desiredBundleSize, pipelineOptions);
   }
 
   @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/BoundedSourceWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/BoundedSourceWrapper.java
@@ -76,7 +76,7 @@ public class BoundedSourceWrapper<OutputT>
     // get the splits early. we assume that the generated splits are stable,
     // this is necessary so that the mapping of state to source is correct
     // when restoring
-    splitSources = source.splitIntoSubSources(desiredBundleSize, pipelineOptions);
+    splitSources = source.split(desiredBundleSize, pipelineOptions);
   }
 
   @Override

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
@@ -62,7 +62,7 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
   }
 
   @Override
-  public List<? extends UnboundedSource<T, UnboundedSource.CheckpointMark>> generateInitialSplits(
+  public List<? extends UnboundedSource<T, UnboundedSource.CheckpointMark>> splitIntoSubSources(
       int desiredNumSplits,
       PipelineOptions options) throws Exception {
     throw new RuntimeException("Flink Sources are supported only when "

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedFlinkSource.java
@@ -62,7 +62,7 @@ public class UnboundedFlinkSource<T> extends UnboundedSource<T, UnboundedSource.
   }
 
   @Override
-  public List<? extends UnboundedSource<T, UnboundedSource.CheckpointMark>> splitIntoSubSources(
+  public List<? extends UnboundedSource<T, UnboundedSource.CheckpointMark>> split(
       int desiredNumSplits,
       PipelineOptions options) throws Exception {
     throw new RuntimeException("Flink Sources are supported only when "

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
@@ -94,7 +94,7 @@ public class UnboundedSocketSource<CheckpointMarkT extends UnboundedSource.Check
   }
 
   @Override
-  public List<? extends UnboundedSource<String, CheckpointMarkT>> splitIntoSubSources(
+  public List<? extends UnboundedSource<String, CheckpointMarkT>> split(
       int desiredNumSplits,
       PipelineOptions options) throws Exception {
     return Collections.<UnboundedSource<String, CheckpointMarkT>>singletonList(this);

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
@@ -94,7 +94,7 @@ public class UnboundedSocketSource<CheckpointMarkT extends UnboundedSource.Check
   }
 
   @Override
-  public List<? extends UnboundedSource<String, CheckpointMarkT>> generateInitialSplits(
+  public List<? extends UnboundedSource<String, CheckpointMarkT>> splitIntoSubSources(
       int desiredNumSplits,
       PipelineOptions options) throws Exception {
     return Collections.<UnboundedSource<String, CheckpointMarkT>>singletonList(this);

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -156,7 +156,7 @@ public class UnboundedSourceWrapper<
     // get the splits early. we assume that the generated splits are stable,
     // this is necessary so that the mapping of state to source is correct
     // when restoring
-    splitSources = source.splitIntoSubSources(parallelism, pipelineOptions);
+    splitSources = source.split(parallelism, pipelineOptions);
   }
 
 

--- a/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/runner/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -156,7 +156,7 @@ public class UnboundedSourceWrapper<
     // get the splits early. we assume that the generated splits are stable,
     // this is necessary so that the mapping of state to source is correct
     // when restoring
-    splitSources = source.generateInitialSplits(parallelism, pipelineOptions);
+    splitSources = source.splitIntoSubSources(parallelism, pipelineOptions);
   }
 
 

--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
@@ -104,7 +104,7 @@ public class TestCountingSource
   }
 
   @Override
-  public List<TestCountingSource> splitIntoSubSources(
+  public List<TestCountingSource> split(
       int desiredNumSplits, PipelineOptions options) {
     List<TestCountingSource> splits = new ArrayList<>();
     int numSplits = allowSplitting ? desiredNumSplits : 1;

--- a/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
+++ b/runners/flink/runner/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
@@ -104,7 +104,7 @@ public class TestCountingSource
   }
 
   @Override
-  public List<TestCountingSource> generateInitialSplits(
+  public List<TestCountingSource> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) {
     List<TestCountingSource> splits = new ArrayList<>();
     int numSplits = allowSplitting ? desiredNumSplits : 1;

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
@@ -98,7 +98,7 @@ public class CustomSources {
       int desiredNumSplits =
           getDesiredNumUnboundedSourceSplits(options.as(DataflowPipelineOptions.class));
       for (UnboundedSource<?, ?> split :
-          unboundedSource.generateInitialSplits(desiredNumSplits, options)) {
+          unboundedSource.splitIntoSubSources(desiredNumSplits, options)) {
         encodedSplits.add(encodeBase64String(serializeToByteArray(split)));
       }
       checkArgument(!encodedSplits.isEmpty(), "UnboundedSources must have at least one split");

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/CustomSources.java
@@ -98,7 +98,7 @@ public class CustomSources {
       int desiredNumSplits =
           getDesiredNumUnboundedSourceSplits(options.as(DataflowPipelineOptions.class));
       for (UnboundedSource<?, ?> split :
-          unboundedSource.splitIntoSubSources(desiredNumSplits, options)) {
+          unboundedSource.split(desiredNumSplits, options)) {
         encodedSplits.add(encodeBase64String(serializeToByteArray(split)));
       }
       checkArgument(!encodedSplits.isEmpty(), "UnboundedSources must have at least one split");

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/MicrobatchSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/MicrobatchSource.java
@@ -102,12 +102,11 @@ public class MicrobatchSource<T, CheckpointMarkT extends UnboundedSource.Checkpo
   }
 
   @Override
-  public List<? extends BoundedSource<T>>
-      splitIntoBundles(long desiredBundleSizeBytes,
+  public List<? extends BoundedSource<T>> splitIntoSubSources(long desiredBundleSizeBytes,
                        PipelineOptions options) throws Exception {
     List<MicrobatchSource<T, CheckpointMarkT>> result = new ArrayList<>();
     List<? extends UnboundedSource<T, CheckpointMarkT>> splits =
-        source.generateInitialSplits(numInitialSplits, options);
+        source.splitIntoSubSources(numInitialSplits, options);
     int numSplits = splits.size();
     long[] numRecords = splitNumRecords(maxNumRecords, numSplits);
     for (int i = 0; i < numSplits; i++) {

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/MicrobatchSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/MicrobatchSource.java
@@ -102,11 +102,11 @@ public class MicrobatchSource<T, CheckpointMarkT extends UnboundedSource.Checkpo
   }
 
   @Override
-  public List<? extends BoundedSource<T>> splitIntoSubSources(long desiredBundleSizeBytes,
+  public List<? extends BoundedSource<T>> split(long desiredBundleSizeBytes,
                        PipelineOptions options) throws Exception {
     List<MicrobatchSource<T, CheckpointMarkT>> result = new ArrayList<>();
     List<? extends UnboundedSource<T, CheckpointMarkT>> splits =
-        source.splitIntoSubSources(numInitialSplits, options);
+        source.split(numInitialSplits, options);
     int numSplits = splits.size();
     long[] numRecords = splitNumRecords(maxNumRecords, numSplits);
     for (int i = 0; i < numSplits; i++) {

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
@@ -104,7 +104,7 @@ class SourceDStream<T, CheckpointMarkT extends UnboundedSource.CheckpointMark>
     try {
       this.numPartitions =
           createMicrobatchSource()
-              .splitIntoSubSources(initialParallelism, options)
+              .split(initialParallelism, options)
               .size();
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceDStream.java
@@ -104,7 +104,7 @@ class SourceDStream<T, CheckpointMarkT extends UnboundedSource.CheckpointMark>
     try {
       this.numPartitions =
           createMicrobatchSource()
-              .splitIntoBundles(initialParallelism, options)
+              .splitIntoSubSources(initialParallelism, options)
               .size();
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
@@ -105,7 +105,7 @@ public class SourceRDD {
             + "size of {} bytes.", source, DEFAULT_BUNDLE_SIZE);
       }
       try {
-        List<? extends Source<T>> partitionedSources = source.splitIntoBundles(desiredSizeBytes,
+        List<? extends Source<T>> partitionedSources = source.splitIntoSubSources(desiredSizeBytes,
             runtimeContext.getPipelineOptions());
         Partition[] partitions = new SourcePartition[partitionedSources.size()];
         for (int i = 0; i < partitionedSources.size(); i++) {
@@ -258,7 +258,7 @@ public class SourceRDD {
     @Override
     public Partition[] getPartitions() {
       try {
-        List<? extends Source<T>> partitionedSources = microbatchSource.splitIntoBundles(
+        List<? extends Source<T>> partitionedSources = microbatchSource.splitIntoSubSources(
             -1 /* ignored */, runtimeContext.getPipelineOptions());
         Partition[] partitions = new CheckpointableSourcePartition[partitionedSources.size()];
         for (int i = 0; i < partitionedSources.size(); i++) {

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
@@ -105,7 +105,7 @@ public class SourceRDD {
             + "size of {} bytes.", source, DEFAULT_BUNDLE_SIZE);
       }
       try {
-        List<? extends Source<T>> partitionedSources = source.splitIntoSubSources(desiredSizeBytes,
+        List<? extends Source<T>> partitionedSources = source.split(desiredSizeBytes,
             runtimeContext.getPipelineOptions());
         Partition[] partitions = new SourcePartition[partitionedSources.size()];
         for (int i = 0; i < partitionedSources.size(); i++) {
@@ -258,7 +258,7 @@ public class SourceRDD {
     @Override
     public Partition[] getPartitions() {
       try {
-        List<? extends Source<T>> partitionedSources = microbatchSource.splitIntoSubSources(
+        List<? extends Source<T>> partitionedSources = microbatchSource.split(
             -1 /* ignored */, runtimeContext.getPipelineOptions());
         Partition[] partitions = new CheckpointableSourcePartition[partitionedSources.size()];
         for (int i = 0; i < partitionedSources.size(); i++) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
@@ -186,12 +186,12 @@ public class BoundedReadFromUnboundedSource<T> extends PTransform<PBegin, PColle
     }
 
     @Override
-    public List<? extends BoundedSource<ValueWithRecordId<T>>> splitIntoSubSources(
+    public List<? extends BoundedSource<ValueWithRecordId<T>>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       List<UnboundedToBoundedSourceAdapter<T>> result = new ArrayList<>();
       int numInitialSplits = numInitialSplits(getMaxNumRecords());
       List<? extends UnboundedSource<T, ?>> splits =
-          getSource().splitIntoSubSources(numInitialSplits, options);
+          getSource().split(numInitialSplits, options);
       int numSplits = splits.size();
       long[] numRecords = splitNumRecords(getMaxNumRecords(), numSplits);
       for (int i = 0; i < numSplits; i++) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedReadFromUnboundedSource.java
@@ -186,12 +186,12 @@ public class BoundedReadFromUnboundedSource<T> extends PTransform<PBegin, PColle
     }
 
     @Override
-    public List<? extends BoundedSource<ValueWithRecordId<T>>> splitIntoBundles(
+    public List<? extends BoundedSource<ValueWithRecordId<T>>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       List<UnboundedToBoundedSourceAdapter<T>> result = new ArrayList<>();
       int numInitialSplits = numInitialSplits(getMaxNumRecords());
       List<? extends UnboundedSource<T, ?>> splits =
-          getSource().generateInitialSplits(numInitialSplits, options);
+          getSource().splitIntoSubSources(numInitialSplits, options);
       int numSplits = splits.size();
       long[] numRecords = splitNumRecords(getMaxNumRecords(), numSplits);
       for (int i = 0; i < numSplits; i++) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -58,6 +58,15 @@ public abstract class BoundedSource<T> extends Source<T> {
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception;
 
   /**
+   * {@link BoundedSource#split(long, PipelineOptions)} old method name to be used with Google Cloud Dataflow
+   */
+  @Deprecated
+  public final List<? extends BoundedSource<T>> splitIntoBundles(
+      long desiredBundleSizeBytes, PipelineOptions options) throws Exception{
+      return split(desiredBundleSizeBytes, options);
+  }
+
+  /**
    * An estimate of the total size (in bytes) of the data that would be read from this source.
    * This estimate is in terms of external storage size, before any decompression or other
    * processing done by the reader.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -61,7 +61,7 @@ public abstract class BoundedSource<T> extends Source<T> {
    * {@link BoundedSource#split(long, PipelineOptions)} old method name to be used with Dataflow.
    */
   @Deprecated
-  public final List<? extends BoundedSource<T>> splitIntoBundles(
+  public List<? extends BoundedSource<T>> splitIntoBundles(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception{
       return split(desiredBundleSizeBytes, options);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -58,7 +58,7 @@ public abstract class BoundedSource<T> extends Source<T> {
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception;
 
   /**
-   * {@link BoundedSource#split(long, PipelineOptions)} old method name to be used with Google Cloud Dataflow
+   * {@link BoundedSource#split(long, PipelineOptions)} old method name to be used with Dataflow.
    */
   @Deprecated
   public final List<? extends BoundedSource<T>> splitIntoBundles(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -34,7 +34,7 @@ import org.joda.time.Instant;
  *
  * <p>The operations are:
  * <ul>
- * <li>Splitting into sources that read bundles of given size: {@link #splitIntoSubSources};
+ * <li>Splitting into sources that read bundles of given size: {@link #split};
  * <li>Size estimation: {@link #getEstimatedSizeBytes};
  * <li>The accompanying {@link BoundedReader reader} has additional functionality to enable runners
  * to dynamically adapt based on runtime conditions.
@@ -54,7 +54,7 @@ public abstract class BoundedSource<T> extends Source<T> {
   /**
    * Splits the source into bundles of approximately {@code desiredBundleSizeBytes}.
    */
-  public abstract List<? extends BoundedSource<T>> splitIntoSubSources(
+  public abstract List<? extends BoundedSource<T>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception;
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/BoundedSource.java
@@ -34,7 +34,7 @@ import org.joda.time.Instant;
  *
  * <p>The operations are:
  * <ul>
- * <li>Splitting into bundles of given size: {@link #splitIntoBundles};
+ * <li>Splitting into sources that read bundles of given size: {@link #splitIntoSubSources};
  * <li>Size estimation: {@link #getEstimatedSizeBytes};
  * <li>The accompanying {@link BoundedReader reader} has additional functionality to enable runners
  * to dynamically adapt based on runtime conditions.
@@ -54,7 +54,7 @@ public abstract class BoundedSource<T> extends Source<T> {
   /**
    * Splits the source into bundles of approximately {@code desiredBundleSizeBytes}.
    */
-  public abstract List<? extends BoundedSource<T>> splitIntoBundles(
+  public abstract List<? extends BoundedSource<T>> splitIntoSubSources(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception;
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -326,7 +326,7 @@ public class CountingSource {
      * {@code [2, 8, 14, ...)}, and {@code [4, 10, 16, ...)}.
      */
     @Override
-    public List<? extends UnboundedSource<Long, CountingSource.CounterMark>> generateInitialSplits(
+    public List<? extends UnboundedSource<Long, CountingSource.CounterMark>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       // Using Javadoc example, stride 2 with 3 splits becomes stride 6.
       long newStride = stride * desiredNumSplits;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -326,7 +326,7 @@ public class CountingSource {
      * {@code [2, 8, 14, ...)}, and {@code [4, 10, 16, ...)}.
      */
     @Override
-    public List<? extends UnboundedSource<Long, CountingSource.CounterMark>> splitIntoSubSources(
+    public List<? extends UnboundedSource<Long, CountingSource.CounterMark>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       // Using Javadoc example, stride 2 with 3 splits becomes stride 6.
       long newStride = stride * desiredNumSplits;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -324,15 +324,15 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       @Override
       public List<? extends FileBasedSource<T>> call() throws Exception {
         return createForSubrangeOfFile(file, 0, Long.MAX_VALUE)
-            .splitIntoBundles(desiredBundleSizeBytes, options);
+            .splitIntoSubSources(desiredBundleSizeBytes, options);
       }
     });
   }
 
   @Override
-  public final List<? extends FileBasedSource<T>> splitIntoBundles(
+  public final List<? extends FileBasedSource<T>> splitIntoSubSources(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
-    // This implementation of method splitIntoBundles is provided to simplify subclasses. Here we
+    // This implementation of method splitIntoSubSources is provided to simplify subclasses. Here we
     // split a FileBasedSource based on a file pattern to FileBasedSources based on full single
     // files. For files that can be efficiently seeked, we further split FileBasedSources based on
     // those files to FileBasedSources based on sub ranges of single files.
@@ -370,7 +370,8 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
     } else {
       if (isSplittable()) {
         List<FileBasedSource<T>> splitResults = new ArrayList<>();
-        for (OffsetBasedSource<T> split : super.splitIntoBundles(desiredBundleSizeBytes, options)) {
+        for (OffsetBasedSource<T> split :
+            super.splitIntoSubSources(desiredBundleSizeBytes, options)) {
           splitResults.add((FileBasedSource<T>) split);
         }
         return splitResults;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -324,15 +324,15 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       @Override
       public List<? extends FileBasedSource<T>> call() throws Exception {
         return createForSubrangeOfFile(file, 0, Long.MAX_VALUE)
-            .splitIntoSubSources(desiredBundleSizeBytes, options);
+            .split(desiredBundleSizeBytes, options);
       }
     });
   }
 
   @Override
-  public final List<? extends FileBasedSource<T>> splitIntoSubSources(
+  public final List<? extends FileBasedSource<T>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
-    // This implementation of method splitIntoSubSources is provided to simplify subclasses. Here we
+    // This implementation of method split is provided to simplify subclasses. Here we
     // split a FileBasedSource based on a file pattern to FileBasedSources based on full single
     // files. For files that can be efficiently seeked, we further split FileBasedSources based on
     // those files to FileBasedSources based on sub ranges of single files.
@@ -371,7 +371,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       if (isSplittable()) {
         List<FileBasedSource<T>> splitResults = new ArrayList<>();
         for (OffsetBasedSource<T> split :
-            super.splitIntoSubSources(desiredBundleSizeBytes, options)) {
+            super.split(desiredBundleSizeBytes, options)) {
           splitResults.add((FileBasedSource<T>) split);
         }
         return splitResults;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -108,7 +108,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
   }
 
   @Override
-  public List<? extends OffsetBasedSource<T>> splitIntoSubSources(
+  public List<? extends OffsetBasedSource<T>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     // Split the range into bundles based on the desiredBundleSizeBytes. Final bundle is adjusted to
     // make sure that we do not end up with a too small bundle at the end. If the desired bundle
@@ -163,7 +163,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
   /**
    * Returns approximately how many bytes of data correspond to a single offset in this source.
    * Used for translation between this source's range and methods defined in terms of bytes, such
-   * as {@link #getEstimatedSizeBytes} and {@link #splitIntoSubSources}.
+   * as {@link #getEstimatedSizeBytes} and {@link #split}.
    *
    * <p>Defaults to {@code 1} byte, which is the common case for, e.g., file sources.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -108,7 +108,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
   }
 
   @Override
-  public List<? extends OffsetBasedSource<T>> splitIntoBundles(
+  public List<? extends OffsetBasedSource<T>> splitIntoSubSources(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     // Split the range into bundles based on the desiredBundleSizeBytes. Final bundle is adjusted to
     // make sure that we do not end up with a too small bundle at the end. If the desired bundle
@@ -163,7 +163,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
   /**
    * Returns approximately how many bytes of data correspond to a single offset in this source.
    * Used for translation between this source's range and methods defined in terms of bytes, such
-   * as {@link #getEstimatedSizeBytes} and {@link #splitIntoBundles}.
+   * as {@link #getEstimatedSizeBytes} and {@link #splitIntoSubSources}.
    *
    * <p>Defaults to {@code 1} byte, which is the common case for, e.g., file sources.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
@@ -65,7 +65,7 @@ public abstract class UnboundedSource<
    * as possible, but does not have to match exactly.  A low number of splits
    * will limit the amount of parallelism in the source.
    */
-  public abstract List<? extends UnboundedSource<OutputT, CheckpointMarkT>> generateInitialSplits(
+  public abstract List<? extends UnboundedSource<OutputT, CheckpointMarkT>> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) throws Exception;
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/UnboundedSource.java
@@ -65,7 +65,7 @@ public abstract class UnboundedSource<
    * as possible, but does not have to match exactly.  A low number of splits
    * will limit the amount of parallelism in the source.
    */
-  public abstract List<? extends UnboundedSource<OutputT, CheckpointMarkT>> splitIntoSubSources(
+  public abstract List<? extends UnboundedSource<OutputT, CheckpointMarkT>> split(
       int desiredNumSplits, PipelineOptions options) throws Exception;
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * amount of test coverage with few code. Most notable ones are:
  * <ul>
  *   <li>{@link #assertSourcesEqualReferenceSource} helps testing that the data read
- *   by the union of sources produced by {@link BoundedSource#splitIntoBundles}
+ *   by the union of sources produced by {@link BoundedSource#splitIntoSubSources}
  *   is the same as data read by the original source.
  *   <li>If your source implements dynamic work rebalancing, use the
  *   {@code assertSplitAtFraction} family of functions - they test behavior of
@@ -685,7 +685,7 @@ public class SourceTestUtils {
    *
    * <p>It forwards most methods to the given {@code boundedSource}, except:
    * <ol>
-   * <li> {@link BoundedSource#splitIntoBundles} rejects initial splitting
+   * <li> {@link BoundedSource#splitIntoSubSources} rejects initial splitting
    * by returning itself in a list.
    * <li> {@link BoundedReader#splitAtFraction} rejects dynamic splitting by returning null.
    * </ol>
@@ -708,7 +708,7 @@ public class SourceTestUtils {
     }
 
     @Override
-    public List<? extends BoundedSource<T>> splitIntoBundles(
+    public List<? extends BoundedSource<T>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
@@ -60,7 +60,7 @@ import org.slf4j.LoggerFactory;
  * amount of test coverage with few code. Most notable ones are:
  * <ul>
  *   <li>{@link #assertSourcesEqualReferenceSource} helps testing that the data read
- *   by the union of sources produced by {@link BoundedSource#splitIntoSubSources}
+ *   by the union of sources produced by {@link BoundedSource#split}
  *   is the same as data read by the original source.
  *   <li>If your source implements dynamic work rebalancing, use the
  *   {@code assertSplitAtFraction} family of functions - they test behavior of
@@ -685,7 +685,7 @@ public class SourceTestUtils {
    *
    * <p>It forwards most methods to the given {@code boundedSource}, except:
    * <ol>
-   * <li> {@link BoundedSource#splitIntoSubSources} rejects initial splitting
+   * <li> {@link BoundedSource#split} rejects initial splitting
    * by returning itself in a list.
    * <li> {@link BoundedReader#splitAtFraction} rejects dynamic splitting by returning null.
    * </ol>
@@ -708,7 +708,7 @@ public class SourceTestUtils {
     }
 
     @Override
-    public List<? extends BoundedSource<T>> splitIntoSubSources(
+    public List<? extends BoundedSource<T>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return ImmutableList.of(this);
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
@@ -168,7 +168,7 @@ public class AvroSourceTest {
 
     AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
     List<? extends BoundedSource<FixedRecord>> splits =
-        source.splitIntoSubSources(file.length() / 3, null);
+        source.split(file.length() / 3, null);
     for (BoundedSource<FixedRecord> subSource : splits) {
       int items = SourceTestUtils.readFromSource(subSource, null).size();
       // Shouldn't split while unstarted.
@@ -201,7 +201,7 @@ public class AvroSourceTest {
     }
 
     List<? extends BoundedSource<FixedRecord>> splits =
-        source.splitIntoSubSources(file.length() / 3, null);
+        source.split(file.length() / 3, null);
     for (BoundedSource<FixedRecord> subSource : splits) {
       try (BoundedSource.BoundedReader<FixedRecord> reader = subSource.createReader(null)) {
         assertEquals(Double.valueOf(0.0), reader.getFractionConsumed());
@@ -339,7 +339,7 @@ public class AvroSourceTest {
     int nonEmptySplits;
 
     // Split with the minimum bundle size
-    splits = source.splitIntoSubSources(100L, options);
+    splits = source.split(100L, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     nonEmptySplits = 0;
@@ -351,7 +351,7 @@ public class AvroSourceTest {
     assertTrue(nonEmptySplits > 2);
 
     // Split with larger bundle size
-    splits = source.splitIntoSubSources(file.length() / 4, options);
+    splits = source.split(file.length() / 4, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     nonEmptySplits = 0;
@@ -363,7 +363,7 @@ public class AvroSourceTest {
     assertTrue(nonEmptySplits > 2);
 
     // Split with the file length
-    splits = source.splitIntoSubSources(file.length(), options);
+    splits = source.split(file.length(), options);
     assertTrue(splits.size() == 1);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
@@ -168,7 +168,7 @@ public class AvroSourceTest {
 
     AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
     List<? extends BoundedSource<FixedRecord>> splits =
-        source.splitIntoBundles(file.length() / 3, null);
+        source.splitIntoSubSources(file.length() / 3, null);
     for (BoundedSource<FixedRecord> subSource : splits) {
       int items = SourceTestUtils.readFromSource(subSource, null).size();
       // Shouldn't split while unstarted.
@@ -201,7 +201,7 @@ public class AvroSourceTest {
     }
 
     List<? extends BoundedSource<FixedRecord>> splits =
-        source.splitIntoBundles(file.length() / 3, null);
+        source.splitIntoSubSources(file.length() / 3, null);
     for (BoundedSource<FixedRecord> subSource : splits) {
       try (BoundedSource.BoundedReader<FixedRecord> reader = subSource.createReader(null)) {
         assertEquals(Double.valueOf(0.0), reader.getFractionConsumed());
@@ -339,7 +339,7 @@ public class AvroSourceTest {
     int nonEmptySplits;
 
     // Split with the minimum bundle size
-    splits = source.splitIntoBundles(100L, options);
+    splits = source.splitIntoSubSources(100L, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     nonEmptySplits = 0;
@@ -351,7 +351,7 @@ public class AvroSourceTest {
     assertTrue(nonEmptySplits > 2);
 
     // Split with larger bundle size
-    splits = source.splitIntoBundles(file.length() / 4, options);
+    splits = source.splitIntoSubSources(file.length() / 4, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     nonEmptySplits = 0;
@@ -363,7 +363,7 @@ public class AvroSourceTest {
     assertTrue(nonEmptySplits > 2);
 
     // Split with the file length
-    splits = source.splitIntoBundles(file.length(), options);
+    splits = source.splitIntoSubSources(file.length(), options);
     assertTrue(splits.size() == 1);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -110,7 +110,7 @@ public class CountingSourceTest {
 
     BoundedSource<Long> initial = CountingSource.upTo(numElements);
     List<? extends BoundedSource<Long>> splits =
-        initial.splitIntoSubSources(splitSizeBytes, p.getOptions());
+        initial.split(splitSizeBytes, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     // Assemble all the splits into one flattened PCollection, also verify their sizes.
@@ -234,7 +234,7 @@ public class CountingSourceTest {
 
     UnboundedSource<Long, ?> initial = CountingSource.unbounded();
     List<? extends UnboundedSource<Long, ?>> splits =
-        initial.splitIntoSubSources(numSplits, p.getOptions());
+        initial.split(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;
@@ -262,7 +262,7 @@ public class CountingSourceTest {
     UnboundedCountingSource initial =
         CountingSource.createUnbounded().withRate(elementsPerPeriod, period);
     List<? extends UnboundedSource<Long, ?>> splits =
-        initial.splitIntoSubSources(numSplits, p.getOptions());
+        initial.split(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -110,7 +110,7 @@ public class CountingSourceTest {
 
     BoundedSource<Long> initial = CountingSource.upTo(numElements);
     List<? extends BoundedSource<Long>> splits =
-        initial.splitIntoBundles(splitSizeBytes, p.getOptions());
+        initial.splitIntoSubSources(splitSizeBytes, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     // Assemble all the splits into one flattened PCollection, also verify their sizes.
@@ -234,7 +234,7 @@ public class CountingSourceTest {
 
     UnboundedSource<Long, ?> initial = CountingSource.unbounded();
     List<? extends UnboundedSource<Long, ?>> splits =
-        initial.generateInitialSplits(numSplits, p.getOptions());
+        initial.splitIntoSubSources(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;
@@ -262,7 +262,7 @@ public class CountingSourceTest {
     UnboundedCountingSource initial =
         CountingSource.createUnbounded().withRate(elementsPerPeriod, period);
     List<? extends UnboundedSource<Long, ?>> splits =
-        initial.generateInitialSplits(numSplits, p.getOptions());
+        initial.splitIntoSubSources(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -410,7 +410,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source =
         new TestFileBasedSource(file0.getParent() + "/" + "file*", Long.MAX_VALUE, null);
-    List<? extends BoundedSource<String>> splits = source.splitIntoBundles(Long.MAX_VALUE, null);
+    List<? extends BoundedSource<String>> splits = source.splitIntoSubSources(Long.MAX_VALUE, null);
     assertEquals(numFiles, splits.size());
   }
 
@@ -421,7 +421,7 @@ public class FileBasedSourceTest {
     TestFileBasedSource source = new TestFileBasedSource(missingFilePath, Long.MAX_VALUE, null);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(String.format("Unable to find any files matching %s", missingFilePath));
-    source.splitIntoBundles(1234, options);
+    source.splitIntoSubSources(1234, options);
   }
 
   @Test
@@ -698,7 +698,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source = new TestFileBasedSource(file.getPath(), 16, null);
 
-    List<? extends BoundedSource<String>> sources = source.splitIntoBundles(32, null);
+    List<? extends BoundedSource<String>> sources = source.splitIntoSubSources(32, null);
 
     // Not a trivial split.
     assertTrue(sources.size() > 1);
@@ -877,7 +877,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source =
         new TestFileBasedSource(new File(file1.getParent(), "file*").getPath(), 64, null);
-    List<? extends BoundedSource<String>> sources = source.splitIntoBundles(512, null);
+    List<? extends BoundedSource<String>> sources = source.splitIntoSubSources(512, null);
 
     // Not a trivial split.
     assertTrue(sources.size() > 1);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -410,7 +410,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source =
         new TestFileBasedSource(file0.getParent() + "/" + "file*", Long.MAX_VALUE, null);
-    List<? extends BoundedSource<String>> splits = source.splitIntoSubSources(Long.MAX_VALUE, null);
+    List<? extends BoundedSource<String>> splits = source.split(Long.MAX_VALUE, null);
     assertEquals(numFiles, splits.size());
   }
 
@@ -421,7 +421,7 @@ public class FileBasedSourceTest {
     TestFileBasedSource source = new TestFileBasedSource(missingFilePath, Long.MAX_VALUE, null);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(String.format("Unable to find any files matching %s", missingFilePath));
-    source.splitIntoSubSources(1234, options);
+    source.split(1234, options);
   }
 
   @Test
@@ -698,7 +698,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source = new TestFileBasedSource(file.getPath(), 16, null);
 
-    List<? extends BoundedSource<String>> sources = source.splitIntoSubSources(32, null);
+    List<? extends BoundedSource<String>> sources = source.split(32, null);
 
     // Not a trivial split.
     assertTrue(sources.size() > 1);
@@ -877,7 +877,7 @@ public class FileBasedSourceTest {
 
     TestFileBasedSource source =
         new TestFileBasedSource(new File(file1.getParent(), "file*").getPath(), 64, null);
-    List<? extends BoundedSource<String>> sources = source.splitIntoSubSources(512, null);
+    List<? extends BoundedSource<String>> sources = source.split(512, null);
 
     // Not a trivial split.
     assertTrue(sources.size() > 1);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
@@ -147,7 +147,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {0, 150, 300, 450, 600, 750, 900, 1000};
     assertSplitsAre(
-        testSource.splitIntoSubSources(150 * testSource.getBytesPerOffset(), null),
+        testSource.split(150 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -159,7 +159,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {300, 450, 600, 750, 900, 1000};
     assertSplitsAre(
-        testSource.splitIntoSubSources(150 * testSource.getBytesPerOffset(), null),
+        testSource.split(150 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -182,7 +182,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {300, 450, 600, 750, 1000};
     assertSplitsAre(
-        testSource.splitIntoSubSources(100 * testSource.getBytesPerOffset(), null),
+        testSource.split(100 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -195,7 +195,7 @@ public class OffsetBasedSourceTest {
     // Last 10 bytes should collapse to the previous bundle.
     long[] boundaries = {0, 110, 220, 330, 440, 550, 660, 770, 880, 1000};
     assertSplitsAre(
-        testSource.splitIntoSubSources(110 * testSource.getBytesPerOffset(), null),
+        testSource.split(110 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/OffsetBasedSourceTest.java
@@ -147,7 +147,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {0, 150, 300, 450, 600, 750, 900, 1000};
     assertSplitsAre(
-        testSource.splitIntoBundles(150 * testSource.getBytesPerOffset(), null),
+        testSource.splitIntoSubSources(150 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -159,7 +159,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {300, 450, 600, 750, 900, 1000};
     assertSplitsAre(
-        testSource.splitIntoBundles(150 * testSource.getBytesPerOffset(), null),
+        testSource.splitIntoSubSources(150 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -182,7 +182,7 @@ public class OffsetBasedSourceTest {
     CoarseRangeSource testSource = new CoarseRangeSource(start, end, minBundleSize, 1);
     long[] boundaries = {300, 450, 600, 750, 1000};
     assertSplitsAre(
-        testSource.splitIntoBundles(100 * testSource.getBytesPerOffset(), null),
+        testSource.splitIntoSubSources(100 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 
@@ -195,7 +195,7 @@ public class OffsetBasedSourceTest {
     // Last 10 bytes should collapse to the previous bundle.
     long[] boundaries = {0, 110, 220, 330, 440, 550, 660, 770, 880, 1000};
     assertSplitsAre(
-        testSource.splitIntoBundles(110 * testSource.getBytesPerOffset(), null),
+        testSource.splitIntoSubSources(110 * testSource.getBytesPerOffset(), null),
         boundaries);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
@@ -152,7 +152,7 @@ public class ReadTest implements Serializable{
 
   private abstract static class CustomBoundedSource extends BoundedSource<String> {
     @Override
-    public List<? extends BoundedSource<String>> splitIntoSubSources(
+    public List<? extends BoundedSource<String>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return null;
     }
@@ -186,7 +186,7 @@ public class ReadTest implements Serializable{
   private abstract static class CustomUnboundedSource
       extends UnboundedSource<String, NoOpCheckpointMark> {
     @Override
-    public List<? extends UnboundedSource<String, NoOpCheckpointMark>> splitIntoSubSources(
+    public List<? extends UnboundedSource<String, NoOpCheckpointMark>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return null;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
@@ -152,7 +152,7 @@ public class ReadTest implements Serializable{
 
   private abstract static class CustomBoundedSource extends BoundedSource<String> {
     @Override
-    public List<? extends BoundedSource<String>> splitIntoBundles(
+    public List<? extends BoundedSource<String>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       return null;
     }
@@ -186,7 +186,7 @@ public class ReadTest implements Serializable{
   private abstract static class CustomUnboundedSource
       extends UnboundedSource<String, NoOpCheckpointMark> {
     @Override
-    public List<? extends UnboundedSource<String, NoOpCheckpointMark>> generateInitialSplits(
+    public List<? extends UnboundedSource<String, NoOpCheckpointMark>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       return null;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -1118,7 +1118,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoBundlesAutoModeTxt() throws Exception {
+  public void testInitialSplitIntoSubSourcesAutoModeTxt() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1127,7 +1127,7 @@ public class TextIOTest {
 
     FileBasedSource<String> source = TextIO.Read.from(largeTxt.getPath()).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoBundles(desiredBundleSize, options);
+        source.splitIntoSubSources(desiredBundleSize, options);
 
     // At least 2 splits and they are equal to reading the whole file.
     assertThat(splits, hasSize(greaterThan(1)));
@@ -1135,7 +1135,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoBundlesAutoModeGz() throws Exception {
+  public void testInitialSplitIntoSubSourcesAutoModeGz() throws Exception {
     long desiredBundleSize = 1000;
     PipelineOptions options = TestPipeline.testingPipelineOptions();
 
@@ -1144,7 +1144,7 @@ public class TextIOTest {
 
     FileBasedSource<String> source = TextIO.Read.from(largeGz.getPath()).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoBundles(desiredBundleSize, options);
+        source.splitIntoSubSources(desiredBundleSize, options);
 
     // Exactly 1 split, even in AUTO mode, since it is a gzip file.
     assertThat(splits, hasSize(equalTo(1)));
@@ -1152,7 +1152,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoBundlesGzipModeTxt() throws Exception {
+  public void testInitialSplitIntoSubSourcesGzipModeTxt() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1162,7 +1162,7 @@ public class TextIOTest {
     FileBasedSource<String> source =
         TextIO.Read.from(largeTxt.getPath()).withCompressionType(GZIP).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoBundles(desiredBundleSize, options);
+        source.splitIntoSubSources(desiredBundleSize, options);
 
     // Exactly 1 split, even though splittable text file, since using GZIP mode.
     assertThat(splits, hasSize(equalTo(1)));
@@ -1170,7 +1170,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoBundlesGzipModeGz() throws Exception {
+  public void testInitialSplitIntoSubSourcesGzipModeGz() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1180,7 +1180,7 @@ public class TextIOTest {
     FileBasedSource<String> source =
         TextIO.Read.from(largeGz.getPath()).withCompressionType(GZIP).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoBundles(desiredBundleSize, options);
+        source.splitIntoSubSources(desiredBundleSize, options);
 
     // Exactly 1 split using .gz extension and using GZIP mode.
     assertThat(splits, hasSize(equalTo(1)));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -1118,7 +1118,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoSubSourcesAutoModeTxt() throws Exception {
+  public void testInitialSplitAutoModeTxt() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1127,7 +1127,7 @@ public class TextIOTest {
 
     FileBasedSource<String> source = TextIO.Read.from(largeTxt.getPath()).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoSubSources(desiredBundleSize, options);
+        source.split(desiredBundleSize, options);
 
     // At least 2 splits and they are equal to reading the whole file.
     assertThat(splits, hasSize(greaterThan(1)));
@@ -1135,7 +1135,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoSubSourcesAutoModeGz() throws Exception {
+  public void testInitialSplitAutoModeGz() throws Exception {
     long desiredBundleSize = 1000;
     PipelineOptions options = TestPipeline.testingPipelineOptions();
 
@@ -1144,7 +1144,7 @@ public class TextIOTest {
 
     FileBasedSource<String> source = TextIO.Read.from(largeGz.getPath()).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoSubSources(desiredBundleSize, options);
+        source.split(desiredBundleSize, options);
 
     // Exactly 1 split, even in AUTO mode, since it is a gzip file.
     assertThat(splits, hasSize(equalTo(1)));
@@ -1152,7 +1152,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoSubSourcesGzipModeTxt() throws Exception {
+  public void testInitialSplitGzipModeTxt() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1162,7 +1162,7 @@ public class TextIOTest {
     FileBasedSource<String> source =
         TextIO.Read.from(largeTxt.getPath()).withCompressionType(GZIP).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoSubSources(desiredBundleSize, options);
+        source.split(desiredBundleSize, options);
 
     // Exactly 1 split, even though splittable text file, since using GZIP mode.
     assertThat(splits, hasSize(equalTo(1)));
@@ -1170,7 +1170,7 @@ public class TextIOTest {
   }
 
   @Test
-  public void testInitialSplitIntoSubSourcesGzipModeGz() throws Exception {
+  public void testInitialSplitGzipModeGz() throws Exception {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
     long desiredBundleSize = 1000;
 
@@ -1180,7 +1180,7 @@ public class TextIOTest {
     FileBasedSource<String> source =
         TextIO.Read.from(largeGz.getPath()).withCompressionType(GZIP).getSource();
     List<? extends FileBasedSource<String>> splits =
-        source.splitIntoSubSources(desiredBundleSize, options);
+        source.split(desiredBundleSize, options);
 
     // Exactly 1 split using .gz extension and using GZIP mode.
     assertThat(splits, hasSize(equalTo(1)));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSourceTest.java
@@ -363,7 +363,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoBundles(50, null);
+    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(50, null);
 
     assertTrue(splits.size() > 2);
 
@@ -686,7 +686,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoBundles(100, null);
+    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(100, null);
 
     assertTrue(splits.size() > 2);
 
@@ -710,7 +710,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoBundles(256, null);
+    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(256, null);
 
     // Not a trivial split
     assertTrue(splits.size() > 2);
@@ -737,7 +737,7 @@ public class XmlSourceTest {
             .withMinBundleSize(10);
 
     List<? extends FileBasedSource<Train>> splits =
-        fileSource.splitIntoBundles(file.length() / 3, null);
+        fileSource.splitIntoSubSources(file.length() / 3, null);
     for (BoundedSource<Train> splitSource : splits) {
       int numItems = readEverythingFromReader(splitSource.createReader(null)).size();
       // Should not split while unstarted.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/XmlSourceTest.java
@@ -363,7 +363,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(50, null);
+    List<? extends FileBasedSource<Train>> splits = source.split(50, null);
 
     assertTrue(splits.size() > 2);
 
@@ -686,7 +686,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(100, null);
+    List<? extends FileBasedSource<Train>> splits = source.split(100, null);
 
     assertTrue(splits.size() > 2);
 
@@ -710,7 +710,7 @@ public class XmlSourceTest {
             .withRecordElement("train")
             .withRecordClass(Train.class)
             .withMinBundleSize(10);
-    List<? extends FileBasedSource<Train>> splits = source.splitIntoSubSources(256, null);
+    List<? extends FileBasedSource<Train>> splits = source.split(256, null);
 
     // Not a trivial split
     assertTrue(splits.size() > 2);
@@ -737,7 +737,7 @@ public class XmlSourceTest {
             .withMinBundleSize(10);
 
     List<? extends FileBasedSource<Train>> splits =
-        fileSource.splitIntoSubSources(file.length() / 3, null);
+        fileSource.split(file.length() / 3, null);
     for (BoundedSource<Train> splitSource : splits) {
       int numItems = readEverythingFromReader(splitSource.createReader(null)).size();
       // Should not split while unstarted.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
@@ -104,7 +104,7 @@ public class TestCountingSource
   }
 
   @Override
-  public List<TestCountingSource> splitIntoSubSources(
+  public List<TestCountingSource> split(
       int desiredNumSplits, PipelineOptions options) {
     List<TestCountingSource> splits = new ArrayList<>();
     int numSplits = allowSplitting ? desiredNumSplits : 1;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/runners/dataflow/TestCountingSource.java
@@ -104,7 +104,7 @@ public class TestCountingSource
   }
 
   @Override
-  public List<TestCountingSource> generateInitialSplits(
+  public List<TestCountingSource> splitIntoSubSources(
       int desiredNumSplits, PipelineOptions options) {
     List<TestCountingSource> splits = new ArrayList<>();
     int numSplits = allowSplitting ? desiredNumSplits : 1;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SourceTestUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SourceTestUtilsTest.java
@@ -43,7 +43,7 @@ public class SourceTestUtilsTest {
     PipelineOptions options = PipelineOptionsFactory.create();
     BoundedSource<Long> baseSource = CountingSource.upTo(100);
     BoundedSource<Long> unsplittableSource = SourceTestUtils.toUnsplittableSource(baseSource);
-    List<?> splits = unsplittableSource.splitIntoBundles(1, options);
+    List<?> splits = unsplittableSource.splitIntoSubSources(1, options);
     assertEquals(splits.size(), 1);
     assertEquals(splits.get(0), unsplittableSource);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SourceTestUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SourceTestUtilsTest.java
@@ -43,7 +43,7 @@ public class SourceTestUtilsTest {
     PipelineOptions options = PipelineOptionsFactory.create();
     BoundedSource<Long> baseSource = CountingSource.upTo(100);
     BoundedSource<Long> unsplittableSource = SourceTestUtils.toUnsplittableSource(baseSource);
-    List<?> splits = unsplittableSource.splitIntoSubSources(1, options);
+    List<?> splits = unsplittableSource.split(1, options);
     assertEquals(splits.size(), 1);
     assertEquals(splits.get(0), unsplittableSource);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -402,32 +402,32 @@ public class CreateTest {
   }
 
   @Test
-  public void testSourceSplitIntoBundles() throws Exception {
+  public void testSourceSplitIntoSubSources() throws Exception {
     CreateSource<Integer> source =
         CreateSource.fromIterable(
             ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8), BigEndianIntegerCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoBundles(12, options);
+    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoSubSources(12, options);
     assertThat(splitSources, hasSize(3));
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 
   @Test
-  public void testSourceSplitIntoBundlesVoid() throws Exception {
+  public void testSourceSplitIntoSubSourcesVoid() throws Exception {
     CreateSource<Void> source =
         CreateSource.fromIterable(
             Lists.<Void>newArrayList(null, null, null, null, null), VoidCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Void>> splitSources = source.splitIntoBundles(3, options);
+    List<? extends BoundedSource<Void>> splitSources = source.splitIntoSubSources(3, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 
   @Test
-  public void testSourceSplitIntoBundlesEmpty() throws Exception {
+  public void testSourceSplitIntoSubSourcesEmpty() throws Exception {
     CreateSource<Integer> source =
         CreateSource.fromIterable(ImmutableList.<Integer>of(), BigEndianIntegerCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoBundles(12, options);
+    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoSubSources(12, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -402,32 +402,32 @@ public class CreateTest {
   }
 
   @Test
-  public void testSourceSplitIntoSubSources() throws Exception {
+  public void testSourceSplit() throws Exception {
     CreateSource<Integer> source =
         CreateSource.fromIterable(
             ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8), BigEndianIntegerCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoSubSources(12, options);
+    List<? extends BoundedSource<Integer>> splitSources = source.split(12, options);
     assertThat(splitSources, hasSize(3));
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 
   @Test
-  public void testSourceSplitIntoSubSourcesVoid() throws Exception {
+  public void testSourceSplitVoid() throws Exception {
     CreateSource<Void> source =
         CreateSource.fromIterable(
             Lists.<Void>newArrayList(null, null, null, null, null), VoidCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Void>> splitSources = source.splitIntoSubSources(3, options);
+    List<? extends BoundedSource<Void>> splitSources = source.split(3, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 
   @Test
-  public void testSourceSplitIntoSubSourcesEmpty() throws Exception {
+  public void testSourceSplitEmpty() throws Exception {
     CreateSource<Integer> source =
         CreateSource.fromIterable(ImmutableList.<Integer>of(), BigEndianIntegerCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<? extends BoundedSource<Integer>> splitSources = source.splitIntoSubSources(12, options);
+    List<? extends BoundedSource<Integer>> splitSources = source.split(12, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splitSources, options);
   }
 

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -428,7 +428,7 @@ public class ElasticsearchIO {
     }
 
     @Override
-    public List<? extends BoundedSource<String>> splitIntoSubSources(
+    public List<? extends BoundedSource<String>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       List<BoundedElasticsearchSource> sources = new ArrayList<>();
 

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -428,7 +428,7 @@ public class ElasticsearchIO {
     }
 
     @Override
-    public List<? extends BoundedSource<String>> splitIntoBundles(
+    public List<? extends BoundedSource<String>> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       List<BoundedElasticsearchSource> sources = new ArrayList<>();
 

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -88,7 +88,7 @@ public class ElasticsearchIOIT {
     // as many bundles as ES shards and bundle size is shard size
     long desiredBundleSizeBytes = 0;
     List<? extends BoundedSource<String>> splits =
-        initialSource.splitIntoBundles(desiredBundleSizeBytes, options);
+        initialSource.splitIntoSubSources(desiredBundleSizeBytes, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
     //this is the number of ES shards
     // (By default, each index in Elasticsearch is allocated 5 primary shards)

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -88,7 +88,7 @@ public class ElasticsearchIOIT {
     // as many bundles as ES shards and bundle size is shard size
     long desiredBundleSizeBytes = 0;
     List<? extends BoundedSource<String>> splits =
-        initialSource.splitIntoSubSources(desiredBundleSizeBytes, options);
+        initialSource.split(desiredBundleSizeBytes, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
     //this is the number of ES shards
     // (By default, each index in Elasticsearch is allocated 5 primary shards)

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -326,7 +326,7 @@ public class ElasticsearchIOTest implements Serializable {
   }
 
   @Test
-  public void testSplitIntoBundles() throws Exception {
+  public void testSplitIntoSubSources() throws Exception {
     ElasticSearchIOTestUtils.insertTestDocuments(ES_INDEX, ES_TYPE, NUM_DOCS, node.client());
     PipelineOptions options = PipelineOptionsFactory.create();
     ElasticsearchIO.Read read =
@@ -336,7 +336,7 @@ public class ElasticsearchIOTest implements Serializable {
     // as many bundles as ES shards and bundle size is shard size
     int desiredBundleSizeBytes = 0;
     List<? extends BoundedSource<String>> splits =
-        initialSource.splitIntoBundles(desiredBundleSizeBytes, options);
+        initialSource.splitIntoSubSources(desiredBundleSizeBytes, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
     //this is the number of ES shards
     // (By default, each index in Elasticsearch is allocated 5 primary shards)

--- a/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -326,7 +326,7 @@ public class ElasticsearchIOTest implements Serializable {
   }
 
   @Test
-  public void testSplitIntoSubSources() throws Exception {
+  public void testSplit() throws Exception {
     ElasticSearchIOTestUtils.insertTestDocuments(ES_INDEX, ES_TYPE, NUM_DOCS, node.client());
     PipelineOptions options = PipelineOptionsFactory.create();
     ElasticsearchIO.Read read =
@@ -336,7 +336,7 @@ public class ElasticsearchIOTest implements Serializable {
     // as many bundles as ES shards and bundle size is shard size
     int desiredBundleSizeBytes = 0;
     List<? extends BoundedSource<String>> splits =
-        initialSource.splitIntoSubSources(desiredBundleSizeBytes, options);
+        initialSource.split(desiredBundleSizeBytes, options);
     SourceTestUtils.assertSourcesEqualReferenceSource(initialSource, splits, options);
     //this is the number of ES shards
     // (By default, each index in Elasticsearch is allocated 5 primary shards)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -81,7 +81,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
   }
 
   @Override
-  public List<BoundedSource<TableRow>> splitIntoBundles(
+  public List<BoundedSource<TableRow>> splitIntoSubSources(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
     TableReference tableToExtract = getTableToExtract(bqOptions);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -81,7 +81,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
   }
 
   @Override
-  public List<BoundedSource<TableRow>> splitIntoSubSources(
+  public List<BoundedSource<TableRow>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
     TableReference tableToExtract = getTableToExtract(bqOptions);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TransformingSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TransformingSource.java
@@ -52,10 +52,10 @@ class TransformingSource<T, V> extends BoundedSource<V> {
   }
 
   @Override
-  public List<? extends BoundedSource<V>> splitIntoSubSources(
+  public List<? extends BoundedSource<V>> split(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     return Lists.transform(
-        boundedSource.splitIntoSubSources(desiredBundleSizeBytes, options),
+        boundedSource.split(desiredBundleSizeBytes, options),
         new Function<BoundedSource<T>, BoundedSource<V>>() {
           @Override
           public BoundedSource<V> apply(BoundedSource<T> input) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TransformingSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TransformingSource.java
@@ -52,10 +52,10 @@ class TransformingSource<T, V> extends BoundedSource<V> {
   }
 
   @Override
-  public List<? extends BoundedSource<V>> splitIntoBundles(
+  public List<? extends BoundedSource<V>> splitIntoSubSources(
       long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
     return Lists.transform(
-        boundedSource.splitIntoBundles(desiredBundleSizeBytes, options),
+        boundedSource.splitIntoSubSources(desiredBundleSizeBytes, options),
         new Function<BoundedSource<T>, BoundedSource<V>>() {
           @Override
           public BoundedSource<V> apply(BoundedSource<T> input) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -724,7 +724,7 @@ public class BigtableIO {
     }
 
     @Override
-    public List<BigtableSource> splitIntoSubSources(
+    public List<BigtableSource> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       // Update the desiredBundleSizeBytes in order to limit the
       // number of splits to maximumNumberOfSplits.
@@ -734,11 +734,11 @@ public class BigtableIO {
           Math.max(sizeEstimate / maximumNumberOfSplits, desiredBundleSizeBytes);
 
       // Delegate to testable helper.
-      return splitIntoSubSourcesBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys(options));
+      return splitBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys(options));
     }
 
     /** Helper that splits this source into bundles based on Cloud Bigtable sampled row keys. */
-    private List<BigtableSource> splitIntoSubSourcesBasedOnSamples(
+    private List<BigtableSource> splitBasedOnSamples(
         long desiredBundleSizeBytes, List<SampleRowKeysResponse> sampleRowKeys) {
       // There are no regions, or no samples available. Just scan the entire range.
       if (sampleRowKeys.isEmpty()) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -724,7 +724,7 @@ public class BigtableIO {
     }
 
     @Override
-    public List<BigtableSource> splitIntoBundles(
+    public List<BigtableSource> splitIntoSubSources(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
       // Update the desiredBundleSizeBytes in order to limit the
       // number of splits to maximumNumberOfSplits.
@@ -734,11 +734,11 @@ public class BigtableIO {
           Math.max(sizeEstimate / maximumNumberOfSplits, desiredBundleSizeBytes);
 
       // Delegate to testable helper.
-      return splitIntoBundlesBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys(options));
+      return splitIntoSubSourcesBasedOnSamples(desiredBundleSizeBytes, getSampleRowKeys(options));
     }
 
     /** Helper that splits this source into bundles based on Cloud Bigtable sampled row keys. */
-    private List<BigtableSource> splitIntoBundlesBasedOnSamples(
+    private List<BigtableSource> splitIntoSubSourcesBasedOnSamples(
         long desiredBundleSizeBytes, List<SampleRowKeysResponse> sampleRowKeys) {
       // There are no regions, or no samples available. Just scan the entire range.
       if (sampleRowKeys.isEmpty()) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
@@ -1119,7 +1119,7 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
     }
 
     @Override
-    public List<PubsubSource<T>> splitIntoSubSources(
+    public List<PubsubSource<T>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       List<PubsubSource<T>> result = new ArrayList<>(desiredNumSplits);
       PubsubSource<T> splitSource = this;
@@ -1142,7 +1142,7 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
       SubscriptionPath subscription = subscriptionPath;
       if (subscription == null) {
         if (checkpoint == null) {
-          // This reader has never been started and there was no call to #splitIntoSubSources;
+          // This reader has never been started and there was no call to #split;
           // create a single random subscription, which will be kept in the checkpoint.
           subscription = outer.createRandomSubscription(options);
         } else {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
@@ -1119,7 +1119,7 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
     }
 
     @Override
-    public List<PubsubSource<T>> generateInitialSplits(
+    public List<PubsubSource<T>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       List<PubsubSource<T>> result = new ArrayList<>(desiredNumSplits);
       PubsubSource<T> splitSource = this;
@@ -1142,8 +1142,8 @@ public class PubsubUnboundedSource<T> extends PTransform<PBegin, PCollection<T>>
       SubscriptionPath subscription = subscriptionPath;
       if (subscription == null) {
         if (checkpoint == null) {
-          // This reader has never been started and there was no call to #splitIntoBundles; create
-          // a single random subscription, which will be kept in the checkpoint.
+          // This reader has never been started and there was no call to #splitIntoSubSources;
+          // create a single random subscription, which will be kept in the checkpoint.
           subscription = outer.createRandomSubscription(options);
         } else {
           subscription = checkpoint.getSubscription();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -1756,7 +1756,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoBundles(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1835,7 +1835,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoBundles(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1917,7 +1917,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoBundles(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1963,7 +1963,7 @@ public class BigQueryIOTest implements Serializable {
         stringSource, 100, 0.3, ExpectedSplitOutcome.MUST_SUCCEED_AND_BE_CONSISTENT, options);
 
     SourceTestUtils.assertSourcesEqualReferenceSource(
-        stringSource, stringSource.splitIntoBundles(100, options), options);
+        stringSource, stringSource.splitIntoSubSources(100, options), options);
   }
 
   @Test
@@ -1994,7 +1994,7 @@ public class BigQueryIOTest implements Serializable {
         stringSource, 100, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
     SourceTestUtils.assertSourcesEqualReferenceSource(
-        stringSource, stringSource.splitIntoBundles(100, options), options);
+        stringSource, stringSource.splitIntoSubSources(100, options), options);
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -1756,7 +1756,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.split(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1835,7 +1835,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.split(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1917,7 +1917,7 @@ public class BigQueryIOTest implements Serializable {
     SourceTestUtils.assertSplitAtFractionBehavior(
         bqSource, 2, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
-    List<? extends BoundedSource<TableRow>> sources = bqSource.splitIntoSubSources(100, options);
+    List<? extends BoundedSource<TableRow>> sources = bqSource.split(100, options);
     assertEquals(1, sources.size());
     BoundedSource<TableRow> actual = sources.get(0);
     assertThat(actual, CoreMatchers.instanceOf(TransformingSource.class));
@@ -1963,7 +1963,7 @@ public class BigQueryIOTest implements Serializable {
         stringSource, 100, 0.3, ExpectedSplitOutcome.MUST_SUCCEED_AND_BE_CONSISTENT, options);
 
     SourceTestUtils.assertSourcesEqualReferenceSource(
-        stringSource, stringSource.splitIntoSubSources(100, options), options);
+        stringSource, stringSource.split(100, options), options);
   }
 
   @Test
@@ -1994,7 +1994,7 @@ public class BigQueryIOTest implements Serializable {
         stringSource, 100, 0.3, ExpectedSplitOutcome.MUST_BE_CONSISTENT_IF_SUCCEEDS, options);
 
     SourceTestUtils.assertSourcesEqualReferenceSource(
-        stringSource, stringSource.splitIntoSubSources(100, options), options);
+        stringSource, stringSource.split(100, options), options);
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -476,7 +476,7 @@ public class BigtableIOTest {
             ByteKeyRange.ALL_KEYS,
             null /*size*/);
     List<BigtableSource> splits =
-        source.splitIntoBundles(numRows * bytesPerRow / numSamples, null /* options */);
+        source.splitIntoSubSources(numRows * bytesPerRow / numSamples, null /* options */);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSamples));
@@ -503,7 +503,8 @@ public class BigtableIOTest {
         null /*filter*/,
         ByteKeyRange.ALL_KEYS,
         null /*size*/);
-    List<BigtableSource> splits = source.splitIntoBundles(numRows * bytesPerRow / numSplits, null);
+    List<BigtableSource> splits =
+        source.splitIntoSubSources(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSplits));
@@ -528,7 +529,8 @@ public class BigtableIOTest {
         RowFilter.newBuilder().setRowKeyRegexFilter(ByteString.copyFromUtf8(".*17.*")).build();
     BigtableSource source =
         new BigtableSource(serviceFactory, table, filter, ByteKeyRange.ALL_KEYS, null /*size*/);
-    List<BigtableSource> splits = source.splitIntoBundles(numRows * bytesPerRow / numSplits, null);
+    List<BigtableSource> splits =
+        source.splitIntoSubSources(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSplits));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -476,7 +476,7 @@ public class BigtableIOTest {
             ByteKeyRange.ALL_KEYS,
             null /*size*/);
     List<BigtableSource> splits =
-        source.splitIntoSubSources(numRows * bytesPerRow / numSamples, null /* options */);
+        source.split(numRows * bytesPerRow / numSamples, null /* options */);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSamples));
@@ -504,7 +504,7 @@ public class BigtableIOTest {
         ByteKeyRange.ALL_KEYS,
         null /*size*/);
     List<BigtableSource> splits =
-        source.splitIntoSubSources(numRows * bytesPerRow / numSplits, null);
+        source.split(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSplits));
@@ -530,7 +530,7 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(serviceFactory, table, filter, ByteKeyRange.ALL_KEYS, null /*size*/);
     List<BigtableSource> splits =
-        source.splitIntoSubSources(numRows * bytesPerRow / numSplits, null);
+        source.split(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
     assertThat(splits, hasSize(numSplits));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -324,7 +324,7 @@ public class PubsubUnboundedSourceTest {
   }
 
   @Test
-  public void noSubscriptionSplitIntoBundlesGeneratesSubscription() throws Exception {
+  public void noSubscriptionSplitIntoSubSourcesGeneratesSubscription() throws Exception {
     TopicPath topicPath = PubsubClient.topicPathFromName("my_project", "my_topic");
     factory = PubsubTestClient.createFactoryForCreateSubscription();
     PubsubUnboundedSource<String> source =
@@ -343,7 +343,7 @@ public class PubsubUnboundedSourceTest {
 
     PipelineOptions options = PipelineOptionsFactory.create();
     List<PubsubSource<String>> splits =
-        (new PubsubSource<>(source)).generateInitialSplits(3, options);
+        (new PubsubSource<>(source)).splitIntoSubSources(3, options);
     // We have at least one returned split
     assertThat(splits, hasSize(greaterThan(0)));
     for (PubsubSource<String> split : splits) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -324,7 +324,7 @@ public class PubsubUnboundedSourceTest {
   }
 
   @Test
-  public void noSubscriptionSplitIntoSubSourcesGeneratesSubscription() throws Exception {
+  public void noSubscriptionSplitGeneratesSubscription() throws Exception {
     TopicPath topicPath = PubsubClient.topicPathFromName("my_project", "my_topic");
     factory = PubsubTestClient.createFactoryForCreateSubscription();
     PubsubUnboundedSource<String> source =
@@ -343,7 +343,7 @@ public class PubsubUnboundedSourceTest {
 
     PipelineOptions options = PipelineOptionsFactory.create();
     List<PubsubSource<String>> splits =
-        (new PubsubSource<>(source)).splitIntoSubSources(3, options);
+        (new PubsubSource<>(source)).split(3, options);
     // We have at least one returned split
     assertThat(splits, hasSize(greaterThan(0)));
     for (PubsubSource<String> split : splits) {

--- a/sdks/java/io/hadoop/input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
+++ b/sdks/java/io/hadoop/input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
@@ -449,7 +449,7 @@ public class HadoopInputFormatIO {
     }
 
     @Override
-    public List<BoundedSource<KV<K, V>>> splitIntoSubSources(long desiredBundleSizeBytes,
+    public List<BoundedSource<KV<K, V>>> split(long desiredBundleSizeBytes,
         PipelineOptions options) throws Exception {
       // desiredBundleSizeBytes is not being considered as splitting based on this
       // value is not supported by inputFormat getSplits() method.
@@ -485,7 +485,7 @@ public class HadoopInputFormatIO {
     /**
      * This is a helper function to compute splits. This method will also calculate size of the
      * data being read. Note: This method is executed exactly once and the splits are retrieved
-     * and cached in this. These splits are further used by splitIntoSubSources() and
+     * and cached in this. These splits are further used by split() and
      * getEstimatedSizeBytes().
      */
     @VisibleForTesting

--- a/sdks/java/io/hadoop/input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
+++ b/sdks/java/io/hadoop/input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
@@ -449,7 +449,7 @@ public class HadoopInputFormatIO {
     }
 
     @Override
-    public List<BoundedSource<KV<K, V>>> splitIntoBundles(long desiredBundleSizeBytes,
+    public List<BoundedSource<KV<K, V>>> splitIntoSubSources(long desiredBundleSizeBytes,
         PipelineOptions options) throws Exception {
       // desiredBundleSizeBytes is not being considered as splitting based on this
       // value is not supported by inputFormat getSplits() method.
@@ -485,7 +485,7 @@ public class HadoopInputFormatIO {
     /**
      * This is a helper function to compute splits. This method will also calculate size of the
      * data being read. Note: This method is executed exactly once and the splits are retrieved
-     * and cached in this. These splits are further used by splitIntoBundles() and
+     * and cached in this. These splits are further used by splitIntoSubSources() and
      * getEstimatedSizeBytes().
      */
     @VisibleForTesting

--- a/sdks/java/io/hadoop/input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
+++ b/sdks/java/io/hadoop/input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.io.hadoop.inputformat.EmployeeInputFormat.NewObjectsE
 import org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIO.HadoopInputFormatBoundedSource;
 import org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIO.SerializableConfiguration;
 import org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIO.SerializableSplit;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.SourceTestUtils;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -518,8 +519,8 @@ public class HadoopInputFormatIOTest {
     // Validate if estimated size is equal to the size of records.
     assertEquals(referenceRecords.size(), estimatedSize);
     List<BoundedSource<KV<Text, Employee>>> boundedSourceList =
-        hifSource.splitIntoBundles(0, p.getOptions());
-    // Validate if splitIntoBundles() has split correctly.
+        hifSource.splitIntoSubSources(0, p.getOptions());
+    // Validate if splitIntoSubSources() has split correctly.
     assertEquals(TestEmployeeDataSet.NUMBER_OF_SPLITS, boundedSourceList.size());
     List<KV<Text, Employee>> bundleRecords = new ArrayList<>();
     for (BoundedSource<KV<Text, Employee>> source : boundedSourceList) {
@@ -638,12 +639,14 @@ public class HadoopInputFormatIOTest {
   }
 
   /**
-   * This test validates behavior of {@link HadoopInputFormatBoundedSource#createReader()
-   * createReader()} method when {@link HadoopInputFormatBoundedSource#splitIntoBundles()
-   * splitIntoBundles()} is not called.
+   * This test validates behavior of
+   * {@link HadoopInputFormatBoundedSource#createReader(PipelineOptions)}
+   * createReader()} method when
+   * {@link HadoopInputFormatBoundedSource#splitIntoSubSources(long, PipelineOptions)}
+   * splitIntoSubSources()} is not called.
    */
   @Test
-  public void testCreateReaderIfSplitIntoBundlesNotCalled() throws Exception {
+  public void testCreateReaderIfSplitIntoSubSourcesNotCalled() throws Exception {
     HadoopInputFormatBoundedSource<Text, Employee> hifSource = getTestHIFSource(
         EmployeeInputFormat.class,
         Text.class,
@@ -658,7 +661,7 @@ public class HadoopInputFormatIOTest {
   /**
    * This test validates behavior of
    * {@link HadoopInputFormatBoundedSource#computeSplitsIfNecessary() computeSplits()} when Hadoop
-   * InputFormat's {@link InputFormat#getSplits() getSplits()} returns empty list.
+   * InputFormat's {@link InputFormat#getSplits(JobContext)} returns empty list.
    */
   @Test
   public void testComputeSplitsIfGetSplitsReturnsEmptyList() throws Exception {
@@ -843,6 +846,6 @@ public class HadoopInputFormatIOTest {
         inputFormatValueClass,
         keyCoder,
         valueCoder);
-    return boundedSource.splitIntoBundles(0, p.getOptions());
+    return boundedSource.splitIntoSubSources(0, p.getOptions());
   }
 }

--- a/sdks/java/io/hadoop/input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
+++ b/sdks/java/io/hadoop/input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
@@ -519,8 +519,8 @@ public class HadoopInputFormatIOTest {
     // Validate if estimated size is equal to the size of records.
     assertEquals(referenceRecords.size(), estimatedSize);
     List<BoundedSource<KV<Text, Employee>>> boundedSourceList =
-        hifSource.splitIntoSubSources(0, p.getOptions());
-    // Validate if splitIntoSubSources() has split correctly.
+        hifSource.split(0, p.getOptions());
+    // Validate if split() has split correctly.
     assertEquals(TestEmployeeDataSet.NUMBER_OF_SPLITS, boundedSourceList.size());
     List<KV<Text, Employee>> bundleRecords = new ArrayList<>();
     for (BoundedSource<KV<Text, Employee>> source : boundedSourceList) {
@@ -642,11 +642,11 @@ public class HadoopInputFormatIOTest {
    * This test validates behavior of
    * {@link HadoopInputFormatBoundedSource#createReader(PipelineOptions)}
    * createReader()} method when
-   * {@link HadoopInputFormatBoundedSource#splitIntoSubSources(long, PipelineOptions)}
-   * splitIntoSubSources()} is not called.
+   * {@link HadoopInputFormatBoundedSource#split(long, PipelineOptions)}
+   * split()} is not called.
    */
   @Test
-  public void testCreateReaderIfSplitIntoSubSourcesNotCalled() throws Exception {
+  public void testCreateReaderIfSplitNotCalled() throws Exception {
     HadoopInputFormatBoundedSource<Text, Employee> hifSource = getTestHIFSource(
         EmployeeInputFormat.class,
         Text.class,
@@ -846,6 +846,6 @@ public class HadoopInputFormatIOTest {
         inputFormatValueClass,
         keyCoder,
         valueCoder);
-    return boundedSource.splitIntoSubSources(0, p.getOptions());
+    return boundedSource.split(0, p.getOptions());
   }
 }

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -422,10 +422,9 @@ public class HBaseIO {
             return sources;
         }
 
-        @Override
-        public List<? extends BoundedSource<Result>>
-            splitIntoBundles(long desiredBundleSizeBytes, PipelineOptions options)
-                throws Exception {
+    @Override
+    public List<? extends BoundedSource<Result>> splitIntoSubSources(
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
             LOG.debug("desiredBundleSize {} bytes", desiredBundleSizeBytes);
             long estimatedSizeBytes = getEstimatedSizeBytes(options);
             int numSplits = 1;

--- a/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
+++ b/sdks/java/io/hbase/src/main/java/org/apache/beam/sdk/io/hbase/HBaseIO.java
@@ -423,7 +423,7 @@ public class HBaseIO {
         }
 
     @Override
-    public List<? extends BoundedSource<Result>> splitIntoSubSources(
+    public List<? extends BoundedSource<Result>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
             LOG.debug("desiredBundleSize {} bytes", desiredBundleSizeBytes);
             long estimatedSizeBytes = getEstimatedSizeBytes(options);

--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -197,7 +197,7 @@ public class HBaseIOTest {
         HBaseIO.Read read = HBaseIO.read().withConfiguration(conf).withTableId(table);
         HBaseSource source = new HBaseSource(read, null /* estimatedSizeBytes */);
         List<? extends BoundedSource<Result>> splits =
-                source.splitIntoSubSources(numRows * bytesPerRow / numRegions,
+                source.split(numRows * bytesPerRow / numRegions,
                         null /* options */);
 
         // Test num splits and split equality.

--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -197,7 +197,7 @@ public class HBaseIOTest {
         HBaseIO.Read read = HBaseIO.read().withConfiguration(conf).withTableId(table);
         HBaseSource source = new HBaseSource(read, null /* estimatedSizeBytes */);
         List<? extends BoundedSource<Result>> splits =
-                source.splitIntoBundles(numRows * bytesPerRow / numRegions,
+                source.splitIntoSubSources(numRows * bytesPerRow / numRegions,
                         null /* options */);
 
         // Test num splits and split equality.

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -265,7 +265,7 @@ public abstract class HDFSFileSource<T, K, V> extends BoundedSource<T> {
   // =======================================================================
 
   @Override
-  public List<? extends BoundedSource<T>> splitIntoSubSources(
+  public List<? extends BoundedSource<T>> split(
       final long desiredBundleSizeBytes,
       PipelineOptions options) throws Exception {
     if (serializableSplit() == null) {
@@ -296,7 +296,7 @@ public abstract class HDFSFileSource<T, K, V> extends BoundedSource<T> {
     long size = 0;
 
     try {
-      // If this source represents a split from splitIntoSubSources,
+      // If this source represents a split from split,
       // then return the size of the split, rather then the entire input
       if (serializableSplit() != null) {
         return serializableSplit().getSplit().getLength();

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HDFSFileSource.java
@@ -265,7 +265,7 @@ public abstract class HDFSFileSource<T, K, V> extends BoundedSource<T> {
   // =======================================================================
 
   @Override
-  public List<? extends BoundedSource<T>> splitIntoBundles(
+  public List<? extends BoundedSource<T>> splitIntoSubSources(
       final long desiredBundleSizeBytes,
       PipelineOptions options) throws Exception {
     if (serializableSplit() == null) {
@@ -296,8 +296,8 @@ public abstract class HDFSFileSource<T, K, V> extends BoundedSource<T> {
     long size = 0;
 
     try {
-      // If this source represents a split from splitIntoBundles, then return the size of the split,
-      // rather then the entire input
+      // If this source represents a split from splitIntoSubSources,
+      // then return the size of the split, rather then the entire input
       if (serializableSplit() != null) {
         return serializableSplit().getSplit().getLength();
       }

--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HDFSFileSourceTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HDFSFileSourceTest.java
@@ -159,7 +159,7 @@ public class HDFSFileSourceTest {
 
     // Split with a small bundle size (has to be at least size of sync interval)
     List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source
-        .splitIntoBundles(SequenceFile.SYNC_INTERVAL, options);
+        .splitIntoSubSources(SequenceFile.SYNC_INTERVAL, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     int nonEmptySplits = 0;
@@ -184,7 +184,7 @@ public class HDFSFileSourceTest {
 
     long originalSize = source.getEstimatedSizeBytes(options);
     long splitTotalSize = 0;
-    List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source.splitIntoBundles(
+    List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source.splitIntoSubSources(
         SequenceFile.SYNC_INTERVAL, options
     );
     for (BoundedSource<KV<IntWritable, Text>> splitSource : splits) {

--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HDFSFileSourceTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HDFSFileSourceTest.java
@@ -159,7 +159,7 @@ public class HDFSFileSourceTest {
 
     // Split with a small bundle size (has to be at least size of sync interval)
     List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source
-        .splitIntoSubSources(SequenceFile.SYNC_INTERVAL, options);
+        .split(SequenceFile.SYNC_INTERVAL, options);
     assertTrue(splits.size() > 2);
     SourceTestUtils.assertSourcesEqualReferenceSource(source, splits, options);
     int nonEmptySplits = 0;
@@ -184,7 +184,7 @@ public class HDFSFileSourceTest {
 
     long originalSize = source.getEstimatedSizeBytes(options);
     long splitTotalSize = 0;
-    List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source.splitIntoSubSources(
+    List<? extends BoundedSource<KV<IntWritable, Text>>> splits = source.split(
         SequenceFile.SYNC_INTERVAL, options
     );
     for (BoundedSource<KV<IntWritable, Text>> splitSource : splits) {

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -340,7 +340,7 @@ public class JmsIO {
     }
 
     @Override
-    public List<UnboundedJmsSource> generateInitialSplits(
+    public List<UnboundedJmsSource> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       List<UnboundedJmsSource> sources = new ArrayList<>();
       if (spec.getTopic() != null) {

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -340,7 +340,7 @@ public class JmsIO {
     }
 
     @Override
-    public List<UnboundedJmsSource> splitIntoSubSources(
+    public List<UnboundedJmsSource> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
       List<UnboundedJmsSource> sources = new ArrayList<>();
       if (spec.getTopic() != null) {

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -214,7 +214,7 @@ public class JmsIOTest {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
     int desiredNumSplits = 5;
     JmsIO.UnboundedJmsSource initialSource = new JmsIO.UnboundedJmsSource(read);
-    List<JmsIO.UnboundedJmsSource> splits = initialSource.generateInitialSplits(desiredNumSplits,
+    List<JmsIO.UnboundedJmsSource> splits = initialSource.splitIntoSubSources(desiredNumSplits,
         pipelineOptions);
     // in the case of a queue, we have concurrent consumers by default, so the initial number
     // splits is equal to the desired number of splits
@@ -227,7 +227,7 @@ public class JmsIOTest {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
     int desiredNumSplits = 5;
     JmsIO.UnboundedJmsSource initialSource = new JmsIO.UnboundedJmsSource(read);
-    List<JmsIO.UnboundedJmsSource> splits = initialSource.generateInitialSplits(desiredNumSplits,
+    List<JmsIO.UnboundedJmsSource> splits = initialSource.splitIntoSubSources(desiredNumSplits,
         pipelineOptions);
     // in the case of a topic, we can have only an unique subscriber on the topic per pipeline
     // else it means we can have duplicate messages (all subscribers on the topic receive every

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -214,7 +214,7 @@ public class JmsIOTest {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
     int desiredNumSplits = 5;
     JmsIO.UnboundedJmsSource initialSource = new JmsIO.UnboundedJmsSource(read);
-    List<JmsIO.UnboundedJmsSource> splits = initialSource.splitIntoSubSources(desiredNumSplits,
+    List<JmsIO.UnboundedJmsSource> splits = initialSource.split(desiredNumSplits,
         pipelineOptions);
     // in the case of a queue, we have concurrent consumers by default, so the initial number
     // splits is equal to the desired number of splits
@@ -227,7 +227,7 @@ public class JmsIOTest {
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
     int desiredNumSplits = 5;
     JmsIO.UnboundedJmsSource initialSource = new JmsIO.UnboundedJmsSource(read);
-    List<JmsIO.UnboundedJmsSource> splits = initialSource.splitIntoSubSources(desiredNumSplits,
+    List<JmsIO.UnboundedJmsSource> splits = initialSource.split(desiredNumSplits,
         pipelineOptions);
     // in the case of a topic, we can have only an unique subscriber on the topic per pipeline
     // else it means we can have duplicate messages (all subscribers on the topic receive every

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -153,7 +153,7 @@ import org.slf4j.LoggerFactory;
  * <h3>Partition Assignment and Checkpointing</h3>
  * The Kafka partitions are evenly distributed among splits (workers).
  * Checkpointing is fully supported and each split can resume from previous checkpoint. See
- * {@link UnboundedKafkaSource#generateInitialSplits(int, PipelineOptions)} for more details on
+ * {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for more details on
  * splits and checkpoint support.
  *
  * <p>When the pipeline starts for the first time without any checkpoint, the source starts
@@ -311,7 +311,7 @@ public class KafkaIO {
 
     /**
      * Returns a new {@link Read} that reads from the topic.
-     * See {@link UnboundedKafkaSource#generateInitialSplits(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopic(String topic) {
@@ -321,7 +321,7 @@ public class KafkaIO {
     /**
      * Returns a new {@link Read} that reads from the topics. All the partitions from each
      * of the topics are read.
-     * See {@link UnboundedKafkaSource#generateInitialSplits(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopics(List<String> topics) {
@@ -333,7 +333,7 @@ public class KafkaIO {
     /**
      * Returns a new {@link Read} that reads from the partitions. This allows reading only a subset
      * of partitions for one or more topics when (if ever) needed.
-     * See {@link UnboundedKafkaSource#generateInitialSplits(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopicPartitions(List<TopicPartition> topicPartitions) {
@@ -626,7 +626,7 @@ public class KafkaIO {
      * {@code <topic, partition>} and then assigned to splits in round-robin order.
      */
     @Override
-    public List<UnboundedKafkaSource<K, V>> generateInitialSplits(
+    public List<UnboundedKafkaSource<K, V>> splitIntoSubSources(
         int desiredNumSplits, PipelineOptions options) throws Exception {
 
       List<TopicPartition> partitions = new ArrayList<>(spec.getTopicPartitions());
@@ -698,7 +698,7 @@ public class KafkaIO {
         LOG.warn("Looks like generateSplits() is not called. Generate single split.");
         try {
           return new UnboundedKafkaReader<K, V>(
-              generateInitialSplits(1, options).get(0), checkpointMark);
+              splitIntoSubSources(1, options).get(0), checkpointMark);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -153,7 +153,7 @@ import org.slf4j.LoggerFactory;
  * <h3>Partition Assignment and Checkpointing</h3>
  * The Kafka partitions are evenly distributed among splits (workers).
  * Checkpointing is fully supported and each split can resume from previous checkpoint. See
- * {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for more details on
+ * {@link UnboundedKafkaSource#split(int, PipelineOptions)} for more details on
  * splits and checkpoint support.
  *
  * <p>When the pipeline starts for the first time without any checkpoint, the source starts
@@ -311,7 +311,7 @@ public class KafkaIO {
 
     /**
      * Returns a new {@link Read} that reads from the topic.
-     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#split(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopic(String topic) {
@@ -321,7 +321,7 @@ public class KafkaIO {
     /**
      * Returns a new {@link Read} that reads from the topics. All the partitions from each
      * of the topics are read.
-     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#split(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopics(List<String> topics) {
@@ -333,7 +333,7 @@ public class KafkaIO {
     /**
      * Returns a new {@link Read} that reads from the partitions. This allows reading only a subset
      * of partitions for one or more topics when (if ever) needed.
-     * See {@link UnboundedKafkaSource#splitIntoSubSources(int, PipelineOptions)} for description
+     * See {@link UnboundedKafkaSource#split(int, PipelineOptions)} for description
      * of how the partitions are distributed among the splits.
      */
     public Read<K, V> withTopicPartitions(List<TopicPartition> topicPartitions) {
@@ -626,7 +626,7 @@ public class KafkaIO {
      * {@code <topic, partition>} and then assigned to splits in round-robin order.
      */
     @Override
-    public List<UnboundedKafkaSource<K, V>> splitIntoSubSources(
+    public List<UnboundedKafkaSource<K, V>> split(
         int desiredNumSplits, PipelineOptions options) throws Exception {
 
       List<TopicPartition> partitions = new ArrayList<>(spec.getTopicPartitions());
@@ -698,7 +698,7 @@ public class KafkaIO {
         LOG.warn("Looks like generateSplits() is not called. Generate single split.");
         try {
           return new UnboundedKafkaReader<K, V>(
-              splitIntoSubSources(1, options).get(0), checkpointMark);
+              split(1, options).get(0), checkpointMark);
         } catch (Exception e) {
           throw new RuntimeException(e);
         }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -389,7 +389,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, ?> initial =
         mkKafkaReadTransform(numElements, null).makeSource();
     List<? extends UnboundedSource<KafkaRecord<Integer, Long>, ?>> splits =
-        initial.generateInitialSplits(numSplits, p.getOptions());
+        initial.splitIntoSubSources(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;
@@ -446,7 +446,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
         mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
           .makeSource()
-          .generateInitialSplits(1, PipelineOptionsFactory.create())
+          .splitIntoSubSources(1, PipelineOptionsFactory.create())
           .get(0);
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
@@ -486,7 +486,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
         mkKafkaReadTransform(initialNumElements, new ValueAsTimestampFn())
             .makeSource()
-            .generateInitialSplits(1, PipelineOptionsFactory.create())
+            .splitIntoSubSources(1, PipelineOptionsFactory.create())
             .get(0);
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
@@ -515,7 +515,7 @@ public class KafkaIOTest {
         .withMaxNumRecords(numElements)
         .withTimestampFn(new ValueAsTimestampFn())
         .makeSource()
-        .generateInitialSplits(1, PipelineOptionsFactory.create())
+        .splitIntoSubSources(1, PipelineOptionsFactory.create())
         .get(0);
 
     reader = source.createReader(null, mark);

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -389,7 +389,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, ?> initial =
         mkKafkaReadTransform(numElements, null).makeSource();
     List<? extends UnboundedSource<KafkaRecord<Integer, Long>, ?>> splits =
-        initial.splitIntoSubSources(numSplits, p.getOptions());
+        initial.split(numSplits, p.getOptions());
     assertEquals("Expected exact splitting", numSplits, splits.size());
 
     long elementsPerSplit = numElements / numSplits;
@@ -446,7 +446,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
         mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
           .makeSource()
-          .splitIntoSubSources(1, PipelineOptionsFactory.create())
+          .split(1, PipelineOptionsFactory.create())
           .get(0);
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
@@ -486,7 +486,7 @@ public class KafkaIOTest {
     UnboundedSource<KafkaRecord<Integer, Long>, KafkaCheckpointMark> source =
         mkKafkaReadTransform(initialNumElements, new ValueAsTimestampFn())
             .makeSource()
-            .splitIntoSubSources(1, PipelineOptionsFactory.create())
+            .split(1, PipelineOptionsFactory.create())
             .get(0);
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
@@ -515,7 +515,7 @@ public class KafkaIOTest {
         .withMaxNumRecords(numElements)
         .withTimestampFn(new ValueAsTimestampFn())
         .makeSource()
-        .splitIntoSubSources(1, PipelineOptionsFactory.create())
+        .split(1, PipelineOptionsFactory.create())
         .get(0);
 
     reader = source.createReader(null, mark);

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
@@ -56,7 +56,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
      * {@code desiredNumSplits} partitions. Each partition is then a split.
      */
     @Override
-    public List<KinesisSource> generateInitialSplits(int desiredNumSplits,
+    public List<KinesisSource> splitIntoSubSources(int desiredNumSplits,
                                                      PipelineOptions options) throws Exception {
         KinesisReaderCheckpoint checkpoint =
                 initialCheckpointGenerator.generate(SimplifiedKinesisClient.from(kinesis));

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisSource.java
@@ -56,7 +56,7 @@ class KinesisSource extends UnboundedSource<KinesisRecord, KinesisReaderCheckpoi
      * {@code desiredNumSplits} partitions. Each partition is then a split.
      */
     @Override
-    public List<KinesisSource> splitIntoSubSources(int desiredNumSplits,
+    public List<KinesisSource> split(int desiredNumSplits,
                                                      PipelineOptions options) throws Exception {
         KinesisReaderCheckpoint checkpoint =
                 initialCheckpointGenerator.generate(SimplifiedKinesisClient.from(kinesis));

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -385,8 +385,8 @@ public class MongoDbGridFSIO {
       }
 
       @Override
-      public List<? extends BoundedSource<ObjectId>> splitIntoBundles(long desiredBundleSizeBytes,
-          PipelineOptions options) throws Exception {
+      public List<? extends BoundedSource<ObjectId>> splitIntoSubSources(
+          long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
         Mongo mongo = spec.connectionConfiguration().setupMongo();
         try {
           GridFS gridfs = spec.connectionConfiguration().setupGridFS(mongo);

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbGridFSIO.java
@@ -385,7 +385,7 @@ public class MongoDbGridFSIO {
       }
 
       @Override
-      public List<? extends BoundedSource<ObjectId>> splitIntoSubSources(
+      public List<? extends BoundedSource<ObjectId>> split(
           long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
         Mongo mongo = spec.connectionConfiguration().setupMongo();
         try {

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -225,7 +225,7 @@ public class MongoDbIO {
     }
 
     @Override
-    public List<BoundedSource<Document>> splitIntoSubSources(long desiredBundleSizeBytes,
+    public List<BoundedSource<Document>> split(long desiredBundleSizeBytes,
                                                 PipelineOptions options) {
       MongoClient mongoClient = new MongoClient(new MongoClientURI(spec.uri()));
       MongoDatabase mongoDatabase = mongoClient.getDatabase(spec.database());

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -225,7 +225,7 @@ public class MongoDbIO {
     }
 
     @Override
-    public List<BoundedSource<Document>> splitIntoBundles(long desiredBundleSizeBytes,
+    public List<BoundedSource<Document>> splitIntoSubSources(long desiredBundleSizeBytes,
                                                 PipelineOptions options) {
       MongoClient mongoClient = new MongoClient(new MongoClientURI(spec.uri()));
       MongoDatabase mongoDatabase = mongoClient.getDatabase(spec.database());

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -267,7 +267,7 @@ public class MongoDBGridFSIOTest implements Serializable {
 
     // make sure 2 files can fit in
     long desiredBundleSizeBytes = (src.getEstimatedSizeBytes(options) * 2L) / 5L + 1000;
-    List<? extends BoundedSource<ObjectId>> splits = src.splitIntoSubSources(
+    List<? extends BoundedSource<ObjectId>> splits = src.split(
         desiredBundleSizeBytes, options);
 
     int expectedNbSplits = 3;

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -267,7 +267,7 @@ public class MongoDBGridFSIOTest implements Serializable {
 
     // make sure 2 files can fit in
     long desiredBundleSizeBytes = (src.getEstimatedSizeBytes(options) * 2L) / 5L + 1000;
-    List<? extends BoundedSource<ObjectId>> splits = src.splitIntoBundles(
+    List<? extends BoundedSource<ObjectId>> splits = src.splitIntoSubSources(
         desiredBundleSizeBytes, options);
 
     int expectedNbSplits = 3;

--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -365,7 +365,7 @@ public class MqttIO {
     }
 
     @Override
-    public List<UnboundedMqttSource> generateInitialSplits(int desiredNumSplits,
+    public List<UnboundedMqttSource> splitIntoSubSources(int desiredNumSplits,
                                                            PipelineOptions options) {
       // MQTT is based on a pub/sub pattern
       // so, if we create several subscribers on the same topic, they all will receive the same

--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -365,7 +365,7 @@ public class MqttIO {
     }
 
     @Override
-    public List<UnboundedMqttSource> splitIntoSubSources(int desiredNumSplits,
+    public List<UnboundedMqttSource> split(int desiredNumSplits,
                                                            PipelineOptions options) {
       // MQTT is based on a pub/sub pattern
       // so, if we create several subscribers on the same topic, they all will receive the same


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
---
As discussed in the ML, rename `generateInitialSplits` and `splitIntoBundles` methods to `splitIntoSubSources` as well as `@Test` methods and description in javadoc.
R: @jkff 
R: @staslev 