### PR TITLE
[BEAM-2128] Restore status quo relationship between PipelineOptions initialization and PipelineRunners

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -148,6 +148,9 @@ public class Pipeline {
    * @return The newly created pipeline.
    */
   public static Pipeline create(PipelineOptions options) {
+    // TODO: fix runners that mutate PipelineOptions in this method, then remove this line
+    PipelineRunner.fromOptions(options);
+
     Pipeline pipeline = new Pipeline(options);
     LOG.debug("Creating {}", pipeline);
     return pipeline;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -422,7 +422,9 @@ public class TestPipeline extends Pipeline implements TestRule {
       Iterator<Entry<String, JsonNode>> entries = optsNode.fields();
       while (entries.hasNext()) {
         Entry<String, JsonNode> entry = entries.next();
-        if (entry.getValue().isTextual()) {
+        if (entry.getValue().isNull()) {
+          continue;
+        } else if (entry.getValue().isTextual()) {
           optArrayList.add("--" + entry.getKey() + "=" + entry.getValue().asText());
         } else {
           optArrayList.add("--" + entry.getKey() + "=" + entry.getValue());


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`. (Even better, enable
       Travis-CI on your fork and ensure the whole test matrix passes).
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

This should fix the MavenInstall postcommit breakage, which has coupled root causes, all of which should be remedied:

 - BigQueryIO depends on pipeline options at construction time
 - Jenkins config for Dataflow does not provide them, but relies on `TestDataflowRunner` mutating some undocumented options
 - `TestDataflowRunner` mutates options in its `fromOptions` constructor, which is a spooky action that allowed bad things to work for a while - other runners do a bit of this too

Given the depth of the issues, this PR does not fix them, but restores the behavior wherein `fromOptions` is called before construction begins, so runners once again have a chance to hack options however they already do.