### PR TITLE
[BEAM-1022] Use Structural Value when comparing Window(AndTrigger) Namespaces

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateNamespaces.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateNamespaces.java
@@ -142,7 +142,12 @@ public class StateNamespaces {
       }
 
       WindowNamespace<?> that = (WindowNamespace<?>) obj;
-      return Objects.equals(this.window, that.window);
+      return Objects.equals(
+          this.windowStructuralValue(), that.windowStructuralValue());
+    }
+
+    private Object windowStructuralValue() {
+      return windowCoder.structuralValue(window);
     }
 
     @Override
@@ -223,7 +228,11 @@ public class StateNamespaces {
 
       WindowAndTriggerNamespace<?> that = (WindowAndTriggerNamespace<?>) obj;
       return this.triggerIndex == that.triggerIndex
-          && Objects.equals(this.window, that.window);
+          && Objects.equals(this.windowStructuralValue(), that.windowStructuralValue());
+    }
+
+    private Object windowStructuralValue() {
+      return windowCoder.structuralValue(window);
     }
 
     @Override


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This makes sure we don't use a potentially default equals method and
instead compare based on the Coder, which is how Beam defines equality.

Improve GlobalWindow and IntervalWindow structuralValue methods.