### PR TITLE
[BEAM-1415] PubsubIO should comply with PTransform style guide

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -86,6 +86,8 @@ import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.WriteFiles;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubUnboundedSink;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubUnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -103,6 +105,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -854,29 +857,30 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   // ================================================================================
 
   /**
-   * Suppress application of {@link PubsubUnboundedSource#expand} in streaming mode so that we
-   * can instead defer to Windmill's implementation.
+   * Suppress application of {@link PubsubUnboundedSource#expand} in streaming mode so that we can
+   * instead defer to Windmill's implementation.
    */
-  private static class StreamingPubsubIORead<T> extends PTransform<PBegin, PCollection<T>> {
-    private final PubsubUnboundedSource<T> transform;
+  private static class StreamingPubsubIORead
+      extends PTransform<PBegin, PCollection<PubsubIO.PubsubMessage>> {
+    private final PubsubUnboundedSource transform;
 
     /**
      * Builds an instance of this class from the overridden transform.
      */
     public StreamingPubsubIORead(
-        DataflowRunner runner, PubsubUnboundedSource<T> transform) {
+        DataflowRunner runner, PubsubUnboundedSource transform) {
       this.transform = transform;
     }
 
-    PubsubUnboundedSource<T> getOverriddenTransform() {
+    PubsubUnboundedSource getOverriddenTransform() {
       return transform;
     }
 
     @Override
-    public PCollection<T> expand(PBegin input) {
-      return PCollection.<T>createPrimitiveOutputInternal(
+    public PCollection<PubsubIO.PubsubMessage> expand(PBegin input) {
+      return PCollection.<PubsubIO.PubsubMessage>createPrimitiveOutputInternal(
           input.getPipeline(), WindowingStrategy.globalDefault(), IsBounded.UNBOUNDED)
-          .setCoder(transform.getElementCoder());
+          .setCoder(new PubsubMessageWithAttributesCoder());
     }
 
     @Override
@@ -886,19 +890,19 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
     static {
       DataflowPipelineTranslator.registerTransformTranslator(
-          StreamingPubsubIORead.class, new StreamingPubsubIOReadTranslator<>());
+          StreamingPubsubIORead.class, new StreamingPubsubIOReadTranslator());
     }
   }
 
   /** Rewrite {@link StreamingPubsubIORead} to the appropriate internal node. */
-  private static class StreamingPubsubIOReadTranslator<T>
-      implements TransformTranslator<StreamingPubsubIORead<T>> {
+  private static class StreamingPubsubIOReadTranslator
+      implements TransformTranslator<StreamingPubsubIORead> {
     @Override
-    public void translate(StreamingPubsubIORead<T> transform, TranslationContext context) {
+    public void translate(StreamingPubsubIORead transform, TranslationContext context) {
       checkArgument(
           context.getPipelineOptions().isStreaming(),
           "StreamingPubsubIORead is only for streaming pipelines.");
-      PubsubUnboundedSource<T> overriddenTransform = transform.getOverriddenTransform();
+      PubsubUnboundedSource overriddenTransform = transform.getOverriddenTransform();
       StepTranslationContext stepContext = context.addStep(transform, "ParallelRead");
       stepContext.addInput(PropertyNames.FORMAT, "pubsub");
       if (overriddenTransform.getTopicProvider() != null) {
@@ -930,13 +934,26 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         stepContext.addInput(
             PropertyNames.PUBSUB_ID_ATTRIBUTE, overriddenTransform.getIdAttribute());
       }
-      if (overriddenTransform.getWithAttributesParseFn() != null) {
+      // In both cases, the transform needs to read PubsubMessage. However, in case it needs
+      // the attributes, we supply an identity "parse fn" so the worker will read PubsubMessage's
+      // from Windmill and simply pass them around; and in case it doesn't need attributes,
+      // we're already implicitly using a "Coder" that interprets the data as a PubsubMessage's
+      // payload.
+      if (overriddenTransform.getNeedsAttributes()) {
         stepContext.addInput(
             PropertyNames.PUBSUB_SERIALIZED_ATTRIBUTES_FN,
             byteArrayToJsonString(
-                serializeToByteArray(overriddenTransform.getWithAttributesParseFn())));
+                serializeToByteArray(new IdentityMessageFn())));
       }
       stepContext.addOutput(context.getOutput(transform));
+    }
+  }
+
+  private static class IdentityMessageFn
+      extends SimpleFunction<PubsubIO.PubsubMessage, PubsubIO.PubsubMessage> {
+    @Override
+    public PubsubIO.PubsubMessage apply(PubsubIO.PubsubMessage input) {
+      return input;
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -958,26 +958,27 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   }
 
   /**
-   * Suppress application of {@link PubsubUnboundedSink#expand} in streaming mode so that we
-   * can instead defer to Windmill's implementation.
+   * Suppress application of {@link PubsubUnboundedSink#expand} in streaming mode so that we can
+   * instead defer to Windmill's implementation.
    */
-  private static class StreamingPubsubIOWrite<T> extends PTransform<PCollection<T>, PDone> {
-    private final PubsubUnboundedSink<T> transform;
+  private static class StreamingPubsubIOWrite
+      extends PTransform<PCollection<PubsubIO.PubsubMessage>, PDone> {
+    private final PubsubUnboundedSink transform;
 
     /**
      * Builds an instance of this class from the overridden transform.
      */
     public StreamingPubsubIOWrite(
-        DataflowRunner runner, PubsubUnboundedSink<T> transform) {
+        DataflowRunner runner, PubsubUnboundedSink transform) {
       this.transform = transform;
     }
 
-    PubsubUnboundedSink<T> getOverriddenTransform() {
+    PubsubUnboundedSink getOverriddenTransform() {
       return transform;
     }
 
     @Override
-    public PDone expand(PCollection<T> input) {
+    public PDone expand(PCollection<PubsubIO.PubsubMessage> input) {
       return PDone.in(input.getPipeline());
     }
 
@@ -988,23 +989,23 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
     static {
       DataflowPipelineTranslator.registerTransformTranslator(
-          StreamingPubsubIOWrite.class, new StreamingPubsubIOWriteTranslator<>());
+          StreamingPubsubIOWrite.class, new StreamingPubsubIOWriteTranslator());
     }
   }
 
   /**
    * Rewrite {@link StreamingPubsubIOWrite} to the appropriate internal node.
    */
-  private static class StreamingPubsubIOWriteTranslator<T> implements
-      TransformTranslator<StreamingPubsubIOWrite<T>> {
+  private static class StreamingPubsubIOWriteTranslator implements
+      TransformTranslator<StreamingPubsubIOWrite> {
 
     @Override
     public void translate(
-        StreamingPubsubIOWrite<T> transform,
+        StreamingPubsubIOWrite transform,
         TranslationContext context) {
       checkArgument(context.getPipelineOptions().isStreaming(),
                     "StreamingPubsubIOWrite is only for streaming pipelines.");
-      PubsubUnboundedSink<T> overriddenTransform = transform.getOverriddenTransform();
+      PubsubUnboundedSink overriddenTransform = transform.getOverriddenTransform();
       StepTranslationContext stepContext = context.addStep(transform, "ParallelWrite");
       stepContext.addInput(PropertyNames.FORMAT, "pubsub");
       if (overriddenTransform.getTopicProvider().isAccessible()) {
@@ -1023,19 +1024,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         stepContext.addInput(
             PropertyNames.PUBSUB_ID_ATTRIBUTE, overriddenTransform.getIdAttribute());
       }
-      if (overriddenTransform.getFormatFn() != null) {
-        stepContext.addInput(
-            PropertyNames.PUBSUB_SERIALIZED_ATTRIBUTES_FN,
-            byteArrayToJsonString(serializeToByteArray(overriddenTransform.getFormatFn())));
-        // No coder is needed in this case since the formatFn formats directly into a byte[],
-        // however the Dataflow backend require a coder to be set.
-        stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(VoidCoder.of()));
-      } else if (overriddenTransform.getElementCoder() != null) {
-        stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(
-            overriddenTransform.getElementCoder()));
-      }
-      PCollection<T> input = context.getInput(transform);
-      stepContext.addInput(PropertyNames.PARALLEL_INPUT, input);
+      // No coder is needed in this case since the collection being written is already of
+      // PubsubMessage, however the Dataflow backend require a coder to be set.
+      stepContext.addEncodingInput(WindowedValue.getValueOnlyCoder(VoidCoder.of()));
+      stepContext.addInput(PropertyNames.PARALLEL_INPUT, context.getInput(transform));
     }
   }
 
@@ -1329,8 +1321,9 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     }
   }
 
-  private class StreamingPubsubIOWriteOverrideFactory<T>
-      implements PTransformOverrideFactory<PCollection<T>, PDone, PubsubUnboundedSink<T>> {
+  private class StreamingPubsubIOWriteOverrideFactory
+      implements PTransformOverrideFactory<
+          PCollection<PubsubIO.PubsubMessage>, PDone, PubsubUnboundedSink> {
     private final DataflowRunner runner;
 
     private StreamingPubsubIOWriteOverrideFactory(DataflowRunner runner) {
@@ -1338,11 +1331,13 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     }
 
     @Override
-    public PTransformReplacement<PCollection<T>, PDone> getReplacementTransform(
-        AppliedPTransform<PCollection<T>, PDone, PubsubUnboundedSink<T>> transform) {
+    public PTransformReplacement<PCollection<PubsubIO.PubsubMessage>, PDone>
+        getReplacementTransform(
+            AppliedPTransform<PCollection<PubsubIO.PubsubMessage>, PDone, PubsubUnboundedSink>
+                transform) {
       return PTransformReplacement.of(
           PTransformReplacements.getSingletonMainInput(transform),
-          new StreamingPubsubIOWrite<>(runner, transform.getTransform()));
+          new StreamingPubsubIOWrite(runner, transform.getTransform()));
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import com.google.protobuf.Message;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
@@ -44,6 +46,7 @@ import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -461,8 +464,34 @@ public class PubsubIO {
   }
 
    /** Returns A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream. */
-  public static <T> Read<T> read() {
-    return new AutoValue_PubsubIO_Read.Builder<T>().build();
+  private static <T> Read<T> read() {
+    return new AutoValue_PubsubIO_Read.Builder<T>().setNeedsAttributes(false).build();
+  }
+
+  /**
+   * Returns A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream. The
+   * messages will only contain a {@link PubsubMessage#getMessage() payload}, but no {@link
+   * PubsubMessage#getAttributeMap() attributes}.
+   */
+  public static Read<PubsubMessage> readPubsubMessagesWithoutAttributes() {
+    return new AutoValue_PubsubIO_Read.Builder<PubsubMessage>()
+        .setCoder(PubsubMessagePayloadOnlyCoder.of())
+        .setParseFn(new IdentityMessageFn())
+        .setNeedsAttributes(false)
+        .build();
+  }
+
+  /**
+   * Returns A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream. The
+   * messages will contain both a {@link PubsubMessage#getMessage() payload} and {@link
+   * PubsubMessage#getAttributeMap() attributes}.
+   */
+  public static Read<PubsubMessage> readPubsubMessagesWithAttributes() {
+    return new AutoValue_PubsubIO_Read.Builder<PubsubMessage>()
+        .setCoder(PubsubMessageWithAttributesCoder.of())
+        .setParseFn(new IdentityMessageFn())
+        .setNeedsAttributes(true)
+        .build();
   }
 
   /**
@@ -470,7 +499,8 @@ public class PubsubIO {
    * Pub/Sub stream.
    */
   public static Read<String> readStrings() {
-    return PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
+    return PubsubIO.<String>read().withCoderAndParseFn(
+        StringUtf8Coder.of(), new ParsePayloadAsUtf8());
   }
 
   /**
@@ -478,7 +508,11 @@ public class PubsubIO {
    * given type from a Google Cloud Pub/Sub stream.
    */
   public static <T extends Message> Read<T> readProtos(Class<T> messageClass) {
-    return PubsubIO.<T>read().withCoder(ProtoCoder.of(messageClass));
+    // TODO: Stop using ProtoCoder and instead parse the payload directly.
+    // We should not be relying on the fact that ProtoCoder's wire format is identical to
+    // the protobuf wire format, as the wire format is not part of a coder's API.
+    ProtoCoder<T> coder = ProtoCoder.of(messageClass);
+    return PubsubIO.<T>read().withCoderAndParseFn(coder, new ParsePayloadUsingCoder<>(coder));
   }
 
   /**
@@ -486,7 +520,11 @@ public class PubsubIO {
    * given type from a Google Cloud Pub/Sub stream.
    */
   public static <T extends Message> Read<T> readAvros(Class<T> clazz) {
-    return PubsubIO.<T>read().withCoder(AvroCoder.of(clazz));
+    // TODO: Stop using AvroCoder and instead parse the payload directly.
+    // We should not be relying on the fact that AvroCoder's wire format is identical to
+    // the Avro wire format, as the wire format is not part of a coder's API.
+    AvroCoder<T> coder = AvroCoder.of(clazz);
+    return PubsubIO.<T>read().withCoderAndParseFn(coder, new ParsePayloadUsingCoder<>(coder));
   }
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
@@ -543,6 +581,8 @@ public class PubsubIO {
     @Nullable
     abstract SimpleFunction<PubsubMessage, T> getParseFn();
 
+    abstract boolean getNeedsAttributes();
+
     abstract Builder<T> toBuilder();
 
     @AutoValue.Builder
@@ -558,6 +598,8 @@ public class PubsubIO {
       abstract Builder<T> setCoder(Coder<T> coder);
 
       abstract Builder<T> setParseFn(SimpleFunction<PubsubMessage, T> parseFn);
+
+      abstract Builder<T> setNeedsAttributes(boolean needsAttributes);
 
       abstract Read<T> build();
     }
@@ -665,20 +707,13 @@ public class PubsubIO {
     }
 
     /**
-     * Uses the given {@link Coder} to decode each record into a value of type {@code T}.
-     */
-    public Read<T> withCoder(Coder<T> coder) {
-      return toBuilder().setCoder(coder).build();
-    }
-
-    /**
      * Causes the source to return a PubsubMessage that includes Pubsub attributes, and uses the
      * given parsing function to transform the PubsubMessage into an output type.
      * A Coder for the output type T must be registered or set on the output via
      * {@link PCollection#setCoder(Coder)}.
      */
-    public Read<T> withParseFn(SimpleFunction<PubsubMessage, T> parseFn) {
-      return toBuilder().setParseFn(parseFn).build();
+    private Read<T> withCoderAndParseFn(Coder<T> coder, SimpleFunction<PubsubMessage, T> parseFn) {
+      return toBuilder().setCoder(coder).setParseFn(parseFn).build();
     }
 
     @Override
@@ -690,10 +725,6 @@ public class PubsubIO {
       if (getTopicProvider() != null && getSubscriptionProvider() != null) {
         throw new IllegalStateException(
             "Can't set both the topic and the subscription for " + "a PubsubIO.Read transform");
-      }
-      if (getCoder() == null) {
-        throw new IllegalStateException(
-            "PubsubIO.Read requires that a coder be set using " + "the withCoder method.");
       }
 
       @Nullable
@@ -711,17 +742,23 @@ public class PubsubIO {
           getSubscriptionProvider() == null
               ? null
               : NestedValueProvider.of(getSubscriptionProvider(), new SubscriptionPathTranslator());
-      PubsubUnboundedSource<T> source =
-          new PubsubUnboundedSource<T>(
+      PubsubUnboundedSource source =
+          new PubsubUnboundedSource(
               FACTORY,
               projectPath,
               topicPath,
               subscriptionPath,
-              getCoder(),
               getTimestampAttribute(),
               getIdAttribute(),
-              getParseFn());
-      return input.getPipeline().apply(source);
+              getNeedsAttributes());
+      return input
+          .getPipeline()
+          .apply(source)
+          .setCoder(
+              getNeedsAttributes()
+                  ? PubsubMessageWithAttributesCoder.of()
+                  : PubsubMessagePayloadOnlyCoder.of())
+          .apply(MapElements.via(getParseFn()));
     }
 
     @Override
@@ -847,7 +884,7 @@ public class PubsubIO {
      * function translates the input type T to a PubsubMessage object, which is used by the sink
      * to separately set the PubSub message's payload and attributes.
      */
-    public Write<T> withFormatFn(SimpleFunction<T, PubsubMessage> formatFn) {
+    private Write<T> withFormatFn(SimpleFunction<T, PubsubMessage> formatFn) {
       return toBuilder().setFormatFn(formatFn).build();
     }
 
@@ -952,6 +989,37 @@ public class PubsubIO {
         super.populateDisplayData(builder);
         builder.delegate(Write.this);
       }
+    }
+  }
+
+  private static class ParsePayloadAsUtf8 extends SimpleFunction<PubsubMessage, String> {
+    @Override
+    public String apply(PubsubMessage input) {
+      return new String(input.getMessage(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private static class ParsePayloadUsingCoder<T> extends SimpleFunction<PubsubMessage, T> {
+    private Coder<T> coder;
+
+    public ParsePayloadUsingCoder(Coder<T> coder) {
+      this.coder = coder;
+    }
+
+    @Override
+    public T apply(PubsubMessage input) {
+      try {
+        return CoderUtils.decodeFromByteArray(coder, input.getMessage());
+      } catch (CoderException e) {
+        throw new RuntimeException("Could not decode Pubsub message", e);
+      }
+    }
+  }
+
+  private static class IdentityMessageFn extends SimpleFunction<PubsubMessage, PubsubMessage> {
+    @Override
+    public PubsubMessage apply(PubsubMessage input) {
+      return input;
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -529,8 +529,13 @@ public class PubsubIO {
   }
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
-  public static <T> Write<T> write() {
+  private static <T> Write<T> write() {
     return new AutoValue_PubsubIO_Write.Builder<T>().build();
+  }
+
+  /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
+  public static Write<PubsubMessage> writePubsubMessages() {
+    return PubsubIO.<PubsubMessage>write().withFormatFn(new IdentityMessageFn());
   }
 
   /**

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessagePayloadOnlyCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessagePayloadOnlyCoder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.util.StreamUtils;
+
+/** A coder for PubsubMessage treating the raw bytes being decoded as the message's payload. */
+public class PubsubMessagePayloadOnlyCoder extends CustomCoder<PubsubIO.PubsubMessage> {
+  public static PubsubMessagePayloadOnlyCoder of() {
+    return new PubsubMessagePayloadOnlyCoder();
+  }
+
+  @Override
+  public void encode(PubsubIO.PubsubMessage value, OutputStream outStream, Context context)
+      throws IOException {
+    checkState(context.isWholeStream, "Expected to only be used in a whole-stream context");
+    outStream.write(value.getMessage());
+  }
+
+  @Override
+  public PubsubIO.PubsubMessage decode(InputStream inStream, Context context) throws IOException {
+    checkState(context.isWholeStream, "Expected to only be used in a whole-stream context");
+    return new PubsubIO.PubsubMessage(
+        StreamUtils.getBytes(inStream), ImmutableMap.<String, String>of());
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithAttributesCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithAttributesCoder.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.NullableCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+
+/** A coder for PubsubMessage including attributes. */
+public class PubsubMessageWithAttributesCoder extends CustomCoder<PubsubIO.PubsubMessage> {
+  private static final Coder<byte[]> PAYLOAD_CODER =
+      NullableCoder.of(ByteArrayCoder.of());
+  private static final Coder<Map<String, String>> ATTRIBUTES_CODER = MapCoder.of(
+      StringUtf8Coder.of(), StringUtf8Coder.of());
+
+  public static PubsubMessageWithAttributesCoder of() {
+    return new PubsubMessageWithAttributesCoder();
+  }
+
+  public void encode(PubsubIO.PubsubMessage value, OutputStream outStream, Context context)
+      throws IOException {
+    PAYLOAD_CODER.encode(
+        value.getMessage(),
+        outStream,
+        context.nested());
+    ATTRIBUTES_CODER.encode(value.getAttributeMap(), outStream, context);
+  }
+
+  @Override
+  public PubsubIO.PubsubMessage decode(InputStream inStream, Context context) throws IOException {
+    byte[] payload = PAYLOAD_CODER.decode(inStream, context.nested());
+    Map<String, String> attributes = ATTRIBUTES_CODER.decode(inStream, context);
+    return new PubsubIO.PubsubMessage(payload, attributes);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -49,19 +49,19 @@ public class PubsubIOTest {
   @Test
   public void testPubsubIOGetName() {
     assertEquals("PubsubIO.Read",
-        PubsubIO.<String>read().fromTopic("projects/myproject/topics/mytopic").getName());
+        PubsubIO.readStrings().fromTopic("projects/myproject/topics/mytopic").getName());
     assertEquals("PubsubIO.Write",
-        PubsubIO.<String>write().to("projects/myproject/topics/mytopic").getName());
+        PubsubIO.writeStrings().to("projects/myproject/topics/mytopic").getName());
   }
 
   @Test
   public void testTopicValidationSuccess() throws Exception {
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/abc");
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/ABC");
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-DeF");
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-1234");
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-1234-_.~%+-_.~%+-_.~%+-abc");
-    PubsubIO.<String>read().fromTopic(new StringBuilder()
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/abc");
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/ABC");
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/AbC-DeF");
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/AbC-1234");
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/AbC-1234-_.~%+-_.~%+-_.~%+-abc");
+    PubsubIO.readStrings().fromTopic(new StringBuilder()
         .append("projects/my-project/topics/A-really-long-one-")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
@@ -72,13 +72,13 @@ public class PubsubIOTest {
   @Test
   public void testTopicValidationBadCharacter() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    PubsubIO.<String>read().fromTopic("projects/my-project/topics/abc-*-abc");
+    PubsubIO.readStrings().fromTopic("projects/my-project/topics/abc-*-abc");
   }
 
   @Test
   public void testTopicValidationTooLong() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    PubsubIO.<String>read().fromTopic(new StringBuilder().append
+    PubsubIO.readStrings().fromTopic(new StringBuilder().append
         ("projects/my-project/topics/A-really-long-one-")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
@@ -91,7 +91,7 @@ public class PubsubIOTest {
     String topic = "projects/project/topics/topic";
     String subscription = "projects/project/subscriptions/subscription";
     Duration maxReadTime = Duration.standardMinutes(5);
-    PubsubIO.Read<String> read = PubsubIO.<String>read()
+    PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromTopic(StaticValueProvider.of(topic))
         .withTimestampAttribute("myTimestamp")
         .withIdAttribute("myId");
@@ -108,7 +108,7 @@ public class PubsubIOTest {
     String topic = "projects/project/topics/topic";
     String subscription = "projects/project/subscriptions/subscription";
     Duration maxReadTime = Duration.standardMinutes(5);
-    PubsubIO.Read<String> read = PubsubIO.<String>read()
+    PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromSubscription(StaticValueProvider.of(subscription))
         .withTimestampAttribute("myTimestamp")
         .withIdAttribute("myId");
@@ -123,7 +123,7 @@ public class PubsubIOTest {
   @Test
   public void testNullTopic() {
     String subscription = "projects/project/subscriptions/subscription";
-    PubsubIO.Read<String> read = PubsubIO.<String>read()
+    PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromSubscription(StaticValueProvider.of(subscription));
     assertNull(read.getTopicProvider());
     assertNotNull(read.getSubscriptionProvider());
@@ -133,7 +133,7 @@ public class PubsubIOTest {
   @Test
   public void testNullSubscription() {
     String topic = "projects/project/topics/topic";
-    PubsubIO.Read<String> read = PubsubIO.<String>read()
+    PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromTopic(StaticValueProvider.of(topic));
     assertNotNull(read.getTopicProvider());
     assertNull(read.getSubscriptionProvider());
@@ -166,7 +166,7 @@ public class PubsubIOTest {
   @Test
   public void testWriteDisplayData() {
     String topic = "projects/project/topics/topic";
-    PubsubIO.Write<?> write = PubsubIO.<String>write()
+    PubsubIO.Write<?> write = PubsubIO.writeStrings()
         .to(topic)
         .withTimestampAttribute("myTimestamp")
         .withIdAttribute("myId");
@@ -182,7 +182,7 @@ public class PubsubIOTest {
   @Category(ValidatesRunner.class)
   public void testPrimitiveWriteDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
-    PubsubIO.Write<?> write = PubsubIO.<String>write().to("projects/project/topics/topic");
+    PubsubIO.Write<?> write = PubsubIO.writeStrings().to("projects/project/topics/topic");
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(write);
     assertThat("PubsubIO.Write should include the topic in its primitive display data",

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -34,12 +34,12 @@ import static org.junit.Assert.assertTrue;
 import com.google.api.client.util.Clock;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
@@ -79,7 +79,7 @@ public class PubsubUnboundedSourceTest {
   private AtomicLong now;
   private Clock clock;
   private PubsubTestClientFactory factory;
-  private PubsubSource<String> primSource;
+  private PubsubSource primSource;
 
   @Rule
   public TestPipeline p = TestPipeline.create();
@@ -93,11 +93,11 @@ public class PubsubUnboundedSourceTest {
       }
     };
     factory = PubsubTestClient.createFactoryForPull(clock, SUBSCRIPTION, ACK_TIMEOUT_S, incoming);
-    PubsubUnboundedSource<String> source =
-        new PubsubUnboundedSource<>(
+    PubsubUnboundedSource source =
+        new PubsubUnboundedSource(
             clock, factory, null, null, StaticValueProvider.of(SUBSCRIPTION),
-            StringUtf8Coder.of(), TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, null);
-    primSource = new PubsubSource<>(source);
+            TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, true /* needsAttributes */);
+    primSource = new PubsubSource(source);
   }
 
   private void setupOneMessage() {
@@ -114,6 +114,10 @@ public class PubsubUnboundedSourceTest {
     factory = null;
   }
 
+  private static String data(PubsubIO.PubsubMessage message) {
+    return new String(message.getMessage(), StandardCharsets.UTF_8);
+  }
+
   @Test
   public void checkpointCoderIsSane() throws Exception {
     setupOneMessage(ImmutableList.<IncomingMessage>of());
@@ -126,13 +130,13 @@ public class PubsubUnboundedSourceTest {
   @Test
   public void readOneMessage() throws IOException {
     setupOneMessage();
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     // Read one message.
     assertTrue(reader.start());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     assertFalse(reader.advance());
     // ACK the message.
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     checkpoint.finalizeCheckpoint();
     reader.close();
   }
@@ -140,19 +144,19 @@ public class PubsubUnboundedSourceTest {
   @Test
   public void timeoutAckAndRereadOneMessage() throws IOException {
     setupOneMessage();
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     PubsubTestClient pubsubClient = (PubsubTestClient) reader.getPubsubClient();
     assertTrue(reader.start());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     // Let the ACK deadline for the above expire.
     now.addAndGet(65 * 1000);
     pubsubClient.advance();
     // We'll now receive the same message again.
     assertTrue(reader.advance());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     assertFalse(reader.advance());
     // Now ACK the message.
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     checkpoint.finalizeCheckpoint();
     reader.close();
   }
@@ -160,11 +164,11 @@ public class PubsubUnboundedSourceTest {
   @Test
   public void extendAck() throws IOException {
     setupOneMessage();
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     PubsubTestClient pubsubClient = (PubsubTestClient) reader.getPubsubClient();
     // Pull the first message but don't take a checkpoint for it.
     assertTrue(reader.start());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     // Extend the ack
     now.addAndGet(55 * 1000);
     pubsubClient.advance();
@@ -174,7 +178,7 @@ public class PubsubUnboundedSourceTest {
     pubsubClient.advance();
     assertFalse(reader.advance());
     // Now ACK the message.
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     checkpoint.finalizeCheckpoint();
     reader.close();
   }
@@ -182,11 +186,11 @@ public class PubsubUnboundedSourceTest {
   @Test
   public void timeoutAckExtensions() throws IOException {
     setupOneMessage();
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     PubsubTestClient pubsubClient = (PubsubTestClient) reader.getPubsubClient();
     // Pull the first message but don't take a checkpoint for it.
     assertTrue(reader.start());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     // Extend the ack.
     now.addAndGet(55 * 1000);
     pubsubClient.advance();
@@ -202,9 +206,9 @@ public class PubsubUnboundedSourceTest {
     pubsubClient.advance();
     // Reread the same message.
     assertTrue(reader.advance());
-    assertEquals(DATA, reader.getCurrent());
+    assertEquals(DATA, data(reader.getCurrent()));
     // Now ACK the message.
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     checkpoint.finalizeCheckpoint();
     reader.close();
   }
@@ -218,20 +222,20 @@ public class PubsubUnboundedSourceTest {
       incoming.add(new IncomingMessage(data.getBytes(), null, TIMESTAMP, 0, ackid, RECORD_ID));
     }
     setupOneMessage(incoming);
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     // Consume two messages, only read one.
     assertTrue(reader.start());
-    assertEquals("data_0", reader.getCurrent());
+    assertEquals("data_0", data(reader.getCurrent()));
 
     // Grab checkpoint.
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     checkpoint.finalizeCheckpoint();
     assertEquals(1, checkpoint.notYetReadIds.size());
     assertEquals("ackid_1", checkpoint.notYetReadIds.get(0));
 
     // Read second message.
     assertTrue(reader.advance());
-    assertEquals("data_1", reader.getCurrent());
+    assertEquals("data_1", data(reader.getCurrent()));
 
     // Restore from checkpoint.
     byte[] checkpointBytes =
@@ -244,7 +248,7 @@ public class PubsubUnboundedSourceTest {
     // Re-read second message.
     reader = primSource.createReader(p.getOptions(), checkpoint);
     assertTrue(reader.start());
-    assertEquals("data_1", reader.getCurrent());
+    assertEquals("data_1", data(reader.getCurrent()));
 
     // We are done.
     assertFalse(reader.advance());
@@ -278,7 +282,7 @@ public class PubsubUnboundedSourceTest {
     }
     setupOneMessage(incoming);
 
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     PubsubTestClient pubsubClient = (PubsubTestClient) reader.getPubsubClient();
 
     for (int i = 0; i < n; i++) {
@@ -290,7 +294,7 @@ public class PubsubUnboundedSourceTest {
       // We'll checkpoint and ack within the 2min limit.
       now.addAndGet(30);
       pubsubClient.advance();
-      String data = reader.getCurrent();
+      String data = data(reader.getCurrent());
       Integer messageNum = dataToMessageNum.remove(data);
       // No duplicate messages.
       assertNotNull(messageNum);
@@ -310,7 +314,7 @@ public class PubsubUnboundedSourceTest {
         }
         assertThat(watermark, lessThanOrEqualTo(minOutstandingTimestamp));
         // Ack messages, but only every other finalization.
-        PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+        PubsubCheckpoint checkpoint = reader.getCheckpointMark();
         if (i % 2000 == 1999) {
           checkpoint.finalizeCheckpoint();
         }
@@ -327,26 +331,25 @@ public class PubsubUnboundedSourceTest {
   public void noSubscriptionSplitGeneratesSubscription() throws Exception {
     TopicPath topicPath = PubsubClient.topicPathFromName("my_project", "my_topic");
     factory = PubsubTestClient.createFactoryForCreateSubscription();
-    PubsubUnboundedSource<String> source =
-        new PubsubUnboundedSource<>(
+    PubsubUnboundedSource source =
+        new PubsubUnboundedSource(
             factory,
             StaticValueProvider.of(PubsubClient.projectPathFromId("my_project")),
             StaticValueProvider.of(topicPath),
-            null,
-            StringUtf8Coder.of(),
-            null,
-            null,
-            null);
+            null /* subscription */,
+            null /* timestampLabel */,
+            null /* idLabel */,
+            false /* needsAttributes */);
     assertThat(source.getSubscription(), nullValue());
 
     assertThat(source.getSubscription(), nullValue());
 
     PipelineOptions options = PipelineOptionsFactory.create();
-    List<PubsubSource<String>> splits =
-        (new PubsubSource<>(source)).split(3, options);
+    List<PubsubSource> splits =
+        (new PubsubSource(source)).split(3, options);
     // We have at least one returned split
     assertThat(splits, hasSize(greaterThan(0)));
-    for (PubsubSource<String> split : splits) {
+    for (PubsubSource split : splits) {
       // Each split is equal
       assertThat(split, equalTo(splits.get(0)));
     }
@@ -358,37 +361,36 @@ public class PubsubUnboundedSourceTest {
   public void noSubscriptionNoSplitGeneratesSubscription() throws Exception {
     TopicPath topicPath = PubsubClient.topicPathFromName("my_project", "my_topic");
     factory = PubsubTestClient.createFactoryForCreateSubscription();
-    PubsubUnboundedSource<String> source =
-        new PubsubUnboundedSource<>(
+    PubsubUnboundedSource source =
+        new PubsubUnboundedSource(
             factory,
             StaticValueProvider.of(PubsubClient.projectPathFromId("my_project")),
             StaticValueProvider.of(topicPath),
-            null,
-            StringUtf8Coder.of(),
-            null,
-            null,
-            null);
+            null /* subscription */,
+            null /* timestampLabel */,
+            null /* idLabel */,
+            false /* needsAttributes */);
     assertThat(source.getSubscription(), nullValue());
 
     assertThat(source.getSubscription(), nullValue());
 
     PipelineOptions options = PipelineOptionsFactory.create();
-    PubsubSource<String> actualSource = new PubsubSource<>(source);
-    PubsubReader<String> reader = actualSource.createReader(options, null);
+    PubsubSource actualSource = new PubsubSource(source);
+    PubsubReader reader = actualSource.createReader(options, null);
     SubscriptionPath createdSubscription = reader.subscription;
     assertThat(createdSubscription, not(nullValue()));
 
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     assertThat(checkpoint.subscriptionPath, equalTo(createdSubscription.getPath()));
 
     checkpoint.finalizeCheckpoint();
-    PubsubCheckpoint<String> deserCheckpoint =
+    PubsubCheckpoint deserCheckpoint =
         CoderUtils.clone(actualSource.getCheckpointMarkCoder(), checkpoint);
     assertThat(checkpoint.subscriptionPath, not(nullValue()));
     assertThat(checkpoint.subscriptionPath, equalTo(deserCheckpoint.subscriptionPath));
 
-    PubsubReader<String> readerFromOriginal = actualSource.createReader(options, checkpoint);
-    PubsubReader<String> readerFromDeser = actualSource.createReader(options, deserCheckpoint);
+    PubsubReader readerFromOriginal = actualSource.createReader(options, checkpoint);
+    PubsubReader readerFromDeser = actualSource.createReader(options, deserCheckpoint);
 
     assertThat(readerFromOriginal.subscription, equalTo(createdSubscription));
     assertThat(readerFromDeser.subscription, equalTo(createdSubscription));
@@ -400,9 +402,9 @@ public class PubsubUnboundedSourceTest {
   @Test
   public void closeWithActiveCheckpoints() throws Exception {
     setupOneMessage();
-    PubsubReader<String> reader = primSource.createReader(p.getOptions(), null);
+    PubsubReader reader = primSource.createReader(p.getOptions(), null);
     reader.start();
-    PubsubCheckpoint<String> checkpoint = reader.getCheckpointMark();
+    PubsubCheckpoint checkpoint = reader.getCheckpointMark();
     reader.close();
     checkpoint.finalizeCheckpoint();
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-1415

There's no longer a way to read/write a generic type T. Instead, there's `PubsubIO.{read,write}{Strings,Protos,Avros,PubsubMessages}`. Strings and protos are a very common case so they have shorthands. For everything else, use `PubsubMessage` and parse it yourself. In case of read, you can read them with or without attributes. This gets rid of the ugly use of Coder for decoding a message's payload (forbidden by the style guide), and since PubsubMessage is easily encodable, again the style guide also dictates to use that explicitly as the input/return type of the transforms.

R: @reuvenlax 
CC: @dhalperi 