### PR TITLE
More robust Counter name parsing

### DIFF
--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -243,7 +243,10 @@ public class DataflowMetricsTest {
         makeCounterMetricUpdate("otherCounter", "otherNamespace", "s3", 12L, false),
         makeCounterMetricUpdate("otherCounter", "otherNamespace", "s3", 12L, true),
         makeCounterMetricUpdate("counterName", "otherNamespace", "s4", 1200L, false),
-        makeCounterMetricUpdate("counterName", "otherNamespace", "s4", 1233L, true)));
+        makeCounterMetricUpdate("counterName", "otherNamespace", "s4", 1233L, true),
+        // The following counter can not have its name translated thus it won't appear.
+        makeCounterMetricUpdate("lostName", "otherNamespace", "s5", 1200L, false),
+        makeCounterMetricUpdate("lostName", "otherNamespace", "s5", 1200L, true)));
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
     MetricQueryResults result = dataflowMetrics.queryMetrics(null);


### PR DESCRIPTION
Dataflow users have reported problems with the queryMetrics call. These occur when the worker reports metrics counters with system_name on their step, instead of original name, and thus the internal name to user name translation fails.

e.g. a counter with step name "s2-c17" can not be translated using the `transformStepNames` property of the dataflow job.

The stacktrace is:
Stacktrace:
Exception in thread "main" java.lang.NullPointerException
  at org.apache.beam.runners.dataflow.DataflowMetrics.metricHashKey(DataflowMetrics.java:84)
  at org.apache.beam.runners.dataflow.DataflowMetrics.populateMetricQueryResults(DataflowMetrics.java:124)
  at org.apache.beam.runners.dataflow.DataflowMetrics.queryServiceForMetrics(DataflowMetrics.java:188)
  at org.apache.beam.runners.dataflow.DataflowMetrics.queryMetrics(DataflowMetrics.java:201)