### PR TITLE
Make it possible to test runners that don't support all metrics

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -122,8 +122,7 @@
             <id>validates-runner-tests</id>
             <configuration>
               <excludedGroups>
-                org.apache.beam.sdk.testing.UsesAttemptedMetrics,
-                org.apache.beam.sdk.testing.UsesCommittedMetrics,
+                org.apache.beam.sdk.testing.UsesDistributionMetrics,
                 org.apache.beam.sdk.testing.UsesSetState,
                 org.apache.beam.sdk.testing.UsesMapState,
                 org.apache.beam.sdk.testing.UsesTimersInParDo,

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -123,6 +123,7 @@
             <configuration>
               <excludedGroups>
                 org.apache.beam.sdk.testing.UsesDistributionMetrics,
+                org.apache.beam.sdk.testing.UsesGaugeMetrics,
                 org.apache.beam.sdk.testing.UsesSetState,
                 org.apache.beam.sdk.testing.UsesMapState,
                 org.apache.beam.sdk.testing.UsesTimersInParDo,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesCounterMetrics.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesCounterMetrics.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.testing;
+
+/**
+ * Category tag for validation tests which utilize {@link org.apache.beam.sdk.metrics.Counter}.
+ * Tests tagged with {@link UsesCounterMetrics} should be run for runners which support counters.
+ */
+public class UsesCounterMetrics {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesDistributionMetrics.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesDistributionMetrics.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.testing;
+
+/**
+ * Category tag for validation tests which utilize {@link org.apache.beam.sdk.metrics.Distribution}.
+ * Tests tagged with {@link UsesDistributionMetrics} should be run for runners which support
+ * distributions.
+ */
+public class UsesDistributionMetrics {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesGaugeMetrics.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesGaugeMetrics.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.testing;
+
+/**
+ * Category tag for validation tests which utilize {@link org.apache.beam.sdk.metrics.Gauge}.
+ * Tests tagged with {@link UsesGaugeMetrics} should be run for runners which support gauges.
+ */
+public class UsesGaugeMetrics {}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
@@ -33,6 +33,9 @@ import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesAttemptedMetrics;
 import org.apache.beam.sdk.testing.UsesCommittedMetrics;
+import org.apache.beam.sdk.testing.UsesCounterMetrics;
+import org.apache.beam.sdk.testing.UsesDistributionMetrics;
+import org.apache.beam.sdk.testing.UsesGaugeMetrics;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -122,7 +125,8 @@ public class MetricsTest implements Serializable {
     assertThat(cell.getCumulative(), CoreMatchers.equalTo(42L));
   }
 
-  @Category({ValidatesRunner.class, UsesCommittedMetrics.class})
+  @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesCounterMetrics.class,
+      UsesDistributionMetrics.class, UsesGaugeMetrics.class})
   @Test
   public void committedMetricsReportToQuery() {
     PipelineResult result = runPipelineWithMetrics();
@@ -151,7 +155,8 @@ public class MetricsTest implements Serializable {
   }
 
 
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class})
+  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class,
+      UsesDistributionMetrics.class, UsesGaugeMetrics.class})
   @Test
   public void attemptedMetricsReportToQuery() {
     PipelineResult result = runPipelineWithMetrics();
@@ -233,7 +238,7 @@ public class MetricsTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class})
+  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
   public void testBoundedSourceMetrics() {
     long numElements = 1000;
 
@@ -259,7 +264,7 @@ public class MetricsTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class})
+  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
   public void testUnboundedSourceMetrics() {
     long numElements = 1000;
 


### PR DESCRIPTION
Runners may only partially support metrics. This partial support runs along axes:
- attempted & committed
- counters & distributions & gauges & ...

Prior to this PR, we have categories for the first axis, but not the second.
This means that a runner that supports only part of the second axis has to blacklist tests
on the first axis. Adding categories for both axes lets runners build a matrix of supported
features.

I also renamed the existing categories so that they are grouped alphabetically. Happy to
undo if this is not a good change.

This also lets the DataflowRunner run more tests by accurately identifying its test
matrix.