### PR TITLE
[BEAM-2318] Ensure that tables that don't exist are not created

### DIFF
--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -282,7 +282,7 @@ public class HBaseIOTest {
     /** Tests that when writing to a non-existent table, the write fails. */
     @Test
     public void testWritingFailsTableDoesNotExist() throws Exception {
-        final String table = "TEST-TABLE";
+        final String table = "TEST-TABLE-DOES-NOT-EXIST";
 
         PCollection<KV<byte[], Iterable<Mutation>>> emptyInput =
                 p.apply(Create.empty(HBaseIO.WRITE_CODER));
@@ -298,7 +298,7 @@ public class HBaseIOTest {
     /** Tests that when writing an element fails, the write fails. */
     @Test
     public void testWritingFailsBadElement() throws Exception {
-        final String table = "TEST-TABLE";
+        final String table = "TEST-TABLE-BAD-ELEMENT";
         final String key = "KEY";
         createTable(table);
 


### PR DESCRIPTION
We use the same test table name in two tests: one that expects the table not to exist, another that
creates the table. Obviously, the correctness of this will depend on the order in which unit tests
are executed.

Fix the flake by using different and more explicit test names.