### PR TITLE
[BEAM-1415] PubsubIO style guide fixes, part 1

### DIFF
--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -24,7 +24,6 @@ import org.apache.beam.examples.common.ExampleUtils;
 import org.apache.beam.examples.complete.game.utils.WriteWindowedToBigQuery;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -252,9 +251,8 @@ public class GameStats extends LeaderBoard {
 
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
-        .apply(PubsubIO.<String>read()
-            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic())
-            .withCoder(StringUtf8Coder.of()))
+        .apply(PubsubIO.readStrings()
+            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     // Extract username/score pairs from the event stream

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -252,7 +252,7 @@ public class GameStats extends LeaderBoard {
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
         .apply(PubsubIO.readStrings()
-            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
+            .withTimestampAttribute(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     // Extract username/score pairs from the event stream

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -253,7 +253,7 @@ public class GameStats extends LeaderBoard {
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
         .apply(PubsubIO.<String>read()
-            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic())
+            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic())
             .withCoder(StringUtf8Coder.of()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -192,7 +192,7 @@ public class LeaderBoard extends HourlyTeamScore {
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
         .apply(PubsubIO.<String>read()
-            .timestampLabel(TIMESTAMP_ATTRIBUTE).topic(options.getTopic())
+            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic())
             .withCoder(StringUtf8Coder.of()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -191,7 +191,7 @@ public class LeaderBoard extends HourlyTeamScore {
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
         .apply(PubsubIO.readStrings()
-            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
+            .withTimestampAttribute(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     gameEvents.apply("CalculateTeamScores",

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -27,7 +27,6 @@ import org.apache.beam.examples.complete.game.utils.WriteToBigQuery;
 import org.apache.beam.examples.complete.game.utils.WriteWindowedToBigQuery;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
@@ -191,9 +190,8 @@ public class LeaderBoard extends HourlyTeamScore {
     // Read game events from Pub/Sub using custom timestamps, which are extracted from the pubsub
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
-        .apply(PubsubIO.<String>read()
-            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic())
-            .withCoder(StringUtf8Coder.of()))
+        .apply(PubsubIO.readStrings()
+            .withTimestampLabel(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     gameEvents.apply("CalculateTeamScores",

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -922,12 +922,13 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               ((NestedValueProvider) overriddenTransform.getSubscriptionProvider()).propertyName());
         }
       }
-      if (overriddenTransform.getTimestampLabel() != null) {
+      if (overriddenTransform.getTimestampAttribute() != null) {
         stepContext.addInput(
-            PropertyNames.PUBSUB_TIMESTAMP_LABEL, overriddenTransform.getTimestampLabel());
+            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE, overriddenTransform.getTimestampAttribute());
       }
-      if (overriddenTransform.getIdLabel() != null) {
-        stepContext.addInput(PropertyNames.PUBSUB_ID_LABEL, overriddenTransform.getIdLabel());
+      if (overriddenTransform.getIdAttribute() != null) {
+        stepContext.addInput(
+            PropertyNames.PUBSUB_ID_ATTRIBUTE, overriddenTransform.getIdAttribute());
       }
       if (overriddenTransform.getWithAttributesParseFn() != null) {
         stepContext.addInput(
@@ -997,12 +998,13 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             PropertyNames.PUBSUB_TOPIC_OVERRIDE,
             ((NestedValueProvider) overriddenTransform.getTopicProvider()).propertyName());
       }
-      if (overriddenTransform.getTimestampLabel() != null) {
+      if (overriddenTransform.getTimestampAttribute() != null) {
         stepContext.addInput(
-            PropertyNames.PUBSUB_TIMESTAMP_LABEL, overriddenTransform.getTimestampLabel());
+            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE, overriddenTransform.getTimestampAttribute());
       }
-      if (overriddenTransform.getIdLabel() != null) {
-        stepContext.addInput(PropertyNames.PUBSUB_ID_LABEL, overriddenTransform.getIdLabel());
+      if (overriddenTransform.getIdAttribute() != null) {
+        stepContext.addInput(
+            PropertyNames.PUBSUB_ID_ATTRIBUTE, overriddenTransform.getIdAttribute());
       }
       if (overriddenTransform.getFormatFn() != null) {
         stepContext.addInput(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PropertyNames.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/PropertyNames.java
@@ -82,11 +82,11 @@ public class PropertyNames {
   public static final String OUTPUT_NAME = "output_name";
   public static final String PARALLEL_INPUT = "parallel_input";
   public static final String PHASE = "phase";
-  public static final String PUBSUB_ID_LABEL = "pubsub_id_label";
+  public static final String PUBSUB_ID_ATTRIBUTE = "pubsub_id_label";
   public static final String PUBSUB_SERIALIZED_ATTRIBUTES_FN = "pubsub_serialized_attributes_fn";
   public static final String PUBSUB_SUBSCRIPTION = "pubsub_subscription";
   public static final String PUBSUB_SUBSCRIPTION_OVERRIDE = "pubsub_subscription_runtime_override";
-  public static final String PUBSUB_TIMESTAMP_LABEL = "pubsub_timestamp_label";
+  public static final String PUBSUB_TIMESTAMP_ATTRIBUTE = "pubsub_timestamp_label";
   public static final String PUBSUB_TOPIC = "pubsub_topic";
   public static final String PUBSUB_TOPIC_OVERRIDE = "pubsub_topic_runtime_override";
   public static final String SCALAR_FIELD_NAME = "value";

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
@@ -42,16 +42,15 @@ abstract class PubsubClient implements Closeable {
    */
   public interface PubsubClientFactory extends Serializable {
     /**
-     * Construct a new Pubsub client. It should be closed via {@link #close} in order
-     * to ensure tidy cleanup of underlying netty resources (or use the try-with-resources
-     * construct). Uses {@code options} to derive pubsub endpoints and application credentials.
-     * If non-{@literal null}, use {@code timestampLabel} and {@code idLabel} to store custom
-     * timestamps/ids within message metadata.
+     * Construct a new Pubsub client. It should be closed via {@link #close} in order to ensure tidy
+     * cleanup of underlying netty resources (or use the try-with-resources construct). Uses {@code
+     * options} to derive pubsub endpoints and application credentials. If non-{@literal null}, use
+     * {@code timestampAttribute} and {@code idAttribute} to store custom timestamps/ids within
+     * message metadata.
      */
     PubsubClient newClient(
-        @Nullable String timestampLabel,
-        @Nullable String idLabel,
-        PubsubOptions options) throws IOException;
+        @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
+        throws IOException;
 
     /**
      * Return the display name for this factory. Eg "Json", "gRPC".
@@ -86,33 +85,33 @@ abstract class PubsubClient implements Closeable {
    * Return the timestamp (in ms since unix epoch) to use for a Pubsub message with {@code
    * attributes} and {@code pubsubTimestamp}.
    *
-   * <p>If {@code timestampLabel} is non-{@literal null} then the message attributes must contain
-   * that label, and the value of that label will be taken as the timestamp.
+   * <p>If {@code timestampAttribute} is non-{@literal null} then the message attributes must
+   * contain that attribute, and the value of that attribute will be taken as the timestamp.
    * Otherwise the timestamp will be taken from the Pubsub publish timestamp {@code
    * pubsubTimestamp}.
    *
    * @throws IllegalArgumentException if the timestamp cannot be recognized as a ms-since-unix-epoch
-   * or RFC3339 time.
+   *     or RFC3339 time.
    */
   protected static long extractTimestamp(
-      @Nullable String timestampLabel,
+      @Nullable String timestampAttribute,
       @Nullable String pubsubTimestamp,
       @Nullable Map<String, String> attributes) {
     Long timestampMsSinceEpoch;
-    if (Strings.isNullOrEmpty(timestampLabel)) {
+    if (Strings.isNullOrEmpty(timestampAttribute)) {
       timestampMsSinceEpoch = asMsSinceEpoch(pubsubTimestamp);
       checkArgument(timestampMsSinceEpoch != null,
                     "Cannot interpret PubSub publish timestamp: %s",
                     pubsubTimestamp);
     } else {
-      String value = attributes == null ? null : attributes.get(timestampLabel);
+      String value = attributes == null ? null : attributes.get(timestampAttribute);
       checkArgument(value != null,
-                    "PubSub message is missing a value for timestamp label %s",
-                    timestampLabel);
+                    "PubSub message is missing a value for timestamp attribute %s",
+                    timestampAttribute);
       timestampMsSinceEpoch = asMsSinceEpoch(value);
       checkArgument(timestampMsSinceEpoch != null,
-                    "Cannot interpret value of label %s as timestamp: %s",
-                    timestampLabel, value);
+                    "Cannot interpret value of attribute %s as timestamp: %s",
+                    timestampAttribute, value);
     }
     return timestampMsSinceEpoch;
   }
@@ -317,11 +316,10 @@ abstract class PubsubClient implements Closeable {
     public final long timestampMsSinceEpoch;
 
     /**
-     * If using an id label, the record id to associate with this record's metadata so the receiver
-     * can reject duplicates. Otherwise {@literal null}.
+     * If using an id attribute, the record id to associate with this record's metadata so the
+     * receiver can reject duplicates. Otherwise {@literal null}.
      */
-    @Nullable
-    public final String recordId;
+    @Nullable public final String recordId;
 
     public OutgoingMessage(byte[] elementBytes, Map<String, String> attributes,
                            long timestampMsSinceEpoch, @Nullable String recordId) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
@@ -79,7 +79,7 @@ class PubsubGrpcClient extends PubsubClient {
   private static class PubsubGrpcClientFactory implements PubsubClientFactory {
     @Override
     public PubsubClient newClient(
-        @Nullable String timestampLabel, @Nullable String idLabel, PubsubOptions options)
+        @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
         throws IOException {
       ManagedChannel channel = NettyChannelBuilder
           .forAddress(PUBSUB_ADDRESS, PUBSUB_PORT)
@@ -87,8 +87,8 @@ class PubsubGrpcClient extends PubsubClient {
           .sslContext(GrpcSslContexts.forClient().ciphers(null).build())
           .build();
 
-      return new PubsubGrpcClient(timestampLabel,
-                                  idLabel,
+      return new PubsubGrpcClient(timestampAttribute,
+                                  idAttribute,
                                   DEFAULT_TIMEOUT_S,
                                   channel,
                                   options.getGcpCredential());
@@ -122,17 +122,17 @@ class PubsubGrpcClient extends PubsubClient {
   private final Credentials credentials;
 
   /**
-   * Label to use for custom timestamps, or {@literal null} if should use Pubsub publish time
+   * Attribute to use for custom timestamps, or {@literal null} if should use Pubsub publish time
    * instead.
    */
   @Nullable
-  private final String timestampLabel;
+  private final String timestampAttribute;
 
   /**
-   * Label to use for custom ids, or {@literal null} if should use Pubsub provided ids.
+   * Attribute to use for custom ids, or {@literal null} if should use Pubsub provided ids.
    */
   @Nullable
-  private final String idLabel;
+  private final String idAttribute;
 
 
   /**
@@ -144,13 +144,13 @@ class PubsubGrpcClient extends PubsubClient {
 
   @VisibleForTesting
   PubsubGrpcClient(
-      @Nullable String timestampLabel,
-      @Nullable String idLabel,
+      @Nullable String timestampAttribute,
+      @Nullable String idAttribute,
       int timeoutSec,
       ManagedChannel publisherChannel,
       Credentials credentials) {
-    this.timestampLabel = timestampLabel;
-    this.idLabel = idLabel;
+    this.timestampAttribute = timestampAttribute;
+    this.idAttribute = idAttribute;
     this.timeoutSec = timeoutSec;
     this.publisherChannel = publisherChannel;
     this.credentials = credentials;
@@ -226,13 +226,13 @@ class PubsubGrpcClient extends PubsubClient {
         message.putAllAttributes(outgoingMessage.attributes);
       }
 
-      if (timestampLabel != null) {
+      if (timestampAttribute != null) {
         message.getMutableAttributes()
-               .put(timestampLabel, String.valueOf(outgoingMessage.timestampMsSinceEpoch));
+               .put(timestampAttribute, String.valueOf(outgoingMessage.timestampMsSinceEpoch));
       }
 
-      if (idLabel != null && !Strings.isNullOrEmpty(outgoingMessage.recordId)) {
-        message.getMutableAttributes().put(idLabel, outgoingMessage.recordId);
+      if (idAttribute != null && !Strings.isNullOrEmpty(outgoingMessage.recordId)) {
+        message.getMutableAttributes().put(idAttribute, outgoingMessage.recordId);
       }
 
       request.addMessages(message);
@@ -273,7 +273,7 @@ class PubsubGrpcClient extends PubsubClient {
                                                + timestampProto.getNanos() / 1000L);
       }
       long timestampMsSinceEpoch =
-          extractTimestamp(timestampLabel, pubsubTimestampString, attributes);
+          extractTimestamp(timestampAttribute, pubsubTimestampString, attributes);
 
       // Ack id.
       String ackId = message.getAckId();
@@ -281,8 +281,8 @@ class PubsubGrpcClient extends PubsubClient {
 
       // Record id, if any.
       @Nullable String recordId = null;
-      if (idLabel != null && attributes != null) {
-        recordId = attributes.get(idLabel);
+      if (idAttribute != null && attributes != null) {
+        recordId = attributes.get(idAttribute);
       }
       if (Strings.isNullOrEmpty(recordId)) {
         // Fall back to the Pubsub provided message id.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -534,8 +534,6 @@ public class PubsubIO {
       return toBuilder()
           .setSubscriptionProvider(
               NestedValueProvider.of(subscription, new SubscriptionTranslator()))
-          /* reset topic to null */
-          .setTopicProvider(null)
           .build();
     }
 
@@ -564,8 +562,6 @@ public class PubsubIO {
       }
       return toBuilder()
           .setTopicProvider(NestedValueProvider.of(topic, new TopicTranslator()))
-          /* reset subscription to null */
-          .setSubscriptionProvider(null)
           .build();
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.pubsub;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -455,64 +456,61 @@ public class PubsubIO {
     }
   }
 
+   /** Returns A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream. */
   public static <T> Read<T> read() {
-    return new Read<>();
+    return new AutoValue_PubsubIO_Read.Builder<T>().build();
   }
 
   public static <T> Write<T> write() {
     return new Write<>();
   }
 
-  /**
-   * A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream and
-   * returns a {@link PCollection} of {@link String Strings} containing the items from
-   * the stream.
-   */
-  public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
-
-    /** The Cloud Pub/Sub topic to read from. */
+  /** Implementation of {@link #read}. */
+  @AutoValue
+  public abstract static class Read<T> extends PTransform<PBegin, PCollection<T>> {
     @Nullable
-    private final ValueProvider<PubsubTopic> topic;
+    abstract ValueProvider<PubsubTopic> getTopicProvider();
 
-    /** The Cloud Pub/Sub subscription to read from. */
     @Nullable
-    private final ValueProvider<PubsubSubscription> subscription;
+    abstract ValueProvider<PubsubSubscription> getSubscriptionProvider();
 
     /** The name of the message attribute to read timestamps from. */
     @Nullable
-    private final String timestampLabel;
+    abstract String getTimestampLabel();
 
     /** The name of the message attribute to read unique message IDs from. */
     @Nullable
-    private final String idLabel;
+    abstract String getIdLabel();
 
     /** The coder used to decode each record. */
     @Nullable
-    private final Coder<T> coder;
+    abstract Coder<T> getCoder();
 
     /** User function for parsing PubsubMessage object. */
-    SimpleFunction<PubsubMessage, T> parseFn;
+    @Nullable
+    abstract SimpleFunction<PubsubMessage, T> getParseFn();
 
-    private Read() {
-      this(null, null, null, null, null, null, null);
-    }
+    abstract Builder<T> toBuilder();
 
-    private Read(String name, ValueProvider<PubsubSubscription> subscription,
-        ValueProvider<PubsubTopic> topic, String timestampLabel, Coder<T> coder,
-        String idLabel,
-        SimpleFunction<PubsubMessage, T> parseFn) {
-      super(name);
-      this.subscription = subscription;
-      this.topic = topic;
-      this.timestampLabel = timestampLabel;
-      this.coder = coder;
-      this.idLabel = idLabel;
-      this.parseFn = parseFn;
+    @AutoValue.Builder
+    abstract static class Builder<T> {
+      abstract Builder<T> setTopicProvider(ValueProvider<PubsubTopic> topic);
+
+      abstract Builder<T> setSubscriptionProvider(ValueProvider<PubsubSubscription> subscription);
+
+      abstract Builder<T> setTimestampLabel(String timestampLabel);
+
+      abstract Builder<T> setIdLabel(String idLabel);
+
+      abstract Builder<T> setCoder(Coder<T> coder);
+
+      abstract Builder<T> setParseFn(SimpleFunction<PubsubMessage, T> parseFn);
+
+      abstract Read<T> build();
     }
 
     /**
-     * Returns a transform that's like this one but reading from the
-     * given subscription.
+     * Reads from the given subscription.
      *
      * <p>See {@link PubsubIO.PubsubSubscription#fromPath(String)} for more details on the format
      * of the {@code subscription} string.
@@ -520,8 +518,6 @@ public class PubsubIO {
      * <p>Multiple readers reading from the same subscription will each receive
      * some arbitrary portion of the data.  Most likely, separate readers should
      * use their own subscriptions.
-     *
-     * <p>Does not modify this object.
      */
     public Read<T> subscription(String subscription) {
       return subscription(StaticValueProvider.of(subscription));
@@ -535,9 +531,12 @@ public class PubsubIO {
         // Validate.
         PubsubSubscription.fromPath(subscription.get());
       }
-      return new Read<>(
-          name, NestedValueProvider.of(subscription, new SubscriptionTranslator()),
-          null /* reset topic to null */, timestampLabel, coder, idLabel, parseFn);
+      return toBuilder()
+          .setSubscriptionProvider(
+              NestedValueProvider.of(subscription, new SubscriptionTranslator()))
+          /* reset topic to null */
+          .setTopicProvider(null)
+          .build();
     }
 
     /**
@@ -563,15 +562,16 @@ public class PubsubIO {
         // Validate.
         PubsubTopic.fromPath(topic.get());
       }
-      return new Read<>(name, null /* reset subscription to null */,
-          NestedValueProvider.of(topic, new TopicTranslator()),
-          timestampLabel, coder, idLabel, parseFn);
+      return toBuilder()
+          .setTopicProvider(NestedValueProvider.of(topic, new TopicTranslator()))
+          /* reset subscription to null */
+          .setSubscriptionProvider(null)
+          .build();
     }
 
     /**
-     * Creates and returns a transform reading from Cloud Pub/Sub where record timestamps are
-     * expected to be provided as Pub/Sub message attributes. The {@code timestampLabel}
-     * parameter specifies the name of the attribute that contains the timestamp.
+     * When reading from Cloud Pub/Sub where record timestamps are provided as Pub/Sub message
+     * attributes, specifies the name of the attribute that contains the timestamp.
      *
      * <p>The timestamp value is expected to be represented in the attribute as either:
      *
@@ -599,88 +599,90 @@ public class PubsubIO {
      * @see <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>
      */
     public Read<T> timestampLabel(String timestampLabel) {
-      return new Read<>(
-          name, subscription, topic, timestampLabel, coder, idLabel,
-          parseFn);
+      return toBuilder().setTimestampLabel(timestampLabel).build();
     }
 
     /**
-     * Creates and returns a transform for reading from Cloud Pub/Sub where unique record
-     * identifiers are expected to be provided as Pub/Sub message attributes. The {@code idLabel}
-     * parameter specifies the attribute name. The value of the attribute can be any string
-     * that uniquely identifies this record.
+     * When reading from Cloud Pub/Sub where unique record identifiers are provided as Pub/Sub
+     * message attributes, specifies the name of the attribute containing the unique identifier.
+     * The value of the attribute can be any string that uniquely identifies this record.
      *
      * <p>Pub/Sub cannot guarantee that no duplicate data will be delivered on the Pub/Sub stream.
      * If {@code idLabel} is not provided, Beam cannot guarantee that no duplicate data will
      * be delivered, and deduplication of the stream will be strictly best effort.
      */
     public Read<T> idLabel(String idLabel) {
-      return new Read<>(
-          name, subscription, topic, timestampLabel, coder, idLabel,
-          parseFn);
+      return toBuilder().setIdLabel(idLabel).build();
     }
 
     /**
-     * Returns a transform that's like this one but that uses the given
-     * {@link Coder} to decode each record into a value of type {@code T}.
-     *
-     * <p>Does not modify this object.
+     * Uses the given {@link Coder} to decode each record into a value of type {@code T}.
      */
     public Read<T> withCoder(Coder<T> coder) {
-      return new Read<>(
-          name, subscription, topic, timestampLabel, coder, idLabel,
-          parseFn);
+      return toBuilder().setCoder(coder).build();
     }
 
     /**
-     * Causes the source to return a PubsubMessage that includes Pubsub attributes.
-     * The user must supply a parsing function to transform the PubsubMessage into an output type.
+     * Causes the source to return a PubsubMessage that includes Pubsub attributes, and uses the
+     * given parsing function to transform the PubsubMessage into an output type.
      * A Coder for the output type T must be registered or set on the output via
      * {@link PCollection#setCoder(Coder)}.
      */
     public Read<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
-      return new Read<T>(
-          name, subscription, topic, timestampLabel, coder, idLabel,
-          parseFn);
+      return toBuilder().setParseFn(parseFn).build();
     }
 
     @Override
     public PCollection<T> expand(PBegin input) {
-      if (topic == null && subscription == null) {
-        throw new IllegalStateException("Need to set either the topic or the subscription for "
-            + "a PubsubIO.Read transform");
+      if (getTopicProvider() == null && getSubscriptionProvider() == null) {
+        throw new IllegalStateException(
+            "Need to set either the topic or the subscription for " + "a PubsubIO.Read transform");
       }
-      if (topic != null && subscription != null) {
-        throw new IllegalStateException("Can't set both the topic and the subscription for "
-            + "a PubsubIO.Read transform");
+      if (getTopicProvider() != null && getSubscriptionProvider() != null) {
+        throw new IllegalStateException(
+            "Can't set both the topic and the subscription for " + "a PubsubIO.Read transform");
       }
-      if (coder == null) {
-        throw new IllegalStateException("PubsubIO.Read requires that a coder be set using "
-            + "the withCoder method.");
+      if (getCoder() == null) {
+        throw new IllegalStateException(
+            "PubsubIO.Read requires that a coder be set using " + "the withCoder method.");
       }
 
-      @Nullable ValueProvider<ProjectPath> projectPath =
-          topic == null ? null : NestedValueProvider.of(topic, new ProjectPathTranslator());
-      @Nullable ValueProvider<TopicPath> topicPath =
-          topic == null ? null : NestedValueProvider.of(topic, new TopicPathTranslator());
-      @Nullable ValueProvider<SubscriptionPath> subscriptionPath =
-          subscription == null
+      @Nullable
+      ValueProvider<ProjectPath> projectPath =
+          getTopicProvider() == null
               ? null
-              : NestedValueProvider.of(subscription, new SubscriptionPathTranslator());
-      PubsubUnboundedSource<T> source = new PubsubUnboundedSource<T>(
-              FACTORY, projectPath, topicPath, subscriptionPath,
-              coder, timestampLabel, idLabel, parseFn);
+              : NestedValueProvider.of(getTopicProvider(), new ProjectPathTranslator());
+      @Nullable
+      ValueProvider<TopicPath> topicPath =
+          getTopicProvider() == null
+              ? null
+              : NestedValueProvider.of(getTopicProvider(), new TopicPathTranslator());
+      @Nullable
+      ValueProvider<SubscriptionPath> subscriptionPath =
+          getSubscriptionProvider() == null
+              ? null
+              : NestedValueProvider.of(getSubscriptionProvider(), new SubscriptionPathTranslator());
+      PubsubUnboundedSource<T> source =
+          new PubsubUnboundedSource<T>(
+              FACTORY,
+              projectPath,
+              topicPath,
+              subscriptionPath,
+              getCoder(),
+              getTimestampLabel(),
+              getIdLabel(),
+              getParseFn());
       return input.getPipeline().apply(source);
     }
 
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      populateCommonDisplayData(builder, timestampLabel, idLabel, topic);
+      populateCommonDisplayData(builder, getTimestampLabel(), getIdLabel(), getTopicProvider());
 
-      if (subscription != null) {
-        String subscriptionString = subscription.isAccessible()
-            ? subscription.get().asPath() : subscription.toString();
+      if (getSubscriptionProvider() != null) {
+        String subscriptionString = getSubscriptionProvider().isAccessible()
+            ? getSubscriptionProvider().get().asPath() : getSubscriptionProvider().toString();
         builder.add(DisplayData.item("subscription", subscriptionString)
             .withLabel("Pubsub Subscription"));
       }
@@ -688,72 +690,8 @@ public class PubsubIO {
 
     @Override
     protected Coder<T> getDefaultOutputCoder() {
-      return coder;
+      return getCoder();
     }
-
-    /**
-     * Get the topic being read from.
-     */
-    @Nullable
-    public PubsubTopic getTopic() {
-      return topic == null ? null : topic.get();
-    }
-
-    /**
-     * Get the {@link ValueProvider} for the topic being read from.
-     */
-    public ValueProvider<PubsubTopic> getTopicProvider() {
-      return topic;
-    }
-
-    /**
-     * Get the subscription being read from.
-     */
-    @Nullable
-    public PubsubSubscription getSubscription() {
-      return subscription == null ? null : subscription.get();
-    }
-
-    /**
-     * Get the {@link ValueProvider} for the subscription being read from.
-     */
-    public ValueProvider<PubsubSubscription> getSubscriptionProvider() {
-      return subscription;
-    }
-
-    /**
-     * Get the timestamp label.
-     */
-    @Nullable
-    public String getTimestampLabel() {
-      return timestampLabel;
-    }
-
-    /**
-     * Get the id label.
-     */
-    @Nullable
-    public String getIdLabel() {
-      return idLabel;
-    }
-
-
-    /**
-     * Get the {@link Coder} used for the transform's output.
-     */
-    @Nullable
-    public Coder<T> getCoder() {
-      return coder;
-    }
-
-    /**
-     * Get the parse function used for PubSub attributes.
-     */
-    @Nullable
-    public SimpleFunction<PubsubMessage, T> getPubSubMessageParseFn() {
-      return parseFn;
-    }
-
   }
 
   /////////////////////////////////////////////////////////////////////////////

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -474,8 +474,8 @@ public class PubsubIO {
   }
 
   /**
-   * Returns A {@link PTransform} that continuously reads binary encoded protos of the given type
-   * from a Google Cloud Pub/Sub stream.
+   * Returns A {@link PTransform} that continuously reads binary encoded protobuf messages of the
+   * given type from a Google Cloud Pub/Sub stream.
    */
   public static <T extends Message> Read<T> readProtos(Class<T> messageClass) {
     return PubsubIO.<T>read().withCoder(ProtoCoder.of(messageClass));
@@ -492,6 +492,30 @@ public class PubsubIO {
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */
   public static <T> Write<T> write() {
     return new AutoValue_PubsubIO_Write.Builder<T>().build();
+  }
+
+  /**
+   * Returns A {@link PTransform} that writes UTF-8 encoded strings to a Google Cloud Pub/Sub
+   * stream.
+   */
+  public static Write<String> writeStrings() {
+    return PubsubIO.<String>write().withCoder(StringUtf8Coder.of());
+  }
+
+  /**
+   * Returns A {@link PTransform} that writes binary encoded protobuf messages of a given type
+   * to a Google Cloud Pub/Sub stream.
+   */
+  public static <T extends Message> Write<T> writeProtos(Class<T> messageClass) {
+    return PubsubIO.<T>write().withCoder(ProtoCoder.of(messageClass));
+  }
+
+  /**
+   * Returns A {@link PTransform} that writes binary encoded Avro messages of a given type
+   * to a Google Cloud Pub/Sub stream.
+   */
+  public static <T extends Message> Write<T> writeAvros(Class<T> clazz) {
+    return PubsubIO.<T>write().withCoder(AvroCoder.of(clazz));
   }
 
   /** Implementation of {@link #read}. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -742,14 +742,14 @@ public class PubsubIO {
      * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format of the
      * {@code topic} string.
      */
-    public Write<T> topic(String topic) {
-      return topic(StaticValueProvider.of(topic));
+    public Write<T> to(String topic) {
+      return to(StaticValueProvider.of(topic));
     }
 
     /**
      * Like {@code topic()} but with a {@link ValueProvider}.
      */
-    public Write<T> topic(ValueProvider<String> topic) {
+    public Write<T> to(ValueProvider<String> topic) {
       return toBuilder()
           .setTopicProvider(NestedValueProvider.of(topic, new TopicTranslator()))
           .build();
@@ -765,7 +765,7 @@ public class PubsubIO {
      * {@link PubsubIO.Read#withTimestampLabel(String)} can be used to ensure the other source reads
      * these timestamps from the appropriate attribute.
      */
-    public Write<T> timestampLabel(String timestampLabel) {
+    public Write<T> withTimestampLabel(String timestampLabel) {
       return toBuilder().setTimestampLabel(timestampLabel).build();
     }
 
@@ -777,7 +777,7 @@ public class PubsubIO {
      * {@link PubsubIO.Read#withIdLabel(String)} can be used to ensure that* the other source reads
      * these unique identifiers from the appropriate attribute.
      */
-    public Write<T> idLabel(String idLabel) {
+    public Write<T> withIdLabel(String idLabel) {
       return toBuilder().setIdLabel(idLabel).build();
     }
 
@@ -794,7 +794,7 @@ public class PubsubIO {
      * function translates the input type T to a PubsubMessage object, which is used by the sink
      * to separately set the PubSub message's payload and attributes.
      */
-    public Write<T> withAttributes(SimpleFunction<T, PubsubMessage> formatFn) {
+    public Write<T> withFormatFn(SimpleFunction<T, PubsubMessage> formatFn) {
       return toBuilder().setFormatFn(formatFn).build();
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
+import com.google.protobuf.Message;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -29,8 +30,11 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.OutgoingMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.ProjectPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
@@ -459,6 +463,30 @@ public class PubsubIO {
    /** Returns A {@link PTransform} that continuously reads from a Google Cloud Pub/Sub stream. */
   public static <T> Read<T> read() {
     return new AutoValue_PubsubIO_Read.Builder<T>().build();
+  }
+
+  /**
+   * Returns A {@link PTransform} that continuously reads UTF-8 encoded strings from a Google Cloud
+   * Pub/Sub stream.
+   */
+  public static Read<String> readStrings() {
+    return PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
+  }
+
+  /**
+   * Returns A {@link PTransform} that continuously reads binary encoded protos of the given type
+   * from a Google Cloud Pub/Sub stream.
+   */
+  public static <T extends Message> Read<T> readProtos(Class<T> messageClass) {
+    return PubsubIO.<T>read().withCoder(ProtoCoder.of(messageClass));
+  }
+
+  /**
+   * Returns A {@link PTransform} that continuously reads binary encoded Avro messages of the
+   * given type from a Google Cloud Pub/Sub stream.
+   */
+  public static <T extends Message> Read<T> readAvros(Class<T> clazz) {
+    return PubsubIO.<T>read().withCoder(AvroCoder.of(clazz));
   }
 
   /** Returns A {@link PTransform} that writes to a Google Cloud Pub/Sub stream. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -136,12 +136,12 @@ public class PubsubIO {
    * Populate common {@link DisplayData} between Pubsub source and sink.
    */
   private static void populateCommonDisplayData(DisplayData.Builder builder,
-      String timestampLabel, String idLabel, ValueProvider<PubsubTopic> topic) {
+      String timestampAttribute, String idAttribute, ValueProvider<PubsubTopic> topic) {
     builder
-        .addIfNotNull(DisplayData.item("timestampLabel", timestampLabel)
-            .withLabel("Timestamp Label Attribute"))
-        .addIfNotNull(DisplayData.item("idLabel", idLabel)
-            .withLabel("ID Label Attribute"));
+        .addIfNotNull(DisplayData.item("timestampAttribute", timestampAttribute)
+            .withLabel("Timestamp Attribute"))
+        .addIfNotNull(DisplayData.item("idAttribute", idAttribute)
+            .withLabel("ID Attribute"));
 
     if (topic != null) {
       String topicString = topic.isAccessible() ? topic.get().asPath()
@@ -529,11 +529,11 @@ public class PubsubIO {
 
     /** The name of the message attribute to read timestamps from. */
     @Nullable
-    abstract String getTimestampLabel();
+    abstract String getTimestampAttribute();
 
     /** The name of the message attribute to read unique message IDs from. */
     @Nullable
-    abstract String getIdLabel();
+    abstract String getIdAttribute();
 
     /** The coder used to decode each record. */
     @Nullable
@@ -551,9 +551,9 @@ public class PubsubIO {
 
       abstract Builder<T> setSubscriptionProvider(ValueProvider<PubsubSubscription> subscription);
 
-      abstract Builder<T> setTimestampLabel(String timestampLabel);
+      abstract Builder<T> setTimestampAttribute(String timestampAttribute);
 
-      abstract Builder<T> setIdLabel(String idLabel);
+      abstract Builder<T> setIdAttribute(String idAttribute);
 
       abstract Builder<T> setCoder(Coder<T> coder);
 
@@ -633,7 +633,7 @@ public class PubsubIO {
      * (i.e., time units smaller than milliseconds) will be ignored.
      * </ul>
      *
-     * <p>If {@code timestampLabel} is not provided, the system will generate record timestamps
+     * <p>If {@code timestampAttribute} is not provided, the system will generate record timestamps
      * the first time it sees each record. All windowing will be done relative to these
      * timestamps.
      *
@@ -643,12 +643,12 @@ public class PubsubIO {
      * specified with the windowing strategy &ndash; by default it will be output immediately.
      *
      * <p>Note that the system can guarantee that no late data will ever be seen when it assigns
-     * timestamps by arrival time (i.e. {@code timestampLabel} is not provided).
+     * timestamps by arrival time (i.e. {@code timestampAttribute} is not provided).
      *
      * @see <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>
      */
-    public Read<T> withTimestampLabel(String timestampLabel) {
-      return toBuilder().setTimestampLabel(timestampLabel).build();
+    public Read<T> withTimestampAttribute(String timestampAttribute) {
+      return toBuilder().setTimestampAttribute(timestampAttribute).build();
     }
 
     /**
@@ -657,11 +657,11 @@ public class PubsubIO {
      * The value of the attribute can be any string that uniquely identifies this record.
      *
      * <p>Pub/Sub cannot guarantee that no duplicate data will be delivered on the Pub/Sub stream.
-     * If {@code idLabel} is not provided, Beam cannot guarantee that no duplicate data will
+     * If {@code idAttribute} is not provided, Beam cannot guarantee that no duplicate data will
      * be delivered, and deduplication of the stream will be strictly best effort.
      */
-    public Read<T> withIdLabel(String idLabel) {
-      return toBuilder().setIdLabel(idLabel).build();
+    public Read<T> withIdAttribute(String idAttribute) {
+      return toBuilder().setIdAttribute(idAttribute).build();
     }
 
     /**
@@ -718,8 +718,8 @@ public class PubsubIO {
               topicPath,
               subscriptionPath,
               getCoder(),
-              getTimestampLabel(),
-              getIdLabel(),
+              getTimestampAttribute(),
+              getIdAttribute(),
               getParseFn());
       return input.getPipeline().apply(source);
     }
@@ -727,7 +727,8 @@ public class PubsubIO {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      populateCommonDisplayData(builder, getTimestampLabel(), getIdLabel(), getTopicProvider());
+      populateCommonDisplayData(
+          builder, getTimestampAttribute(), getIdAttribute(), getTopicProvider());
 
       if (getSubscriptionProvider() != null) {
         String subscriptionString = getSubscriptionProvider().isAccessible()
@@ -757,11 +758,11 @@ public class PubsubIO {
 
     /** The name of the message attribute to publish message timestamps in. */
     @Nullable
-    abstract String getTimestampLabel();
+    abstract String getTimestampAttribute();
 
     /** The name of the message attribute to publish unique message IDs in. */
     @Nullable
-    abstract String getIdLabel();
+    abstract String getIdAttribute();
 
     /** The input type Coder. */
     @Nullable
@@ -777,9 +778,9 @@ public class PubsubIO {
     abstract static class Builder<T> {
       abstract Builder<T> setTopicProvider(ValueProvider<PubsubTopic> topicProvider);
 
-      abstract Builder<T> setTimestampLabel(String timestampLabel);
+      abstract Builder<T> setTimestampAttribute(String timestampAttribute);
 
-      abstract Builder<T> setIdLabel(String idLabel);
+      abstract Builder<T> setIdAttribute(String idAttribute);
 
       abstract Builder<T> setCoder(Coder<T> coder);
 
@@ -814,23 +815,23 @@ public class PubsubIO {
      * time classes, {@link Instant#Instant(long)} can be used to parse this value.
      *
      * <p>If the output from this sink is being read by another Beam pipeline, then
-     * {@link PubsubIO.Read#withTimestampLabel(String)} can be used to ensure the other source reads
-     * these timestamps from the appropriate attribute.
+     * {@link PubsubIO.Read#withTimestampAttribute(String)} can be used to ensure the other source
+     * reads these timestamps from the appropriate attribute.
      */
-    public Write<T> withTimestampLabel(String timestampLabel) {
-      return toBuilder().setTimestampLabel(timestampLabel).build();
+    public Write<T> withTimestampAttribute(String timestampAttribute) {
+      return toBuilder().setTimestampAttribute(timestampAttribute).build();
     }
 
     /**
      * Writes to Pub/Sub, adding each record's unique identifier to the published messages in an
      * attribute with the specified name. The value of the attribute is an opaque string.
      *
-     * <p>If the the output from this sink is being read by another Beam pipeline, then
-     * {@link PubsubIO.Read#withIdLabel(String)} can be used to ensure that* the other source reads
+     * <p>If the the output from this sink is being read by another Beam pipeline, then {@link
+     * PubsubIO.Read#withIdAttribute(String)} can be used to ensure that* the other source reads
      * these unique identifiers from the appropriate attribute.
      */
-    public Write<T> withIdLabel(String idLabel) {
-      return toBuilder().setIdLabel(idLabel).build();
+    public Write<T> withIdAttribute(String idAttribute) {
+      return toBuilder().setIdAttribute(idAttribute).build();
     }
 
     /**
@@ -864,8 +865,8 @@ public class PubsubIO {
               FACTORY,
               NestedValueProvider.of(getTopicProvider(), new TopicPathTranslator()),
               getCoder(),
-              getTimestampLabel(),
-              getIdLabel(),
+              getTimestampAttribute(),
+              getIdAttribute(),
               getFormatFn(),
               100 /* numShards */));
       }
@@ -875,7 +876,8 @@ public class PubsubIO {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      populateCommonDisplayData(builder, getTimestampLabel(), getIdLabel(), getTopicProvider());
+      populateCommonDisplayData(
+          builder, getTimestampAttribute(), getIdAttribute(), getTopicProvider());
     }
 
     @Override
@@ -897,9 +899,9 @@ public class PubsubIO {
       @StartBundle
       public void startBundle(Context c) throws IOException {
         this.output = new ArrayList<>();
-        // NOTE: idLabel is ignored.
+        // NOTE: idAttribute is ignored.
         this.pubsubClient =
-            FACTORY.newClient(getTimestampLabel(), null,
+            FACTORY.newClient(getTimestampAttribute(), null,
                 c.getPipelineOptions().as(PubsubOptions.class));
       }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -519,14 +519,14 @@ public class PubsubIO {
      * some arbitrary portion of the data.  Most likely, separate readers should
      * use their own subscriptions.
      */
-    public Read<T> subscription(String subscription) {
-      return subscription(StaticValueProvider.of(subscription));
+    public Read<T> fromSubscription(String subscription) {
+      return fromSubscription(StaticValueProvider.of(subscription));
     }
 
     /**
      * Like {@code subscription()} but with a {@link ValueProvider}.
      */
-    public Read<T> subscription(ValueProvider<String> subscription) {
+    public Read<T> fromSubscription(ValueProvider<String> subscription) {
       if (subscription.isAccessible()) {
         // Validate.
         PubsubSubscription.fromPath(subscription.get());
@@ -541,7 +541,7 @@ public class PubsubIO {
 
     /**
      * Creates and returns a transform for reading from a Cloud Pub/Sub topic. Mutually exclusive
-     * with {@link #subscription(String)}.
+     * with {@link #fromSubscription(String)}.
      *
      * <p>See {@link PubsubIO.PubsubTopic#fromPath(String)} for more details on the format
      * of the {@code topic} string.
@@ -550,14 +550,14 @@ public class PubsubIO {
      * pipeline is started. Any data published on the topic before the pipeline is started will
      * not be read by the runner.
      */
-    public Read<T> topic(String topic) {
-      return topic(StaticValueProvider.of(topic));
+    public Read<T> fromTopic(String topic) {
+      return fromTopic(StaticValueProvider.of(topic));
     }
 
     /**
      * Like {@code topic()} but with a {@link ValueProvider}.
      */
-    public Read<T> topic(ValueProvider<String> topic) {
+    public Read<T> fromTopic(ValueProvider<String> topic) {
       if (topic.isAccessible()) {
         // Validate.
         PubsubTopic.fromPath(topic.get());
@@ -598,7 +598,7 @@ public class PubsubIO {
      *
      * @see <a href="https://www.ietf.org/rfc/rfc3339.txt">RFC 3339</a>
      */
-    public Read<T> timestampLabel(String timestampLabel) {
+    public Read<T> withTimestampLabel(String timestampLabel) {
       return toBuilder().setTimestampLabel(timestampLabel).build();
     }
 
@@ -611,7 +611,7 @@ public class PubsubIO {
      * If {@code idLabel} is not provided, Beam cannot guarantee that no duplicate data will
      * be delivered, and deduplication of the stream will be strictly best effort.
      */
-    public Read<T> idLabel(String idLabel) {
+    public Read<T> withIdLabel(String idLabel) {
       return toBuilder().setIdLabel(idLabel).build();
     }
 
@@ -628,7 +628,7 @@ public class PubsubIO {
      * A Coder for the output type T must be registered or set on the output via
      * {@link PCollection#setCoder(Coder)}.
      */
-    public Read<T> withAttributes(SimpleFunction<PubsubMessage, T> parseFn) {
+    public Read<T> withParseFn(SimpleFunction<PubsubMessage, T> parseFn) {
       return toBuilder().setParseFn(parseFn).build();
     }
 
@@ -760,7 +760,7 @@ public class PubsubIO {
      * time classes, {@link Instant#Instant(long)} can be used to parse this value.
      *
      * <p>If the output from this sink is being read by another Beam pipeline, then
-     * {@link PubsubIO.Read#timestampLabel(String)} can be used to ensure the other source reads
+     * {@link PubsubIO.Read#withTimestampLabel(String)} can be used to ensure the other source reads
      * these timestamps from the appropriate attribute.
      */
     public Write<T> timestampLabel(String timestampLabel) {
@@ -773,7 +773,7 @@ public class PubsubIO {
      * opaque string.
      *
      * <p>If the the output from this sink is being read by another Beam pipeline, then
-     * {@link PubsubIO.Read#idLabel(String)} can be used to ensure that* the other source reads
+     * {@link PubsubIO.Read#withIdLabel(String)} can be used to ensure that* the other source reads
      * these unique identifiers from the appropriate attribute.
      */
     public Write<T> idLabel(String idLabel) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
@@ -69,7 +69,7 @@ class PubsubJsonClient extends PubsubClient {
 
     @Override
     public PubsubClient newClient(
-        @Nullable String timestampLabel, @Nullable String idLabel, PubsubOptions options)
+        @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
         throws IOException {
       Pubsub pubsub = new Builder(
           Transport.getTransport(),
@@ -82,7 +82,7 @@ class PubsubJsonClient extends PubsubClient {
           .setApplicationName(options.getAppName())
           .setGoogleClientRequestInitializer(options.getGoogleApiTrace())
           .build();
-      return new PubsubJsonClient(timestampLabel, idLabel, pubsub);
+      return new PubsubJsonClient(timestampAttribute, idAttribute, pubsub);
     }
 
     @Override
@@ -97,17 +97,17 @@ class PubsubJsonClient extends PubsubClient {
   public static final PubsubClientFactory FACTORY = new PubsubJsonClientFactory();
 
   /**
-   * Label to use for custom timestamps, or {@literal null} if should use Pubsub publish time
+   * Attribute to use for custom timestamps, or {@literal null} if should use Pubsub publish time
    * instead.
    */
   @Nullable
-  private final String timestampLabel;
+  private final String timestampAttribute;
 
   /**
-   * Label to use for custom ids, or {@literal null} if should use Pubsub provided ids.
+   * Attribute to use for custom ids, or {@literal null} if should use Pubsub provided ids.
    */
   @Nullable
-  private final String idLabel;
+  private final String idAttribute;
 
   /**
    * Underlying JSON transport.
@@ -116,11 +116,11 @@ class PubsubJsonClient extends PubsubClient {
 
   @VisibleForTesting
   PubsubJsonClient(
-      @Nullable String timestampLabel,
-      @Nullable String idLabel,
+      @Nullable String timestampAttribute,
+      @Nullable String idAttribute,
       Pubsub pubsub) {
-    this.timestampLabel = timestampLabel;
-    this.idLabel = idLabel;
+    this.timestampAttribute = timestampAttribute;
+    this.idAttribute = idAttribute;
     this.pubsub = pubsub;
   }
 
@@ -137,19 +137,19 @@ class PubsubJsonClient extends PubsubClient {
       PubsubMessage pubsubMessage = new PubsubMessage().encodeData(outgoingMessage.elementBytes);
 
       Map<String, String> attributes = outgoingMessage.attributes;
-      if ((timestampLabel != null || idLabel != null) && attributes == null) {
+      if ((timestampAttribute != null || idAttribute != null) && attributes == null) {
         attributes = new TreeMap<>();
       }
       if (attributes != null) {
         pubsubMessage.setAttributes(attributes);
       }
 
-      if (timestampLabel != null) {
-        attributes.put(timestampLabel, String.valueOf(outgoingMessage.timestampMsSinceEpoch));
+      if (timestampAttribute != null) {
+        attributes.put(timestampAttribute, String.valueOf(outgoingMessage.timestampMsSinceEpoch));
       }
 
-      if (idLabel != null && !Strings.isNullOrEmpty(outgoingMessage.recordId)) {
-        attributes.put(idLabel, outgoingMessage.recordId);
+      if (idAttribute != null && !Strings.isNullOrEmpty(outgoingMessage.recordId)) {
+        attributes.put(idAttribute, outgoingMessage.recordId);
       }
 
       pubsubMessages.add(pubsubMessage);
@@ -188,7 +188,7 @@ class PubsubJsonClient extends PubsubClient {
 
       // Timestamp.
       long timestampMsSinceEpoch =
-          extractTimestamp(timestampLabel, message.getMessage().getPublishTime(), attributes);
+          extractTimestamp(timestampAttribute, message.getMessage().getPublishTime(), attributes);
 
       // Ack id.
       String ackId = message.getAckId();
@@ -196,8 +196,8 @@ class PubsubJsonClient extends PubsubClient {
 
       // Record id, if any.
       @Nullable String recordId = null;
-      if (idLabel != null && attributes != null) {
-        recordId = attributes.get(idLabel);
+      if (idAttribute != null && attributes != null) {
+        recordId = attributes.get(idAttribute);
       }
       if (Strings.isNullOrEmpty(recordId)) {
         // Fall back to the Pubsub provided message id.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
@@ -136,7 +136,7 @@ class PubsubTestClient extends PubsubClient implements Serializable {
     return new PubsubTestClientFactory() {
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampLabel, @Nullable String idLabel, PubsubOptions options)
+          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient();
       }
@@ -182,7 +182,7 @@ class PubsubTestClient extends PubsubClient implements Serializable {
     return new PubsubTestClientFactory() {
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampLabel, @Nullable String idLabel, PubsubOptions options)
+          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient();
       }
@@ -226,7 +226,7 @@ class PubsubTestClient extends PubsubClient implements Serializable {
 
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampLabel, @Nullable String idLabel, PubsubOptions options)
+          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient() {
           @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
@@ -82,7 +82,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A PTransform which streams messages from Pubsub.
+ * Users should use {@link PubsubIO#read} instead.
+ *
+ * <p>A PTransform which streams messages from Pubsub.
  * <ul>
  * <li>The underlying implementation in an {@link UnboundedSource} which receives messages
  * in batches and hands them out one at a time.

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClientTest.java
@@ -45,8 +45,8 @@ public class PubsubClientTest {
   //
 
   private long parse(String timestamp) {
-    Map<String, String> map = ImmutableMap.of("myLabel", timestamp);
-    return PubsubClient.extractTimestamp("myLabel", null, map);
+    Map<String, String> map = ImmutableMap.of("myAttribute", timestamp);
+    return PubsubClient.extractTimestamp("myAttribute", null, map);
   }
 
   private void roundTripRfc339(String timestamp) {
@@ -58,106 +58,106 @@ public class PubsubClientTest {
   }
 
   @Test
-  public void noTimestampLabelReturnsPubsubPublish() {
+  public void noTimestampAttributeReturnsPubsubPublish() {
     final long time = 987654321L;
     long timestamp = PubsubClient.extractTimestamp(null, String.valueOf(time), null);
     assertEquals(time, timestamp);
   }
 
   @Test
-  public void noTimestampLabelAndInvalidPubsubPublishThrowsError() {
+  public void noTimestampAttributeAndInvalidPubsubPublishThrowsError() {
     thrown.expect(NumberFormatException.class);
     PubsubClient.extractTimestamp(null, "not-a-date", null);
   }
 
   @Test
-  public void timestampLabelWithNullAttributesThrowsError() {
+  public void timestampAttributeWithNullAttributesThrowsError() {
     thrown.expect(RuntimeException.class);
-    thrown.expectMessage("PubSub message is missing a value for timestamp label myLabel");
-    PubsubClient.extractTimestamp("myLabel", null, null);
+    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
+    PubsubClient.extractTimestamp("myAttribute", null, null);
   }
 
   @Test
-  public void timestampLabelSetWithMissingAttributeThrowsError() {
+  public void timestampAttributeSetWithMissingAttributeThrowsError() {
     thrown.expect(RuntimeException.class);
-    thrown.expectMessage("PubSub message is missing a value for timestamp label myLabel");
+    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
     Map<String, String> map = ImmutableMap.of("otherLabel", "whatever");
-    PubsubClient.extractTimestamp("myLabel", null, map);
+    PubsubClient.extractTimestamp("myAttribute", null, map);
   }
 
   @Test
-  public void timestampLabelParsesMillisecondsSinceEpoch() {
+  public void timestampAttributeParsesMillisecondsSinceEpoch() {
     long time = 1446162101123L;
-    Map<String, String> map = ImmutableMap.of("myLabel", String.valueOf(time));
-    long timestamp = PubsubClient.extractTimestamp("myLabel", null, map);
+    Map<String, String> map = ImmutableMap.of("myAttribute", String.valueOf(time));
+    long timestamp = PubsubClient.extractTimestamp("myAttribute", null, map);
     assertEquals(time, timestamp);
   }
 
   @Test
-  public void timestampLabelParsesRfc3339Seconds() {
+  public void timestampAttributeParsesRfc3339Seconds() {
     roundTripRfc339("2015-10-29T23:41:41Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339Tenths() {
+  public void timestampAttributeParsesRfc3339Tenths() {
     roundTripRfc339("2015-10-29T23:41:41.1Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339Hundredths() {
+  public void timestampAttributeParsesRfc3339Hundredths() {
     roundTripRfc339("2015-10-29T23:41:41.12Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339Millis() {
+  public void timestampAttributeParsesRfc3339Millis() {
     roundTripRfc339("2015-10-29T23:41:41.123Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339Micros() {
+  public void timestampAttributeParsesRfc3339Micros() {
     // Note: micros part 456/1000 is dropped.
     truncatedRfc339("2015-10-29T23:41:41.123456Z", "2015-10-29T23:41:41.123Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339MicrosRounding() {
+  public void timestampAttributeParsesRfc3339MicrosRounding() {
     // Note: micros part 999/1000 is dropped, not rounded up.
     truncatedRfc339("2015-10-29T23:41:41.123999Z", "2015-10-29T23:41:41.123Z");
   }
 
   @Test
-  public void timestampLabelWithInvalidFormatThrowsError() {
+  public void timestampAttributeWithInvalidFormatThrowsError() {
     thrown.expect(NumberFormatException.class);
     parse("not-a-timestamp");
   }
 
   @Test
-  public void timestampLabelWithInvalidFormat2ThrowsError() {
+  public void timestampAttributeWithInvalidFormat2ThrowsError() {
     thrown.expect(NumberFormatException.class);
     parse("null");
   }
 
   @Test
-  public void timestampLabelWithInvalidFormat3ThrowsError() {
+  public void timestampAttributeWithInvalidFormat3ThrowsError() {
     thrown.expect(NumberFormatException.class);
     parse("2015-10");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339WithSmallYear() {
+  public void timestampAttributeParsesRfc3339WithSmallYear() {
     // Google and JodaTime agree on dates after 1582-10-15, when the Gregorian Calendar was adopted
     // This is therefore a "small year" until this difference is reconciled.
     roundTripRfc339("1582-10-15T01:23:45.123Z");
   }
 
   @Test
-  public void timestampLabelParsesRfc3339WithLargeYear() {
+  public void timestampAttributeParsesRfc3339WithLargeYear() {
     // Year 9999 in range.
     roundTripRfc339("9999-10-29T23:41:41.123999Z");
   }
 
   @Test
-  public void timestampLabelRfc3339WithTooLargeYearThrowsError() {
+  public void timestampAttributeRfc3339WithTooLargeYearThrowsError() {
     thrown.expect(NumberFormatException.class);
     // Year 10000 out of range.
     parse("10000-10-29T23:41:41.123999Z");

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
@@ -72,8 +72,8 @@ public class PubsubGrpcClientTest {
   private static final long REQ_TIME = 1234L;
   private static final long PUB_TIME = 3456L;
   private static final long MESSAGE_TIME = 6789L;
-  private static final String TIMESTAMP_LABEL = "timestamp";
-  private static final String ID_LABEL = "id";
+  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final String ID_ATTRIBUTE = "id";
   private static final String MESSAGE_ID = "testMessageId";
   private static final String DATA = "testData";
   private static final String RECORD_ID = "testRecordId";
@@ -87,7 +87,9 @@ public class PubsubGrpcClientTest {
         PubsubGrpcClientTest.class.getName(), ThreadLocalRandom.current().nextInt());
     inProcessChannel = InProcessChannelBuilder.forName(channelName).directExecutor().build();
     testCredentials = new TestCredential();
-    client = new PubsubGrpcClient(TIMESTAMP_LABEL, ID_LABEL, 10, inProcessChannel, testCredentials);
+    client =
+        new PubsubGrpcClient(
+            TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, 10, inProcessChannel, testCredentials);
   }
 
   @After
@@ -117,9 +119,9 @@ public class PubsubGrpcClientTest {
                      .setPublishTime(timestamp)
                      .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
-                         ImmutableMap.of(TIMESTAMP_LABEL,
+                         ImmutableMap.of(TIMESTAMP_ATTRIBUTE,
                                          String.valueOf(MESSAGE_TIME),
-                                         ID_LABEL, RECORD_ID))
+                             ID_ATTRIBUTE, RECORD_ID))
                      .build();
     ReceivedMessage expectedReceivedMessage =
         ReceivedMessage.newBuilder()
@@ -167,8 +169,8 @@ public class PubsubGrpcClientTest {
                      .setData(ByteString.copyFrom(DATA.getBytes()))
                      .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
-                         ImmutableMap.of(TIMESTAMP_LABEL, String.valueOf(MESSAGE_TIME),
-                                         ID_LABEL, RECORD_ID))
+                         ImmutableMap.of(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME),
+                                         ID_ATTRIBUTE, RECORD_ID))
                      .build();
     final PublishRequest expectedRequest =
         PublishRequest.newBuilder()

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.Set;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.UsesUnboundedPCollections;
 import org.apache.beam.sdk.testing.ValidatesRunner;
@@ -146,7 +145,7 @@ public class PubsubIOTest {
   public void testPrimitiveReadDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
     Set<DisplayData> displayData;
-    PubsubIO.Read<String> baseRead = PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
+    PubsubIO.Read<String> baseRead = PubsubIO.readStrings();
 
     // Reading from a subscription.
     PubsubIO.Read<String> read =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -50,19 +50,19 @@ public class PubsubIOTest {
   @Test
   public void testPubsubIOGetName() {
     assertEquals("PubsubIO.Read",
-        PubsubIO.<String>read().topic("projects/myproject/topics/mytopic").getName());
+        PubsubIO.<String>read().fromTopic("projects/myproject/topics/mytopic").getName());
     assertEquals("PubsubIO.Write",
         PubsubIO.<String>write().topic("projects/myproject/topics/mytopic").getName());
   }
 
   @Test
   public void testTopicValidationSuccess() throws Exception {
-    PubsubIO.<String>read().topic("projects/my-project/topics/abc");
-    PubsubIO.<String>read().topic("projects/my-project/topics/ABC");
-    PubsubIO.<String>read().topic("projects/my-project/topics/AbC-DeF");
-    PubsubIO.<String>read().topic("projects/my-project/topics/AbC-1234");
-    PubsubIO.<String>read().topic("projects/my-project/topics/AbC-1234-_.~%+-_.~%+-_.~%+-abc");
-    PubsubIO.<String>read().topic(new StringBuilder()
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/abc");
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/ABC");
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-DeF");
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-1234");
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/AbC-1234-_.~%+-_.~%+-_.~%+-abc");
+    PubsubIO.<String>read().fromTopic(new StringBuilder()
         .append("projects/my-project/topics/A-really-long-one-")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
@@ -73,13 +73,13 @@ public class PubsubIOTest {
   @Test
   public void testTopicValidationBadCharacter() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    PubsubIO.<String>read().topic("projects/my-project/topics/abc-*-abc");
+    PubsubIO.<String>read().fromTopic("projects/my-project/topics/abc-*-abc");
   }
 
   @Test
   public void testTopicValidationTooLong() throws Exception {
     thrown.expect(IllegalArgumentException.class);
-    PubsubIO.<String>read().topic(new StringBuilder().append
+    PubsubIO.<String>read().fromTopic(new StringBuilder().append
         ("projects/my-project/topics/A-really-long-one-")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
         .append("111111111111111111111111111111111111111111111111111111111111111111111111111111111")
@@ -93,9 +93,9 @@ public class PubsubIOTest {
     String subscription = "projects/project/subscriptions/subscription";
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.<String>read()
-        .topic(StaticValueProvider.of(topic))
-        .timestampLabel("myTimestamp")
-        .idLabel("myId");
+        .fromTopic(StaticValueProvider.of(topic))
+        .withTimestampLabel("myTimestamp")
+        .withIdLabel("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
@@ -110,9 +110,9 @@ public class PubsubIOTest {
     String subscription = "projects/project/subscriptions/subscription";
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.<String>read()
-        .subscription(StaticValueProvider.of(subscription))
-        .timestampLabel("myTimestamp")
-        .idLabel("myId");
+        .fromSubscription(StaticValueProvider.of(subscription))
+        .withTimestampLabel("myTimestamp")
+        .withIdLabel("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
@@ -125,7 +125,7 @@ public class PubsubIOTest {
   public void testNullTopic() {
     String subscription = "projects/project/subscriptions/subscription";
     PubsubIO.Read<String> read = PubsubIO.<String>read()
-        .subscription(StaticValueProvider.of(subscription));
+        .fromSubscription(StaticValueProvider.of(subscription));
     assertNull(read.getTopicProvider());
     assertNotNull(read.getSubscriptionProvider());
     assertNotNull(DisplayData.from(read));
@@ -135,7 +135,7 @@ public class PubsubIOTest {
   public void testNullSubscription() {
     String topic = "projects/project/topics/topic";
     PubsubIO.Read<String> read = PubsubIO.<String>read()
-        .topic(StaticValueProvider.of(topic));
+        .fromTopic(StaticValueProvider.of(topic));
     assertNotNull(read.getTopicProvider());
     assertNull(read.getSubscriptionProvider());
     assertNotNull(DisplayData.from(read));
@@ -149,13 +149,13 @@ public class PubsubIOTest {
     PubsubIO.Read<String> read = PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
 
     // Reading from a subscription.
-    read = read.subscription("projects/project/subscriptions/subscription");
+    read = read.fromSubscription("projects/project/subscriptions/subscription");
     displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("PubsubIO.Read should include the subscription in its primitive display data",
         displayData, hasItem(hasDisplayItem("subscription")));
 
     // Reading from a topic.
-    read = read.topic("projects/project/topics/topic");
+    read = read.fromTopic("projects/project/topics/topic");
     displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("PubsubIO.Read should include the topic in its primitive display data",
         displayData, hasItem(hasDisplayItem("topic")));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -126,8 +126,8 @@ public class PubsubIOTest {
     String subscription = "projects/project/subscriptions/subscription";
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .subscription(StaticValueProvider.of(subscription));
-    assertNull(read.getTopic());
-    assertNotNull(read.getSubscription());
+    assertNull(read.getTopicProvider());
+    assertNotNull(read.getSubscriptionProvider());
     assertNotNull(DisplayData.from(read));
   }
 
@@ -136,8 +136,8 @@ public class PubsubIOTest {
     String topic = "projects/project/topics/topic";
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .topic(StaticValueProvider.of(topic));
-    assertNotNull(read.getTopic());
-    assertNull(read.getSubscription());
+    assertNotNull(read.getTopicProvider());
+    assertNull(read.getSubscriptionProvider());
     assertNotNull(DisplayData.from(read));
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -93,14 +93,14 @@ public class PubsubIOTest {
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .fromTopic(StaticValueProvider.of(topic))
-        .withTimestampLabel("myTimestamp")
-        .withIdLabel("myId");
+        .withTimestampAttribute("myTimestamp")
+        .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("topic", topic));
-    assertThat(displayData, hasDisplayItem("timestampLabel", "myTimestamp"));
-    assertThat(displayData, hasDisplayItem("idLabel", "myId"));
+    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 
   @Test
@@ -110,14 +110,14 @@ public class PubsubIOTest {
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.<String>read()
         .fromSubscription(StaticValueProvider.of(subscription))
-        .withTimestampLabel("myTimestamp")
-        .withIdLabel("myId");
+        .withTimestampAttribute("myTimestamp")
+        .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("subscription", subscription));
-    assertThat(displayData, hasDisplayItem("timestampLabel", "myTimestamp"));
-    assertThat(displayData, hasDisplayItem("idLabel", "myId"));
+    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 
   @Test
@@ -168,14 +168,14 @@ public class PubsubIOTest {
     String topic = "projects/project/topics/topic";
     PubsubIO.Write<?> write = PubsubIO.<String>write()
         .to(topic)
-        .withTimestampLabel("myTimestamp")
-        .withIdLabel("myId");
+        .withTimestampAttribute("myTimestamp")
+        .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(write);
 
     assertThat(displayData, hasDisplayItem("topic", topic));
-    assertThat(displayData, hasDisplayItem("timestampLabel", "myTimestamp"));
-    assertThat(displayData, hasDisplayItem("idLabel", "myId"));
+    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -146,16 +146,19 @@ public class PubsubIOTest {
   public void testPrimitiveReadDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
     Set<DisplayData> displayData;
-    PubsubIO.Read<String> read = PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
+    PubsubIO.Read<String> baseRead = PubsubIO.<String>read().withCoder(StringUtf8Coder.of());
 
     // Reading from a subscription.
-    read = read.fromSubscription("projects/project/subscriptions/subscription");
+    PubsubIO.Read<String> read =
+        baseRead.fromSubscription("projects/project/subscriptions/subscription");
     displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
-    assertThat("PubsubIO.Read should include the subscription in its primitive display data",
-        displayData, hasItem(hasDisplayItem("subscription")));
+    assertThat(
+        "PubsubIO.Read should include the subscription in its primitive display data",
+        displayData,
+        hasItem(hasDisplayItem("subscription")));
 
     // Reading from a topic.
-    read = read.fromTopic("projects/project/topics/topic");
+    read = baseRead.fromTopic("projects/project/topics/topic");
     displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("PubsubIO.Read should include the topic in its primitive display data",
         displayData, hasItem(hasDisplayItem("topic")));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -52,7 +52,7 @@ public class PubsubIOTest {
     assertEquals("PubsubIO.Read",
         PubsubIO.<String>read().fromTopic("projects/myproject/topics/mytopic").getName());
     assertEquals("PubsubIO.Write",
-        PubsubIO.<String>write().topic("projects/myproject/topics/mytopic").getName());
+        PubsubIO.<String>write().to("projects/myproject/topics/mytopic").getName());
   }
 
   @Test
@@ -168,9 +168,9 @@ public class PubsubIOTest {
   public void testWriteDisplayData() {
     String topic = "projects/project/topics/topic";
     PubsubIO.Write<?> write = PubsubIO.<String>write()
-        .topic(topic)
-        .timestampLabel("myTimestamp")
-        .idLabel("myId");
+        .to(topic)
+        .withTimestampLabel("myTimestamp")
+        .withIdLabel("myId");
 
     DisplayData displayData = DisplayData.from(write);
 
@@ -183,7 +183,7 @@ public class PubsubIOTest {
   @Category(ValidatesRunner.class)
   public void testPrimitiveWriteDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
-    PubsubIO.Write<?> write = PubsubIO.<String>write().topic("projects/project/topics/topic");
+    PubsubIO.Write<?> write = PubsubIO.<String>write().to("projects/project/topics/topic");
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(write);
     assertThat("PubsubIO.Write should include the topic in its primitive display data",

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
@@ -58,8 +58,8 @@ public class PubsubJsonClientTest {
   private static final long REQ_TIME = 1234L;
   private static final long PUB_TIME = 3456L;
   private static final long MESSAGE_TIME = 6789L;
-  private static final String TIMESTAMP_LABEL = "timestamp";
-  private static final String ID_LABEL = "id";
+  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final String ID_ATTRIBUTE = "id";
   private static final String MESSAGE_ID = "testMessageId";
   private static final String DATA = "testData";
   private static final String RECORD_ID = "testRecordId";
@@ -68,7 +68,7 @@ public class PubsubJsonClientTest {
   @Before
   public void setup() throws IOException {
     mockPubsub = Mockito.mock(Pubsub.class, Mockito.RETURNS_DEEP_STUBS);
-    client = new PubsubJsonClient(TIMESTAMP_LABEL, ID_LABEL, mockPubsub);
+    client = new PubsubJsonClient(TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, mockPubsub);
   }
 
   @After
@@ -88,8 +88,8 @@ public class PubsubJsonClientTest {
         .encodeData(DATA.getBytes())
         .setPublishTime(String.valueOf(PUB_TIME))
         .setAttributes(
-            ImmutableMap.of(TIMESTAMP_LABEL, String.valueOf(MESSAGE_TIME),
-                            ID_LABEL, RECORD_ID));
+            ImmutableMap.of(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME),
+                ID_ATTRIBUTE, RECORD_ID));
     ReceivedMessage expectedReceivedMessage =
         new ReceivedMessage().setMessage(expectedPubsubMessage)
                              .setAckId(ACK_ID);
@@ -117,8 +117,8 @@ public class PubsubJsonClientTest {
         .encodeData(DATA.getBytes())
         .setAttributes(
             ImmutableMap.<String, String> builder()
-                    .put(TIMESTAMP_LABEL, String.valueOf(MESSAGE_TIME))
-                    .put(ID_LABEL, RECORD_ID)
+                    .put(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME))
+                    .put(ID_ATTRIBUTE, RECORD_ID)
                     .put("k", "v").build());
     PublishRequest expectedRequest = new PublishRequest()
         .setMessages(ImmutableList.of(expectedPubsubMessage));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
@@ -58,8 +58,8 @@ public class PubsubUnboundedSinkTest implements Serializable {
   private static final Map<String, String> ATTRIBUTES =
           ImmutableMap.<String, String>builder().put("a", "b").put("c", "d").build();
   private static final long TIMESTAMP = 1234L;
-  private static final String TIMESTAMP_LABEL = "timestamp";
-  private static final String ID_LABEL = "id";
+  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final String ID_ATTRIBUTE = "id";
   private static final int NUM_SHARDS = 10;
 
   private static class Stamp extends DoFn<String, String> {
@@ -99,7 +99,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink<String> sink =
           new PubsubUnboundedSink<>(factory, StaticValueProvider.of(TOPIC), StringUtf8Coder.of(),
-              TIMESTAMP_LABEL, ID_LABEL, NUM_SHARDS, batchSize, batchBytes,
+              TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
               Duration.standardSeconds(2),
               new SimpleFunction<String, PubsubIO.PubsubMessage>() {
                 @Override
@@ -135,7 +135,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink<String> sink =
           new PubsubUnboundedSink<>(factory, StaticValueProvider.of(TOPIC), StringUtf8Coder.of(),
-              TIMESTAMP_LABEL, ID_LABEL, NUM_SHARDS, batchSize, batchBytes,
+              TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
               Duration.standardSeconds(2), null, RecordIdMethod.DETERMINISTIC);
       p.apply(Create.of(data))
        .apply(ParDo.of(new Stamp()))
@@ -170,7 +170,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink<String> sink =
           new PubsubUnboundedSink<>(factory, StaticValueProvider.of(TOPIC),
-              StringUtf8Coder.of(), TIMESTAMP_LABEL, ID_LABEL,
+              StringUtf8Coder.of(), TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE,
               NUM_SHARDS, batchSize, batchBytes, Duration.standardSeconds(2),
               null, RecordIdMethod.DETERMINISTIC);
       p.apply(Create.of(data))

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -70,8 +70,8 @@ public class PubsubUnboundedSourceTest {
   private static final String DATA = "testData";
   private static final long TIMESTAMP = 1234L;
   private static final long REQ_TIME = 6373L;
-  private static final String TIMESTAMP_LABEL = "timestamp";
-  private static final String ID_LABEL = "id";
+  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final String ID_ATTRIBUTE = "id";
   private static final String ACK_ID = "testAckId";
   private static final String RECORD_ID = "testRecordId";
   private static final int ACK_TIMEOUT_S = 60;
@@ -96,7 +96,7 @@ public class PubsubUnboundedSourceTest {
     PubsubUnboundedSource<String> source =
         new PubsubUnboundedSource<>(
             clock, factory, null, null, StaticValueProvider.of(SUBSCRIPTION),
-            StringUtf8Coder.of(), TIMESTAMP_LABEL, ID_LABEL, null);
+            StringUtf8Coder.of(), TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, null);
     primSource = new PubsubSource<>(source);
   }
 


### PR DESCRIPTION
This is just renames, syntax, and AutoValue. Part 2 will be more dramatic (getting rid of Coder in both read and write).

R: @reuvenlax 