### PR TITLE
[BEAM-2052] Allow dynamic sharding in windowed file sinks

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -161,6 +161,10 @@ public class WindowedWordCount {
     @Default.InstanceFactory(DefaultToMinTimestampPlusOneHour.class)
     Long getMaxTimestampMillis();
     void setMaxTimestampMillis(Long value);
+
+    @Description("Whether to use dynamic (runner-determined) sharding or not")
+    Boolean getDynamicSharding();
+    void setDynamicSharding(Boolean dynamicSharding);
   }
 
   public static void main(String[] args) throws IOException {
@@ -207,7 +211,7 @@ public class WindowedWordCount {
      */
     wordCounts
         .apply(MapElements.via(new WordCount.FormatAsTextFn()))
-        .apply(new WriteOneFilePerWindow(output));
+        .apply(new WriteOneFilePerWindow(output, options.getDynamicSharding()));
 
     PipelineResult result = pipeline.run();
     try {

--- a/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
@@ -40,7 +40,7 @@ import org.joda.time.format.ISODateTimeFormat;
  * lessons.
  */
 public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone> {
-  private static DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
+  private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
   private String filenamePrefix;
   private boolean dynamicSharding;
 

--- a/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
@@ -40,12 +40,13 @@ import org.joda.time.format.ISODateTimeFormat;
  * lessons.
  */
 public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone> {
+  private static DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
+  private String filenamePrefix;
+  private boolean dynamicSharding;
 
-  private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
-  private final String filenamePrefix;
-
-  public WriteOneFilePerWindow(String filenamePrefix) {
+  public WriteOneFilePerWindow(String filenamePrefix, boolean dynamicSharding) {
     this.filenamePrefix = filenamePrefix;
+    this.dynamicSharding = dynamicSharding;
   }
 
   @Override
@@ -61,12 +62,15 @@ public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone
           resource);
     }
 
-    return input.apply(
-        TextIO.write()
-            .to(resource.getCurrentDirectory())
-            .withFilenamePolicy(new PerWindowFiles(prefix))
-            .withWindowedWrites()
-            .withNumShards(3));
+
+    TextIO.Write write = TextIO.write()
+        .to(resource.getCurrentDirectory())
+        .withFilenamePolicy(new PerWindowFiles(prefix))
+        .withWindowedWrites();
+    if (!dynamicSharding) {
+      write = write.withNumShards(3);
+    }
+    return input.apply(write);
   }
 
   /**

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -101,14 +101,6 @@ public class WindowedWordCountIT {
 
   @Test
   @Category(StreamingIT.class)
-  public void testWindowedWordCountInStreamingDynamicSharding() throws Exception {
-    WindowedWordCountITOptions options = streamingOptions();
-    options.setDynamicSharding(true);
-    testWindowedWordCountPipeline(options);
-  }
-
-  @Test
-  @Category(StreamingIT.class)
   public void testWindowedWordCountInStreamingStaticSharding() throws Exception {
     WindowedWordCountITOptions options = streamingOptions();
     options.setDynamicSharding(false);

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -86,14 +86,33 @@ public class WindowedWordCountIT {
   }
 
   @Test
-  public void testWindowedWordCountInBatch() throws Exception {
-    testWindowedWordCountPipeline(defaultOptions());
+  public void testWindowedWordCountInBatchDynamicSharding() throws Exception {
+    WindowedWordCountITOptions options = defaultOptions();
+    options.setDynamicSharding(true);
+    testWindowedWordCountPipeline(options);
+  }
+
+  @Test
+  public void testWindowedWordCountInBatchStaticSharding() throws Exception {
+    WindowedWordCountITOptions options = defaultOptions();
+    options.setDynamicSharding(false);
+    testWindowedWordCountPipeline(options);
   }
 
   @Test
   @Category(StreamingIT.class)
-  public void testWindowedWordCountInStreaming() throws Exception {
-    testWindowedWordCountPipeline(streamingOptions());
+  public void testWindowedWordCountInStreamingDynamicSharding() throws Exception {
+    WindowedWordCountITOptions options = streamingOptions();
+    options.setDynamicSharding(true);
+    testWindowedWordCountPipeline(options);
+  }
+
+  @Test
+  @Category(StreamingIT.class)
+  public void testWindowedWordCountInStreamingStaticSharding() throws Exception {
+    WindowedWordCountITOptions options = streamingOptions();
+    options.setDynamicSharding(false);
+    testWindowedWordCountPipeline(options);
   }
 
   private WindowedWordCountITOptions defaultOptions() throws Exception {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -510,7 +510,7 @@ public class PTransformMatchersTest implements Serializable {
         WriteFiles.to(
             new FileBasedSink<Integer>(StaticValueProvider.of(outputDirectory), policy) {
               @Override
-              public FileBasedWriteOperation<Integer> createWriteOperation() {
+              public WriteOperation<Integer> createWriteOperation() {
                 return null;
               }
             });

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
@@ -134,7 +134,7 @@ public class WriteWithShardingFactoryTest {
     WriteFiles<Object> original = WriteFiles.to(
         new FileBasedSink<Object>(StaticValueProvider.of(outputDirectory), policy) {
           @Override
-          public FileBasedWriteOperation<Object> createWriteOperation() {
+          public WriteOperation<Object> createWriteOperation() {
             throw new IllegalArgumentException("Should not be used");
           }
         });

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
@@ -47,7 +47,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.TextualIntegerCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.io.FileBasedSink.FileResultCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestinationCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
 
@@ -91,7 +90,6 @@ public class DefaultCoderCloudObjectTranslatorRegistrar
           ByteCoder.class,
           DoubleCoder.class,
           DurationCoder.class,
-          FileResultCoder.class,
           FooterCoder.class,
           InstantCoder.class,
           IsmShardCoder.class,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -24,6 +24,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -266,6 +267,20 @@ public abstract class Coder<T> implements Serializable {
       } catch (Exception exn) {
         throw new IllegalArgumentException(
             "Unable to encode element '" + value + "' with coder '" + this + "'.", exn);
+      }
+    }
+  }
+
+  public T fromStructuralValue(Object o) {
+    if (consistentWithEquals()) {
+      return (T) o;
+    } else {
+      try {
+        StructuralByteArray structuralByteArray = (StructuralByteArray) o;
+        return decode(new ByteArrayInputStream(structuralByteArray.getValue()), Context.OUTER);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Unable to decode element '" + o + "' with coder '"
+        + this + "'.", e);
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -271,6 +271,10 @@ public abstract class Coder<T> implements Serializable {
     }
   }
 
+  /**
+   * Give a {@link Object} returned by {@link #fromStructuralValue}, returns the original encoded
+   * object.
+   */
   public T fromStructuralValue(Object o) {
     if (consistentWithEquals()) {
       return (T) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -51,12 +51,12 @@ class AvroSink<T> extends FileBasedSink<T> {
   }
 
   @Override
-  public FileBasedWriteOperation<T> createWriteOperation() {
+  public WriteOperation<T> createWriteOperation() {
     return new AvroWriteOperation<>(this, coder, codec, metadata);
   }
 
-  /** A {@link FileBasedWriteOperation FileBasedWriteOperation} for Avro files. */
-  private static class AvroWriteOperation<T> extends FileBasedWriteOperation<T> {
+  /** A {@link WriteOperation WriteOperation} for Avro files. */
+  private static class AvroWriteOperation<T> extends WriteOperation<T> {
     private final AvroCoder<T> coder;
     private final SerializableAvroCodecFactory codec;
     private final ImmutableMap<String, Object> metadata;
@@ -72,19 +72,19 @@ class AvroSink<T> extends FileBasedSink<T> {
     }
 
     @Override
-    public FileBasedWriter<T> createWriter() throws Exception {
+    public Writer<T> createWriter() throws Exception {
       return new AvroWriter<>(this, coder, codec, metadata);
     }
   }
 
-  /** A {@link FileBasedWriter FileBasedWriter} for Avro files. */
-  private static class AvroWriter<T> extends FileBasedWriter<T> {
+  /** A {@link Writer Writer} for Avro files. */
+  private static class AvroWriter<T> extends Writer<T> {
     private final AvroCoder<T> coder;
     private DataFileWriter<T> dataFileWriter;
     private SerializableAvroCodecFactory codec;
     private final ImmutableMap<String, Object> metadata;
 
-    public AvroWriter(FileBasedWriteOperation<T> writeOperation,
+    public AvroWriter(WriteOperation<T> writeOperation,
                       AvroCoder<T> coder,
                       SerializableAvroCodecFactory codec,
                       ImmutableMap<String, Object> metadata) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -557,7 +557,6 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
                 second.getTempFilename().toString());
           }
         }).sortedCopy(unshardedFiles);
-        FilenamePolicy filenamePolicy = getSink().getFilenamePolicy();
         for (int i = 0; i < unshardedFiles.size(); i++) {
           FileResult result = unshardedFiles.get(i);
           result.setShard(i);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -952,6 +952,8 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     public ResourceId getDestinationFile(FilenamePolicy policy, ResourceId outputDirectory,
                                          String extension) {
+      checkArgument(getShard() != WriteFiles.UNKNOWN_SHARDNUM);
+      checkArgument(getNumShards() != WriteFiles.UNKNOWN_NUMSHARDS);
       if (getWindow() != null) {
         return policy.windowedFilename(outputDirectory, new WindowedContext(
             getWindow(), getPaneInfo(), getShard(), getNumShards()), extension);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -34,6 +34,7 @@ import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -44,11 +45,11 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.Context;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.WindowedContext;
@@ -961,18 +962,23 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
   /**
    * A coder for {@link FileResult} objects.
    */
-  public static final class FileResultCoder extends AtomicCoder<FileResult> {
+  public static final class FileResultCoder extends StructuredCoder<FileResult> {
     private final Coder<String> stringCoder = StringUtf8Coder.of();
     private final Coder<Integer> integerCoder = VarIntCoder.of();
     private final Coder<PaneInfo> paneInfoCoder = NullableCoder.of(PaneInfoCoder.INSTANCE);
     private final Coder<BoundedWindow> windowCoder;
 
-    private FileResultCoder(Coder<BoundedWindow> windowCoder) {
+    protected FileResultCoder(Coder<BoundedWindow> windowCoder) {
       this.windowCoder = NullableCoder.of(windowCoder);
     }
 
     public static FileResultCoder of(Coder<BoundedWindow> windowCoder) {
       return new FileResultCoder(windowCoder);
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      return Arrays.asList(windowCoder);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -567,7 +567,7 @@ public class TFRecordIO {
     }
 
     @Override
-    public FileBasedWriteOperation<byte[]> createWriteOperation() {
+    public WriteOperation<byte[]> createWriteOperation() {
       return new TFRecordWriteOperation(this);
     }
 
@@ -587,29 +587,29 @@ public class TFRecordIO {
     }
 
     /**
-     * A {@link org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation
-     * FileBasedWriteOperation} for TFRecord files.
+     * A {@link WriteOperation
+     * WriteOperation} for TFRecord files.
      */
-    private static class TFRecordWriteOperation extends FileBasedWriteOperation<byte[]> {
+    private static class TFRecordWriteOperation extends WriteOperation<byte[]> {
       private TFRecordWriteOperation(TFRecordSink sink) {
         super(sink);
       }
 
       @Override
-      public FileBasedWriter<byte[]> createWriter() throws Exception {
+      public Writer<byte[]> createWriter() throws Exception {
         return new TFRecordWriter(this);
       }
     }
 
     /**
-     * A {@link org.apache.beam.sdk.io.FileBasedSink.FileBasedWriter FileBasedWriter}
+     * A {@link Writer Writer}
      * for TFRecord files.
      */
-    private static class TFRecordWriter extends FileBasedWriter<byte[]> {
+    private static class TFRecordWriter extends Writer<byte[]> {
       private WritableByteChannel outChannel;
       private TFRecordCodec codec;
 
-      private TFRecordWriter(FileBasedWriteOperation<byte[]> writeOperation) {
+      private TFRecordWriter(WriteOperation<byte[]> writeOperation) {
         super(writeOperation, MimeTypes.BINARY);
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
@@ -49,12 +49,12 @@ class TextSink extends FileBasedSink<String> {
     this.footer = footer;
   }
   @Override
-  public FileBasedWriteOperation<String> createWriteOperation() {
+  public WriteOperation<String> createWriteOperation() {
     return new TextWriteOperation(this, header, footer);
   }
 
-  /** A {@link FileBasedWriteOperation FileBasedWriteOperation} for text files. */
-  private static class TextWriteOperation extends FileBasedWriteOperation<String> {
+  /** A {@link WriteOperation WriteOperation} for text files. */
+  private static class TextWriteOperation extends WriteOperation<String> {
     @Nullable private final String header;
     @Nullable private final String footer;
 
@@ -65,20 +65,20 @@ class TextSink extends FileBasedSink<String> {
     }
 
     @Override
-    public FileBasedWriter<String> createWriter() throws Exception {
+    public Writer<String> createWriter() throws Exception {
       return new TextWriter(this, header, footer);
     }
   }
 
-  /** A {@link FileBasedWriter FileBasedWriter} for text files. */
-  private static class TextWriter extends FileBasedWriter<String> {
+  /** A {@link Writer Writer} for text files. */
+  private static class TextWriter extends Writer<String> {
     private static final String NEWLINE = "\n";
     @Nullable private final String header;
     @Nullable private final String footer;
     private OutputStreamWriter out;
 
     public TextWriter(
-        FileBasedWriteOperation<String> writeOperation,
+        WriteOperation<String> writeOperation,
         @Nullable String header,
         @Nullable String footer) {
       super(writeOperation, MimeTypes.TEXT);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -355,7 +355,6 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
 
     @ProcessElement
     public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
-      int numShards = numShardsView != null ? c.sideInput(numShardsView) : getNumShards().get();
       // In a sharded write, single input element represents one shard. We can open and close
       // the writer in each call to processElement.
       LOG.info("Opening writer for write operation {}", writeOperation);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -325,7 +325,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
         c.output(result, window.maxTimestamp(), window);
         // Reset state in case of reuse.
         writer = null;
-      } else {
+      } else if (windowedWrites) {
         for (Map.Entry<KV<Object, PaneInfo>, Writer<T>> entry : windowedWriters.entrySet()) {
           FileResult result = entry.getValue().close();
           BoundedWindow window = windowCoder.fromStructuralValue(entry.getKey().getKey());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -87,8 +87,6 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
   private static final Logger LOG = LoggerFactory.getLogger(WriteFiles.class);
 
   static final int UNKNOWN_SHARDNUM = -1;
-  static final int UNKNOWN_NUMSHARDS = -1;
-
   private FileBasedSink<T> sink;
   private WriteOperation<T> writeOperation;
   // This allows the number of shards to be dynamically computed based on the input
@@ -269,8 +267,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
         if (writer == null) {
           LOG.info("Opening writer for write operation {}, window {}", writeOperation, window);
           writer = writeOperation.createWriter();
-          writer.openWindowed(UUID.randomUUID().toString(), window, paneInfo, UNKNOWN_SHARDNUM,
-              UNKNOWN_NUMSHARDS);
+          writer.openWindowed(UUID.randomUUID().toString(), window, paneInfo, UNKNOWN_SHARDNUM);
           windowedWriters.put(key, writer);
           LOG.debug("Done opening writer {} for operation {} window {}", writer, writeOperation,
               window);
@@ -281,7 +278,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
         if (writer == null) {
           LOG.info("Opening writer for write operation {}", writeOperation);
           writer = this.writer = writeOperation.createWriter();
-          writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM, UNKNOWN_NUMSHARDS);
+          writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM);
           LOG.debug("Done opening writer {} for operation {}", writer, writeOperation);
         }
         this.window = window;
@@ -364,10 +361,9 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
       LOG.info("Opening writer for write operation {}", writeOperation);
       Writer<T> writer = writeOperation.createWriter();
       if (windowedWrites) {
-        writer.openWindowed(UUID.randomUUID().toString(), window, c.pane(), c.element().getKey(),
-            numShards);
+        writer.openWindowed(UUID.randomUUID().toString(), window, c.pane(), c.element().getKey());
       } else {
-        writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM, UNKNOWN_NUMSHARDS);
+        writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM);
       }
       LOG.debug("Done opening writer {} for operation {}", writer, writeOperation);
 
@@ -589,8 +585,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
                     extraShardsNeeded, results.size(), minShardsNeeded);
                 for (int i = 0; i < extraShardsNeeded; ++i) {
                   Writer<T> writer = writeOperation.createWriter();
-                  writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM,
-                      UNKNOWN_NUMSHARDS);
+                  writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM);
                   FileResult emptyWrite = writer.close();
                   results.add(emptyWrite);
                 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -103,7 +103,7 @@ public class FileBasedSinkTest {
 
     SimpleSink.SimpleWriter writer =
         buildWriteOperationWithTempDir(getBaseTempDirectory()).createWriter();
-    writer.openUnwindowed(testUid, -1, -1);
+    writer.openUnwindowed(testUid, -1);
     for (String value : values) {
       writer.write(value);
     }
@@ -205,7 +205,6 @@ public class FileBasedSinkTest {
           new FileResult(
               LocalResources.fromFile(temporaryFiles.get(i), false),
               WriteFiles.UNKNOWN_SHARDNUM,
-              WriteFiles.UNKNOWN_NUMSHARDS,
               null,
               null));
     }
@@ -364,9 +363,9 @@ public class FileBasedSinkTest {
     try {
       Iterable<FileResult> results =
           Lists.newArrayList(
-              new FileResult(temp1, 1, 1, null, null),
-              new FileResult(temp2, 1, 1, null, null),
-              new FileResult(temp3, 1, 1, null, null));
+              new FileResult(temp1, 1, null, null),
+              new FileResult(temp2, 1, null, null),
+              new FileResult(temp3, 1, null, null));
       writeOp.buildOutputFilenames(results);
       fail("Should have failed.");
     } catch (IllegalStateException exn) {
@@ -504,7 +503,7 @@ public class FileBasedSinkTest {
     expected.add("footer");
     expected.add("footer");
 
-    writer.openUnwindowed(testUid, -1, -1);
+    writer.openUnwindowed(testUid, -1);
     writer.write("a");
     writer.write("b");
     final FileResult result = writer.close();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -46,12 +46,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.apache.beam.sdk.io.FileBasedSink.CompressionType;
-import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
-import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.io.FileBasedSink.FileResult;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.Context;
 import org.apache.beam.sdk.io.FileBasedSink.WritableByteChannelFactory;
+import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
+import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -93,7 +93,7 @@ public class FileBasedSinkTest {
   @Test
   public void testWriter() throws Exception {
     String testUid = "testId";
-    ResourceId expectedFile = getBaseTempDirectory()
+    ResourceId expectedTempFile = getBaseTempDirectory()
         .resolve(testUid, StandardResolveOptions.RESOLVE_FILE);
     List<String> values = Arrays.asList("sympathetic vulture", "boresome hummingbird");
     List<String> expected = new ArrayList<>();
@@ -110,9 +110,8 @@ public class FileBasedSinkTest {
     FileResult result = writer.close();
 
     FileBasedSink sink = writer.getWriteOperation().getSink();
-    assertEquals(expectedFile, result.getDestinationFile(sink.getFilenamePolicy(),
-        getBaseTempDirectory(), sink.getExtension()));
-    assertFileContains(expected, expectedFile);
+    assertEquals(expectedTempFile, result.getTempFilename());
+    assertFileContains(expected, expectedTempFile);
   }
 
   /**
@@ -510,8 +509,7 @@ public class FileBasedSinkTest {
     writer.write("b");
     final FileResult result = writer.close();
 
-    assertEquals(
-        expectedFile, result.getDestinationFile(writeOp.getSink().getFilenamePolicy(), root, ""));
+    assertEquals(expectedFile, result.getTempFilename());
     assertFileContains(expected, expectedFile);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -46,8 +46,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.apache.beam.sdk.io.FileBasedSink.CompressionType;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriter;
+import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
+import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.io.FileBasedSink.FileResult;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.Context;
@@ -87,7 +87,7 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * FileBasedWriter opens the correct file, writes the header, footer, and elements in the correct
+   * Writer opens the correct file, writes the header, footer, and elements in the correct
    * order, and returns the correct filename.
    */
   @Test
@@ -179,12 +179,12 @@ public class FileBasedSinkTest {
     runFinalize(writeOp, files);
   }
 
-  /** Generate n temporary files using the temporary file pattern of FileBasedWriter. */
+  /** Generate n temporary files using the temporary file pattern of Writer. */
   private List<File> generateTemporaryFilesForFinalize(int numFiles) throws Exception {
     List<File> temporaryFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
       ResourceId temporaryFile =
-          FileBasedWriteOperation.buildTemporaryFilename(getBaseTempDirectory(), "" + i);
+          WriteOperation.buildTemporaryFilename(getBaseTempDirectory(), "" + i);
       File tmpFile = new File(tmpFolder.getRoot(), temporaryFile.toString());
       tmpFile.getParentFile().mkdirs();
       assertTrue(tmpFile.createNewFile());
@@ -236,14 +236,14 @@ public class FileBasedSinkTest {
     SimpleSink sink =
         new SimpleSink(getBaseOutputDirectory(), prefix, "", "");
 
-    FileBasedWriteOperation<String> writeOp =
+    WriteOperation<String> writeOp =
         new SimpleSink.SimpleWriteOperation(sink, tempDirectory);
 
     List<File> temporaryFiles = new ArrayList<>();
     List<File> outputFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
       ResourceId tempResource =
-          FileBasedWriteOperation.buildTemporaryFilename(tempDirectory, prefix + i);
+          WriteOperation.buildTemporaryFilename(tempDirectory, prefix + i);
       File tmpFile = new File(tempResource.toString());
       tmpFile.getParentFile().mkdirs();
       assertTrue("not able to create new temp file", tmpFile.createNewFile());
@@ -481,17 +481,17 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * {@link FileBasedWriter} writes to the {@link WritableByteChannel} provided by {@link
+   * {@link Writer} writes to the {@link WritableByteChannel} provided by {@link
    * DrunkWritableByteChannelFactory}.
    */
   @Test
   public void testFileBasedWriterWithWritableByteChannelFactory() throws Exception {
     final String testUid = "testId";
     ResourceId root = getBaseOutputDirectory();
-    FileBasedWriteOperation<String> writeOp =
+    WriteOperation<String> writeOp =
         new SimpleSink(root, "file", "-SS-of-NN", "txt", new DrunkWritableByteChannelFactory())
             .createWriteOperation();
-    final FileBasedWriter<String> writer = writeOp.createWriter();
+    final Writer<String> writer = writeOp.createWriter();
     final ResourceId expectedFile =
         writeOp.tempDirectory.get().resolve(testUid, StandardResolveOptions.RESOLVE_FILE);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
@@ -45,7 +45,7 @@ class SimpleSink extends FileBasedSink<String> {
     return new SimpleWriteOperation(this);
   }
 
-  static final class SimpleWriteOperation extends FileBasedWriteOperation<String> {
+  static final class SimpleWriteOperation extends WriteOperation<String> {
     public SimpleWriteOperation(SimpleSink sink, ResourceId tempOutputDirectory) {
       super(sink, tempOutputDirectory);
     }
@@ -60,7 +60,7 @@ class SimpleSink extends FileBasedSink<String> {
     }
   }
 
-  static final class SimpleWriter extends FileBasedWriter<String> {
+  static final class SimpleWriter extends Writer<String> {
     static final String HEADER = "header";
     static final String FOOTER = "footer";
 

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
@@ -76,9 +76,9 @@ class XmlSink<T> extends FileBasedSink<T> {
   }
 
   /**
-   * {@link FileBasedSink.FileBasedWriteOperation} for XML {@link FileBasedSink}s.
+   * {@link WriteOperation} for XML {@link FileBasedSink}s.
    */
-  protected static final class XmlWriteOperation<T> extends FileBasedWriteOperation<T> {
+  protected static final class XmlWriteOperation<T> extends WriteOperation<T> {
     public XmlWriteOperation(XmlSink<T> sink) {
       super(sink);
     }
@@ -113,9 +113,9 @@ class XmlSink<T> extends FileBasedSink<T> {
   }
 
   /**
-   * A {@link FileBasedWriter} that can write objects as XML elements.
+   * A {@link Writer} that can write objects as XML elements.
    */
-  protected static final class XmlWriter<T> extends FileBasedWriter<T> {
+  protected static final class XmlWriter<T> extends Writer<T> {
     final Marshaller marshaller;
     private OutputStream os = null;
 


### PR DESCRIPTION
We now allow windowed FileBasedSinks to support dynamic sharding. This requires encoding the window and pane in the FileResult object, and delaying calling into the FilenamePolicy until the finalize step when we know how many shards there are. It also requires us to ensure that elements from different windows are written to different temporary files in the WriteBundles step (since at that point, the bundle might contain elements from several windows).

R: @kennknowles 