### PR TITLE
[BEAM-2040] Upgrade autovalue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <datastore.client.version>1.4.0</datastore.client.version>
     <datastore.proto.version>1.3.0</datastore.proto.version>
     <google-auto-service.version>1.0-rc2</google-auto-service.version>
-    <google-auto-value.version>1.3</google-auto-value.version>
+    <google-auto-value.version>1.4.1</google-auto-value.version>
     <google-auth.version>0.6.1</google-auth.version>
     <google-clients.version>1.22.0</google-clients.version>
     <google-cloud-bigdataoss.version>1.4.5</google-cloud-bigdataoss.version>


### PR DESCRIPTION
I believe we are occasionally being hit by these issues fixed in
release.

> We guard against spurious exceptions due to a JDK bug in reading resources from jars. (#365)
>
> We don't propagate an exception if a corrupt jar is found in extension loading.

R: @lukecwik @tgroh @klk @jbonofre  or anyone else ;)