### PR TITLE
[BEAM-2086] Remove TestDataflowRunner reliance on metrics in streaming

### DIFF
--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -17,32 +17,21 @@
  */
 package org.apache.beam.runners.dataflow.testing;
 
-import static org.apache.beam.runners.dataflow.testing.TestDataflowRunner.LEGACY_WATERMARK_METRIC_SUFFIX;
-import static org.apache.beam.runners.dataflow.testing.TestDataflowRunner.WATERMARK_METRIC_SUFFIX;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.LowLevelHttpResponse;
-import com.google.api.client.json.Json;
-import com.google.api.client.testing.http.MockHttpTransport;
-import com.google.api.client.testing.http.MockLowLevelHttpRequest;
-import com.google.api.client.testing.http.MockLowLevelHttpResponse;
-import com.google.api.services.dataflow.Dataflow;
 import com.google.api.services.dataflow.model.JobMessage;
 import com.google.api.services.dataflow.model.JobMetrics;
 import com.google.api.services.dataflow.model.MetricStructuredName;
@@ -55,6 +44,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.runners.dataflow.DataflowClient;
 import org.apache.beam.runners.dataflow.DataflowPipelineJob;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.util.MonitoringUtil;
@@ -69,7 +59,6 @@ import org.apache.beam.sdk.testing.SerializableMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.util.GcsUtil;
 import org.apache.beam.sdk.util.NoopPathValidator;
 import org.apache.beam.sdk.util.TestCredential;
 import org.apache.beam.sdk.util.Transport;
@@ -94,21 +83,13 @@ import org.mockito.stubbing.Answer;
 @RunWith(JUnit4.class)
 public class TestDataflowRunnerTest {
   @Rule public ExpectedException expectedException = ExpectedException.none();
-  @Mock private MockHttpTransport transport;
-  @Mock private MockLowLevelHttpRequest request;
-  @Mock private GcsUtil mockGcsUtil;
-
-  private static final BigDecimal DEFAULT_MAX_WATERMARK = new BigDecimal(-2);
+  @Mock private DataflowClient mockClient;
 
   private TestDataflowPipelineOptions options;
-  private Dataflow service;
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    when(transport.buildRequest(anyString(), anyString())).thenReturn(request);
-    doCallRealMethod().when(request).getContentAsString();
-    service = new Dataflow(transport, Transport.getJsonFactory(), null);
 
     options = PipelineOptionsFactory.as(TestDataflowPipelineOptions.class);
     options.setAppName("TestAppName");
@@ -116,7 +97,6 @@ public class TestDataflowRunnerTest {
     options.setTempLocation("gs://test/temp/location");
     options.setTempRoot("gs://test");
     options.setGcpCredential(new TestCredential());
-    options.setDataflowClient(service);
     options.setRunner(TestDataflowRunner.class);
     options.setPathValidatorClass(NoopPathValidator.class);
   }
@@ -124,12 +104,12 @@ public class TestDataflowRunnerTest {
   @Test
   public void testToString() {
     assertEquals("TestDataflowRunner#TestAppName",
-        new TestDataflowRunner(options).toString());
+        TestDataflowRunner.fromOptions(options).toString());
   }
 
   @Test
   public void testRunBatchJobThatSucceeds() throws Exception {
-    Pipeline p = TestPipeline.create(options);
+    Pipeline p = Pipeline.create(options);
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
@@ -141,9 +121,9 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* additionalMetrics */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
     assertEquals(mockJob, runner.run(p, mockRunner));
   }
 
@@ -161,9 +141,9 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        false /* tentative */, null /* additionalMetrics */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(false /* success */, false /* tentative */));
     try {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {
@@ -201,9 +181,9 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* additionalMetrics */));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(false /* success */, true /* tentative */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     try {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {
@@ -216,6 +196,9 @@ public class TestDataflowRunnerTest {
     fail("AssertionError expected");
   }
 
+  /**
+   * A streaming job that terminates with no error messages is a success.
+   */
   @Test
   public void testRunStreamingJobUsingPAssertThatSucceeds() throws Exception {
     options.setStreaming(true);
@@ -224,17 +207,18 @@ public class TestDataflowRunnerTest {
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
     DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.RUNNING);
+    when(mockJob.getState()).thenReturn(State.DONE);
+    when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
+        .thenReturn(State.DONE);
     when(mockJob.getProjectId()).thenReturn("test-project");
     when(mockJob.getJobId()).thenReturn("test-job");
 
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    when(request.execute())
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */,
-            ImmutableMap.of(WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     runner.run(p, mockRunner);
   }
 
@@ -245,60 +229,37 @@ public class TestDataflowRunnerTest {
     p.apply(Create.of(1, 2, 3));
 
     DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.RUNNING);
+    when(mockJob.getState()).thenReturn(State.DONE);
+    when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
+        .thenReturn(State.DONE);
     when(mockJob.getProjectId()).thenReturn("test-project");
     when(mockJob.getJobId()).thenReturn("test-job");
 
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    when(request.execute())
-        .thenReturn(generateMockStreamingMetricResponse(
-            ImmutableMap.of(WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockStreamingMetricResponse(ImmutableMap.<String, BigDecimal>of()));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     runner.run(p, mockRunner);
   }
 
+  /**
+   * Tests that a streaming job with a false {@link PAssert} fails.
+   *
+   * <p>Currently, this failure is indistinguishable from a non-{@link PAssert} failure, because it
+   * is detected only by failure job messages. With fuller metric support, this can detect a PAssert
+   * failure via metrics and raise an {@link AssertionError} in just that case.
+   */
   @Test
   public void testRunStreamingJobThatFails() throws Exception {
-    options.setStreaming(true);
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
-    PAssert.that(pc).containsInAnyOrder(1, 2, 3);
-
-    DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
-    when(mockJob.getState()).thenReturn(State.RUNNING);
-    when(mockJob.getProjectId()).thenReturn("test-project");
-    when(mockJob.getJobId()).thenReturn("test-job");
-
-    DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
-    when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
-
-    when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* additionalMetrics */));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    try {
-      runner.run(p, mockRunner);
-    } catch (AssertionError expected) {
-      return;
-    }
-    // Note that fail throws an AssertionError which is why it is placed out here
-    // instead of inside the try-catch block.
-    fail("AssertionError expected");
+    testStreamingPipelineFailsIfException();
   }
 
-  private LowLevelHttpResponse generateMockMetricResponse(boolean success, boolean tentative,
-                                                          Map<String, BigDecimal> additionalMetrics)
+  private JobMetrics generateMockMetricResponse(boolean success, boolean tentative)
       throws Exception {
-    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-    response.setContentType(Json.MEDIA_TYPE);
     List<MetricUpdate> metrics = generateMockMetrics(success, tentative);
-    if (additionalMetrics != null && !additionalMetrics.isEmpty()) {
-      metrics.addAll(generateMockStreamingMetrics(additionalMetrics));
-    }
-    JobMetrics jobMetrics = buildJobMetrics(metrics);
-    response.setContent(jobMetrics.toPrettyString());
-    return response;
+    return buildJobMetrics(metrics);
   }
 
   private List<MetricUpdate> generateMockMetrics(boolean success, boolean tentative) {
@@ -313,13 +274,9 @@ public class TestDataflowRunnerTest {
     return Lists.newArrayList(metric);
   }
 
-  private LowLevelHttpResponse generateMockStreamingMetricResponse(Map<String,
+  private JobMetrics generateMockStreamingMetricResponse(Map<String,
       BigDecimal> metricMap) throws IOException {
-    MockLowLevelHttpResponse response = new MockLowLevelHttpResponse();
-    response.setContentType(Json.MEDIA_TYPE);
-    JobMetrics jobMetrics = buildJobMetrics(generateMockStreamingMetrics(metricMap));
-    response.setContent(jobMetrics.toPrettyString());
-    return response;
+    return buildJobMetrics(generateMockStreamingMetrics(metricMap));
   }
 
   private List<MetricUpdate> generateMockStreamingMetrics(Map<String, BigDecimal> metricMap) {
@@ -344,6 +301,10 @@ public class TestDataflowRunnerTest {
     return jobMetrics;
   }
 
+  /**
+   * Tests that a tentative {@code true} from metrics indicates that every {@link PAssert} has
+   * succeeded.
+   */
   @Test
   public void testCheckingForSuccessWhenPAssertSucceeds() throws Exception {
     DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
@@ -351,13 +312,18 @@ public class TestDataflowRunnerTest {
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(buildJobMetrics(generateMockMetrics(true /* success */, true /* tentative */)));
+
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     doReturn(State.DONE).when(job).getState();
-    JobMetrics metrics = buildJobMetrics(
-        generateMockMetrics(true /* success */, true /* tentative */));
-    assertEquals(Optional.of(true), runner.checkForPAssertSuccess(job, metrics));
+    assertThat(runner.checkForPAssertSuccess(job), equalTo(Optional.of(true)));
   }
 
+  /**
+   * Tests that when we just see a tentative failure for a {@link PAssert} it is considered a
+   * conclusive failure.
+   */
   @Test
   public void testCheckingForSuccessWhenPAssertFails() throws Exception {
     DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
@@ -365,11 +331,13 @@ public class TestDataflowRunnerTest {
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(
+            buildJobMetrics(generateMockMetrics(false /* success */, true /* tentative */)));
+
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     doReturn(State.DONE).when(job).getState();
-    JobMetrics metrics = buildJobMetrics(
-        generateMockMetrics(false /* success */, true /* tentative */));
-    assertEquals(Optional.of(false), runner.checkForPAssertSuccess(job, metrics));
+    assertThat(runner.checkForPAssertSuccess(job), equalTo(Optional.of(false)));
   }
 
   @Test
@@ -379,108 +347,20 @@ public class TestDataflowRunnerTest {
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(
+            buildJobMetrics(generateMockMetrics(true /* success */, false /* tentative */)));
+
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     runner.updatePAssertCount(p);
     doReturn(State.RUNNING).when(job).getState();
-    JobMetrics metrics = buildJobMetrics(
-        generateMockMetrics(true /* success */, false /* tentative */));
-    assertEquals(Optional.absent(), runner.checkForPAssertSuccess(job, metrics));
+    assertThat(runner.checkForPAssertSuccess(job), equalTo(Optional.<Boolean>absent()));
   }
 
-  @Test
-  public void testCheckMaxWatermarkWithNoWatermarkMetric() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of("no-watermark", new BigDecimal(100))));
-    doReturn(State.RUNNING).when(job).getState();
-    assertFalse(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkWithSingleWatermarkAtMax() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of(WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
-    doReturn(State.RUNNING).when(job).getState();
-    assertTrue(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkWithLegacyWatermarkAtMax() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of(LEGACY_WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
-    doReturn(State.RUNNING).when(job).getState();
-    assertTrue(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkWithSingleWatermarkNotAtMax() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics
-        (ImmutableMap.of(WATERMARK_METRIC_SUFFIX, new BigDecimal(100))));
-    doReturn(State.RUNNING).when(job).getState();
-    assertFalse(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkWithMultipleWatermarksAtMax() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of("one" + WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK,
-            "two" + WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
-    doReturn(State.RUNNING).when(job).getState();
-    assertTrue(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkWithMultipleMaxAndNotMaxWatermarks() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of("one" + WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK,
-            "two" + WATERMARK_METRIC_SUFFIX, new BigDecimal(100))));
-    doReturn(State.RUNNING).when(job).getState();
-    assertFalse(runner.atMaxWatermark(job, metrics));
-  }
-
-  @Test
-  public void testCheckMaxWatermarkIgnoresUnrelatedMatrics() throws IOException {
-    DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
-    Pipeline p = TestPipeline.create(options);
-    p.apply(Create.of(1, 2, 3));
-
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
-    JobMetrics metrics = buildJobMetrics(generateMockStreamingMetrics(
-        ImmutableMap.of("one" + WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK,
-            "no-watermark", new BigDecimal(100))));
-    doReturn(State.RUNNING).when(job).getState();
-    assertTrue(runner.atMaxWatermark(job, metrics));
-  }
-
+  /**
+   * Tests that if a streaming pipeline terminates with FAIL that the check for PAssert
+   * success is a conclusive failure.
+   */
   @Test
   public void testStreamingPipelineFailsIfServiceFails() throws Exception {
     DataflowPipelineJob job = spy(new DataflowPipelineJob("test-job", options, null));
@@ -488,16 +368,23 @@ public class TestDataflowRunnerTest {
     PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     doReturn(State.FAILED).when(job).getState();
-    assertEquals(Optional.of(false), runner.checkForPAssertSuccess(job, null /* metrics */));
+    assertThat(runner.checkForPAssertSuccess(job), equalTo(Optional.of(false)));
   }
 
+  /**
+   * Tests that if a streaming pipeline crash loops for a non-assertion reason that the test run
+   * throws an {@link AssertionError}.
+   *
+   * <p>This is a known limitation/bug of the runner that it does not distinguish the two modes of
+   * failure.
+   */
   @Test
   public void testStreamingPipelineFailsIfException() throws Exception {
     options.setStreaming(true);
-    Pipeline p = TestPipeline.create(options);
-    PCollection<Integer> pc = p.apply(Create.of(1, 2, 3));
+    Pipeline pipeline = TestPipeline.create(options);
+    PCollection<Integer> pc = pipeline.apply(Create.of(1, 2, 3));
     PAssert.that(pc).containsInAnyOrder(1, 2, 3);
 
     DataflowPipelineJob mockJob = Mockito.mock(DataflowPipelineJob.class);
@@ -521,18 +408,15 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* additionalMetrics */));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(false /* success */, true /* tentative */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
+
     try {
-      runner.run(p, mockRunner);
-    } catch (AssertionError expected) {
-      assertThat(expected.getMessage(), containsString("FooException"));
-      verify(mockJob, atLeastOnce()).cancel();
+      runner.run(pipeline, mockRunner);
+    } catch (AssertionError exc) {
       return;
     }
-    // Note that fail throws an AssertionError which is why it is placed out here
-    // instead of inside the try-catch block.
     fail("AssertionError expected");
   }
 
@@ -542,9 +426,9 @@ public class TestDataflowRunnerTest {
     Pipeline p = TestPipeline.create(options);
     p.apply(Create.of(1, 2, 3));
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* additionalMetrics */));
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     JobMetrics metrics = runner.getJobMetrics(job);
 
     assertEquals(1, metrics.getMetrics().size());
@@ -558,8 +442,8 @@ public class TestDataflowRunnerTest {
     Pipeline p = TestPipeline.create(options);
     p.apply(Create.of(1, 2, 3));
 
-    when(request.execute()).thenThrow(new IOException());
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    when(mockClient.getJobMetrics(anyString())).thenThrow(new IOException());
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     assertNull(runner.getJobMetrics(job));
   }
 
@@ -577,12 +461,12 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnCreateMatcher(new TestSuccessMatcher(mockJob, 0));
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* additionalMetrics */));
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
     runner.run(p, mockRunner);
   }
 
@@ -601,16 +485,16 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnCreateMatcher(new TestSuccessMatcher(mockJob, 0));
 
     when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
         .thenReturn(State.DONE);
 
-    when(request.execute())
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */,
-            ImmutableMap.of(WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */
+        ));
     runner.run(p, mockRunner);
   }
 
@@ -628,15 +512,20 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnSuccessMatcher(new TestSuccessMatcher(mockJob, 1));
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(true /* success */,
-        true /* tentative */, null /* additionalMetrics */));
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
     runner.run(p, mockRunner);
   }
 
+  /**
+   * Tests that when a streaming pipeline terminates and doesn't fail due to {@link PAssert} that
+   * the {@link TestPipelineOptions#setOnSuccessMatcher(SerializableMatcher) on success matcher} is
+   * invoked.
+   */
   @Test
   public void testStreamingOnSuccessMatcherWhenPipelineSucceeds() throws Exception {
     options.setStreaming(true);
@@ -652,16 +541,15 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnSuccessMatcher(new TestSuccessMatcher(mockJob, 1));
 
     when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
         .thenReturn(State.DONE);
 
-    when(request.execute())
-        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */,
-            ImmutableMap.of(WATERMARK_METRIC_SUFFIX, DEFAULT_MAX_WATERMARK)));
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(true /* success */, true /* tentative */));
     runner.run(p, mockRunner);
   }
 
@@ -679,12 +567,12 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnSuccessMatcher(new TestFailureMatcher());
 
-    when(request.execute()).thenReturn(generateMockMetricResponse(false /* success */,
-        true /* tentative */, null /* additionalMetrics */));
+    when(mockClient.getJobMetrics(anyString()))
+        .thenReturn(generateMockMetricResponse(false /* success */, true /* tentative */));
     try {
       runner.run(p, mockRunner);
     } catch (AssertionError expected) {
@@ -695,6 +583,11 @@ public class TestDataflowRunnerTest {
     fail("Expected an exception on pipeline failure.");
   }
 
+  /**
+   * Tests that when a streaming pipeline terminates in FAIL that the {@link
+   * TestPipelineOptions#setOnSuccessMatcher(SerializableMatcher) on success matcher} is not
+   * invoked.
+   */
   @Test
   public void testStreamingOnSuccessMatcherWhenPipelineFails() throws Exception {
     options.setStreaming(true);
@@ -710,24 +603,15 @@ public class TestDataflowRunnerTest {
     DataflowRunner mockRunner = Mockito.mock(DataflowRunner.class);
     when(mockRunner.run(any(Pipeline.class))).thenReturn(mockJob);
 
-    TestDataflowRunner runner = TestDataflowRunner.fromOptions(options);
+    TestDataflowRunner runner = TestDataflowRunner.fromOptionsAndClient(options, mockClient);
     p.getOptions().as(TestPipelineOptions.class)
         .setOnSuccessMatcher(new TestFailureMatcher());
 
     when(mockJob.waitUntilFinish(any(Duration.class), any(JobMessagesHandler.class)))
         .thenReturn(State.FAILED);
 
-    when(request.execute()).thenReturn(
-        generateMockMetricResponse(false /* success */, true /* tentative */,
-            ImmutableMap.of(WATERMARK_METRIC_SUFFIX, new BigDecimal(100))));
-    try {
-      runner.run(p, mockRunner);
-    } catch (AssertionError expected) {
-      verify(mockJob, Mockito.times(1)).waitUntilFinish(any(Duration.class),
-          any(JobMessagesHandler.class));
-      return;
-    }
-    fail("Expected an exception on pipeline failure.");
+    runner.run(p, mockRunner);
+    // If the onSuccessMatcher were invoked, it would have crashed here.
   }
 
   static class TestSuccessMatcher extends BaseMatcher<PipelineResult> implements


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Metrics are not supported yet in Dataflow streaming.

 - The Dataflow service automatically shuts down jobs when their input watermarks reach infinity, so we don't need metrics for that.
 - Counting `PAsserts` is nice but given the current architecture less of a critical concern. And anyhow, Dataflow just doesn't support it yet!