### PR TITLE
BEAM-2581: KinesisClientProvider interface needs to be public

### DIFF
--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisClientProvider.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisClientProvider.java
@@ -27,7 +27,7 @@ import java.io.Serializable;
  * <p>Please note, that any instance of {@link KinesisClientProvider} must be
  * {@link Serializable} to ensure it can be sent to worker machines.
  */
-interface KinesisClientProvider extends Serializable {
+public interface KinesisClientProvider extends Serializable {
 
   AmazonKinesis get();
 }


### PR DESCRIPTION
Using Beam to read from kinesis stream. `KinesisIO` provides two overloaded methods - `withClientProvider` to provide AWS credentials or implement an interface - `KinesisClientProvider`  to pass `AWSKinesisClient` as described on [here](https://beam.apache.org/documentation/sdks/javadoc/2.0.0/)

```
There's also possibility to start reading using arbitrary point in time - in this case you need to provide Instant object:
 p.apply(KinesisIO.read()
     .from("streamName", instant)
     .withClientProvider(new KinesisClientProvider() {
                        @Override
                        public AmazonKinesis get() {
                            return null;
                        }
      })
  .apply( ... ) // other transformations
```

The above code requires org.apache.beam.sdk.io.kinesis.KinesisClientProvider interface to be public.

Jira Ticket: [https://issues.apache.org/jira/browse/BEAM-2581](https://issues.apache.org/jira/browse/BEAM-2581) 