### PR TITLE
[BEAM-2019] Count.globally() requires default values for non-GlobalWindows

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Count.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Count.java
@@ -57,6 +57,9 @@ public class Count {
   /**
    * Returns a {@link PTransform} that counts the number of elements in
    * its input {@link PCollection}.
+   *
+   * <p>Note, for {@code none-GlobalWindow} use
+   * {@code Combine.globally(Count.<T>combineFn()).withoutDefaults()} instead.
    */
   public static <T> PTransform<PCollection<T>, PCollection<Long>> globally() {
     return Combine.globally(new CountFn<T>());


### PR DESCRIPTION
fix below error of Count.globally() when not using `GlobalWindows`:
```
Exception in thread "main" java.lang.IllegalStateException: Default values are not supported in Combine.globally() \
if the output PCollection is not windowed by GlobalWindows. Instead, use Combine.globally().withoutDefaults() \
to output an empty PCollection if the input PCollection is empty, or Combine.globally().asSingletonView() \
to get the default output of the CombineFn if the input PCollection is empty.
```