### PR TITLE
[BEAM-1871] Remove irrelevant runtime dependencies

### DIFF
--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -144,20 +144,6 @@
       <artifactId>google-http-client</artifactId>
     </dependency>
 
-    <!-- Required by com.google.apis:google-api-services-datastore-protobuf, but 
-      the version they depend on differs from our api-client versions -->
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-jackson</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client-protobuf</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>


### PR DESCRIPTION
Confirmed that sdks/java/io/gcp uses 1.22 for the removed libraries.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
