### PR TITLE
[BEAM-1871] Drop usage of Jackson/CloudObject from CoGbkResultSchema

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResultSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/join/CoGbkResultSchema.java
@@ -17,16 +17,9 @@
  */
 package org.apache.beam.sdk.transforms.join;
 
-import static org.apache.beam.sdk.util.Structs.addList;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import org.apache.beam.sdk.util.CloudObject;
-import org.apache.beam.sdk.util.PropertyNames;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 
@@ -41,9 +34,7 @@ public class CoGbkResultSchema implements Serializable {
 
   private final TupleTagList tupleTagList;
 
-  @JsonCreator
-  public static CoGbkResultSchema of(
-      @JsonProperty(PropertyNames.TUPLE_TAGS) List<TupleTag<?>> tags) {
+  public static CoGbkResultSchema of(List<TupleTag<?>> tags) {
     TupleTagList tupleTags = TupleTagList.empty();
     for (TupleTag<?> tag : tags) {
       tupleTags = tupleTags.and(tag);
@@ -97,16 +88,6 @@ public class CoGbkResultSchema implements Serializable {
    */
   public TupleTagList getTupleTagList() {
     return tupleTagList;
-  }
-
-  public CloudObject asCloudObject() {
-    CloudObject result = CloudObject.forClass(getClass());
-    List<CloudObject> serializedTags = new ArrayList<>(tupleTagList.size());
-    for (TupleTag<?> tag : tupleTagList.getAll()) {
-      serializedTags.add(tag.asCloudObject());
-    }
-    addList(result, PropertyNames.TUPLE_TAGS, serializedTags);
-    return result;
   }
 
   @Override


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
Note that the schema is only java serialized within the ConstructCoGbkResultFn (a DoFn) and hence the CloudObject/Jackson annotations represent dead code.