### PR TITLE
[BEAM-2745] Add Jenkins Suite for Python Performance Test

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -264,8 +264,10 @@ class common_job_properties {
         shell('rm -rf PerfKitBenchmarker')
         // Clone appropriate perfkit branch
         shell('git clone https://github.com/GoogleCloudPlatform/PerfKitBenchmarker.git')
-        // Install job requirements.
+        // Install Perfkit benchmark requirements.
         shell('pip install --user -r PerfKitBenchmarker/requirements.txt')
+        // Install job requirements for Python SDK.
+        shell('pip install --user -e sdks/python/[gcp,test]')
         // Launch performance test.
         shell("python PerfKitBenchmarker/pkb.py $pkbArgs")
     }

--- a/.test-infra/jenkins/job_beam_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_Python.groovy
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common_job_properties
+
+// This job runs the Beam Python performance tests on PerfKit Benchmarker.
+job('beam_PerformanceTests_Python'){
+  // Set default Beam job properties.
+  common_job_properties.setTopLevelMainJobProperties(delegate)
+
+  // Run job in postcommit every 6 hours, don't trigger every push.
+  common_job_properties.setPostCommit(
+      delegate,
+      '0 */6 * * *',
+      false,
+      'commits@beam.apache.org')
+
+  // Allows triggering this build against pull requests.
+  common_job_properties.enablePhraseTriggeringFromPullRequest(
+      delegate,
+      'Python SDK Performance Test',
+      'Run Python Performance Test')
+
+  def pipelineArgs = [
+      project: 'apache-beam-testing',
+      staging_location: 'gs://temp-storage-for-end-to-end-tests/staging-it',
+      temp_location: 'gs://temp-storage-for-end-to-end-tests/temp-it',
+      output: 'gs://temp-storage-for-end-to-end-tests/py-it-cloud/output'
+  ]
+  def pipelineArgList = []
+  pipelineArgs.each({
+    key, value -> pipelineArgList.add("--$key=$value")
+  })
+  def pipelineArgsJoined = pipelineArgList.join(',')
+
+  def argMap = [
+      beam_sdk : 'python',
+      benchmarks: 'beam_integration_benchmark',
+      beam_it_args: pipelineArgsJoined
+  ]
+
+  common_job_properties.buildPerformanceTest(delegate, argMap)
+}


### PR DESCRIPTION
Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [x] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [ ] Make sure tests pass via `mvn clean verify`.
 - [x] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [ ] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Create a new Jenkins suite that runs beam integration benchmark using Python SDK and it's scheduled in every 6 hours. As default, `word_count_it` test is used to run with a small set of input. 

[Here](https://builds.apache.org/job/beam_PerformanceTests_Python/) is the Jenkins suite link.