### PR TITLE
TestPipeline should support errors in expand

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -496,7 +496,7 @@ public class Pipeline {
    *
    * @see Pipeline#apply
    */
-  private <InputT extends PInput, OutputT extends POutput> OutputT applyInternal(
+  protected <InputT extends PInput, OutputT extends POutput> OutputT applyInternal(
       String name, InputT input, PTransform<? super InputT, OutputT> transform) {
     String namePrefix = transforms.getCurrent().getFullName();
     String uniqueName = uniquifyInternal(namePrefix, name);


### PR DESCRIPTION
Writing a test that expects an exception during transform application is
currently not possible with TestPipeline in a NeedsRunner or
ValidatesRunner test. The exception causes the pipeline to be unrunnable.

Be sure to do all of the following to help us incorporate your contribution
quickly and easily:

 - [*] Make sure the PR title is formatted like:
   `[BEAM-<Jira issue #>] Description of pull request`
 - [*] Make sure tests pass via `mvn clean verify`.
 - [*] Replace `<Jira issue #>` in the title with the actual Jira issue
       number, if there is one.
 - [*] If this contribution is large, please file an Apache
       [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
