### PR TITLE
[trivial] pom.xml: add license-maven-plugin and some default license merges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
     <maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
     <maven-exec-plugin.version>1.6.0</maven-exec-plugin.version>
     <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+    <maven-license-plugin.version>1.13</maven-license-plugin.version>
     <maven-resources-plugin.version>3.0.2</maven-resources-plugin.version>
     <maven-shade-plugin.version>3.0.0</maven-shade-plugin.version>
 
@@ -1366,6 +1367,19 @@
           </executions>
           <configuration>
             <skipIfEmpty>true</skipIfEmpty>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${maven-license-plugin.version}</version>
+          <configuration>
+            <licenseMerges>
+              <licenseMerge>The Apache Software License, Version 2.0|Apache License, Version 2.0|Apache 2.0|Apache License 2.0|Apache 2|Apache-2.0|Apache License Version 2.0|Apache License Version 2|Apache Software License - Version 2.0|Apache 2.0 License|the Apache License, ASL Version 2.0|Apache v2|The Apache License, Version 2.0|http://www.apache.org/licenses/LICENSE-2.0.txt|ASL, version 2</licenseMerge>
+              <licenseMerge>MIT License|MIT|MIT license|The MIT License</licenseMerge>
+              <licenseMerge>CDDL 1.0|Common Development and Distribution License (CDDL) v1.0|COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</licenseMerge>
+            </licenseMerges>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
When reviewing the license of third-party dependencies, it's a mess because the
output is determined by strings people put in their `pom.xml` files rather than
a standard list.

Use `license-maven-plugin` to clean this up a bit -- each merge defines a standard name
for the license (the first in the list) followed by a list of variants. This makes
the output of `mvn license:aggregate-add-third-party` much cleaner.

I was conservative about which licenses I merged - for example, I left 'Apache License'
alone rather than necessarily mapping it to 'The Apache Software License, Version 2.0',
since there are other versions.