### PR TITLE
[BEAM-2151]Fix inconsistent mapping for SQL FLOAT

### DIFF
--- a/dsls/sql/pom.xml
+++ b/dsls/sql/pom.xml
@@ -24,7 +24,7 @@
     <artifactId>beam-dsls-parent</artifactId>
     <version>0.7.0-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>beam-dsls-sql</artifactId>
   <name>Apache Beam :: DSLs :: SQL</name>
   <description>Beam SQL provides a new interface to generate a Beam pipeline from SQL statement</description>
@@ -36,7 +36,7 @@
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
     <calcite-version>1.11.0</calcite-version>
   </properties>
-  
+
   <build>
     <resources>
       <resource>
@@ -202,7 +202,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/dsls/sql/pom.xml
+++ b/dsls/sql/pom.xml
@@ -199,5 +199,11 @@
       <artifactId>calcite-linq4j</artifactId>
       <version>${calcite-version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
@@ -63,28 +63,29 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
       }
 
       switch (value.getDataType().getFieldsType().get(idx)) {
-      case INTEGER:
-        intCoder.encode(value.getInteger(idx), outStream, context.nested());
-        break;
-      case SMALLINT:
-      case TINYINT:
-        intCoder.encode((int) value.getShort(idx), outStream, context.nested());
-        break;
-      case DOUBLE:
-        doubleCoder.encode(value.getDouble(idx), outStream, context.nested());
-        break;
-      case FLOAT:
-        doubleCoder.encode((double) value.getFloat(idx), outStream, context.nested());
-        break;
-      case BIGINT:
-        longCoder.encode(value.getLong(idx), outStream, context.nested());
-        break;
-      case VARCHAR:
-        stringCoder.encode(value.getString(idx), outStream, context.nested());
-        break;
+        case INTEGER:
+          intCoder.encode(value.getInteger(idx), outStream, context.nested());
+          break;
+        case SMALLINT:
+        case TINYINT:
+          intCoder.encode((int) value.getShort(idx), outStream, context.nested());
+          break;
+        case DOUBLE:
+          doubleCoder.encode(value.getDouble(idx), outStream, context.nested());
+          break;
+        case FLOAT:
+          doubleCoder.encode(Double.parseDouble(
+              String.valueOf(value.getFloat(idx))), outStream, context.nested());
+          break;
+        case BIGINT:
+          longCoder.encode(value.getLong(idx), outStream, context.nested());
+          break;
+        case VARCHAR:
+          stringCoder.encode(value.getString(idx), outStream, context.nested());
+          break;
 
-      default:
-        throw new UnsupportedDataTypeException(value.getDataType().getFieldsType().get(idx));
+        default:
+          throw new UnsupportedDataTypeException(value.getDataType().getFieldsType().get(idx));
       }
     }
     //add a dummy field to indicate the end of record
@@ -106,30 +107,30 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
       }
 
       switch (type.getFieldsType().get(idx)) {
-      case INTEGER:
-        record.addField(idx, intCoder.decode(inStream, context.nested()));
-        break;
-      case SMALLINT:
-        record.addField(idx, intCoder.decode(inStream, context.nested()).shortValue());
-        break;
-      case TINYINT:
-        record.addField(idx, intCoder.decode(inStream, context.nested()).byteValue());
-        break;
-      case DOUBLE:
-        record.addField(idx, doubleCoder.decode(inStream, context.nested()));
-        break;
-      case FLOAT:
-        record.addField(idx, doubleCoder.decode(inStream, context.nested()).floatValue());
-        break;
-      case BIGINT:
-        record.addField(idx, longCoder.decode(inStream, context.nested()));
-        break;
-      case VARCHAR:
-        record.addField(idx, stringCoder.decode(inStream, context.nested()));
-        break;
+        case INTEGER:
+          record.addField(idx, intCoder.decode(inStream, context.nested()));
+          break;
+        case SMALLINT:
+          record.addField(idx, intCoder.decode(inStream, context.nested()).shortValue());
+          break;
+        case TINYINT:
+          record.addField(idx, intCoder.decode(inStream, context.nested()).byteValue());
+          break;
+        case DOUBLE:
+          record.addField(idx, doubleCoder.decode(inStream, context.nested()));
+          break;
+        case FLOAT:
+          record.addField(idx, doubleCoder.decode(inStream, context.nested()).floatValue());
+          break;
+        case BIGINT:
+          record.addField(idx, longCoder.decode(inStream, context.nested()));
+          break;
+        case VARCHAR:
+          record.addField(idx, stringCoder.decode(inStream, context.nested()));
+          break;
 
-      default:
-        throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
+        default:
+          throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
       }
     }
     intCoder.decode(inStream, context);

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
@@ -107,7 +107,6 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
       }
 
       switch (type.getFieldsType().get(idx)) {
-<<<<<<< 88986bb2ed25bae2d5077718bed380f851d8a725
         case INTEGER:
           record.addField(idx, intCoder.decode(inStream, context.nested()));
           break;
@@ -132,32 +131,6 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
 
         default:
           throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
-=======
-      case INTEGER:
-      case SMALLINT:
-      case TINYINT:
-        record.addField(idx, intCoder.decode(inStream, nested));
-        break;
-      case DOUBLE:
-        record.addField(idx, doubleCoder.decode(inStream, nested));
-        break;
-      case FLOAT:
-        record.addField(idx, doubleCoder.decode(inStream, nested).floatValue());
-        break;
-      case BIGINT:
-        record.addField(idx, longCoder.decode(inStream, nested));
-        break;
-      case VARCHAR:
-        record.addField(idx, stringCoder.decode(inStream, nested));
-        break;
-      case TIME:
-      case TIMESTAMP:
-        record.addField(idx, new Date(longCoder.decode(inStream, nested)));
-        break;
-
-      default:
-        throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
->>>>>>> cleanup
       }
     }
     intCoder.decode(inStream, context);

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
@@ -107,6 +107,7 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
       }
 
       switch (type.getFieldsType().get(idx)) {
+<<<<<<< 88986bb2ed25bae2d5077718bed380f851d8a725
         case INTEGER:
           record.addField(idx, intCoder.decode(inStream, context.nested()));
           break;
@@ -131,6 +132,32 @@ public class BeamSqlRowCoder extends StandardCoder<BeamSQLRow>{
 
         default:
           throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
+=======
+      case INTEGER:
+      case SMALLINT:
+      case TINYINT:
+        record.addField(idx, intCoder.decode(inStream, nested));
+        break;
+      case DOUBLE:
+        record.addField(idx, doubleCoder.decode(inStream, nested));
+        break;
+      case FLOAT:
+        record.addField(idx, doubleCoder.decode(inStream, nested).floatValue());
+        break;
+      case BIGINT:
+        record.addField(idx, longCoder.decode(inStream, nested));
+        break;
+      case VARCHAR:
+        record.addField(idx, stringCoder.decode(inStream, nested));
+        break;
+      case TIME:
+      case TIMESTAMP:
+        record.addField(idx, new Date(longCoder.decode(inStream, nested)));
+        break;
+
+      default:
+        throw new UnsupportedDataTypeException(type.getFieldsType().get(idx));
+>>>>>>> cleanup
       }
     }
     intCoder.decode(inStream, context);

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.dsls.sql.schema;
+
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Test;
+
+/**
+ * Tests for BeamSqlRowCoder.
+ */
+public class BeamSqlRowCoderTest {
+
+  @Test
+  public void encode() throws Exception {
+    final RelProtoDataType protoRowType = new RelProtoDataType() {
+      @Override
+      public RelDataType apply(RelDataTypeFactory a0) {
+        return a0.builder()
+            .add("id", SqlTypeName.INTEGER)
+            .add("order_id", SqlTypeName.BIGINT)
+            .add("price", SqlTypeName.FLOAT)
+            .add("amount", SqlTypeName.DOUBLE)
+            .add("user_name", SqlTypeName.VARCHAR)
+            .build();
+      }
+    };
+
+    BeamSQLRecordType beamSQLRecordType = BeamSQLRecordType.from(
+        protoRowType.apply(new JavaTypeFactoryImpl(
+        RelDataTypeSystem.DEFAULT)));
+    BeamSQLRow row = new BeamSQLRow(beamSQLRecordType);
+    row.addField(0, 1);
+    row.addField(1, 1L);
+    row.addField(2, 1.1F);
+    row.addField(3, 1.1);
+    row.addField(4, "hello");
+
+    BeamSqlRowCoder coder = BeamSqlRowCoder.of();
+    CoderProperties.coderDecodeEncodeEqual(coder, row);
+  }
+}

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class BeamSqlRowCoderTest {
 
   @Test
-  public void encode() throws Exception {
+  public void encodeAndDecode() throws Exception {
     final RelProtoDataType protoRowType = new RelProtoDataType() {
       @Override
       public RelDataType apply(RelDataTypeFactory a0) {


### PR DESCRIPTION
This pull request is mainly to fix the SQL FLOAT mapping, previously it is mapped to Float in `BeamSQLRow`, but mapped to `Double` in `BeamSQLRowCoder`, now we consistently map SQL FLOAT to java Float.

When try to unit test this, found another bug in BeamSQLRow: the VARCHAR field is not encode/decoded correctly(mainly because OUTTER Context vs NESTED Context), so fixed this bug at the same time.