### PR TITLE
[BEAM-2140] Execute Splittable DoFn directly in Flink Runner

### DIFF
--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -92,8 +92,7 @@
                     org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders,
                     org.apache.beam.sdk.testing.LargeKeys$Above100MB,
                     org.apache.beam.sdk.testing.UsesCommittedMetrics,
-                    org.apache.beam.sdk.testing.UsesTestStream,
-                    org.apache.beam.sdk.testing.UsesSplittableParDo
+                    org.apache.beam.sdk.testing.UsesTestStream
                   </excludedGroups>
                   <parallel>none</parallel>
                   <failIfNoTests>true</failIfNoTests>

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -564,7 +564,8 @@ class FlinkStreamingTransformTranslators {
                     Coder keyCoder,
                     Map<Integer, PCollectionView<?>> transformedSideInputs) {
               return new SplittableDoFnOperator<>(
-                  doFn,
+                  (SplittableParDoViaKeyedWorkItems.ProcessFn<
+                      InputT, OutputT, RestrictionT, TrackerT>) doFn,
                   stepName,
                   inputCoder,
                   mainOutputTag,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -145,7 +145,7 @@ public class DoFnOperator<InputT, OutputT>
 
   private final Coder<?> keyCoder;
 
-  private final TimerInternals.TimerDataCoder timerCoder;
+  protected final TimerInternals.TimerDataCoder timerCoder;
 
   protected transient HeapInternalTimerService<?, TimerInternals.TimerData> timerService;
 
@@ -329,6 +329,9 @@ public class DoFnOperator<InputT, OutputT>
       }
     }
     doFnInvoker.invokeTeardown();
+
+    // signal to downstream that there won't be any more data in the future
+    output.emitWatermark(new Watermark(BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()));
   }
 
   protected final long getPushbackWatermarkHold() {
@@ -362,7 +365,7 @@ public class DoFnOperator<InputT, OutputT>
   }
 
   @Override
-  public final void processElement(
+  public void processElement(
       StreamRecord<WindowedValue<InputT>> streamRecord) throws Exception {
     doFnRunner.startBundle();
     doFnRunner.processElement(streamRecord.getValue());


### PR DESCRIPTION
Before, we were using ProcessFn. This was causing problems with the
Flink Runner for two reasons:

1. StatefulDoFnRunner is in the processing path, which means
processing-time timers are being dropped when the watermark reaches +Inf

2. When a pipeline shuts down (for example, when bounded sources shut
down) Flink will drop any outstanding processing-time timers, meaning
that that any remaining Restrictions will not be processed.

The fix for 1. is to execute the splittable DoFn directly, thereby
bypassing the late data/timer dropping logic.

The fix for 2. builds on the fix for 1. and also introduces a "last
resort" even-time timer that fires at +Inf and makes sure that any
remaining restrictions are being exhausted.

R: @jkff Not sure if we wan't to fix it like this or maybe adapt `ProcessFn` and remove `StatefulDoFnRunner` from the processing path.
