### PR TITLE
Fix HBaseIOTest: Move expected assertion to correct place

### DIFF
--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -287,11 +287,11 @@ public class HBaseIOTest {
         PCollection<KV<byte[], Iterable<Mutation>>> emptyInput =
                 p.apply(Create.empty(HBaseIO.WRITE_CODER));
 
+        emptyInput.apply("write", HBaseIO.write().withConfiguration(conf).withTableId(table));
+
         // Exception will be thrown by write.validate() when write is applied.
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage(String.format("Table %s does not exist", table));
-
-        emptyInput.apply("write", HBaseIO.write().withConfiguration(conf).withTableId(table));
         p.run();
     }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

HBaseIOTest#testWritingFailsTableDoesNotExist failed in OpenJDK8 ([here](https://builds.apache.org/job/beam_PostCommit_Java_JDK_Versions_Test/jdk=OpenJDK%208%20(on%20Ubuntu%20only),label=beam/8/console)). Should move expect assertion to `p.run()` closer.