### PR TITLE
Fix GCP import check in bigquery.py

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -370,7 +370,7 @@ class BigQuerySource(dataflow_io.NativeSource):
     # Import here to avoid adding the dependency for local running scenarios.
     try:
       # pylint: disable=wrong-import-order, wrong-import-position
-      import apitools.base.py
+      from apitools.base import py  # pylint: disable=unused-variable
     except ImportError:
       raise ImportError(
           'Google Cloud IO not available, '
@@ -480,7 +480,7 @@ class BigQuerySink(dataflow_io.NativeSink):
     # Import here to avoid adding the dependency for local running scenarios.
     try:
       # pylint: disable=wrong-import-order, wrong-import-position
-      import apitools.base.py
+      from apitools.base import py  # pylint: disable=unused-variable
     except ImportError:
       raise ImportError(
           'Google Cloud IO not available, '

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -370,7 +370,7 @@ class BigQuerySource(dataflow_io.NativeSource):
     # Import here to avoid adding the dependency for local running scenarios.
     try:
       # pylint: disable=wrong-import-order, wrong-import-position
-      from apitools.base.py import *
+      import apitools.base.py
     except ImportError:
       raise ImportError(
           'Google Cloud IO not available, '
@@ -480,7 +480,7 @@ class BigQuerySink(dataflow_io.NativeSink):
     # Import here to avoid adding the dependency for local running scenarios.
     try:
       # pylint: disable=wrong-import-order, wrong-import-position
-      from apitools.base.py import *
+      import apitools.base.py
     except ImportError:
       raise ImportError(
           'Google Cloud IO not available, '


### PR DESCRIPTION
This change fixes the following warning which occurs when "import apache_beam" is run in an interactive session directly from the "sdks/python/" directory.

```
apache_beam/io/gcp/bigquery.py:326: SyntaxWarning: import * only allowed at module level
  def __init__(self, table=None, dataset=None, project=None, query=None,
apache_beam/io/gcp/bigquery.py:431: SyntaxWarning: import * only allowed at module level
  def __init__(self, table, dataset=None, project=None, schema=None,
```