### PR TITLE
[BEAM-2608] Closes the reader in TextIO.readAll()

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -462,12 +462,13 @@ public class TextIO {
             TextIO.Read.wrapWithCompression(
                 new TextSource(StaticValueProvider.of(metadata.toString())),
                 spec.getCompressionType());
-        BoundedSource.BoundedReader<String> reader =
+        try (BoundedSource.BoundedReader<String> reader =
             source
                 .createForSubrangeOfFile(metadata, range.getFrom(), range.getTo())
-                .createReader(c.getPipelineOptions());
-        for (boolean more = reader.start(); more; more = reader.advance()) {
-          c.output(reader.getCurrent());
+                .createReader(c.getPipelineOptions())) {
+          for (boolean more = reader.start(); more; more = reader.advance()) {
+            c.output(reader.getCurrent());
+          }
         }
       }
     }


### PR DESCRIPTION
R: @tedyu or @reuvenlax 