### PR TITLE
[BEAM-2606] make WindowFnTestUtils use the value in addition to the timestamp of the elements

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -68,13 +68,11 @@ public class WindowFnTestUtils {
   public static <T, W extends BoundedWindow> Map<W, Set<String>> runWindowFn(
       WindowFn<T, W> windowFn,
       List<Long> timestamps) throws Exception {
-    // lift List<Timestamp> into List<TimestampedValue> to factorize implementation
     List<TimestampedValue<T>> timestampedValues = new ArrayList<>();
     for (Long timestamp : timestamps){
       timestampedValues.add(TimestampedValue.of((T) null, new Instant(timestamp)));
     }
     return runWindowFnWithValue(windowFn, timestampedValues);
-
   }
 
   /**
@@ -105,7 +103,6 @@ public class WindowFnTestUtils {
    */
   public static <T, W extends BoundedWindow> Collection<W> assignedWindows(
       WindowFn<T, W> windowFn, long timestamp) throws Exception {
-    // lift Timestamp into TimestampedValue to factorize implementation
     return assignedWindowsWithValue(windowFn,
         TimestampedValue.of((T) null, new Instant(timestamp)));
   }
@@ -229,7 +226,6 @@ public class WindowFnTestUtils {
    */
   public static <T, W extends BoundedWindow> void validateNonInterferingOutputTimes(
       WindowFn<T, W> windowFn, long timestamp) throws Exception {
-    // lift Timestamp into TimestampedValue to factorize implementation
     validateNonInterferingOutputTimesWithValue(windowFn,
         TimestampedValue.of((T) null, new Instant(timestamp)));
   }
@@ -265,7 +261,6 @@ public class WindowFnTestUtils {
    */
   public static <T, W extends BoundedWindow> void validateGetOutputTimestamp(
       WindowFn<T, W> windowFn, long timestamp) throws Exception {
-    // lift Timestamp into TimestampedValue to factorize implementation
     validateGetOutputTimestampWithValue(windowFn,
         TimestampedValue.of((T) null, new Instant(timestamp)));
   }
@@ -333,7 +328,6 @@ public class WindowFnTestUtils {
       TimestampCombiner timestampCombiner,
       List<List<Long>> timestampsPerWindow) throws Exception {
 
-    // lift List<List<Timestamp>> into List<List<TimestampedValue>> to factorize implementation
     List<List<TimestampedValue<T>>> timestampValuesPerWindow = new ArrayList<>();
     for (List<Long> timestamps : timestampsPerWindow){
       List<TimestampedValue<T>> timestampedValues = new ArrayList<>();


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
R: @kennknowles 
Besides, I saw that the current `WindowFnTestUtils` has no test. I guess that is because all windows use `WindowFnTestUtils` to test themselves. So I did not add any test. That is said, the methods added in that PR are actually called by the current windows tests but always with a `null` value in  `TimestampedValue`. I was thinking I could wait for that PR https://github.com/apache/beam/pull/3286 to be merged. Indeed it defines a `CustomWindowFn` in `WindowTest` that relies on values for window assignment. I could then add a test of this `CustomWindowFn` with the new `WindowFnTestUtils`.
@kennknowles WDYT?