### PR TITLE
[BEAM-1820] Source.getDefaultOutputCoder() throws CannotProvideCoderException

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ApexPipelineTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ApexPipelineTranslator.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,7 +149,7 @@ public class ApexPipelineTranslator extends Pipeline.PipelineVisitor.Defaults {
     public void translate(Read.Bounded<T> transform, TranslationContext context) {
       // TODO: adapter is visibleForTesting
       BoundedToUnboundedSourceAdapter unboundedSource = new BoundedToUnboundedSourceAdapter<>(
-          transform.getSource());
+          transform.getSource(), context.<PCollection<T>>getOutput().getCoder());
       ApexReadUnboundedInputOperator<T, ?> operator = new ApexReadUnboundedInputOperator<>(
           unboundedSource, true, context.getPipelineOptions());
       context.addOperator(operator, operator.output);

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSourceTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSourceTest.java
@@ -39,6 +39,7 @@ import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource.
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.FileBasedSource;
@@ -106,7 +107,7 @@ public class UnboundedReadFromBoundedSourceTest {
     long numElements = 100;
     BoundedSource<Long> boundedSource = CountingSource.upTo(numElements);
     UnboundedSource<Long, Checkpoint<Long>> unboundedSource =
-        new BoundedToUnboundedSourceAdapter<>(boundedSource);
+        new BoundedToUnboundedSourceAdapter<>(boundedSource, VarLongCoder.of());
 
     PCollection<Long> output =
         p.apply(Read.from(unboundedSource).withMaxNumRecords(numElements));
@@ -161,7 +162,7 @@ public class UnboundedReadFromBoundedSourceTest {
       BoundedSource<T> boundedSource,
       List<T> expectedElements) throws Exception {
     BoundedToUnboundedSourceAdapter<T> unboundedSource =
-        new BoundedToUnboundedSourceAdapter<>(boundedSource);
+        new BoundedToUnboundedSourceAdapter<>(boundedSource, boundedSource.getDefaultOutputCoder());
 
     PipelineOptions options = PipelineOptionsFactory.create();
     BoundedToUnboundedSourceAdapter<T>.Reader reader =
@@ -214,7 +215,7 @@ public class UnboundedReadFromBoundedSourceTest {
       BoundedSource<T> boundedSource,
       List<T> expectedElements) throws Exception {
     BoundedToUnboundedSourceAdapter<T> unboundedSource =
-        new BoundedToUnboundedSourceAdapter<>(boundedSource);
+        new BoundedToUnboundedSourceAdapter<>(boundedSource, boundedSource.getDefaultOutputCoder());
 
     PipelineOptions options = PipelineOptionsFactory.create();
     BoundedToUnboundedSourceAdapter<T>.Reader reader =
@@ -255,7 +256,7 @@ public class UnboundedReadFromBoundedSourceTest {
 
     BoundedSource<Long> countingSource = CountingSource.upTo(100);
     BoundedToUnboundedSourceAdapter<Long> unboundedSource =
-        new BoundedToUnboundedSourceAdapter<>(countingSource);
+        new BoundedToUnboundedSourceAdapter<>(countingSource, VarLongCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
 
     unboundedSource.createReader(options, null).getCurrent();
@@ -267,7 +268,7 @@ public class UnboundedReadFromBoundedSourceTest {
 
     BoundedSource<Long> countingSource = CountingSource.upTo(100);
     BoundedToUnboundedSourceAdapter<Long> unboundedSource =
-        new BoundedToUnboundedSourceAdapter<>(countingSource);
+        new BoundedToUnboundedSourceAdapter<>(countingSource, VarLongCoder.of());
     PipelineOptions options = PipelineOptionsFactory.create();
 
     List<TimestampedValue<Long>> elements =

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.ListCoder;
@@ -573,7 +574,7 @@ public class DirectRunnerTest implements Serializable {
     }
 
     @Override
-    public Coder<T> getDefaultOutputCoder() {
+    public Coder<T> getDefaultOutputCoder() throws CannotProvideCoderException {
       return underlying.getDefaultOutputCoder();
     }
   }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/StateSpecFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/StateSpecFunctions.java
@@ -161,7 +161,7 @@ public class StateSpecFunctions {
         final List<byte[]> readValues = new ArrayList<>();
         WindowedValue.FullWindowedValueCoder<T> coder =
             WindowedValue.FullWindowedValueCoder.of(
-                source.getDefaultOutputCoder(),
+                microbatchSource.getOutputCoder(),
                 GlobalWindow.Coder.INSTANCE);
         try {
           // measure how long a read takes per-partition.

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -127,6 +127,7 @@ public final class StreamingTransformTranslator {
                 context.getStreamingContext(),
                 context.getRuntimeContext(),
                 transform.getSource(),
+                context.getOutput(transform).getCoder(),
                 stepName));
       }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -35,6 +35,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -407,7 +408,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
    * Returns the delegate source's default output coder.
    */
   @Override
-  public final Coder<T> getDefaultOutputCoder() {
+  public final Coder<T> getDefaultOutputCoder() throws CannotProvideCoderException {
     return sourceDelegate.getDefaultOutputCoder();
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -95,7 +96,7 @@ public class Read {
     }
 
     @Override
-    protected Coder<T> getDefaultOutputCoder() {
+    protected Coder<T> getDefaultOutputCoder() throws CannotProvideCoderException {
       return source.getDefaultOutputCoder();
     }
 
@@ -103,9 +104,8 @@ public class Read {
     public final PCollection<T> expand(PBegin input) {
       source.validate();
 
-      return PCollection.<T>createPrimitiveOutputInternal(input.getPipeline(),
-          WindowingStrategy.globalDefault(), IsBounded.BOUNDED)
-          .setCoder(getDefaultOutputCoder());
+      return PCollection.createPrimitiveOutputInternal(input.getPipeline(),
+          WindowingStrategy.globalDefault(), IsBounded.BOUNDED);
     }
 
     /**
@@ -150,7 +150,7 @@ public class Read {
      * records.
      */
     public BoundedReadFromUnboundedSource<T> withMaxNumRecords(long maxNumRecords) {
-      return new BoundedReadFromUnboundedSource<T>(source, maxNumRecords, null);
+      return new BoundedReadFromUnboundedSource<T>(source, null, maxNumRecords, null);
     }
 
     /**
@@ -159,11 +159,11 @@ public class Read {
      * of time to read for.  Each split of the source will read for this much time.
      */
     public BoundedReadFromUnboundedSource<T> withMaxReadTime(Duration maxReadTime) {
-      return new BoundedReadFromUnboundedSource<T>(source, Long.MAX_VALUE, maxReadTime);
+      return new BoundedReadFromUnboundedSource<T>(source, null, Long.MAX_VALUE, maxReadTime);
     }
 
     @Override
-    protected Coder<T> getDefaultOutputCoder() {
+    protected Coder<T> getDefaultOutputCoder() throws CannotProvideCoderException {
       return source.getDefaultOutputCoder();
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.NoSuchElementException;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
@@ -63,8 +64,17 @@ public abstract class Source<T> implements Serializable, HasDisplayData {
 
   /**
    * Returns the default {@code Coder} to use for the data read from this source.
+   *
+   * <p>If this throws {@link CannotProvideCoderException}, the user will need to explicitly set a
+   * coder on the result of {@link Read#from}.
    */
-  public abstract Coder<T> getDefaultOutputCoder();
+  public Coder<T> getDefaultOutputCoder() throws CannotProvideCoderException {
+    throw new CannotProvideCoderException(
+        "Source "
+            + this
+            + " does not implement getDefaultOutputCoder(), "
+            + "set the coder explicitly via PCollection.setCoder()");
+  }
 
   /**
    * {@inheritDoc}


### PR DESCRIPTION
This is based on https://github.com/apache/beam/pull/3549 by @lgajowy, but it turned out that a lot more needs to be done to fix it properly, and the necessary changes require knowledge of sufficiently dark corners of the SDK and runners that asking an external contributor to do this is unfair, so I did the changes myself.

TL;DR: callers of Source.getDefaultOutputCoder shouldn't require it to succeed.

Source.getDefaultOutputCoder is only a hint for inferring the Coder of its elements, and it should not be required to succeed.

E.g. when a runner is replacing a Read.from(source) transform, and the override needs to know a coder for elements of the source, if the source doesn't provide a coder, the user may have set a coder on the returned PCollection explicitly. In this case, the runner should use that coder.

In other cases, when an API uses a Source and needs its coder, it must let the caller provide a Coder explicitly (e.g. SourceTestUtils).

I am treating this as a backwards-compatible change because Source.getDefaultOutputCoder() is a runner-facing rather than user-facing API. From the point of view of a user implementing a Source, adding a throws to the base class method signature is compatible.

R: @tgroh 
CC: @lgajowy
