### PR TITLE
[proposal] Improving naming of steps that consume side inputs

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -517,10 +517,12 @@ class DataflowRunner(PipelineRunner):
       si_labels[side_pval] = si_label
 
     # Now create the step for the ParDo transform being handled.
+    transform_name = transform_node.full_label.rsplit('/', 1)[-1]
     step = self._add_step(
         TransformNames.DO,
         transform_node.full_label + (
-            '/Do' if transform_node.side_inputs else ''),
+            '/{}'.format(transform_name)
+            if transform_node.side_inputs else ''),
         transform_node,
         transform_node.transform.output_tags)
     fn_data = self._pardo_fn_data(transform_node, lookup_label)


### PR DESCRIPTION
This would allow steps which consume side inputs to have a more intuitive name. We've had several users express confusion about their counters being associated to a step named **Do**.

The previous appearance was like this:
![image](https://user-images.githubusercontent.com/1301740/28727697-9b5dbf66-737a-11e7-9327-7f76dbb37519.png)

This change makes it look like this:
![image](https://user-images.githubusercontent.com/1301740/28727569-2d34bb66-737a-11e7-91e4-d5ec3e36f46a.png)

r: @robertwb what do you think about this?