### PR TITLE
[BEAM-2141] Disable JDBC tests

### DIFF
--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -57,4 +57,7 @@ job('beam_PerformanceTests_JDBC'){
     ]
 
     common_job_properties.buildPerformanceTest(delegate, argMap)
+
+    // [BEAM-2141] Perf tests do not pass.
+    disabled()
 }


### PR DESCRIPTION
They do not pass, they spam mail, and they use up valuable executor space.