### PR TITLE
Enable SerializableCoder to Serialize with Generic Types

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -74,6 +74,16 @@
   </Match>
 
   <Match>
+    <Class name="org.apache.beam.sdk.coders.SerializableCoder"/>
+    <Field name="typeDescriptor"/>
+    <Bug pattern="SE_TRANSIENT_FIELD_NOT_RESTORED"/>
+    <!--
+    the field is used only in getEncodedTypeDescriptor, where it is restored if it is not present due to
+    serialization
+    -->
+  </Match>
+
+  <Match>
     <Class name="org.apache.beam.sdk.io.jms.JmsRecord"/>
     <Field name="jmsDestination"/>
     <Bug pattern="SE_BAD_FIELD"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -107,7 +107,7 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
   }
 
   private final Class<T> type;
-  private final TypeDescriptor<T> typeDescriptor;
+  private transient TypeDescriptor<T> typeDescriptor;
 
   protected SerializableCoder(Class<T> type, TypeDescriptor<T> typeDescriptor) {
     this.type = type;
@@ -166,6 +166,9 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
 
   @Override
   public TypeDescriptor<T> getEncodedTypeDescriptor() {
+    if (typeDescriptor == null) {
+      typeDescriptor = TypeDescriptor.of(type);
+    }
     return typeDescriptor;
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
@@ -125,9 +125,15 @@ public class SerializableCoderTest implements Serializable {
     assertEquals(coder.getRecordType(), MyRecord.class);
     CoderProperties.coderSerializable(coder);
 
-
     SerializableCoder<?> decoded = SerializableUtils.clone(coder);
     assertThat(decoded.getRecordType(), Matchers.<Object>equalTo(MyRecord.class));
+  }
+
+  @Test
+  public <T extends Serializable> void testSerializableCoderIsSerializableWithGenericTypeToken()
+  throws Exception {
+    SerializableCoder<T> coder = SerializableCoder.of(new TypeDescriptor<T>() {});
+    CoderProperties.coderSerializable(coder);
   }
 
   @Test


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`.
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [x] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
A TypeToken that contains generics is not serializable. However, the
TypeDescriptor does not need to be transmitted via the serialized form,
so mark it as transient.

