### PR TITLE
 [BEAM-2379] Avoid reading projectId from environment variable in tests.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -149,14 +149,6 @@ public class SpannerIO {
       abstract Write build();
     }
 
-    SpannerOptions getSpannerOptions() {
-      SpannerOptions.Builder builder = SpannerOptions.newBuilder();
-      if (getServiceFactory() != null) {
-        builder.setServiceFactory(getServiceFactory());
-      }
-      return builder.build();
-    }
-
     /**
      * Returns a new {@link SpannerIO.Write} that will write to the specified Cloud Spanner project.
      *
@@ -259,10 +251,10 @@ public class SpannerIO {
 
     @Setup
     public void setup() throws Exception {
-      spanner = spec.getSpannerOptions().getService();
-      dbClient =
-          spanner.getDatabaseClient(
-              DatabaseId.of(projectId(), spec.getInstanceId(), spec.getDatabaseId()));
+      SpannerOptions spannerOptions = getSpannerOptions();
+      spanner = spannerOptions.getService();
+      dbClient = spanner.getDatabaseClient(
+          DatabaseId.of(projectId(), spec.getInstanceId(), spec.getDatabaseId()));
       mutations = new ArrayList<>();
       batchSizeBytes = 0;
     }
@@ -297,6 +289,17 @@ public class SpannerIO {
       }
       spanner.closeAsync().get();
       spanner = null;
+    }
+
+    private SpannerOptions getSpannerOptions() {
+      SpannerOptions.Builder spannerOptionsBuider = SpannerOptions.newBuilder();
+      if (spec.getServiceFactory() != null) {
+        spannerOptionsBuider.setServiceFactory(spec.getServiceFactory());
+      }
+      if (spec.getProjectId() != null) {
+        spannerOptionsBuider.setProjectId(spec.getProjectId());
+      }
+      return spannerOptionsBuider.build();
     }
 
     /**


### PR DESCRIPTION
SpannerOptions.Builder requires projectId to be not-null.

Was green because I had GOOGLE_APPLICATION_CREDENTIALS configured on my dev machine. Same for Jenkins, I guess.