### PR TITLE
Add a cloud-pubsub dependency to the list of gcp extra packages

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -118,6 +118,7 @@ GCP_REQUIREMENTS = [
   'google-apitools>=0.5.10,<=0.5.11',
   'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4',
   'googledatastore==7.0.1',
+  'google-cloud-pubsub==0.25.0',
   # GCP packages required by tests
   'google-cloud-bigquery>=0.23.0,<0.25.0',
 ]


### PR DESCRIPTION
R: @charlesccychen 
cc: @tvalentyn 

There is an additional change to `streaming_wordcount.py` to move an import inside a function. This is required to run on DataflowRunner because --save_main_session flag is not supported in streaming mode.