### PR TITLE
[BEAM-2277] Fix URI_SCHEME_PATTERN in FileSystems

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -67,7 +67,7 @@ public class FileSystems {
 
   public static final String DEFAULT_SCHEME = "default";
   private static final Pattern URI_SCHEME_PATTERN = Pattern.compile(
-      "(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*)://.*");
+      "(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*):/.*");
 
   private static final AtomicReference<Map<String, FileSystem>> SCHEME_TO_FILESYSTEM =
       new AtomicReference<Map<String, FileSystem>>(


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [x] Make sure tests pass via `mvn clean verify`.
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
[`FileSystems#URI_SCHEME_PATTERN`](https://github.com/apache/beam/blob/e0b3f8064b97d8678e75bf6ba25244bca31e6a7d/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java#L69-L70) was `(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*)://.*` which caused `IllegalArgumentException` when using Hadoop filesystem.

The reason is that as part of its flow in [`HadoopResourceId#getCurrentDirectory`](https://github.com/apache/beam/blob/e0b3f8064b97d8678e75bf6ba25244bca31e6a7d/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java#L42-L44) it uses `java.net.URI#resolve` which converts URIs of format "hdfs:///path/to/file" to "hdfs:/path/to/file", which is still a valid URI which Hadoop accepts, however was not correctly identified as HDFS scheme in [`FileSystems#parseScheme`](https://github.com/apache/beam/blob/e0b3f8064b97d8678e75bf6ba25244bca31e6a7d/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java#L413-L426)