### PR TITLE
[BEAM-2033] Add HadoopResourceId

### DIFF
--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
@@ -17,26 +17,71 @@
  */
 package org.apache.beam.sdk.io.hdfs;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.hadoop.fs.Path;
 
 /**
  * {@link ResourceId} implementation for the {@link HadoopFileSystem}.
  */
 public class HadoopResourceId implements ResourceId {
 
+  private final Path path;
+
+  /**
+   * Constructs a HadoopResourceId from the provided absolute path. If only a relative path is
+   * available, you can create a {@link HadoopResourceId} from the absolute path of the root of the
+   * server, and then use resolve to add the relative path to the root.
+   * @param path
+   * @return
+   */
+  public static HadoopResourceId fromPath(Path path) {
+    checkNotNull(path);
+    checkArgument(path.isAbsolute());
+    return new HadoopResourceId(path);
+  }
+
+  private HadoopResourceId(Path path) {
+    this.path = path;
+  }
+
   @Override
   public ResourceId resolve(String other, ResolveOptions resolveOptions) {
-    throw new UnsupportedOperationException();
+    checkArgument(
+        resolveOptions.equals(ResolveOptions.StandardResolveOptions.RESOLVE_FILE)
+            || resolveOptions.equals(ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY),
+        String.format("ResolveOptions: [%s] is not supported. "
+            + "Supported ResolveOptions are RESOLVE_FILE and RESOLVE_DIRECTORY.", resolveOptions));
+    if (resolveOptions.equals(ResolveOptions.StandardResolveOptions.RESOLVE_FILE)) {
+      checkArgument(
+          !other.endsWith("/"),
+          "ResolveOptions: [%s] ends with '/', which is not supported for RESOLVE_FILE.",
+          other);
+    }
+    return new HadoopResourceId(new Path(path, other));
   }
 
   @Override
   public ResourceId getCurrentDirectory() {
+    // See BEAM-2069. Possible workaround: inject FileSystem into this class, and call
+    // org.apache.hadoop.fs.FileSystem#isDirectory.
     throw new UnsupportedOperationException();
   }
 
   @Override
   public String getScheme() {
-    throw new UnsupportedOperationException();
+    return path.toUri().getScheme();
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  @Override
+  public String toString() {
+    return path.toString();
   }
 }

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
@@ -35,12 +35,10 @@ public class HadoopResourceId implements ResourceId {
    * Constructs a HadoopResourceId from the provided absolute path. If only a relative path is
    * available, you can create a {@link HadoopResourceId} from the absolute path of the root of the
    * server, and then use resolve to add the relative path to the root.
-   * @param path
-   * @return
    */
   public static HadoopResourceId fromPath(Path path) {
-    checkNotNull(path);
-    checkArgument(path.isAbsolute());
+    checkNotNull(path, "path must not be null");
+    checkArgument(path.isAbsolute(), "path must be absolute");
     return new HadoopResourceId(path);
   }
 

--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
@@ -1,0 +1,66 @@
+package org.apache.beam.sdk.io.hdfs;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.beam.sdk.io.fs.ResolveOptions;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+/**
+ * Tests for the HadoopResourceId class.
+ */
+public class HadoopResourceIdTest {
+  @Test
+  public void fromAndToPath() {
+    // Directory path without slash
+    Path dirPathWithoutSlash = new Path("hdfs://myhost/mydir");
+    HadoopResourceId resourceDirWithoutSlash = HadoopResourceId.fromPath(dirPathWithoutSlash);
+    assertEquals("hdfs://myhost/mydir",
+        resourceDirWithoutSlash.toString());
+    assertEquals(dirPathWithoutSlash, resourceDirWithoutSlash.getPath());
+
+    // Directory path with slash
+    Path dirPathWithSlash = new Path("hdfs://myhost/mydir/");
+    HadoopResourceId resourceDirWithSlash = HadoopResourceId.fromPath(dirPathWithSlash);
+    assertEquals("hdfs://myhost/mydir",
+        resourceDirWithSlash.toString());
+    assertEquals(dirPathWithSlash, resourceDirWithSlash.getPath());
+
+    // File path
+    Path filePath = new Path("hdfs://myhost/mydir/myfile.txt");
+    HadoopResourceId resourceFile = HadoopResourceId.fromPath(filePath);
+    assertEquals("hdfs://myhost/mydir/myfile.txt",
+        resourceFile.toString());
+    assertEquals(filePath, resourceFile.getPath());
+  }
+
+  @Test
+  public void handlesRelativePathsAddedToDir() {
+    // Directory + file - slash on Directory
+    HadoopResourceId dirWithSlash = HadoopResourceId.fromPath(new Path("hdfs://myhost/mydir/"));
+    assertEquals("hdfs://myhost/mydir/myfile.txt",
+        dirWithSlash.resolve("myfile.txt",
+            ResolveOptions.StandardResolveOptions.RESOLVE_FILE).toString());
+
+    // Directory + Directory
+    assertEquals("hdfs://myhost/mydir/2nddir",
+        dirWithSlash.resolve("2nddir",
+            ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY).toString());
+    assertEquals("hdfs://myhost/mydir/2nddir",
+        dirWithSlash.resolve("2nddir/",
+            ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY).toString());
+
+
+    // Directory + File - no slash on either
+    HadoopResourceId dirWithoutSlash = HadoopResourceId.fromPath(new Path("hdfs://myhost/mydir"));
+    assertEquals("hdfs://myhost/mydir/myfile.txt",
+        dirWithoutSlash.resolve("myfile.txt",
+            ResolveOptions.StandardResolveOptions.RESOLVE_FILE).toString());
+  }
+
+  @Test
+  public void testScheme() {
+    assertEquals("hdfs",
+        HadoopResourceId.fromPath(new Path("hdfs://myhost/mydir/file.txt")).getScheme());
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [X] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [X] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [X] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [X] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
merging person: I believe we'll want to do the implementation of this in a feature branch - this'd be a good time to create that feature branch. 

R: @tgroh 

It's worth noting that GcsResourceId spends a lot of time on worrying about slashes - that's not a thing we'll need for this since Hadoop's Path does a good job of cleaning it up, so all that's handled at a lower level.