### PR TITLE
[BEAM-2157] Fix HDFS Test That Failed in Other JDK Versions

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModuleTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModuleTest.java
@@ -57,7 +57,7 @@ public class HadoopFileSystemModuleTest {
     String serializedConfiguration = objectMapper.writeValueAsString(configuration);
     Configuration deserializedConfiguration =
         objectMapper.readValue(serializedConfiguration, Configuration.class);
-    assertThat(deserializedConfiguration, Matchers.<Map.Entry<String, String>>contains(
+    assertThat(deserializedConfiguration, Matchers.<Map.Entry<String, String>>containsInAnyOrder(
         new AbstractMap.SimpleEntry("testPropertyA", "A"),
         new AbstractMap.SimpleEntry("testPropertyB", "B"),
         new AbstractMap.SimpleEntry("testPropertyC", "baseC")));


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Quick fix HadoopFileSystemModuleTest that's failed in JDK 1.7, OpenJDK 7 and OpenJDK 8.