### PR TITLE
[BEAM-59] Switch mimeType from mutable protected field to constructor

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -1032,8 +1032,7 @@ public class AvroIO {
                         AvroCoder<T> coder,
                         SerializableAvroCodecFactory codec,
                         ImmutableMap<String, Object> metadata) {
-        super(writeOperation);
-        this.mimeType = MimeTypes.BINARY;
+        super(writeOperation, MimeTypes.BINARY);
         this.coder = coder;
         this.codec = codec;
         this.metadata = metadata;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -792,6 +792,11 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     /**
      * The MIME type used in the creation of the output channel (if the file system supports it).
+     *
+     * <p>This is the default for the sink, but it may be overridden by a supplied
+     * {@link WritableByteChannelFactory}. For example, {@link TextIO.Write} uses
+     * {@link MimeTypes#TEXT} by default but if {@link CompressionType#BZIP2} is set then
+     * The MIME type will be overridden to {@link MimeTypes#BINARY}.
      */
     private final String mimeType;
 
@@ -1025,7 +1030,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     /**
      * Returns the MIME type that should be used for the files that will hold the output data. May
-     * return {@code null} if this {@code WritableByteChannelFactory} does not meaningful change
+     * return {@code null} if this {@code WritableByteChannelFactory} does not meaningfully change
      * the MIME type (e.g., for {@link CompressionType#UNCOMPRESSED}).
      *
      * @see MimeTypes

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
@@ -156,7 +157,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     /**
      * No compression, or any other transformation, will be used.
      */
-    UNCOMPRESSED("", MimeTypes.TEXT) {
+    UNCOMPRESSED("", null) {
       @Override
       public WritableByteChannel create(WritableByteChannel channel) throws IOException {
         return channel;
@@ -193,9 +194,9 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     };
 
     private String filenameSuffix;
-    private String mimeType;
+    @Nullable private String mimeType;
 
-    CompressionType(String suffix, String mimeType) {
+    CompressionType(String suffix, @Nullable String mimeType) {
       this.filenameSuffix = suffix;
       this.mimeType = mimeType;
     }
@@ -206,7 +207,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     }
 
     @Override
-    public String getMimeType() {
+    @Nullable public String getMimeType() {
       return mimeType;
     }
   }
@@ -791,20 +792,16 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     /**
      * The MIME type used in the creation of the output channel (if the file system supports it).
-     *
-     * <p>GCS, for example, supports writing files with Content-Type metadata.
-     *
-     * <p>May be overridden. Default is {@link MimeTypes#TEXT}. See {@link MimeTypes} for other
-     * options.
      */
-    protected String mimeType = MimeTypes.TEXT;
+    private final String mimeType;
 
     /**
      * Construct a new FileBasedWriter with a base filename.
      */
-    public FileBasedWriter(FileBasedWriteOperation<T> writeOperation) {
+    public FileBasedWriter(FileBasedWriteOperation<T> writeOperation, String mimeType) {
       checkNotNull(writeOperation);
       this.writeOperation = writeOperation;
+      this.mimeType = mimeType;
     }
 
     /**
@@ -888,8 +885,9 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
       LOG.debug("Opening {}.", filename);
       final WritableByteChannelFactory factory =
           getWriteOperation().getSink().writableByteChannelFactory;
-      mimeType = factory.getMimeType();
-      channel = factory.create(IOChannelUtils.create(filename, mimeType));
+      // The factory may force a MIME type or it may return null, indicating to use the sink's MIME.
+      String channelMimeType = firstNonNull(factory.getMimeType(), mimeType);
+      channel = factory.create(IOChannelUtils.create(filename, channelMimeType));
       try {
         prepareWrite(channel);
         LOG.debug("Writing header to {}.", filename);
@@ -1026,11 +1024,15 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     WritableByteChannel create(WritableByteChannel channel) throws IOException;
 
     /**
-     * @return the MIME type that should be used for the files that will hold the output data
+     * Returns the MIME type that should be used for the files that will hold the output data. May
+     * return {@code null} if this {@code WritableByteChannelFactory} does not meaningful change
+     * the MIME type (e.g., for {@link CompressionType#UNCOMPRESSED}).
+     *
      * @see MimeTypes
      * @see <a href=
      *      'http://www.iana.org/assignments/media-types/media-types.xhtml'>http://www.iana.org/assignments/media-types/media-types.xhtml</a>
      */
+    @Nullable
     String getMimeType();
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -603,8 +603,7 @@ public class TFRecordIO {
       private TFRecordCodec codec;
 
       private TFRecordWriter(FileBasedWriteOperation<byte[]> writeOperation) {
-        super(writeOperation);
-        this.mimeType = MimeTypes.BINARY;
+        super(writeOperation, MimeTypes.BINARY);
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -1079,10 +1079,9 @@ public class TextIO {
           FileBasedWriteOperation<String> writeOperation,
           @Nullable String header,
           @Nullable String footer) {
-        super(writeOperation);
+        super(writeOperation, MimeTypes.TEXT);
         this.header = header;
         this.footer = footer;
-        this.mimeType = MimeTypes.TEXT;
       }
 
       /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io;
 import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.MimeTypes;
 
 /**
  * A simple FileBasedSink that writes String values as lines with header and footer lines.
@@ -65,7 +66,7 @@ class SimpleSink extends FileBasedSink<String> {
     private WritableByteChannel channel;
 
     public SimpleWriter(SimpleWriteOperation writeOperation) {
-      super(writeOperation);
+      super(writeOperation, MimeTypes.TEXT);
     }
 
     private static ByteBuffer wrap(String value) throws Exception {

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.util.MimeTypes;
 
 /** Implementation of {@link XmlIO#write}. */
 class XmlSink<T> extends FileBasedSink<T> {
@@ -111,7 +112,7 @@ class XmlSink<T> extends FileBasedSink<T> {
     private OutputStream os = null;
 
     public XmlWriter(XmlWriteOperation<T> writeOperation, Marshaller marshaller) {
-      super(writeOperation);
+      super(writeOperation, MimeTypes.TEXT);
       this.marshaller = marshaller;
     }
 


### PR DESCRIPTION
Protected mutable fields are a terrible design pattern, and this
information is known at construction time.

Also fix a minor bug in which the Binary MIME type of a FileBasedSink could erroneously be changed back to a Text MIME type when using an uncompressed channel.