### PR TITLE
[BEAM-991] Comply with byte limit for Datastore Commit in python SDK

### DIFF
--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
@@ -313,8 +313,11 @@ class _Mutate(PTransform):
   supported, as the commits are retried when failures occur.
   """
 
-  # Max allowed Datastore write batch size.
+  # Max allowed Datastore writes per batch, and max bytes per batch.
+  # Note that the max bytes per batch is lower than the actual limit enforced
+  # by the API, to allow space for the CommitRequest wrapper around it.
   _WRITE_BATCH_SIZE = 500
+  _WRITE_BATCH_BYTES_SIZE = 5000000
 
   def __init__(self, project, mutation_fn):
     """Initializes a Mutate transform.
@@ -353,13 +356,20 @@ class _Mutate(PTransform):
       self._project = project
       self._datastore = None
       self._mutations = []
+      self._mutations_size = 0  # Total size of entries in _mutations.
 
     def start_bundle(self):
       self._mutations = []
+      self._mutations_size = 0
       self._datastore = helper.get_datastore(self._project)
 
     def process(self, element):
+      size = element.ByteSize()
+      if (self._mutations and
+          size + self._mutations_size > _Mutate._WRITE_BATCH_BYTES_SIZE):
+        self._flush_batch()
       self._mutations.append(element)
+      self._mutations_size += size
       if len(self._mutations) >= _Mutate._WRITE_BATCH_SIZE:
         self._flush_batch()
 
@@ -367,12 +377,14 @@ class _Mutate(PTransform):
       if self._mutations:
         self._flush_batch()
       self._mutations = []
+      self._mutations_size = 0
 
     def _flush_batch(self):
       # Flush the current batch of mutations to Cloud Datastore.
       helper.write_mutations(self._datastore, self._project, self._mutations)
       logging.debug("Successfully wrote %d mutations.", len(self._mutations))
       self._mutations = []
+      self._mutations_size = 0
 
 
 class WriteToDatastore(_Mutate):

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
@@ -314,8 +314,9 @@ class _Mutate(PTransform):
   """
 
   # Max allowed Datastore writes per batch, and max bytes per batch.
-  # Note that the max bytes per batch is lower than the actual limit enforced
-  # by the API, to allow space for the CommitRequest wrapper around it.
+  # Note that the max bytes per batch set here is lower than the 10MB limit
+  # actually enforced by the API, to allow space for the CommitRequest wrapper
+  # around it.
   _WRITE_BATCH_SIZE = 500
   _WRITE_BATCH_BYTES_SIZE = 5000000
 

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
@@ -315,10 +315,10 @@ class _Mutate(PTransform):
 
   # Max allowed Datastore writes per batch, and max bytes per batch.
   # Note that the max bytes per batch set here is lower than the 10MB limit
-  # actually enforced by the API, to allow space for the CommitRequest wrapper
-  # around it.
+  # actually enforced by the API, to leave space for the CommitRequest wrapper
+  # around the mutations.
   _WRITE_BATCH_SIZE = 500
-  _WRITE_BATCH_BYTES_SIZE = 5000000
+  _WRITE_BATCH_BYTES_SIZE = 9000000
 
   def __init__(self, project, mutation_fn):
     """Initializes a Mutate transform.

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+import math
 import unittest
 
 from mock import MagicMock, call, patch
@@ -190,6 +191,26 @@ class DatastoreioTest(unittest.TestCase):
       self.assertEqual(actual_mutations, expected_mutations)
       self.assertEqual((num_entities - 1) / _Mutate._WRITE_BATCH_SIZE + 1,
                        self._mock_datastore.commit.call_count)
+
+  def test_DatastoreWriteLargeEntities(self):
+    """60*100kB entities gets split over two Commit RPCs."""
+    with patch.object(helper, 'get_datastore',
+                      return_value=self._mock_datastore):
+      entities = [e.entity for e in
+                  fake_datastore.create_entities(60)]
+
+      datastore_write_fn = _Mutate.DatastoreWriteFn(self._PROJECT)
+      datastore_write_fn.start_bundle()
+      for entity in entities:
+        datastore_helper.add_properties(
+            entity, {'large': u'A' * 100000}, exclude_from_indexes=True)
+        datastore_write_fn.process(WriteToDatastore.to_upsert_mutation(entity))
+      datastore_write_fn.finish_bundle()
+
+      self.assertEqual(
+          math.ceil(sum(e.ByteSize() for e in entities) /
+                    float(_Mutate._WRITE_BATCH_BYTES_SIZE)),
+          self._mock_datastore.commit.call_count)
 
   def verify_unique_keys(self, queries):
     """A helper function that verifies if all the queries have unique keys."""

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
@@ -196,8 +196,7 @@ class DatastoreioTest(unittest.TestCase):
     """60*100kB entities gets split over two Commit RPCs."""
     with patch.object(helper, 'get_datastore',
                       return_value=self._mock_datastore):
-      entities = [e.entity for e in
-                  fake_datastore.create_entities(60)]
+      entities = [e.entity for e in fake_datastore.create_entities(60)]
 
       datastore_write_fn = _Mutate.DatastoreWriteFn(self._PROJECT)
       datastore_write_fn.start_bundle()
@@ -207,10 +206,7 @@ class DatastoreioTest(unittest.TestCase):
         datastore_write_fn.process(WriteToDatastore.to_upsert_mutation(entity))
       datastore_write_fn.finish_bundle()
 
-      self.assertEqual(
-          math.ceil(sum(e.ByteSize() for e in entities) /
-                    float(_Mutate._WRITE_BATCH_BYTES_SIZE)),
-          self._mock_datastore.commit.call_count)
+      self.assertEqual(2, self._mock_datastore.commit.call_count)
 
   def verify_unique_keys(self, queries):
     """A helper function that verifies if all the queries have unique keys."""

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio_test.py
@@ -193,10 +193,10 @@ class DatastoreioTest(unittest.TestCase):
                        self._mock_datastore.commit.call_count)
 
   def test_DatastoreWriteLargeEntities(self):
-    """60*100kB entities gets split over two Commit RPCs."""
+    """100*100kB entities gets split over two Commit RPCs."""
     with patch.object(helper, 'get_datastore',
                       return_value=self._mock_datastore):
-      entities = [e.entity for e in fake_datastore.create_entities(60)]
+      entities = [e.entity for e in fake_datastore.create_entities(100)]
 
       datastore_write_fn = _Mutate.DatastoreWriteFn(self._PROJECT)
       datastore_write_fn.start_bundle()


### PR DESCRIPTION
This is the equivalent of https://github.com/apache/beam/pull/2948 for the python SDK. RPCs are limited both by overall size and by the number of entities contained, to fit within the Datastore API limits https://cloud.google.com/datastore/docs/concepts/limits .
