### PR TITLE
[BEAM-2377] Allow usage of scala 2.11 dependencies as well as cross compilation for flink runner

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -93,7 +93,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <scope>runtime</scope>
         </dependency>
       </dependencies>

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -93,7 +93,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <scope>runtime</scope>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,7 @@
     <woodstox.version>4.4.1</woodstox.version>
     <spring.version>4.3.5.RELEASE</spring.version>
     <snappy-java.version>1.1.4-M3</snappy-java.version>
+    <flink.scala.version>2.10</flink.scala.version>
 
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
     <groovy-maven-plugin.version>2.0</groovy-maven-plugin.version>
@@ -339,6 +340,19 @@
         </pluginManagement>
       </build>
     </profile>
+
+    <profile> 
+      <id>flink-scala-2.11</id>
+      <activation>
+        <property>
+          <name>flink-scala-2.11</name>
+        </property>
+      </activation>
+      <properties>
+        <flink.scala.version>2.11</flink.scala.version>
+      </properties>
+    </profile>
+
   </profiles>
 
   <dependencyManagement>
@@ -529,7 +543,7 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>beam-runners-flink_2.10</artifactId>
+        <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>beam-runners-flink_2.10</artifactId>
+  <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
   <name>Apache Beam :: Runners :: Flink</name>
   <packaging>jar</packaging>
 
@@ -167,7 +167,7 @@
     <!-- Flink dependencies -->
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-clients_2.10</artifactId>
+      <artifactId>flink-clients_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -191,13 +191,13 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_2.10</artifactId>
+      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_2.10</artifactId>
+      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -212,7 +212,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_2.10</artifactId>
+      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -343,7 +343,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_2.10</artifactId>
+      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
@@ -351,7 +351,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-test-utils_2.10</artifactId>
+      <artifactId>flink-test-utils_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/sdks/java/javadoc/pom.xml
+++ b/sdks/java/javadoc/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-flink_2.10</artifactId>
+      <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -215,7 +215,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -214,7 +214,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Flink allows being built against scala 2.11. But the Flink Runner did
not.

This commit alleviates that, as well as allowing for ensuring that
builds work against scala 2.11 dependencies for flink. It introduces a
flink.scala.version mvn property that is set to 2.10 as a default, as well as
a mvn profile that overrides the flink scala version to 2.11.

It would be nice if you could cross publish the flink runner for
scala-2.11 based on this pull request.