### PR TITLE
[BEAM-1402] AvroIO should comply with PTransform style guide

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
@@ -75,7 +75,7 @@ public class AvroPipelineTest {
     Pipeline p = pipelineRule.createPipeline();
     PCollection<GenericRecord> input = p.apply(
         AvroIO.readGenericRecords(schema).from(inputFile.getAbsolutePath()));
-    input.apply(AvroIO.Write.to(outputDir.getAbsolutePath()).withSchema(schema));
+    input.apply(AvroIO.write().to(outputDir.getAbsolutePath()).withSchema(schema));
     p.run().waitUntilFinish();
 
     List<GenericRecord> records = readGenericFile();

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
@@ -74,7 +74,7 @@ public class AvroPipelineTest {
 
     Pipeline p = pipelineRule.createPipeline();
     PCollection<GenericRecord> input = p.apply(
-        AvroIO.Read.from(inputFile.getAbsolutePath()).withSchema(schema));
+        AvroIO.read().from(inputFile.getAbsolutePath()).withSchema(schema));
     input.apply(AvroIO.Write.to(outputDir.getAbsolutePath()).withSchema(schema));
     p.run().waitUntilFinish();
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
@@ -75,7 +75,7 @@ public class AvroPipelineTest {
     Pipeline p = pipelineRule.createPipeline();
     PCollection<GenericRecord> input = p.apply(
         AvroIO.readGenericRecords(schema).from(inputFile.getAbsolutePath()));
-    input.apply(AvroIO.write().to(outputDir.getAbsolutePath()).withSchema(schema));
+    input.apply(AvroIO.writeGenericRecords(schema).to(outputDir.getAbsolutePath()));
     p.run().waitUntilFinish();
 
     List<GenericRecord> records = readGenericFile();

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/io/AvroPipelineTest.java
@@ -74,7 +74,7 @@ public class AvroPipelineTest {
 
     Pipeline p = pipelineRule.createPipeline();
     PCollection<GenericRecord> input = p.apply(
-        AvroIO.read().from(inputFile.getAbsolutePath()).withSchema(schema));
+        AvroIO.readGenericRecords(schema).from(inputFile.getAbsolutePath()));
     input.apply(AvroIO.Write.to(outputDir.getAbsolutePath()).withSchema(schema));
     p.run().waitUntilFinish();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -133,6 +133,18 @@ public class AvroIO {
     return new Read<>();
   }
 
+  /** Reads Avro file(s) containing records of the specified schema. */
+  public static Read<GenericRecord> readGenericRecords(Schema schema) {
+    return new Read<>(null, null, GenericRecord.class, schema);
+  }
+
+  /**
+   * Like {@link #readGenericRecords(Schema)} but the schema is specified as a JSON-encoded string.
+   */
+  public static Read<GenericRecord> readGenericRecords(String schema) {
+    return readGenericRecords(new Schema.Parser().parse(schema));
+  }
+
   /** Implementation of {@link #read}. */
   public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
     /** The filepattern to read from. */
@@ -176,25 +188,6 @@ public class AvroIO {
      */
     public Read<T> withSchema(Class<T> type) {
       return new Read<>(name, filepattern, type, ReflectData.get().getSchema(type));
-    }
-
-    /**
-     * Returns a new {@link PTransform} that's like this one but
-     * that reads Avro file(s) containing records of the specified schema.
-     */
-    public Read<GenericRecord> withSchema(Schema schema) {
-      return new Read<>(name, filepattern, GenericRecord.class, schema);
-    }
-
-    /**
-     * Returns a new {@link PTransform} that's like this one but
-     * that reads Avro file(s) containing records of the specified schema
-     * in a JSON-encoded string form.
-     *
-     * <p>Does not modify this object.
-     */
-    public Read<GenericRecord> withSchema(String schema) {
-      return withSchema((new Schema.Parser()).parse(schema));
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -30,9 +30,7 @@ import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.MimeTypes;
 
-/**
- * A {@link FileBasedSink} for Avro files.
- */
+/** A {@link FileBasedSink} for Avro files. */
 class AvroSink<T> extends FileBasedSink<T> {
   private final AvroCoder<T> coder;
   private final SerializableAvroCodecFactory codec;
@@ -67,10 +65,7 @@ class AvroSink<T> extends FileBasedSink<T> {
     return new AvroWriteOperation<>(this, coder, codec, metadata);
   }
 
-  /**
-   * A {@link FileBasedWriteOperation
-   * FileBasedWriteOperation} for Avro files.
-   */
+  /** A {@link FileBasedWriteOperation FileBasedWriteOperation} for Avro files. */
   private static class AvroWriteOperation<T> extends FileBasedWriteOperation<T> {
     private final AvroCoder<T> coder;
     private final SerializableAvroCodecFactory codec;
@@ -92,10 +87,7 @@ class AvroSink<T> extends FileBasedSink<T> {
     }
   }
 
-  /**
-   * A {@link FileBasedWriter FileBasedWriter}
-   * for Avro files.
-   */
+  /** A {@link FileBasedWriter FileBasedWriter} for Avro files. */
   private static class AvroWriter<T> extends FileBasedWriter<T> {
     private final AvroCoder<T> coder;
     private DataFileWriter<T> dataFileWriter;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io;
+
+import com.google.common.collect.ImmutableMap;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.Map;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.MimeTypes;
+
+/**
+ * A {@link FileBasedSink} for Avro files.
+ */
+class AvroSink<T> extends FileBasedSink<T> {
+  private final AvroCoder<T> coder;
+  private final SerializableAvroCodecFactory codec;
+  private final ImmutableMap<String, Object> metadata;
+
+  AvroSink(
+      FilenamePolicy filenamePolicy,
+      AvroCoder<T> coder,
+      SerializableAvroCodecFactory codec,
+      ImmutableMap<String, Object> metadata) {
+    super(filenamePolicy);
+    this.coder = coder;
+    this.codec = codec;
+    this.metadata = metadata;
+  }
+
+  AvroSink(
+      String baseOutputFilename,
+      String extension,
+      String fileNameTemplate,
+      AvroCoder<T> coder,
+      SerializableAvroCodecFactory codec,
+      ImmutableMap<String, Object> metadata) {
+    super(baseOutputFilename, extension, fileNameTemplate);
+    this.coder = coder;
+    this.codec = codec;
+    this.metadata = metadata;
+  }
+
+  @Override
+  public FileBasedWriteOperation<T> createWriteOperation() {
+    return new AvroWriteOperation<>(this, coder, codec, metadata);
+  }
+
+  /**
+   * A {@link FileBasedWriteOperation
+   * FileBasedWriteOperation} for Avro files.
+   */
+  private static class AvroWriteOperation<T> extends FileBasedWriteOperation<T> {
+    private final AvroCoder<T> coder;
+    private final SerializableAvroCodecFactory codec;
+    private final ImmutableMap<String, Object> metadata;
+
+    private AvroWriteOperation(AvroSink<T> sink,
+                               AvroCoder<T> coder,
+                               SerializableAvroCodecFactory codec,
+                               ImmutableMap<String, Object> metadata) {
+      super(sink);
+      this.coder = coder;
+      this.codec = codec;
+      this.metadata = metadata;
+    }
+
+    @Override
+    public FileBasedWriter<T> createWriter(PipelineOptions options) throws Exception {
+      return new AvroWriter<>(this, coder, codec, metadata);
+    }
+  }
+
+  /**
+   * A {@link FileBasedWriter FileBasedWriter}
+   * for Avro files.
+   */
+  private static class AvroWriter<T> extends FileBasedWriter<T> {
+    private final AvroCoder<T> coder;
+    private DataFileWriter<T> dataFileWriter;
+    private SerializableAvroCodecFactory codec;
+    private final ImmutableMap<String, Object> metadata;
+
+    public AvroWriter(FileBasedWriteOperation<T> writeOperation,
+                      AvroCoder<T> coder,
+                      SerializableAvroCodecFactory codec,
+                      ImmutableMap<String, Object> metadata) {
+      super(writeOperation, MimeTypes.BINARY);
+      this.coder = coder;
+      this.codec = codec;
+      this.metadata = metadata;
+    }
+
+    @SuppressWarnings("deprecation") // uses internal test functionality.
+    @Override
+    protected void prepareWrite(WritableByteChannel channel) throws Exception {
+      DatumWriter<T> datumWriter = coder.getType().equals(GenericRecord.class)
+          ? new GenericDatumWriter<T>(coder.getSchema())
+          : new ReflectDatumWriter<T>(coder.getSchema());
+
+      dataFileWriter = new DataFileWriter<>(datumWriter).setCodec(codec.getCodec());
+      for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+        Object v = entry.getValue();
+        if (v instanceof String) {
+          dataFileWriter.setMeta(entry.getKey(), (String) v);
+        } else if (v instanceof Long) {
+          dataFileWriter.setMeta(entry.getKey(), (Long) v);
+        } else if (v instanceof byte[]) {
+          dataFileWriter.setMeta(entry.getKey(), (byte[]) v);
+        } else {
+          throw new IllegalStateException(
+              "Metadata value type must be one of String, Long, or byte[]. Found "
+                  + v.getClass().getSimpleName());
+        }
+      }
+      dataFileWriter.create(coder.getSchema(), Channels.newOutputStream(channel));
+    }
+
+    @Override
+    public void write(T value) throws Exception {
+      dataFileWriter.append(value);
+    }
+
+    @Override
+    protected void finishWrite() throws Exception {
+      dataFileWriter.flush();
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -62,7 +62,9 @@ import org.apache.commons.compress.utils.CountingInputStream;
 
 // CHECKSTYLE.OFF: JavadocStyle
 /**
- * A {@link FileBasedSource} for reading Avro files.
+ * Do not use in pipelines directly: most users should use {@link AvroIO.Read}.
+ *
+ * <p>A {@link FileBasedSource} for reading Avro files.
  *
  * <p>To read a {@link PCollection} of objects from one or more Avro files, use
  * {@link AvroSource#from} to specify the path(s) of the files to read. The {@link AvroSource} that

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -85,9 +85,9 @@ import org.apache.beam.sdk.values.PDone;
  *
  * <p>By default, all input is put into the global window before writing. If per-window writes are
  * desired - for example, when using a streaming runner -
- * {@link AvroIO.Write.Bound#withWindowedWrites()} will cause windowing and triggering to be
+ * {@link TextIO.Write.Bound#withWindowedWrites()} will cause windowing and triggering to be
  * preserved. When producing windowed writes, the number of output shards must be set explicitly
- * using {@link AvroIO.Write.Bound#withNumShards(int)}; some runners may set this for you to a
+ * using {@link TextIO.Write.Bound#withNumShards(int)}; some runners may set this for you to a
  * runner-chosen value, so you may need not set it yourself. A {@link FilenamePolicy} must be
  * set, and unique windows and triggers must produce unique filenames.
  *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SourceTestUtils.java
@@ -72,9 +72,8 @@ import org.slf4j.LoggerFactory;
  *   as a heavy-weight stress test including concurrency. We strongly recommend to
  *   use both.
  * </ul>
- * For example usages, see the unit tests of classes such as
- * {@link org.apache.beam.sdk.io.AvroSource} or
- * {@link org.apache.beam.sdk.io.TextIO TextIO.TextSource}.
+ * For example usages, see the unit tests of classes such as {@code AvroSource} or
+ * {@code TextSource}.
  *
  * <p>Like {@link PAssert}, requires JUnit and Hamcrest to be present in the classpath.
  */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -102,7 +102,7 @@ public class AvroIOTest {
 
   @Test
   public void testAvroIOGetName() {
-    assertEquals("AvroIO.Read", AvroIO.read().from("gs://bucket/foo*/baz").getName());
+    assertEquals("AvroIO.Read", AvroIO.read(String.class).from("gs://bucket/foo*/baz").getName());
     assertEquals("AvroIO.Write", AvroIO.write().to("gs://bucket/foo/baz").getName());
   }
 
@@ -151,9 +151,8 @@ public class AvroIOTest {
 
     PCollection<GenericClass> input =
         p.apply(
-            AvroIO.<GenericClass>read()
-                .from(outputFile.getAbsolutePath())
-                .withSchema(GenericClass.class));
+            AvroIO.read(GenericClass.class)
+                .from(outputFile.getAbsolutePath()));
 
     PAssert.that(input).containsInAnyOrder(values);
     p.run();
@@ -175,9 +174,8 @@ public class AvroIOTest {
     p.run();
 
     PCollection<GenericClass> input = p
-        .apply(AvroIO.<GenericClass>read()
-            .from(outputFile.getAbsolutePath())
-            .withSchema(GenericClass.class));
+        .apply(AvroIO.read(GenericClass.class)
+            .from(outputFile.getAbsolutePath()));
 
     PAssert.that(input).containsInAnyOrder(values);
     p.run();
@@ -202,9 +200,8 @@ public class AvroIOTest {
     p.run();
 
     PCollection<GenericClass> input = p
-        .apply(AvroIO.<GenericClass>read()
-            .from(outputFile.getAbsolutePath())
-            .withSchema(GenericClass.class));
+        .apply(AvroIO.read(GenericClass.class)
+            .from(outputFile.getAbsolutePath()));
 
     PAssert.that(input).containsInAnyOrder(values);
     p.run();
@@ -273,9 +270,8 @@ public class AvroIOTest {
 
     PCollection<GenericClassV2> input =
         p.apply(
-            AvroIO.<GenericClassV2>read()
-                .from(outputFile.getAbsolutePath())
-                .withSchema(GenericClassV2.class));
+            AvroIO.read(GenericClassV2.class)
+                .from(outputFile.getAbsolutePath()));
 
     PAssert.that(input).containsInAnyOrder(expected);
     p.run();
@@ -535,7 +531,7 @@ public class AvroIOTest {
 
   @Test
   public void testReadDisplayData() {
-    AvroIO.Read<?> read = AvroIO.read().from("foo.*");
+    AvroIO.Read<?> read = AvroIO.read(String.class).from("foo.*");
 
     DisplayData displayData = DisplayData.from(read);
     assertThat(displayData, hasDisplayItem("filePattern", "foo.*"));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -422,9 +422,9 @@ public class AvroIOTest {
         .to("gs://bucket/foo/baz")
         .withCodec(CodecFactory.deflateCodec(9));
 
-    AvroIO.Write<GenericRecord> serdeWrite = SerializableUtils.clone(write);
-
-    assertEquals(CodecFactory.deflateCodec(9).toString(), serdeWrite.getCodec().toString());
+    assertEquals(
+        CodecFactory.deflateCodec(9).toString(),
+        SerializableUtils.clone(write.getCodec()).getCodec().toString());
   }
 
   @Test
@@ -434,9 +434,9 @@ public class AvroIOTest {
         .to("gs://bucket/foo/baz")
         .withCodec(CodecFactory.xzCodec(9));
 
-    AvroIO.Write<GenericRecord> serdeWrite = SerializableUtils.clone(write);
-
-    assertEquals(CodecFactory.xzCodec(9).toString(), serdeWrite.getCodec().toString());
+    assertEquals(
+        CodecFactory.xzCodec(9).toString(),
+        SerializableUtils.clone(write.getCodec()).getCodec().toString());
   }
 
   @Test
@@ -482,7 +482,7 @@ public class AvroIOTest {
     p.apply(Create.of(ImmutableList.copyOf(expectedElements))).apply(write);
     p.run();
 
-    String shardNameTemplate = write.getShardNameTemplate();
+    String shardNameTemplate = write.getShardTemplate();
 
     assertTestOutputs(expectedElements, numShards, outputFilePrefix, shardNameTemplate);
   }
@@ -580,9 +580,8 @@ public class AvroIOTest {
 
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create(options);
 
-    AvroIO.Write<?> write = AvroIO.<GenericRecord>write()
-        .to(outputPath)
-        .withSchema(Schema.create(Schema.Type.STRING));
+    AvroIO.Write<?> write = AvroIO.writeGenericRecords(Schema.create(Schema.Type.STRING))
+        .to(outputPath);
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(write);
     assertThat("AvroIO.Write should include the file pattern in its primitive transform",

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -282,10 +282,6 @@ public class AvroIOTest {
     p.run();
   }
 
-  private TimestampedValue<GenericClass> newValue(GenericClass element, Duration duration) {
-    return TimestampedValue.of(element, new Instant(0).plus(duration));
-  }
-
   private static class WindowedFilenamePolicy extends FilenamePolicy {
     String outputFilePrefix;
 
@@ -550,8 +546,8 @@ public class AvroIOTest {
   public void testPrimitiveReadDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
 
-    AvroIO.Read<?> read = AvroIO.read().from("foo.*")
-        .withSchema(Schema.create(Schema.Type.STRING));
+    AvroIO.Read<?> read =
+        AvroIO.readGenericRecords(Schema.create(Schema.Type.STRING)).from("foo.*");
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);
     assertThat("AvroIO.Read should include the file pattern in its primitive transform",

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -103,7 +103,7 @@ public class AvroIOTest {
 
   @Test
   public void testAvroIOGetName() {
-    assertEquals("AvroIO.Read", AvroIO.Read.from("gs://bucket/foo*/baz").getName());
+    assertEquals("AvroIO.Read", AvroIO.read().from("gs://bucket/foo*/baz").getName());
     assertEquals("AvroIO.Write", AvroIO.Write.to("gs://bucket/foo/baz").getName());
   }
 
@@ -150,8 +150,11 @@ public class AvroIOTest {
           .withSchema(GenericClass.class));
     p.run();
 
-    PCollection<GenericClass> input = p
-        .apply(AvroIO.Read.from(outputFile.getAbsolutePath()).withSchema(GenericClass.class));
+    PCollection<GenericClass> input =
+        p.apply(
+            AvroIO.<GenericClass>read()
+                .from(outputFile.getAbsolutePath())
+                .withSchema(GenericClass.class));
 
     PAssert.that(input).containsInAnyOrder(values);
     p.run();
@@ -173,7 +176,7 @@ public class AvroIOTest {
     p.run();
 
     PCollection<GenericClass> input = p
-        .apply(AvroIO.Read
+        .apply(AvroIO.<GenericClass>read()
             .from(outputFile.getAbsolutePath())
             .withSchema(GenericClass.class));
 
@@ -200,7 +203,7 @@ public class AvroIOTest {
     p.run();
 
     PCollection<GenericClass> input = p
-        .apply(AvroIO.Read
+        .apply(AvroIO.<GenericClass>read()
             .from(outputFile.getAbsolutePath())
             .withSchema(GenericClass.class));
 
@@ -269,8 +272,11 @@ public class AvroIOTest {
     List<GenericClassV2> expected = ImmutableList.of(new GenericClassV2(3, "hi", null),
         new GenericClassV2(5, "bar", null));
 
-    PCollection<GenericClassV2> input = p
-        .apply(AvroIO.Read.from(outputFile.getAbsolutePath()).withSchema(GenericClassV2.class));
+    PCollection<GenericClassV2> input =
+        p.apply(
+            AvroIO.<GenericClassV2>read()
+                .from(outputFile.getAbsolutePath())
+                .withSchema(GenericClassV2.class));
 
     PAssert.that(input).containsInAnyOrder(expected);
     p.run();
@@ -533,7 +539,7 @@ public class AvroIOTest {
 
   @Test
   public void testReadDisplayData() {
-    AvroIO.Read.Bound<?> read = AvroIO.Read.from("foo.*");
+    AvroIO.Read<?> read = AvroIO.read().from("foo.*");
 
     DisplayData displayData = DisplayData.from(read);
     assertThat(displayData, hasDisplayItem("filePattern", "foo.*"));
@@ -544,7 +550,7 @@ public class AvroIOTest {
   public void testPrimitiveReadDisplayData() {
     DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
 
-    AvroIO.Read.Bound<?> read = AvroIO.Read.from("foo.*")
+    AvroIO.Read<?> read = AvroIO.read().from("foo.*")
         .withSchema(Schema.create(Schema.Type.STRING));
 
     Set<DisplayData> displayData = evaluator.displayDataForPrimitiveSourceTransforms(read);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -169,14 +169,14 @@ public class AvroIOTransformTest {
                   // test read using generated class
                   new Object[] {
                       null,
-                      AvroIO.<AvroGeneratedUser>read().withSchema(AvroGeneratedUser.class),
+                      AvroIO.read(AvroGeneratedUser.class),
                       "AvroIO.Read/Read.out",
                       generateAvroObjects(),
                       generatedClass
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.<AvroGeneratedUser>read().withSchema(AvroGeneratedUser.class),
+                      AvroIO.read(AvroGeneratedUser.class),
                       "MyRead/Read.out",
                       generateAvroObjects(),
                       generatedClass

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -271,7 +271,7 @@ public class AvroIOTransformTest {
           ImmutableList.<Object[]>builder()
               .add(
                   new Object[] {
-                      AvroIO.<AvroGeneratedUser>write().withSchema(AvroGeneratedUser.class),
+                      AvroIO.write(AvroGeneratedUser.class),
                       generatedClass
                   },
                   new Object[] {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -138,13 +138,13 @@ public class AvroIOTransformTest {
     }
 
     private <T> void runTestRead(@Nullable final String applyName,
-                                 final AvroIO.Read.Bound<T> readBuilder,
+                                 final AvroIO.Read<T> readBuilder,
                                  final String expectedName,
                                  final T[] expectedOutput) throws Exception {
 
       final File avroFile = tmpFolder.newFile("file.avro");
       generateAvroFile(generateAvroObjects(), avroFile);
-      final AvroIO.Read.Bound<T> read = readBuilder.from(avroFile.getPath());
+      final AvroIO.Read<T> read = readBuilder.from(avroFile.getPath());
       final PCollection<T> output =
           applyName == null ? pipeline.apply(read) : pipeline.apply(applyName, read);
 
@@ -169,14 +169,14 @@ public class AvroIOTransformTest {
                   // test read using generated class
                   new Object[] {
                       null,
-                      AvroIO.Read.withSchema(AvroGeneratedUser.class),
+                      AvroIO.<AvroGeneratedUser>read().withSchema(AvroGeneratedUser.class),
                       "AvroIO.Read/Read.out",
                       generateAvroObjects(),
                       generatedClass
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.Read.withSchema(AvroGeneratedUser.class),
+                      AvroIO.<AvroGeneratedUser>read().withSchema(AvroGeneratedUser.class),
                       "MyRead/Read.out",
                       generateAvroObjects(),
                       generatedClass
@@ -185,14 +185,14 @@ public class AvroIOTransformTest {
                   // test read using schema object
                   new Object[] {
                       null,
-                      AvroIO.Read.withSchema(SCHEMA),
+                      AvroIO.read().withSchema(SCHEMA),
                       "AvroIO.Read/Read.out",
                       generateAvroGenericRecords(),
                       fromSchema
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.Read.withSchema(SCHEMA),
+                      AvroIO.read().withSchema(SCHEMA),
                       "MyRead/Read.out",
                       generateAvroGenericRecords(),
                       fromSchema
@@ -201,14 +201,14 @@ public class AvroIOTransformTest {
                   // test read using schema string
                   new Object[] {
                       null,
-                      AvroIO.Read.withSchema(SCHEMA_STRING),
+                      AvroIO.read().withSchema(SCHEMA_STRING),
                       "AvroIO.Read/Read.out",
                       generateAvroGenericRecords(),
                       fromSchemaString
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.Read.withSchema(SCHEMA_STRING),
+                      AvroIO.read().withSchema(SCHEMA_STRING),
                       "MyRead/Read.out",
                       generateAvroGenericRecords(),
                       fromSchemaString
@@ -221,7 +221,7 @@ public class AvroIOTransformTest {
     public String transformName;
 
     @Parameterized.Parameter(1)
-    public AvroIO.Read.Bound readTransform;
+    public AvroIO.Read readTransform;
 
     @Parameterized.Parameter(2)
     public String expectedReadTransformName;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -275,12 +275,12 @@ public class AvroIOTransformTest {
                       generatedClass
                   },
                   new Object[] {
-                      AvroIO.write().withSchema(SCHEMA),
+                      AvroIO.writeGenericRecords(SCHEMA),
                       fromSchema
                   },
 
                   new Object[] {
-                      AvroIO.write().withSchema(SCHEMA_STRING),
+                      AvroIO.writeGenericRecords(SCHEMA_STRING),
                       fromSchemaString
                   })
               .build();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -271,16 +271,16 @@ public class AvroIOTransformTest {
           ImmutableList.<Object[]>builder()
               .add(
                   new Object[] {
-                      AvroIO.Write.withSchema(AvroGeneratedUser.class),
+                      AvroIO.<AvroGeneratedUser>write().withSchema(AvroGeneratedUser.class),
                       generatedClass
                   },
                   new Object[] {
-                      AvroIO.Write.withSchema(SCHEMA),
+                      AvroIO.write().withSchema(SCHEMA),
                       fromSchema
                   },
 
                   new Object[] {
-                      AvroIO.Write.withSchema(SCHEMA_STRING),
+                      AvroIO.write().withSchema(SCHEMA_STRING),
                       fromSchemaString
                   })
               .build();
@@ -288,17 +288,17 @@ public class AvroIOTransformTest {
 
     @SuppressWarnings("DefaultAnnotationParam")
     @Parameterized.Parameter(0)
-    public AvroIO.Write.Bound writeTransform;
+    public AvroIO.Write writeTransform;
 
     @Parameterized.Parameter(1)
     public String testAlias;
 
-    private <T> void runTestWrite(final AvroIO.Write.Bound<T> writeBuilder)
+    private <T> void runTestWrite(final AvroIO.Write<T> writeBuilder)
         throws Exception {
 
       final File avroFile = tmpFolder.newFile("file.avro");
       final AvroGeneratedUser[] users = generateAvroObjects();
-      final AvroIO.Write.Bound<T> write = writeBuilder.to(avroFile.getPath());
+      final AvroIO.Write<T> write = writeBuilder.to(avroFile.getPath());
 
       @SuppressWarnings("unchecked") final
       PCollection<T> input =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -185,14 +185,14 @@ public class AvroIOTransformTest {
                   // test read using schema object
                   new Object[] {
                       null,
-                      AvroIO.read().withSchema(SCHEMA),
+                      AvroIO.readGenericRecords(SCHEMA),
                       "AvroIO.Read/Read.out",
                       generateAvroGenericRecords(),
                       fromSchema
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.read().withSchema(SCHEMA),
+                      AvroIO.readGenericRecords(SCHEMA),
                       "MyRead/Read.out",
                       generateAvroGenericRecords(),
                       fromSchema
@@ -201,14 +201,14 @@ public class AvroIOTransformTest {
                   // test read using schema string
                   new Object[] {
                       null,
-                      AvroIO.read().withSchema(SCHEMA_STRING),
+                      AvroIO.readGenericRecords(SCHEMA_STRING),
                       "AvroIO.Read/Read.out",
                       generateAvroGenericRecords(),
                       fromSchemaString
                   },
                   new Object[] {
                       "MyRead",
-                      AvroIO.read().withSchema(SCHEMA_STRING),
+                      AvroIO.readGenericRecords(SCHEMA_STRING),
                       "MyRead/Read.out",
                       generateAvroGenericRecords(),
                       fromSchemaString


### PR DESCRIPTION
Migration guide:
- AvroIO.Read.from(...).withSchema(Foo.class) -> AvroIO.read(Foo.class).from(...)
- AvroIO.Read.from(...).withSchema(Schema or String) -> AvroIO.readGenericRecords(String).from(...)
- Likewise for AvroIO.Write

This is the last PR in https://issues.apache.org/jira/browse/BEAM-1353 !

R: @reuvenlax 