### PR TITLE
[BEAM-2181] Upgrade Bigtable dependency to 0.9.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <apex.kryo.version>2.24.0</apex.kryo.version>
     <avro.version>1.8.1</avro.version>
     <bigquery.version>v2-rev295-1.22.0</bigquery.version>
-    <bigtable.version>0.9.6</bigtable.version>
+    <bigtable.version>0.9.6.2</bigtable.version>
     <cloudresourcemanager.version>v1-rev6-1.22.0</cloudresourcemanager.version>
     <pubsubgrpc.version>0.1.0</pubsubgrpc.version>
     <clouddebugger.version>v2-rev8-1.22.0</clouddebugger.version>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -74,15 +74,6 @@ class BigtableServiceImpl implements BigtableService {
 
   @Override
   public boolean tableExists(String tableId) throws IOException {
-    if (!BigtableSession.isAlpnProviderEnabled()) {
-      LOG.info(
-          "Skipping existence check for table {} (BigtableOptions {}) because ALPN is not"
-              + " configured.",
-          tableId,
-          options);
-      return true;
-    }
-
     try (BigtableSession session = new BigtableSession(options)) {
       GetTableRequest getTable =
           GetTableRequest.newBuilder()
@@ -98,7 +89,8 @@ class BigtableServiceImpl implements BigtableService {
           String.format(
               "Error checking whether table %s (BigtableOptions %s) exists", tableId, options);
       LOG.error(message, e);
-      throw new IOException(message, e);
+      // Ignore issues relating to temporary issues or boringssl configuration.
+      return true;
     }
   }
 


### PR DESCRIPTION
Cloud Bigtable 0.9.6.2 has some fixes relating to:
1) Using dependencies for GCP protobuf objects rather than including generated artifacts directly in bigtable-protos
2) BulkMutation bug fixes
3) Auth token management
4) Using fewer grpc experimental features.
All are important in the context of beam, so the beam dependency should be upgraded.
One snag came up. BigtableSession.isAlpnProviderEnabled() was removed in order to reduce the number of grpc experimental features. BigtableServiceImpl.tableExists() can no longer depend on isAlpnProviderEnabled().

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
