### PR TITLE
Makes cachedSplitResult transient in BigQuerySourceBase

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -68,7 +68,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
   protected final BigQueryServices bqServices;
   protected final ValueProvider<String> executingProject;
 
-  private List<BoundedSource<TableRow>> cachedSplitResult;
+  private transient List<BoundedSource<TableRow>> cachedSplitResult;
 
   BigQuerySourceBase(
       ValueProvider<String> jobIdToken,


### PR DESCRIPTION
Otherwise this leads to O(N^2) explosion in serialized size of splits.

R: @dhalperi 