### PR TITLE
[BEAM-539] Fixes several issues of FileSink

### DIFF
--- a/sdks/python/apache_beam/io/fileio_test.py
+++ b/sdks/python/apache_beam/io/fileio_test.py
@@ -26,6 +26,7 @@ import tempfile
 import unittest
 
 import hamcrest as hc
+import mock
 
 import apache_beam as beam
 from apache_beam import coders
@@ -183,6 +184,52 @@ class TestFileSink(_TestCaseWithTempDirCleanUp):
         for shard_num in range(3))
     self.assertTrue('][a][' in concat, concat)
     self.assertTrue('][b][' in concat, concat)
+
+  # Not using 'test' in name so that 'nose' doesn't pick this as a test.
+  def run_temp_dir_check(self, no_dir_path, dir_path, no_dir_root_path,
+                         dir_root_path, prefix, separator):
+    def _get_temp_dir(file_path_prefix):
+      sink = MyFileSink(
+          file_path_prefix, file_name_suffix='.output',
+          coder=coders.ToStringCoder())
+      return sink.initialize_write()
+
+    temp_dir = _get_temp_dir(no_dir_path)
+    self.assertTrue(temp_dir.startswith(prefix))
+    last_sep = temp_dir.rfind(separator)
+    self.assertTrue(temp_dir[last_sep + 1:].startswith('beam-temp'))
+
+    temp_dir = _get_temp_dir(dir_path)
+    self.assertTrue(temp_dir.startswith(prefix))
+    last_sep = temp_dir.rfind(separator)
+    self.assertTrue(temp_dir[last_sep + 1:].startswith('beam-temp'))
+
+    with self.assertRaises(ValueError):
+      _get_temp_dir(no_dir_root_path)
+
+    with self.assertRaises(ValueError):
+      _get_temp_dir(dir_root_path)
+
+  def test_temp_dir_gcs(self):
+    self.run_temp_dir_check(
+        'gs://aaa/bbb', 'gs://aaa/bbb/', 'gs://aaa', 'gs://aaa/', 'gs://', '/')
+
+  @mock.patch('apache_beam.io.localfilesystem.os')
+  def test_temp_dir_local(self, filesystem_os_mock):
+    # Here we test a unix-like mock file-system
+    # (not really testing Unix or Windows since we mock the function of 'os'
+    # module).
+
+    def _fake_unix_split(path):
+      sep = path.rfind('/')
+      if sep < 0:
+        raise ValueError('Path must contain a separator')
+      return (path[:sep], path[sep + 1:])
+
+    filesystem_os_mock.path.abspath = lambda a: a
+    filesystem_os_mock.path.split.side_effect = _fake_unix_split
+    self.run_temp_dir_check(
+        '/aaa/bbb', '/aaa/bbb/', '/', '/', 'gs://', '/')
 
   def test_file_sink_multi_shards(self):
     temp_path = os.path.join(self._new_tempdir(), 'multishard')

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -438,6 +438,23 @@ class FileSystem(object):
     raise NotImplementedError
 
   @abc.abstractmethod
+  def split(self, path):
+    """Splits the given path into two parts.
+
+    Splits the path into a pair (head, tail) such that tail contains the last
+    component of the path and head contains everything up to that.
+
+    For file-systems other than the local file-system, head should include the
+    prefix.
+
+    Args:
+      path: path as a string
+    Returns:
+      a pair of path components as strings.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
   def mkdirs(self, path):
     """Recursively create directories for the provided path.
 

--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -50,6 +50,24 @@ class FileSystems(object):
     return filesystem.join(basepath, *paths)
 
   @staticmethod
+  def split(path):
+    """Splits the given path into two parts.
+
+    Splits the path into a pair (head, tail) such that tail contains the last
+    component of the path and head contains everything up to that.
+
+    For file-systems other than the local file-system, head should include the
+    prefix.
+
+    Args:
+      path: path as a string
+    Returns:
+      a pair of path components as strings.
+    """
+    filesystem = FileSystems.get_filesystem(path)
+    return filesystem.split(path)
+
+  @staticmethod
   def mkdirs(path):
     """Recursively create directories for the provided path.
 

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -32,6 +32,7 @@ class GCSFileSystem(FileSystem):
   """
 
   CHUNK_SIZE = gcsio.MAX_BATCH_OPERATION_SIZE  # Chuck size in batch operations
+  GCS_PREFIX = 'gs://'
 
   def join(self, basepath, *paths):
     """Join two or more pathname components for the filesystem
@@ -42,12 +43,41 @@ class GCSFileSystem(FileSystem):
 
     Returns: full path after combining all the passed components
     """
-    if not basepath.startswith('gs://'):
+    if not basepath.startswith(GCSFileSystem.GCS_PREFIX):
       raise ValueError('Basepath %r must be GCS path.', basepath)
     path = basepath
     for p in paths:
       path = path.rstrip('/') + '/' + p.lstrip('/')
     return path
+
+  def split(self, path):
+    """Splits the given path into two parts.
+
+    Splits the path into a pair (head, tail) such that tail contains the last
+    component of the path and head contains everything up to that.
+
+    Head will include the GCS prefix ('gs://').
+
+    Args:
+      path: path as a string
+    Returns:
+      a pair of path components as strings.
+    """
+    path = path.strip()
+    if not path.startswith(GCSFileSystem.GCS_PREFIX):
+      raise ValueError('Path %r must be GCS path.', path)
+
+    prefix_len = len(GCSFileSystem.GCS_PREFIX)
+    last_sep = path[prefix_len:].rfind('/')
+    if last_sep >= 0:
+      last_sep += prefix_len
+
+    if last_sep > 0:
+      return (path[:last_sep], path[last_sep + 1:])
+    elif last_sep < 0:
+      return (path, '')
+    else:
+      raise ValueError('Invalid path: %s', path)
 
   def mkdirs(self, path):
     """Recursively create directories for the provided path.
@@ -154,7 +184,7 @@ class GCSFileSystem(FileSystem):
     def _copy_path(source, destination):
       """Recursively copy the file tree from the source to the destination
       """
-      if not destination.startswith('gs://'):
+      if not destination.startswith(GCSFileSystem.GCS_PREFIX):
         raise ValueError('Destination %r must be GCS path.', destination)
       # Use copy_tree if the path ends with / as it is a directory
       if source.endswith('/'):

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
@@ -53,6 +53,18 @@ class GCSFileSystemTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       file_system.join('/bucket/path/', '/to/file')
 
+  def test_split(self):
+    file_system = gcsfilesystem.GCSFileSystem()
+    self.assertEqual(('gs://foo/bar', 'baz'),
+                     file_system.split('gs://foo/bar/baz'))
+    self.assertEqual(('gs://foo', ''),
+                     file_system.split('gs://foo/'))
+    self.assertEqual(('gs://foo', ''),
+                     file_system.split('gs://foo'))
+
+    with self.assertRaises(ValueError):
+      file_system.split('/no/gcs/prefix')
+
   @mock.patch('apache_beam.io.gcp.gcsfilesystem.gcsio')
   def test_match_multiples(self, mock_gcsio):
     # Prepare mocks.

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -45,6 +45,19 @@ class LocalFileSystem(FileSystem):
     """
     return os.path.join(basepath, *paths)
 
+  def split(self, path):
+    """Splits the given path into two parts.
+
+    Splits the path into a pair (head, tail) such that tail contains the last
+    component of the path and head contains everything up to that.
+
+    Args:
+      path: path as a string
+    Returns:
+      a pair of path components as strings.
+    """
+    return os.path.split(os.path.abspath(path))
+
   def mkdirs(self, path):
     """Recursively create directories for the provided path.
 

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -39,6 +39,19 @@ def _gen_fake_join(separator):
   return _join
 
 
+def _gen_fake_split(separator):
+  """Returns a callable that splits a with the given separator."""
+
+  def _split(path):
+    sep_index = path.rfind(separator)
+    if sep_index >= 0:
+      return (path[:sep_index], path[sep_index + 1:])
+    else:
+      return (path, '')
+
+  return _split
+
+
 class LocalFileSystemTest(unittest.TestCase):
 
   def setUp(self):
@@ -65,6 +78,28 @@ class LocalFileSystemTest(unittest.TestCase):
                      self.fs.join(r'C:\tmp\path', 'to', 'file'))
     self.assertEqual(r'C:\tmp\path\to\file',
                      self.fs.join(r'C:\tmp\path', r'to\file'))
+
+  @mock.patch('apache_beam.io.localfilesystem.os')
+  def test_unix_path_split(self, os_mock):
+    os_mock.path.abspath.side_effect = lambda a: a
+    os_mock.path.split.side_effect = _gen_fake_split('/')
+    self.assertEqual(('/tmp/path/to', 'file'),
+                     self.fs.split('/tmp/path/to/file'))
+    # Actual os.path.split will split following to '/' and 'tmp' when run in
+    # Unix.
+    self.assertEqual(('', 'tmp'),
+                     self.fs.split('/tmp'))
+
+  @mock.patch('apache_beam.io.localfilesystem.os')
+  def test_windows_path_split(self, os_mock):
+    os_mock.path.abspath = lambda a: a
+    os_mock.path.split.side_effect = _gen_fake_split('\\')
+    self.assertEqual((r'C:\tmp\path\to', 'file'),
+                     self.fs.split(r'C:\tmp\path\to\file'))
+    # Actual os.path.split will split following to 'C:\' and 'tmp' when run in
+    # Windows.
+    self.assertEqual((r'C:', 'tmp'),
+                     self.fs.split(r'C:\tmp'))
 
   def test_mkdirs(self):
     path = os.path.join(self.tmpdir, 't1/t2')


### PR DESCRIPTION
(1) Updates FileSink to fail for file name prefixes that only contain a single component (for example GCS buckets).

For example, currently FileSink fails for  gs://aaa while passing for gs://aaa/. This change makes FileSink fail for both cases (and makes the behavior consistent with Java).

(2) Updates the name of the temporary directory created by FileSink

Currently , for a filename prefix 'gs://aaa/bbb', the temp path would be of the form gs://aaa/bbb-temp-... .
This is error prone since a user pattern 'gs://aaa/bbb*' would match temp files. This changes makes the temp path format 'gs://aaa/beam-temp-bbb-...' instead.

To achieve above this PR adds a method 'split()' to FileSystem interface that is analogous to Python 'os.path.split()' (and which has the opposite effect of current method FileSystem.join())