### PR TITLE
[BEAM-1886] Remove TextIO override in Flink runner

### DIFF
--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -94,7 +94,8 @@
                     org.apache.beam.sdk.testing.UsesMapState,
                     org.apache.beam.sdk.testing.UsesAttemptedMetrics,
                     org.apache.beam.sdk.testing.UsesCommittedMetrics,
-                    org.apache.beam.sdk.testing.UsesTestStream
+                    org.apache.beam.sdk.testing.UsesTestStream,
+                    org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs
                   </excludedGroups>
                   <parallel>none</parallel>
                   <failIfNoTests>true</failIfNoTests>

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink.streaming;
 
 import com.google.common.base.Joiner;
+import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import org.apache.beam.runners.flink.FlinkTestPipeline;
@@ -41,7 +42,7 @@ import org.joda.time.Instant;
  */
 public class GroupByNullKeyTest extends StreamingProgramTestBase implements Serializable {
 
-
+  protected String resultDir;
   protected String resultPath;
 
   static final String[] EXPECTED_RESULT = new String[] {
@@ -53,12 +54,16 @@ public class GroupByNullKeyTest extends StreamingProgramTestBase implements Seri
 
   @Override
   protected void preSubmit() throws Exception {
-    resultPath = getTempDirPath("result");
+    // Beam Write will add shard suffix to fileName, see ShardNameTemplate.
+    // So tempFile need have a parent to compare.
+    File resultParent = createAndRegisterTempFile("result");
+    resultDir = resultParent.toURI().toString();
+    resultPath = new File(resultParent, "file.txt").getAbsolutePath();
   }
 
   @Override
   protected void postSubmit() throws Exception {
-    compareResultsByLinesInMemory(Joiner.on('\n').join(EXPECTED_RESULT), resultPath);
+    compareResultsByLinesInMemory(Joiner.on('\n').join(EXPECTED_RESULT), resultDir);
   }
 
   /**


### PR DESCRIPTION
This is a duplicate of #2537. The tests work locally but not on Jenkins, I'm trying to figure out why that might be.