### PR TITLE
[BEAM-1542] Introduced SpannerIO.readAll

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
@@ -36,7 +36,14 @@ abstract class AbstractSpannerFn<InputT, OutputT> extends DoFn<InputT, OutputT> 
   @Setup
   public void setup() throws Exception {
     SpannerConfig spannerConfig = getSpannerConfig();
-    SpannerOptions options = spannerConfig.buildSpannerOptions();
+    SpannerOptions.Builder builder = SpannerOptions.newBuilder();
+    if (spannerConfig.getProjectId() != null) {
+      builder.setProjectId(spannerConfig.getProjectId().get());
+    }
+    if (spannerConfig.getServiceFactory() != null) {
+      builder.setServiceFactory(spannerConfig.getServiceFactory());
+    }
+    SpannerOptions options = builder.build();
     spanner = options.getService();
     databaseClient = spanner.getDatabaseClient(DatabaseId
         .of(options.getProjectId(), spannerConfig.getInstanceId().get(),

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
@@ -29,7 +29,8 @@ import org.apache.beam.sdk.util.ReleaseInfo;
  * AbstractSpannerFn#databaseClient} to access the Cloud Spanner database client.
  */
 abstract class AbstractSpannerFn<InputT, OutputT> extends DoFn<InputT, OutputT> {
-  private static final String USER_AGENT_PREFIX = "apache.beam.java";
+  // A common user agent token that indicates that this request was originated from Apache Beam.
+  private static final String USER_AGENT_PREFIX = "Apache_Beam_Java";
 
   private transient Spanner spanner;
   private transient DatabaseClient databaseClient;
@@ -47,7 +48,7 @@ abstract class AbstractSpannerFn<InputT, OutputT> extends DoFn<InputT, OutputT> 
       builder.setServiceFactory(spannerConfig.getServiceFactory());
     }
     ReleaseInfo releaseInfo = ReleaseInfo.getReleaseInfo();
-    builder.setUserAgentPrefix(USER_AGENT_PREFIX + "." + releaseInfo.getVersion());
+    builder.setUserAgentPrefix(USER_AGENT_PREFIX + "/" + releaseInfo.getVersion());
     SpannerOptions options = builder.build();
     spanner = options.getService();
     databaseClient = spanner.getDatabaseClient(DatabaseId

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/AbstractSpannerFn.java
@@ -22,12 +22,15 @@ import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.util.ReleaseInfo;
 
 /**
  * Abstract {@link DoFn} that manages {@link Spanner} lifecycle. Use {@link
  * AbstractSpannerFn#databaseClient} to access the Cloud Spanner database client.
  */
 abstract class AbstractSpannerFn<InputT, OutputT> extends DoFn<InputT, OutputT> {
+  private static final String USER_AGENT_PREFIX = "apache.beam.java";
+
   private transient Spanner spanner;
   private transient DatabaseClient databaseClient;
 
@@ -43,6 +46,8 @@ abstract class AbstractSpannerFn<InputT, OutputT> extends DoFn<InputT, OutputT> 
     if (spannerConfig.getServiceFactory() != null) {
       builder.setServiceFactory(spannerConfig.getServiceFactory());
     }
+    ReleaseInfo releaseInfo = ReleaseInfo.getReleaseInfo();
+    builder.setUserAgentPrefix(USER_AGENT_PREFIX + "." + releaseInfo.getVersion());
     SpannerOptions options = builder.build();
     spanner = options.getService();
     databaseClient = spanner.getDatabaseClient(DatabaseId

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
@@ -28,17 +28,17 @@ import javax.annotation.Nullable;
 
 /** A simplest read function implementation. Parallelism support is coming. */
 @VisibleForTesting
-public class NaiveSpannerReadFn extends AbstractSpannerFn<ReadOperation, Struct> {
+class NaiveSpannerReadFn extends AbstractSpannerFn<ReadOperation, Struct> {
   private final SpannerConfig config;
   @Nullable
   private final PCollectionView<Transaction> transaction;
 
-  public NaiveSpannerReadFn(SpannerConfig config, @Nullable PCollectionView<Transaction> transaction) {
+  NaiveSpannerReadFn(SpannerConfig config, @Nullable PCollectionView<Transaction> transaction) {
     this.config = config;
     this.transaction = transaction;
   }
 
-  public NaiveSpannerReadFn(SpannerConfig config) {
+  NaiveSpannerReadFn(SpannerConfig config) {
     this(config, null);
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
@@ -22,9 +22,8 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.beam.sdk.values.PCollectionView;
-
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.values.PCollectionView;
 
 /** A simplest read function implementation. Parallelism support is coming. */
 @VisibleForTesting

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerReadFn.java
@@ -22,44 +22,55 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.sdk.values.PCollectionView;
+
+import javax.annotation.Nullable;
 
 /** A simplest read function implementation. Parallelism support is coming. */
 @VisibleForTesting
-class NaiveSpannerReadFn extends AbstractSpannerFn<Object, Struct> {
-  private final SpannerIO.Read config;
+public class NaiveSpannerReadFn extends AbstractSpannerFn<ReadOperation, Struct> {
+  private final SpannerConfig config;
+  @Nullable
+  private final PCollectionView<Transaction> transaction;
 
-  NaiveSpannerReadFn(SpannerIO.Read config) {
+  public NaiveSpannerReadFn(SpannerConfig config, @Nullable PCollectionView<Transaction> transaction) {
     this.config = config;
+    this.transaction = transaction;
+  }
+
+  public NaiveSpannerReadFn(SpannerConfig config) {
+    this(config, null);
   }
 
   SpannerConfig getSpannerConfig() {
-    return config.getSpannerConfig();
+    return config;
   }
 
   @ProcessElement
   public void processElement(ProcessContext c) throws Exception {
     TimestampBound timestampBound = TimestampBound.strong();
-    if (config.getTransaction() != null) {
-      Transaction transaction = c.sideInput(config.getTransaction());
+    if (transaction != null) {
+      Transaction transaction = c.sideInput(this.transaction);
       timestampBound = TimestampBound.ofReadTimestamp(transaction.timestamp());
     }
+    ReadOperation op = c.element();
     try (ReadOnlyTransaction readOnlyTransaction =
         databaseClient().readOnlyTransaction(timestampBound)) {
-      ResultSet resultSet = execute(readOnlyTransaction);
+      ResultSet resultSet = execute(op, readOnlyTransaction);
       while (resultSet.next()) {
         c.output(resultSet.getCurrentRowAsStruct());
       }
     }
   }
 
-  private ResultSet execute(ReadOnlyTransaction readOnlyTransaction) {
-    if (config.getQuery() != null) {
-      return readOnlyTransaction.executeQuery(config.getQuery());
+  private ResultSet execute(ReadOperation op, ReadOnlyTransaction readOnlyTransaction) {
+    if (op.getQuery() != null) {
+      return readOnlyTransaction.executeQuery(op.getQuery());
     }
-    if (config.getIndex() != null) {
-      return readOnlyTransaction.readUsingIndex(
-          config.getTable(), config.getIndex(), config.getKeySet(), config.getColumns());
+    if (op.getIndex() != null) {
+      return readOnlyTransaction
+          .readUsingIndex(op.getTable(), op.getIndex(), op.getKeySet(), op.getColumns());
     }
-    return readOnlyTransaction.read(config.getTable(), config.getKeySet(), config.getColumns());
+    return readOnlyTransaction.read(op.getTable(), op.getKeySet(), op.getColumns());
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadOperation.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadOperation.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner;
+
+import com.google.auto.value.AutoValue;
+import com.google.cloud.spanner.KeySet;
+import com.google.cloud.spanner.Statement;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Encapsulates a spanner read operation.
+ */
+@AutoValue
+public abstract class ReadOperation implements Serializable {
+
+  public static ReadOperation create() {
+    return new AutoValue_ReadOperation.Builder().setKeySet(KeySet.all()).build();
+  }
+
+  @Nullable public abstract Statement getQuery();
+
+  @Nullable public abstract String getTable();
+
+  @Nullable public abstract String getIndex();
+
+  @Nullable public abstract List<String> getColumns();
+
+  @Nullable public abstract KeySet getKeySet();
+
+  @AutoValue.Builder abstract static class Builder {
+
+    abstract Builder setQuery(Statement statement);
+
+    abstract Builder setTable(String table);
+
+    abstract Builder setIndex(String index);
+
+    abstract Builder setColumns(List<String> columns);
+
+    abstract Builder setKeySet(KeySet keySet);
+
+    abstract ReadOperation build();
+  }
+
+  abstract Builder toBuilder();
+
+  public ReadOperation withTable(String table) {
+    return toBuilder().setTable(table).build();
+  }
+
+  public ReadOperation withColumns(String... columns) {
+    return withColumns(Arrays.asList(columns));
+  }
+
+  public ReadOperation withColumns(List<String> columns) {
+    return toBuilder().setColumns(columns).build();
+  }
+
+  public ReadOperation withQuery(Statement statement) {
+    return toBuilder().setQuery(statement).build();
+  }
+
+  public ReadOperation withQuery(String sql) {
+    return withQuery(Statement.of(sql));
+  }
+
+  public ReadOperation withKeySet(KeySet keySet) {
+    return toBuilder().setKeySet(keySet).build();
+  }
+
+  public ReadOperation withIndex(String index) {
+    return toBuilder().setIndex(index).build();
+  }
+
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadOperation.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadOperation.java
@@ -20,11 +20,10 @@ package org.apache.beam.sdk.io.gcp.spanner;
 import com.google.auto.value.AutoValue;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Statement;
-
-import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates a spanner read operation.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
@@ -49,17 +49,6 @@ public abstract class SpannerConfig implements Serializable {
 
   abstract Builder toBuilder();
 
-  SpannerOptions buildSpannerOptions() {
-    SpannerOptions.Builder builder = SpannerOptions.newBuilder();
-    if (getProjectId() != null) {
-      builder.setProjectId(getProjectId().get());
-    }
-    if (getServiceFactory() != null) {
-      builder.setServiceFactory(getServiceFactory());
-    }
-    return builder.build();
-  }
-
   public static SpannerConfig create() {
     return builder().build();
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -189,8 +189,15 @@ public class SpannerIO {
         .build();
   }
 
+  /**
+   * Returns a {@link DoFn} that can be applied to a {@link PCollection<ReadOperation>}.
+   * @param config a spanner configuration.
+   * @param transaction a PCollectionView with a transaction, usually created with
+   * {@link Read#createTransaction()}. If null, the doesn't provide a transactional guarantees.
+   * @return a {@link DoFn} that concurrently reads from multiple Cloud Spanner sources.
+   */
   @Experimental
-  public DoFn<ReadOperation, Struct> readFn(SpannerConfig config,
+  public static DoFn<ReadOperation, Struct> readFn(SpannerConfig config,
       @Nullable PCollectionView<Transaction> transaction) {
     return new NaiveSpannerReadFn(config, transaction);
   }
@@ -372,7 +379,7 @@ public class SpannerIO {
       return input
           .apply(Create.of(getReadOperation()))
           .apply(
-              "Execute query", ParDo.of(new NaiveSpannerReadFn(getSpannerConfig(), transaction))
+              "Execute query", ParDo.of(readFn(getSpannerConfig(), transaction))
                   .withSideInputs(sideInputs));
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -183,7 +183,7 @@ public class SpannerIO {
 
   /**
    * A {@link PTransform} that works like {@link #read}, but executes read operations coming from
-   * a {@link PCollection<ReadOperation>}.
+   * a {@link PCollection}.
    */
    @Experimental(Experimental.Kind.SOURCE_SINK)
   public static ReadAll readAll() {
@@ -218,9 +218,12 @@ public class SpannerIO {
         .build();
   }
 
+  /**
+   * A {@link PTransform} that reads data from Google Cloud Spanner.
+   */
   @Experimental(Experimental.Kind.SOURCE_SINK)
-  @AutoValue
-  public abstract static class ReadAll extends PTransform<PCollection<ReadOperation>, PCollection<Struct>> {
+  @AutoValue public abstract static class ReadAll
+      extends PTransform<PCollection<ReadOperation>, PCollection<Struct>> {
 
     abstract SpannerConfig getSpannerConfig();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -189,6 +189,12 @@ public class SpannerIO {
         .build();
   }
 
+  @Experimental
+  public DoFn<ReadOperation, Struct> readFn(SpannerConfig config,
+      @Nullable PCollectionView<Transaction> transaction) {
+    return new NaiveSpannerReadFn(config, transaction);
+  }
+
   /**
    * Creates an uninitialized instance of {@link Write}. Before use, the {@link Write} must be
    * configured with a {@link Write#withInstanceId} and {@link Write#withDatabaseId} that identify

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOReadTest.java
@@ -153,19 +153,18 @@ public class SpannerIOReadTest implements Serializable {
             .withProjectId("test")
             .withInstanceId("123")
             .withDatabaseId("aaa")
-            .withTimestamp(Timestamp.now())
             .withQuery("SELECT * FROM users")
             .withServiceFactory(serviceFactory);
 
-    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read);
-    DoFnTester<Object, Struct> fnTester = DoFnTester.of(readFn);
+    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read.getSpannerConfig());
+    DoFnTester<ReadOperation, Struct> fnTester = DoFnTester.of(readFn);
 
     when(serviceFactory.mockDatabaseClient().readOnlyTransaction(any(TimestampBound.class)))
         .thenReturn(mockTx);
     when(mockTx.executeQuery(any(Statement.class)))
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
-    List<Struct> result = fnTester.processBundle(1);
+    List<Struct> result = fnTester.processBundle(read.getReadOperation());
     assertThat(result, Matchers.<Struct>iterableWithSize(2));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound
@@ -180,20 +179,19 @@ public class SpannerIOReadTest implements Serializable {
             .withProjectId("test")
             .withInstanceId("123")
             .withDatabaseId("aaa")
-            .withTimestamp(Timestamp.now())
             .withTable("users")
             .withColumns("id", "name")
             .withServiceFactory(serviceFactory);
 
-    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read);
-    DoFnTester<Object, Struct> fnTester = DoFnTester.of(readFn);
+    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read.getSpannerConfig());
+    DoFnTester<ReadOperation, Struct> fnTester = DoFnTester.of(readFn);
 
     when(serviceFactory.mockDatabaseClient().readOnlyTransaction(any(TimestampBound.class)))
         .thenReturn(mockTx);
     when(mockTx.read("users", KeySet.all(), Arrays.asList("id", "name")))
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
-    List<Struct> result = fnTester.processBundle(1);
+    List<Struct> result = fnTester.processBundle(read.getReadOperation());
     assertThat(result, Matchers.<Struct>iterableWithSize(2));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound.strong());
@@ -213,15 +211,15 @@ public class SpannerIOReadTest implements Serializable {
             .withIndex("theindex")
             .withServiceFactory(serviceFactory);
 
-    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read);
-    DoFnTester<Object, Struct> fnTester = DoFnTester.of(readFn);
+    NaiveSpannerReadFn readFn = new NaiveSpannerReadFn(read.getSpannerConfig());
+    DoFnTester<ReadOperation, Struct> fnTester = DoFnTester.of(readFn);
 
     when(serviceFactory.mockDatabaseClient().readOnlyTransaction(any(TimestampBound.class)))
         .thenReturn(mockTx);
     when(mockTx.readUsingIndex("users", "theindex", KeySet.all(), Arrays.asList("id", "name")))
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
-    List<Struct> result = fnTester.processBundle(1);
+    List<Struct> result = fnTester.processBundle(read.getReadOperation());
     assertThat(result, Matchers.<Struct>iterableWithSize(2));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound.strong());
@@ -244,7 +242,6 @@ public class SpannerIOReadTest implements Serializable {
         .withProjectId("test")
         .withInstanceId("123")
         .withDatabaseId("aaa")
-        .withTimestamp(Timestamp.now())
         .withQuery("SELECT * FROM users")
         .withServiceFactory(serviceFactory)
         .withTransaction(tx));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIOReadTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFnTester;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -55,6 +56,7 @@ import org.mockito.Mockito;
 /** Unit tests for {@link SpannerIO}. */
 @RunWith(JUnit4.class)
 public class SpannerIOReadTest implements Serializable {
+
   @Rule
   public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule
@@ -63,12 +65,15 @@ public class SpannerIOReadTest implements Serializable {
   private FakeServiceFactory serviceFactory;
   private ReadOnlyTransaction mockTx;
 
-  private Type fakeType = Type.struct(Type.StructField.of("id", Type.int64()),
+  private transient Type fakeType = Type.struct(Type.StructField.of("id", Type.int64()),
       Type.StructField.of("name", Type.string()));
 
-  private List<Struct> fakeRows = Arrays.asList(
+  private transient List<Struct> fakeRows = Arrays.asList(
       Struct.newBuilder().add("id", Value.int64(1)).add("name", Value.string("Alice")).build(),
-      Struct.newBuilder().add("id", Value.int64(2)).add("name", Value.string("Bob")).build());
+      Struct.newBuilder().add("id", Value.int64(2)).add("name", Value.string("Bob")).build(),
+      Struct.newBuilder().add("id", Value.int64(3)).add("name", Value.string("Carl")).build(),
+      Struct.newBuilder().add("id", Value.int64(4)).add("name", Value.string("Dan")).build()
+  );
 
   @Before
   @SuppressWarnings("unchecked")
@@ -165,7 +170,7 @@ public class SpannerIOReadTest implements Serializable {
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
     List<Struct> result = fnTester.processBundle(read.getReadOperation());
-    assertThat(result, Matchers.<Struct>iterableWithSize(2));
+    assertThat(result, Matchers.containsInAnyOrder(fakeRows.toArray()));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound
         .strong());
@@ -192,7 +197,7 @@ public class SpannerIOReadTest implements Serializable {
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
     List<Struct> result = fnTester.processBundle(read.getReadOperation());
-    assertThat(result, Matchers.<Struct>iterableWithSize(2));
+    assertThat(result, Matchers.containsInAnyOrder(fakeRows.toArray()));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound.strong());
     verify(mockTx).read("users", KeySet.all(), Arrays.asList("id", "name"));
@@ -220,7 +225,7 @@ public class SpannerIOReadTest implements Serializable {
         .thenReturn(ResultSets.forRows(fakeType, fakeRows));
 
     List<Struct> result = fnTester.processBundle(read.getReadOperation());
-    assertThat(result, Matchers.<Struct>iterableWithSize(2));
+    assertThat(result, Matchers.containsInAnyOrder(fakeRows.toArray()));
 
     verify(serviceFactory.mockDatabaseClient()).readOnlyTransaction(TimestampBound.strong());
     verify(mockTx).readUsingIndex("users", "theindex", KeySet.all(), Arrays.asList("id", "name"));
@@ -231,28 +236,24 @@ public class SpannerIOReadTest implements Serializable {
   public void readPipeline() throws Exception {
     Timestamp timestamp = Timestamp.ofTimeMicroseconds(12345);
 
+    SpannerConfig spannerConfig = SpannerConfig.create()
+        .withProjectId("test")
+        .withInstanceId("123")
+        .withDatabaseId("aaa")
+        .withServiceFactory(serviceFactory);
+
     PCollectionView<Transaction> tx = pipeline
-        .apply("tx", SpannerIO.createTransaction()
-            .withProjectId("test")
-            .withInstanceId("123")
-            .withDatabaseId("aaa")
-            .withServiceFactory(serviceFactory));
+        .apply("tx", SpannerIO.createTransaction().withSpannerConfig(spannerConfig));
 
     PCollection<Struct> one = pipeline.apply("read q", SpannerIO.read()
-        .withProjectId("test")
-        .withInstanceId("123")
-        .withDatabaseId("aaa")
+        .withSpannerConfig(spannerConfig)
         .withQuery("SELECT * FROM users")
-        .withServiceFactory(serviceFactory)
         .withTransaction(tx));
     PCollection<Struct> two = pipeline.apply("read r", SpannerIO.read()
-        .withProjectId("test")
-        .withInstanceId("123")
-        .withDatabaseId("aaa")
+        .withSpannerConfig(spannerConfig)
         .withTimestamp(Timestamp.now())
         .withTable("users")
         .withColumns("id", "name")
-        .withServiceFactory(serviceFactory)
         .withTransaction(tx));
 
     when(serviceFactory.mockDatabaseClient().readOnlyTransaction(any(TimestampBound.class)))
@@ -269,6 +270,49 @@ public class SpannerIOReadTest implements Serializable {
 
     PAssert.that(one).containsInAnyOrder(fakeRows);
     PAssert.that(two).containsInAnyOrder(fakeRows);
+
+    pipeline.run();
+
+    verify(serviceFactory.mockDatabaseClient(), times(2))
+        .readOnlyTransaction(TimestampBound.ofReadTimestamp(timestamp));
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void readAllPipeline() throws Exception {
+    Timestamp timestamp = Timestamp.ofTimeMicroseconds(12345);
+
+    SpannerConfig spannerConfig = SpannerConfig.create()
+        .withProjectId("test")
+        .withInstanceId("123")
+        .withDatabaseId("aaa")
+        .withServiceFactory(serviceFactory);
+
+    PCollectionView<Transaction> tx = pipeline
+        .apply("tx", SpannerIO.createTransaction().withSpannerConfig(spannerConfig));
+
+    PCollection<ReadOperation> reads = pipeline.apply(Create.of(
+        ReadOperation.create().withQuery("SELECT * FROM users"),
+        ReadOperation.create().withTable("users").withColumns("id", "name")
+    ));
+
+    PCollection<Struct> one = reads.apply("read all",
+        SpannerIO.readAll().withSpannerConfig(spannerConfig).withTransaction(tx));
+
+
+    when(serviceFactory.mockDatabaseClient().readOnlyTransaction(any(TimestampBound.class)))
+        .thenReturn(mockTx);
+
+    when(mockTx.executeQuery(Statement.of("SELECT 1"))).thenReturn(ResultSets.forRows(Type.struct(),
+        Collections.<Struct>emptyList()));
+
+    when(mockTx.executeQuery(Statement.of("SELECT * FROM users")))
+        .thenReturn(ResultSets.forRows(fakeType, fakeRows.subList(0, 2)));
+    when(mockTx.read("users", KeySet.all(), Arrays.asList("id", "name")))
+        .thenReturn(ResultSets.forRows(fakeType, fakeRows.subList(2, 4)));
+    when(mockTx.getReadTimestamp()).thenReturn(timestamp);
+
+    PAssert.that(one).containsInAnyOrder(fakeRows);
 
     pipeline.run();
 


### PR DESCRIPTION
`SpannerIO.readAll` allows to pipe reading from Cloud Spanner to other computations. The motivating use case is exporting data from a Spanner database, when list of the tables is generated in a previous transform.

R: @jkff 