### PR TITLE
[BEAM-1909] BigQuery read transform fails for DirectRunner when querying non-US regions

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -605,9 +605,7 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
     else:
       self.query = self.source.query
 
-  def __enter__(self):
-    self.client = BigQueryWrapper(client=self.test_bigquery_client)
-
+  def _get_source_table_location(self):
     tr = self.source.table_reference
     if tr.projectId is None:
       source_project_id = self.executing_project
@@ -618,9 +616,12 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
     source_table_id = tr.tableId
     source_location = self.client.get_table_location(
         source_project_id, source_dataset_id, source_table_id)
+    return source_location
 
+  def __enter__(self):
+    self.client = BigQueryWrapper(client=self.test_bigquery_client)
     self.client.create_temporary_dataset(
-        self.executing_project, location=source_location)
+        self.executing_project, location=self._get_source_table_location())
     return self
 
   def __exit__(self, exception_type, exception_value, traceback):

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -607,6 +607,10 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
 
   def _get_source_table_location(self):
     tr = self.source.table_reference
+    if tr is None:
+      # TODO: implement location retrieval for query sources
+      return
+
     if tr.projectId is None:
       source_project_id = self.executing_project
     else:


### PR DESCRIPTION
**Note**: This is an updated and condensed PR for the original PR: https://github.com/apache/beam/pull/2509

**Description**:
I partially (!) fixed the issue by getting the location of the source table. Then I use this location as location of the created temp dataset. The added parameters are optional and should not break anything.

**Tests**: I tested with an US and EU dataset as source in a `DirectRunner`, i.e., using a `BigQuerySource` with `table=<some-table>`.

**What's missing**: It does not work for a `BigQuerySource` with `query=<some-query>`.

The corresponding Jira issue should not yet be closed.