### PR TITLE
Slight debuggability improvements in BigtableIO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/ByteKeyRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/range/ByteKeyRangeTracker.java
@@ -71,6 +71,10 @@ public final class ByteKeyRangeTracker implements RangeTracker<ByteKey> {
         "Trying to return record which is before the last-returned record");
 
     if (position == null) {
+      LOG.info(
+          "Adjusting range start from {} to {} as position of first returned record",
+          range.getStartKey(),
+          recordStart);
       range = range.withStartKey(recordStart);
     }
     position = recordStart;
@@ -87,6 +91,15 @@ public final class ByteKeyRangeTracker implements RangeTracker<ByteKey> {
 
   @Override
   public synchronized boolean trySplitAtPosition(ByteKey splitPosition) {
+    // Sanity check.
+    if (!range.containsKey(splitPosition)) {
+      LOG.warn(
+          "{}: Rejecting split request at {} because it is not within the range.",
+          this,
+          splitPosition);
+      return false;
+    }
+
     // Unstarted.
     if (position == null) {
       LOG.warn(
@@ -103,15 +116,6 @@ public final class ByteKeyRangeTracker implements RangeTracker<ByteKey> {
           this,
           splitPosition,
           position);
-      return false;
-    }
-
-    // Sanity check.
-    if (!range.containsKey(splitPosition)) {
-      LOG.warn(
-          "{}: Rejecting split request at {} because it is not within the range.",
-          this,
-          splitPosition);
       return false;
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -1027,7 +1027,7 @@ public class BigtableIO {
             "{}: Failed to interpolate key for fraction {}.", rangeTracker.getRange(), fraction, e);
         return null;
       }
-      LOG.debug(
+      LOG.info(
           "Proposing to split {} at fraction {} (key {})", rangeTracker, fraction, splitKey);
       BigtableSource primary;
       BigtableSource residual;


### PR DESCRIPTION
- ByteKeyRangeTracker.splitAtPosition logs the "insane" case first.
- BigtableIO logs the split position at INFO
- Log when adjusting range for first position

R: @sduskis