### PR TITLE
[BEAM-2503] use static table name in BeamSql.simpleQuery

### DIFF
--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslAggregationTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslAggregationTest.java
@@ -37,7 +37,7 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
    */
   @Test
   public void testAggregationWithoutWindow() throws Exception {
-    String sql = "SELECT f_int2, COUNT(*) AS `size` FROM TABLE_A GROUP BY f_int2";
+    String sql = "SELECT f_int2, COUNT(*) AS `size` FROM PCOLLECTION GROUP BY f_int2";
 
     PCollection<BeamSqlRow> result =
         inputA1.apply("testAggregationWithoutWindow", BeamSql.simpleQuery(sql));
@@ -125,7 +125,7 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
    */
   @Test
   public void testDistinct() throws Exception {
-    String sql = "SELECT distinct f_int, f_long FROM TABLE_A ";
+    String sql = "SELECT distinct f_int, f_long FROM PCOLLECTION ";
 
     PCollection<BeamSqlRow> result =
         inputA1.apply("testDistinct", BeamSql.simpleQuery(sql));
@@ -190,7 +190,7 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
    */
   @Test
   public void testHopWindow() throws Exception {
-    String sql = "SELECT f_int2, COUNT(*) AS `size` FROM TABLE_A "
+    String sql = "SELECT f_int2, COUNT(*) AS `size` FROM PCOLLECTION "
         + "GROUP BY f_int2, HOP(f_timestamp, INTERVAL '1' HOUR, INTERVAL '30' MINUTE)";
     PCollection<BeamSqlRow> result =
         inputA1.apply("testHopWindow", BeamSql.simpleQuery(sql));

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslFilterTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslFilterTest.java
@@ -33,7 +33,7 @@ public class BeamSqlDslFilterTest extends BeamSqlDslBase {
    */
   @Test
   public void testSingleFilter() throws Exception {
-    String sql = "SELECT * FROM TABLE_A WHERE f_int = 1";
+    String sql = "SELECT * FROM PCOLLECTION WHERE f_int = 1";
 
     PCollection<BeamSqlRow> result =
         inputA1.apply("testSingleFilter", BeamSql.simpleQuery(sql));

--- a/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslProjectTest.java
+++ b/dsls/sql/src/test/java/org/apache/beam/dsls/sql/BeamSqlDslProjectTest.java
@@ -36,7 +36,7 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
    */
   @Test
   public void testSelectAll() throws Exception {
-    String sql = "SELECT * FROM TABLE_A";
+    String sql = "SELECT * FROM PCOLLECTION";
 
     PCollection<BeamSqlRow> result =
         inputA2.apply("testSelectAll", BeamSql.simpleQuery(sql));


### PR DESCRIPTION
R: @takidau 
As discussed in #3372, here's the part to use fixed table name `PCOLLECTION` in `BeamSql.simpleQuery`.
