### PR TITLE
[BEAM-2005] Move getScheme from FileSystemRegistrar to FileSystem

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystem.java
@@ -151,4 +151,11 @@ public abstract class FileSystem<ResourceIdT extends ResourceId> {
    * such as when the specified {@code singleResourceSpec} is not a valid resource name.
    */
   protected abstract ResourceIdT matchNewResource(String singleResourceSpec, boolean isDirectory);
+
+  /**
+   * Get the URI scheme which defines the namespace of the {@link FileSystem}.
+   *
+   * @see <a href="https://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
+   */
+  protected abstract String getScheme();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io;
 
 import com.google.auto.service.AutoService;
-import java.util.List;
 import java.util.ServiceLoader;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -39,5 +38,5 @@ public interface FileSystemRegistrar {
    * <p>Each {@link FileSystem#getScheme() scheme} is required to be unique among all
    * {@link FileSystem}s registered by all {@link FileSystemRegistrar}s.
    */
-  List<FileSystem> fromOptions(@Nullable PipelineOptions options);
+  Iterable<FileSystem> fromOptions(@Nullable PipelineOptions options);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
@@ -36,8 +36,8 @@ public interface FileSystemRegistrar {
   /**
    * Create zero or more {@link FileSystem filesystems} from the given {@link PipelineOptions}.
    *
-   * <p>The {@link FileSystem#getScheme() scheme} is required to be unique among all
-   * {@link FileSystemRegistrar FileSystemRegistrars}.
+   * <p>Each {@link FileSystem#getScheme() scheme} is required to be unique among all
+   * {@link FileSystem}s registered by all {@link FileSystemRegistrar}s.
    */
   List<FileSystem> fromOptions(@Nullable PipelineOptions options);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystemRegistrar.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import com.google.auto.service.AutoService;
+import java.util.List;
 import java.util.ServiceLoader;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -33,17 +34,10 @@ import org.apache.beam.sdk.options.PipelineOptions;
  */
 public interface FileSystemRegistrar {
   /**
-   * Create a {@link FileSystem} from the given {@link PipelineOptions}.
-   */
-  FileSystem fromOptions(@Nullable PipelineOptions options);
-
-  /**
-   * Get the URI scheme which defines the namespace of the {@link FileSystemRegistrar}.
+   * Create zero or more {@link FileSystem filesystems} from the given {@link PipelineOptions}.
    *
-   * <p>The scheme is required to be unique among all
+   * <p>The {@link FileSystem#getScheme() scheme} is required to be unique among all
    * {@link FileSystemRegistrar FileSystemRegistrars}.
-   *
-   * @see <a href="https://www.ietf.org/rfc/rfc2396.txt">RFC 2396</a>
    */
-  String getScheme();
+  List<FileSystem> fromOptions(@Nullable PipelineOptions options);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -404,7 +404,7 @@ public class FileSystems {
   }
 
   /**
-   * Internal method to get {@link FileSystem} for {@code spec}.
+   * Internal method to get {@link FileSystem} for {@code scheme}.
    */
   @VisibleForTesting
   static FileSystem getFileSystemInternal(String scheme) {
@@ -425,7 +425,7 @@ public class FileSystems {
    *
    * <p>It will be used in {@link FileSystemRegistrar FileSystemRegistrars} for all schemes.
    */
-  public static void setDefaultConfigInWorkers(PipelineOptions options) {
+  public static synchronized void setDefaultConfigInWorkers(PipelineOptions options) {
     checkNotNull(options, "options");
     SCHEME_TO_FILESYSTEM.clear();
     Set<FileSystemRegistrar> registrars =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -171,6 +171,11 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
     return LocalResourceId.fromPath(path, isDirectory);
   }
 
+  @Override
+  protected String getScheme() {
+    return "file";
+  }
+
   private MatchResult matchOne(String spec) throws IOException {
     File file = Paths.get(spec).toFile();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystemRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystemRegistrar.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.options.PipelineOptions;
 
@@ -29,7 +28,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 @AutoService(FileSystemRegistrar.class)
 public class LocalFileSystemRegistrar implements FileSystemRegistrar {
   @Override
-  public List<FileSystem> fromOptions(@Nullable PipelineOptions options) {
+  public Iterable<FileSystem> fromOptions(@Nullable PipelineOptions options) {
     return ImmutableList.<FileSystem>of(new LocalFileSystem());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystemRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystemRegistrar.java
@@ -18,24 +18,18 @@
 package org.apache.beam.sdk.io;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
- * {@link AutoService} registrar for the {@link FileSystem}.
+ * {@link AutoService} registrar for the {@link LocalFileSystem}.
  */
 @AutoService(FileSystemRegistrar.class)
 public class LocalFileSystemRegistrar implements FileSystemRegistrar {
-
-  static final String LOCAL_FILE_SCHEME = "file";
-
   @Override
-  public FileSystem fromOptions(@Nullable PipelineOptions options) {
-    return new LocalFileSystem();
-  }
-
-  @Override
-  public String getScheme() {
-    return LOCAL_FILE_SCHEME;
+  public List<FileSystem> fromOptions(@Nullable PipelineOptions options) {
+    return ImmutableList.<FileSystem>of(new LocalFileSystem());
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalResourceId.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalResourceId.java
@@ -113,7 +113,7 @@ class LocalResourceId implements ResourceId {
 
   @Override
   public String getScheme() {
-    return LocalFileSystemRegistrar.LOCAL_FILE_SCHEME;
+    return "file";
   }
 
   Path getPath() {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
@@ -27,7 +27,6 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-
 import java.io.Writer;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
@@ -35,12 +34,10 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import javax.annotation.Nullable;
-
 import org.apache.beam.sdk.io.fs.CreateOptions;
 import org.apache.beam.sdk.io.fs.MoveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Rule;
@@ -77,21 +74,12 @@ public class FileSystemsTest {
   @Test
   public void testVerifySchemesAreUnique() throws Exception {
     thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Scheme: [file] has conflicting registrars");
+    thrown.expectMessage("Scheme: [file] has conflicting filesystems");
     FileSystems.verifySchemesAreUnique(
+        PipelineOptionsFactory.create(),
         Sets.<FileSystemRegistrar>newHashSet(
             new LocalFileSystemRegistrar(),
-            new FileSystemRegistrar() {
-              @Override
-              public FileSystem fromOptions(@Nullable PipelineOptions options) {
-                return null;
-              }
-
-              @Override
-              public String getScheme() {
-                return "FILE";
-              }
-            }));
+            new LocalFileSystemRegistrar()));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemRegistrarTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemRegistrarTest.java
@@ -17,10 +17,15 @@
  */
 package org.apache.beam.sdk.io;
 
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.ServiceLoader;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -36,6 +41,8 @@ public class LocalFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof LocalFileSystemRegistrar) {
+        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        assertThat(fileSystems, contains(instanceOf(LocalFileSystem.class)));
         return;
       }
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemRegistrarTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalFileSystemRegistrarTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
-import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
@@ -41,7 +40,7 @@ public class LocalFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof LocalFileSystemRegistrar) {
-        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        Iterable<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
         assertThat(fileSystems, contains(instanceOf(LocalFileSystem.class)));
         return;
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystem.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystem.java
@@ -145,6 +145,11 @@ class GcsFileSystem extends FileSystem<GcsResourceId> {
     options.getGcsUtil().copy(toFilenames(srcResourceIds), toFilenames(destResourceIds));
   }
 
+  @Override
+  protected String getScheme() {
+    return "gs";
+  }
+
   private List<MatchResult> matchGlobs(List<GcsPath> globs) {
     // TODO: Executes in parallel, address https://issues.apache.org/jira/browse/BEAM-1503.
     return FluentIterable.from(globs)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrar.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrar.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.io.FileSystem;
@@ -35,7 +34,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public class GcsFileSystemRegistrar implements FileSystemRegistrar {
 
   @Override
-  public List<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
+  public Iterable<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
     checkNotNull(
         options,
         "Expect the runner have called FileSystems.setDefaultConfigInWorkers().");

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrar.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrar.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.io.gcp.storage;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.io.FileSystem;
@@ -32,18 +34,11 @@ import org.apache.beam.sdk.options.PipelineOptions;
 @AutoService(FileSystemRegistrar.class)
 public class GcsFileSystemRegistrar implements FileSystemRegistrar {
 
-  static final String GCS_SCHEME = "gs";
-
   @Override
-  public FileSystem fromOptions(@Nonnull PipelineOptions options) {
+  public List<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
     checkNotNull(
         options,
         "Expect the runner have called FileSystems.setDefaultConfigInWorkers().");
-    return new GcsFileSystem(options.as(GcsOptions.class));
-  }
-
-  @Override
-  public String getScheme() {
-    return GCS_SCHEME;
+    return ImmutableList.<FileSystem>of(new GcsFileSystem(options.as(GcsOptions.class)));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceId.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceId.java
@@ -88,7 +88,7 @@ public class GcsResourceId implements ResourceId {
 
   @Override
   public String getScheme() {
-    return GcsFileSystemRegistrar.GCS_SCHEME;
+    return "gs";
   }
 
   GcsPath getGcsPath() {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrarTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrarTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
-import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
@@ -43,7 +42,7 @@ public class GcsFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof GcsFileSystemRegistrar) {
-        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        Iterable<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
         assertThat(fileSystems, contains(instanceOf(GcsFileSystem.class)));
         return;
       }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrarTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsFileSystemRegistrarTest.java
@@ -17,13 +17,15 @@
  */
 package org.apache.beam.sdk.io.gcp.storage;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.ServiceLoader;
-
+import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
@@ -41,8 +43,8 @@ public class GcsFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof GcsFileSystemRegistrar) {
-        assertEquals("gs", registrar.getScheme());
-        assertTrue(registrar.fromOptions(PipelineOptionsFactory.create()) instanceof GcsFileSystem);
+        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        assertThat(fileSystems, contains(instanceOf(GcsFileSystem.class)));
         return;
       }
     }

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -73,4 +73,9 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
   protected HadoopResourceId matchNewResource(String singleResourceSpec, boolean isDirectory) {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  protected String getScheme() {
+    return "hdfs";
+  }
 }

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrar.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrar.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io.hdfs;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
@@ -32,7 +31,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public class HadoopFileSystemRegistrar implements FileSystemRegistrar {
 
   @Override
-  public List<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
+  public Iterable<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
     return ImmutableList.<FileSystem>of(new HadoopFileSystem());
   }
 }

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrar.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrar.java
@@ -18,10 +18,11 @@
 package org.apache.beam.sdk.io.hdfs;
 
 import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
-import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptions;
 
 /**
@@ -31,12 +32,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public class HadoopFileSystemRegistrar implements FileSystemRegistrar {
 
   @Override
-  public FileSystem fromOptions(@Nonnull PipelineOptions options) {
-    return new HadoopFileSystem();
-  }
-
-  @Override
-  public String getScheme() {
-    return FileSystems.DEFAULT_SCHEME;
+  public List<FileSystem> fromOptions(@Nonnull PipelineOptions options) {
+    return ImmutableList.<FileSystem>of(new HadoopFileSystem());
   }
 }

--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
-import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
@@ -43,7 +42,7 @@ public class HadoopFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof HadoopFileSystemRegistrar) {
-        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        Iterable<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
         assertThat(fileSystems, contains(instanceOf(HadoopFileSystem.class)));
         return;
       }

--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
@@ -17,14 +17,16 @@
  */
 package org.apache.beam.sdk.io.hdfs;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
+import java.util.List;
 import java.util.ServiceLoader;
+import org.apache.beam.sdk.io.FileSystem;
 import org.apache.beam.sdk.io.FileSystemRegistrar;
-import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,9 +43,8 @@ public class HadoopFileSystemRegistrarTest {
     for (FileSystemRegistrar registrar
         : Lists.newArrayList(ServiceLoader.load(FileSystemRegistrar.class).iterator())) {
       if (registrar instanceof HadoopFileSystemRegistrar) {
-        assertEquals(FileSystems.DEFAULT_SCHEME, registrar.getScheme());
-        assertTrue(
-            registrar.fromOptions(PipelineOptionsFactory.create()) instanceof HadoopFileSystem);
+        List<FileSystem> fileSystems = registrar.fromOptions(PipelineOptionsFactory.create());
+        assertThat(fileSystems, contains(instanceOf(HadoopFileSystem.class)));
         return;
       }
     }


### PR DESCRIPTION
Note that I needed to update FileSystems to instantiate the FileSystem(s) upfront instead of remembering the mapping from scheme to registrar during "registration" of the PipelineOptions.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
