### PR TITLE
Fix Flink compile error occurs in some JDK versions

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -363,8 +363,13 @@ class FlinkStreamingTransformTranslators {
       Map<TupleTag<?>, OutputTag<WindowedValue<?>>> tagsToOutputTags = Maps.newHashMap();
       for (Map.Entry<TupleTag<?>, PValue> entry : outputs.entrySet()) {
         if (!tagsToOutputTags.containsKey(entry.getKey())) {
-          tagsToOutputTags.put(entry.getKey(), new OutputTag<>(entry.getKey().getId(),
-              (TypeInformation) context.getTypeInfo((PCollection<?>) entry.getValue())));
+          tagsToOutputTags.put(
+              entry.getKey(),
+              new OutputTag<WindowedValue<?>>(
+                  entry.getKey().getId(),
+                  (TypeInformation) context.getTypeInfo((PCollection<?>) entry.getValue())
+              )
+          );
         }
       }
 


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [ ] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [ ] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

maven-compiler-plugin reports compiling error in `runners/flink` when running Postcommit build in JD1.7, OpenJDK7 and OpenJDK8. Jenkins failed [link](https://builds.apache.org/job/beam_PostCommit_Java_JDK_Versions_Test/56/).

Test is done by running Postcommit_Java_JDK_Version_test to verify the fix.