### PR TITLE
[BEAM-1948] Add protection against null pointer exception if aggregator key is not present in aggregatorSteps in DirectRunner.DirectPipelineResult.getAggregatorValues(aggregator)

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -384,7 +384,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
       Collection<PTransform<?, ?>> steps = aggregatorSteps.get(aggregator);
       final Map<String, T> stepValues = new HashMap<>();
       for (AppliedPTransform<?, ?, ?> transform : evaluationContext.getSteps()) {
-        if (steps.contains(transform.getTransform())) {
+        if (steps != null && steps.contains(transform.getTransform())) {
           T aggregate = aggregators.getAggregate(
               evaluationContext.getStepName(transform), aggregator.getName());
           if (aggregate != null) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -383,12 +383,14 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
       AggregatorContainer aggregators = evaluationContext.getAggregatorContainer();
       Collection<PTransform<?, ?>> steps = aggregatorSteps.get(aggregator);
       final Map<String, T> stepValues = new HashMap<>();
-      for (AppliedPTransform<?, ?, ?> transform : evaluationContext.getSteps()) {
-        if (steps != null && steps.contains(transform.getTransform())) {
-          T aggregate = aggregators.getAggregate(
-              evaluationContext.getStepName(transform), aggregator.getName());
-          if (aggregate != null) {
-            stepValues.put(transform.getFullName(), aggregate);
+      if (steps != null) {
+        for (AppliedPTransform<?, ?, ?> transform : evaluationContext.getSteps()) {
+          if (steps.contains(transform.getTransform())) {
+            T aggregate = aggregators
+                .getAggregate(evaluationContext.getStepName(transform), aggregator.getName());
+            if (aggregate != null) {
+              stepValues.put(transform.getFullName(), aggregate);
+            }
           }
         }
       }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.runners.direct.DirectRunner.DirectPipelineResult;
+import org.apache.beam.sdk.AggregatorRetrievalException;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
@@ -47,6 +48,7 @@ import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.ListCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -58,6 +60,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Aggregator;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -66,9 +69,13 @@ import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.IllegalMutationException;
+import org.apache.beam.sdk.util.state.StateSpec;
+import org.apache.beam.sdk.util.state.StateSpecs;
+import org.apache.beam.sdk.util.state.ValueState;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
@@ -523,6 +530,36 @@ public class DirectRunnerTest implements Serializable {
     thrown.expectCause(isA(CoderException.class));
     thrown.expectMessage("Cannot decode a long");
     p.run();
+  }
+
+
+  @Test
+  public void testAggregatorNotPresentInGraph() throws AggregatorRetrievalException {
+    Pipeline p = getPipeline();
+    IdentityDoFn identityDoFn = new IdentityDoFn();
+    p.apply(Create.of(KV.of("key", "element1"), KV.of("key", "element2"), KV.of("key", "element3")))
+        .apply(ParDo.of(identityDoFn));
+    PipelineResult pipelineResult = p.run();
+    pipelineResult.getAggregatorValues(identityDoFn.getCounter()).getValues();
+  }
+
+  private static class IdentityDoFn extends DoFn<KV<String, String>, String> {
+    private final Aggregator<Long, Long> counter = createAggregator("counter", Sum.ofLongs());
+    private static final String STATE_ID = "state";
+    @StateId(STATE_ID)
+    private static final StateSpec<Object, ValueState<String>> stateSpec =
+        StateSpecs.value(StringUtf8Coder.of());
+
+    @ProcessElement
+    public void processElement(ProcessContext context, @StateId(STATE_ID) ValueState<String> state){
+      state.write("state content");
+      counter.addValue(1L);
+      context.output(context.element().getValue());
+    }
+
+    public Aggregator<Long, Long> getCounter() {
+      return counter;
+    }
   }
 
   private static class LongNoDecodeCoder extends AtomicCoder<Long> {


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
---
I have run into a case in which `aggregator` key is not present in `aggregatorSteps` in `DirectRunner.DirectPipelineResult.getAggregatorValues(aggregator)` causing a null pointer exception.  It might be because, in the user code, the `aggregator` is created but the `aggregator.addValue()` is never called (aggregator is a fatal errors counter). 

This PR is just a simple protection against this error.

R: @tgroh 
CC: @jbonofre 