### PR TITLE
[BEAM-2690] HCatalogIO needs provided scope dependencies on Hadoop, Hive

### DIFF
--- a/sdks/java/io/hcatalog/pom.xml
+++ b/sdks/java/io/hcatalog/pom.xml
@@ -61,6 +61,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <!-- Fix build on JDK-9 -->
         <exclusion>
@@ -89,6 +90,7 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <version>${hive.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>
@@ -101,6 +103,7 @@
       <groupId>org.apache.hive.hcatalog</groupId>
       <artifactId>hive-hcatalog-core</artifactId>
       <version>${hive.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
`beam-sdks-java-io-hcatalog`'s Hadoop and Hive dependencies have a`compile` scope, causing redundant classes to get compiled into the uber jars created for job submission.

This changes the dependencies to `provided` scope, and is consistent with how Hadoop dependencies are handled in `beam-sdks-java-io-hadoop-file-system`.