### PR TITLE
[BEAM-2556] Add client-side throttling.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Utility functions & classes that are _not_ specific to the datastore client.
+#
+# For internal use only; no backwards-compatibility guarantees.
+
+import random
+
+from apache_beam.io.gcp.datastore.v1 import util
+
+
+class AdaptiveThrottler(object):
+  """Implements adaptive throttling.
+
+  See
+  https://landing.google.com/sre/book/chapters/handling-overload.html#client-side-throttling-a7sYUg
+  for a full discussion of the use case and algorithm applied.
+  """
+
+  # The target minimum number of requests per samplePeriodMs, even if no
+  # requests succeed. Must be greater than 0, else we could throttle to zero.
+  # Because every decision is probabilistic, there is no guarantee that the
+  # request rate in any given interval will not be zero. (This is the +1 from
+  # the formula in
+  # https://landing.google.com/sre/book/chapters/handling-overload.html )
+  MIN_REQUESTS = 1
+
+  def __init__(self, window_ms, bucket_ms, overload_ratio):
+    """Args:
+      window_ms: int, length of history to consider, in ms, to set throttling.
+      bucket_ms: int, granularity of time buckets that we store data in, in ms.
+      overload_ratio: float, the target ratio between requests sent and
+          successful requests. This is "K" in the formula in
+          https://landing.google.com/sre/book/chapters/handling-overload.html
+    """
+    self._all_requests = util.MovingSum(window_ms, bucket_ms)
+    self._successful_requests = util.MovingSum(window_ms, bucket_ms)
+    self._overload_ratio = float(overload_ratio)
+    self._random = random.Random()
+
+  def _throttling_probability(self, now):
+    if not self._all_requests.has_data(now):
+      return 0
+    all_requests = self._all_requests.sum(now)
+    successful_requests = self._successful_requests.sum(now)
+    return max(
+        0, (all_requests - self._overload_ratio * successful_requests)
+        / (all_requests + AdaptiveThrottler.MIN_REQUESTS))
+
+  def throttle_request(self, now):
+    """Determines whether one RPC attempt should be throttled.
+
+    This should be called once each time the caller intends to send an RPC; if
+    it returns true, drop or delay that request (calling this function again
+    after the delay).
+
+    Args:
+      now: int, time in ms since the epoch
+    Returns:
+      bool, True if the caller should throttle or delay the request.
+    """
+    throttling_probability = self._throttling_probability(now)
+    self._all_requests.add(now, 1)
+    return self._random.uniform(0, 1) < throttling_probability
+
+  def successful_request(self, now):
+    """Notifies the throttler of a successful request.
+
+    Must be called once for each request (for which throttle_request was
+    previously called) that succeeded.
+
+    Args:
+      now: int, time in ms since the epoch
+    """
+    self._successful_requests.add(now, 1)

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler_test.py
@@ -1,0 +1,94 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from mock import patch
+
+from apache_beam.io.gcp.datastore.v1.adaptive_throttler import AdaptiveThrottler
+
+
+class AdaptiveThrottlerTest(unittest.TestCase):
+
+  START_TIME = 1500000000000
+  SAMPLE_PERIOD = 60000
+  BUCKET = 1000
+  OVERLOAD_RATIO = 2
+
+  def setUp(self):
+    self._throttler = AdaptiveThrottler(
+        AdaptiveThrottlerTest.SAMPLE_PERIOD, AdaptiveThrottlerTest.BUCKET,
+        AdaptiveThrottlerTest.OVERLOAD_RATIO)
+
+  # As far as practical, keep these tests aligned with
+  # AdaptiveThrottlerTest.java.
+
+  def test_no_initial_throttling(self):
+    self.assertEqual(0, self._throttler._throttling_probability(
+        AdaptiveThrottlerTest.START_TIME))
+
+  def test_no_throttling_if_no_errors(self):
+    for t in range(AdaptiveThrottlerTest.START_TIME,
+                   AdaptiveThrottlerTest.START_TIME + 20):
+      self.assertFalse(self._throttler.throttle_request(t))
+      self._throttler.successful_request(t)
+    self.assertEqual(0, self._throttler._throttling_probability(
+        AdaptiveThrottlerTest.START_TIME + 20))
+
+  def test_no_throttling_after_errors_expire(self):
+    for t in range(AdaptiveThrottlerTest.START_TIME,
+                   AdaptiveThrottlerTest.START_TIME
+                   + AdaptiveThrottlerTest.SAMPLE_PERIOD, 100):
+      self._throttler.throttle_request(t)
+      # And no sucessful_request
+    self.assertLess(0, self._throttler._throttling_probability(
+        AdaptiveThrottlerTest.START_TIME + AdaptiveThrottlerTest.SAMPLE_PERIOD
+        ))
+    for t in range(AdaptiveThrottlerTest.START_TIME
+                   + AdaptiveThrottlerTest.SAMPLE_PERIOD,
+                   AdaptiveThrottlerTest.START_TIME
+                   + AdaptiveThrottlerTest.SAMPLE_PERIOD*2, 100):
+      self._throttler.throttle_request(t)
+      self._throttler.successful_request(t)
+
+    self.assertEqual(0, self._throttler._throttling_probability(
+        AdaptiveThrottlerTest.START_TIME +
+        AdaptiveThrottlerTest.SAMPLE_PERIOD*2))
+
+  @patch('random.Random')
+  def test_throttling_after_errors(self, mock_random):
+    mock_random().uniform.side_effect = [x/10.0 for x in range(0, 10)]*2
+    self._throttler = AdaptiveThrottler(
+        AdaptiveThrottlerTest.SAMPLE_PERIOD, AdaptiveThrottlerTest.BUCKET,
+        AdaptiveThrottlerTest.OVERLOAD_RATIO)
+    for t in range(AdaptiveThrottlerTest.START_TIME,
+                   AdaptiveThrottlerTest.START_TIME + 20):
+      throttled = self._throttler.throttle_request(t)
+      # 1/3rd of requests succeeding.
+      if t % 3 == 1:
+        self._throttler.successful_request(t)
+
+      if t > AdaptiveThrottlerTest.START_TIME + 10:
+        # Roughly 1/3rd succeeding, 1/3rd failing, 1/3rd throttled.
+        self.assertAlmostEqual(
+            0.33, self._throttler._throttling_probability(t), delta=0.1)
+        # Given the mocked random numbers, we expect 10..13 to be throttled and
+        # 14+ to be unthrottled.
+        self.assertEqual(t < AdaptiveThrottlerTest.START_TIME + 14, throttled)
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
The approach used is as described in
https://landing.google.com/sre/book/chapters/handling-overload.html#client-side-throttling-a7sYUg
. By backing off individual workers in response to high error rates, we relieve
pressure on the Datastore service, increasing the chance that the workload can
complete successfully. This matches the implementation in the Java SDK.

Also fix the timekeeping of the dynamic batching (seconds vs milliseconds).

R: @vikkyrk