### PR TITLE
[BEAM-1428] KinesisIO should comply with PTransform style guide

### DIFF
--- a/sdks/java/io/kinesis/pom.xml
+++ b/sdks/java/io/kinesis/pom.xml
@@ -120,6 +120,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockReadTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockReadTest.java
@@ -46,13 +46,13 @@ public class KinesisMockReadTest {
         List<List<AmazonKinesisMock.TestData>> testData =
                 provideTestData(noOfShards, noOfEventsPerShard);
 
-        PCollection<AmazonKinesisMock.TestData> result = p.
-                apply(
-                        KinesisIO.Read.
-                                from("stream", InitialPositionInStream.TRIM_HORIZON).
-                                using(new AmazonKinesisMock.Provider(testData, 10)).
-                                withMaxNumRecords(noOfShards * noOfEventsPerShard)).
-                apply(ParDo.of(new KinesisRecordToTestData()));
+        PCollection<AmazonKinesisMock.TestData> result = p
+                .apply(
+                        KinesisIO.read()
+                                .from("stream", InitialPositionInStream.TRIM_HORIZON)
+                                .withClientProvider(new AmazonKinesisMock.Provider(testData, 10))
+                                .withMaxNumRecords(noOfShards * noOfEventsPerShard))
+                .apply(ParDo.of(new KinesisRecordToTestData()));
         PAssert.that(result).containsInAnyOrder(Iterables.concat(testData));
         p.run();
     }

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderIT.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderIT.java
@@ -80,11 +80,11 @@ public class KinesisReaderIT {
             throws InterruptedException {
 
         PCollection<String> result = p.
-                apply(KinesisIO.Read.
-                        from(options.getAwsKinesisStream(), Instant.now()).
-                        using(options.getAwsAccessKey(), options.getAwsSecretKey(),
-                                Regions.fromName(options.getAwsKinesisRegion())).
-                        withMaxReadTime(Duration.standardMinutes(3))
+                apply(KinesisIO.read()
+                        .from(options.getAwsKinesisStream(), Instant.now())
+                        .withClientProvider(options.getAwsAccessKey(), options.getAwsSecretKey(),
+                                Regions.fromName(options.getAwsKinesisRegion()))
+                        .withMaxReadTime(Duration.standardMinutes(3))
                 ).
                 apply(ParDo.of(new RecordDataToString()));
         PAssert.that(result).containsInAnyOrder(testData);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-1428

There's lots of other issues in KinesisIO, but this at least brings its API surface to a level where making it more style-compliant will not require backward-incompatible changes.

R: @jbonofre 