### PR TITLE
Adds dependency on findbugs to examples/java

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -473,6 +473,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
     </dependency>


### PR DESCRIPTION
This fixes the build breakage from https://github.com/apache/beam/pull/3023. Sorry.

CC: @davorbonaci