### PR TITLE
Sets desired bundle size on AvroIO.readAll

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -178,6 +178,7 @@ public class AvroIO {
     return new AutoValue_AvroIO_ReadAll.Builder<GenericRecord>()
         .setRecordClass(GenericRecord.class)
         .setSchema(schema)
+        .setDesiredBundleSizeBytes(64 * 1024 * 1024L)
         .build();
   }
 


### PR DESCRIPTION
This was overlooked cause unit tests set it explicitly to a small value in order to provide more coverage.

R: @mairbek 