### PR TITLE
[BEAM-818,BEAM-828] Make tempLocation an inaccessible ValueProvider

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java
@@ -71,7 +71,7 @@ public class DistinctExample {
       @Override
       public String create(PipelineOptions options) {
         if (options.getTempLocation() != null) {
-          return GcsPath.fromUri(options.getTempLocation())
+          return GcsPath.fromUri(options.getTempLocation().get())
               .resolve("deduped.txt").toString();
         } else {
           throw new IllegalArgumentException("Must specify --output or --tempLocation");

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunner.java
@@ -39,6 +39,7 @@ import org.apache.beam.runners.dataflow.util.MonitoringUtil.JobMessagesHandler;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.runners.PipelineRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -78,7 +79,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         dataflowOptions.getJobName(),
         "output",
         "results");
-    dataflowOptions.setTempLocation(tempLocation);
+    dataflowOptions.setTempLocation(StaticValueProvider.of(tempLocation));
 
     return new TestDataflowRunner(
         dataflowOptions, DataflowClient.create(options.as(DataflowPipelineOptions.class)));

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverridesTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverridesTest.java
@@ -40,6 +40,7 @@ import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -161,7 +162,8 @@ public class BatchStatefulParDoOverridesTest implements Serializable {
     options.setGcpCredential(new TestCredential());
     options.setJobName("some-job-name");
     options.setProject("some-project");
-    options.setTempLocation(GcsPath.fromComponents("somebucket", "some/path").toString());
+    options.setTempLocation(
+        StaticValueProvider.of(GcsPath.fromComponents("somebucket", "some/path").toString()));
     options.setFilesToStage(new LinkedList<String>());
     options.setGcsUtil(mockGcsUtil);
     return options;

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -42,6 +42,7 @@ import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.util.NoopPathValidator;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,7 +84,7 @@ public class DataflowMetricsTest {
     options.setDataflowClient(mockWorkflowClient);
     options.setProject(PROJECT_ID);
     options.setRunner(DataflowRunner.class);
-    options.setTempLocation("gs://fakebucket/temp");
+    options.setTempLocation(StaticValueProvider.of("gs://fakebucket/temp"));
     options.setPathValidatorClass(NoopPathValidator.class);
     options.setGcpCredential(new TestCredential());
   }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineJobTest.java
@@ -55,6 +55,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.ExpectedLogs;
 import org.apache.beam.sdk.testing.FastNanoClockAndSleeper;
 import org.apache.beam.sdk.transforms.AppliedPTransform;
@@ -121,7 +122,7 @@ public class DataflowPipelineJobTest {
     options.setProject(PROJECT_ID);
     options.setRegion(REGION_ID);
     options.setRunner(DataflowRunner.class);
-    options.setTempLocation("gs://fakebucket/temp");
+    options.setTempLocation(StaticValueProvider.of("gs://fakebucket/temp"));
     options.setPathValidatorClass(NoopPathValidator.class);
     options.setGcpCredential(new TestCredential());
   }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -70,6 +70,7 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -179,7 +180,8 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     options.setGcpCredential(new TestCredential());
     options.setJobName("some-job-name");
     options.setProject("some-project");
-    options.setTempLocation(GcsPath.fromComponents("somebucket", "some/path").toString());
+    options.setTempLocation(
+        StaticValueProvider.of(GcsPath.fromComponents("somebucket", "some/path").toString()));
     options.setFilesToStage(new LinkedList<String>());
     options.setDataflowClient(buildMockDataflow(new IsValidCreateRequest()));
     options.setGcsUtil(mockGcsUtil);

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -74,6 +74,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.testing.ExpectedLogs;
@@ -235,7 +236,7 @@ public class DataflowRunnerTest {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setRunner(DataflowRunner.class);
     options.setProject(PROJECT_ID);
-    options.setTempLocation(VALID_TEMP_BUCKET);
+    options.setTempLocation(StaticValueProvider.of(VALID_TEMP_BUCKET));
     options.setRegion(REGION_ID);
     // Set FILES_PROPERTY to empty to prevent a default value calculated from classpath.
     options.setFilesToStage(new LinkedList<String>());
@@ -466,7 +467,7 @@ public class DataflowRunnerTest {
         temp1.getAbsolutePath(),
         overridePackageName + "=" + temp2.getAbsolutePath()));
     options.setStagingLocation(VALID_STAGING_BUCKET);
-    options.setTempLocation(VALID_TEMP_BUCKET);
+    options.setTempLocation(StaticValueProvider.of(VALID_TEMP_BUCKET));
     options.setTempDatasetId(cloudDataflowDataset);
     options.setProject(PROJECT_ID);
     options.setRegion(REGION_ID);
@@ -555,7 +556,7 @@ public class DataflowRunnerTest {
   public void testGcsStagingLocationInitialization() throws Exception {
     // Set temp location (required), and check that staging location is set.
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    options.setTempLocation(VALID_TEMP_BUCKET);
+    options.setTempLocation(StaticValueProvider.of(VALID_TEMP_BUCKET));
     options.setProject(PROJECT_ID);
     options.setGcpCredential(new TestCredential());
     options.setGcsUtil(mockGcsUtil);
@@ -637,7 +638,7 @@ public class DataflowRunnerTest {
   @Test
   public void testNonGcsTempLocation() throws IOException {
     DataflowPipelineOptions options = buildPipelineOptions();
-    options.setTempLocation("file://temp/location");
+    options.setTempLocation(StaticValueProvider.of("file://temp/location"));
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(
@@ -851,7 +852,7 @@ public class DataflowRunnerTest {
     options.setRunner(DataflowRunner.class);
     options.setGcpCredential(new TestCredential());
     options.setProject("foo-project");
-    options.setTempLocation(VALID_TEMP_BUCKET);
+    options.setTempLocation(StaticValueProvider.of(VALID_TEMP_BUCKET));
     options.setGcsUtil(mockGcsUtil);
 
     DataflowRunner.fromOptions(options);
@@ -1071,7 +1072,7 @@ public class DataflowRunnerTest {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setJobName("TestJobName");
     options.setProject("test-project");
-    options.setTempLocation("gs://test/temp/location");
+    options.setTempLocation(StaticValueProvider.of("gs://test/temp/location"));
     options.setGcpCredential(new TestCredential());
     options.setPathValidatorClass(NoopPathValidator.class);
     options.setRunner(DataflowRunner.class);
@@ -1094,7 +1095,7 @@ public class DataflowRunnerTest {
     options.setProject("test-project");
     options.setRunner(DataflowRunner.class);
     options.setTemplateLocation(existingFile.getPath());
-    options.setTempLocation(tmpFolder.getRoot().getPath());
+    options.setTempLocation(StaticValueProvider.of(tmpFolder.getRoot().getPath()));
     Pipeline p = Pipeline.create(options);
 
     p.run();
@@ -1112,7 +1113,7 @@ public class DataflowRunnerTest {
     options.setRunner(DataflowRunner.class);
     options.setTemplateLocation("//bad/path");
     options.setProject("test-project");
-    options.setTempLocation(tmpFolder.getRoot().getPath());
+    options.setTempLocation(StaticValueProvider.of(tmpFolder.getRoot().getPath()));
     options.setGcpCredential(new TestCredential());
     options.setPathValidatorClass(NoopPathValidator.class);
     Pipeline p = Pipeline.create(options);

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.ResetDateTimeProvider;
 import org.apache.beam.sdk.testing.RestoreSystemProperties;
 import org.apache.beam.sdk.util.IOChannelUtils;
@@ -129,7 +130,7 @@ public class DataflowPipelineOptionsTest {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     IOChannelUtils.registerIOFactoriesAllowOverride(options);
     options.setPathValidatorClass(NoopPathValidator.class);
-    options.setTempLocation("gs://temp_location");
+    options.setTempLocation(StaticValueProvider.of("gs://temp_location"));
     options.setStagingLocation("gs://staging_location");
     assertEquals("gs://temp_location", options.getGcpTempLocation());
     assertEquals("gs://staging_location", options.getStagingLocation());
@@ -140,7 +141,7 @@ public class DataflowPipelineOptionsTest {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     IOChannelUtils.registerIOFactoriesAllowOverride(options);
     options.setPathValidatorClass(NoopPathValidator.class);
-    options.setTempLocation("gs://temp_location");
+    options.setTempLocation(StaticValueProvider.of("gs://temp_location"));
     assertEquals("gs://temp_location", options.getGcpTempLocation());
     assertEquals("gs://temp_location/staging", options.getStagingLocation());
   }
@@ -150,7 +151,7 @@ public class DataflowPipelineOptionsTest {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     IOChannelUtils.registerIOFactoriesAllowOverride(options);
     options.setPathValidatorClass(NoopPathValidator.class);
-    options.setTempLocation("gs://temp_location");
+    options.setTempLocation(StaticValueProvider.of("gs://temp_location"));
     options.setGcpTempLocation("gs://gcp_temp_location");
     assertEquals("gs://gcp_temp_location/staging", options.getStagingLocation());
   }
@@ -158,7 +159,7 @@ public class DataflowPipelineOptionsTest {
   @Test
   public void testDefaultNoneGcsTempLocation() {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    options.setTempLocation("file://temp_location");
+    options.setTempLocation(StaticValueProvider.of("file://temp_location"));
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Error constructing default value for stagingLocation: "
         + "failed to retrieve gcpTempLocation.");

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/testing/TestDataflowRunnerTest.java
@@ -55,6 +55,7 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.SerializableMatcher;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -94,7 +95,7 @@ public class TestDataflowRunnerTest {
     options = PipelineOptionsFactory.as(TestDataflowPipelineOptions.class);
     options.setAppName("TestAppName");
     options.setProject("test-project");
-    options.setTempLocation("gs://test/temp/location");
+    options.setTempLocation(StaticValueProvider.of("gs://test/temp/location"));
     options.setTempRoot("gs://test");
     options.setGcpCredential(new TestCredential());
     options.setRunner(TestDataflowRunner.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.InaccessibleValueProvider;
 import org.apache.beam.sdk.runners.PTransformOverride;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory.PTransformReplacement;
@@ -447,6 +448,7 @@ public class Pipeline {
   private final PipelineOptions defaultOptions;
 
   protected Pipeline(PipelineOptions options) {
+    options.setTempLocation(InaccessibleValueProvider.of(options.getTempLocation()));
     this.defaultOptions = options;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -247,16 +247,13 @@ public interface PipelineOptions extends HasDisplayData {
   /**
    * A pipeline level default location for storing temporary files.
    *
-   * <p>This can be a path of any file system.
-   *
-   * <p>{@link #getTempLocation()} can be used as a default location in other
-   * {@link PipelineOptions}.
-   *
-   * <p>If it is unset, {@link PipelineRunner} can override it.
+   * <p>This option is not accessible to transforms during construction, as it may be controlled by
+   * the runner. Transforms instead use the {@link ValueProvider} in order to receive an appropriate
+   * temporary location at run time.
    */
   @Description("A pipeline level default location for storing temporary files.")
-  String getTempLocation();
-  void setTempLocation(String value);
+  ValueProvider<String> getTempLocation();
+  void setTempLocation(ValueProvider<String> value);
 
   @Description("Name of the pipeline execution."
       + "It must match the regular expression '[a-z]([-a-z0-9]{0,38}[a-z0-9])?'."

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -101,6 +101,43 @@ public interface ValueProvider<T> extends Serializable {
   }
 
   /**
+   * An implementation of {@link ValueProvider} that has a statically-provided value but is
+   * still considered inaccessible. During pipeline execution, it will be accessible as
+   * a {@link RuntimeValueProvider}.
+   */
+  class InaccessibleValueProvider<T> implements ValueProvider<T>, Serializable {
+    private final ValueProvider<T> wrapped;
+
+    InaccessibleValueProvider(ValueProvider<T> wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    /**
+     * Creates a {@link StaticValueProvider} that wraps the provided value.
+     */
+    public static <T> InaccessibleValueProvider<T> of(ValueProvider<T> wrapped) {
+      return new InaccessibleValueProvider<>(wrapped);
+    }
+
+    @Override
+    public T get() {
+      return wrapped.get();
+    }
+
+    @Override
+    public boolean isAccessible() {
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("wrapped", wrapped)
+          .toString();
+    }
+  }
+
+  /**
    * {@link NestedValueProvider} is an implementation of {@link ValueProvider} that
    * allows for wrapping another {@link ValueProvider} object.
    */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -724,7 +725,7 @@ public class ProxyInvocationHandlerTest {
   @Test
   public void testDisplayDataItemProperties() {
     PipelineOptions options = PipelineOptionsFactory.create();
-    options.setTempLocation("myTemp");
+    options.setTempLocation(StaticValueProvider.of("myTemp"));
     DisplayData displayData = DisplayData.from(options);
 
     assertThat(displayData, hasDisplayItem(allOf(

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.InstanceBuilder;
 import org.apache.beam.sdk.util.PathValidator;
@@ -233,11 +234,11 @@ public interface GcpOptions extends GoogleApiDebugOptions, PipelineOptions {
     @Override
     @Nullable
     public String create(PipelineOptions options) {
-      String tempLocation = options.getTempLocation();
+      String tempLocation = options.getTempLocation().get();
       if (isNullOrEmpty(tempLocation)) {
         tempLocation = tryCreateDefaultBucket(options,
             newCloudResourceManagerClient(options.as(CloudResourceManagerOptions.class)).build());
-        options.setTempLocation(tempLocation);
+        options.setTempLocation(StaticValueProvider.of(tempLocation));
       } else {
         try {
           PathValidator validator = options.as(GcsOptions.class).getPathValidator();

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptionsTest.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.extensions.gcp.options.GcpOptions.DefaultProjectFacto
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions.GcpTempLocationFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.RestoreSystemProperties;
 import org.apache.beam.sdk.util.GcsUtil;
 import org.apache.beam.sdk.util.NoopPathValidator;
@@ -140,7 +141,7 @@ public class GcpOptionsTest {
     public void testDefaultGcpTempLocation() throws Exception {
       GcpOptions options = PipelineOptionsFactory.as(GcpOptions.class);
       String tempLocation = "gs://bucket";
-      options.setTempLocation(tempLocation);
+      options.setTempLocation(StaticValueProvider.of(tempLocation));
       options.as(GcsOptions.class).setPathValidatorClass(NoopPathValidator.class);
       assertEquals(tempLocation, options.getGcpTempLocation());
     }
@@ -148,7 +149,7 @@ public class GcpOptionsTest {
     @Test
     public void testDefaultGcpTempLocationInvalid() throws Exception {
       GcpOptions options = PipelineOptionsFactory.as(GcpOptions.class);
-      options.setTempLocation("file://");
+      options.setTempLocation(StaticValueProvider.of("file://"));
       thrown.expect(IllegalArgumentException.class);
       thrown.expectMessage(
           "Error constructing default value for gcpTempLocation: tempLocation is not"
@@ -160,7 +161,7 @@ public class GcpOptionsTest {
     public void testDefaultGcpTempLocationDoesNotExist() {
       GcpOptions options = PipelineOptionsFactory.as(GcpOptions.class);
       String tempLocation = "gs://does/not/exist";
-      options.setTempLocation(tempLocation);
+      options.setTempLocation(StaticValueProvider.of(tempLocation));
       thrown.expect(IllegalArgumentException.class);
       thrown.expectMessage(
           "Error constructing default value for gcpTempLocation: tempLocation is not"

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -56,7 +56,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
       ValueProvider<TableReference> queryTempTableRef,
       Boolean flattenResults,
       Boolean useLegacySql,
-      String extractDestinationDir,
+      ValueProvider<String> extractDestinationDir,
       BigQueryServices bqServices) {
     return new BigQueryQuerySource(
         jobIdToken,
@@ -80,7 +80,7 @@ class BigQueryQuerySource extends BigQuerySourceBase {
       ValueProvider<TableReference> queryTempTableRef,
       Boolean flattenResults,
       Boolean useLegacySql,
-      String extractDestinationDir,
+      ValueProvider<String> extractDestinationDir,
       BigQueryServices bqServices) {
     super(jobIdToken, extractDestinationDir, bqServices,
         NestedValueProvider.of(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -63,7 +63,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
   protected static final int JOB_POLL_MAX_RETRIES = Integer.MAX_VALUE;
 
   protected final ValueProvider<String> jobIdToken;
-  protected final String extractDestinationDir;
+  protected final ValueProvider<String> extractDestinationDir;
   protected final BigQueryServices bqServices;
   protected final ValueProvider<String> executingProject;
 
@@ -71,7 +71,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
 
   BigQuerySourceBase(
       ValueProvider<String> jobIdToken,
-      String extractDestinationDir,
+      ValueProvider<String> extractDestinationDir,
       BigQueryServices bqServices,
       ValueProvider<String> executingProject) {
     this.jobIdToken = checkNotNull(jobIdToken, "jobIdToken");
@@ -124,7 +124,7 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
         .setProjectId(executingProject.get())
         .setJobId(jobId);
 
-    String destinationUri = BigQueryIO.getExtractDestinationUri(extractDestinationDir);
+    String destinationUri = BigQueryIO.getExtractDestinationUri(extractDestinationDir.get());
     JobConfigurationExtract extract = new JobConfigurationExtract()
         .setSourceTable(table)
         .setDestinationFormat("AVRO")
@@ -141,7 +141,8 @@ abstract class BigQuerySourceBase extends BoundedSource<TableRow> {
           BigQueryHelpers.statusToPrettyString(extractJob.getStatus())));
     }
 
-    List<String> tempFiles = BigQueryIO.getExtractFilePaths(extractDestinationDir, extractJob);
+    List<String> tempFiles =
+        BigQueryIO.getExtractFilePaths(extractDestinationDir.get(), extractJob);
     return ImmutableList.copyOf(tempFiles);
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
@@ -45,7 +45,7 @@ class BigQueryTableSource extends BigQuerySourceBase {
   static BigQueryTableSource create(
       ValueProvider<String> jobIdToken,
       ValueProvider<TableReference> table,
-      String extractDestinationDir,
+      ValueProvider<String> extractDestinationDir,
       BigQueryServices bqServices,
       ValueProvider<String> executingProject) {
     return new BigQueryTableSource(
@@ -58,7 +58,7 @@ class BigQueryTableSource extends BigQuerySourceBase {
   private BigQueryTableSource(
       ValueProvider<String> jobIdToken,
       ValueProvider<TableReference> table,
-      String extractDestinationDir,
+      ValueProvider<String> extractDestinationDir,
       BigQueryServices bqServices,
       ValueProvider<String> executingProject) {
     super(jobIdToken, extractDestinationDir, bqServices, executingProject);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CustomCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.KV;
@@ -45,7 +46,7 @@ class WriteBundlesToFiles extends DoFn<KV<TableDestination, TableRow>, WriteBund
 
   // Map from tablespec to a writer for that table.
   private transient Map<TableDestination, TableRowWriter> writers;
-  private final String tempFilePrefix;
+  private final ValueProvider<String> tempFilePrefix;
 
   /**
    * The result of the {@link WriteBundlesToFiles} transform. Corresponds to a single output file,
@@ -101,7 +102,7 @@ class WriteBundlesToFiles extends DoFn<KV<TableDestination, TableRow>, WriteBund
     public void verifyDeterministic() {}
   }
 
-  WriteBundlesToFiles(String tempFilePrefix) {
+  WriteBundlesToFiles(ValueProvider<String> tempFilePrefix) {
     this.tempFilePrefix = tempFilePrefix;
   }
 
@@ -116,7 +117,7 @@ class WriteBundlesToFiles extends DoFn<KV<TableDestination, TableRow>, WriteBund
   public void processElement(ProcessContext c) throws Exception {
     TableRowWriter writer = writers.get(c.element().getKey());
     if (writer == null) {
-      writer = new TableRowWriter(tempFilePrefix);
+      writer = new TableRowWriter(tempFilePrefix.get());
       writer.open(UUID.randomUUID().toString());
       writers.put(c.element().getKey(), writer);
       LOG.debug("Done opening writer {}", writer);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -30,7 +30,6 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
 import javax.annotation.Nullable;
-
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
@@ -38,6 +37,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -71,7 +71,7 @@ class WriteTables extends DoFn<KV<ShardedKey<TableDestination>, List<String>>,
   private final boolean singlePartition;
   private final BigQueryServices bqServices;
   private final PCollectionView<String> jobIdToken;
-  private final String tempFilePrefix;
+  private final ValueProvider<String> tempFilePrefix;
   private final WriteDisposition writeDisposition;
   private final CreateDisposition createDisposition;
   private final SerializableFunction<TableDestination, TableSchema> schemaFunction;
@@ -80,7 +80,7 @@ class WriteTables extends DoFn<KV<ShardedKey<TableDestination>, List<String>>,
       boolean singlePartition,
       BigQueryServices bqServices,
       PCollectionView<String> jobIdToken,
-      String tempFilePrefix,
+      ValueProvider<String> tempFilePrefix,
       WriteDisposition writeDisposition,
       CreateDisposition createDisposition,
       SerializableFunction<TableDestination, TableSchema> schemaFunction) {
@@ -119,7 +119,7 @@ class WriteTables extends DoFn<KV<ShardedKey<TableDestination>, List<String>>,
         tableDestination.getTableDescription());
     c.output(KV.of(tableDestination, BigQueryHelpers.toJsonString(ref)));
 
-    removeTemporaryFiles(c.getPipelineOptions(), tempFilePrefix, partitionFiles);
+    removeTemporaryFiles(c.getPipelineOptions(), tempFilePrefix.get(), partitionFiles);
   }
 
   private void load(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -279,7 +279,7 @@ public class BigQueryIOTest implements Serializable {
     bqOptions.setProject(projectId);
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testValidateReadSetsDefaultProject");
-    bqOptions.setTempLocation(baseDir.toString());
+    bqOptions.setTempLocation(StaticValueProvider.of(baseDir.toString()));
 
     FakeDatasetService fakeDatasetService = new FakeDatasetService();
     fakeDatasetService.createDataset(projectId, datasetId, "", "");
@@ -330,7 +330,7 @@ public class BigQueryIOTest implements Serializable {
   public void testBuildSourceWithTableAndFlatten() {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
 
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
@@ -348,7 +348,7 @@ public class BigQueryIOTest implements Serializable {
   public void testBuildSourceWithTableAndFlattenWithoutValidation() {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
 
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
@@ -367,7 +367,7 @@ public class BigQueryIOTest implements Serializable {
   public void testBuildSourceWithTableAndSqlDialect() {
     BigQueryOptions bqOptions = PipelineOptionsFactory.as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
 
     Pipeline p = TestPipeline.create(bqOptions);
     thrown.expect(IllegalStateException.class);
@@ -385,7 +385,8 @@ public class BigQueryIOTest implements Serializable {
   public void testReadFromTable() throws IOException, InterruptedException {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     Job job = new Job();
     JobStatus status = new JobStatus();
@@ -445,7 +446,8 @@ public class BigQueryIOTest implements Serializable {
   public void testWrite() throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     FakeDatasetService datasetService = new FakeDatasetService();
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
@@ -470,7 +472,7 @@ public class BigQueryIOTest implements Serializable {
         .withoutValidation());
     p.run();
 
-    File tempDir = new File(bqOptions.getTempLocation());
+    File tempDir = new File(bqOptions.getTempLocation().get());
     testNumFiles(tempDir, 0);
   }
 
@@ -478,7 +480,8 @@ public class BigQueryIOTest implements Serializable {
   public void testStreamingWrite() throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     FakeDatasetService datasetService = new FakeDatasetService();
     datasetService.createDataset("project-id", "dataset-id", "", "");
@@ -618,7 +621,8 @@ public class BigQueryIOTest implements Serializable {
   public void testWriteWithDynamicTables(boolean streaming) throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     FakeDatasetService datasetService = new FakeDatasetService();
     datasetService.createDataset("project-id", "dataset-id", "", "");
@@ -703,7 +707,8 @@ public class BigQueryIOTest implements Serializable {
   public void testWriteUnknown() throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     FakeDatasetService datasetService = new FakeDatasetService();
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
@@ -726,7 +731,7 @@ public class BigQueryIOTest implements Serializable {
     try {
       p.run();
     } finally {
-      File tempDir = new File(bqOptions.getTempLocation());
+      File tempDir = new File(bqOptions.getTempLocation().get());
       testNumFiles(tempDir, 0);
     }
   }
@@ -735,7 +740,8 @@ public class BigQueryIOTest implements Serializable {
   public void testWriteFailedJobs() throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     FakeDatasetService datasetService = new FakeDatasetService();
     FakeBigQueryServices fakeBqServices = new FakeBigQueryServices()
@@ -761,7 +767,7 @@ public class BigQueryIOTest implements Serializable {
     try {
       p.run();
     } finally {
-      File tempDir = new File(bqOptions.getTempLocation());
+      File tempDir = new File(bqOptions.getTempLocation().get());
       testNumFiles(tempDir, 0);
     }
   }
@@ -1214,10 +1220,13 @@ public class BigQueryIOTest implements Serializable {
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryTableSourceThroughJsonAPI");
     String jobIdToken = "testJobIdToken";
-    BoundedSource<TableRow> bqSource = BigQueryTableSource.create(
-        StaticValueProvider.of(jobIdToken), StaticValueProvider.of(table),
-        baseDir.toString(), fakeBqServices,
-        StaticValueProvider.of("project"));
+    BoundedSource<TableRow> bqSource =
+        BigQueryTableSource.create(
+            StaticValueProvider.of(jobIdToken),
+            StaticValueProvider.of(table),
+            StaticValueProvider.of(baseDir.toString()),
+            fakeBqServices,
+            StaticValueProvider.of("project"));
 
     PipelineOptions options = PipelineOptionsFactory.create();
     Assert.assertThat(
@@ -1257,13 +1266,17 @@ public class BigQueryIOTest implements Serializable {
 
     String jobIdToken = "testJobIdToken";
     String extractDestinationDir = baseDir.toString();
-    BoundedSource<TableRow> bqSource = BigQueryTableSource.create(
-        StaticValueProvider.of(jobIdToken), StaticValueProvider.of(table),
-        extractDestinationDir, fakeBqServices, StaticValueProvider.of("project"));
+    BoundedSource<TableRow> bqSource =
+        BigQueryTableSource.create(
+            StaticValueProvider.of(jobIdToken),
+            StaticValueProvider.of(table),
+            StaticValueProvider.of(extractDestinationDir),
+            fakeBqServices,
+            StaticValueProvider.of("project"));
 
 
     PipelineOptions options = PipelineOptionsFactory.create();
-    options.setTempLocation(baseDir.toString());
+    options.setTempLocation(StaticValueProvider.of(baseDir.toString()));
 
     List<TableRow> read = SourceTestUtils.readFromSource(bqSource, options);
     assertThat(read, containsInAnyOrder(Iterables.toArray(expected, TableRow.class)));
@@ -1330,14 +1343,18 @@ public class BigQueryIOTest implements Serializable {
     String jobIdToken = "testJobIdToken";
     String query = FakeBigQueryServices.encodeQuery(expected);
     String extractDestinationDir = baseDir.toString();
-    BoundedSource<TableRow> bqSource = BigQueryQuerySource.create(
-        StaticValueProvider.of(jobIdToken), StaticValueProvider.of(query),
-        StaticValueProvider.of(destinationTable),
-        true /* flattenResults */, true /* useLegacySql */,
-        extractDestinationDir, fakeBqServices);
+    BoundedSource<TableRow> bqSource =
+        BigQueryQuerySource.create(
+            StaticValueProvider.of(jobIdToken),
+            StaticValueProvider.of(query),
+            StaticValueProvider.of(destinationTable),
+            true /* flattenResults */,
+            true /* useLegacySql */,
+            StaticValueProvider.of(extractDestinationDir),
+            fakeBqServices);
 
     PipelineOptions options = PipelineOptionsFactory.create();
-    options.setTempLocation(extractDestinationDir);
+    options.setTempLocation(StaticValueProvider.of(extractDestinationDir));
 
     TableReference queryTable = new TableReference()
         .setProjectId("project")
@@ -1415,16 +1432,20 @@ public class BigQueryIOTest implements Serializable {
 
     Path baseDir = Files.createTempDirectory(tempFolder, "testBigQueryNoTableQuerySourceInitSplit");
     String jobIdToken = "testJobIdToken";
-    BoundedSource<TableRow> bqSource = BigQueryQuerySource.create(
-        StaticValueProvider.of(jobIdToken),
-        StaticValueProvider.of(query),
-        StaticValueProvider.of(destinationTable),
-        true /* flattenResults */, true /* useLegacySql */, baseDir.toString(), fakeBqServices);
+    BoundedSource<TableRow> bqSource =
+        BigQueryQuerySource.create(
+            StaticValueProvider.of(jobIdToken),
+            StaticValueProvider.of(query),
+            StaticValueProvider.of(destinationTable),
+            true /* flattenResults */,
+            true /* useLegacySql */,
+            StaticValueProvider.of(baseDir.toString()),
+            fakeBqServices);
 
 
 
     PipelineOptions options = PipelineOptionsFactory.create();
-    options.setTempLocation(baseDir.toString());
+    options.setTempLocation(StaticValueProvider.of(baseDir.toString()));
     List<TableRow> read = convertBigDecimaslToLong(
         SourceTestUtils.readFromSource(bqSource, options));
     assertThat(read, containsInAnyOrder(Iterables.toArray(expected, TableRow.class)));
@@ -1738,7 +1759,7 @@ public class BigQueryIOTest implements Serializable {
         false,
         fakeBqServices,
         jobIdTokenView,
-        tempFilePrefix,
+        StaticValueProvider.of(tempFilePrefix),
         WriteDisposition.WRITE_EMPTY,
         CreateDisposition.CREATE_IF_NEEDED,
         null);
@@ -1766,7 +1787,8 @@ public class BigQueryIOTest implements Serializable {
   public void testRemoveTemporaryFiles() throws Exception {
     BigQueryOptions bqOptions = PipelineOptionsFactory.as(BigQueryOptions.class);
     bqOptions.setProject("defaultproject");
-    bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
+    bqOptions.setTempLocation(
+        StaticValueProvider.of(testFolder.newFolder("BigQueryIOTest").getAbsolutePath()));
 
     int numFiles = 10;
     List<String> fileNames = Lists.newArrayList();
@@ -1779,7 +1801,7 @@ public class BigQueryIOTest implements Serializable {
     }
     fileNames.add(tempFilePrefix + String.format("files%05d", numFiles));
 
-    File tempDir = new File(bqOptions.getTempLocation());
+    File tempDir = new File(bqOptions.getTempLocation().get());
     testNumFiles(tempDir, 10);
 
     WriteTables.removeTemporaryFiles(bqOptions, tempFilePrefix, fileNames);
@@ -1942,7 +1964,7 @@ public class BigQueryIOTest implements Serializable {
   public void testRuntimeOptionsNotCalledInApplyInputTable() {
     RuntimeTestOptions options = PipelineOptionsFactory.as(RuntimeTestOptions.class);
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
     Pipeline pipeline = TestPipeline.create(options);
     BigQueryIO.Read read = BigQueryIO.read().from(
         options.getInputTable()).withoutValidation();
@@ -1955,7 +1977,7 @@ public class BigQueryIOTest implements Serializable {
   public void testRuntimeOptionsNotCalledInApplyInputQuery() {
     RuntimeTestOptions options = PipelineOptionsFactory.as(RuntimeTestOptions.class);
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
     Pipeline pipeline = TestPipeline.create(options);
     BigQueryIO.Read read = BigQueryIO.read().fromQuery(
         options.getInputQuery()).withoutValidation();
@@ -1968,7 +1990,7 @@ public class BigQueryIOTest implements Serializable {
   public void testRuntimeOptionsNotCalledInApplyOutput() {
     RuntimeTestOptions options = PipelineOptionsFactory.as(RuntimeTestOptions.class);
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
-    bqOptions.setTempLocation("gs://testbucket/testdir");
+    bqOptions.setTempLocation(StaticValueProvider.of("gs://testbucket/testdir"));
     Pipeline pipeline = TestPipeline.create(options);
     BigQueryIO.Write<TableRow> write = BigQueryIO.writeTableRows()
         .to(options.getOutputTable())


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

This is my first foray into `ValueProvider` and `PipelineOptions` excitement. The goal: allow users to access the `tempLocation` that they specify but make it inaccessible to `PTransform.expand(..)` implementations.

The natural way to do this would be to clone and alter the pipeline options, something that runners also ought to be doing when they tweak them like `TestDataflowRunner` does. I am informed this is not possible or feasible in a short timeframe.

So this is a hack that might not actually work that lets `get()` succeed but makes `isAccessible()` false. Throwing it out there as a strawman as I don't see a way to do this correctly given today's constraints.

Once an approach is decided upon, I will propagate as needed, to e.g. `gcpTempLocation`.