### PR TITLE
[BEAM-2066] TextIO & AvroIO no longer validate schemas against IOChannelFactory

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -100,20 +99,6 @@ public class AvroIOTest {
   @BeforeClass
   public static void setupClass() {
     IOChannelUtils.registerIOFactoriesAllowOverride(TestPipeline.testingPipelineOptions());
-  }
-
-  @Test
-  public void testReadWithoutValidationFlag() throws Exception {
-    AvroIO.Read.Bound<GenericRecord> read = AvroIO.Read.from("gs://bucket/foo*/baz");
-    assertTrue(read.needsValidation());
-    assertFalse(read.withoutValidation().needsValidation());
-  }
-
-  @Test
-  public void testWriteWithoutValPuidationFlag() throws Exception {
-    AvroIO.Write.Bound<GenericRecord> write = AvroIO.Write.to("gs://bucket/foo/baz");
-    assertTrue(write.needsValidation());
-    assertFalse(write.withoutValidation().needsValidation());
   }
 
   @Test
@@ -546,12 +531,10 @@ public class AvroIOTest {
 
   @Test
   public void testReadDisplayData() {
-    AvroIO.Read.Bound<?> read = AvroIO.Read.from("foo.*")
-        .withoutValidation();
+    AvroIO.Read.Bound<?> read = AvroIO.Read.from("foo.*");
 
     DisplayData displayData = DisplayData.from(read);
     assertThat(displayData, hasDisplayItem("filePattern", "foo.*"));
-    assertThat(displayData, hasDisplayItem("validation", false));
   }
 
   @Test
@@ -560,8 +543,7 @@ public class AvroIOTest {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
 
     AvroIO.Read.Bound<?> read = AvroIO.Read.from("foo.*")
-        .withSchema(Schema.create(Schema.Type.STRING))
-        .withoutValidation();
+        .withSchema(Schema.create(Schema.Type.STRING));
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("AvroIO.Read should include the file pattern in its primitive transform",
@@ -576,7 +558,6 @@ public class AvroIOTest {
         .withSuffix("bar")
         .withSchema(GenericClass.class)
         .withNumShards(100)
-        .withoutValidation()
         .withCodec(CodecFactory.snappyCodec());
 
     DisplayData displayData = DisplayData.from(write);
@@ -586,7 +567,6 @@ public class AvroIOTest {
     assertThat(displayData, hasDisplayItem("fileSuffix", "bar"));
     assertThat(displayData, hasDisplayItem("schema", GenericClass.class));
     assertThat(displayData, hasDisplayItem("numShards", 100));
-    assertThat(displayData, hasDisplayItem("validation", false));
     assertThat(displayData, hasDisplayItem("codec", CodecFactory.snappyCodec().toString()));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOTest.java
@@ -34,7 +34,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -247,24 +246,22 @@ public class TextIOTest {
 
     assertEquals(
         "TextIO.Read/Read.out",
-        p.apply(TextIO.Read.withoutValidation().from("somefile")).getName());
+        p.apply(TextIO.Read.from("somefile")).getName());
     assertEquals(
         "MyRead/Read.out",
-        p.apply("MyRead", TextIO.Read.withoutValidation().from(emptyTxt.getPath())).getName());
+        p.apply("MyRead", TextIO.Read.from(emptyTxt.getPath())).getName());
   }
 
   @Test
   public void testReadDisplayData() {
     TextIO.Read.Bound read = TextIO.Read
         .from("foo.*")
-        .withCompressionType(BZIP2)
-        .withoutValidation();
+        .withCompressionType(BZIP2);
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("filePattern", "foo.*"));
     assertThat(displayData, hasDisplayItem("compressionType", BZIP2.toString()));
-    assertThat(displayData, hasDisplayItem("validation", false));
   }
 
   @Test
@@ -273,8 +270,7 @@ public class TextIOTest {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
 
     TextIO.Read.Bound read = TextIO.Read
-        .from("foobar")
-        .withoutValidation();
+        .from("foobar");
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("TextIO.Read should include the file prefix in its primitive display data",
@@ -493,8 +489,7 @@ public class TextIOTest {
         .withShardNameTemplate("-SS-of-NN-")
         .withNumShards(100)
         .withFooter("myFooter")
-        .withHeader("myHeader")
-        .withoutValidation();
+        .withHeader("myHeader");
 
     DisplayData displayData = DisplayData.from(write);
 
@@ -504,7 +499,6 @@ public class TextIOTest {
     assertThat(displayData, hasDisplayItem("fileFooter", "myFooter"));
     assertThat(displayData, hasDisplayItem("shardNameTemplate", "-SS-of-NN-"));
     assertThat(displayData, hasDisplayItem("numShards", 100));
-    assertThat(displayData, hasDisplayItem("validation", false));
     assertThat(displayData, hasDisplayItem("writableByteChannelFactory", "UNCOMPRESSED"));
   }
 
@@ -517,7 +511,6 @@ public class TextIOTest {
     DisplayData displayData = DisplayData.from(write);
 
     assertThat(displayData, hasDisplayItem("fileHeader", "myHeader"));
-    assertThat(displayData, not(hasDisplayItem("validation", false)));
   }
 
   @Test
@@ -529,7 +522,6 @@ public class TextIOTest {
     DisplayData displayData = DisplayData.from(write);
 
     assertThat(displayData, hasDisplayItem("fileFooter", "myFooter"));
-    assertThat(displayData, not(hasDisplayItem("validation", false)));
   }
 
   @Test
@@ -580,22 +572,8 @@ public class TextIOTest {
     RuntimeTestOptions options = PipelineOptionsFactory.as(RuntimeTestOptions.class);
 
     p
-        .apply(TextIO.Read.from(options.getInput()).withoutValidation())
-        .apply(TextIO.Write.to(options.getOutput()).withoutValidation());
-  }
-
-  @Test
-  public void testReadWithoutValidationFlag() throws Exception {
-    TextIO.Read.Bound read = TextIO.Read.from("gs://bucket/foo*/baz");
-    assertTrue(read.needsValidation());
-    assertFalse(read.withoutValidation().needsValidation());
-  }
-
-  @Test
-  public void testWriteWithoutValidationFlag() throws Exception {
-    TextIO.Write.Bound write = TextIO.Write.to("gs://bucket/foo/baz");
-    assertTrue(write.needsValidation());
-    assertFalse(write.withoutValidation().needsValidation());
+        .apply(TextIO.Read.from(options.getInput()))
+        .apply(TextIO.Write.to(options.getOutput()));
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

IOChannelFactory is no longer relevant in the new Beam FileSystem world, so using it to validate is not useful. We also expect that validation at expand time will no longer have access to pipeline options, so any future use for a manually specified validation won't be useful.

R: @dhalperi 
