### PR TITLE
[BEAM-2021] Rename StandardCoder to StructuredCoder

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Coders.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Coders.java
@@ -36,7 +36,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.LengthPrefixCoder;
-import org.apache.beam.sdk.coders.StandardCoder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.common.runner.v1.RunnerApi.Components;
@@ -59,8 +59,8 @@ public class Coders {
 
   // The URNs for coders which are shared across languages
   @VisibleForTesting
-  static final BiMap<Class<? extends StandardCoder>, String> KNOWN_CODER_URNS =
-      ImmutableBiMap.<Class<? extends StandardCoder>, String>builder()
+  static final BiMap<Class<? extends StructuredCoder>, String> KNOWN_CODER_URNS =
+      ImmutableBiMap.<Class<? extends StructuredCoder>, String>builder()
           .put(ByteArrayCoder.class, "urn:beam:coders:bytes:0.1")
           .put(KvCoder.class, "urn:beam:coders:kv:0.1")
           .put(VarLongCoder.class, "urn:beam:coders:varint:0.1")
@@ -82,13 +82,13 @@ public class Coders {
   private static RunnerApi.Coder toKnownCoder(Coder<?> coder, SdkComponents components)
       throws IOException {
     checkArgument(
-        coder instanceof StandardCoder,
+        coder instanceof StructuredCoder,
         "A Known %s must implement %s, but %s of class %s does not",
         Coder.class.getSimpleName(),
-        StandardCoder.class.getSimpleName(),
+        StructuredCoder.class.getSimpleName(),
         coder,
         coder.getClass().getName());
-    StandardCoder<?> stdCoder = (StandardCoder<?>) coder;
+    StructuredCoder<?> stdCoder = (StructuredCoder<?>) coder;
     List<String> componentIds = new ArrayList<>();
     for (Coder<?> componentCoder : stdCoder.getComponents()) {
       componentIds.add(components.registerCoder(componentCoder));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CodersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CodersTest.java
@@ -40,8 +40,8 @@ import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.LengthPrefixCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.coders.StandardCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.common.runner.v1.RunnerApi;
 import org.apache.beam.sdk.common.runner.v1.RunnerApi.Components;
@@ -60,8 +60,8 @@ import org.junit.runners.Parameterized.Parameters;
 /** Tests for {@link Coders}. */
 @RunWith(Enclosed.class)
 public class CodersTest {
-  private static final Set<StandardCoder<?>> KNOWN_CODERS =
-      ImmutableSet.<StandardCoder<?>>builder()
+  private static final Set<StructuredCoder<?>> KNOWN_CODERS =
+      ImmutableSet.<StructuredCoder<?>>builder()
           .add(ByteArrayCoder.of())
           .add(KvCoder.of(VarLongCoder.of(), VarLongCoder.of()))
           .add(VarLongCoder.of())
@@ -85,12 +85,12 @@ public class CodersTest {
       // Validates that every known coder in the Coders class is represented in a "Known Coder"
       // tests, which demonstrates that they are serialized via components and specified URNs rather
       // than java serialized
-      Set<Class<? extends StandardCoder>> knownCoderClasses = Coders.KNOWN_CODER_URNS.keySet();
-      Set<Class<? extends StandardCoder>> knownCoderTests = new HashSet<>();
-      for (StandardCoder<?> coder : KNOWN_CODERS) {
+      Set<Class<? extends StructuredCoder>> knownCoderClasses = Coders.KNOWN_CODER_URNS.keySet();
+      Set<Class<? extends StructuredCoder>> knownCoderTests = new HashSet<>();
+      for (StructuredCoder<?> coder : KNOWN_CODERS) {
         knownCoderTests.add(coder.getClass());
       }
-      Set<Class<? extends StandardCoder>> missingKnownCoders = new HashSet<>(knownCoderClasses);
+      Set<Class<? extends StructuredCoder>> missingKnownCoders = new HashSet<>(knownCoderClasses);
       missingKnownCoders.removeAll(knownCoderTests);
       checkState(
           missingKnownCoders.isEmpty(),

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.coders.Coder;
 @AutoService(CoderCloudObjectTranslatorRegistrar.class)
 public class DefaultCoderCloudObjectTranslatorRegistrar
     implements CoderCloudObjectTranslatorRegistrar {
-  @Override
   public Map<String, CloudObjectTranslator<? extends Coder>> classNamesToTranslators() {
     // TODO: Add translators
     return Collections.emptyMap();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteArrayCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ByteArrayCoder.java
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * encoded via a {@link VarIntCoder}.</li>
  * </ul>
  */
-public class ByteArrayCoder extends StandardCoder<byte[]> {
+public class ByteArrayCoder extends StructuredCoder<byte[]> {
 
   @JsonCreator
   public static ByteArrayCoder of() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CustomCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CustomCoder.java
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.util.StringUtils;
  *
  * @param <T> the type of elements handled by this coder
  */
-public abstract class CustomCoder<T> extends StandardCoder<T>
+public abstract class CustomCoder<T> extends StructuredCoder<T>
     implements Serializable {
 
   @JsonCreator
@@ -116,5 +116,5 @@ public abstract class CustomCoder<T> extends StandardCoder<T>
 
   // This coder inherits isRegisterByteSizeObserverCheap,
   // getEncodedElementByteSize and registerByteSizeObserver
-  // from StandardCoder. Override if we can do better.
+  // from StructuredCoder. Override if we can do better.
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DelegateCoder.java
@@ -170,7 +170,7 @@ public final class DelegateCoder<T, IntermediateT> extends CustomCoder<T> {
   private final CodingFunction<IntermediateT, T> fromFn;
 
   // null unless the user explicitly provides a TypeDescriptor.
-  // If null, then the machinery from the superclass (StandardCoder) will be used
+  // If null, then the machinery from the superclass (StructuredCoder) will be used
   // to try to deduce a good type descriptor.
   @Nullable private final TypeDescriptor<T> typeDescriptor;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableLikeCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableLikeCoder.java
@@ -58,7 +58,7 @@ import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
  * @param <IterableT> the type of the Iterables being transcoded
  */
 public abstract class IterableLikeCoder<T, IterableT extends Iterable<T>>
-    extends StandardCoder<IterableT> {
+    extends StructuredCoder<IterableT> {
   public Coder<T> getElemCoder() {
     return elementCoder;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/KvCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/KvCoder.java
@@ -40,7 +40,7 @@ import org.apache.beam.sdk.values.TypeParameter;
  * @param <K> the type of the keys of the KVs being transcoded
  * @param <V> the type of the values of the KVs being transcoded
  */
-public class KvCoder<K, V> extends StandardCoder<KV<K, V>> {
+public class KvCoder<K, V> extends StructuredCoder<KV<K, V>> {
   public static <K, V> KvCoder<K, V> of(Coder<K> keyCoder,
                                         Coder<V> valueCoder) {
     return new KvCoder<>(keyCoder, valueCoder);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
@@ -41,7 +41,7 @@ import org.apache.beam.sdk.util.VarInt;
  *
  * @param <T> the type of the values being transcoded
  */
-public class LengthPrefixCoder<T> extends StandardCoder<T> {
+public class LengthPrefixCoder<T> extends StructuredCoder<T> {
 
   public static <T> LengthPrefixCoder<T> of(
       Coder<T> valueCoder) {
@@ -112,7 +112,7 @@ public class LengthPrefixCoder<T> extends StandardCoder<T> {
   }
 
   /**
-   * Overridden to short-circuit the default {@code StandardCoder} behavior of encoding and
+   * Overridden to short-circuit the default {@code StructuredCoder} behavior of encoding and
    * counting the bytes. The size is known to be the size of the value plus the number of bytes
    * required to prefix the length.
    *
@@ -120,15 +120,15 @@ public class LengthPrefixCoder<T> extends StandardCoder<T> {
    */
   @Override
   protected long getEncodedElementByteSize(T value, Context context) throws Exception {
-    if (valueCoder instanceof StandardCoder) {
-      // If valueCoder is a StandardCoder then we can ask it directly for the encoded size of
+    if (valueCoder instanceof StructuredCoder) {
+      // If valueCoder is a StructuredCoder then we can ask it directly for the encoded size of
       // the value, adding the number of bytes to represent the length.
-      long valueSize = ((StandardCoder<T>) valueCoder).getEncodedElementByteSize(
+      long valueSize = ((StructuredCoder<T>) valueCoder).getEncodedElementByteSize(
           value, Context.OUTER);
       return VarInt.getLength(valueSize) + valueSize;
     }
 
-    // If value is not a StandardCoder then fall back to the default StandardCoder behavior
+    // If value is not a StructuredCoder then fall back to the default StructuredCoder behavior
     // of encoding and counting the bytes. The encoding will include the length prefix.
     return super.getEncodedElementByteSize(value, context);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/NullableCoder.java
@@ -119,7 +119,7 @@ public class NullableCoder<T> extends CustomCoder<T> {
   }
 
   /**
-   * Overridden to short-circuit the default {@code StandardCoder} behavior of encoding and
+   * Overridden to short-circuit the default {@code StructuredCoder} behavior of encoding and
    * counting the bytes. The size is known (1 byte) when {@code value} is {@code null}, otherwise
    * the size is 1 byte plus the size of nested {@code Coder}'s encoding of {@code value}.
    *
@@ -135,7 +135,7 @@ public class NullableCoder<T> extends CustomCoder<T> {
   }
 
   /**
-   * Overridden to short-circuit the default {@code StandardCoder} behavior of encoding and
+   * Overridden to short-circuit the default {@code StructuredCoder} behavior of encoding and
    * counting the bytes. The size is known (1 byte) when {@code value} is {@code null}, otherwise
    * the size is 1 byte plus the size of nested {@code Coder}'s encoding of {@code value}.
    *
@@ -147,14 +147,14 @@ public class NullableCoder<T> extends CustomCoder<T> {
       return 1;
     }
 
-    if (valueCoder instanceof StandardCoder) {
-      // If valueCoder is a StandardCoder then we can ask it directly for the encoded size of
+    if (valueCoder instanceof StructuredCoder) {
+      // If valueCoder is a StructuredCoder then we can ask it directly for the encoded size of
       // the value, adding 1 byte to count the null indicator.
-      return 1  + ((StandardCoder<T>) valueCoder)
+      return 1  + ((StructuredCoder<T>) valueCoder)
           .getEncodedElementByteSize(value, context);
     }
 
-    // If value is not a StandardCoder then fall back to the default StandardCoder behavior
+    // If value is not a StructuredCoder then fall back to the default StructuredCoder behavior
     // of encoding and counting the bytes. The encoding will include the null indicator byte.
     return super.getEncodedElementByteSize(value, context);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -152,6 +152,6 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
 
   // This coder inherits isRegisterByteSizeObserverCheap,
   // getEncodedElementByteSize and registerByteSizeObserver
-  // from StandardCoder. Looks like we cannot do much better
+  // from StructuredCoder. Looks like we cannot do much better
   // in this case.
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -35,7 +35,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * An abstract base class to implement a {@link Coder} that defines equality, hashing, and printing
  * via the class name and recursively using {@link #getComponents}.
  *
- * <p>To extend {@link StandardCoder}, override the following methods as appropriate:
+ * <p>To extend {@link StructuredCoder}, override the following methods as appropriate:
  *
  * <ul>
  *   <li>{@link #getComponents}: the default implementation returns {@link #getCoderArguments}.</li>
@@ -45,8 +45,8 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  *       expensive.</li>
  * </ul>
  */
-public abstract class StandardCoder<T> implements Coder<T> {
-  protected StandardCoder() {}
+public abstract class StructuredCoder<T> implements Coder<T> {
+  protected StructuredCoder() {}
 
   /**
    * Returns the list of {@link Coder Coders} that are components of this {@link Coder}.
@@ -63,7 +63,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
   /**
    * {@inheritDoc}
    *
-   * @return {@code true} if the two {@link StandardCoder} instances have the
+   * @return {@code true} if the two {@link StructuredCoder} instances have the
    * same class and equal components.
    */
   @Override
@@ -71,7 +71,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
     if (o == null || this.getClass() != o.getClass()) {
       return false;
     }
-    StandardCoder<?> that = (StandardCoder<?>) o;
+    StructuredCoder<?> that = (StructuredCoder<?>) o;
     return this.getComponents().equals(that.getComponents());
   }
 
@@ -110,7 +110,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
    *       equivalent to the {@link #getCoderArguments}.</li>
    * </ul>
    *
-   * <p>{@link StandardCoder} implementations should override {@link #initializeCloudObject}
+   * <p>{@link StructuredCoder} implementations should override {@link #initializeCloudObject}
    * to customize the {@link CloudObject} representation.
    */
   @Override
@@ -131,7 +131,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
 
   /**
    * Subclasses should override this method to customize the {@link CloudObject}
-   * representation. {@link StandardCoder#asCloudObject} delegates to this method
+   * representation. {@link StructuredCoder#asCloudObject} delegates to this method
    * to provide an initial {@link CloudObject}.
    *
    * <p>The default implementation returns a {@link CloudObject} using
@@ -144,7 +144,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
   /**
    * {@inheritDoc}
    *
-   * @return {@code false} unless it is overridden. {@link StandardCoder#registerByteSizeObserver}
+   * @return {@code false} unless it is overridden. {@link StructuredCoder#registerByteSizeObserver}
    *         invokes {@link #getEncodedElementByteSize} which requires re-encoding an element
    *         unless it is overridden. This is considered expensive.
    */
@@ -170,7 +170,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
   /**
    * {@inheritDoc}
    *
-   * <p>For {@link StandardCoder} subclasses, this notifies {@code observer} about the byte size
+   * <p>For {@link StructuredCoder} subclasses, this notifies {@code observer} about the byte size
    * of the encoded value using this coder as returned by {@link #getEncodedElementByteSize}.
    */
   @Override
@@ -199,7 +199,7 @@ public abstract class StandardCoder<T> implements Coder<T> {
   /**
    * {@inheritDoc}
    *
-   * @return {@code false} for {@link StandardCoder} unless overridden.
+   * @return {@code false} for {@link StructuredCoder} unless overridden.
    */
   @Override
   public boolean consistentWithEquals() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarLongCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VarLongCoder.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * numbers always take 10 bytes, so {@link BigEndianLongCoder} may be preferable for
  * longs that are known to often be large or negative.
  */
-public class VarLongCoder extends StandardCoder<Long> {
+public class VarLongCoder extends StructuredCoder<Long> {
   public static VarLongCoder of() {
     return INSTANCE;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindow.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
-import org.apache.beam.sdk.coders.StandardCoder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.util.CloudObject;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -64,7 +64,7 @@ public class GlobalWindow extends BoundedWindow {
   /**
    * {@link Coder} for encoding and decoding {@code GlobalWindow}s.
    */
-  public static class Coder extends StandardCoder<GlobalWindow> {
+  public static class Coder extends StructuredCoder<GlobalWindow> {
     public static final Coder INSTANCE = new Coder();
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/IntervalWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/IntervalWindow.java
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.DurationCoder;
 import org.apache.beam.sdk.coders.InstantCoder;
-import org.apache.beam.sdk.coders.StandardCoder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.util.CloudObject;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -168,7 +168,7 @@ public class IntervalWindow extends BoundedWindow
   /**
    * Encodes an {@link IntervalWindow} as a pair of its upper bound and duration.
    */
-  public static class IntervalWindowCoder extends StandardCoder<IntervalWindow> {
+  public static class IntervalWindowCoder extends StructuredCoder<IntervalWindow> {
 
     private static final IntervalWindowCoder INSTANCE = new IntervalWindowCoder();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/WindowedValue.java
@@ -39,7 +39,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CollectionCoder;
 import org.apache.beam.sdk.coders.InstantCoder;
-import org.apache.beam.sdk.coders.StandardCoder;
+import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
@@ -576,7 +576,7 @@ public abstract class WindowedValue<T> {
    * Abstract class for {@code WindowedValue} coder.
    */
   public abstract static class WindowedValueCoder<T>
-      extends StandardCoder<WindowedValue<T>> {
+      extends StructuredCoder<WindowedValue<T>> {
     final Coder<T> valueCoder;
 
     WindowedValueCoder(Coder<T> valueCoder) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/LengthPrefixCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/LengthPrefixCoderTest.java
@@ -33,7 +33,8 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link LengthPrefixCoder}. */
 @RunWith(JUnit4.class)
 public class LengthPrefixCoderTest {
-  private static final StandardCoder<byte[]> TEST_CODER = LengthPrefixCoder.of(ByteArrayCoder.of());
+  private static final StructuredCoder<byte[]> TEST_CODER =
+      LengthPrefixCoder.of(ByteArrayCoder.of());
 
   private static final List<byte[]> TEST_VALUES = Arrays.asList(
     new byte[]{ 0xa, 0xb, 0xc },

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StructuredCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StructuredCoderTest.java
@@ -34,15 +34,15 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Test case for {@link StandardCoder}.
+ * Test case for {@link StructuredCoder}.
  */
 @RunWith(JUnit4.class)
-public class StandardCoderTest {
+public class StructuredCoderTest {
 
   /**
    * A coder for nullable {@code Boolean} values that is consistent with equals.
    */
-  private static class NullBooleanCoder extends StandardCoder<Boolean> {
+  private static class NullBooleanCoder extends StructuredCoder<Boolean> {
 
     private static final long serialVersionUID = 0L;
 
@@ -104,7 +104,7 @@ public class StandardCoderTest {
   /**
    * A coder for nullable boxed {@code Boolean} values that is not consistent with equals.
    */
-  private static class ObjectIdentityBooleanCoder extends StandardCoder<ObjectIdentityBoolean> {
+  private static class ObjectIdentityBooleanCoder extends StructuredCoder<ObjectIdentityBoolean> {
 
     private static final long serialVersionUID = 0L;
 
@@ -152,8 +152,8 @@ public class StandardCoderTest {
   }
 
   /**
-   * Tests that {@link StandardCoder#structuralValue()} is correct whenever a subclass has a correct
-   * {@link Coder#consistentWithEquals()}.
+   * Tests that {@link StructuredCoder#structuralValue()} is correct whenever a subclass has a
+   * correct {@link Coder#consistentWithEquals()}.
    */
   @Test
   public void testStructuralValue() throws Exception {
@@ -177,12 +177,12 @@ public class StandardCoderTest {
   }
 
   /**
-   * Test for verifying {@link StandardCoder#toString()}.
+   * Test for verifying {@link StructuredCoder#toString()}.
    */
   @Test
   public void testToString() {
     Assert.assertThat(new ObjectIdentityBooleanCoder().toString(),
-        CoreMatchers.equalTo("StandardCoderTest$ObjectIdentityBooleanCoder"));
+        CoreMatchers.equalTo("StructuredCoderTest$ObjectIdentityBooleanCoder"));
 
     ObjectIdentityBooleanCoder coderWithArgs = new ObjectIdentityBooleanCoder() {
       @Override
@@ -194,7 +194,7 @@ public class StandardCoderTest {
     };
 
     Assert.assertThat(coderWithArgs.toString(),
-        CoreMatchers.equalTo("StandardCoderTest$1(BigDecimalCoder,BigIntegerCoder)"));
+        CoreMatchers.equalTo("StructuredCoderTest$1(BigDecimalCoder,BigIntegerCoder)"));
   }
 
   @Test
@@ -210,7 +210,7 @@ public class StandardCoderTest {
         CoreMatchers.equalTo(TypeDescriptor.of(String.class)));
   }
 
-  private static class Foo<T> extends StandardCoder<T> {
+  private static class Foo<T> extends StructuredCoder<T> {
 
     @Override
     public void encode(T value, OutputStream outStream, Coder.Context context)


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
StandardCoder has improper connotations - mainly, "Standard" as in
"Standardized" as opposed to "Standard" as in "normal". StructuredCoder
communicates the important part of the class, which is that the coder
has some meaningful structure, and that structure can be used by a
runner.

Keep StandardCoder around as a temporary shim for the DataflowRunner.
Will be removed as soon as an updated worker is available.

To be merged after https://github.com/apache/beam/pull/2717

R: @kennknowles or @lukecwik 