### PR TITLE
[BEAM-1630] Adds ability to dynamically replace PTransforms during runtime.

### DIFF
--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -318,7 +318,8 @@ class PipelineTest(unittest.TestCase):
           return TripleParDo()
         raise ValueError('Unsupported type of transform: %r', ptransform)
 
-    DirectRunner.PTRANSFORM_OVERRIDES.append(MyParDoOverride())
+    # Using following private variable for testing.
+    DirectRunner._PTRANSFORM_OVERRIDES.append(MyParDoOverride())
     with Pipeline() as p:
       pcoll = p | beam.Create([1, 2, 3]) | 'Multiply' >> DoubleParDo()
       assert_that(pcoll, equal_to([3, 6, 9]))

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -28,7 +28,6 @@ import apache_beam as beam
 from apache_beam.io import Read
 from apache_beam.metrics import Metrics
 from apache_beam.pipeline import Pipeline
-from apache_beam.pipeline import PTransformMatcher
 from apache_beam.pipeline import PTransformOverride
 from apache_beam.pipeline import PipelineOptions
 from apache_beam.pipeline import PipelineVisitor
@@ -302,9 +301,9 @@ class PipelineTest(unittest.TestCase):
 
   def test_ptransform_overrides(self):
 
-    class MyParDoMatcher(PTransformMatcher):
+    class MyParDoMatcher(object):
 
-      def match(self, applied_ptransform):
+      def __call__(self, applied_ptransform):
         if isinstance(applied_ptransform.transform, DoubleParDo):
           return True
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -301,16 +301,13 @@ class PipelineTest(unittest.TestCase):
 
   def test_ptransform_overrides(self):
 
-    class MyParDoMatcher(object):
-
-      def __call__(self, applied_ptransform):
-        if isinstance(applied_ptransform.transform, DoubleParDo):
-          return True
+    def my_par_do_matcher(applied_ptransform):
+      return isinstance(applied_ptransform.transform, DoubleParDo)
 
     class MyParDoOverride(PTransformOverride):
 
       def get_matcher(self):
-        return MyParDoMatcher()
+        return my_par_do_matcher
 
       def get_replacement_transform(self, ptransform):
         if isinstance(ptransform, DoubleParDo):

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -46,7 +46,9 @@ class DirectRunner(PipelineRunner):
   # using DirectRunner.
   # Currently this only works for overrides where the input and output types do
   # not change.
-  PTRANSFORM_OVERRIDES = []
+  # For internal SDK use only. This should not be updated by Beam pipeline
+  # authors.
+  _PTRANSFORM_OVERRIDES = []
 
   def __init__(self):
     self._cache = None
@@ -66,7 +68,7 @@ class DirectRunner(PipelineRunner):
     """Execute the entire pipeline and returns an DirectPipelineResult."""
 
     # Performing configured PTransform overrides.
-    pipeline.replace_all(DirectRunner.PTRANSFORM_OVERRIDES)
+    pipeline.replace_all(DirectRunner._PTRANSFORM_OVERRIDES)
 
     # TODO: Move imports to top. Pipeline <-> Runner dependency cause problems
     # with resolving imports when they are at top.

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -42,6 +42,12 @@ __all__ = ['DirectRunner']
 class DirectRunner(PipelineRunner):
   """Executes a single pipeline on the local machine."""
 
+  # A list of PTransformOverride objects to be applied before running a pipeline
+  # using DirectRunner.
+  # Currently this only works for overrides where the input and output types do
+  # not change.
+  PTRANSFORM_OVERRIDES = []
+
   def __init__(self):
     self._cache = None
 
@@ -58,6 +64,9 @@ class DirectRunner(PipelineRunner):
 
   def run(self, pipeline):
     """Execute the entire pipeline and returns an DirectPipelineResult."""
+
+    # Performing configured PTransform overrides.
+    pipeline.replace_all(DirectRunner.PTRANSFORM_OVERRIDES)
 
     # TODO: Move imports to top. Pipeline <-> Runner dependency cause problems
     # with resolving imports when they are at top.


### PR DESCRIPTION
Adds two new interfaces, PTransformMatcher and PTransformOverride.

Currently only supports replacements where input and output types are an exact match (we have to address complexities due to type hints before supporting replacements with different types).

This can be used to dynamically update a populated pipeline at runtime. Each runner can configure it's own overrides.

This will be used by SplittableDoFn where matching ParDo transforms will be dynamically replaced by SplittableParDo.
