### PR TITLE
[BEAM-2660] Set PubsubIO batch size using builder

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -734,7 +734,7 @@ public class PubsubIO {
   /** Implementation of {@link #write}. */
   @AutoValue
   public abstract static class Write<T> extends PTransform<PCollection<T>, PDone> {
-    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = 1000000;
+    private static final int MAX_PUBLISH_BATCH_BYTE_SIZE_DEFAULT = 10 * 1024 * 1024;
     private static final int MAX_PUBLISH_BATCH_SIZE = 100;
 
     @Nullable

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
@@ -84,10 +84,10 @@ import org.joda.time.Duration;
  */
 public class PubsubUnboundedSink extends PTransform<PCollection<PubsubMessage>, PDone> {
   /** Default maximum number of messages per publish. */
-  private static final int DEFAULT_PUBLISH_BATCH_SIZE = 1000;
+  static final int DEFAULT_PUBLISH_BATCH_SIZE = 1000;
 
   /** Default maximum size of a publish batch, in bytes. */
-  private static final int DEFAULT_PUBLISH_BATCH_BYTES = 400000;
+  static final int DEFAULT_PUBLISH_BATCH_BYTES = 400000;
 
   /** Default longest delay between receiving a message and pushing it to Pubsub. */
   private static final Duration DEFAULT_MAX_LATENCY = Duration.standardSeconds(2);
@@ -368,16 +368,23 @@ public class PubsubUnboundedSink extends PTransform<PCollection<PubsubMessage>, 
   }
 
   public PubsubUnboundedSink(
-          PubsubClientFactory pubsubFactory,
-          ValueProvider<TopicPath> topic,
-          String timestampAttribute,
-          String idAttribute,
-          int numShards,
-          int publishBatchSize,
-          int publishBatchBytes) {
-    this(pubsubFactory, topic, timestampAttribute, idAttribute, numShards,
-            publishBatchSize, publishBatchBytes, DEFAULT_MAX_LATENCY,
-            RecordIdMethod.RANDOM);
+      PubsubClientFactory pubsubFactory,
+      ValueProvider<TopicPath> topic,
+      String timestampAttribute,
+      String idAttribute,
+      int numShards,
+      int publishBatchSize,
+      int publishBatchBytes) {
+    this(
+        pubsubFactory,
+        topic,
+        timestampAttribute,
+        idAttribute,
+        numShards,
+        publishBatchSize,
+        publishBatchBytes,
+        DEFAULT_MAX_LATENCY,
+        RecordIdMethod.RANDOM);
   }
   /** Get the topic being written to. */
   public TopicPath getTopic() {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSink.java
@@ -367,6 +367,18 @@ public class PubsubUnboundedSink extends PTransform<PCollection<PubsubMessage>, 
         RecordIdMethod.RANDOM);
   }
 
+  public PubsubUnboundedSink(
+          PubsubClientFactory pubsubFactory,
+          ValueProvider<TopicPath> topic,
+          String timestampAttribute,
+          String idAttribute,
+          int numShards,
+          int publishBatchSize,
+          int publishBatchBytes) {
+    this(pubsubFactory, topic, timestampAttribute, idAttribute, numShards,
+            publishBatchSize, publishBatchBytes, DEFAULT_MAX_LATENCY,
+            RecordIdMethod.RANDOM);
+  }
   /** Get the topic being written to. */
   public TopicPath getTopic() {
     return topic.get();


### PR DESCRIPTION
BEAM-2660 asks for controlling batch size using the `PubsubIO.Write.Builder`

This PR adds Two values configurable through the `PubsubIO.Write.Builder`:
- `maxBatchSize` - controls the bulk batch request size
- `maxBatchByteSize` - controls the bulk batch bytes request size

In this PR I have also made a modification to the `PubsubIO.Write.PubsubBoundedWriter`. Now the writer will dynamically track the number of bytes allocated for all messages. If the number of bytes exceeds the threshold it will publish before adding more messages.

If the message size exceeds the `maxBatchByteSize` then an exception will be thrown

An example use case of the new parameter is:

```java
PubsubIO.writeMessages()
    .withMaxBatchSize(100)
    .withMaxBatchByteSize(100000)
   .to("my-topic")
```