### PR TITLE
[BEAM-1871] [BEAM-1019 ] Shade dependencies in sdks/core

### DIFF
--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -120,6 +120,80 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-and-repackage</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.google.guava:guava</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                  <include>net.bytebuddy:byte-buddy</include>
+                  <include>org.apache.commons:*</include>
+                </includes>
+              </artifactSet>
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.common</pattern>
+                  <!--suppress MavenModelInspection -->
+                  <shadedPattern>
+                    org.apache.beam.sdk.repackaged.com.google.common
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.thirdparty</pattern>
+                  <!--suppress MavenModelInspection -->
+                  <shadedPattern>
+                    org.apache.beam.sdk.repackaged.com.google.thirdparty
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <!--suppress MavenModelInspection -->
+                  <shadedPattern>
+                    org.apache.beam.sdk.repackaged.com.google.protobuf
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>net.bytebuddy</pattern>
+                  <!--suppress MavenModelInspection -->
+                  <shadedPattern>
+                    org.apache.beam.sdk.repackaged.net.bytebuddy
+                  </shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.commons</pattern>
+                  <!--suppress MavenModelInspection -->
+                  <shadedPattern>
+                    org.apache.beam.sdk.repackaged.org.apache.commons
+                  </shadedPattern>
+                </relocation>
+              </relocations>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
@@ -352,7 +352,15 @@ public class ApiSurface {
 
     Set<Class<?>> newRootClasses = Sets.newHashSet();
     for (ClassPath.ClassInfo classInfo : classPath.getTopLevelClassesRecursive(packageName)) {
-      Class clazz = classInfo.load();
+      Class clazz = null;
+      try {
+        clazz = classInfo.load();
+      } catch (Throwable e) {
+        // Ignore any class loading errors.
+        LOG.warn("Failed to load class: {}", classInfo.toString(), e);
+        continue;
+      }
+
       if (exposed(clazz.getModifiers())) {
         newRootClasses.add(clazz);
       }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
@@ -355,8 +355,8 @@ public class ApiSurface {
       Class clazz = null;
       try {
         clazz = classInfo.load();
-      } catch (Throwable e) {
-        // Ignore any class loading errors.
+      } catch (NoClassDefFoundError e) {
+        // TODO(BEAM-2231): Ignore any NoClassDefFoundError errors as a workaround.
         LOG.warn("Failed to load class: {}", classInfo.toString(), e);
         continue;
       }


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
- Shade `com.google.guava:guava`, `com.google.protobuf:protobuf-java`, `net.bytebuddy:byte-buddy`, `org.apache.commons:*`
- Shading `net.bytebuddy` fails the `GcpApiSurfaceTest` with `NoClassDefFoundError` for ` org/apache/beam/sdk/repackaged/net/bytebuddy/jar/asm/tree/MethodNode`. Looks like an issue with how `net.bytebuddy` does shading for `org.objectweb.asm`. Either way the `ApiSurfaceTest` should be fixed to be able to prune and load classes lazily. For release-2.0.0 we catch and ignore any class loading errors.  