### PR TITLE
[BEAM-828] BigQueryIO: Remove PipelineOptions.getJobName usages at pipeline construction time

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -297,11 +297,11 @@ public class BigQueryHelpers {
     }
   }
 
-  static String getJobIdToken(String jobName, String stepUuid) {
-    return "beam_job_" + getJobUuid(jobName, stepUuid);
+  static String createJobIdToken(String jobName, String stepUuid) {
+    return "beam_job_" + createJobUuid(jobName, stepUuid);
   }
 
-  static String getJobUuid(String jobName, String stepUuid) {
+  static String createJobUuid(String jobName, String stepUuid) {
     return stepUuid + "_" + jobName.replaceAll("-", "");
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -256,15 +256,6 @@ public class BigQueryHelpers {
     }
   }
 
-  @VisibleForTesting
-  static class BeamJobUuidToBigQueryJobUuid
-      implements SerializableFunction<String, String> {
-    @Override
-    public String apply(String from) {
-      return "beam_job_" + from;
-    }
-  }
-
   static class TableSchemaToJsonSchema
       implements SerializableFunction<TableSchema, String> {
     @Override
@@ -297,14 +288,6 @@ public class BigQueryHelpers {
     }
   }
 
-  static class TableRefToProjectId
-      implements SerializableFunction<TableReference, String> {
-    @Override
-    public String apply(TableReference from) {
-      return from.getProjectId();
-    }
-  }
-
   @VisibleForTesting
   static class TableSpecToTableRef
       implements SerializableFunction<String, TableReference> {
@@ -314,39 +297,25 @@ public class BigQueryHelpers {
     }
   }
 
-  @VisibleForTesting
-  static class CreatePerBeamJobUuid
-      implements SerializableFunction<String, String> {
-    private final String stepUuid;
-
-    CreatePerBeamJobUuid(String stepUuid) {
-      this.stepUuid = stepUuid;
-    }
-
-    @Override
-    public String apply(String jobUuid) {
-      return stepUuid + "_" + jobUuid.replaceAll("-", "");
-    }
+  static String getJobIdToken(String jobName, String stepUuid) {
+    return "beam_job_" + getJobUuid(jobName, stepUuid);
   }
 
-  @VisibleForTesting
-  static class CreateJsonTableRefFromUuid
-      implements SerializableFunction<String, TableReference> {
-    private final String executingProject;
+  static String getJobUuid(String jobName, String stepUuid) {
+    return stepUuid + "_" + jobName.replaceAll("-", "");
+  }
 
-    CreateJsonTableRefFromUuid(String executingProject) {
-      this.executingProject = executingProject;
-    }
+  static String getExtractJobId(String jobIdToken) {
+    return jobIdToken + "-extract";
+  }
 
-    @Override
-    public TableReference apply(String jobUuid) {
-      String queryTempDatasetId = "temp_dataset_" + jobUuid;
-      String queryTempTableId = "temp_table_" + jobUuid;
-      TableReference queryTempTableRef = new TableReference()
-          .setProjectId(executingProject)
-          .setDatasetId(queryTempDatasetId)
-          .setTableId(queryTempTableId);
-      return queryTempTableRef;
-    }
+  static TableReference createTempTableReference(String projectId, String jobUuid) {
+    String queryTempDatasetId = "temp_dataset_" + jobUuid;
+    String queryTempTableId = "temp_table_" + jobUuid;
+    TableReference queryTempTableRef = new TableReference()
+        .setProjectId(projectId)
+        .setDatasetId(queryTempDatasetId)
+        .setTableId(queryTempTableId);
+    return queryTempTableRef;
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -298,15 +298,11 @@ public class BigQueryHelpers {
   }
 
   static String createJobIdToken(String jobName, String stepUuid) {
-    return "beam_job_" + createJobUuid(jobName, stepUuid);
-  }
-
-  static String createJobUuid(String jobName, String stepUuid) {
-    return stepUuid + "_" + jobName.replaceAll("-", "");
+    return String.format("beam_job_%s_%s", stepUuid, jobName.replaceAll("-", ""));
   }
 
   static String getExtractJobId(String jobIdToken) {
-    return jobIdToken + "-extract";
+    return String.format("%s-extract", jobIdToken);
   }
 
   static TableReference createTempTableReference(String projectId, String jobUuid) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -19,8 +19,8 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobIdToken;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getExtractJobId;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobIdToken;
 
 import com.google.api.client.json.JsonFactory;
 import com.google.api.services.bigquery.model.Job;
@@ -507,7 +507,8 @@ public class BigQueryIO {
               JobReference jobRef =
                   new JobReference()
                       .setProjectId(bqOptions.getProject())
-                      .setJobId(getExtractJobId(getJobIdToken(bqOptions.getJobName(), stepUuid)));
+                      .setJobId(
+                          getExtractJobId(createJobIdToken(bqOptions.getJobName(), stepUuid)));
 
               Job extractJob = getBigQueryServices().getJobService(bqOptions).getJob(jobRef);
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobIdToken;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobUuid;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createTempTableReference;
 
 import com.google.api.services.bigquery.model.Job;
@@ -112,7 +111,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
 
     // 2. Create the temporary dataset in the query location.
     TableReference tableToExtract = createTempTableReference(
-        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobIdToken(bqOptions.getJobName(), stepUuid));
 
     tableService.createDataset(
         tableToExtract.getProjectId(),
@@ -133,7 +132,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
   @Override
   protected void cleanupTempResource(BigQueryOptions bqOptions) throws Exception {
     TableReference tableToRemove = createTempTableReference(
-        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobIdToken(bqOptions.getJobName(), stepUuid));
 
     DatasetService tableService = bqServices.getDatasetService(bqOptions);
     tableService.deleteTable(tableToRemove);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -19,7 +19,9 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createTempTableReference;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobIdToken;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobUuid;
 
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationQuery;
@@ -34,13 +36,10 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.TableRefToJson;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.TableRefToProjectId;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
-import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 
 
@@ -51,17 +50,15 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 class BigQueryQuerySource extends BigQuerySourceBase {
 
   static BigQueryQuerySource create(
-      ValueProvider<String> jobIdToken,
+      String stepUuid,
       ValueProvider<String> query,
-      ValueProvider<TableReference> queryTempTableRef,
       Boolean flattenResults,
       Boolean useLegacySql,
       String extractDestinationDir,
       BigQueryServices bqServices) {
     return new BigQueryQuerySource(
-        jobIdToken,
+        stepUuid,
         query,
-        queryTempTableRef,
         flattenResults,
         useLegacySql,
         extractDestinationDir,
@@ -69,25 +66,19 @@ class BigQueryQuerySource extends BigQuerySourceBase {
   }
 
   private final ValueProvider<String> query;
-  private final ValueProvider<String> jsonQueryTempTable;
   private final Boolean flattenResults;
   private final Boolean useLegacySql;
   private transient AtomicReference<JobStatistics> dryRunJobStats;
 
   private BigQueryQuerySource(
-      ValueProvider<String> jobIdToken,
+      String stepUuid,
       ValueProvider<String> query,
-      ValueProvider<TableReference> queryTempTableRef,
       Boolean flattenResults,
       Boolean useLegacySql,
       String extractDestinationDir,
       BigQueryServices bqServices) {
-    super(jobIdToken, extractDestinationDir, bqServices,
-        NestedValueProvider.of(
-            checkNotNull(queryTempTableRef, "queryTempTableRef"), new TableRefToProjectId()));
+    super(stepUuid, extractDestinationDir, bqServices);
     this.query = checkNotNull(query, "query");
-    this.jsonQueryTempTable = NestedValueProvider.of(
-        queryTempTableRef, new TableRefToJson());
     this.flattenResults = checkNotNull(flattenResults, "flattenResults");
     this.useLegacySql = checkNotNull(useLegacySql, "useLegacySql");
     this.dryRunJobStats = new AtomicReference<>();
@@ -103,7 +94,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
   public BoundedReader<TableRow> createReader(PipelineOptions options) throws IOException {
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
     return new BigQueryReader(this, bqServices.getReaderFromQuery(
-        bqOptions, executingProject.get(), createBasicQueryConfig()));
+        bqOptions, bqOptions.getProject(), createBasicQueryConfig()));
   }
 
   @Override
@@ -120,8 +111,9 @@ class BigQueryQuerySource extends BigQuerySourceBase {
     }
 
     // 2. Create the temporary dataset in the query location.
-    TableReference tableToExtract =
-        BigQueryIO.JSON_FACTORY.fromString(jsonQueryTempTable.get(), TableReference.class);
+    TableReference tableToExtract = createTempTableReference(
+        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
+
     tableService.createDataset(
         tableToExtract.getProjectId(),
         tableToExtract.getDatasetId(),
@@ -129,9 +121,9 @@ class BigQueryQuerySource extends BigQuerySourceBase {
         "Dataset for BigQuery query job temporary table");
 
     // 3. Execute the query.
-    String queryJobId = jobIdToken.get() + "-query";
+    String queryJobId = getJobIdToken(bqOptions.getJobName(), stepUuid) + "-query";
     executeQuery(
-        executingProject.get(),
+        bqOptions.getProject(),
         queryJobId,
         tableToExtract,
         bqServices.getJobService(bqOptions));
@@ -140,9 +132,8 @@ class BigQueryQuerySource extends BigQuerySourceBase {
 
   @Override
   protected void cleanupTempResource(BigQueryOptions bqOptions) throws Exception {
-    checkState(jsonQueryTempTable.isAccessible());
-    TableReference tableToRemove =
-        BigQueryIO.JSON_FACTORY.fromString(jsonQueryTempTable.get(), TableReference.class);
+    TableReference tableToRemove = createTempTableReference(
+        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
 
     DatasetService tableService = bqServices.getDatasetService(bqOptions);
     tableService.deleteTable(tableToRemove);
@@ -159,7 +150,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
       throws InterruptedException, IOException {
     if (dryRunJobStats.get() == null) {
       JobStatistics jobStats = bqServices.getJobService(bqOptions).dryRunQuery(
-          executingProject.get(), createBasicQueryConfig());
+          bqOptions.getProject(), createBasicQueryConfig());
       dryRunJobStats.compareAndSet(null, jobStats);
     }
     return dryRunJobStats.get();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -19,9 +19,9 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobIdToken;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobUuid;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createTempTableReference;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobIdToken;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobUuid;
 
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationQuery;
@@ -112,7 +112,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
 
     // 2. Create the temporary dataset in the query location.
     TableReference tableToExtract = createTempTableReference(
-        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
 
     tableService.createDataset(
         tableToExtract.getProjectId(),
@@ -121,7 +121,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
         "Dataset for BigQuery query job temporary table");
 
     // 3. Execute the query.
-    String queryJobId = getJobIdToken(bqOptions.getJobName(), stepUuid) + "-query";
+    String queryJobId = createJobIdToken(bqOptions.getJobName(), stepUuid) + "-query";
     executeQuery(
         bqOptions.getProject(),
         queryJobId,
@@ -133,7 +133,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
   @Override
   protected void cleanupTempResource(BigQueryOptions bqOptions) throws Exception {
     TableReference tableToRemove = createTempTableReference(
-        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
 
     DatasetService tableService = bqServices.getDatasetService(bqOptions);
     tableService.deleteTable(tableToRemove);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -19,8 +19,8 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobIdToken;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getExtractJobId;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobIdToken;
 
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationExtract;
@@ -86,7 +86,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
       BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
       TableReference tableToExtract = getTableToExtract(bqOptions);
       JobService jobService = bqServices.getJobService(bqOptions);
-      String extractJobId = getExtractJobId(getJobIdToken(options.getJobName(), stepUuid));
+      String extractJobId = getExtractJobId(createJobIdToken(options.getJobName(), stepUuid));
       List<String> tempFiles = executeExtract(
           extractJobId, tableToExtract, jobService, bqOptions.getProject());
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
@@ -43,25 +43,22 @@ class BigQueryTableSource extends BigQuerySourceBase {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryTableSource.class);
 
   static BigQueryTableSource create(
-      ValueProvider<String> jobIdToken,
+      String stepUuid,
       ValueProvider<TableReference> table,
       String extractDestinationDir,
-      BigQueryServices bqServices,
-      ValueProvider<String> executingProject) {
-    return new BigQueryTableSource(
-        jobIdToken, table, extractDestinationDir, bqServices, executingProject);
+      BigQueryServices bqServices) {
+    return new BigQueryTableSource(stepUuid, table, extractDestinationDir, bqServices);
   }
 
   private final ValueProvider<String> jsonTable;
   private final AtomicReference<Long> tableSizeBytes;
 
   private BigQueryTableSource(
-      ValueProvider<String> jobIdToken,
+      String stepUuid,
       ValueProvider<TableReference> table,
       String extractDestinationDir,
-      BigQueryServices bqServices,
-      ValueProvider<String> executingProject) {
-    super(jobIdToken, extractDestinationDir, bqServices, executingProject);
+      BigQueryServices bqServices) {
+    super(stepUuid, extractDestinationDir, bqServices);
     this.jsonTable = NestedValueProvider.of(checkNotNull(table, "table"), new TableRefToJson());
     this.tableSizeBytes = new AtomicReference<>();
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -20,8 +20,8 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobUuid;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createTempTableReference;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.getJobUuid;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.toJsonString;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -1262,6 +1262,8 @@ public class BigQueryIOTest implements Serializable {
 
     PipelineOptions options = PipelineOptionsFactory.create();
     options.setTempLocation(baseDir.toString());
+    BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
+    bqOptions.setProject("project");
 
     List<TableRow> read = SourceTestUtils.readFromSource(bqSource, options);
     assertThat(read, containsInAnyOrder(Iterables.toArray(expected, TableRow.class)));
@@ -1320,7 +1322,7 @@ public class BigQueryIOTest implements Serializable {
     String stepUuid = "testStepUuid";
 
     TableReference tempTableReference = createTempTableReference(
-        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
     fakeDatasetService.createDataset(
         bqOptions.getProject(), tempTableReference.getDatasetId(), "", "");
     fakeDatasetService.createTable(new Table()
@@ -1395,7 +1397,7 @@ public class BigQueryIOTest implements Serializable {
     String stepUuid = "testStepUuid";
 
     TableReference tempTableReference = createTempTableReference(
-        bqOptions.getProject(), getJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
     List<TableRow> expected = ImmutableList.of(
         new TableRow().set("name", "a").set("number", 1L),
         new TableRow().set("name", "b").set("number", 2L),

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -20,7 +20,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobUuid;
+import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createJobIdToken;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.createTempTableReference;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.toJsonString;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
@@ -1322,7 +1322,7 @@ public class BigQueryIOTest implements Serializable {
     String stepUuid = "testStepUuid";
 
     TableReference tempTableReference = createTempTableReference(
-        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobIdToken(bqOptions.getJobName(), stepUuid));
     fakeDatasetService.createDataset(
         bqOptions.getProject(), tempTableReference.getDatasetId(), "", "");
     fakeDatasetService.createTable(new Table()
@@ -1397,7 +1397,7 @@ public class BigQueryIOTest implements Serializable {
     String stepUuid = "testStepUuid";
 
     TableReference tempTableReference = createTempTableReference(
-        bqOptions.getProject(), createJobUuid(bqOptions.getJobName(), stepUuid));
+        bqOptions.getProject(), createJobIdToken(bqOptions.getJobName(), stepUuid));
     List<TableRow> expected = ImmutableList.of(
         new TableRow().set("name", "a").set("number", 1L),
         new TableRow().set("name", "b").set("number", 2L),

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -76,7 +76,6 @@ import org.joda.time.Duration;
  */
 class FakeJobService implements JobService, Serializable {
   static final JsonFactory JSON_FACTORY = Transport.getJsonFactory();
-
   // Whenever a job is started, the first 5 calls to GetJob will report the job as pending,
   // the next 5 will return the job as running, and only then will the job report as done.
   private static final int GET_JOBS_TRANSITION_INTERVAL = 5;
@@ -240,7 +239,9 @@ class FakeJobService implements JobService, Serializable {
             job.job.setStatus(runJob(job.job));
           }
         } catch (Exception e) {
-          job.job.getStatus().setState("FAILED").setErrorResult(new ErrorProto());
+          job.job.getStatus().setState("FAILED").setErrorResult(
+              new ErrorProto().setMessage(
+                  String.format("Job %s failed: %s", job.job.getConfiguration(), e.toString())));
         }
         return JSON_FACTORY.fromString(JSON_FACTORY.toString(job.job), Job.class);
       }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

- stepUuid    -> A random uuid created for every expansion of the BQ read transform
- jobUuid      ->  stepUuid + pipelineOptions.jobName (used for temp table name)
- jobIdToken -> "beam_job_" + jobUuid (used as job id for BQ JobReference)

Currently pipelineOptions.jobName is accessed at pipeline construction time and wrapped in a NestedValueProvider to provide jobUuid and jobIdToken to the BQSource. 

This PR,
- removes the jobName access at construction time and lets the source compute the jobIdToken by fetching the jobName at runtime. 
- uses jobIdToken for both temp table name and BQ job id. 

Semantically there is no difference apart from same id being used for temp table name and job id.