### PR TITLE
[BEAM-93] Adding support for subnetwork in Python Pipelineoptions

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -455,6 +455,12 @@ class WorkerOptions(PipelineOptions):
             'GCE network for launching workers. Default is up to the Dataflow '
             'service.'))
     parser.add_argument(
+        '--subnetwork',
+        default=None,
+        help=(
+            'GCE subnetwork for launching workers. Default is up to the Dataflow '
+            'service.'))
+    parser.add_argument(
         '--worker_harness_container_image',
         default=None,
         help=('Docker registry location of container image to use for the '

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -458,8 +458,8 @@ class WorkerOptions(PipelineOptions):
         '--subnetwork',
         default=None,
         help=(
-            'GCE subnetwork for launching workers. Default is up to the Dataflow '
-            'service.'))
+            'GCE subnetwork for launching workers. Default is up to the '
+            'Dataflow service.'))
     parser.add_argument(
         '--worker_harness_container_image',
         default=None,

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -169,7 +169,7 @@ class PipelineOptions(HasDisplayData):
     """Returns a PipelineOptions from a dictionary of arguments.
 
     Args:
-      options: Dictinary of argument value pairs.
+      options: Dictionary of argument value pairs.
 
     Returns:
       A PipelineOptions object representing the given arguments.
@@ -459,7 +459,10 @@ class WorkerOptions(PipelineOptions):
         default=None,
         help=(
             'GCE subnetwork for launching workers. Default is up to the '
-            'Dataflow service.'))
+            'Dataflow service. Expected format is '
+            'regions/REGION/subnetworks/SUBNETWORK or the fully qualified '
+            'subnetwork name. For more information, see '
+            'https://cloud.google.com/compute/docs/vpc/'))
     parser.add_argument(
         '--worker_harness_container_image',
         default=None,

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -199,6 +199,8 @@ class Environment(object):
       pool.zone = self.worker_options.zone
     if self.worker_options.network:
       pool.network = self.worker_options.network
+    if self.worker_options.subnetwork:
+      pool.subnetwork = self.worker_options.subnetwork
     if self.worker_options.worker_harness_container_image:
       pool.workerHarnessContainerImage = (
           self.worker_options.worker_harness_container_image)

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -47,7 +47,7 @@ class UtilTest(unittest.TestCase):
 
   def test_set_network(self):
     pipeline_options = PipelineOptions(
-        ['--network','anetworkname',
+        ['--network', 'anetworkname',
          '--temp_location', 'gs://any-location/temp'])
     env = apiclient.Environment([], #packages
                                 pipeline_options,

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -44,6 +44,28 @@ class UtilTest(unittest.TestCase):
         pipeline_options,
         DataflowRunner.BATCH_ENVIRONMENT_MAJOR_VERSION)
 
+
+  def test_set_network(self):
+    pipeline_options = PipelineOptions(
+        ['--network','anetworkname',
+         '--temp_location', 'gs://any-location/temp'])
+    env = apiclient.Environment([], #packages
+                                pipeline_options,
+                                '2.0.0') #any environment version
+    self.assertEqual(env.proto.workerPools[0].network,
+                     'anetworkname')
+
+  def test_set_subnetwork(self):
+    pipeline_options = PipelineOptions(
+        ['--subnetwork', '/regions/MY/subnetworks/SUBNETWORK',
+         '--temp_location', 'gs://any-location/temp'])
+
+    env = apiclient.Environment([], #packages
+                                pipeline_options,
+                                '2.0.0') #any environment version
+    self.assertEqual(env.proto.workerPools[0].subnetwork,
+                     '/regions/MY/subnetworks/SUBNETWORK')
+
   def test_invalid_default_job_name(self):
     # Regexp for job names in dataflow.
     regexp = '^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$'

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -44,7 +44,6 @@ class UtilTest(unittest.TestCase):
         pipeline_options,
         DataflowRunner.BATCH_ENVIRONMENT_MAJOR_VERSION)
 
-
   def test_set_network(self):
     pipeline_options = PipelineOptions(
         ['--network', 'anetworkname',


### PR DESCRIPTION
r: @aaltay 
also adding simple unittests for network and subnetwork options.
I have not yet submitted a job to dtaflow using these options. will do in a moment.

Feature missing for user: http://stackoverflow.com/questions/43977859/network-interface-must-specify-a-subnet-if-the-network-resource-is-in-custom-sub