### PR TITLE
[BEAM-2164] Fix generate-sources.sh if directory contains space

### DIFF
--- a/sdks/java/maven-archetypes/examples-java8/generate-sources.sh
+++ b/sdks/java/maven-archetypes/examples-java8/generate-sources.sh
@@ -22,7 +22,7 @@
 # Usage: Invoke with no arguments from any working directory.
 
 # The directory of this script. Assumes root of the maven-archetypes module.
-HERE="$( cd "$( dirname '$0' )" && pwd )"
+HERE="$( dirname "$0" )"
 
 # The directory of the examples-java and examples-java8 modules
 EXAMPLES_ROOT="${HERE}/../../../../examples/java"

--- a/sdks/java/maven-archetypes/examples-java8/generate-sources.sh
+++ b/sdks/java/maven-archetypes/examples-java8/generate-sources.sh
@@ -22,7 +22,7 @@
 # Usage: Invoke with no arguments from any working directory.
 
 # The directory of this script. Assumes root of the maven-archetypes module.
-HERE="$(dirname $0)"
+HERE="$( cd "$( dirname '$0' )" && pwd )"
 
 # The directory of the examples-java and examples-java8 modules
 EXAMPLES_ROOT="${HERE}/../../../../examples/java"

--- a/sdks/java/maven-archetypes/examples/generate-sources.sh
+++ b/sdks/java/maven-archetypes/examples/generate-sources.sh
@@ -21,7 +21,7 @@
 # Usage: Invoke with no arguments from any working directory.
 
 # The directory of this script. Assumes root of the maven-archetypes module.
-HERE="$( cd "$( dirname '$0' )" && pwd )"
+HERE="$( dirname "$0" )"
 
 # The directory of the examples-java module
 EXAMPLES_ROOT="${HERE}/../../../../examples/java"

--- a/sdks/java/maven-archetypes/examples/generate-sources.sh
+++ b/sdks/java/maven-archetypes/examples/generate-sources.sh
@@ -21,7 +21,7 @@
 # Usage: Invoke with no arguments from any working directory.
 
 # The directory of this script. Assumes root of the maven-archetypes module.
-HERE="$(dirname $0)"
+HERE="$( cd "$( dirname '$0' )" && pwd )"
 
 # The directory of the examples-java module
 EXAMPLES_ROOT="${HERE}/../../../../examples/java"


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

[generate-sources.sh](https://github.com/apache/beam/blob/master/sdks/java/maven-archetypes/examples/generate-sources.sh) is executed in beam-sdks-java-maven-archetypes-examples and beam-sdks-java-maven-archetypes-examples-java8. If project directory contains space, mvn build of the two module will fail because the space character is not handled properly.

Test is done by successfully running mvn clean install. 