### PR TITLE
[BEAM-1642] Try PTransform-based coder inference before using fallback coder.

### DIFF
--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -578,4 +578,14 @@ public class DirectRunnerTest implements Serializable {
       return underlying.getDefaultOutputCoder();
     }
   }
+
+  @Test
+  public void fallbackCoderProviderAllowsInference() {
+    // See https://issues.apache.org/jira/browse/BEAM-1642
+    Pipeline p = getPipeline();
+    p.getCoderRegistry().setFallbackCoderProvider(
+        org.apache.beam.sdk.coders.AvroCoder.PROVIDER);
+    p.apply(Create.of(Arrays.asList(100, 200))).apply(Count.<Integer>globally());
+    p.run().waitUntilFinish();
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypedPValue.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TypedPValue.java
@@ -140,7 +140,16 @@ public abstract class TypedPValue<T> extends PValueBase implements PValue {
       return coderOrFailure;
     }
 
-    // Second option for a coder: Look in the coder registry.
+    // Second option for a coder: use the default Coder from the producing PTransform.
+    CannotProvideCoderException inputCoderException;
+    try {
+      return new CoderOrFailure<>(
+          ((PTransform) transform).getDefaultOutputCoder(input, this), null);
+    } catch (CannotProvideCoderException exc) {
+      inputCoderException = exc;
+    }
+
+    // Third option for a coder: Look in the coder registry.
     TypeDescriptor<T> token = getTypeDescriptor();
     CannotProvideCoderException inferFromTokenException = null;
     if (token != null) {
@@ -160,15 +169,6 @@ public abstract class TypedPValue<T> extends PValueBase implements PValue {
               + "TupleTag Javadoc) or explicitly set the Coder to use if this is not possible.");
         }
       }
-    }
-
-    // Third option for a coder: use the default Coder from the producing PTransform.
-    CannotProvideCoderException inputCoderException;
-    try {
-      return new CoderOrFailure<>(
-          ((PTransform) transform).getDefaultOutputCoder(input, this), null);
-    } catch (CannotProvideCoderException exc) {
-      inputCoderException = exc;
     }
 
     // Build up the error message and list of causes.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineFnsTest.java
@@ -231,7 +231,7 @@ public class  CombineFnsTest {
                 KV.of("b", KV.of(13, UserString.of("13")))),
             Arrays.asList(0L, 4L, 7L, 10L, 16L))
         .withCoder(KvCoder.of(
-            StringUtf8Coder.of(),
+            NullableCoder.of(StringUtf8Coder.of()),
             KvCoder.of(
                 BigEndianIntegerCoder.of(), NullableCoder.of(UserStringCoder.of())))));
 


### PR DESCRIPTION
This is particularly important for fallback coders that claim
to provide a coder for Object (or equivalently an unconstrained
type parameter).  See BEAM-1642.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
