### PR TITLE
[BEAM-2029] null pointer exception while evaluating group by key in spark runner in streaming mode

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslatorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslatorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation.streaming;
+
+import org.apache.beam.runners.spark.PipelineRule;
+import org.apache.beam.runners.spark.io.CreateStream;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.transforms.Max;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test class for StreamingTransformTranslator.
+ */
+public class StreamingTransformTranslatorTest {
+  @Rule public final transient PipelineRule pipelineRule = PipelineRule.streaming();
+
+  @Test
+  public void testEvaluationGroupByKeyInStreamingMode() {
+    Pipeline pipeline = pipelineRule.createPipeline();
+    Instant instant = new Instant(0);
+    CreateStream<Integer> source =
+        CreateStream.of(VarIntCoder.of(), pipelineRule.batchDuration())
+            .emptyBatch()
+            .advanceWatermarkForNextBatch(instant.plus(Duration.standardMinutes(6)))
+            .nextBatch(
+                TimestampedValue.of(1, instant),
+                TimestampedValue.of(2, instant),
+                TimestampedValue.of(3, instant))
+            .advanceNextBatchWatermarkToInfinity();
+
+    PCollection<Integer> windowed =
+        pipeline
+            .apply(source)
+            .apply(Window.<Integer>into(FixedWindows.of(Duration.standardMinutes(5))));
+    PCollectionView<Integer> max =
+        windowed.apply(Max.integersGlobally().withFanout(5).asSingletonView());
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
R: @aviemzur 
This PR, for now, just adds a test that raises a null pointer exception in spark runner so it cannot be merged as it is now.  I don't know Spark runner well enough for now to do the fix. But I suspect that the problem is due to the `withFanout()` support in spark runner. 

@aviemzur , can you take a  look at the test and do the fix? 
As we need the fix to have the build pass and merge this PR, what do you think about forking this PR and do the fix there, I will merge your PR and we will put the global PR (test + fix) to review and take care that your commits do not get squashed?
