### PR TITLE
[BEAM-48] BigQuery: swap from asSingleton to asIterable for Cleanup

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PassThroughThenCleanup.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PassThroughThenCleanup.java
@@ -53,9 +53,9 @@ class PassThroughThenCleanup<T> extends PTransform<PCollection<T>, PCollection<T
     PCollectionTuple outputs = input.apply(ParDo.of(new IdentityFn<T>())
         .withOutputTags(mainOutput, TupleTagList.of(cleanupSignal)));
 
-    PCollectionView<Void> cleanupSignalView = outputs.get(cleanupSignal)
+    PCollectionView<Iterable<Void>> cleanupSignalView = outputs.get(cleanupSignal)
         .setCoder(VoidCoder.of())
-        .apply(View.<Void>asSingleton().withDefaultValue(null));
+        .apply(View.<Void>asIterable());
 
     input.getPipeline()
         .apply("Create(CleanupOperation)", Create.of(cleanupOperation))


### PR DESCRIPTION
asIterable can be simpler for runners to implement as it does not require semantically
that the PCollection being viewed contains exactly one element.
