### PR TITLE
[BEAM-2141] disable beam_PerformanceTests_Dataflow

### DIFF
--- a/.test-infra/jenkins/job_beam_PerformanceTests_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_Dataflow.groovy
@@ -40,4 +40,7 @@ job('beam_PerformanceTests_Dataflow'){
     ]
 
     common_job_properties.buildPerformanceTest(delegate, argMap)
+
+    // [BEAM-2141] Perf tests do not pass.
+    disabled()
 }


### PR DESCRIPTION
Has not passed in Jenkins memory, at least multiple weeks.
