### PR TITLE
[BEAM-2298] Making LocalFileSystem default and stripping file spec prefixes.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -69,13 +69,13 @@ import org.apache.beam.sdk.values.KV;
 @Experimental(Kind.FILESYSTEM)
 public class FileSystems {
 
-  public static final String DEFAULT_SCHEME = "default";
+  public static final String DEFAULT_SCHEME = "file";
   private static final Pattern FILE_SCHEME_PATTERN =
       Pattern.compile("(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*):.*");
 
   private static final AtomicReference<Map<String, FileSystem>> SCHEME_TO_FILESYSTEM =
       new AtomicReference<Map<String, FileSystem>>(
-          ImmutableMap.<String, FileSystem>of("file", new LocalFileSystem()));
+          ImmutableMap.<String, FileSystem>of(DEFAULT_SCHEME, new LocalFileSystem()));
 
   /********************************** METHODS FOR CLIENT **********************************/
 
@@ -98,6 +98,9 @@ public class FileSystems {
    * <p>All {@link FileSystem} implementations should support glob in the final hierarchical path
    * component of {@link ResourceId}. This allows SDK libraries to construct file system agnostic
    * spec. {@link FileSystem FileSystems} can support additional patterns for user-provided specs.
+   *
+   * <p>In case the spec schemes don't match any known {@link FileSystem} implementations,
+   * FileSystems will attempt to use {@link LocalFileSystem} to resolve a path.
    *
    * @return {@code List<MatchResult>} in the same order of the input specs.
    *
@@ -176,7 +179,7 @@ public class FileSystems {
         .transform(new Function<ResourceId, String>() {
           @Override
           public String apply(@Nonnull ResourceId resourceId) {
-          return resourceId.toString();
+            return resourceId.toString();
           }})
         .toList());
   }
@@ -423,7 +426,7 @@ public class FileSystems {
     Matcher matcher = FILE_SCHEME_PATTERN.matcher(spec);
 
     if (!matcher.matches()) {
-      return "file";
+      return DEFAULT_SCHEME;
     } else {
       return matcher.group("scheme").toLowerCase();
     }
@@ -440,11 +443,7 @@ public class FileSystems {
     if (rval != null) {
       return rval;
     }
-    rval = schemeToFileSystem.get(DEFAULT_SCHEME);
-    if (rval != null) {
-      return rval;
-    }
-    throw new IllegalStateException("Unable to find registrar for " + scheme);
+    return schemeToFileSystem.get(DEFAULT_SCHEME);
   }
 
   /********************************** METHODS FOR REGISTRATION **********************************/

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/LocalFileSystem.java
@@ -38,6 +38,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -46,11 +47,32 @@ import org.apache.beam.sdk.io.fs.CreateOptions;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.MatchResult.Status;
+import org.apache.commons.lang3.SystemUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * {@link FileSystem} implementation for local files.
+ *
+ * {@link #match} should interpret {@code spec} and resolve paths correctly according to OS being
+ * used. In order to do that specs should be defined in one of the below formats:
+ *
+ * <p>Linux/Mac:
+ * <ul>
+ *   <li>pom.xml</li>
+ *   <li>/Users/beam/Documents/pom.xml</li>
+ *   <li>file:/Users/beam/Documents/pom.xml</li>
+ *   <li>file:///Users/beam/Documents/pom.xml</li>
+ * </ul>
+ *
+ * <p>Windows OS:
+ * <ul>
+ *   <li>pom.xml</li>
+ *   <li>C:/Users/beam/Documents/pom.xml</li>
+ *   <li>C:\\Users\\beam\\Documents\\pom.xml</li>
+ *   <li>file:/C:/Users/beam/Documents/pom.xml</li>
+ *   <li>file:///C:/Users/beam/Documents/pom.xml</li>
+ * </ul>
  */
 class LocalFileSystem extends FileSystem<LocalResourceId> {
 
@@ -176,8 +198,20 @@ class LocalFileSystem extends FileSystem<LocalResourceId> {
   }
 
   private MatchResult matchOne(String spec) throws IOException {
-    File file = Paths.get(spec).toFile();
+    if (spec.toLowerCase().startsWith("file:")) {
+      spec = spec.substring("file:".length());
+    }
 
+    if (SystemUtils.IS_OS_WINDOWS) {
+      List<String> prefixes = Arrays.asList("///", "/");
+      for (String prefix : prefixes) {
+        if (spec.toLowerCase().startsWith(prefix)) {
+          spec = spec.substring(prefix.length());
+        }
+      }
+    }
+
+    File file = Paths.get(spec).toFile();
     if (file.exists()) {
       return MatchResult.create(Status.OK, ImmutableList.of(toMetadata(file)));
     }


### PR DESCRIPTION
Hi @lukecwik, can you please take a look?

Windows OS currently has three problems reading file specs from pipeline options.
1. The scheme parsing fails to recognize local drive as local filesystem.
2. It fails if we add “file:” to start of path (also true for Linux)
3. It doesn’t recognize glob (*) in file matching.

This change fixes problem number 1 and 2, not 3. Because of that, more tests run in Windows OS start passing, but the glob tests still fail.

The approach is to set LocalFileSystem as default, remove "file:", and get rid of any forward-slashes in the beginning of paths for Windows OS, since Windows Path Parser rejects slashes before the drive specification.

From the examples linked in the JIRA issue:
inputFile=c:/Users/lcwik/Desktop/beamRC4Java/word-count-beam/pom.xml (Still works)
inputFile=c:/Users/lcwik/Desktop/beamRC4Java/word-count-beam/pom.x* (Still doesn’t work, because of glob)
inputFile=file:/c:/Users/lcwik/Desktop/beamRC4Java/word-count-beam/pom.xml (Starts working)
inputFile=file:///c:/Users/lcwik/Desktop/beamRC4Java/word-count-beam/pom.xml (Starts working)

