### PR TITLE
[BEAM-2005, BEAM-2030, BEAM-2031, BEAM-2032, BEAM-2033, BEAM-2070] Base implementation of HadoopFileSystem.

### DIFF
--- a/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
+++ b/sdks/java/io/hdfs/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.hdfs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link HadoopResourceId}.
+ */
+@RunWith(JUnit4.class)
+public class HadoopResourceIdTest {
+  private static final String DIR = "hdfs://localhost:999/dir/";
+  private static final String FILE = "hdfs://localhost:999/dir/file";
+
+  @Test
+  public void testEquals() {
+    assertEquals(new HadoopResourceId(URI.create(DIR)),
+        new HadoopResourceId(URI.create(DIR)));
+    assertNotEquals(new HadoopResourceId(URI.create(DIR)),
+        new HadoopResourceId(URI.create(FILE)));
+  }
+
+  @Test
+  public void testIsDirectory() {
+    assertTrue(new HadoopResourceId(URI.create(DIR)).isDirectory());
+    assertFalse(new HadoopResourceId(URI.create(FILE)).isDirectory());
+  }
+
+  @Test
+  public void testToString() {
+    assertEquals(DIR, new HadoopResourceId(URI.create(DIR)).toString());
+    assertEquals(FILE, new HadoopResourceId(URI.create(FILE)).toString());
+  }
+
+  @Test
+  public void testFilename() {
+    assertEquals("file", new HadoopResourceId(URI.create(FILE)).getFilename());
+  }
+
+  @Test
+  public void testScheme() {
+    assertEquals("hdfs", new HadoopResourceId(URI.create(FILE)).getScheme());
+  }
+
+  @Test
+  public void testGetCurrentDirectory() {
+    assertEquals(DIR, new HadoopResourceId(URI.create(DIR)).getCurrentDirectory().toString());
+    assertEquals(DIR, new HadoopResourceId(URI.create(FILE)).getCurrentDirectory().toString());
+  }
+}


### PR DESCRIPTION
TODO:
* Add multiplexing FileSystem that is able to route requests based upon the base URI when configured for multiple file systems.
* Take a look at copy/rename again to see if we can do better than moving all the bytes through the local machine.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
