### PR TITLE
[BEAM-2233,BEAM-2223] Adjust TestSparkPipelineOptions registration; add per-runner profiles to Java 8 examples pom

### DIFF
--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -41,21 +41,11 @@
 
   <profiles>
     <!--
-      A default profile that includes optional dependencies
-      on all of our runners. This is aimed at making it very
-      easy for users to run examples with any runner without
-      any configuration. It is not needed or desirable when
-      testing the examples with a particular runner.
-
-      This profile can be disabled on the command line
-      by specifying -P !include-runners.
-
-      This profile cannot be lifted to examples-parent because
-      it would be automatically deactivated when the Java 8
-      profile were activated.
+      The direct runner is available by default.
+      You can also include it on the classpath explicitly with -P direct-runner
     -->
     <profile>
-      <id>include-runners</id>
+      <id>direct-runner</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
@@ -63,41 +53,72 @@
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-direct-java</artifactId>
-          <version>${project.version}</version>
           <scope>runtime</scope>
-          <optional>true</optional>
         </dependency>
+      </dependencies>
+    </profile>
 
+    <!-- Include the Apache Apex runner with -P apex-runner -->
+    <profile>
+      <id>apex-runner</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-apex</artifactId>
+          <scope>runtime</scope>
+        </dependency>
+        <!--
+          Apex depends on httpclient version 4.3.5, project has a transitive dependency to httpclient 4.0.1 from
+          google-http-client. Apex dependency version being specified explicitly so that it gets picked up. This
+          can be removed when the project no longer has a dependency on a different httpclient version.
+        -->
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.3.5</version>
+          <scope>runtime</scope>
+          <exclusions>
+            <exclusion>
+              <groupId>commons-codec</groupId>
+              <artifactId>commons-codec</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <!-- Include the Apache Flink runner with -P flink-runner -->
+    <profile>
+      <id>flink-runner</id>
+      <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-flink_2.10</artifactId>
-          <version>${project.version}</version>
           <scope>runtime</scope>
-          <optional>true</optional>
         </dependency>
+      </dependencies>
+    </profile>
 
-        <dependency>
-          <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
-          <version>${project.version}</version>
-          <scope>runtime</scope>
-          <optional>true</optional>
-        </dependency>
-
+    <!-- Include the Apache Spark runner -P spark-runner -->
+    <profile>
+      <id>spark-runner</id>
+      <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
           <artifactId>beam-runners-spark</artifactId>
-          <version>${project.version}</version>
           <scope>runtime</scope>
-          <optional>true</optional>
         </dependency>
-
+        <dependency>
+          <groupId>org.apache.spark</groupId>
+          <artifactId>spark-streaming_2.10</artifactId>
+          <version>${spark.version}</version>
+          <scope>runtime</scope>
+        </dependency>
         <dependency>
           <groupId>org.apache.spark</groupId>
           <artifactId>spark-core_2.10</artifactId>
           <version>${spark.version}</version>
           <scope>runtime</scope>
-          <optional>true</optional>
           <exclusions>
             <exclusion>
               <groupId>org.slf4j</groupId>
@@ -105,13 +126,17 @@
             </exclusion>
           </exclusions>
         </dependency>
+      </dependencies>
+    </profile>
 
+    <!-- Include the Google Cloud Dataflow runner -P dataflow-runner -->
+    <profile>
+      <id>dataflow-runner</id>
+      <dependencies>
         <dependency>
-          <groupId>org.apache.spark</groupId>
-          <artifactId>spark-streaming_2.10</artifactId>
-          <version>${spark.version}</version>
+          <groupId>org.apache.beam</groupId>
+          <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
           <scope>runtime</scope>
-          <optional>true</optional>
         </dependency>
       </dependencies>
     </profile>

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunnerRegistrar.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunnerRegistrar.java
@@ -54,9 +54,7 @@ public final class SparkRunnerRegistrar {
   public static class Options implements PipelineOptionsRegistrar {
     @Override
     public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
-      return ImmutableList.<Class<? extends PipelineOptions>>of(
-          SparkPipelineOptions.class,
-          TestSparkPipelineOptions.class);
+      return ImmutableList.<Class<? extends PipelineOptions>>of(SparkPipelineOptions.class);
     }
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerRegistrarTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerRegistrarTest.java
@@ -38,7 +38,7 @@ public class SparkRunnerRegistrarTest {
   @Test
   public void testOptions() {
     assertEquals(
-        ImmutableList.of(SparkPipelineOptions.class, TestSparkPipelineOptions.class),
+        ImmutableList.of(SparkPipelineOptions.class),
         new SparkRunnerRegistrar.Options().getPipelineOptions());
   }
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/TestSparkPipelineOptionsRegistrar.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/TestSparkPipelineOptionsRegistrar.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.spark;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsRegistrar;
+
+/**
+ * A registrar for {@link TestSparkPipelineOptions} to temporarily work around some complexities in
+ * {@link PipelineOptions} parsing.
+ */
+@AutoService(PipelineOptionsRegistrar.class)
+public final class TestSparkPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+  @Override
+  public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
+    return ImmutableList.<Class<? extends PipelineOptions>>of(TestSparkPipelineOptions.class);
+  }
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

We have cascading failures:

 - All runners were included together in the `include-runners` profile in the Java 8 examples
 - `TestOptions` has a hard dep on hamcrest that we list as `provided`, putting a burden on users
 - `TestSparkPipelineOptions` was registered, so the Spark runner had this same hard dep and class load time
 - If you do `options.as(MyUnregisteredOptions.class)` this will cause `TestPipeline`/`PipelineOptionsFactory` to crash with a parse error even if none of the unregistered options were present

These should all be fixed, IMO as follows:

 - Runners should have separate profiles (done in this PR)
 - `TestOptions` should either not use hamcrest or should declare a correct dependency (not resolved)
 - `TestSparkPipelineOptions` should either not need to be registered or should be allowed to be registered (expected resolution: no need to register)
 - `TestPipeline` / `PipelineOptionsFactory` should not crash due to how options have been observed, when they are not mutated, and probably should just not crash at all