### PR TITLE
BEAM-2578 DebuggingWordCountTest Fails on Windows

### DIFF
--- a/examples/java/src/test/java/org/apache/beam/examples/DebuggingWordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/DebuggingWordCountTest.java
@@ -37,8 +37,7 @@ public class DebuggingWordCountTest {
 
   private String getFilePath(String filePath) {
       if (filePath.contains(":")) {
-          String restPath = filePath.replace("\\", "/").split(":")[1];
-          return restPath;
+          return filePath.replace("\\", "/").split(":")[1];
       }
       return filePath;
   }

--- a/examples/java/src/test/java/org/apache/beam/examples/DebuggingWordCountTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/DebuggingWordCountTest.java
@@ -35,6 +35,14 @@ import org.junit.runners.JUnit4;
 public class DebuggingWordCountTest {
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
+  private String getFilePath(String filePath) {
+      if (filePath.contains(":")) {
+          String restPath = filePath.replace("\\", "/").split(":")[1];
+          return restPath;
+      }
+      return filePath;
+  }
+
   @Test
   public void testDebuggingWordCount() throws Exception {
     File inputFile = tmpFolder.newFile();
@@ -45,8 +53,8 @@ public class DebuggingWordCountTest {
         StandardCharsets.UTF_8);
     WordCountOptions options =
         TestPipeline.testingPipelineOptions().as(WordCountOptions.class);
-    options.setInputFile(inputFile.getAbsolutePath());
-    options.setOutput(outputFile.getAbsolutePath());
+    options.setInputFile(getFilePath(inputFile.getAbsolutePath()));
+    options.setOutput(getFilePath(outputFile.getAbsolutePath()));
     DebuggingWordCount.main(TestPipeline.convertToArgs(options));
   }
 }


### PR DESCRIPTION
[INFO] --- maven-failsafe-plugin:2.20:integration-test (default) @ beam-examples-java ---
[INFO] Tests are skipped.
[INFO] 
[INFO] --- maven-dependency-plugin:3.0.1:analyze-only (default) @ beam-examples-java ---
[INFO] No dependency problems found
[INFO] 
[INFO] --- maven-failsafe-plugin:2.20:verify (default) @ beam-examples-java ---
[INFO] Tests are skipped.
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:41 min
[INFO] Finished at: 2017-07-10T23:18:01+05:30
[INFO] Final Memory: 45M/129M
[INFO] ------------------------------------------------------------------------