### PR TITLE
[BEAM-2154] Make BigQuery's dynamic-destination support scale to large numbers of destinations

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -34,9 +34,12 @@ import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.WriteBundlesToFiles.Result;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -49,6 +52,7 @@ import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
@@ -57,6 +61,15 @@ import org.apache.beam.sdk.values.TupleTagList;
 /** PTransform that uses BigQuery batch-load jobs to write a PCollection to BigQuery. */
 class BatchLoads<DestinationT>
     extends PTransform<PCollection<KV<DestinationT, TableRow>>, WriteResult> {
+  // The maximum number of file writers to keep open in a single bundle at a time, since file
+  // writers default to 64mb buffers. This comes into play when writing dynamic table destinations.
+  // The first 20 tables from a single BatchLoads transform will write files inline in the
+  // transform. Anything beyond that might be shuffled.  Users using this transform directly who
+  // know that they are running on workers with sufficient memory can increase this by calling
+  // BatchLoads#setMaxNumWorkers. This allows the workers to do more work in memory, and save on the
+  // cost of shuffling some of this data.
+  private static final int DEFAULT_MAX_NUM_WRITERS = 20;
+
   private BigQueryServices bigQueryServices;
   private final WriteDisposition writeDisposition;
   private final CreateDisposition createDisposition;
@@ -65,6 +78,7 @@ class BatchLoads<DestinationT>
   private final boolean singletonTable;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
   private final Coder<DestinationT> destinationCoder;
+  private int maxNumWriters;
 
   BatchLoads(WriteDisposition writeDisposition, CreateDisposition createDisposition,
              boolean singletonTable,
@@ -76,10 +90,21 @@ class BatchLoads<DestinationT>
     this.singletonTable = singletonTable;
     this.dynamicDestinations = dynamicDestinations;
     this.destinationCoder = destinationCoder;
+    this.maxNumWriters = DEFAULT_MAX_NUM_WRITERS;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
     this.bigQueryServices = bigQueryServices;
+  }
+
+  /** Get the maximum number of file writers that will be open simultaneously in a bundle. */
+  public int getMaxNumWriters() {
+    return maxNumWriters;
+  }
+
+  /** Set the maximum number of file writers that will be open simultaneously in a bundle. */
+  public void setMaxNumWriters(int maxNumWriters) {
+    this.maxNumWriters = maxNumWriters;
   }
 
   @Override
@@ -144,12 +169,34 @@ class BatchLoads<DestinationT>
     PCollectionView<Map<DestinationT, String>> schemasView =
         inputInGlobalWindow.apply(new CalculateSchemas<>(dynamicDestinations));
 
+    TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
+        new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles"){};
+    TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
+        new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {};
+    PCollectionTuple writeBundlesTuple = inputInGlobalWindow
+            .apply("WriteBundlesToFiles",
+                ParDo.of(new WriteBundlesToFiles<>(stepUuid, unwrittedRecordsTag,
+                    maxNumWriters))
+                .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
+        writeBundlesTuple.get(writtenFilesTag)
+        .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
+    // If the bundles contain too many output tables to be written inline to files (due to memory
+    // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
+    // Group these records by key, and write the files after grouping. Since the record is grouped
+    // by key, we can ensure that only one file is open at a time in each bundle.
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFilesGrouped =
+        writeBundlesTuple.get(unwrittedRecordsTag)
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
+        .apply(GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
+        .apply(ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(stepUuid)))
+            .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
     // PCollection of filename, file byte size, and table destination.
     PCollection<WriteBundlesToFiles.Result<DestinationT>> results =
-        inputInGlobalWindow
-            .apply("WriteBundlesToFiles", ParDo.of(
-                new WriteBundlesToFiles<DestinationT>(stepUuid)))
-            .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+        PCollectionList.of(writtenFiles).and(writtenFilesGrouped)
+        .apply(Flatten.<Result<DestinationT>>pCollections());
 
     TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag =
         new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("multiPartitionsTag") {};

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLocation;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -70,7 +71,8 @@ class BatchLoads<DestinationT>
   // save on the cost of shuffling some of this data.
   // Keep in mind that specific runners may decide to run multiple bundles in parallel, based on
   // their own policy.
-  private static final int DEFAULT_MAX_NUM_WRITERS_PER_BUNDLE = 20;
+  @VisibleForTesting
+  static final int DEFAULT_MAX_NUM_WRITERS_PER_BUNDLE = 20;
 
   private BigQueryServices bigQueryServices;
   private final WriteDisposition writeDisposition;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -691,6 +691,7 @@ public class BigQueryIO {
     /** An option to indicate if table validation is desired. Default is true. */
     abstract boolean getValidate();
     abstract BigQueryServices getBigQueryServices();
+    @Nullable abstract Integer getMaxFilesPerBundle();
 
     abstract Builder<T> toBuilder();
 
@@ -708,6 +709,7 @@ public class BigQueryIO {
       abstract Builder<T> setTableDescription(String tableDescription);
       abstract Builder<T> setValidate(boolean validate);
       abstract Builder<T> setBigQueryServices(BigQueryServices bigQueryServices);
+      abstract Builder<T> setMaxFilesPerBundle(Integer maxFilesPerBundle);
 
       abstract Write<T> build();
     }
@@ -886,6 +888,11 @@ public class BigQueryIO {
       return toBuilder().setBigQueryServices(testServices).build();
     }
 
+    @VisibleForTesting
+    Write<T> withMaxFilesPerBundle(int maxFilesPerBundle) {
+      return toBuilder().setMaxFilesPerBundle(maxFilesPerBundle).build();
+    }
+
     @Override
     public void validate(PipelineOptions pipelineOptions) {
       BigQueryOptions options = pipelineOptions.as(BigQueryOptions.class);
@@ -997,6 +1004,9 @@ public class BigQueryIO {
             dynamicDestinations,
             destinationCoder);
         batchLoads.setTestServices(getBigQueryServices());
+        if (getMaxFilesPerBundle() != null) {
+          batchLoads.setMaxNumWritersPerBundle(getMaxFilesPerBundle());
+        }
         return rowsWithDestination.apply(batchLoads);
       }
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -670,6 +670,9 @@ public class BigQueryIO {
     // The maximum number of retry jobs.
     static final int MAX_RETRY_JOBS = 3;
 
+    // The maximum size of a single file - 14TiB, just under the 15 TiB limit.
+    static final long MAX_FILE_SIZE = 14 * (1L << 40);
+
     // The maximum number of retries to poll the status of a job.
     // It sets to {@code Integer.MAX_VALUE} to block until the BigQuery job finishes.
     static final int LOAD_JOB_POLL_MAX_RETRIES = Integer.MAX_VALUE;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -659,24 +659,6 @@ public class BigQueryIO {
   /** Implementation of {@link #write}. */
   @AutoValue
   public abstract static class Write<T> extends PTransform<PCollection<T>, WriteResult> {
-    @VisibleForTesting
-    // Maximum number of files in a single partition.
-    static final int MAX_NUM_FILES = 10000;
-
-    @VisibleForTesting
-    // Maximum number of bytes in a single partition -- 11 TiB just under BQ's 12 TiB limit.
-    static final long MAX_SIZE_BYTES = 11 * (1L << 40);
-
-    // The maximum number of retry jobs.
-    static final int MAX_RETRY_JOBS = 3;
-
-    // The maximum size of a single file - 4TiB, just under the 5 TiB limit.
-    static final long MAX_FILE_SIZE = 4 * (1L << 40);
-
-    // The maximum number of retries to poll the status of a job.
-    // It sets to {@code Integer.MAX_VALUE} to block until the BigQuery job finishes.
-    static final int LOAD_JOB_POLL_MAX_RETRIES = Integer.MAX_VALUE;
-
     @Nullable abstract ValueProvider<String> getJsonTableRef();
     @Nullable abstract SerializableFunction<ValueInSingleWindow<T>, TableDestination>
       getTableFunction();
@@ -692,6 +674,7 @@ public class BigQueryIO {
     abstract boolean getValidate();
     abstract BigQueryServices getBigQueryServices();
     @Nullable abstract Integer getMaxFilesPerBundle();
+    @Nullable abstract Long getMaxFileSize();
 
     abstract Builder<T> toBuilder();
 
@@ -710,6 +693,7 @@ public class BigQueryIO {
       abstract Builder<T> setValidate(boolean validate);
       abstract Builder<T> setBigQueryServices(BigQueryServices bigQueryServices);
       abstract Builder<T> setMaxFilesPerBundle(Integer maxFilesPerBundle);
+      abstract Builder<T> setMaxFileSize(Long maxFileSize);
 
       abstract Write<T> build();
     }
@@ -893,6 +877,11 @@ public class BigQueryIO {
       return toBuilder().setMaxFilesPerBundle(maxFilesPerBundle).build();
     }
 
+    @VisibleForTesting
+    Write<T> withMaxFileSize(long maxFileSize) {
+      return toBuilder().setMaxFileSize(maxFileSize).build();
+    }
+
     @Override
     public void validate(PipelineOptions pipelineOptions) {
       BigQueryOptions options = pipelineOptions.as(BigQueryOptions.class);
@@ -1006,6 +995,9 @@ public class BigQueryIO {
         batchLoads.setTestServices(getBigQueryServices());
         if (getMaxFilesPerBundle() != null) {
           batchLoads.setMaxNumWritersPerBundle(getMaxFilesPerBundle());
+        }
+        if (getMaxFileSize() != null) {
+          batchLoads.setMaxFileSize(getMaxFileSize());
         }
         return rowsWithDestination.apply(batchLoads);
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -670,8 +670,8 @@ public class BigQueryIO {
     // The maximum number of retry jobs.
     static final int MAX_RETRY_JOBS = 3;
 
-    // The maximum size of a single file - 14TiB, just under the 15 TiB limit.
-    static final long MAX_FILE_SIZE = 14 * (1L << 40);
+    // The maximum size of a single file - 4TiB, just under the 5 TiB limit.
+    static final long MAX_FILE_SIZE = 4 * (1L << 40);
 
     // The maximum number of retries to poll the status of a job.
     // It sets to {@code Integer.MAX_VALUE} to block until the BigQuery job finishes.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ShardedKeyCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ShardedKeyCoder.java
@@ -56,7 +56,7 @@ class ShardedKeyCoder<KeyT>
   public void encode(ShardedKey<KeyT> key, OutputStream outStream, Context context)
       throws IOException {
     keyCoder.encode(key.getKey(), outStream, context.nested());
-    shardNumberCoder.encode(key.getShardNumber(), outStream, context);
+    shardNumberCoder.encode(key.getShardNumber(), outStream, context.nested());
   }
 
   @Override
@@ -64,7 +64,7 @@ class ShardedKeyCoder<KeyT>
       throws IOException {
     return new ShardedKey<>(
         keyCoder.decode(inStream, context.nested()),
-        shardNumberCoder.decode(inStream, context));
+        shardNumberCoder.decode(inStream, context.nested()));
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ShardedKeyCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ShardedKeyCoder.java
@@ -56,15 +56,14 @@ class ShardedKeyCoder<KeyT>
   public void encode(ShardedKey<KeyT> key, OutputStream outStream, Context context)
       throws IOException {
     keyCoder.encode(key.getKey(), outStream, context.nested());
-    shardNumberCoder.encode(key.getShardNumber(), outStream, context.nested());
+    shardNumberCoder.encode(key.getShardNumber(), outStream, context);
   }
 
   @Override
   public ShardedKey<KeyT> decode(InputStream inStream, Context context)
       throws IOException {
     return new ShardedKey<>(
-        keyCoder.decode(inStream, context.nested()),
-        shardNumberCoder.decode(inStream, context.nested()));
+        keyCoder.decode(inStream, context.nested()), shardNumberCoder.decode(inStream, context));
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowWriter.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowWriter.java
@@ -45,7 +45,7 @@ class TableRowWriter {
   protected String mimeType = MimeTypes.TEXT;
   private CountingOutputStream out;
 
-  public static final class Result {
+  static final class Result {
     final ResourceId resourceId;
     final long byteSize;
 
@@ -59,7 +59,7 @@ class TableRowWriter {
     this.tempFilePrefix = basename;
   }
 
-  public final void open(String uId) throws Exception {
+  final void open(String uId) throws Exception {
     id = uId;
     resourceId = FileSystems.matchNewResource(tempFilePrefix + id, false);
     LOG.debug("Opening {}.", resourceId);
@@ -79,12 +79,16 @@ class TableRowWriter {
     LOG.debug("Starting write of bundle {} to {}.", this.id, resourceId);
   }
 
-  public void write(TableRow value) throws Exception {
+  void write(TableRow value) throws Exception {
     CODER.encode(value, out, Context.OUTER);
     out.write(NEWLINE);
   }
 
-  public final Result close() throws IOException {
+  long getByteSize() {
+    return out.getCount();
+  }
+
+  final Result close() throws IOException {
     channel.close();
     return new Result(resourceId, out.getCount());
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -176,18 +176,20 @@ class WriteBundlesToFiles<DestinationT>
                 c.element().getValue()));
       }
     }
-    try {
-      writer.write(c.element().getValue());
-    } catch (Exception e) {
-      // Discard write result and close the write.
+    if (writer != null) {
       try {
-        writer.close();
-        // The writer does not need to be reset, as this DoFn cannot be reused.
-      } catch (Exception closeException) {
-        // Do not mask the exception that caused the write to fail.
-        e.addSuppressed(closeException);
+        writer.write(c.element().getValue());
+      } catch (Exception e) {
+        // Discard write result and close the write.
+        try {
+          writer.close();
+          // The writer does not need to be reset, as this DoFn cannot be reused.
+        } catch (Exception closeException) {
+          // Do not mask the exception that caused the write to fail.
+          e.addSuppressed(closeException);
+        }
+        throw e;
       }
-      throw e;
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLocation;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,14 +31,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,12 +53,17 @@ class WriteBundlesToFiles<DestinationT>
     extends DoFn<KV<DestinationT, TableRow>, WriteBundlesToFiles.Result<DestinationT>> {
   private static final Logger LOG = LoggerFactory.getLogger(WriteBundlesToFiles.class);
 
+  // When we spill records, shard the output keys to prevent hotspots. Experiments running up to
+  // 10TB of data have shown a sharding of 10 to be a good choice.
+  @VisibleForTesting
+  static final int SPILLED_RECORD_SHARDING_FACTOR = 10;
+
   // Map from tablespec to a writer for that table.
   private transient Map<DestinationT, TableRowWriter> writers;
   private transient Map<DestinationT, BoundedWindow> writerWindows;
   private final String stepUuid;
-
-
+  private final TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag;
+  private int maxNumWriters;
   /**
    * The result of the {@link WriteBundlesToFiles} transform. Corresponds to a single output file,
    * and encapsulates the table it is destined to as well as the file byte size.
@@ -115,13 +124,18 @@ class WriteBundlesToFiles<DestinationT>
     public void verifyDeterministic() {}
   }
 
-  WriteBundlesToFiles(String stepUuid) {
+  WriteBundlesToFiles(
+      String stepUuid,
+      TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag,
+      int maxNumWriters) {
     this.stepUuid = stepUuid;
+    this.unwrittedRecordsTag = unwrittedRecordsTag;
+    this.maxNumWriters = maxNumWriters;
   }
 
   @StartBundle
   public void startBundle() {
-    // This must be done each bundle, as by default the {@link DoFn} might be reused between
+    // This must be done for each bundle, as by default the {@link DoFn} might be reused between
     // bundles.
     this.writers = Maps.newHashMap();
     this.writerWindows = Maps.newHashMap();
@@ -132,25 +146,42 @@ class WriteBundlesToFiles<DestinationT>
     String tempFilePrefix = resolveTempLocation(
         c.getPipelineOptions().getTempLocation(), "BigQueryWriteTemp", stepUuid);
     TableRowWriter writer = writers.get(c.element().getKey());
-    if (writer == null) {
-      writer = new TableRowWriter(tempFilePrefix);
-      writer.open(UUID.randomUUID().toString());
-      writers.put(c.element().getKey(), writer);
-      writerWindows.put(c.element().getKey(), window);
-      LOG.debug("Done opening writer {}", writer);
+    if (writer != null && writer.getByteSize() > Write.MAX_FILE_SIZE) {
+      // File is too big. Close it and open a new file.
+      TableRowWriter.Result result = writer.close();
+      c.output(new Result<>(result.resourceId.toString(), result.byteSize, c.element().getKey()));
+      writer = null;
     }
-    try {
-      writer.write(c.element().getValue());
-    } catch (Exception e) {
-      // Discard write result and close the write.
-      try {
-        writer.close();
-        // The writer does not need to be reset, as this DoFn cannot be reused.
-      } catch (Exception closeException) {
-        // Do not mask the exception that caused the write to fail.
-        e.addSuppressed(closeException);
+    if (writer == null) {
+      // Only create a new writer if we have fewer than maxNumWriters already in this bundle.
+      if (writers.size() <= maxNumWriters) {
+        writer = new TableRowWriter(tempFilePrefix);
+        writer.open(UUID.randomUUID().toString());
+        writers.put(c.element().getKey(), writer);
+        LOG.debug("Done opening writer {}", writer);
       }
-      throw e;
+    }
+    if (writer != null) {
+      try {
+        writer.write(c.element().getValue());
+      } catch (Exception e) {
+        // Discard write result and close the write.
+        try {
+          writer.close();
+          // The writer does not need to be reset, as this DoFn cannot be reused.
+        } catch (Exception closeException) {
+          // Do not mask the exception that caused the write to fail.
+          e.addSuppressed(closeException);
+        }
+        throw e;
+      }
+    } else {
+      // This means that we already had too many writers open in this bundle. "spill" this record
+      // into the output. It will be grouped and written to a file in a subsequent stage.
+      c.output(unwrittedRecordsTag,
+          KV.of(ShardedKey.of(c.element().getKey(),
+              ThreadLocalRandom.current().nextInt(SPILLED_RECORD_SHARDING_FACTOR)),
+              c.element().getValue()));
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteGroupedRecordsToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteGroupedRecordsToFiles.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import com.google.api.services.bigquery.model.TableRow;
+import java.util.UUID;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.KV;
+
+/** Created by relax on 4/29/17. */
+class WriteGroupedRecordsToFiles<DestinationT>
+    extends DoFn<KV<ShardedKey<DestinationT>, Iterable<TableRow>>,
+    WriteBundlesToFiles.Result<DestinationT>> {
+  private final String tempFilePrefix;
+
+  WriteGroupedRecordsToFiles(String tempFilePrefix) {
+    this.tempFilePrefix = tempFilePrefix;
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) throws Exception {
+    TableRowWriter writer = createWriter();
+    for (TableRow tableRow : c.element().getValue()) {
+      if (writer.getByteSize() > Write.MAX_FILE_SIZE) {
+        TableRowWriter.Result result = writer.close();
+        c.output(new WriteBundlesToFiles.Result<>(
+            result.resourceId.toString(), result.byteSize, c.element().getKey().getKey()));
+        writer = createWriter();
+      }
+      writer.write(tableRow);
+    }
+    TableRowWriter.Result result = writer.close();
+    c.output(new WriteBundlesToFiles.Result<>(
+        result.resourceId.toString(), result.byteSize, c.element().getKey().getKey()));
+  }
+
+  TableRowWriter createWriter() throws Exception {
+    TableRowWriter writer = new TableRowWriter(tempFilePrefix);
+    writer.open(UUID.randomUUID().toString());
+    return writer;
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteBundlesToFiles.Result;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.KV;
@@ -73,8 +72,8 @@ class WritePartition<DestinationT>
     // Check to see whether we can add to this partition without exceeding the maximum partition
     // size.
     boolean canAccept(int numFiles, long numBytes) {
-      return this.numFiles + numFiles <= Write.MAX_NUM_FILES
-          && this.byteSize + numBytes <= Write.MAX_SIZE_BYTES;
+      return this.numFiles + numFiles <= BatchLoads.MAX_NUM_FILES
+          && this.byteSize + numBytes <= BatchLoads.MAX_SIZE_BYTES;
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
@@ -123,13 +122,13 @@ class WriteRename extends DoFn<String, Void> {
 
     String projectId = ref.getProjectId();
     Job lastFailedCopyJob = null;
-    for (int i = 0; i < Write.MAX_RETRY_JOBS; ++i) {
+    for (int i = 0; i < BatchLoads.MAX_RETRY_JOBS; ++i) {
       String jobId = jobIdPrefix + "-" + i;
       JobReference jobRef = new JobReference()
           .setProjectId(projectId)
           .setJobId(jobId);
       jobService.startCopyJob(jobRef, copyConfig);
-      Job copyJob = jobService.pollJob(jobRef, Write.LOAD_JOB_POLL_MAX_RETRIES);
+      Job copyJob = jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
       Status jobStatus = BigQueryHelpers.parseStatus(copyJob);
       switch (jobStatus) {
         case SUCCEEDED:
@@ -154,7 +153,7 @@ class WriteRename extends DoFn<String, Void> {
         "Failed to create copy job with id prefix %s, "
             + "reached max retries: %d, last failed copy job: %s.",
         jobIdPrefix,
-        Write.MAX_RETRY_JOBS,
+        BatchLoads.MAX_RETRY_JOBS,
         BigQueryHelpers.jobToPrettyString(lastFailedCopyJob)));
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -29,7 +29,7 @@ import org.apache.beam.sdk.values.TupleTag;
 /**
  * The result of a {@link BigQueryIO.Write} transform.
  */
-final class WriteResult implements POutput {
+public final class WriteResult implements POutput {
 
   private final Pipeline pipeline;
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -35,7 +35,6 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.MoveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
@@ -149,11 +148,11 @@ class WriteTables<DestinationT>
 
     String projectId = ref.getProjectId();
     Job lastFailedLoadJob = null;
-    for (int i = 0; i < Write.MAX_RETRY_JOBS; ++i) {
+    for (int i = 0; i < BatchLoads.MAX_RETRY_JOBS; ++i) {
       String jobId = jobIdPrefix + "-" + i;
       JobReference jobRef = new JobReference().setProjectId(projectId).setJobId(jobId);
       jobService.startLoadJob(jobRef, loadConfig);
-      Job loadJob = jobService.pollJob(jobRef, Write.LOAD_JOB_POLL_MAX_RETRIES);
+      Job loadJob = jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
       Status jobStatus = BigQueryHelpers.parseStatus(loadJob);
       switch (jobStatus) {
         case SUCCEEDED:
@@ -181,7 +180,7 @@ class WriteTables<DestinationT>
             "Failed to create load job with id prefix %s, "
                 + "reached max retries: %d, last failed load job: %s.",
             jobIdPrefix,
-            Write.MAX_RETRY_JOBS,
+            BatchLoads.MAX_RETRY_JOBS,
             BigQueryHelpers.jobToPrettyString(lastFailedLoadJob)));
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -513,6 +513,7 @@ public class BigQueryIOTest implements Serializable {
     }
     users.apply("WriteBigQuery", BigQueryIO.<String>write()
             .withTestServices(fakeBqServices)
+            .withMaxFilesPerBundle(5)
             .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
             .withFormatFunction(new SerializableFunction<String, TableRow>() {
               @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -493,8 +493,9 @@ public class BigQueryIOTest implements Serializable {
 
     final List<String> allUsernames = ImmutableList.of("bill", "bob", "randolph");
     List<String> userList = Lists.newArrayList();
-    // Make sure that we generate enough users so that WriteBundlesToFiles is forced to spill.
-    for (int i = 0; i < WriteBundlesToFiles.SPILLED_RECORD_SHARDING_FACTOR * 2; ++i) {
+    // Make sure that we generate enough users so that WriteBundlesToFiles is forced to spill to
+    // WriteGroupedRecordsToFiles.
+    for (int i = 0; i < BatchLoads.DEFAULT_MAX_NUM_WRITERS_PER_BUNDLE * 10; ++i) {
       String userName = allUsernames.get(ThreadLocalRandom.current().nextInt(allUsernames.size()));
       userList.add(userName + i);
     }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -495,11 +495,10 @@ public class BigQueryIOTest implements Serializable {
     List<String> userList = Lists.newArrayList();
     // Make sure that we generate enough users so that WriteBundlesToFiles is forced to spill.
     for (int i = 0; i < WriteBundlesToFiles.SPILLED_RECORD_SHARDING_FACTOR * 2; ++i) {
-      String user = allUsernames.get(ThreadLocalRandom.current().nextInt(allUsernames.size()));
-      userList.add(user + i);
+      String userName = allUsernames.get(ThreadLocalRandom.current().nextInt(allUsernames.size()));
+      userList.add(userName + i);
     }
-    PCollection<String> users = p.apply("CreateUsers",
-        Create.of(userList).withCoder(StringUtf8Coder.of()))
+    PCollection<String> users = p.apply("CreateUsers", Create.of(userList))
         .apply(Window.into(new PartitionedGlobalWindows<>(
             new SerializableFunction<String, String>() {
               @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -76,9 +76,9 @@ import org.joda.time.Duration;
  */
 class FakeJobService implements JobService, Serializable {
   static final JsonFactory JSON_FACTORY = Transport.getJsonFactory();
-  // Whenever a job is started, the first 5 calls to GetJob will report the job as pending,
-  // the next 5 will return the job as running, and only then will the job report as done.
-  private static final int GET_JOBS_TRANSITION_INTERVAL = 5;
+  // Whenever a job is started, the first 2 calls to GetJob will report the job as pending,
+  // the next 2 will return the job as running, and only then will the job report as done.
+  private static final int GET_JOBS_TRANSITION_INTERVAL = 2;
 
   private FakeDatasetService datasetService;
 


### PR DESCRIPTION
 Generating hundreds or thousands of file write buffers in a single bundle was causing workers to crash with out of memory. We now detect when too many files have been written in a bundle, and spill the remaining records to another PCollection. This PCollection is then grouped by destination before we write the remaining data to files. We shard destination keys 10 ways to prevent hotspotting. Tests of up to 10TB of data (going from 20 output tables up to 4000) were run, and a sharding factor of 10 seems to work quite well on all runs (and is noticeably faster than not sharding).

In this PR we also guard against the maximum file size that BigQuery supports.

R: @jkff 