### PR TITLE
Do not prune branches in Jenkins

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -69,7 +69,6 @@ class common_job_properties {
         branch('${sha1}')
         extensions {
           cleanAfterCheckout()
-          pruneBranches()
         }
       }
     }


### PR DESCRIPTION
It seems that pruning in Jenkins has bugs which result in
branches being pruned when they should not, resulting in
log spam and build delays.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Reverting my prior change bd6db885836af40940fca20cf680833661180e67. The prior change supports changing the refspec, but I suspect bugs in this feature are behind unreasonable behavior such as the git fetch here: https://builds.apache.org/job/beam_PreCommit_Java_MavenInstall/10329/consoleFull