### PR TITLE
DO NOT MERGE - Direct runner debugging

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
@@ -165,6 +165,7 @@ public class WordCount {
      */
     @Description("Path of the file to write to")
     @Required
+    @Default.String("/tmp/output/out")
     String getOutput();
     void setOutput(String value);
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/BoundedReadEvaluatorFactory.java
@@ -21,7 +21,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -57,7 +59,15 @@ final class BoundedReadEvaluatorFactory implements TransformEvaluatorFactory {
    */
   private static final long REQUIRED_DYNAMIC_SPLIT_ORIGINAL_SIZE = 0;
   private final EvaluationContext evaluationContext;
-  @VisibleForTesting final ExecutorService executor = Executors.newCachedThreadPool();
+
+  // TODO: (BEAM-723) Create a shared ExecutorService for maintenance tasks in the DirectRunner.
+  @VisibleForTesting
+  final ExecutorService executor =
+      Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+          .setThreadFactory(MoreExecutors.platformThreadFactory())
+          .setDaemon(true)
+          .setNameFormat("direct-bounded-read-evaluator")
+          .build());
 
   private final long minimumDynamicSplitSize;
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
@@ -21,6 +21,8 @@ import static java.util.Arrays.asList;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -51,7 +53,12 @@ import org.apache.beam.sdk.metrics.MetricsMap;
 class DirectMetrics extends MetricResults {
 
   // TODO: (BEAM-723) Create a shared ExecutorService for maintenance tasks in the DirectRunner.
-  private static final ExecutorService COUNTER_COMMITTER = Executors.newCachedThreadPool();
+  private static final ExecutorService COUNTER_COMMITTER =
+      Executors.newCachedThreadPool(new ThreadFactoryBuilder()
+          .setThreadFactory(MoreExecutors.platformThreadFactory())
+          .setDaemon(true)
+          .setNameFormat("direct-metrics-counter-committer")
+          .build());
 
   private interface MetricAggregation<UpdateT, ResultT> {
     UpdateT zero();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -28,6 +28,8 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -132,7 +134,12 @@ final class ExecutorServiceParallelExecutor implements PipelineExecutor {
       Map<Class<? extends PTransform>, Collection<ModelEnforcementFactory>> transformEnforcements,
       EvaluationContext context) {
     this.targetParallelism = targetParallelism;
-    this.executorService = Executors.newFixedThreadPool(targetParallelism);
+    this.executorService = Executors
+        .newFixedThreadPool(targetParallelism, new ThreadFactoryBuilder()
+            .setThreadFactory(MoreExecutors.platformThreadFactory())
+            .setDaemon(true)
+            .setNameFormat("direct-executor-service-parallel-executor")
+            .build());
     this.graph = graph;
     this.rootProviderRegistry = rootProviderRegistry;
     this.registry = registry;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -97,7 +97,7 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
    */
   private static class UnboundedReadEvaluator<OutputT, CheckpointMarkT extends CheckpointMark>
       implements TransformEvaluator<UnboundedSourceShard<OutputT, CheckpointMarkT>> {
-    private static final int ARBITRARY_MAX_ELEMENTS = 10;
+    private static final int ARBITRARY_MAX_ELEMENTS = 100;
 
     private final AppliedPTransform<?, PCollection<OutputT>, ?> transform;
     private final EvaluationContext evaluationContext;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -63,6 +63,8 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Manages watermarks of {@link PCollection PCollections} and input and output watermarks of
@@ -127,6 +129,7 @@ import org.joda.time.Instant;
  * </pre>
  */
 class WatermarkManager {
+  private static final Logger LOG = LoggerFactory.getLogger(WatermarkManager.class);
   // The number of updates to apply in #tryApplyPendingUpdates
   private static final int MAX_INCREMENTAL_UPDATES = 10;
 
@@ -546,6 +549,7 @@ class WatermarkManager {
       }
 
       for (TimerData completedTimer : update.completedTimers) {
+        LOG.info("removing a timer");
         pendingTimers.remove(completedTimer);
       }
       for (TimerData deletedTimer : update.deletedTimers) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -42,6 +42,8 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Source that reads from compressed files. A {@code CompressedSources} wraps a delegate
@@ -73,6 +75,7 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class CompressedSource<T> extends FileBasedSource<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(CompressedSource.class);
   /**
    * Factory interface for creating channels that decompress the content of an underlying channel.
    */
@@ -384,6 +387,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
    */
   @Override
   protected final FileBasedReader<T> createSingleFileReader(PipelineOptions options) {
+    LOG.info("Creating single file reader in compressed source");
     if (channelFactory instanceof FileNameBasedDecompressingChannelFactory) {
       FileNameBasedDecompressingChannelFactory fileNameBasedChannelFactory =
           (FileNameBasedDecompressingChannelFactory) channelFactory;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -268,7 +268,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       LOG.info(
           "Splitting filepattern {} into bundles of size {} took {} ms "
               + "and produced {} files and {} bundles",
-          fileOrPatternSpec,
+          fileOrPatternSpec.get(),
           desiredBundleSizeBytes,
           System.currentTimeMillis() - startTime,
           expandedFiles.size(),
@@ -327,7 +327,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
       }
       LOG.debug(
           "Creating a reader for file pattern {} took {} ms",
-          fileOrPatternSpec,
+          fileOrPatternSpec.get(),
           System.currentTimeMillis() - startTime);
       if (fileReaders.size() == 1) {
         return fileReaders.get(0);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSource.java
@@ -313,6 +313,7 @@ public abstract class FileBasedSource<T> extends OffsetBasedSource<T> {
 
   @Override
   public final BoundedReader<T> createReader(PipelineOptions options) throws IOException {
+    LOG.info("Creating reader for {}", this);
     // Validate the current source prior to creating a reader for it.
     this.validate();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSource.java
@@ -31,6 +31,8 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation detail of {@link TextIO.Read}.
@@ -47,6 +49,7 @@ import org.apache.beam.sdk.options.ValueProvider;
  */
 @VisibleForTesting
 class TextSource extends FileBasedSource<String> {
+  private static final Logger LOG = LoggerFactory.getLogger(TextSource.class);
   TextSource(ValueProvider<String> fileSpec) {
     super(fileSpec, 1L);
   }
@@ -124,6 +127,7 @@ class TextSource extends FileBasedSource<String> {
 
     @Override
     protected void startReading(ReadableByteChannel channel) throws IOException {
+      LOG.info("Starting reading");
       this.inChannel = channel;
       // If the first offset is greater than zero, we need to skip bytes until we see our
       // first separator.
@@ -139,6 +143,7 @@ class TextSource extends FileBasedSource<String> {
         endOfSeparatorInBuffer = 0;
         startOfSeparatorInBuffer = 0;
       }
+      LOG.info("Done with startReading");
     }
 
     /**
@@ -189,6 +194,7 @@ class TextSource extends FileBasedSource<String> {
 
     @Override
     protected boolean readNextRecord() throws IOException {
+      LOG.info("RNR");
       startOfRecord = startOfNextRecord;
       findSeparatorBounds();
 
@@ -196,11 +202,13 @@ class TextSource extends FileBasedSource<String> {
       // that there are no more records.
       if (eof && buffer.size() == 0) {
         elementIsPresent = false;
+        LOG.info("DONE RNR");
         return false;
       }
 
       decodeCurrentElement();
       startOfNextRecord = startOfRecord + endOfSeparatorInBuffer;
+      LOG.info("DONE RNR");
       return true;
     }
 


### PR DESCRIPTION
R: @tgroh 

1. Converting all the executor services seems to have done the trick on the 60s delay. We should always uses the ones that take `ThreadPoolBuilders`! (Or actually implement the "one shared executor" task).

2. Added a bunch of debugging logs, finding many seconds of slowly removing timers. Maybe that's useful information?

Logs in this gist: https://gist.github.com/dhalperi/a8f96207040a790f98aa8168c47e0fae