### PR TITLE
Improving labeling of side inputs for Dataflow

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -500,8 +500,15 @@ class DataflowRunner(PipelineRunner):
     lookup_label = lambda side_pval: si_labels[side_pval]
     for side_pval in transform_node.side_inputs:
       assert isinstance(side_pval, AsSideInput)
-      si_label = 'SideInput-' + self._get_unique_step_name()
-      si_full_label = '%s/%s' % (transform_node.full_label, si_label)
+      step_number = self._get_unique_step_name()
+      si_label = 'SideInput-' + step_number
+      pcollection_label = '%s.%s' % (
+          side_pval.pvalue.producer.full_label.split('/')[-1],
+          side_pval.pvalue.tag if side_pval.pvalue.tag else 'out')
+      si_full_label = '%s/%s(%s)' % (transform_node.full_label,
+                                     side_pval.__class__.__name__,
+                                     pcollection_label)
+
       self._add_singleton_step(
           si_label, si_full_label, side_pval.pvalue.tag,
           self._cache.get_pvalue(side_pval.pvalue))

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -498,7 +498,7 @@ class DataflowRunner(PipelineRunner):
     si_dict = {}
     # We must call self._cache.get_pvalue exactly once due to refcounting.
     si_labels = {}
-    full_label_counts = defaultdict(lambda : 0)
+    full_label_counts = defaultdict(lambda: 0)
     lookup_label = lambda side_pval: si_labels[side_pval]
     for side_pval in transform_node.side_inputs:
       assert isinstance(side_pval, AsSideInput)

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -21,6 +21,7 @@ The runner will create a JSON description of the job graph and then submit it
 to the Dataflow Service for remote execution by a worker.
 """
 
+from collections import defaultdict
 import logging
 import threading
 import time
@@ -497,6 +498,7 @@ class DataflowRunner(PipelineRunner):
     si_dict = {}
     # We must call self._cache.get_pvalue exactly once due to refcounting.
     si_labels = {}
+    full_label_counts = defaultdict(lambda : 0)
     lookup_label = lambda side_pval: si_labels[side_pval]
     for side_pval in transform_node.side_inputs:
       assert isinstance(side_pval, AsSideInput)
@@ -505,9 +507,14 @@ class DataflowRunner(PipelineRunner):
       pcollection_label = '%s.%s' % (
           side_pval.pvalue.producer.full_label.split('/')[-1],
           side_pval.pvalue.tag if side_pval.pvalue.tag else 'out')
-      si_full_label = '%s/%s(%s)' % (transform_node.full_label,
-                                     side_pval.__class__.__name__,
-                                     pcollection_label)
+      si_full_label = '%s/%s(%s.%s)' % (transform_node.full_label,
+                                        side_pval.__class__.__name__,
+                                        pcollection_label,
+                                        full_label_counts[pcollection_label])
+
+      # Count the number of times the same PCollection is a side input
+      # to the same ParDo.
+      full_label_counts[pcollection_label] += 1
 
       self._add_singleton_step(
           si_label, si_full_label, side_pval.pvalue.tag,


### PR DESCRIPTION
Side inputs in Python show the internal step name on their user-visible label. This is not useful, and in fact undesirable as it also hides what kind of side input the pcollection is.
This PR improves the labeling of side inputs by showing the side input kind and pcollection in the label.

r: @robertwb 
I have three questions regarding this change:
* A side input that is passed twice to the same ParDo may have problems here. But this may be a scenario that we want to discourage anyway. What do you think?
* I feel that the `'/Do' ` relabeling of the ParDo in line 525 could also be reconsidered to something more intuitive for the users (we've had bugs filed because users can't figure out which step owns their counters).
* Also, the `side_pval.pvalue.producer.full_label.split('/')[-1]` operation I'm adding in line 507 seems a bit sketchy, but I believe it should work in every scenario..