### PR TITLE
[BEAM-2442] BeamSql api surface test

### DIFF
--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSql.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSql.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.dsls.sql;
 
+import static org.apache.beam.dsls.sql.BeamSqlEnv.planner;
+import static org.apache.beam.dsls.sql.BeamSqlEnv.registerTable;
+
 import org.apache.beam.dsls.sql.rel.BeamRelNode;
 import org.apache.beam.dsls.sql.schema.BeamPCollectionTable;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
@@ -70,7 +73,7 @@ p.run().waitUntilFinish();
  * </pre>
  */
 @Experimental
-public class BeamSql extends BeamSqlEnv {
+public class BeamSql {
 
   /**
    * Transforms a SQL query into a {@link PTransform} representing an equivalent execution plan.

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlCli.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlCli.java
@@ -25,22 +25,18 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.calcite.plan.RelOptUtil;
-import org.apache.calcite.sql.parser.SqlParseException;
-import org.apache.calcite.tools.RelConversionException;
-import org.apache.calcite.tools.ValidationException;
 
 /**
  * {@link BeamSqlCli} provides methods to execute Beam SQL with an interactive client.
  */
 @Experimental
-public class BeamSqlCli {
+public class BeamSqlCli extends BeamSqlEnv {
 
   /**
    * Returns a human readable representation of the query execution plan.
    */
-  public static String explainQuery(String sqlString)
-      throws ValidationException, RelConversionException, SqlParseException {
-    BeamRelNode exeTree = BeamSqlEnv.planner.convertToBeamRel(sqlString);
+  public static String explainQuery(String sqlString) throws Exception {
+    BeamRelNode exeTree = planner.convertToBeamRel(sqlString);
     String beamPlan = RelOptUtil.toString(exeTree);
     return beamPlan;
   }
@@ -63,8 +59,7 @@ public class BeamSqlCli {
   public static PCollection<BeamSqlRow> compilePipeline(String sqlStatement, Pipeline basePipeline)
       throws Exception{
     PCollection<BeamSqlRow> resultStream =
-        BeamSqlEnv.planner.compileBeamPipeline(sqlStatement, basePipeline);
+        planner.compileBeamPipeline(sqlStatement, basePipeline);
     return resultStream;
   }
-
 }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlCli.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlCli.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.dsls.sql;
 
+import static org.apache.beam.dsls.sql.BeamSqlEnv.planner;
+
 import org.apache.beam.dsls.sql.rel.BeamRelNode;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.sdk.Pipeline;
@@ -30,7 +32,7 @@ import org.apache.calcite.plan.RelOptUtil;
  * {@link BeamSqlCli} provides methods to execute Beam SQL with an interactive client.
  */
 @Experimental
-public class BeamSqlCli extends BeamSqlEnv {
+public class BeamSqlCli {
 
   /**
    * Returns a human readable representation of the query execution plan.

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlEnv.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/BeamSqlEnv.java
@@ -80,7 +80,7 @@ public class BeamSqlEnv {
     }
     @Override
     public RelDataType getRowType(RelDataTypeFactory typeFactory) {
-      return CalciteUtils.toRelDataType(this.beamSqlRecordType)
+      return CalciteUtils.toCalciteRecordType(this.beamSqlRecordType)
           .apply(BeamQueryPlanner.TYPE_FACTORY);
     }
 

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/example/BeamSqlExample.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/example/BeamSqlExample.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.dsls.sql.example;
 
+import java.sql.Types;
 import org.apache.beam.dsls.sql.BeamSql;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
@@ -31,7 +32,6 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,9 +48,9 @@ public class BeamSqlExample {
 
     //define the input row format
     BeamSqlRecordType type = new BeamSqlRecordType();
-    type.addField("c1", SqlTypeName.INTEGER);
-    type.addField("c2", SqlTypeName.VARCHAR);
-    type.addField("c3", SqlTypeName.DOUBLE);
+    type.addField("c1", Types.INTEGER);
+    type.addField("c2", Types.VARCHAR);
+    type.addField("c3", Types.DOUBLE);
     BeamSqlRow row = new BeamSqlRow(type);
     row.addField(0, 1);
     row.addField(1, "row");

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamAggregationRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamAggregationRel.java
@@ -110,13 +110,13 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
         stageName + "_aggregation",
         Combine.<BeamSqlRow, BeamSqlRow, BeamSqlRow>groupedValues(
             new BeamAggregationTransforms.AggregationCombineFn(getAggCallList(),
-                CalciteUtils.buildRecordType(input.getRowType()))))
+                CalciteUtils.toBeamRecordType(input.getRowType()))))
         .setCoder(KvCoder.<BeamSqlRow, BeamSqlRow>of(keyCoder, aggCoder));
 
     PCollection<BeamSqlRow> mergedStream = aggregatedStream.apply(stageName + "_mergeRecord",
         ParDo.of(new BeamAggregationTransforms.MergeAggregationRecord(
-            CalciteUtils.buildRecordType(getRowType()), getAggCallList())));
-    mergedStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
+            CalciteUtils.toBeamRecordType(getRowType()), getAggCallList())));
+    mergedStream.setCoder(new BeamSqlRowCoder(CalciteUtils.toBeamRecordType(getRowType())));
 
     return mergedStream;
   }
@@ -125,7 +125,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
    * Type of sub-rowrecord used as Group-By keys.
    */
   private BeamSqlRecordType exKeyFieldsSchema(RelDataType relDataType) {
-    BeamSqlRecordType inputRecordType = CalciteUtils.buildRecordType(relDataType);
+    BeamSqlRecordType inputRecordType = CalciteUtils.toBeamRecordType(relDataType);
     BeamSqlRecordType typeOfKey = new BeamSqlRecordType();
     for (int i : groupSet.asList()) {
       if (i != windowFieldIdx) {
@@ -142,7 +142,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
   private BeamSqlRecordType exAggFieldsSchema() {
     BeamSqlRecordType typeOfAggFields = new BeamSqlRecordType();
     for (AggregateCall ac : getAggCallList()) {
-      typeOfAggFields.addField(ac.name, CalciteUtils.getJavaSqlType(ac.type.getSqlTypeName()));
+      typeOfAggFields.addField(ac.name, CalciteUtils.toJavaType(ac.type.getSqlTypeName()));
     }
     return typeOfAggFields;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamFilterRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamFilterRel.java
@@ -20,10 +20,10 @@ package org.apache.beam.dsls.sql.rel;
 import org.apache.beam.dsls.sql.interpreter.BeamSqlExpressionExecutor;
 import org.apache.beam.dsls.sql.interpreter.BeamSqlFnExecutor;
 import org.apache.beam.dsls.sql.planner.BeamSqlRelUtils;
-import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.dsls.sql.schema.BeamSqlRowCoder;
 import org.apache.beam.dsls.sql.transform.BeamSqlFilterFn;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
@@ -63,7 +63,7 @@ public class BeamFilterRel extends Filter implements BeamRelNode {
 
     PCollection<BeamSqlRow> filterStream = upstream.apply(stageName,
         ParDo.of(new BeamSqlFilterFn(getRelTypeName(), executor)));
-    filterStream.setCoder(new BeamSqlRowCoder(BeamSqlRecordType.from(getRowType())));
+    filterStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
 
     return filterStream;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamFilterRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamFilterRel.java
@@ -63,7 +63,7 @@ public class BeamFilterRel extends Filter implements BeamRelNode {
 
     PCollection<BeamSqlRow> filterStream = upstream.apply(stageName,
         ParDo.of(new BeamSqlFilterFn(getRelTypeName(), executor)));
-    filterStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
+    filterStream.setCoder(new BeamSqlRowCoder(CalciteUtils.toBeamRecordType(getRowType())));
 
     return filterStream;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamProjectRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamProjectRel.java
@@ -22,10 +22,10 @@ import java.util.List;
 import org.apache.beam.dsls.sql.interpreter.BeamSqlExpressionExecutor;
 import org.apache.beam.dsls.sql.interpreter.BeamSqlFnExecutor;
 import org.apache.beam.dsls.sql.planner.BeamSqlRelUtils;
-import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.dsls.sql.schema.BeamSqlRowCoder;
 import org.apache.beam.dsls.sql.transform.BeamSqlProjectFn;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
@@ -72,8 +72,9 @@ public class BeamProjectRel extends Project implements BeamRelNode {
     BeamSqlExpressionExecutor executor = new BeamSqlFnExecutor(this);
 
     PCollection<BeamSqlRow> projectStream = upstream.apply(stageName, ParDo
-        .of(new BeamSqlProjectFn(getRelTypeName(), executor, BeamSqlRecordType.from(rowType))));
-    projectStream.setCoder(new BeamSqlRowCoder(BeamSqlRecordType.from(getRowType())));
+        .of(new BeamSqlProjectFn(getRelTypeName(), executor,
+            CalciteUtils.buildRecordType(rowType))));
+    projectStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
 
     return projectStream;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamProjectRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamProjectRel.java
@@ -73,8 +73,8 @@ public class BeamProjectRel extends Project implements BeamRelNode {
 
     PCollection<BeamSqlRow> projectStream = upstream.apply(stageName, ParDo
         .of(new BeamSqlProjectFn(getRelTypeName(), executor,
-            CalciteUtils.buildRecordType(rowType))));
-    projectStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
+            CalciteUtils.toBeamRecordType(rowType))));
+    projectStream.setCoder(new BeamSqlRowCoder(CalciteUtils.toBeamRecordType(getRowType())));
 
     return projectStream;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamSortRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamSortRel.java
@@ -149,7 +149,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
 
     PCollection<BeamSqlRow> orderedStream = rawStream.apply(
         "flatten", Flatten.<BeamSqlRow>iterables());
-    orderedStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
+    orderedStream.setCoder(new BeamSqlRowCoder(CalciteUtils.toBeamRecordType(getRowType())));
 
     return orderedStream;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamSortRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamSortRel.java
@@ -25,9 +25,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.beam.dsls.sql.planner.BeamSqlRelUtils;
-import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.dsls.sql.schema.BeamSqlRowCoder;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -149,7 +149,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
 
     PCollection<BeamSqlRow> orderedStream = rawStream.apply(
         "flatten", Flatten.<BeamSqlRow>iterables());
-    orderedStream.setCoder(new BeamSqlRowCoder(BeamSqlRecordType.from(getRowType())));
+    orderedStream.setCoder(new BeamSqlRowCoder(CalciteUtils.buildRecordType(getRowType())));
 
     return orderedStream;
   }
@@ -191,7 +191,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
       for (int i = 0; i < fieldsIndices.size(); i++) {
         int fieldIndex = fieldsIndices.get(i);
         int fieldRet = 0;
-        SqlTypeName fieldType = row1.getDataType().getFieldsType().get(fieldIndex);
+        SqlTypeName fieldType = CalciteUtils.getFieldType(row1.getDataType(), fieldIndex);
         // whether NULL should be ordered first or last(compared to non-null values) depends on
         // what user specified in SQL(NULLS FIRST/NULLS LAST)
         if (row1.isNull(fieldIndex) && row2.isNull(fieldIndex)) {

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamValuesRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamValuesRel.java
@@ -28,6 +28,7 @@ import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.dsls.sql.schema.BeamSqlRowCoder;
 import org.apache.beam.dsls.sql.schema.BeamTableUtils;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
@@ -65,7 +66,7 @@ public class BeamValuesRel extends Values implements BeamRelNode {
       throw new IllegalStateException("Values with empty tuples!");
     }
 
-    BeamSqlRecordType beamSQLRecordType = BeamSqlRecordType.from(this.getRowType());
+    BeamSqlRecordType beamSQLRecordType = CalciteUtils.buildRecordType(this.getRowType());
     for (ImmutableList<RexLiteral> tuple : tuples) {
       BeamSqlRow row = new BeamSqlRow(beamSQLRecordType);
       for (int i = 0; i < tuple.size(); i++) {

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamValuesRel.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/rel/BeamValuesRel.java
@@ -66,7 +66,7 @@ public class BeamValuesRel extends Values implements BeamRelNode {
       throw new IllegalStateException("Values with empty tuples!");
     }
 
-    BeamSqlRecordType beamSQLRecordType = CalciteUtils.buildRecordType(this.getRowType());
+    BeamSqlRecordType beamSQLRecordType = CalciteUtils.toBeamRecordType(this.getRowType());
     for (ImmutableList<RexLiteral> tuple : tuples) {
       BeamSqlRow row = new BeamSqlRow(beamSQLRecordType);
       for (int i = 0; i < tuple.size(); i++) {

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTable.java
@@ -22,7 +22,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PDone;
-import org.apache.calcite.rel.type.RelProtoDataType;
 
 /**
  * {@code BeamPCollectionTable} converts a {@code PCollection<BeamSqlRow>} as a virtual table,
@@ -32,12 +31,13 @@ public class BeamPCollectionTable extends BaseBeamTable {
   private BeamIOType ioType;
   private PCollection<BeamSqlRow> upstream;
 
-  protected BeamPCollectionTable(RelProtoDataType protoRowType) {
-    super(protoRowType);
+  protected BeamPCollectionTable(BeamSqlRecordType beamSqlRecordType) {
+    super(beamSqlRecordType);
   }
 
-  public BeamPCollectionTable(PCollection<BeamSqlRow> upstream, RelProtoDataType protoRowType){
-    this(protoRowType);
+  public BeamPCollectionTable(PCollection<BeamSqlRow> upstream,
+      BeamSqlRecordType beamSqlRecordType){
+    this(beamSqlRecordType);
     ioType = upstream.isBounded().equals(IsBounded.BOUNDED)
         ? BeamIOType.BOUNDED : BeamIOType.UNBOUNDED;
     this.upstream = upstream;

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRecordType.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRecordType.java
@@ -20,12 +20,6 @@ package org.apache.beam.dsls.sql.schema;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
-import org.apache.calcite.rel.type.RelDataTypeFactory.FieldInfoBuilder;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rel.type.RelProtoDataType;
-import org.apache.calcite.sql.type.SqlTypeName;
 
 /**
  * Field type information in {@link BeamSqlRow}.
@@ -33,39 +27,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
  */
 public class BeamSqlRecordType implements Serializable {
   private List<String> fieldsName = new ArrayList<>();
-  private List<SqlTypeName> fieldsType = new ArrayList<>();
+  private List<Integer> fieldsType = new ArrayList<>();
 
-  /**
-   * Generate from {@link RelDataType} which is used to create table.
-   */
-  public static BeamSqlRecordType from(RelDataType tableInfo) {
-    BeamSqlRecordType record = new BeamSqlRecordType();
-    for (RelDataTypeField f : tableInfo.getFieldList()) {
-      record.fieldsName.add(f.getName());
-      record.fieldsType.add(f.getType().getSqlTypeName());
-    }
-    return record;
-  }
-
-  public void addField(String fieldName, SqlTypeName fieldType) {
+  public void addField(String fieldName, Integer fieldType) {
     fieldsName.add(fieldName);
     fieldsType.add(fieldType);
-  }
-
-  /**
-   * Create an instance of {@link RelDataType} so it can be used to create a table.
-   */
-  public RelProtoDataType toRelDataType() {
-    return new RelProtoDataType() {
-      @Override
-      public RelDataType apply(RelDataTypeFactory a) {
-        FieldInfoBuilder builder = a.builder();
-        for (int idx = 0; idx < fieldsName.size(); ++idx) {
-          builder.add(fieldsName.get(idx), fieldsType.get(idx));
-        }
-        return builder.build();
-      }
-    };
   }
 
   public int size() {
@@ -80,11 +46,11 @@ public class BeamSqlRecordType implements Serializable {
     this.fieldsName = fieldsName;
   }
 
-  public List<SqlTypeName> getFieldsType() {
+  public List<Integer> getFieldsType() {
     return fieldsType;
   }
 
-  public void setFieldsType(List<SqlTypeName> fieldsType) {
+  public void setFieldsType(List<Integer> fieldsType) {
     this.fieldsType = fieldsType;
   }
 

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRow.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRow.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -81,7 +82,7 @@ public class BeamSqlRow implements Serializable {
       }
     }
 
-    SqlTypeName fieldType = dataType.getFieldsType().get(index);
+    SqlTypeName fieldType = CalciteUtils.getFieldType(dataType, index);
     switch (fieldType) {
       case INTEGER:
         if (!(fieldValue instanceof Integer)) {
@@ -201,7 +202,7 @@ public class BeamSqlRow implements Serializable {
     }
 
     Object fieldValue = dataValues.get(fieldIdx);
-    SqlTypeName fieldType = dataType.getFieldsType().get(fieldIdx);
+    SqlTypeName fieldType = CalciteUtils.getFieldType(dataType, fieldIdx);
 
     switch (fieldType) {
       case INTEGER:

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoder.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.coders.BigDecimalCoder;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
@@ -62,7 +64,7 @@ public class BeamSqlRowCoder extends CustomCoder<BeamSqlRow> {
         continue;
       }
 
-      switch (value.getDataType().getFieldsType().get(idx)) {
+      switch (CalciteUtils.getFieldType(value.getDataType(), idx)) {
         case INTEGER:
           intCoder.encode(value.getInteger(idx), outStream);
           break;
@@ -117,7 +119,7 @@ public class BeamSqlRowCoder extends CustomCoder<BeamSqlRow> {
         continue;
       }
 
-      switch (tableSchema.getFieldsType().get(idx)) {
+      switch (CalciteUtils.getFieldType(tableSchema, idx)) {
         case INTEGER:
           record.addField(idx, intCoder.decode(inStream));
           break;

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamSqlTable.java
@@ -15,20 +15,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.beam.dsls.sql.schema;
 
-import java.io.Serializable;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
 
 /**
- * Each IO in Beam has one table schema, by extending {@link BaseBeamTable}.
+ * This interface defines a Beam Sql Table.
  */
-public abstract class BaseBeamTable implements BeamSqlTable, Serializable {
-  protected BeamSqlRecordType beamSqlRecordType;
-  public BaseBeamTable(BeamSqlRecordType beamSqlRecordType) {
-    this.beamSqlRecordType = beamSqlRecordType;
-  }
+public interface BeamSqlTable {
+  /**
+   * In Beam SQL, there's no difference between a batch query and a streaming
+   * query. {@link BeamIOType} is used to validate the sources.
+   */
+  BeamIOType getSourceType();
 
-  @Override public BeamSqlRecordType getRecordType() {
-    return beamSqlRecordType;
-  }
+  /**
+   * create a {@code PCollection<BeamSqlRow>} from source.
+   *
+   */
+  PCollection<BeamSqlRow> buildIOReader(Pipeline pipeline);
+
+  /**
+   * create a {@code IO.write()} instance to write to target.
+   *
+   */
+   PTransform<? super PCollection<BeamSqlRow>, PDone> buildIOWriter();
+
+  /**
+   * Get the schema info of the table.
+   */
+   BeamSqlRecordType getRecordType();
 }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamTableUtils.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/BeamTableUtils.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigDecimal;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.apache.commons.csv.CSVFormat;
@@ -78,7 +79,7 @@ public final class BeamTableUtils {
       return;
     }
 
-    SqlTypeName columnType = row.getDataType().getFieldsType().get(idx);
+    SqlTypeName columnType = CalciteUtils.getFieldType(row.getDataType(), idx);
     // auto-casting for numberics
     if ((rawObj instanceof String && SqlTypeName.NUMERIC_TYPES.contains(columnType))
         || (rawObj instanceof BigDecimal && columnType != SqlTypeName.DECIMAL)) {

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTable.java
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.commons.csv.CSVFormat;
 
 /**
@@ -38,14 +37,14 @@ import org.apache.commons.csv.CSVFormat;
  */
 public class BeamKafkaCSVTable extends BeamKafkaTable {
   private CSVFormat csvFormat;
-  public BeamKafkaCSVTable(RelProtoDataType protoRowType, String bootstrapServers,
+  public BeamKafkaCSVTable(BeamSqlRecordType beamSqlRecordType, String bootstrapServers,
       List<String> topics) {
-    this(protoRowType, bootstrapServers, topics, CSVFormat.DEFAULT);
+    this(beamSqlRecordType, bootstrapServers, topics, CSVFormat.DEFAULT);
   }
 
-  public BeamKafkaCSVTable(RelProtoDataType protoRowType, String bootstrapServers,
+  public BeamKafkaCSVTable(BeamSqlRecordType beamSqlRecordType, String bootstrapServers,
       List<String> topics, CSVFormat format) {
-    super(protoRowType, bootstrapServers, topics);
+    super(beamSqlRecordType, bootstrapServers, topics);
     this.csvFormat = format;
   }
 

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaTable.java
@@ -18,11 +18,14 @@
 package org.apache.beam.dsls.sql.schema.kafka;
 
 import static com.google.common.base.Preconditions.checkArgument;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.beam.dsls.sql.schema.BaseBeamTable;
 import org.apache.beam.dsls.sql.schema.BeamIOType;
+import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
@@ -32,7 +35,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
-import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 
@@ -47,13 +49,13 @@ public abstract class BeamKafkaTable extends BaseBeamTable implements Serializab
   private List<String> topics;
   private Map<String, Object> configUpdates;
 
-  protected BeamKafkaTable(RelProtoDataType protoRowType) {
-    super(protoRowType);
+  protected BeamKafkaTable(BeamSqlRecordType beamSqlRecordType) {
+    super(beamSqlRecordType);
   }
 
-  public BeamKafkaTable(RelProtoDataType protoRowType, String bootstrapServers,
+  public BeamKafkaTable(BeamSqlRecordType beamSqlRecordType, String bootstrapServers,
       List<String> topics) {
-    super(protoRowType);
+    super(beamSqlRecordType);
     this.bootstrapServers = bootstrapServers;
     this.topics = topics;
   }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.dsls.sql.schema.text;
 
+import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
@@ -25,7 +26,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
-import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.commons.csv.CSVFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,13 +46,13 @@ public class BeamTextCSVTable extends BeamTextTable {
   /**
    * CSV table with {@link CSVFormat#DEFAULT DEFAULT} format.
    */
-  public BeamTextCSVTable(RelProtoDataType protoDataType, String filePattern)  {
-    this(protoDataType, filePattern, CSVFormat.DEFAULT);
+  public BeamTextCSVTable(BeamSqlRecordType beamSqlRecordType, String filePattern)  {
+    this(beamSqlRecordType, filePattern, CSVFormat.DEFAULT);
   }
 
-  public BeamTextCSVTable(RelProtoDataType protoDataType, String filePattern,
+  public BeamTextCSVTable(BeamSqlRecordType beamSqlRecordType, String filePattern,
       CSVFormat csvFormat) {
-    super(protoDataType, filePattern);
+    super(beamSqlRecordType, filePattern);
     this.csvFormat = csvFormat;
   }
 

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/text/BeamTextTable.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/schema/text/BeamTextTable.java
@@ -22,19 +22,16 @@ import java.io.Serializable;
 
 import org.apache.beam.dsls.sql.schema.BaseBeamTable;
 import org.apache.beam.dsls.sql.schema.BeamIOType;
-import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 
 /**
  * {@code BeamTextTable} represents a text file/directory(backed by {@code TextIO}).
  */
 public abstract class BeamTextTable extends BaseBeamTable implements Serializable {
   protected String filePattern;
-  protected BeamTextTable(RelProtoDataType protoRowType) {
-    super(protoRowType);
-  }
 
-  protected BeamTextTable(RelProtoDataType protoDataType, String filePattern) {
-    super(protoDataType);
+  protected BeamTextTable(BeamSqlRecordType beamSqlRecordType, String filePattern) {
+    super(beamSqlRecordType);
     this.filePattern = filePattern;
   }
 

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/transform/BeamAggregationTransforms.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/transform/BeamAggregationTransforms.java
@@ -164,7 +164,7 @@ public class BeamAggregationTransforms implements Serializable{
         //verify it's supported.
         verifySupportedAggregation(ac);
 
-        aggDataType.addField(ac.name, CalciteUtils.getJavaSqlType(ac.type.getSqlTypeName()));
+        aggDataType.addField(ac.name, CalciteUtils.toJavaType(ac.type.getSqlTypeName()));
 
         SqlAggFunction aggFn = ac.getAggregation();
         switch (aggFn.getName()) {
@@ -193,7 +193,7 @@ public class BeamAggregationTransforms implements Serializable{
       // add a COUNT holder if only have AVG
       if (hasAvg && !hasCount) {
         aggDataType.addField("__COUNT",
-            CalciteUtils.getJavaSqlType(SqlTypeName.BIGINT));
+            CalciteUtils.toJavaType(SqlTypeName.BIGINT));
 
         aggFunctions.add("COUNT");
         aggElementExpressions.add(BeamSqlPrimitive.<Long>of(SqlTypeName.BIGINT, 1L));

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/CalciteUtils.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/CalciteUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.dsls.sql.utils;
+
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rel.type.RelProtoDataType;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/**
+ * Utility methods for Calcite related operations.
+ */
+public class CalciteUtils {
+  private static final Map<Integer, SqlTypeName> SQL_TYPE_MAPPING = new HashMap<>();
+  private static final Map<SqlTypeName, Integer> INVERSED_SQL_TYPE_MAPPING = new HashMap<>();
+  static {
+    SQL_TYPE_MAPPING.put(Types.TINYINT, SqlTypeName.TINYINT);
+    SQL_TYPE_MAPPING.put(Types.SMALLINT, SqlTypeName.SMALLINT);
+    SQL_TYPE_MAPPING.put(Types.INTEGER, SqlTypeName.INTEGER);
+    SQL_TYPE_MAPPING.put(Types.BIGINT, SqlTypeName.BIGINT);
+
+    SQL_TYPE_MAPPING.put(Types.FLOAT, SqlTypeName.FLOAT);
+    SQL_TYPE_MAPPING.put(Types.DOUBLE, SqlTypeName.DOUBLE);
+
+    SQL_TYPE_MAPPING.put(Types.DECIMAL, SqlTypeName.DECIMAL);
+
+    SQL_TYPE_MAPPING.put(Types.CHAR, SqlTypeName.CHAR);
+    SQL_TYPE_MAPPING.put(Types.VARCHAR, SqlTypeName.VARCHAR);
+
+    SQL_TYPE_MAPPING.put(Types.TIME, SqlTypeName.TIME);
+    SQL_TYPE_MAPPING.put(Types.TIMESTAMP, SqlTypeName.TIMESTAMP);
+
+    for (Map.Entry<Integer, SqlTypeName> pair : SQL_TYPE_MAPPING.entrySet()) {
+      INVERSED_SQL_TYPE_MAPPING.put(pair.getValue(), pair.getKey());
+    }
+  }
+
+  /**
+   * Get the corresponding {@code SqlTypeName} for an integer sql type.
+   */
+  public static SqlTypeName getSqlTypeName(int type) {
+    return SQL_TYPE_MAPPING.get(type);
+  }
+
+  /**
+   * Get the integer sql type from Calcite {@code SqlTypeName}.
+   */
+  public static Integer getJavaSqlType(SqlTypeName typeName) {
+    return INVERSED_SQL_TYPE_MAPPING.get(typeName);
+  }
+
+  /**
+   * Get the {@code SqlTypeName} for the specified column of a table.
+   * @return
+   */
+  public static SqlTypeName getFieldType(BeamSqlRecordType schema, int index) {
+    return getSqlTypeName(schema.getFieldsType().get(index));
+  }
+
+  /**
+   * Generate {@code BeamSqlRecordType} from {@code RelDataType} which is used to create table.
+   */
+  public static BeamSqlRecordType buildRecordType(RelDataType tableInfo) {
+    BeamSqlRecordType record = new BeamSqlRecordType();
+    for (RelDataTypeField f : tableInfo.getFieldList()) {
+      record.getFieldsName().add(f.getName());
+      record.getFieldsType().add(getJavaSqlType(f.getType().getSqlTypeName()));
+    }
+    return record;
+  }
+
+  /**
+   * Create an instance of {@code RelDataType} so it can be used to create a table.
+   */
+  public static RelProtoDataType toRelDataType(final BeamSqlRecordType that) {
+    return new RelProtoDataType() {
+      @Override
+      public RelDataType apply(RelDataTypeFactory a) {
+        RelDataTypeFactory.FieldInfoBuilder builder = a.builder();
+        for (int idx = 0; idx < that.getFieldsName().size(); ++idx) {
+          builder.add(that.getFieldsName().get(idx), getSqlTypeName(that.getFieldsType().get(idx)));
+        }
+        return builder.build();
+      }
+    };
+  }
+}

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/CalciteUtils.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/CalciteUtils.java
@@ -21,7 +21,6 @@ package org.apache.beam.dsls.sql.utils;
 import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -33,42 +32,42 @@ import org.apache.calcite.sql.type.SqlTypeName;
  * Utility methods for Calcite related operations.
  */
 public class CalciteUtils {
-  private static final Map<Integer, SqlTypeName> SQL_TYPE_MAPPING = new HashMap<>();
-  private static final Map<SqlTypeName, Integer> INVERSED_SQL_TYPE_MAPPING = new HashMap<>();
+  private static final Map<Integer, SqlTypeName> JAVA_TO_CALCITE_MAPPING = new HashMap<>();
+  private static final Map<SqlTypeName, Integer> CALCITE_TO_JAVA_MAPPING = new HashMap<>();
   static {
-    SQL_TYPE_MAPPING.put(Types.TINYINT, SqlTypeName.TINYINT);
-    SQL_TYPE_MAPPING.put(Types.SMALLINT, SqlTypeName.SMALLINT);
-    SQL_TYPE_MAPPING.put(Types.INTEGER, SqlTypeName.INTEGER);
-    SQL_TYPE_MAPPING.put(Types.BIGINT, SqlTypeName.BIGINT);
+    JAVA_TO_CALCITE_MAPPING.put(Types.TINYINT, SqlTypeName.TINYINT);
+    JAVA_TO_CALCITE_MAPPING.put(Types.SMALLINT, SqlTypeName.SMALLINT);
+    JAVA_TO_CALCITE_MAPPING.put(Types.INTEGER, SqlTypeName.INTEGER);
+    JAVA_TO_CALCITE_MAPPING.put(Types.BIGINT, SqlTypeName.BIGINT);
 
-    SQL_TYPE_MAPPING.put(Types.FLOAT, SqlTypeName.FLOAT);
-    SQL_TYPE_MAPPING.put(Types.DOUBLE, SqlTypeName.DOUBLE);
+    JAVA_TO_CALCITE_MAPPING.put(Types.FLOAT, SqlTypeName.FLOAT);
+    JAVA_TO_CALCITE_MAPPING.put(Types.DOUBLE, SqlTypeName.DOUBLE);
 
-    SQL_TYPE_MAPPING.put(Types.DECIMAL, SqlTypeName.DECIMAL);
+    JAVA_TO_CALCITE_MAPPING.put(Types.DECIMAL, SqlTypeName.DECIMAL);
 
-    SQL_TYPE_MAPPING.put(Types.CHAR, SqlTypeName.CHAR);
-    SQL_TYPE_MAPPING.put(Types.VARCHAR, SqlTypeName.VARCHAR);
+    JAVA_TO_CALCITE_MAPPING.put(Types.CHAR, SqlTypeName.CHAR);
+    JAVA_TO_CALCITE_MAPPING.put(Types.VARCHAR, SqlTypeName.VARCHAR);
 
-    SQL_TYPE_MAPPING.put(Types.TIME, SqlTypeName.TIME);
-    SQL_TYPE_MAPPING.put(Types.TIMESTAMP, SqlTypeName.TIMESTAMP);
+    JAVA_TO_CALCITE_MAPPING.put(Types.TIME, SqlTypeName.TIME);
+    JAVA_TO_CALCITE_MAPPING.put(Types.TIMESTAMP, SqlTypeName.TIMESTAMP);
 
-    for (Map.Entry<Integer, SqlTypeName> pair : SQL_TYPE_MAPPING.entrySet()) {
-      INVERSED_SQL_TYPE_MAPPING.put(pair.getValue(), pair.getKey());
+    for (Map.Entry<Integer, SqlTypeName> pair : JAVA_TO_CALCITE_MAPPING.entrySet()) {
+      CALCITE_TO_JAVA_MAPPING.put(pair.getValue(), pair.getKey());
     }
   }
 
   /**
    * Get the corresponding {@code SqlTypeName} for an integer sql type.
    */
-  public static SqlTypeName getSqlTypeName(int type) {
-    return SQL_TYPE_MAPPING.get(type);
+  public static SqlTypeName toCalciteType(int type) {
+    return JAVA_TO_CALCITE_MAPPING.get(type);
   }
 
   /**
    * Get the integer sql type from Calcite {@code SqlTypeName}.
    */
-  public static Integer getJavaSqlType(SqlTypeName typeName) {
-    return INVERSED_SQL_TYPE_MAPPING.get(typeName);
+  public static Integer toJavaType(SqlTypeName typeName) {
+    return CALCITE_TO_JAVA_MAPPING.get(typeName);
   }
 
   /**
@@ -76,17 +75,17 @@ public class CalciteUtils {
    * @return
    */
   public static SqlTypeName getFieldType(BeamSqlRecordType schema, int index) {
-    return getSqlTypeName(schema.getFieldsType().get(index));
+    return toCalciteType(schema.getFieldsType().get(index));
   }
 
   /**
    * Generate {@code BeamSqlRecordType} from {@code RelDataType} which is used to create table.
    */
-  public static BeamSqlRecordType buildRecordType(RelDataType tableInfo) {
+  public static BeamSqlRecordType toBeamRecordType(RelDataType tableInfo) {
     BeamSqlRecordType record = new BeamSqlRecordType();
     for (RelDataTypeField f : tableInfo.getFieldList()) {
       record.getFieldsName().add(f.getName());
-      record.getFieldsType().add(getJavaSqlType(f.getType().getSqlTypeName()));
+      record.getFieldsType().add(toJavaType(f.getType().getSqlTypeName()));
     }
     return record;
   }
@@ -94,13 +93,13 @@ public class CalciteUtils {
   /**
    * Create an instance of {@code RelDataType} so it can be used to create a table.
    */
-  public static RelProtoDataType toRelDataType(final BeamSqlRecordType that) {
+  public static RelProtoDataType toCalciteRecordType(final BeamSqlRecordType that) {
     return new RelProtoDataType() {
       @Override
       public RelDataType apply(RelDataTypeFactory a) {
         RelDataTypeFactory.FieldInfoBuilder builder = a.builder();
         for (int idx = 0; idx < that.getFieldsName().size(); ++idx) {
-          builder.add(that.getFieldsName().get(idx), getSqlTypeName(that.getFieldsType().get(idx)));
+          builder.add(that.getFieldsName().get(idx), toCalciteType(that.getFieldsType().get(idx)));
         }
         return builder.build();
       }

--- a/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/package-info.java
+++ b/dsls/sql/src/main/java/org/apache/beam/dsls/sql/utils/package-info.java
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
- * define table schema, to map with Beam IO components.
- *
+ * Utility classes.
  */
-package org.apache.beam.dsls.sql.schema;
+package org.apache.beam.dsls.sql.utils;

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlApiSurfaceTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlApiSurfaceTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.dsls.sql;
+
+import static org.apache.beam.sdk.util.ApiSurface.containsOnlyPackages;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.apache.beam.sdk.util.ApiSurface;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Surface test for BeamSql api.
+ */
+@RunWith(JUnit4.class)
+public class BeamSqlApiSurfaceTest {
+  @Test
+  public void testSdkApiSurface() throws Exception {
+
+    @SuppressWarnings("unchecked")
+    final Set<String> allowed =
+        ImmutableSet.of(
+            "org.apache.beam",
+            "org.joda.time",
+            "org.apache.commons.csv");
+
+    ApiSurface surface = ApiSurface
+        .ofClass(BeamSqlCli.class)
+        .includingClass(BeamSql.class)
+        .includingClass(BeamSqlEnv.class)
+        .includingPackage("org.apache.beam.dsls.sql.schema",
+            getClass().getClassLoader())
+        .pruningPrefix("java")
+        .pruningPattern("org[.]apache[.]beam[.]dsls[.]sql[.].*Test")
+        .pruningPattern("org[.]apache[.]beam[.]dsls[.]sql[.].*TestBase");
+
+    assertThat(surface, containsOnlyPackages(allowed));
+  }
+
+}

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/interpreter/BeamSqlFnExecutorTestBase.java
@@ -25,6 +25,7 @@ import org.apache.beam.dsls.sql.planner.BeamRelDataTypeSystem;
 import org.apache.beam.dsls.sql.planner.BeamRuleSets;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
@@ -69,7 +70,7 @@ public class BeamSqlFnExecutorTestBase {
         .add("price", SqlTypeName.DOUBLE)
         .add("order_time", SqlTypeName.BIGINT).build();
 
-    beamRecordType = BeamSqlRecordType.from(relDataType);
+    beamRecordType = CalciteUtils.buildRecordType(relDataType);
     record = new BeamSqlRow(beamRecordType);
 
     record.addField(0, 1234567L);

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/interpreter/BeamSqlFnExecutorTestBase.java
@@ -70,7 +70,7 @@ public class BeamSqlFnExecutorTestBase {
         .add("price", SqlTypeName.DOUBLE)
         .add("order_time", SqlTypeName.BIGINT).build();
 
-    beamRecordType = CalciteUtils.buildRecordType(relDataType);
+    beamRecordType = CalciteUtils.toBeamRecordType(relDataType);
     record = new BeamSqlRow(beamRecordType);
 
     record.addField(0, 1234567L);

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BasePlanner.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BasePlanner.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.dsls.sql.planner;
 
-import static org.apache.beam.dsls.sql.BeamSqlCli.registerTable;
+import static org.apache.beam.dsls.sql.BeamSqlEnv.registerTable;
 
 import java.util.Arrays;
 import java.util.Date;

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BasePlanner.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BasePlanner.java
@@ -58,7 +58,7 @@ public class BasePlanner {
     };
 
     BeamSqlRecordType dataType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
     BeamSqlRow row1 = new BeamSqlRow(dataType);
     row1.addField(0, 12345L);
     row1.addField(1, 0);
@@ -97,7 +97,7 @@ public class BasePlanner {
     };
 
     BeamSqlRecordType dataType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
 
     Map<String, Object> consumerPara = new HashMap<String, Object>();
     consumerPara.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BeamPlannerAggregationSubmitTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BeamPlannerAggregationSubmitTest.java
@@ -27,6 +27,7 @@ import org.apache.beam.dsls.sql.BeamSqlEnv;
 import org.apache.beam.dsls.sql.schema.BaseBeamTable;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -69,8 +70,8 @@ public class BeamPlannerAggregationSubmitTest {
       }
     };
 
-    BeamSqlRecordType dataType = BeamSqlRecordType.from(
-        protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+    BeamSqlRecordType dataType = CalciteUtils
+        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
     BeamSqlRow row1 = new BeamSqlRow(dataType);
     row1.addField(0, 12345L);
     row1.addField(1, 1);
@@ -91,7 +92,7 @@ public class BeamPlannerAggregationSubmitTest {
     row4.addField(1, 0);
     row4.addField(2, format.parse("2017-01-01 03:04:05"));
 
-    return new MockedBeamSqlTable(protoRowType).withInputRecords(
+    return new MockedBeamSqlTable(dataType).withInputRecords(
         Arrays.asList(row1
             , row2, row3, row4
             ));
@@ -108,7 +109,10 @@ public class BeamPlannerAggregationSubmitTest {
             .add("size", SqlTypeName.BIGINT).build();
       }
     };
-    return new MockedBeamSqlTable(protoRowType);
+    BeamSqlRecordType dataType = CalciteUtils
+        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+
+    return new MockedBeamSqlTable(dataType);
   }
 
 

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BeamPlannerAggregationSubmitTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/BeamPlannerAggregationSubmitTest.java
@@ -71,7 +71,7 @@ public class BeamPlannerAggregationSubmitTest {
     };
 
     BeamSqlRecordType dataType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
     BeamSqlRow row1 = new BeamSqlRow(dataType);
     row1.addField(0, 12345L);
     row1.addField(1, 1);
@@ -110,7 +110,7 @@ public class BeamPlannerAggregationSubmitTest {
       }
     };
     BeamSqlRecordType dataType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
 
     return new MockedBeamSqlTable(dataType);
   }

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/MockedBeamSqlTable.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/MockedBeamSqlTable.java
@@ -26,6 +26,7 @@ import org.apache.beam.dsls.sql.schema.BaseBeamTable;
 import org.apache.beam.dsls.sql.schema.BeamIOType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -49,8 +50,8 @@ public class MockedBeamSqlTable extends BaseBeamTable {
 
   private List<BeamSqlRow> inputRecords;
 
-  public MockedBeamSqlTable(RelProtoDataType protoRowType) {
-    super(protoRowType);
+  public MockedBeamSqlTable(BeamSqlRecordType beamSqlRecordType) {
+    super(beamSqlRecordType);
   }
 
   public MockedBeamSqlTable withInputRecords(List<BeamSqlRow> inputRecords){
@@ -102,8 +103,8 @@ public class MockedBeamSqlTable extends BaseBeamTable {
     };
 
     List<BeamSqlRow> rows = new ArrayList<>();
-    BeamSqlRecordType beamSQLRecordType = BeamSqlRecordType.from(
-        protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+    BeamSqlRecordType beamSQLRecordType = CalciteUtils
+        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
     int fieldCount = beamSQLRecordType.size();
 
     for (int i = fieldCount * 2; i < args.length; i += fieldCount) {
@@ -113,7 +114,7 @@ public class MockedBeamSqlTable extends BaseBeamTable {
       }
       rows.add(row);
     }
-    return new MockedBeamSqlTable(protoRowType).withInputRecords(rows);
+    return new MockedBeamSqlTable(beamSQLRecordType).withInputRecords(rows);
   }
 
   @Override

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/MockedBeamSqlTable.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/planner/MockedBeamSqlTable.java
@@ -104,7 +104,7 @@ public class MockedBeamSqlTable extends BaseBeamTable {
 
     List<BeamSqlRow> rows = new ArrayList<>();
     BeamSqlRecordType beamSQLRecordType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
     int fieldCount = beamSQLRecordType.size();
 
     for (int i = fieldCount * 2; i < args.length; i += fieldCount) {

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTableTest.java
@@ -21,6 +21,7 @@ import org.apache.beam.dsls.sql.BeamSqlCli;
 import org.apache.beam.dsls.sql.BeamSqlEnv;
 import org.apache.beam.dsls.sql.planner.BasePlanner;
 import org.apache.beam.dsls.sql.planner.BeamQueryPlanner;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PBegin;
@@ -49,14 +50,16 @@ public class BeamPCollectionTableTest extends BasePlanner{
             .add("c2", SqlTypeName.VARCHAR).build();
       }
     };
+    BeamSqlRecordType dataType = CalciteUtils
+        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
 
-    BeamSqlRow row = new BeamSqlRow(BeamSqlRecordType.from(
+    BeamSqlRow row = new BeamSqlRow(CalciteUtils.buildRecordType(
         protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY)));
     row.addField(0, 1);
     row.addField(1, "hello world.");
     PCollection<BeamSqlRow> inputStream = PBegin.in(pipeline).apply(Create.of(row));
     BeamSqlEnv.registerTable("COLLECTION_TABLE",
-        new BeamPCollectionTable(inputStream, protoRowType));
+        new BeamPCollectionTable(inputStream, dataType));
   }
 
   @Test

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamPCollectionTableTest.java
@@ -51,9 +51,9 @@ public class BeamPCollectionTableTest extends BasePlanner{
       }
     };
     BeamSqlRecordType dataType = CalciteUtils
-        .buildRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
+        .toBeamRecordType(protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY));
 
-    BeamSqlRow row = new BeamSqlRow(CalciteUtils.buildRecordType(
+    BeamSqlRow row = new BeamSqlRow(CalciteUtils.toBeamRecordType(
         protoRowType.apply(BeamQueryPlanner.TYPE_FACTORY)));
     row.addField(0, 1);
     row.addField(1, "hello world.");

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
@@ -56,7 +57,7 @@ public class BeamSqlRowCoderTest {
       }
     };
 
-    BeamSqlRecordType beamSQLRecordType = BeamSqlRecordType.from(
+    BeamSqlRecordType beamSQLRecordType = CalciteUtils.buildRecordType(
         protoRowType.apply(new JavaTypeFactoryImpl(
         RelDataTypeSystem.DEFAULT)));
     BeamSqlRow row = new BeamSqlRow(beamSQLRecordType);

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/BeamSqlRowCoderTest.java
@@ -57,7 +57,7 @@ public class BeamSqlRowCoderTest {
       }
     };
 
-    BeamSqlRecordType beamSQLRecordType = CalciteUtils.buildRecordType(
+    BeamSqlRecordType beamSQLRecordType = CalciteUtils.toBeamRecordType(
         protoRowType.apply(new JavaTypeFactoryImpl(
         RelDataTypeSystem.DEFAULT)));
     BeamSqlRow row = new BeamSqlRow(beamSQLRecordType);

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTableTest.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import org.apache.beam.dsls.sql.planner.BeamQueryPlanner;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -91,16 +92,14 @@ public class BeamKafkaCSVTableTest {
   }
 
   private static BeamSqlRecordType genRowType() {
-    return BeamSqlRecordType.from(
-        new RelProtoDataType() {
-          @Override public RelDataType apply(RelDataTypeFactory a0) {
-            return a0.builder()
-                .add("order_id", SqlTypeName.BIGINT)
-                .add("site_id", SqlTypeName.INTEGER)
-                .add("price", SqlTypeName.DOUBLE)
-                .build();
-          }
-        }.apply(BeamQueryPlanner.TYPE_FACTORY));
+    return CalciteUtils.buildRecordType(new RelProtoDataType() {
+
+      @Override public RelDataType apply(RelDataTypeFactory a0) {
+        return a0.builder().add("order_id", SqlTypeName.BIGINT)
+            .add("site_id", SqlTypeName.INTEGER)
+            .add("price", SqlTypeName.DOUBLE).build();
+      }
+    }.apply(BeamQueryPlanner.TYPE_FACTORY));
   }
 
   private static class String2KvBytes extends DoFn<String, KV<byte[], byte[]>>

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/kafka/BeamKafkaCSVTableTest.java
@@ -92,7 +92,7 @@ public class BeamKafkaCSVTableTest {
   }
 
   private static BeamSqlRecordType genRowType() {
-    return CalciteUtils.buildRecordType(new RelProtoDataType() {
+    return CalciteUtils.toBeamRecordType(new RelProtoDataType() {
 
       @Override public RelDataType apply(RelDataTypeFactory a0) {
         return a0.builder().add("order_id", SqlTypeName.BIGINT)

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTableTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import org.apache.beam.dsls.sql.planner.BeamQueryPlanner;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.PCollection;
@@ -80,19 +81,20 @@ public class BeamTextCSVTableTest {
   private static File writerTargetFile;
 
   @Test public void testBuildIOReader() {
-    PCollection<BeamSqlRow> rows = new BeamTextCSVTable(buildRowType(),
+    PCollection<BeamSqlRow> rows = new BeamTextCSVTable(buildBeamSqlRecordType(),
         readerSourceFile.getAbsolutePath()).buildIOReader(pipeline);
     PAssert.that(rows).containsInAnyOrder(testDataRows);
     pipeline.run();
   }
 
   @Test public void testBuildIOWriter() {
-    new BeamTextCSVTable(buildRowType(), readerSourceFile.getAbsolutePath()).buildIOReader(pipeline)
-        .apply(new BeamTextCSVTable(buildRowType(), writerTargetFile.getAbsolutePath())
+    new BeamTextCSVTable(buildBeamSqlRecordType(),
+        readerSourceFile.getAbsolutePath()).buildIOReader(pipeline)
+        .apply(new BeamTextCSVTable(buildBeamSqlRecordType(), writerTargetFile.getAbsolutePath())
             .buildIOWriter());
     pipeline.run();
 
-    PCollection<BeamSqlRow> rows = new BeamTextCSVTable(buildRowType(),
+    PCollection<BeamSqlRow> rows = new BeamTextCSVTable(buildBeamSqlRecordType(),
         writerTargetFile.getAbsolutePath()).buildIOReader(pipeline2);
 
     // confirm the two reads match
@@ -166,7 +168,7 @@ public class BeamTextCSVTableTest {
   }
 
   private static BeamSqlRecordType buildBeamSqlRecordType() {
-    return BeamSqlRecordType.from(buildRelDataType());
+    return CalciteUtils.buildRecordType(buildRelDataType());
   }
 
   private static BeamSqlRow buildRow(Object[] data) {

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTableTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/text/BeamTextCSVTableTest.java
@@ -168,7 +168,7 @@ public class BeamTextCSVTableTest {
   }
 
   private static BeamSqlRecordType buildBeamSqlRecordType() {
-    return CalciteUtils.buildRecordType(buildRelDataType());
+    return CalciteUtils.toBeamRecordType(buildRelDataType());
   }
 
   private static BeamSqlRow buildRow(Object[] data) {

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamAggregationTransformTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamAggregationTransformTest.java
@@ -21,11 +21,13 @@ import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import org.apache.beam.dsls.sql.planner.BeamQueryPlanner;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
 import org.apache.beam.dsls.sql.schema.BeamSqlRowCoder;
 import org.apache.beam.dsls.sql.transform.BeamAggregationTransforms;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.testing.PAssert;
@@ -431,7 +433,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest{
     for (KV<String, SqlTypeName> cm : columnMetadata) {
       builder.add(cm.getKey(), cm.getValue());
     }
-    return BeamSqlRecordType.from(builder.build());
+    return CalciteUtils.buildRecordType(builder.build());
   }
 
   /**

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamAggregationTransformTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamAggregationTransformTest.java
@@ -433,7 +433,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest{
     for (KV<String, SqlTypeName> cm : columnMetadata) {
       builder.add(cm.getKey(), cm.getValue());
     }
-    return CalciteUtils.buildRecordType(builder.build());
+    return CalciteUtils.toBeamRecordType(builder.build());
   }
 
   /**

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamTransformBaseTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamTransformBaseTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.beam.dsls.sql.planner.BeamQueryPlanner;
 import org.apache.beam.dsls.sql.schema.BeamSqlRecordType;
 import org.apache.beam.dsls.sql.schema.BeamSqlRow;
+import org.apache.beam.dsls.sql.utils.CalciteUtils;
 import org.apache.beam.sdk.values.KV;
 import org.apache.calcite.rel.type.RelDataTypeFactory.FieldInfoBuilder;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -72,7 +73,7 @@ public class BeamTransformBaseTest {
     for (KV<String, SqlTypeName> cm : columnMetadata) {
       builder.add(cm.getKey(), cm.getValue());
     }
-    return BeamSqlRecordType.from(builder.build());
+    return CalciteUtils.buildRecordType(builder.build());
   }
 
   /**

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamTransformBaseTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/schema/transform/BeamTransformBaseTest.java
@@ -73,7 +73,7 @@ public class BeamTransformBaseTest {
     for (KV<String, SqlTypeName> cm : columnMetadata) {
       builder.add(cm.getKey(), cm.getValue());
     }
-    return CalciteUtils.buildRecordType(builder.build());
+    return CalciteUtils.toBeamRecordType(builder.build());
   }
 
   /**


### PR DESCRIPTION
Summary:

* The surface api of BeamSql includes the following:
  * BeamSql
  * BeamSqlCli
  * BeamSqlEnv
  * All the classes in package `org.apache.beam.dsls.sql.schema`
* Calcite related methods are encapsulated into `CalciteUtils`(which is not part of surface api) to avoid exposure.
* Created a new `BeamSqlTable` interface which abstracts the beam `table` concept.
* `RelDataType`, `RelProtoDataType` are all removed from surface api, `BeamSqlRecordType` is the only class which represents the schema of a table.
  * java.sql.Types is used to represent sql type instead of Calcite `SqlTypeName`.
