### PR TITLE
[BEAM-1972] Only compile HIFIO ITs when compiling with java 8.

### DIFF
--- a/sdks/java/io/hadoop/pom.xml
+++ b/sdks/java/io/hadoop/pom.xml
@@ -29,9 +29,19 @@
   <description>Parent for Beam SDK Hadoop IO which reads data from any source which implements Hadoop Input Format.</description>
 
   <modules>
-    <module>jdk1.8-tests</module>
     <module>input-format</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <modules>
+        <module>jdk1.8-tests</module>
+      </modules>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>

--- a/sdks/java/io/hadoop/pom.xml
+++ b/sdks/java/io/hadoop/pom.xml
@@ -35,7 +35,7 @@
   <profiles>
     <profile>
       <activation>
-        <jdk>1.8</jdk>
+        <jdk>[1.8,)</jdk>
       </activation>
       <modules>
         <module>jdk1.8-tests</module>


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
The HIFIO jdk1.8-tests directory contains dependencies that require java8 (notably cassandra.) 

The enforcer rules in jdk1.8-test mean that enforcer won't treat that as a problem, however the module itself was still compiling in that scenario.  This change makes it so that the module is skipped.

I've verified this fix works by doing mvn clean verify on a machine with java8 and a machine with only java7 (which previously failed mvn clean verify) - I also verified that the jdk1.8-tests module actually compiled on the java8 machine and that we can still run the integration tests.

mvn is a tricky one, so let me know if there's something I haven't thought of/etc...

Presumably, we will need java8-only modules in the future, so I'm guessing this will be a pattern that may be followed elsewhere (eg. in the upcoming cassandra module - cc @jbonofre )

R @dhalperi 