### PR TITLE
Datastore: fix use of deprecated function

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
@@ -943,7 +943,7 @@ public class DatastoreV1Test {
     RunQueryResponse.Builder statKindResponse = RunQueryResponse.newBuilder();
     Entity.Builder entity = Entity.newBuilder();
     entity.setKey(makeKey("dummyKind", "dummyId"));
-    entity.getMutableProperties().put("entity_bytes", makeValue(entitySizeInBytes).build());
+    entity.putProperties("entity_bytes", makeValue(entitySizeInBytes).build());
     EntityResult.Builder entityResult = EntityResult.newBuilder();
     entityResult.setEntity(entity);
     QueryResultBatch.Builder batch = QueryResultBatch.newBuilder();
@@ -957,7 +957,7 @@ public class DatastoreV1Test {
     RunQueryResponse.Builder timestampResponse = RunQueryResponse.newBuilder();
     Entity.Builder entity = Entity.newBuilder();
     entity.setKey(makeKey("dummyKind", "dummyId"));
-    entity.getMutableProperties().put("timestamp", makeValue(new Date(timestamp * 1000)).build());
+    entity.putProperties("timestamp", makeValue(new Date(timestamp * 1000)).build());
     EntityResult.Builder entityResult = EntityResult.newBuilder();
     entityResult.setEntity(entity);
     QueryResultBatch.Builder batch = QueryResultBatch.newBuilder();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1TestUtil.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/V1TestUtil.java
@@ -104,7 +104,7 @@ class V1TestUtil {
     }
 
     entityBuilder.setKey(keyBuilder.build());
-    entityBuilder.getMutableProperties().put("value", makeValue(value).build());
+    entityBuilder.putProperties("value", makeValue(value).build());
     return entityBuilder.build();
   }
 


### PR DESCRIPTION
getMutableProperties().put() has been deprecated in favor of putProperties()