### PR TITLE
[BEAM-2047] Use the Input Coder in Dataflow Pubsub Write

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -1022,8 +1022,12 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         // however the Dataflow backend require a coder to be set.
         stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(VoidCoder.of()));
       } else if (overriddenTransform.getElementCoder() != null) {
-        stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(
-            overriddenTransform.getElementCoder()));
+        stepContext.addEncodingInput(
+            WindowedValue.getValueOnlyCoder(overriddenTransform.getElementCoder()));
+      } else {
+        // Reuse the input coder
+        stepContext.addEncodingInput(
+            WindowedValue.getValueOnlyCoder(context.getInput(transform).getCoder()));
       }
       PCollection<T> input = context.getInput(transform);
       stepContext.addInput(PropertyNames.PARALLEL_INPUT, input);


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
If no element coder is specified, and one is required, use the element
coder of the input PCollection as the encoding input. The coder is known
to have the appropriate type.

R: @reuvenlax 

This is likely going away as part of https://issues.apache.org/jira/browse/BEAM-1353;
we should require a `T -> bytes` conversion to be explicitly specified rather than using a Coder.
Right now the input coder is not always defined. This fixes that bug.