### PR TITLE
[BEAM-2406] Fix NullPointerException when writing an empty table

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -251,12 +251,16 @@ class BatchLoads<DestinationT>
     // loading.
     PCollection<Void> singleton = p.apply("singleton",
         Create.of((Void) null).withCoder(VoidCoder.of()));
+    DestinationT singletonTableDestination = null;
+    if (singletonTable) {
+      singletonTableDestination = dynamicDestinations.getDestination(null);
+    }
     PCollectionTuple partitions =
         singleton.apply(
             "WritePartition",
             ParDo.of(
                     new WritePartition<>(
-                        singletonTable,
+                        singletonTableDestination,
                         tempFilePrefix,
                         resultsView,
                         multiPartitionsTag,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -251,16 +251,13 @@ class BatchLoads<DestinationT>
     // loading.
     PCollection<Void> singleton = p.apply("singleton",
         Create.of((Void) null).withCoder(VoidCoder.of()));
-    DestinationT singletonTableDestination = null;
-    if (singletonTable) {
-      singletonTableDestination = dynamicDestinations.getDestination(null);
-    }
     PCollectionTuple partitions =
         singleton.apply(
             "WritePartition",
             ParDo.of(
                     new WritePartition<>(
-                        singletonTableDestination,
+                        singletonTable,
+                        dynamicDestinations,
                         tempFilePrefix,
                         resultsView,
                         multiPartitionsTag,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.io.gcp.bigquery;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLocation;
 
 import com.google.api.services.bigquery.model.TableRow;
@@ -79,6 +80,7 @@ class WriteBundlesToFiles<DestinationT>
     public final DestinationT destination;
 
     public Result(String filename, Long fileByteSize, DestinationT destination) {
+      checkNotNull(destination);
       this.filename = filename;
       this.fileByteSize = fileByteSize;
       this.destination = destination;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
@@ -34,7 +34,7 @@ import org.apache.beam.sdk.values.TupleTag;
  */
 class WritePartition<DestinationT>
     extends DoFn<Void, KV<ShardedKey<DestinationT>, List<String>>> {
-  private final boolean singletonTable;
+  private final DestinationT singletonTable;
   private final PCollectionView<String> tempFilePrefix;
   private final PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> results;
   private TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag;
@@ -99,7 +99,7 @@ class WritePartition<DestinationT>
   }
 
   WritePartition(
-      boolean singletonTable,
+      DestinationT singletonTable,
       PCollectionView<String> tempFilePrefix,
       PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> results,
       TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag,
@@ -118,7 +118,7 @@ class WritePartition<DestinationT>
 
     // If there are no elements to write _and_ the user specified a constant output table, then
     // generate an empty table of that name.
-    if (results.isEmpty() && singletonTable) {
+    if (results.isEmpty() && singletonTable != null) {
       String tempFilePrefix = c.sideInput(this.tempFilePrefix);
       TableRowWriter writer = new TableRowWriter(tempFilePrefix);
       writer.close();
@@ -127,7 +127,7 @@ class WritePartition<DestinationT>
       // resolve it to the singleton output table.
       results.add(
           new Result<DestinationT>(
-              writerResult.resourceId.toString(), writerResult.byteSize, null));
+              writerResult.resourceId.toString(), writerResult.byteSize, singletonTable));
     }
 
     Map<DestinationT, DestinationData> currentResults = Maps.newHashMap();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -1797,10 +1797,13 @@ public class BigQueryIOTest implements Serializable {
     // function) and there is no input data, WritePartition will generate an empty table. This
     // code is to test that path.
     boolean isSingleton = numTables == 1 && numFilesPerTable == 0;
-
+    String singletonDestination = null
+    if (isSingleton) {
+      singletonDestination = "SINGLETON";
+    }
     List<ShardedKey<String>> expectedPartitions = Lists.newArrayList();
     if (isSingleton) {
-      expectedPartitions.add(ShardedKey.<String>of(null, 1));
+      expectedPartitions.add(ShardedKey.<String>of(singletonDestination, 1));
     } else {
       for (int i = 0; i < numTables; ++i) {
         for (int j = 1; j <= expectedNumPartitionsPerTable; ++j) {
@@ -1842,8 +1845,8 @@ public class BigQueryIOTest implements Serializable {
         p.apply(Create.of(tempFilePrefix)).apply(View.<String>asSingleton());
 
     WritePartition<String> writePartition =
-        new WritePartition<>(
-            isSingleton, tempFilePrefixView, resultsView, multiPartitionsTag, singlePartitionTag);
+        new WritePartition<>(singletonDestination, tempFilePrefixView, resultsView,
+            multiPartitionsTag, singlePartitionTag);
 
     DoFnTester<Void, KV<ShardedKey<String>, List<String>>> tester =
         DoFnTester.of(writePartition);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -1797,23 +1797,23 @@ public class BigQueryIOTest implements Serializable {
     // function) and there is no input data, WritePartition will generate an empty table. This
     // code is to test that path.
     boolean isSingleton = numTables == 1 && numFilesPerTable == 0;
-    String singletonDestination = null
+    DynamicDestinations<String, TableDestination> dynamicDestinations =
+        new DynamicDestinationsHelpers.ConstantTableDestinations<>(
+            StaticValueProvider.of("SINGLETON"), "");
+    List<ShardedKey<TableDestination>> expectedPartitions = Lists.newArrayList();
     if (isSingleton) {
-      singletonDestination = "SINGLETON";
-    }
-    List<ShardedKey<String>> expectedPartitions = Lists.newArrayList();
-    if (isSingleton) {
-      expectedPartitions.add(ShardedKey.<String>of(singletonDestination, 1));
+      expectedPartitions.add(ShardedKey.<TableDestination>of(
+          new TableDestination("SINGLETON", ""), 1));
     } else {
       for (int i = 0; i < numTables; ++i) {
         for (int j = 1; j <= expectedNumPartitionsPerTable; ++j) {
           String tableName = String.format("project-id:dataset-id.tables%05d", i);
-          expectedPartitions.add(ShardedKey.of(tableName, j));
+          expectedPartitions.add(ShardedKey.of(new TableDestination(tableName, ""), j));
         }
       }
     }
 
-    List<WriteBundlesToFiles.Result<String>> files = Lists.newArrayList();
+    List<WriteBundlesToFiles.Result<TableDestination>> files = Lists.newArrayList();
     Map<String, List<String>> filenamesPerTable = Maps.newHashMap();
     for (int i = 0; i < numTables; ++i) {
       String tableName = String.format("project-id:dataset-id.tables%05d", i);
@@ -1825,36 +1825,36 @@ public class BigQueryIOTest implements Serializable {
       for (int j = 0; j < numFilesPerTable; ++j) {
         String fileName = String.format("%s_files%05d", tableName, j);
         filenames.add(fileName);
-        files.add(new Result<>(fileName, fileSize, tableName));
+        files.add(new Result<>(fileName, fileSize, new TableDestination(tableName, "")));
       }
     }
 
-    TupleTag<KV<ShardedKey<String>, List<String>>> multiPartitionsTag =
-        new TupleTag<KV<ShardedKey<String>, List<String>>>("multiPartitionsTag") {};
-    TupleTag<KV<ShardedKey<String>, List<String>>> singlePartitionTag =
-        new TupleTag<KV<ShardedKey<String>, List<String>>>("singlePartitionTag") {};
+    TupleTag<KV<ShardedKey<TableDestination>, List<String>>> multiPartitionsTag =
+        new TupleTag<KV<ShardedKey<TableDestination>, List<String>>>("multiPartitionsTag") {};
+    TupleTag<KV<ShardedKey<TableDestination>, List<String>>> singlePartitionTag =
+        new TupleTag<KV<ShardedKey<TableDestination>, List<String>>>("singlePartitionTag") {};
 
-    PCollectionView<Iterable<WriteBundlesToFiles.Result<String>>> resultsView =
+    PCollectionView<Iterable<WriteBundlesToFiles.Result<TableDestination>>> resultsView =
         p.apply(
                 Create.of(files)
-                    .withCoder(WriteBundlesToFiles.ResultCoder.of(StringUtf8Coder.of())))
-            .apply(View.<WriteBundlesToFiles.Result<String>>asIterable());
+                    .withCoder(WriteBundlesToFiles.ResultCoder.of(TableDestinationCoder.of())))
+            .apply(View.<WriteBundlesToFiles.Result<TableDestination>>asIterable());
 
     String tempFilePrefix = testFolder.newFolder("BigQueryIOTest").getAbsolutePath();
     PCollectionView<String> tempFilePrefixView =
         p.apply(Create.of(tempFilePrefix)).apply(View.<String>asSingleton());
 
-    WritePartition<String> writePartition =
-        new WritePartition<>(singletonDestination, tempFilePrefixView, resultsView,
-            multiPartitionsTag, singlePartitionTag);
+    WritePartition<TableDestination> writePartition =
+        new WritePartition<>(isSingleton, dynamicDestinations, tempFilePrefixView,
+            resultsView, multiPartitionsTag, singlePartitionTag);
 
-    DoFnTester<Void, KV<ShardedKey<String>, List<String>>> tester =
+    DoFnTester<Void, KV<ShardedKey<TableDestination>, List<String>>> tester =
         DoFnTester.of(writePartition);
     tester.setSideInput(resultsView, GlobalWindow.INSTANCE, files);
     tester.setSideInput(tempFilePrefixView, GlobalWindow.INSTANCE, tempFilePrefix);
     tester.processElement(null);
 
-    List<KV<ShardedKey<String>, List<String>>> partitions;
+    List<KV<ShardedKey<TableDestination>, List<String>>> partitions;
     if (expectedNumPartitionsPerTable > 1) {
       partitions = tester.takeOutputElements(multiPartitionsTag);
     } else {
@@ -1862,10 +1862,10 @@ public class BigQueryIOTest implements Serializable {
     }
 
 
-    List<ShardedKey<String>> partitionsResult = Lists.newArrayList();
+    List<ShardedKey<TableDestination>> partitionsResult = Lists.newArrayList();
     Map<String, List<String>> filesPerTableResult = Maps.newHashMap();
-    for (KV<ShardedKey<String>, List<String>> partition : partitions) {
-      String table = partition.getKey().getKey();
+    for (KV<ShardedKey<TableDestination>, List<String>> partition : partitions) {
+      String table = partition.getKey().getKey().getTableSpec();
       partitionsResult.add(partition.getKey());
       List<String> tableFilesResult = filesPerTableResult.get(table);
       if (tableFilesResult == null) {


### PR DESCRIPTION
When writing to an empty table, BigQueryIO was throwing a NPE because WritePartitions was returning null. This was a regression in previous behavior.

R: @jkff 