### PR TITLE
ResourceId: Add #isDirectory

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalResourceId.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalResourceId.java
@@ -123,6 +123,11 @@ class LocalResourceId implements ResourceId {
     return "file";
   }
 
+  @Override
+  public boolean isDirectory() {
+    return isDirectory;
+  }
+
   Path getPath() {
     if (cachedPath == null) {
       cachedPath = Paths.get(pathString);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceId.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceId.java
@@ -112,6 +112,11 @@ public interface ResourceId extends Serializable {
   @Nullable String getFilename();
 
   /**
+   * Returns {@code true} if this {@link ResourceId} represents a directory, false otherwise.
+   */
+  boolean isDirectory();
+
+  /**
    * Returns the string representation of this {@link ResourceId}.
    *
    * <p>The corresponding {@link FileSystem#match} is required to accept this string representation.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
@@ -22,8 +22,10 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -221,6 +223,13 @@ public class LocalResourceIdTest {
     assertNotEquals(
         toResourceIdentifier("/root/tmp"),
         toResourceIdentifier("/root/tmp/"));
+  }
+
+  @Test
+  public void testIsDirectory() throws Exception {
+    assertTrue(toResourceIdentifier("/").isDirectory());
+    assertTrue(toResourceIdentifier("/root/tmp/").isDirectory());
+    assertFalse(toResourceIdentifier("/root").isDirectory());
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceId.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceId.java
@@ -83,7 +83,8 @@ public class GcsResourceId implements ResourceId {
     }
   }
 
-  private boolean isDirectory() {
+  @Override
+  public boolean isDirectory() {
     return gcsPath.endsWith("/");
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceIdTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsResourceIdTest.java
@@ -18,7 +18,9 @@
 package org.apache.beam.sdk.io.gcp.storage;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -112,6 +114,15 @@ public class GcsResourceIdTest {
     assertEquals(
         toResourceIdentifier("gs://my_bucket/"),
         toResourceIdentifier("gs://my_bucket").getCurrentDirectory());
+  }
+
+  @Test
+  public void testIsDirectory() throws Exception {
+    assertTrue(toResourceIdentifier("gs://my_bucket/tmp dir/").isDirectory());
+    assertTrue(toResourceIdentifier("gs://my_bucket/").isDirectory());
+    assertTrue(toResourceIdentifier("gs://my_bucket").isDirectory());
+
+    assertFalse(toResourceIdentifier("gs://my_bucket/file").isDirectory());
   }
 
   @Test

--- a/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
+++ b/sdks/java/io/hdfs/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
@@ -44,4 +44,8 @@ public class HadoopResourceId implements ResourceId {
   public String getFilename() {
     throw new UnsupportedOperationException();
   }
+
+  public boolean isDirectory() {
+    throw new UnsupportedOperationException();
+  }
 }


### PR DESCRIPTION
Seems like all existing ResourceIds already support this, and it's needed in transforms where users pass in ResourceIds that might or might not be directories.
