### PR TITLE
[BEAM-2166] Split Coder's encode/decode methods into two methods depending on context.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -59,6 +59,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  */
 public interface Coder<T> extends Serializable {
   /** The context in which encoding or decoding is being done. */
+  @Deprecated
   class Context {
     /**
      * The outer context: the value being encoded or decoded takes
@@ -111,6 +112,28 @@ public interface Coder<T> extends Serializable {
   }
 
   /**
+   * Encodes the given value of type {@code T} onto the given output stream.
+   *
+   * @throws IOException if writing to the {@code OutputStream} fails
+   * for some reason
+   * @throws CoderException if the value could not be encoded for some reason
+   */
+  void encode(T value, OutputStream outStream)
+      throws CoderException, IOException;
+
+  /**
+   * Encodes the given value of type {@code T} onto the given output stream
+   * in the outer context.
+   *
+   * @throws IOException if writing to the {@code OutputStream} fails
+   * for some reason
+   * @throws CoderException if the value could not be encoded for some reason
+   */
+  @Deprecated
+  void encodeOuter(T value, OutputStream outStream)
+      throws CoderException, IOException;
+
+  /**
    * Encodes the given value of type {@code T} onto the given output stream
    * in the given context.
    *
@@ -118,6 +141,7 @@ public interface Coder<T> extends Serializable {
    * for some reason
    * @throws CoderException if the value could not be encoded for some reason
    */
+  @Deprecated
   void encode(T value, OutputStream outStream, Context context)
       throws CoderException, IOException;
 
@@ -129,6 +153,28 @@ public interface Coder<T> extends Serializable {
    * for some reason
    * @throws CoderException if the value could not be decoded for some reason
    */
+  T decode(InputStream inStream) throws CoderException, IOException;
+
+  /**
+   * Decodes a value of type {@code T} from the given input stream in
+   * the outer context.  Returns the decoded value.
+   *
+   * @throws IOException if reading from the {@code InputStream} fails
+   * for some reason
+   * @throws CoderException if the value could not be decoded for some reason
+   */
+  @Deprecated
+  T decodeOuter(InputStream inStream) throws CoderException, IOException;
+
+  /**
+   * Decodes a value of type {@code T} from the given input stream in
+   * the given context.  Returns the decoded value.
+   *
+   * @throws IOException if reading from the {@code InputStream} fails
+   * for some reason
+   * @throws CoderException if the value could not be decoded for some reason
+   */
+  @Deprecated
   T decode(InputStream inStream, Context context)
       throws CoderException, IOException;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/Coder.java
@@ -246,6 +246,19 @@ public interface Coder<T> extends Serializable {
    * {@link org.apache.beam.sdk.runners.PipelineRunner}
    * implementations.
    */
+  boolean isRegisterByteSizeObserverCheap(T value);
+
+  /**
+   * Returns whether {@link #registerByteSizeObserver} cheap enough to
+   * call for every element, that is, if this {@code Coder} can
+   * calculate the byte size of the element to be coded in roughly
+   * constant time (or lazily).
+   *
+   * <p>Not intended to be called by user code, but instead by
+   * {@link org.apache.beam.sdk.runners.PipelineRunner}
+   * implementations.
+   */
+  @Deprecated
   boolean isRegisterByteSizeObserverCheap(T value, Context context);
 
   /**
@@ -256,6 +269,19 @@ public interface Coder<T> extends Serializable {
    * {@link org.apache.beam.sdk.runners.PipelineRunner}
    * implementations.
    */
+  void registerByteSizeObserver(
+      T value, ElementByteSizeObserver observer)
+      throws Exception;
+
+  /**
+   * Notifies the {@code ElementByteSizeObserver} about the byte size
+   * of the encoded value using this {@code Coder}.
+   *
+   * <p>Not intended to be called by user code, but instead by
+   * {@link org.apache.beam.sdk.runners.PipelineRunner}
+   * implementations.
+   */
+  @Deprecated
   void registerByteSizeObserver(
       T value, ElementByteSizeObserver observer, Context context)
       throws Exception;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -149,6 +149,18 @@ public abstract class StructuredCoder<T> implements Coder<T> {
    *         unless it is overridden. This is considered expensive.
    */
   @Override
+  public boolean isRegisterByteSizeObserverCheap(T value) {
+    return isRegisterByteSizeObserverCheap(value, Context.NESTED);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * @return {@code false} unless it is overridden. {@link StructuredCoder#registerByteSizeObserver}
+   *         invokes {@link #getEncodedElementByteSize} which requires re-encoding an element
+   *         unless it is overridden. This is considered expensive.
+   */
+  @Override
   public boolean isRegisterByteSizeObserverCheap(T value, Context context) {
     return false;
   }
@@ -165,6 +177,12 @@ public abstract class StructuredCoder<T> implements Coder<T> {
       throw new IllegalArgumentException(
           "Unable to encode element '" + value + "' with coder '" + this + "'.", exn);
     }
+  }
+
+  @Override
+  public void registerByteSizeObserver(T value, ElementByteSizeObserver observer)
+      throws Exception {
+    registerByteSizeObserver(value, observer, Context.NESTED);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -20,6 +20,9 @@ package org.apache.beam.sdk.coders;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingOutputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -96,6 +99,34 @@ public abstract class StructuredCoder<T> implements Coder<T> {
       builder.append(')');
     }
     return builder.toString();
+  }
+
+  public void encode(T value, OutputStream outStream)
+      throws CoderException, IOException {
+    encode(value, outStream, Coder.Context.NESTED);
+  }
+
+  @Deprecated
+  public void encodeOuter(T value, OutputStream outStream)
+      throws CoderException, IOException {
+    encode(value, outStream, Coder.Context.OUTER);
+  }
+
+  public T decode(InputStream inStream) throws CoderException, IOException {
+    return decode(inStream, Coder.Context.NESTED);
+  }
+
+  /**
+   * Decodes a value of type {@code T} from the given input stream in
+   * the outer context.  Returns the decoded value.
+   *
+   * @throws IOException if reading from the {@code InputStream} fails
+   * for some reason
+   * @throws CoderException if the value could not be decoded for some reason
+   */
+  @Deprecated
+  public T decodeOuter(InputStream inStream) throws CoderException, IOException {
+    return decode(inStream, Coder.Context.OUTER);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -112,21 +112,33 @@ public abstract class StructuredCoder<T> implements Coder<T> {
     encode(value, outStream, Coder.Context.OUTER);
   }
 
+  @Deprecated
+  public void encode(T value, OutputStream outStream, Coder.Context context)
+      throws CoderException, IOException {
+    if (context == Coder.Context.NESTED) {
+      encode(value, outStream);
+    } else {
+      encodeOuter(value, outStream);
+    }
+  }
+
   public T decode(InputStream inStream) throws CoderException, IOException {
     return decode(inStream, Coder.Context.NESTED);
   }
 
-  /**
-   * Decodes a value of type {@code T} from the given input stream in
-   * the outer context.  Returns the decoded value.
-   *
-   * @throws IOException if reading from the {@code InputStream} fails
-   * for some reason
-   * @throws CoderException if the value could not be decoded for some reason
-   */
   @Deprecated
   public T decodeOuter(InputStream inStream) throws CoderException, IOException {
     return decode(inStream, Coder.Context.OUTER);
+  }
+
+  @Deprecated
+  public T decode(InputStream inStream, Coder.Context context)
+      throws CoderException, IOException {
+    if (context == Coder.Context.NESTED) {
+      return decode(inStream);
+    } else {
+      return decodeOuter(inStream);
+    }
   }
 
   /**


### PR DESCRIPTION
…text.

This allows the outer context to be marked deprecated.  A follow-up PR will
remove the old method once all consumers have been updated.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
