### PR TITLE
[BEAM-806] Use filtering for the version of the reference test project

### DIFF
--- a/sdks/java/maven-archetypes/pom.xml
+++ b/sdks/java/maven-archetypes/pom.xml
@@ -54,7 +54,13 @@
         </excludes>
       </resource>
     </resources>
-
+    <!-- needed to replace version in the reference projects -->
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <pluginManagement>
       <plugins>
         <plugin>

--- a/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
+++ b/sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml
@@ -25,7 +25,7 @@
   <version>0.1</version>
 
   <properties>
-    <beam.version>0.7.0-SNAPSHOT</beam.version>
+    <beam.version>@project.version@</beam.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
With BEAM-2093 the archetypes almos could be released with maven commands without manual version adjustment.

The missing part is in the starter archetype where an integration test compares a predefined project with the generated one. The prefefined reference project also should be filtered to always use the current version.

sdks/java/maven-archetypes/starter/src/test/resources/projects/basic/reference/pom.xml

To reproduce the problem (without this patch) do `mvn versions:set -DnewVersion=0.8.0-SNAPSHOT`, and try to build the project.