### PR TITLE
[BEAM-1542] SpannerIO: Introduced a MutationGroup.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner;
+
+import com.google.cloud.spanner.Mutation;
+import com.google.common.collect.ImmutableList;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A bundle of mutations that must be submitted atomically.
+ *
+ * <p>One of the mutations is chosen to be "primary", and can be used to determine partitions.
+ */
+public final class MutationGroup implements Serializable, Iterable<Mutation> {
+  private final ImmutableList<Mutation> mutations;
+
+  public static Builder withPrimary(Mutation primary) {
+    return new Builder(primary);
+  }
+
+  @Override
+  public Iterator<Mutation> iterator() {
+    return mutations.iterator();
+  }
+
+  /** Builder for {@link org.apache.beam.sdk.io.gcp.spanner.MutationGroup}. */
+  public static class Builder {
+    private final ImmutableList.Builder<Mutation> builder;
+
+    private Builder(Mutation primary) {
+      this.builder = ImmutableList.<Mutation>builder().add(primary);
+    }
+
+    public Builder attach(Mutation m) {
+      this.builder.add(m);
+      return this;
+    }
+
+    public Builder attach(Iterable<Mutation> mutations) {
+      this.builder.addAll(mutations);
+      return this;
+    }
+
+    public Builder attach(Mutation... mutations) {
+      this.builder.addAll(Arrays.asList(mutations));
+      return this;
+    }
+
+    public MutationGroup build() {
+      return new MutationGroup(builder.build());
+    }
+  }
+
+  private MutationGroup(ImmutableList<Mutation> mutations) {
+    this.mutations = mutations;
+  }
+
+  public Mutation primary() {
+    return mutations.get(0);
+  }
+
+  public List<Mutation> attached() {
+    return mutations.subList(1, mutations.size());
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
@@ -33,36 +33,24 @@ import java.util.List;
 public final class MutationGroup implements Serializable, Iterable<Mutation> {
   private final ImmutableList<Mutation> mutations;
 
-  public static Builder withPrimary(Mutation primary) {
-    return new Builder(primary);
+  /**
+   * Creates a new group.
+   *
+   * @param primary a primary mutation.
+   * @param other other mutations, usually interleaved in parent.
+   * @return new mutation group.
+   */
+  public static MutationGroup create(Mutation primary, Mutation... other) {
+    return create(primary, Arrays.asList(other));
+  }
+
+  public static MutationGroup create(Mutation primary, Iterable<Mutation> other) {
+    return new MutationGroup(ImmutableList.<Mutation>builder().add(primary).addAll(other).build());
   }
 
   @Override
   public Iterator<Mutation> iterator() {
     return mutations.iterator();
-  }
-
-  /** Builder for {@link org.apache.beam.sdk.io.gcp.spanner.MutationGroup}. */
-  public static class Builder {
-    private final ImmutableList.Builder<Mutation> builder;
-
-    private Builder(Mutation primary) {
-      this.builder = ImmutableList.<Mutation>builder().add(primary);
-    }
-
-    public Builder attach(Iterable<Mutation> mutations) {
-      this.builder.addAll(mutations);
-      return this;
-    }
-
-    public Builder attach(Mutation... mutations) {
-      this.builder.addAll(Arrays.asList(mutations));
-      return this;
-    }
-
-    public MutationGroup build() {
-      return new MutationGroup(builder.build());
-    }
   }
 
   private MutationGroup(ImmutableList<Mutation> mutations) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroup.java
@@ -50,11 +50,6 @@ public final class MutationGroup implements Serializable, Iterable<Mutation> {
       this.builder = ImmutableList.<Mutation>builder().add(primary);
     }
 
-    public Builder attach(Mutation m) {
-      this.builder.add(m);
-      return this;
-    }
-
     public Builder attach(Iterable<Mutation> mutations) {
       this.builder.addAll(mutations);
       return this;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
@@ -44,6 +44,15 @@ class MutationSizeEstimator {
     return result;
   }
 
+  /** Estimates a size of the mutation group in bytes. */
+  public static long sizeOf(MutationGroup group) {
+    long result = 0;
+    for (Mutation m : group) {
+      result += sizeOf(m);
+    }
+    return result;
+  }
+
   private static long estimatePrimitiveValue(Value v) {
     switch (v.getType().getCode()) {
       case BOOL:

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -197,8 +197,8 @@ public class SpannerIO {
     /**
      * Same transform but can be applied to {@link PCollection} of {@link MutationGroup}.
      */
-    public WriteGroup grouped() {
-      return new WriteGroup(this);
+    public WriteGrouped grouped() {
+      return new WriteGrouped(this);
     }
 
     @VisibleForTesting
@@ -244,10 +244,10 @@ public class SpannerIO {
   }
 
   /** Same as {@link Write} but supports grouped mutations. */
-  public static class WriteGroup extends PTransform<PCollection<MutationGroup>, PDone> {
+  public static class WriteGrouped extends PTransform<PCollection<MutationGroup>, PDone> {
     private final Write spec;
 
-    public WriteGroup(Write spec) {
+    public WriteGrouped(Write spec) {
       this.spec = spec;
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -261,7 +261,7 @@ public class SpannerIO {
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
       Mutation value = c.element();
-      c.output(MutationGroup.withPrimary(value).build());
+      c.output(MutationGroup.create(value));
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -29,10 +29,12 @@ import com.google.cloud.spanner.Mutation;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -88,6 +90,11 @@ import org.slf4j.LoggerFactory;
  *   <li>If the pipeline was unexpectedly stopped, mutations that were already applied will not get
  *       rolled back.
  * </ul>
+ *
+ * <p>Use {@link MutationGroup} to ensure that a small set mutations is bundled together. It is
+ * guaranteed that mutations in a group are submitted in the same transaction. Build
+ * {@link SpannerIO.Write} transform, and call {@link Write#grouped()} method. It will return a
+ * transformation that can be applied to a PCollection of MutationGroup.
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class SpannerIO {
@@ -187,6 +194,13 @@ public class SpannerIO {
       return toBuilder().setDatabaseId(databaseId).build();
     }
 
+    /**
+     * Same transform but can be applied to {@link PCollection} of {@link MutationGroup}.
+     */
+    public WriteGroup grouped() {
+      return new WriteGroup(this);
+    }
+
     @VisibleForTesting
     Write withServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory) {
       return toBuilder().setServiceFactory(serviceFactory).build();
@@ -204,7 +218,9 @@ public class SpannerIO {
 
     @Override
     public PDone expand(PCollection<Mutation> input) {
-      input.apply("Write mutations to Cloud Spanner", ParDo.of(new SpannerWriteFn(this)));
+      input
+          .apply("To mutation group", ParDo.of(new ToMutationGroupFn()))
+          .apply("Write mutations to Cloud Spanner", ParDo.of(new SpannerWriteGroupFn(this)));
       return PDone.in(input.getPipeline());
     }
 
@@ -227,15 +243,37 @@ public class SpannerIO {
     }
   }
 
+  /** Same as {@link Write} but supports grouped mutations. */
+  public static class WriteGroup extends PTransform<PCollection<MutationGroup>, PDone> {
+    private final Write spec;
+
+    public WriteGroup(Write spec) {
+      this.spec = spec;
+    }
+
+    @Override public PDone expand(PCollection<MutationGroup> input) {
+      input.apply("Write mutations to Cloud Spanner", ParDo.of(new SpannerWriteGroupFn(spec)));
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  private static class ToMutationGroupFn extends DoFn<Mutation, MutationGroup> {
+    @ProcessElement
+    public void processElement(ProcessContext c) throws Exception {
+      Mutation value = c.element();
+      c.output(MutationGroup.withPrimary(value).build());
+    }
+  }
+
   /** Batches together and writes mutations to Google Cloud Spanner. */
   @VisibleForTesting
-  static class SpannerWriteFn extends DoFn<Mutation, Void> {
-    private static final Logger LOG = LoggerFactory.getLogger(SpannerWriteFn.class);
+  static class SpannerWriteGroupFn extends DoFn<MutationGroup, Void> {
+    private static final Logger LOG = LoggerFactory.getLogger(SpannerWriteGroupFn.class);
     private final Write spec;
     private transient Spanner spanner;
     private transient DatabaseClient dbClient;
     // Current batch of mutations to be written.
-    private List<Mutation> mutations;
+    private List<MutationGroup> mutations;
     private long batchSizeBytes = 0;
 
     private static final int MAX_RETRIES = 5;
@@ -244,8 +282,7 @@ public class SpannerIO {
             .withMaxRetries(MAX_RETRIES)
             .withInitialBackoff(Duration.standardSeconds(5));
 
-    @VisibleForTesting
-    SpannerWriteFn(Write spec) {
+    @VisibleForTesting SpannerWriteGroupFn(Write spec) {
       this.spec = spec;
     }
 
@@ -261,7 +298,7 @@ public class SpannerIO {
 
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
-      Mutation m = c.element();
+      MutationGroup m = c.element();
       mutations.add(m);
       batchSizeBytes += MutationSizeEstimator.sizeOf(m);
       if (batchSizeBytes >= spec.getBatchSizeBytes()) {
@@ -319,7 +356,7 @@ public class SpannerIO {
       while (true) {
         // Batch upsert rows.
         try {
-          dbClient.writeAtLeastOnce(mutations);
+          dbClient.writeAtLeastOnce(Iterables.concat(mutations));
 
           // Break if the commit threw no exception.
           break;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
@@ -135,4 +135,16 @@ public class MutationSizeEstimatorTest {
     assertThat(MutationSizeEstimator.sizeOf(timestampArray), is(24L));
     assertThat(MutationSizeEstimator.sizeOf(dateArray), is(48L));
   }
+
+  @Test
+  public void group() throws Exception {
+    Mutation int64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(1).build();
+    Mutation float64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(2.9).build();
+    Mutation bool = Mutation.newInsertOrUpdateBuilder("test").set("one").to(false).build();
+
+    MutationGroup group = MutationGroup.withPrimary(int64).attach(float64).attach(bool).build();
+
+    assertThat(MutationSizeEstimator.sizeOf(group), is(17L));
+  }
+
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
@@ -142,7 +142,7 @@ public class MutationSizeEstimatorTest {
     Mutation float64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(2.9).build();
     Mutation bool = Mutation.newInsertOrUpdateBuilder("test").set("one").to(false).build();
 
-    MutationGroup group = MutationGroup.withPrimary(int64).attach(float64).attach(bool).build();
+    MutationGroup group = MutationGroup.create(int64, float64, bool);
 
     assertThat(MutationSizeEstimator.sizeOf(group), is(17L));
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOTest.java
@@ -291,6 +291,6 @@ public class SpannerIOTest implements Serializable {
   }
 
   private static MutationGroup g(Mutation m, Mutation... other) {
-    return MutationGroup.withPrimary(m).attach(other).build();
+    return MutationGroup.create(m, other);
   }
 }


### PR DESCRIPTION
Allows to group mutations together in a logical bundle that is submitted in the same transaction.