### PR TITLE
[BEAM-2052] Allow dynamic sharding in windowed file sinks

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -161,12 +161,15 @@ public class WindowedWordCount {
     @Default.InstanceFactory(DefaultToMinTimestampPlusOneHour.class)
     Long getMaxTimestampMillis();
     void setMaxTimestampMillis(Long value);
+
+    @Description("Fixed number of shards to produce per window, or null for runner-chosen sharding")
+    Integer getNumShards();
+    void setNumShards(Integer numShards);
   }
 
   public static void main(String[] args) throws IOException {
     Options options = PipelineOptionsFactory.fromArgs(args).withValidation().as(Options.class);
     final String output = options.getOutput();
-    final Duration windowSize = Duration.standardMinutes(options.getWindowSize());
     final Instant minTimestamp = new Instant(options.getMinTimestampMillis());
     final Instant maxTimestamp = new Instant(options.getMaxTimestampMillis());
 
@@ -207,7 +210,7 @@ public class WindowedWordCount {
      */
     wordCounts
         .apply(MapElements.via(new WordCount.FormatAsTextFn()))
-        .apply(new WriteOneFilePerWindow(output));
+        .apply(new WriteOneFilePerWindow(output, options.getNumShards()));
 
     PipelineResult result = pipeline.run();
     try {

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -86,14 +86,29 @@ public class WindowedWordCountIT {
   }
 
   @Test
-  public void testWindowedWordCountInBatch() throws Exception {
-    testWindowedWordCountPipeline(defaultOptions());
+  public void testWindowedWordCountInBatchDynamicSharding() throws Exception {
+    WindowedWordCountITOptions options = batchOptions();
+    // This is the default value, but make it explicit
+    options.setNumShards(null);
+    testWindowedWordCountPipeline(options);
   }
 
   @Test
+  public void testWindowedWordCountInBatchStaticSharding() throws Exception {
+    WindowedWordCountITOptions options = batchOptions();
+    options.setNumShards(3);
+    testWindowedWordCountPipeline(options);
+  }
+
+  // TODO: add a test with streaming and dynamic sharding after resolving
+  // https://issues.apache.org/jira/browse/BEAM-1438
+
+  @Test
   @Category(StreamingIT.class)
-  public void testWindowedWordCountInStreaming() throws Exception {
-    testWindowedWordCountPipeline(streamingOptions());
+  public void testWindowedWordCountInStreamingStaticSharding() throws Exception {
+    WindowedWordCountITOptions options = streamingOptions();
+    options.setNumShards(3);
+    testWindowedWordCountPipeline(options);
   }
 
   private WindowedWordCountITOptions defaultOptions() throws Exception {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -510,7 +510,7 @@ public class PTransformMatchersTest implements Serializable {
         WriteFiles.to(
             new FileBasedSink<Integer>(StaticValueProvider.of(outputDirectory), policy) {
               @Override
-              public FileBasedWriteOperation<Integer> createWriteOperation() {
+              public WriteOperation<Integer> createWriteOperation() {
                 return null;
               }
             });

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
@@ -134,7 +134,7 @@ public class WriteWithShardingFactoryTest {
     WriteFiles<Object> original = WriteFiles.to(
         new FileBasedSink<Object>(StaticValueProvider.of(outputDirectory), policy) {
           @Override
-          public FileBasedWriteOperation<Object> createWriteOperation() {
+          public WriteOperation<Object> createWriteOperation() {
             throw new IllegalArgumentException("Should not be used");
           }
         });

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
@@ -47,7 +47,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.TextualIntegerCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.io.FileBasedSink.FileResultCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.TableDestinationCoder;
 import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
 
@@ -91,7 +90,6 @@ public class DefaultCoderCloudObjectTranslatorRegistrar
           ByteCoder.class,
           DoubleCoder.class,
           DurationCoder.class,
-          FileResultCoder.class,
           FooterCoder.class,
           InstantCoder.class,
           IsmShardCoder.class,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -51,12 +51,12 @@ class AvroSink<T> extends FileBasedSink<T> {
   }
 
   @Override
-  public FileBasedWriteOperation<T> createWriteOperation() {
+  public WriteOperation<T> createWriteOperation() {
     return new AvroWriteOperation<>(this, coder, codec, metadata);
   }
 
-  /** A {@link FileBasedWriteOperation FileBasedWriteOperation} for Avro files. */
-  private static class AvroWriteOperation<T> extends FileBasedWriteOperation<T> {
+  /** A {@link WriteOperation WriteOperation} for Avro files. */
+  private static class AvroWriteOperation<T> extends WriteOperation<T> {
     private final AvroCoder<T> coder;
     private final SerializableAvroCodecFactory codec;
     private final ImmutableMap<String, Object> metadata;
@@ -72,19 +72,19 @@ class AvroSink<T> extends FileBasedSink<T> {
     }
 
     @Override
-    public FileBasedWriter<T> createWriter() throws Exception {
+    public Writer<T> createWriter() throws Exception {
       return new AvroWriter<>(this, coder, codec, metadata);
     }
   }
 
-  /** A {@link FileBasedWriter FileBasedWriter} for Avro files. */
-  private static class AvroWriter<T> extends FileBasedWriter<T> {
+  /** A {@link Writer Writer} for Avro files. */
+  private static class AvroWriter<T> extends Writer<T> {
     private final AvroCoder<T> coder;
     private DataFileWriter<T> dataFileWriter;
     private SerializableAvroCodecFactory codec;
     private final ImmutableMap<String, Object> metadata;
 
-    public AvroWriter(FileBasedWriteOperation<T> writeOperation,
+    public AvroWriter(WriteOperation<T> writeOperation,
                       AvroCoder<T> coder,
                       SerializableAvroCodecFactory codec,
                       ImmutableMap<String, Object> metadata) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -78,7 +78,7 @@ import org.slf4j.LoggerFactory;
  * type, etc.).
  *
  * <p>At pipeline construction time, the methods of FileBasedSink are called to validate the sink
- * and to create a {@link FileBasedWriteOperation} that manages the process of writing to the sink.
+ * and to create a {@link WriteOperation} that manages the process of writing to the sink.
  *
  * <p>The process of writing to file-based sink is as follows:
  * <ol>
@@ -89,8 +89,8 @@ import org.slf4j.LoggerFactory;
  *
  * <p>In order to ensure fault-tolerance, a bundle may be executed multiple times (e.g., in the
  * event of failure/retry or for redundancy). However, exactly one of these executions will have its
- * result passed to the finalize method. Each call to {@link FileBasedWriter#openWindowed}
- * or {@link FileBasedWriter#openUnwindowed} is passed a unique <i>bundle id</i> when it is called
+ * result passed to the finalize method. Each call to {@link Writer#openWindowed}
+ * or {@link Writer#openUnwindowed} is passed a unique <i>bundle id</i> when it is called
  * by the WriteFiles transform, so even redundant or retried bundles will have a unique way of
  * identifying
  * their output.
@@ -359,10 +359,10 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
   public void validate(PipelineOptions options) {}
 
   /**
-   * Return a subclass of {@link FileBasedSink.FileBasedWriteOperation} that will manage the write
+   * Return a subclass of {@link WriteOperation} that will manage the write
    * to the sink.
    */
-  public abstract FileBasedWriteOperation<T> createWriteOperation();
+  public abstract WriteOperation<T> createWriteOperation();
 
   public void populateDisplayData(DisplayData.Builder builder) {
     getFilenamePolicy().populateDisplayData(builder);
@@ -371,24 +371,24 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
   /**
    * Abstract operation that manages the process of writing to {@link FileBasedSink}.
    *
-   * <p>The primary responsibilities of the FileBasedWriteOperation is the management of output
-   * files. During a write, {@link FileBasedSink.FileBasedWriter}s write bundles to temporary file
+   * <p>The primary responsibilities of the WriteOperation is the management of output
+   * files. During a write, {@link Writer}s write bundles to temporary file
    * locations. After the bundles have been written,
    * <ol>
-   * <li>{@link FileBasedSink.FileBasedWriteOperation#finalize} is given a list of the temporary
+   * <li>{@link WriteOperation#finalize} is given a list of the temporary
    * files containing the output bundles.
    * <li>During finalize, these temporary files are copied to final output locations and named
    * according to a file naming template.
    * <li>Finally, any temporary files that were created during the write are removed.
    * </ol>
    *
-   * <p>Subclass implementations of FileBasedWriteOperation must implement
-   * {@link FileBasedSink.FileBasedWriteOperation#createWriter} to return a concrete
+   * <p>Subclass implementations of WriteOperation must implement
+   * {@link WriteOperation#createWriter} to return a concrete
    * FileBasedSinkWriter.
    *
    * <h2>Temporary and Output File Naming:</h2> During the write, bundles are written to temporary
    * files using the tempDirectory that can be provided via the constructor of
-   * FileBasedWriteOperation. These temporary files will be named
+   * WriteOperation. These temporary files will be named
    * {@code {tempDirectory}/{bundleId}}, where bundleId is the unique id of the bundle.
    * For example, if tempDirectory is "gs://my-bucket/my_temp_output", the output for a
    * bundle with bundle id 15723 will be "gs://my-bucket/my_temp_output/15723".
@@ -408,7 +408,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
    *
    * @param <T> the type of values written to the sink.
    */
-  public abstract static class FileBasedWriteOperation<T> implements Serializable {
+  public abstract static class WriteOperation<T> implements Serializable {
     /**
      * The Sink that this WriteOperation will write to.
      */
@@ -427,7 +427,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     }
 
     /**
-     * Constructs a FileBasedWriteOperation using the default strategy for generating a temporary
+     * Constructs a WriteOperation using the default strategy for generating a temporary
      * directory from the base output filename.
      *
      * <p>Default is a uniquely named sibling of baseOutputFilename, e.g. if baseOutputFilename is
@@ -435,7 +435,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
      *
      * @param sink the FileBasedSink that will be used to configure this write operation.
      */
-    public FileBasedWriteOperation(FileBasedSink<T> sink) {
+    public WriteOperation(FileBasedSink<T> sink) {
       this(sink, NestedValueProvider.of(
           sink.getBaseOutputDirectoryProvider(), new TemporaryDirectoryBuilder()));
     }
@@ -461,16 +461,16 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     }
 
     /**
-     * Create a new FileBasedWriteOperation.
+     * Create a new WriteOperation.
      *
      * @param sink the FileBasedSink that will be used to configure this write operation.
      * @param tempDirectory the base directory to be used for temporary output files.
      */
-    public FileBasedWriteOperation(FileBasedSink<T> sink, ResourceId tempDirectory) {
+    public WriteOperation(FileBasedSink<T> sink, ResourceId tempDirectory) {
       this(sink, StaticValueProvider.of(tempDirectory));
     }
 
-    private FileBasedWriteOperation(
+    private WriteOperation(
         FileBasedSink<T> sink, ValueProvider<ResourceId> tempDirectory) {
       this.sink = sink;
       this.tempDirectory = tempDirectory;
@@ -478,10 +478,10 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     }
 
     /**
-     * Clients must implement to return a subclass of {@link FileBasedSink.FileBasedWriter}. This
+     * Clients must implement to return a subclass of {@link Writer}. This
      * method must not mutate the state of the object.
      */
-    public abstract FileBasedWriter<T> createWriter() throws Exception;
+    public abstract Writer<T> createWriter() throws Exception;
 
     /**
      * Indicates that the operation will be performing windowed writes.
@@ -558,7 +558,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     /**
      * Copy temporary files to final output filenames using the file naming template.
      *
-     * <p>Can be called from subclasses that override {@link FileBasedWriteOperation#finalize}.
+     * <p>Can be called from subclasses that override {@link WriteOperation#finalize}.
      *
      * <p>Files will be named according to the file naming template. The order of the output files
      * will be the same as the sorted order of the input filenames.  In other words, if the input
@@ -591,7 +591,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     /**
      * Removes temporary output files. Uses the temporary directory to find files to remove.
      *
-     * <p>Can be called from subclasses that override {@link FileBasedWriteOperation#finalize}.
+     * <p>Can be called from subclasses that override {@link WriteOperation#finalize}.
      * <b>Note:</b>If finalize is overridden and does <b>not</b> rename or otherwise finalize
      * temporary files, this method will remove them.
      */
@@ -667,15 +667,15 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
    * after the values in a bundle, respectively, as well as provide a MIME type for the output
    * channel.
    *
-   * <p>Multiple {@link FileBasedWriter} instances may be created on the same worker, and therefore
+   * <p>Multiple {@link Writer} instances may be created on the same worker, and therefore
    * any access to static members or methods should be thread safe.
    *
    * @param <T> the type of values to write.
    */
-  public abstract static class FileBasedWriter<T> {
-    private static final Logger LOG = LoggerFactory.getLogger(FileBasedWriter.class);
+  public abstract static class Writer<T> {
+    private static final Logger LOG = LoggerFactory.getLogger(Writer.class);
 
-    private final FileBasedWriteOperation<T> writeOperation;
+    private final WriteOperation<T> writeOperation;
 
     /** Unique id for this output bundle. */
     private String id;
@@ -704,9 +704,9 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     private final String mimeType;
 
     /**
-     * Construct a new {@link FileBasedWriter} that will produce files of the given MIME type.
+     * Construct a new {@link Writer} that will produce files of the given MIME type.
      */
-    public FileBasedWriter(FileBasedWriteOperation<T> writeOperation, String mimeType) {
+    public Writer(WriteOperation<T> writeOperation, String mimeType) {
       checkNotNull(writeOperation);
       this.writeOperation = writeOperation;
       this.mimeType = mimeType;
@@ -739,7 +739,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     /**
      *  Performs bundle initialization. For example, creates a temporary file for writing or
-     * initializes any state that will be used across calls to {@link FileBasedWriter#write}.
+     * initializes any state that will be used across calls to {@link Writer#write}.
      *
      * <p>The unique id that is given to open should be used to ensure that the writer's output
      * does not interfere with the output of other Writers, as a bundle may be executed many
@@ -818,7 +818,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
         closeChannelAndThrow(tempChannel, outputFile, e);
       }
 
-      // The caller shouldn't have to close() this FileBasedWriter if it fails to open(), so close
+      // The caller shouldn't have to close() this Writer if it fails to open(), so close
       // the channel if prepareWrite() or writeHeader() fails.
       String step = "";
       try {
@@ -895,9 +895,9 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     }
 
     /**
-     * Return the FileBasedWriteOperation that this Writer belongs to.
+     * Return the WriteOperation that this Writer belongs to.
      */
-    public FileBasedWriteOperation<T> getWriteOperation() {
+    public WriteOperation<T> getWriteOperation() {
       return writeOperation;
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -34,7 +34,9 @@ import java.io.Serializable;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,10 +45,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.StructuredCoder;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.Context;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.WindowedContext;
 import org.apache.beam.sdk.io.fs.MatchResult;
@@ -63,6 +67,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo.PaneInfoCoder;
 import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.commons.compress.compressors.deflate.DeflateCompressorOutputStream;
@@ -306,8 +311,7 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
   }
 
   /** The policy used to generate names of files to be produced. */
-  @VisibleForTesting
-  final FilenamePolicy filenamePolicy;
+  private final FilenamePolicy filenamePolicy;
   /** The directory to which files will be written. */
   private final ValueProvider<ResourceId> baseOutputDirectoryProvider;
 
@@ -523,27 +527,43 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
 
     protected final Map<ResourceId, ResourceId> buildOutputFilenames(
         Iterable<FileResult> writerResults) {
+      int numShards = Iterables.size(writerResults);
       Map<ResourceId, ResourceId> outputFilenames = new HashMap<>();
-      List<ResourceId> files = new ArrayList<>();
+
+      List<FileResult> unshardedFiles = new ArrayList<>();
+      FilenamePolicy policy = getSink().getFilenamePolicy();
       for (FileResult result : writerResults) {
-        if (result.getDestinationFilename() != null) {
-          outputFilenames.put(result.getFilename(), result.getDestinationFilename());
+        if (result.getShard() != WriteFiles.UNKNOWN_SHARDNUM) {
+          outputFilenames.put(result.getTempFilename(),
+              result.getDestinationFile(policy, getSink().getBaseOutputDirectoryProvider().get(),
+                  numShards, getSink().getExtension()));
         } else {
-          files.add(result.getFilename());
+          unshardedFiles.add(result);
         }
       }
 
       // writerResults won't contain destination filenames, so we dynamically generate them here.
-      if (files.size() > 0) {
+      if (unshardedFiles.size() > 0) {
         checkArgument(outputFilenames.isEmpty());
-        // Sort files for idempotence.
-        files = Ordering.usingToString().sortedCopy(files);
-        ResourceId outputDirectory = getSink().getBaseOutputDirectoryProvider().get();
-        FilenamePolicy filenamePolicy = getSink().filenamePolicy;
-        for (int i = 0; i < files.size(); i++) {
-          outputFilenames.put(files.get(i),
-              filenamePolicy.unwindowedFilename(outputDirectory, new Context(i, files.size()),
-                  getSink().getExtension()));
+
+        // Sort files for idempotence. Sort by temporary filename.
+        // Note that this codepath should not be used when processing triggered windows. In the
+        // case of triggers, the list of FileResult objects in the Finalize iterable is not
+        // deterministic, and might change over retries. This breaks the assumption below that
+        // sorting the FileResult objects provides idempotency.
+        unshardedFiles = Ordering.from(new Comparator<FileResult>() {
+          @Override
+          public int compare(FileResult first, FileResult second) {
+            return first.getTempFilename().toString().compareTo(
+                second.getTempFilename().toString());
+          }
+        }).sortedCopy(unshardedFiles);
+        for (int i = 0; i < unshardedFiles.size(); i++) {
+          FileResult result = unshardedFiles.get(i);
+          result.setShard(i);
+          outputFilenames.put(result.getTempFilename(),
+              result.getDestinationFile(policy, getSink().getBaseOutputDirectoryProvider().get(),
+                  numShards, getSink().getExtension()));
         }
       }
 
@@ -647,6 +667,19 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     public FileBasedSink<T> getSink() {
       return sink;
     }
+
+    @Override
+    public String toString() {
+      String tempDirectoryStr =
+          tempDirectory.isAccessible() ? tempDirectory.get().toString() : tempDirectory.toString();
+      return getClass().getSimpleName()
+          + "{"
+          + "tempDirectory="
+          + tempDirectoryStr
+          + ", windowedWrites="
+          + windowedWrites
+          + '}';
+    }
   }
 
   /** Returns the extension that will be written to the produced files. */
@@ -683,7 +716,6 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     private BoundedWindow window;
     private PaneInfo paneInfo;
     private int shard = -1;
-    private int numShards = -1;
 
     /** The output file for this bundle. May be null if opening failed. */
     private @Nullable ResourceId outputFile;
@@ -738,24 +770,23 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     protected void finishWrite() throws Exception {}
 
     /**
-     *  Performs bundle initialization. For example, creates a temporary file for writing or
+     * Performs bundle initialization. For example, creates a temporary file for writing or
      * initializes any state that will be used across calls to {@link Writer#write}.
      *
-     * <p>The unique id that is given to open should be used to ensure that the writer's output
-     * does not interfere with the output of other Writers, as a bundle may be executed many
-     * times for fault tolerance.
+     * <p>The unique id that is given to open should be used to ensure that the writer's output does
+     * not interfere with the output of other Writers, as a bundle may be executed many times for
+     * fault tolerance.
      *
-     * <p>The window and paneInfo arguments are populated when windowed writes are requested.
-     * shard and numShards are populated for the case of static sharding. In cases where the
-     * runner is dynamically picking sharding, shard and numShards might both be set to -1.
+     * <p>The window and paneInfo arguments are populated when windowed writes are requested. shard
+     * id populated for the case of static sharding. In cases where the runner is dynamically
+     * picking sharding, shard might be set to -1.
      */
-    public final void openWindowed(
-        String uId, BoundedWindow window, PaneInfo paneInfo, int shard, int numShards)
+    public final void openWindowed(String uId, BoundedWindow window, PaneInfo paneInfo, int shard)
         throws Exception {
       if (!getWriteOperation().windowedWrites) {
         throw new IllegalStateException("openWindowed called a non-windowed sink.");
       }
-      open(uId, window, paneInfo, shard, numShards);
+      open(uId, window, paneInfo, shard);
     }
 
     /**
@@ -767,13 +798,11 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
      * Similar to {@link #openWindowed} however for the case where unwindowed writes were
      * requested.
      */
-    public final void openUnwindowed(String uId,
-                                     int shard,
-                                     int numShards) throws Exception {
+    public final void openUnwindowed(String uId, int shard) throws Exception {
       if (getWriteOperation().windowedWrites) {
         throw new IllegalStateException("openUnwindowed called a windowed sink.");
       }
-      open(uId, null, null, shard, numShards);
+      open(uId, null, null, shard);
     }
 
     // Helper function to close a channel, on exception cases.
@@ -792,13 +821,11 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
     private void open(String uId,
                       @Nullable BoundedWindow window,
                       @Nullable PaneInfo paneInfo,
-                      int shard,
-                      int numShards) throws Exception {
+                      int shard) throws Exception {
       this.id = uId;
       this.window = window;
       this.paneInfo = paneInfo;
       this.shard = shard;
-      this.numShards = numShards;
       ResourceId tempDirectory = getWriteOperation().tempDirectory.get();
       outputFile = tempDirectory.resolve(id, StandardResolveOptions.RESOLVE_FILE);
       verifyNotNull(
@@ -874,23 +901,8 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
         throw new IOException(String.format("Failed closing channel to %s", outputFile), e);
       }
 
-      FileBasedSink<T> sink = getWriteOperation().getSink();
-      ResourceId outputDirectory = sink.getBaseOutputDirectoryProvider().get();
-      FilenamePolicy filenamePolicy = sink.filenamePolicy;
-      String extension = sink.getExtension();
-      @Nullable ResourceId destinationFile;
-      if (window != null) {
-        destinationFile = filenamePolicy.windowedFilename(outputDirectory, new WindowedContext(
-            window, paneInfo, shard, numShards), extension);
-      } else if (numShards > 0) {
-        destinationFile = filenamePolicy.unwindowedFilename(
-            outputDirectory, new Context(shard, numShards), extension);
-      } else {
-        // Destination filename to be generated in the next step.
-        destinationFile = null;
-      }
-      FileResult result = new FileResult(outputFile, destinationFile);
-      LOG.debug("Result for bundle {}: {} {}", this.id, outputFile, destinationFile);
+      FileResult result = new FileResult(outputFile, shard, window, paneInfo);
+      LOG.debug("Result for bundle {}: {}", this.id, outputFile);
       return result;
     }
 
@@ -906,31 +918,56 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
    * Result of a single bundle write. Contains the filename produced by the bundle, and if known
    * the final output filename.
    */
-  public static final class FileResult implements Serializable {
-    private final ResourceId filename;
-    @Nullable private final ResourceId destinationFilename;
+  public static final class FileResult {
+    private final ResourceId tempFilename;
+    private int shard;
+    private BoundedWindow window;
+    private PaneInfo paneInfo;
 
-    public FileResult(ResourceId filename, @Nullable ResourceId destinationFilename) {
-      this.filename = filename;
-      this.destinationFilename = destinationFilename;
+    public FileResult(ResourceId tempFilename, int shard, BoundedWindow window,
+                      PaneInfo paneInfo) {
+      this.tempFilename = tempFilename;
+      this.shard = shard;
+      this.window = window;
+      this.paneInfo = paneInfo;
     }
 
-    public ResourceId getFilename() {
-      return filename;
+    public ResourceId getTempFilename() {
+      return tempFilename;
     }
 
-    /**
-     * The filename to be written. Will be null if the output filename is unknown because the number
-     * of shards is determined dynamically by the runner.
-     */
-    @Nullable public ResourceId getDestinationFilename() {
-      return destinationFilename;
+    public int getShard() {
+      return shard;
+    }
+
+    public void setShard(int shard) {
+      this.shard = shard;
+    }
+
+    public BoundedWindow getWindow() {
+      return window;
+    }
+
+    public PaneInfo getPaneInfo() {
+      return paneInfo;
+    }
+
+    public ResourceId getDestinationFile(FilenamePolicy policy, ResourceId outputDirectory,
+                                         int numShards, String extension) {
+      checkArgument(getShard() != WriteFiles.UNKNOWN_SHARDNUM);
+      checkArgument(numShards > 0);
+      if (getWindow() != null) {
+        return policy.windowedFilename(outputDirectory, new WindowedContext(
+            getWindow(), getPaneInfo(), getShard(), numShards), extension);
+      } else {
+        return policy.unwindowedFilename(outputDirectory, new Context(getShard(), numShards),
+            extension);
+      }
     }
 
     public String toString() {
-      return MoreObjects.toStringHelper(FileResult.class)
-          .add("filename", filename)
-          .add("destinationFilename", destinationFilename)
+      return MoreObjects.toStringHelper(FileBasedSink.FileResult.class)
+          .add("tempFilename", tempFilename)
           .toString();
     }
   }
@@ -938,12 +975,23 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
   /**
    * A coder for {@link FileResult} objects.
    */
-  public static final class FileResultCoder extends AtomicCoder<FileResult> {
-    private static final FileResultCoder INSTANCE = new FileResultCoder();
-    private final NullableCoder<String> stringCoder = NullableCoder.of(StringUtf8Coder.of());
+  public static final class FileResultCoder extends StructuredCoder<FileResult> {
+    private final Coder<String> stringCoder = StringUtf8Coder.of();
+    private final Coder<Integer> integerCoder = VarIntCoder.of();
+    private final Coder<PaneInfo> paneInfoCoder = NullableCoder.of(PaneInfoCoder.INSTANCE);
+    private final Coder<BoundedWindow> windowCoder;
 
-    public static FileResultCoder of() {
-      return INSTANCE;
+    protected FileResultCoder(Coder<BoundedWindow> windowCoder) {
+      this.windowCoder = NullableCoder.of(windowCoder);
+    }
+
+    public static FileResultCoder of(Coder<BoundedWindow> windowCoder) {
+      return new FileResultCoder(windowCoder);
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      return Arrays.asList(windowCoder);
     }
 
     @Override
@@ -952,29 +1000,30 @@ public abstract class FileBasedSink<T> implements Serializable, HasDisplayData {
       if (value == null) {
         throw new CoderException("cannot encode a null value");
       }
-      stringCoder.encode(value.getFilename().toString(), outStream);
-      if (value.getDestinationFilename() == null) {
-        stringCoder.encode(null, outStream);
-      } else {
-        stringCoder.encode(value.getDestinationFilename().toString(), outStream);
-      }
+      stringCoder.encode(value.getTempFilename().toString(), outStream);
+      windowCoder.encode(value.getWindow(), outStream);
+      paneInfoCoder.encode(value.getPaneInfo(), outStream);
+      integerCoder.encode(value.getShard(), outStream);
     }
 
     @Override
-    public FileResult decode(InputStream inStream) throws IOException {
-      String filename = stringCoder.decode(inStream);
-      assert filename != null;  // fixes a compiler warning
-      @Nullable String destinationFilename = stringCoder.decode(inStream);
-      return new FileResult(
-          FileSystems.matchNewResource(filename, false /* isDirectory */),
-          destinationFilename == null
-              ? null
-              : FileSystems.matchNewResource(destinationFilename, false /* isDirectory */));
+    public FileResult decode(InputStream inStream)
+        throws IOException {
+      String tempFilename = stringCoder.decode(inStream);
+      assert tempFilename != null;  // fixes a compiler warning
+      BoundedWindow window = windowCoder.decode(inStream);
+      PaneInfo paneInfo = paneInfoCoder.decode(inStream);
+      int shard = integerCoder.decode(inStream);
+      return new FileResult(FileSystems.matchNewResource(tempFilename, false /* isDirectory */),
+          shard, window, paneInfo);
     }
 
     @Override
     public void verifyDeterministic() throws NonDeterministicException {
       stringCoder.verifyDeterministic();
+      windowCoder.verifyDeterministic();
+      paneInfoCoder.verifyDeterministic();
+      integerCoder.verifyDeterministic();
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -567,7 +567,7 @@ public class TFRecordIO {
     }
 
     @Override
-    public FileBasedWriteOperation<byte[]> createWriteOperation() {
+    public WriteOperation<byte[]> createWriteOperation() {
       return new TFRecordWriteOperation(this);
     }
 
@@ -587,29 +587,29 @@ public class TFRecordIO {
     }
 
     /**
-     * A {@link org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation
-     * FileBasedWriteOperation} for TFRecord files.
+     * A {@link WriteOperation
+     * WriteOperation} for TFRecord files.
      */
-    private static class TFRecordWriteOperation extends FileBasedWriteOperation<byte[]> {
+    private static class TFRecordWriteOperation extends WriteOperation<byte[]> {
       private TFRecordWriteOperation(TFRecordSink sink) {
         super(sink);
       }
 
       @Override
-      public FileBasedWriter<byte[]> createWriter() throws Exception {
+      public Writer<byte[]> createWriter() throws Exception {
         return new TFRecordWriter(this);
       }
     }
 
     /**
-     * A {@link org.apache.beam.sdk.io.FileBasedSink.FileBasedWriter FileBasedWriter}
+     * A {@link Writer Writer}
      * for TFRecord files.
      */
-    private static class TFRecordWriter extends FileBasedWriter<byte[]> {
+    private static class TFRecordWriter extends Writer<byte[]> {
       private WritableByteChannel outChannel;
       private TFRecordCodec codec;
 
-      private TFRecordWriter(FileBasedWriteOperation<byte[]> writeOperation) {
+      private TFRecordWriter(WriteOperation<byte[]> writeOperation) {
         super(writeOperation, MimeTypes.BINARY);
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextSink.java
@@ -49,12 +49,12 @@ class TextSink extends FileBasedSink<String> {
     this.footer = footer;
   }
   @Override
-  public FileBasedWriteOperation<String> createWriteOperation() {
+  public WriteOperation<String> createWriteOperation() {
     return new TextWriteOperation(this, header, footer);
   }
 
-  /** A {@link FileBasedWriteOperation FileBasedWriteOperation} for text files. */
-  private static class TextWriteOperation extends FileBasedWriteOperation<String> {
+  /** A {@link WriteOperation WriteOperation} for text files. */
+  private static class TextWriteOperation extends WriteOperation<String> {
     @Nullable private final String header;
     @Nullable private final String footer;
 
@@ -65,20 +65,20 @@ class TextSink extends FileBasedSink<String> {
     }
 
     @Override
-    public FileBasedWriter<String> createWriter() throws Exception {
+    public Writer<String> createWriter() throws Exception {
       return new TextWriter(this, header, footer);
     }
   }
 
-  /** A {@link FileBasedWriter FileBasedWriter} for text files. */
-  private static class TextWriter extends FileBasedWriter<String> {
+  /** A {@link Writer Writer} for text files. */
+  private static class TextWriter extends Writer<String> {
     private static final String NEWLINE = "\n";
     @Nullable private final String header;
     @Nullable private final String footer;
     private OutputStreamWriter out;
 
     public TextWriter(
-        FileBasedWriteOperation<String> writeOperation,
+        WriteOperation<String> writeOperation,
         @Nullable String header,
         @Nullable String footer) {
       super(writeOperation, MimeTypes.TEXT);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WriteFiles.java
@@ -30,10 +30,10 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriter;
 import org.apache.beam.sdk.io.FileBasedSink.FileResult;
 import org.apache.beam.sdk.io.FileBasedSink.FileResultCoder;
+import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
+import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * finalization of the write. The output of a write is {@link PDone}.
  *
  * <p>By default, every bundle in the input {@link PCollection} will be processed by a
- * {@link org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation}, so the number of output
+ * {@link WriteOperation}, so the number of output
  * will vary based on runner behavior, though at least 1 output will always be produced. The
  * exact parallelism of the write stage can be controlled using {@link WriteFiles#withNumShards},
  * typically used to control how many files are produced or to globally limit the number of
@@ -86,7 +86,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
   private static final int UNKNOWN_NUMSHARDS = -1;
 
   private FileBasedSink<T> sink;
-  private FileBasedWriteOperation<T> writeOperation;
+  private WriteOperation<T> writeOperation;
   // This allows the number of shards to be dynamically computed based on the input
   // PCollection.
   @Nullable
@@ -238,13 +238,13 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
   }
 
   /**
-   * Writes all the elements in a bundle using a {@link FileBasedWriter} produced by the
-   * {@link FileBasedSink.FileBasedWriteOperation} associated with the {@link FileBasedSink}.
+   * Writes all the elements in a bundle using a {@link Writer} produced by the
+   * {@link WriteOperation} associated with the {@link FileBasedSink}.
    */
   private class WriteBundles extends DoFn<T, FileResult> {
     // Writer that will write the records in this bundle. Lazily
     // initialized in processElement.
-    private FileBasedWriter<T> writer = null;
+    private Writer<T> writer = null;
     private BoundedWindow window = null;
 
     WriteBundles() {
@@ -320,7 +320,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
       // In a sharded write, single input element represents one shard. We can open and close
       // the writer in each call to processElement.
       LOG.info("Opening writer for write operation {}", writeOperation);
-      FileBasedWriter<T> writer = writeOperation.createWriter();
+      Writer<T> writer = writeOperation.createWriter();
       if (windowedWrites) {
         writer.openWindowed(UUID.randomUUID().toString(), window, c.pane(), c.element().getKey(),
             numShards);
@@ -404,29 +404,29 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
   /**
    * A write is performed as sequence of three {@link ParDo}'s.
    *
-   * <p>This singleton collection containing the FileBasedWriteOperation is then used as a side
+   * <p>This singleton collection containing the WriteOperation is then used as a side
    * input to a ParDo over the PCollection of elements to write. In this bundle-writing phase,
-   * {@link FileBasedWriteOperation#createWriter} is called to obtain a {@link FileBasedWriter}.
-   * {@link FileBasedWriter#open} and {@link FileBasedWriter#close} are called in
+   * {@link WriteOperation#createWriter} is called to obtain a {@link Writer}.
+   * {@link Writer#open} and {@link Writer#close} are called in
    * {@link DoFn.StartBundle} and {@link DoFn.FinishBundle}, respectively, and
-   * {@link FileBasedWriter#write} method is called for every element in the bundle. The output
+   * {@link Writer#write} method is called for every element in the bundle. The output
    * of this ParDo is a PCollection of <i>writer result</i> objects (see {@link FileBasedSink}
    * for a description of writer results)-one for each bundle.
    *
    * <p>The final do-once ParDo uses a singleton collection asinput and the collection of writer
-   * results as a side-input. In this ParDo, {@link FileBasedWriteOperation#finalize} is called
+   * results as a side-input. In this ParDo, {@link WriteOperation#finalize} is called
    * to finalize the write.
    *
-   * <p>If the write of any element in the PCollection fails, {@link FileBasedWriter#close} will be
+   * <p>If the write of any element in the PCollection fails, {@link Writer#close} will be
    * called before the exception that caused the write to fail is propagated and the write result
    * will be discarded.
    *
-   * <p>Since the {@link FileBasedWriteOperation} is serialized after the initialization ParDo and
+   * <p>Since the {@link WriteOperation} is serialized after the initialization ParDo and
    * deserialized in the bundle-writing and finalization phases, any state change to the
-   * FileBasedWriteOperation object that occurs during initialization is visible in the latter
-   * phases. However, the FileBasedWriteOperation is not serialized after the bundle-writing
+   * WriteOperation object that occurs during initialization is visible in the latter
+   * phases. However, the WriteOperation is not serialized after the bundle-writing
    * phase. This is why implementations should guarantee that
-   * {@link FileBasedWriteOperation#createWriter} does not mutate FileBasedWriteOperation).
+   * {@link WriteOperation#createWriter} does not mutate WriteOperation).
    */
   private PDone createWrite(PCollection<T> input) {
     Pipeline p = input.getPipeline();
@@ -442,9 +442,9 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
 
 
     // Perform the per-bundle writes as a ParDo on the input PCollection (with the
-    // FileBasedWriteOperation as a side input) and collect the results of the writes in a
+    // WriteOperation as a side input) and collect the results of the writes in a
     // PCollection. There is a dependency between this ParDo and the first (the
-    // FileBasedWriteOperation PCollection as a side input), so this will happen after the
+    // WriteOperation PCollection as a side input), so this will happen after the
     // initial ParDo.
     PCollection<FileResult> results;
     final PCollectionView<Integer> numShardsView;
@@ -511,7 +511,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
 
       // Finalize the write in another do-once ParDo on the singleton collection containing the
       // Writer. The results from the per-bundle writes are given as an Iterable side input.
-      // The FileBasedWriteOperation's state is the same as after its initialization in the first
+      // The WriteOperation's state is the same as after its initialization in the first
       // do-once ParDo. There is a dependency between this ParDo and the parallel write (the writer
       // results collection as a side input), so it will happen after the parallel write.
       // For the non-windowed case, we guarantee that  if no data is written but the user has
@@ -542,7 +542,7 @@ public class WriteFiles<T> extends PTransform<PCollection<T>, PDone> {
                     "Creating {} empty output shards in addition to {} written for a total of {}.",
                     extraShardsNeeded, results.size(), minShardsNeeded);
                 for (int i = 0; i < extraShardsNeeded; ++i) {
-                  FileBasedWriter<T> writer = writeOperation.createWriter();
+                  Writer<T> writer = writeOperation.createWriter();
                   writer.openUnwindowed(UUID.randomUUID().toString(), UNKNOWN_SHARDNUM,
                       UNKNOWN_NUMSHARDS);
                   FileResult emptyWrite = writer.close();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -46,12 +46,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import org.apache.beam.sdk.io.FileBasedSink.CompressionType;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriteOperation;
-import org.apache.beam.sdk.io.FileBasedSink.FileBasedWriter;
 import org.apache.beam.sdk.io.FileBasedSink.FileResult;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy.Context;
 import org.apache.beam.sdk.io.FileBasedSink.WritableByteChannelFactory;
+import org.apache.beam.sdk.io.FileBasedSink.WriteOperation;
+import org.apache.beam.sdk.io.FileBasedSink.Writer;
 import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
@@ -88,7 +88,7 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * FileBasedWriter opens the correct file, writes the header, footer, and elements in the
+   * Writer opens the correct file, writes the header, footer, and elements in the
    * correct order, and returns the correct filename.
    */
   @Test
@@ -187,13 +187,13 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * Generate n temporary files using the temporary file pattern of FileBasedWriter.
+   * Generate n temporary files using the temporary file pattern of Writer.
    */
   private List<File> generateTemporaryFilesForFinalize(int numFiles) throws Exception {
     List<File> temporaryFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
       ResourceId temporaryFile =
-          FileBasedWriteOperation.buildTemporaryFilename(getBaseTempDirectory(), "" + i);
+          WriteOperation.buildTemporaryFilename(getBaseTempDirectory(), "" + i);
       File tmpFile = new File(tmpFolder.getRoot(), temporaryFile.toString());
       tmpFile.getParentFile().mkdirs();
       assertTrue(tmpFile.createNewFile());
@@ -242,14 +242,14 @@ public class FileBasedSinkTest {
     SimpleSink sink =
         new SimpleSink(getBaseOutputDirectory(), prefix, "", "");
 
-    FileBasedWriteOperation<String> writeOp =
+    WriteOperation<String> writeOp =
         new SimpleSink.SimpleWriteOperation(sink, tempDirectory);
 
     List<File> temporaryFiles = new ArrayList<>();
     List<File> outputFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
       ResourceId tempResource =
-          FileBasedWriteOperation.buildTemporaryFilename(tempDirectory, prefix + i);
+          WriteOperation.buildTemporaryFilename(tempDirectory, prefix + i);
       File tmpFile = new File(tempResource.toString());
       tmpFile.getParentFile().mkdirs();
       assertTrue("not able to create new temp file", tmpFile.createNewFile());
@@ -487,17 +487,17 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * {@link FileBasedWriter} writes to the {@link WritableByteChannel} provided by
+   * {@link Writer} writes to the {@link WritableByteChannel} provided by
    * {@link DrunkWritableByteChannelFactory}.
    */
   @Test
   public void testFileBasedWriterWithWritableByteChannelFactory() throws Exception {
     final String testUid = "testId";
     ResourceId root = getBaseOutputDirectory();
-    FileBasedWriteOperation<String> writeOp =
+    WriteOperation<String> writeOp =
         new SimpleSink(root, "file", "-SS-of-NN", "txt", new DrunkWritableByteChannelFactory())
             .createWriteOperation();
-    final FileBasedWriter<String> writer = writeOp.createWriter();
+    final Writer<String> writer = writeOp.createWriter();
     final ResourceId expectedFile =
         writeOp.tempDirectory.get().resolve(testUid, StandardResolveOptions.RESOLVE_FILE);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSinkTest.java
@@ -67,8 +67,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class FileBasedSinkTest {
-  @Rule
-  public TemporaryFolder tmpFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
   private final String tempDirectoryName = "temp";
 
@@ -88,13 +87,13 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * Writer opens the correct file, writes the header, footer, and elements in the
-   * correct order, and returns the correct filename.
+   * Writer opens the correct file, writes the header, footer, and elements in the correct
+   * order, and returns the correct filename.
    */
   @Test
   public void testWriter() throws Exception {
     String testUid = "testId";
-    ResourceId expectedFile = getBaseTempDirectory()
+    ResourceId expectedTempFile = getBaseTempDirectory()
         .resolve(testUid, StandardResolveOptions.RESOLVE_FILE);
     List<String> values = Arrays.asList("sympathetic vulture", "boresome hummingbird");
     List<String> expected = new ArrayList<>();
@@ -104,14 +103,15 @@ public class FileBasedSinkTest {
 
     SimpleSink.SimpleWriter writer =
         buildWriteOperationWithTempDir(getBaseTempDirectory()).createWriter();
-    writer.openUnwindowed(testUid, -1, -1);
+    writer.openUnwindowed(testUid, -1);
     for (String value : values) {
       writer.write(value);
     }
     FileResult result = writer.close();
 
-    assertEquals(expectedFile, result.getFilename());
-    assertFileContains(expected, expectedFile);
+    FileBasedSink sink = writer.getWriteOperation().getSink();
+    assertEquals(expectedTempFile, result.getTempFilename());
+    assertFileContains(expected, expectedTempFile);
   }
 
   /**
@@ -131,9 +131,7 @@ public class FileBasedSinkTest {
     }
   }
 
-  /**
-   * Write lines to a file.
-   */
+  /** Write lines to a file. */
   private void writeFile(List<String> lines, File file) throws Exception {
     try (PrintWriter writer = new PrintWriter(new FileOutputStream(file))) {
       for (String line : lines) {
@@ -150,18 +148,14 @@ public class FileBasedSinkTest {
     testRemoveTemporaryFiles(3, getBaseTempDirectory());
   }
 
-  /**
-   * Finalize copies temporary files to output files and removes any temporary files.
-   */
+  /** Finalize copies temporary files to output files and removes any temporary files. */
   @Test
   public void testFinalize() throws Exception {
     List<File> files = generateTemporaryFilesForFinalize(3);
     runFinalize(buildWriteOperation(), files);
   }
 
-  /**
-   * Finalize can be called repeatedly.
-   */
+  /** Finalize can be called repeatedly. */
   @Test
   public void testFinalizeMultipleCalls() throws Exception {
     List<File> files = generateTemporaryFilesForFinalize(3);
@@ -170,9 +164,7 @@ public class FileBasedSinkTest {
     runFinalize(writeOp, files);
   }
 
-  /**
-   * Finalize can be called when some temporary files do not exist and output files exist.
-   */
+  /** Finalize can be called when some temporary files do not exist and output files exist. */
   @Test
   public void testFinalizeWithIntermediateState() throws Exception {
     SimpleSink.SimpleWriteOperation writeOp = buildWriteOperation();
@@ -186,9 +178,7 @@ public class FileBasedSinkTest {
     runFinalize(writeOp, files);
   }
 
-  /**
-   * Generate n temporary files using the temporary file pattern of Writer.
-   */
+  /** Generate n temporary files using the temporary file pattern of Writer. */
   private List<File> generateTemporaryFilesForFinalize(int numFiles) throws Exception {
     List<File> temporaryFiles = new ArrayList<>();
     for (int i = 0; i < numFiles; i++) {
@@ -203,18 +193,20 @@ public class FileBasedSinkTest {
     return temporaryFiles;
   }
 
-  /**
-   * Finalize and verify that files are copied and temporary files are optionally removed.
-   */
+  /** Finalize and verify that files are copied and temporary files are optionally removed. */
   private void runFinalize(SimpleSink.SimpleWriteOperation writeOp, List<File> temporaryFiles)
       throws Exception {
     int numFiles = temporaryFiles.size();
 
     List<FileResult> fileResults = new ArrayList<>();
     // Create temporary output bundles and output File objects.
-    for (File f : temporaryFiles) {
-      ResourceId file = LocalResources.fromFile(f, false);
-      fileResults.add(new FileResult(file, null));
+    for (int i = 0; i < numFiles; i++) {
+      fileResults.add(
+          new FileResult(
+              LocalResources.fromFile(temporaryFiles.get(i), false),
+              WriteFiles.UNKNOWN_SHARDNUM,
+              null,
+              null));
     }
 
     writeOp.finalize(fileResults);
@@ -233,8 +225,8 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * Create n temporary and output files and verify that removeTemporaryFiles only
-   * removes temporary files.
+   * Create n temporary and output files and verify that removeTemporaryFiles only removes temporary
+   * files.
    */
   private void testRemoveTemporaryFiles(int numFiles, ResourceId tempDirectory)
       throws Exception {
@@ -276,9 +268,7 @@ public class FileBasedSinkTest {
     }
   }
 
-  /**
-   * Output files are copied to the destination location with the correct names and contents.
-   */
+  /** Output files are copied to the destination location with the correct names and contents. */
   @Test
   public void testCopyToOutputFiles() throws Exception {
     SimpleSink.SimpleWriteOperation writeOp = buildWriteOperation();
@@ -329,6 +319,7 @@ public class FileBasedSinkTest {
   /**
    * Output filenames are generated correctly when an extension is supplied.
    */
+
   @Test
   public void testGenerateOutputFilenames() {
     List<ResourceId> expected;
@@ -357,9 +348,7 @@ public class FileBasedSinkTest {
     assertEquals(expected, actual);
   }
 
-  /**
-   * Reject non-distinct output filenames.
-   */
+  /** Reject non-distinct output filenames. */
   @Test
   public void testCollidingOutputFilenames() throws IOException {
     ResourceId root = getBaseOutputDirectory();
@@ -372,22 +361,19 @@ public class FileBasedSinkTest {
     ResourceId output = root.resolve("file-03.test", StandardResolveOptions.RESOLVE_FILE);
     // More than one shard does.
     try {
-      Iterable<FileResult> results = Lists.newArrayList(
-          new FileResult(temp1, output),
-          new FileResult(temp2, output),
-          new FileResult(temp3, output));
-
+      Iterable<FileResult> results =
+          Lists.newArrayList(
+              new FileResult(temp1, 1, null, null),
+              new FileResult(temp2, 1, null, null),
+              new FileResult(temp3, 1, null, null));
       writeOp.buildOutputFilenames(results);
       fail("Should have failed.");
     } catch (IllegalStateException exn) {
-      assertEquals("Only generated 1 distinct file names for 3 files.",
-                   exn.getMessage());
+      assertEquals("Only generated 1 distinct file names for 3 files.", exn.getMessage());
     }
   }
 
-  /**
-   * Output filenames are generated correctly when an extension is not supplied.
-   */
+  /** Output filenames are generated correctly when an extension is not supplied. */
   @Test
   public void testGenerateOutputFilenamesWithoutExtension() {
     List<ResourceId> expected;
@@ -415,53 +401,59 @@ public class FileBasedSinkTest {
     assertEquals(expected, actual);
   }
 
-  /**
-   * {@link CompressionType#BZIP2} correctly writes BZip2 data.
-   */
+  /** {@link CompressionType#BZIP2} correctly writes BZip2 data. */
   @Test
   public void testCompressionTypeBZIP2() throws FileNotFoundException, IOException {
     final File file =
         writeValuesWithWritableByteChannelFactory(CompressionType.BZIP2, "abc", "123");
     // Read Bzip2ed data back in using Apache commons API (de facto standard).
-    assertReadValues(new BufferedReader(new InputStreamReader(
-        new BZip2CompressorInputStream(new FileInputStream(file)), StandardCharsets.UTF_8.name())),
-        "abc", "123");
+    assertReadValues(
+        new BufferedReader(
+            new InputStreamReader(
+                new BZip2CompressorInputStream(new FileInputStream(file)),
+                StandardCharsets.UTF_8.name())),
+        "abc",
+        "123");
   }
 
-  /**
-   * {@link CompressionType#GZIP} correctly writes Gzipped data.
-   */
+  /** {@link CompressionType#GZIP} correctly writes Gzipped data. */
   @Test
   public void testCompressionTypeGZIP() throws FileNotFoundException, IOException {
     final File file = writeValuesWithWritableByteChannelFactory(CompressionType.GZIP, "abc", "123");
     // Read Gzipped data back in using standard API.
-    assertReadValues(new BufferedReader(new InputStreamReader(
-        new GZIPInputStream(new FileInputStream(file)), StandardCharsets.UTF_8.name())), "abc",
+    assertReadValues(
+        new BufferedReader(
+            new InputStreamReader(
+                new GZIPInputStream(new FileInputStream(file)), StandardCharsets.UTF_8.name())),
+        "abc",
         "123");
   }
 
-  /**
-   * {@link CompressionType#DEFLATE} correctly writes deflate data.
-   */
+  /** {@link CompressionType#DEFLATE} correctly writes deflate data. */
   @Test
   public void testCompressionTypeDEFLATE() throws FileNotFoundException, IOException {
-    final File file = writeValuesWithWritableByteChannelFactory(
-        CompressionType.DEFLATE, "abc", "123");
+    final File file =
+        writeValuesWithWritableByteChannelFactory(CompressionType.DEFLATE, "abc", "123");
     // Read Gzipped data back in using standard API.
-    assertReadValues(new BufferedReader(new InputStreamReader(new DeflateCompressorInputStream(
-        new FileInputStream(file)), StandardCharsets.UTF_8.name())), "abc", "123");
+    assertReadValues(
+        new BufferedReader(
+            new InputStreamReader(
+                new DeflateCompressorInputStream(new FileInputStream(file)),
+                StandardCharsets.UTF_8.name())),
+        "abc",
+        "123");
   }
 
-  /**
-   * {@link CompressionType#UNCOMPRESSED} correctly writes uncompressed data.
-   */
+  /** {@link CompressionType#UNCOMPRESSED} correctly writes uncompressed data. */
   @Test
   public void testCompressionTypeUNCOMPRESSED() throws FileNotFoundException, IOException {
     final File file =
         writeValuesWithWritableByteChannelFactory(CompressionType.UNCOMPRESSED, "abc", "123");
     // Read uncompressed data back in using standard API.
-    assertReadValues(new BufferedReader(new InputStreamReader(
-        new FileInputStream(file), StandardCharsets.UTF_8.name())), "abc",
+    assertReadValues(
+        new BufferedReader(
+            new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8.name())),
+        "abc",
         "123");
   }
 
@@ -487,8 +479,8 @@ public class FileBasedSinkTest {
   }
 
   /**
-   * {@link Writer} writes to the {@link WritableByteChannel} provided by
-   * {@link DrunkWritableByteChannelFactory}.
+   * {@link Writer} writes to the {@link WritableByteChannel} provided by {@link
+   * DrunkWritableByteChannelFactory}.
    */
   @Test
   public void testFileBasedWriterWithWritableByteChannelFactory() throws Exception {
@@ -511,18 +503,16 @@ public class FileBasedSinkTest {
     expected.add("footer");
     expected.add("footer");
 
-    writer.openUnwindowed(testUid, -1, -1);
+    writer.openUnwindowed(testUid, -1);
     writer.write("a");
     writer.write("b");
     final FileResult result = writer.close();
 
-    assertEquals(expectedFile, result.getFilename());
+    assertEquals(expectedFile, result.getTempFilename());
     assertFileContains(expected, expectedFile);
   }
 
-  /**
-   * Build a SimpleSink with default options.
-   */
+  /** Build a SimpleSink with default options. */
   private SimpleSink buildSink() {
     return new SimpleSink(getBaseOutputDirectory(), "file", "-SS-of-NN", ".test");
   }
@@ -535,9 +525,7 @@ public class FileBasedSinkTest {
     return new SimpleSink.SimpleWriteOperation(sink, tempDirectory);
   }
 
-  /**
-   * Build a write operation with the default options for it and its parent sink.
-   */
+  /** Build a write operation with the default options for it and its parent sink. */
   private SimpleSink.SimpleWriteOperation buildWriteOperation() {
     return buildSink().createWriteOperation();
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/SimpleSink.java
@@ -45,7 +45,7 @@ class SimpleSink extends FileBasedSink<String> {
     return new SimpleWriteOperation(this);
   }
 
-  static final class SimpleWriteOperation extends FileBasedWriteOperation<String> {
+  static final class SimpleWriteOperation extends WriteOperation<String> {
     public SimpleWriteOperation(SimpleSink sink, ResourceId tempOutputDirectory) {
       super(sink, tempOutputDirectory);
     }
@@ -60,7 +60,7 @@ class SimpleSink extends FileBasedSink<String> {
     }
   }
 
-  static final class SimpleWriter extends FileBasedWriter<String> {
+  static final class SimpleWriter extends Writer<String> {
     static final String HEADER = "header";
     static final String FOOTER = "footer";
 

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlSink.java
@@ -76,9 +76,9 @@ class XmlSink<T> extends FileBasedSink<T> {
   }
 
   /**
-   * {@link FileBasedSink.FileBasedWriteOperation} for XML {@link FileBasedSink}s.
+   * {@link WriteOperation} for XML {@link FileBasedSink}s.
    */
-  protected static final class XmlWriteOperation<T> extends FileBasedWriteOperation<T> {
+  protected static final class XmlWriteOperation<T> extends WriteOperation<T> {
     public XmlWriteOperation(XmlSink<T> sink) {
       super(sink);
     }
@@ -113,9 +113,9 @@ class XmlSink<T> extends FileBasedSink<T> {
   }
 
   /**
-   * A {@link FileBasedWriter} that can write objects as XML elements.
+   * A {@link Writer} that can write objects as XML elements.
    */
-  protected static final class XmlWriter<T> extends FileBasedWriter<T> {
+  protected static final class XmlWriter<T> extends Writer<T> {
     final Marshaller marshaller;
     private OutputStream os = null;
 


### PR DESCRIPTION
This is a slightly modified and rearranged version of @reuvenlax 's #2647 .

My concerns about it are:

1) In direct runner, the integration tests of dynamic sharding are vacuous, because direct runner replaces unspecified sharding with fixed sharding at https://github.com/apache/beam/blob/master/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java (applied at https://github.com/apache/beam/blob/master/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java#L217). However, this is a testing-only concern: other runners don't have this override, so overall the testing is non-vacuous, this is just hard to test against direct runner and I suspect that we probably want these tests to be non-vacuous in direct runner too.

2) When I removed that override for testing purposes, I noticed that there's a very large number of files being written - primarily, I guess, because the bundles are very small. So large a number of files that the test time for batch with dynamic sharding grows from 21 seconds to 5 minutes. In particular, we write many, many files for each window/pane - presumably because in streaming runners and in direct runner, there's at least 1 bundle per key, and we create at least 1 file per bundle in WriteFiles.Write(Windowed,Unwindowed)Bundles.

Reuven, can you please comment on whether this "at least 1 file per key" is expected behavior in a streaming runner? I suspect that it's not, but then I'm not sure how to fix the PR semantically.

CC: @reuvenlax @davorbonaci @dhalperi 