### PR TITLE
[BEAM-2551] KafkaIO reader blocks indefinitely in case of network issues

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -986,7 +986,7 @@ public class KafkaIO {
           TopicPartition partition = new TopicPartition(ckptMark.getTopic(),
                                                         ckptMark.getPartition());
           checkState(partition.equals(assigned),
-                "checkpointed partition %s and assigned partition %s don't match",
+                     "checkpointed partition %s and assigned partition %s don't match",
                      partition, assigned);
 
           partitionStates.get(i).nextOffset = ckptMark.getNextOffset();

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1090,7 +1090,7 @@ public class KafkaIO {
 
       // Seek to start offset for each partition. This is the first interaction with the server.
       // Unfortunately it can block forever in case of network issues like incorrect ACLs.
-      // Initialize partition in a separate thread and cancel it if takes longer than minute.
+      // Initialize partition in a separate thread and cancel it if takes longer than a minute.
       for (final PartitionState p : partitionStates) {
         Future<?> future =  consumerPollThread.submit(new Runnable() {
           public void run() {

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -83,6 +83,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -367,7 +368,7 @@ public class KafkaIOTest {
   public void testUnreachableKafkaBrokers() {
     // Expect an exception when the Kafka brokers are not reachable on the workers.
     // We specify partitions explicitly so that splitting does not involve server interaction.
-    // Set intialization timeout to 10ms so that test does not take long.
+    // Set request timeout to 10ms so that test does not take long.
 
     thrown.expect(Exception.class);
     thrown.expectMessage("Timeout while initializing partition");
@@ -381,7 +382,10 @@ public class KafkaIOTest {
             .withKeyDeserializer(IntegerDeserializer.class)
             .withValueDeserializer(LongDeserializer.class)
             .updateConsumerProperties(ImmutableMap.<String, Object>of(
-                KafkaIO.PARTITION_INITIALIZATION_TIMEOUT_MS_CONFIG, 10L))
+                ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10,
+                ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 5,
+                ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 8,
+                ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 8))
             .withMaxNumRecords(10)
             .withoutMetadata())
         .apply(Values.<Long>create());

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -371,8 +371,7 @@ public class KafkaIOTest {
     // Set request timeout to 10ms so that test does not take long.
 
     thrown.expect(Exception.class);
-    thrown.expectMessage("Timeout while initializing partition");
-    thrown.expectMessage("Check network connectivity");
+    thrown.expectMessage("Reader-0: Timeout while initializing partition 'test-0'");
 
     int numElements = 1000;
     PCollection<Long> input = p


### PR DESCRIPTION
If the KafaIO source reader on the worker can't reach the server, Kafka consumer blocks forever inside UnboundedReader.start(). Users have no indication of the error. It is better if start() fails with an error.

It is easy to reproduce with Kafka command line. I reported it on Kafka users list here : https://lists.apache.org/thread.html/98cebefacbd65b0d6c6817fe0b5197e26bc60252e72d05fced91e628@%3Cusers.kafka.apache.org%3E

It blocks inside Kafka client. Fortunately it can be unblocked with KafkaConsumer.wakeup(). This PR initializes partition on a separate thread and cancels it if it does not complete in one minute. Added a unit test.