### PR TITLE
[BEAM-2700] Support load jobs in streaming

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -212,9 +212,8 @@ class BatchLoads<DestinationT>
                     AfterProcessingTime.pastFirstElementInPane().plusDelayOf(triggeringFrequency),
                     AfterPane.elementCountAtLeast(FILE_TRIGGERING_RECORD_COUNT))))
                 .discardingFiredPanes());
-    PCollection<WriteBundlesToFiles.Result<DestinationT>> results = (numFileShards == 0)
-        ? writeDynamicallyShardedFiles(inputInGlobalWindow, tempFilePrefixView) :
-        writeShardedFiles(inputInGlobalWindow, tempFilePrefixView);
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> results = writeShardedFiles(
+        inputInGlobalWindow, tempFilePrefixView);
 
     // Apply the user's trigger before we start generating BigQuery load jobs.
     results  =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -61,7 +61,6 @@ import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Trigger;
-import org.apache.beam.sdk.transforms.windowing.Trigger.OnceTrigger;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.values.KV;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -24,11 +24,14 @@ import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLoc
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
@@ -48,9 +51,14 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.values.KV;
@@ -62,6 +70,7 @@ import org.apache.beam.sdk.values.ShardedKey;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +102,8 @@ class BatchLoads<DestinationT>
   // The maximum size of a single file - 4TiB, just under the 5 TiB limit.
   static final long DEFAULT_MAX_FILE_SIZE = 4 * (1L << 40);
 
+  static final int DEFAULT_NUM_FILE_SHARDS = 0;
+
   // The maximum number of retries to poll the status of a job.
   // It sets to {@code Integer.MAX_VALUE} to block until the BigQuery job finishes.
   static final int LOAD_JOB_POLL_MAX_RETRIES = Integer.MAX_VALUE;
@@ -110,6 +121,9 @@ class BatchLoads<DestinationT>
   private final Coder<DestinationT> destinationCoder;
   private int maxNumWritersPerBundle;
   private long maxFileSize;
+  private int numFileShards;
+  private Duration triggeringFrequency;
+
 
   BatchLoads(WriteDisposition writeDisposition, CreateDisposition createDisposition,
              boolean singletonTable,
@@ -123,6 +137,8 @@ class BatchLoads<DestinationT>
     this.destinationCoder = destinationCoder;
     this.maxNumWritersPerBundle = DEFAULT_MAX_NUM_WRITERS_PER_BUNDLE;
     this.maxFileSize = DEFAULT_MAX_FILE_SIZE;
+    this.numFileShards = DEFAULT_NUM_FILE_SHARDS;
+    this.triggeringFrequency = null;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
@@ -137,6 +153,14 @@ class BatchLoads<DestinationT>
   /** Set the maximum number of file writers that will be open simultaneously in a bundle. */
   public void setMaxNumWritersPerBundle(int maxNumWritersPerBundle) {
     this.maxNumWritersPerBundle = maxNumWritersPerBundle;
+  }
+
+  public void setTriggeringFrequency(Duration triggeringFrequency) {
+    this.triggeringFrequency = triggeringFrequency;
+  }
+
+  public void setNumFileShards(int numFileShards) {
+    this.numFileShards = numFileShards;
   }
 
   @VisibleForTesting
@@ -166,6 +190,10 @@ class BatchLoads<DestinationT>
 
   @Override
   public WriteResult expand(PCollection<KV<DestinationT, TableRow>> input) {
+    if (triggeringFrequency != null) {
+      checkArgument(numFileShards > 0);
+    }
+
     Pipeline p = input.getPipeline();
 
     // Create a singleton job ID token at execution time. This will be used as the base for all
@@ -195,84 +223,148 @@ class BatchLoads<DestinationT>
                             "BigQueryWriteTemp", c.element());
                         LOG.info("Writing BigQuery temporary files to {} before loading them.",
                             tempLocation);
-                        c.output(tempLocation);
+                          c.output(tempLocation);
                       }
                     }))
             .apply("TempFilePrefixView", View.<String>asSingleton());
 
+    Trigger trigger = (triggeringFrequency == null) ? DefaultTrigger.of()
+        : Repeatedly.forever(AfterProcessingTime.pastFirstElementInPane()
+        .plusDelayOf(triggeringFrequency));
     PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
         input.apply(
             "rewindowIntoGlobal",
             Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
-                .triggering(DefaultTrigger.of())
+                .triggering(trigger)
                 .discardingFiredPanes());
-    PCollectionView<Map<DestinationT, String>> schemasView =
-        inputInGlobalWindow.apply(new CalculateSchemas<>(dynamicDestinations));
-
-    TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
-        new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles"){};
-    TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
-        new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {};
-    PCollectionTuple writeBundlesTuple = inputInGlobalWindow
-            .apply("WriteBundlesToFiles",
-                ParDo.of(new WriteBundlesToFiles<>(tempFilePrefix, unwrittedRecordsTag,
-                    maxNumWritersPerBundle, maxFileSize))
-                    .withSideInputs(tempFilePrefix)
-                    .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
-    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
-        writeBundlesTuple.get(writtenFilesTag)
-        .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
-
-    // If the bundles contain too many output tables to be written inline to files (due to memory
-    // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
-    // Group these records by key, and write the files after grouping. Since the record is grouped
-    // by key, we can ensure that only one file is open at a time in each bundle.
-    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFilesGrouped =
-        writeBundlesTuple
-            .get(unwrittedRecordsTag)
-            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
-            .apply(GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
-            .apply(
-                ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(tempFilePrefix, maxFileSize))
-                    .withSideInputs(tempFilePrefix))
-            .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
 
     // PCollection of filename, file byte size, and table destination.
-    PCollection<WriteBundlesToFiles.Result<DestinationT>> results =
-        PCollectionList.of(writtenFiles).and(writtenFilesGrouped)
-        .apply(Flatten.<Result<DestinationT>>pCollections());
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> results;
+    if (numFileShards == 0) {
+      TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
+          new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles") {
+          };
+      TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
+          new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {
+          };
+      PCollectionTuple writeBundlesTuple = inputInGlobalWindow
+          .apply("WriteBundlesToFiles",
+              ParDo.of(new WriteBundlesToFiles<>(tempFilePrefix, unwrittedRecordsTag,
+                  maxNumWritersPerBundle, maxFileSize))
+                  .withSideInputs(tempFilePrefix)
+                  .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
+      PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
+          writeBundlesTuple.get(writtenFilesTag)
+              .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
+      // If the bundles contain too many output tables to be written inline to files (due to memory
+      // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
+      // Group these records by key, and write the files after grouping. Since the record is grouped
+      // by key, we can ensure that only one file is open at a time in each bundle.
+      PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFilesGrouped =
+          writeBundlesTuple
+              .get(unwrittedRecordsTag)
+              .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
+              .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
+              .apply("WriteGroupedRecords",
+                  ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(
+                      tempFilePrefix, maxFileSize))
+                      .withSideInputs(tempFilePrefix))
+              .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
+      // PCollection of filename, file byte size, and table destination.
+      results = PCollectionList.of(writtenFiles).and(writtenFilesGrouped)
+          .apply("FlattenFiles", Flatten.<Result<DestinationT>>pCollections());
+    } else {
+      // TODO: Consider using different triggering for file writes.
+      // The user-supplied triggeringDuration is often chosen to to control how many BigQuery load
+      // jobs are generated, to prevent going over BigQuery's daily quota for load jobs. If this
+      // is set to a large value, currently we have to buffer all the data unti the trigger fires.
+      // However we could give these file writes a more-frequent (or count-based) trigger,
+      // and use the user-supplied trigger on the actual BigQuery load. This allows us to offload
+      // the data to the filesystem.
+      results = inputInGlobalWindow
+          .apply("AddShard", ParDo.of(new DoFn<KV<DestinationT, TableRow>,
+              KV<ShardedKey<DestinationT>, TableRow>>() {
+        int shardNumber;
+        @Setup
+        public void setup() {
+          shardNumber = ThreadLocalRandom.current().nextInt(numFileShards);
+        }
+
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+          DestinationT destination = c.element().getKey();
+          TableRow tableRow = c.element().getValue();
+          c.output(KV.of(ShardedKey.of(destination, (shardNumber + 1) % numFileShards),
+              tableRow));
+        }
+      }))
+          .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
+          .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
+          .apply("WriteGroupedRecords",
+              ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(tempFilePrefix, maxFileSize))
+                  .withSideInputs(tempFilePrefix));
+    }
+    results.setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
 
     TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag =
         new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("multiPartitionsTag") {};
     TupleTag<KV<ShardedKey<DestinationT>, List<String>>> singlePartitionTag =
         new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("singlePartitionTag") {};
 
-    // Turn the list of files and record counts in a PCollectionView that can be used as a
-    // side input.
-    PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView =
-        results.apply("ResultsView",
-            View.<WriteBundlesToFiles.Result<DestinationT>>asIterable());
-    // This transform will look at the set of files written for each table, and if any table has
-    // too many files or bytes, will partition that table's files into multiple partitions for
-    // loading.
-    PCollection<Void> singleton = p.apply("singleton",
-        Create.of((Void) null).withCoder(VoidCoder.of()));
-    PCollectionTuple partitions =
-        singleton.apply(
-            "WritePartition",
-            ParDo.of(
-                    new WritePartition<>(
-                        singletonTable,
-                        dynamicDestinations,
-                        tempFilePrefix,
-                        resultsView,
-                        multiPartitionsTag,
-                        singlePartitionTag))
-                .withSideInputs(tempFilePrefix, resultsView)
-                .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
+    PCollectionTuple partitions;
+    if (triggeringFrequency == null) {
+      // Turn the list of files and record counts in a PCollectionView that can be used as a
+      // side input.
+      PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView =
+          results.apply("ResultsView",
+              View.<WriteBundlesToFiles.Result<DestinationT>>asIterable());
+      // This transform will look at the set of files written for each table, and if any table has
+      // too many files or bytes, will partition that table's files into multiple partitions for
+      // loading.
+      PCollection<Iterable<Result<DestinationT>>> singleton = p.apply("singleton",
+          Create.<Iterable<Result<DestinationT>>>of(ImmutableList.<Result<DestinationT>>of())
+              .withCoder(IterableCoder.of(WriteBundlesToFiles.ResultCoder.of(destinationCoder))));
+      partitions =
+          singleton.apply(
+              "WritePartitionUntriggered",
+              ParDo.of(
+                  new WritePartition<>(
+                      singletonTable,
+                      dynamicDestinations,
+                      tempFilePrefix,
+                      resultsView,
+                      multiPartitionsTag,
+                      singlePartitionTag))
+                  .withSideInputs(tempFilePrefix, resultsView)
+                  .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
+    } else {
+      // If we have non-default triggered output, the above side-input path is incorrect. Instead
+      // make the result list a main input. Apply a GroupByKey first for determinism.
+      partitions = results
+          .apply("AttachSingletonKey",
+              WithKeys.<Void, WriteBundlesToFiles.Result<DestinationT>>of((Void) null))
+          .setCoder(KvCoder.of(VoidCoder.of(),
+              WriteBundlesToFiles.ResultCoder.of(destinationCoder)))
+          .apply("GroupOntoSingleton", GroupByKey.<Void, Result<DestinationT>>create())
+          .apply("ExtractValues", Values.<Iterable<Result<DestinationT>>>create())
+          .apply(
+              "WritePartitionTriggered",
+              ParDo.of(
+                  new WritePartition<>(
+                      singletonTable,
+                      dynamicDestinations,
+                      tempFilePrefix,
+                      null,
+                      multiPartitionsTag,
+                      singlePartitionTag))
+                  .withSideInputs(tempFilePrefix)
+                  .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
+    }
 
     List<PCollectionView<?>> writeTablesSideInputs =
-        Lists.newArrayList(jobIdTokenView, schemasView);
+        Lists.<PCollectionView<?>>newArrayList(jobIdTokenView);
     writeTablesSideInputs.addAll(dynamicDestinations.getSideInputs());
 
     Coder<KV<ShardedKey<DestinationT>, List<String>>> partitionsCoder =
@@ -299,27 +391,46 @@ class BatchLoads<DestinationT>
                             false,
                             bigQueryServices,
                             jobIdTokenView,
-                            schemasView,
                             WriteDisposition.WRITE_EMPTY,
                             CreateDisposition.CREATE_IF_NEEDED,
                             dynamicDestinations))
                     .withSideInputs(writeTablesSideInputs));
 
-    // This view maps each final table destination to the set of temporary partitioned tables
-    // the PCollection was loaded into.
-    PCollectionView<Map<TableDestination, Iterable<String>>> tempTablesView =
-        tempTables.apply("TempTablesView", View.<TableDestination, String>asMultimap());
+    if (triggeringFrequency == null) {
+      // This view maps each final table destination to the set of temporary partitioned tables
+      // the PCollection was loaded into.
+      PCollectionView<Map<TableDestination, Iterable<String>>> tempTablesView =
+          tempTables.apply("TempTablesView", View.<TableDestination, String>asMultimap());
 
-    singleton.apply(
-        "WriteRename",
-        ParDo.of(
-                new WriteRename(
-                    bigQueryServices,
-                    jobIdTokenView,
-                    writeDisposition,
-                    createDisposition,
-                    tempTablesView))
-            .withSideInputs(tempTablesView, jobIdTokenView));
+      PCollection<KV<TableDestination, Iterable<String>>> singleton = p
+          .apply("singletonRename", Create.<KV<TableDestination, Iterable<String>>>of(
+              (KV<TableDestination, Iterable<String>>) null)
+              .withCoder(NullableCoder.of(KvCoder.of(TableDestinationCoder.of(), IterableCoder.of
+                  (StringUtf8Coder.of())))));
+      singleton.apply(
+          "WriteRenameUntriggered",
+          ParDo.of(
+              new WriteRename(
+                  bigQueryServices,
+                  jobIdTokenView,
+                  writeDisposition,
+                  createDisposition,
+                  tempTablesView))
+              .withSideInputs(tempTablesView, jobIdTokenView));
+    } else {
+      tempTables
+          .setCoder(KvCoder.of(TableDestinationCoder.of(), StringUtf8Coder.of()))
+          .apply(GroupByKey.<TableDestination, String>create())
+          .apply("WriteRenameTriggered",
+              ParDo.of(
+                  new WriteRename(
+                      bigQueryServices,
+                      jobIdTokenView,
+                      writeDisposition,
+                      createDisposition,
+                      null))
+                  .withSideInputs(jobIdTokenView));
+    }
 
     // Write single partition to final table
     partitions
@@ -336,7 +447,6 @@ class BatchLoads<DestinationT>
                         true,
                         bigQueryServices,
                         jobIdTokenView,
-                        schemasView,
                         writeDisposition,
                         createDisposition,
                         dynamicDestinations))

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -19,15 +19,14 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLocation;
 
 import com.google.api.services.bigquery.model.TableRow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
@@ -60,7 +59,6 @@ import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
-import org.apache.beam.sdk.transforms.windowing.Trigger;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.values.KV;
@@ -194,214 +192,274 @@ class BatchLoads<DestinationT>
     }
   }
 
-  @Override
-  public WriteResult expand(PCollection<KV<DestinationT, TableRow>> input) {
-    if (triggeringFrequency != null) {
-      checkArgument(numFileShards > 0);
-    }
-
+  // Expand the pipeline when the user has requested periodically-triggered file writes.
+  private WriteResult expandTriggered(PCollection<KV<DestinationT, TableRow>> input) {
+    checkArgument(numFileShards > 0);
     Pipeline p = input.getPipeline();
+    final PCollectionView<String> jobIdTokenView = createJobIdView(p);
+    final PCollectionView<String> tempFilePrefixView = createTempFilePrefixView(jobIdTokenView);
+    // The user-supplied triggeringDuration is often chosen to to control how many BigQuery load
+    // jobs are generated, to prevent going over BigQuery's daily quota for load jobs. If this
+    // is set to a large value, currently we have to buffer all the data unti the trigger fires.
+    // Instead we ensure that the files are written if a threshold number of records are ready.
+    // We use only the user-supplied trigger on the actual BigQuery load. This allows us to
+    // offload the data to the filesystem.
+    PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
+        input.apply(
+            "rewindowIntoGlobal",
+            Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
+                .triggering(Repeatedly.forever(AfterFirst.of(
+                    AfterProcessingTime.pastFirstElementInPane().plusDelayOf(triggeringFrequency),
+                    AfterPane.elementCountAtLeast(FILE_TRIGGERING_RECORD_COUNT))))
+                .discardingFiredPanes());
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> results = (numFileShards == 0)
+        ? writeDynamicallyShardedFiles(inputInGlobalWindow, tempFilePrefixView) :
+        writeShardedFiles(inputInGlobalWindow, tempFilePrefixView);
 
-    // Create a singleton job ID token at execution time. This will be used as the base for all
-    // load jobs issued from this instance of the transform.
-    final PCollection<String> jobIdToken =
-        p.apply("TriggerIdCreation", Create.of("ignored"))
-            .apply(
-                "CreateJobId",
-                MapElements.via(
-                    new SimpleFunction<String, String>() {
-                      @Override
-                      public String apply(String input) {
-                        return BigQueryHelpers.randomUUIDString();
-                      }
-                    }));
-    final PCollectionView<String> jobIdTokenView = jobIdToken.apply(View.<String>asSingleton());
-
-    PCollectionView<String> tempFilePrefix = jobIdToken
-            .apply(
-                "GetTempFilePrefix",
-                ParDo.of(
-                    new DoFn<String, String>() {
-                      @ProcessElement
-                      public void getTempFilePrefix(ProcessContext c) {
-                        String tempLocation = resolveTempLocation(
-                            c.getPipelineOptions().getTempLocation(),
-                            "BigQueryWriteTemp", c.element());
-                        LOG.info("Writing BigQuery temporary files to {} before loading them.",
-                            tempLocation);
-                          c.output(tempLocation);
-                      }
-                    }))
-            .apply("TempFilePrefixView", View.<String>asSingleton());
-
-    // PCollection of filename, file byte size, and table destination.
-    PCollection<WriteBundlesToFiles.Result<DestinationT>> results;
-    if (numFileShards == 0) {
-      PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
-          input.apply(
-              "rewindowIntoGlobal",
-              Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
-                  .triggering(DefaultTrigger.of())
-                  .discardingFiredPanes());
-      TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
-          new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles") {
-          };
-      TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
-          new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {
-          };
-      PCollectionTuple writeBundlesTuple = inputInGlobalWindow
-          .apply("WriteBundlesToFiles",
-              ParDo.of(new WriteBundlesToFiles<>(tempFilePrefix, unwrittedRecordsTag,
-                  maxNumWritersPerBundle, maxFileSize))
-                  .withSideInputs(tempFilePrefix)
-                  .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
-      PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
-          writeBundlesTuple.get(writtenFilesTag)
-              .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
-
-      // If the bundles contain too many output tables to be written inline to files (due to memory
-      // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
-      // Group these records by key, and write the files after grouping. Since the record is grouped
-      // by key, we can ensure that only one file is open at a time in each bundle.
-      PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFilesGrouped =
-          writeBundlesTuple
-              .get(unwrittedRecordsTag)
-              .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
-              .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
-              .apply("WriteGroupedRecords",
-                  ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(
-                      tempFilePrefix, maxFileSize))
-                      .withSideInputs(tempFilePrefix))
-              .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
-
-      // PCollection of filename, file byte size, and table destination.
-      results = PCollectionList.of(writtenFiles).and(writtenFilesGrouped)
-          .apply("FlattenFiles", Flatten.<Result<DestinationT>>pCollections());
-    } else {
-      // The user-supplied triggeringDuration is often chosen to to control how many BigQuery load
-      // jobs are generated, to prevent going over BigQuery's daily quota for load jobs. If this
-      // is set to a large value, currently we have to buffer all the data unti the trigger fires.
-      // Instead we ensure that the files are written if a threshold number of records are ready.
-      // We use only the user-supplied trigger on the actual BigQuery load. This allows us to
-      // offload the data to the filesystem.
-      Trigger trigger = DefaultTrigger.of();
-      if (triggeringFrequency != null) {
-        trigger = Repeatedly.forever(AfterFirst.of(
-            AfterProcessingTime.pastFirstElementInPane().plusDelayOf(triggeringFrequency),
-            AfterPane.elementCountAtLeast(FILE_TRIGGERING_RECORD_COUNT)));
-      }
-      PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
-          input.apply(
-              "rewindowIntoGlobal",
-              Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
-                  .triggering(trigger)
-                  .discardingFiredPanes());
-
-      results = inputInGlobalWindow
-          .apply("AddShard", ParDo.of(new DoFn<KV<DestinationT, TableRow>,
-              KV<ShardedKey<DestinationT>, TableRow>>() {
-        int shardNumber;
-        @Setup
-        public void setup() {
-          shardNumber = ThreadLocalRandom.current().nextInt(numFileShards);
-        }
-
-        @ProcessElement
-        public void processElement(ProcessContext c) {
-          DestinationT destination = c.element().getKey();
-          TableRow tableRow = c.element().getValue();
-          c.output(KV.of(ShardedKey.of(destination, (shardNumber + 1) % numFileShards),
-              tableRow));
-        }
-      }))
-          .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
-          .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
-          .apply("WriteGroupedRecords",
-              ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(tempFilePrefix, maxFileSize))
-                  .withSideInputs(tempFilePrefix));
-    }
-    results.setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+    // Apply the user's trigger before we start generating BigQuery load jobs.
+    results  =
+        results.apply(
+            "applyUserTrigger",
+            Window.< WriteBundlesToFiles.Result<DestinationT>>into(new GlobalWindows())
+                .triggering(Repeatedly.forever(
+                    AfterProcessingTime.pastFirstElementInPane()
+                        .plusDelayOf(triggeringFrequency)))
+                .discardingFiredPanes());
 
     TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag =
         new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("multiPartitionsTag") {};
     TupleTag<KV<ShardedKey<DestinationT>, List<String>>> singlePartitionTag =
         new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("singlePartitionTag") {};
 
-    PCollectionTuple partitions;
-    if (triggeringFrequency == null) {
-      // Turn the list of files and record counts in a PCollectionView that can be used as a
-      // side input.
-      PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView =
-          results.apply("ResultsView",
-              View.<WriteBundlesToFiles.Result<DestinationT>>asIterable());
-      // This transform will look at the set of files written for each table, and if any table has
-      // too many files or bytes, will partition that table's files into multiple partitions for
-      // loading.
-      PCollection<Iterable<Result<DestinationT>>> singleton = p.apply("singleton",
-          Create.<Iterable<Result<DestinationT>>>of(ImmutableList.<Result<DestinationT>>of())
-              .withCoder(IterableCoder.of(WriteBundlesToFiles.ResultCoder.of(destinationCoder))));
-      partitions =
-          singleton.apply(
-              "WritePartitionUntriggered",
-              ParDo.of(
-                  new WritePartition<>(
-                      singletonTable,
-                      dynamicDestinations,
-                      tempFilePrefix,
-                      resultsView,
-                      multiPartitionsTag,
-                      singlePartitionTag))
-                  .withSideInputs(tempFilePrefix, resultsView)
-                  .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
-    } else {
-      // Apply the user's trigger to ensure we don't generate too many BigQuery load jobs.
-      results  =
-          results.apply(
-              "applyUserTrigger",
-              Window.< WriteBundlesToFiles.Result<DestinationT>>into(new GlobalWindows())
-                  .triggering(Repeatedly.forever(
-                      AfterProcessingTime.pastFirstElementInPane()
-                          .plusDelayOf(triggeringFrequency)))
-                  .discardingFiredPanes());
+    // If we have non-default triggered output, we can't use the side-input technique used in
+    // expandUntriggered . Instead make the result list a main input. Apply a GroupByKey first for
+    // determinism.
+    PCollectionTuple partitions = results
+        .apply("AttachSingletonKey",
+            WithKeys.<Void, WriteBundlesToFiles.Result<DestinationT>>of((Void) null))
+        .setCoder(KvCoder.of(VoidCoder.of(), WriteBundlesToFiles.ResultCoder.of(destinationCoder)))
+        .apply("GroupOntoSingleton", GroupByKey.<Void, Result<DestinationT>>create())
+        .apply("ExtractResultValues", Values.<Iterable<Result<DestinationT>>>create())
+        .apply("WritePartitionTriggered",
+            ParDo.of(
+                new WritePartition<>(
+                    singletonTable,
+                    dynamicDestinations,
+                    tempFilePrefixView,
+                    multiPartitionsTag,
+                    singlePartitionTag))
+                .withSideInputs(tempFilePrefixView)
+                .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
+    PCollection<KV<TableDestination, String>> tempTables = writeTempTables(
+        partitions.get(multiPartitionsTag), jobIdTokenView);
+    tempTables
+        // Now that the load job has happened, we want the rename to happen immediately.
+        .apply(Window.<KV<TableDestination, String>>into(new GlobalWindows())
+            .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1))))
+        .apply(WithKeys.<Void, KV<TableDestination, String>>of((Void) null))
+        .setCoder(KvCoder.of(
+            VoidCoder.of(), KvCoder.of(TableDestinationCoder.of(), StringUtf8Coder.of())))
+        .apply(GroupByKey.<Void, KV<TableDestination, String>>create())
+        .apply(Values.<Iterable<KV<TableDestination, String>>>create())
+        .apply("WriteRenameTriggered",
+            ParDo.of(
+                new WriteRename(
+                    bigQueryServices,
+                    jobIdTokenView,
+                    writeDisposition,
+                    createDisposition))
+                .withSideInputs(jobIdTokenView));
+    writeSinglePartition(partitions.get(singlePartitionTag), jobIdTokenView);
+    return writeResult(p);
+  }
 
-      // If we have non-default triggered output, the above side-input path is incorrect. Instead
-      // make the result list a main input. Apply a GroupByKey first for determinism.
-      partitions = results
-          .apply("AttachSingletonKey",
-              WithKeys.<Void, WriteBundlesToFiles.Result<DestinationT>>of((Void) null))
-          .setCoder(KvCoder.of(VoidCoder.of(),
-              WriteBundlesToFiles.ResultCoder.of(destinationCoder)))
-          .apply("GroupOntoSingleton", GroupByKey.<Void, Result<DestinationT>>create())
-          .apply("ExtractValues", Values.<Iterable<Result<DestinationT>>>create())
-          .apply(
-              "WritePartitionTriggered",
-              ParDo.of(
-                  new WritePartition<>(
-                      singletonTable,
-                      dynamicDestinations,
-                      tempFilePrefix,
-                      null,
-                      multiPartitionsTag,
-                      singlePartitionTag))
-                  .withSideInputs(tempFilePrefix)
-                  .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
-    }
+  // Expand the pipeline when the user has not requested periodically-triggered file writes.
+  public WriteResult expandUntriggered(PCollection<KV<DestinationT, TableRow>> input) {
+    Pipeline p = input.getPipeline();
+    final PCollectionView<String> jobIdTokenView = createJobIdView(p);
+    final PCollectionView<String> tempFilePrefixView = createTempFilePrefixView(jobIdTokenView);
+    PCollection<KV<DestinationT, TableRow>> inputInGlobalWindow =
+        input.apply(
+            "rewindowIntoGlobal",
+            Window.<KV<DestinationT, TableRow>>into(new GlobalWindows())
+                .triggering(DefaultTrigger.of())
+                .discardingFiredPanes());
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> results = (numFileShards == 0)
+        ? writeDynamicallyShardedFiles(inputInGlobalWindow, tempFilePrefixView) :
+        writeShardedFiles(inputInGlobalWindow, tempFilePrefixView);
 
-    List<PCollectionView<?>> writeTablesSideInputs =
-        Lists.<PCollectionView<?>>newArrayList(jobIdTokenView);
-    writeTablesSideInputs.addAll(dynamicDestinations.getSideInputs());
+    TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag =
+        new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("multiPartitionsTag") {};
+    TupleTag<KV<ShardedKey<DestinationT>, List<String>>> singlePartitionTag =
+        new TupleTag<KV<ShardedKey<DestinationT>, List<String>>>("singlePartitionTag") {};
+
+    // Turn the list of files and record counts in a PCollectionView that can be used as a
+    // side input.
+    PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView =
+        results.apply("ResultsView",
+            View.<WriteBundlesToFiles.Result<DestinationT>>asIterable());
+    // This transform will look at the set of files written for each table, and if any table has
+    // too many files or bytes, will partition that table's files into multiple partitions for
+    // loading.
+    PCollectionTuple partitions =
+        p.apply("SelectPartitionInput", ExtractSideInput.fromSideInput(resultsView))
+            .setCoder(IterableCoder.of(WriteBundlesToFiles.ResultCoder.of(destinationCoder)))
+            .apply("WritePartitionUntriggered",
+                ParDo.of(
+                    new WritePartition<>(
+                        singletonTable,
+                        dynamicDestinations,
+                        tempFilePrefixView,
+                        multiPartitionsTag,
+                        singlePartitionTag))
+                    .withSideInputs(tempFilePrefixView)
+                    .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
+    PCollection<KV<TableDestination, String>> tempTables = writeTempTables(
+        partitions.get(multiPartitionsTag), jobIdTokenView);
+
+    // This view maps each final table destination to the set of temporary partitioned tables
+    // the PCollection was loaded into.
+    PCollectionView<Iterable<KV<TableDestination, String>>> tempTablesView =
+        tempTables.apply("TempTablesView", View.<KV<TableDestination, String>>asIterable());
+    p.apply("SelectRenameInput", ExtractSideInput.fromSideInput(tempTablesView))
+        .setCoder(IterableCoder.of(KvCoder.of(TableDestinationCoder.of(), StringUtf8Coder.of())))
+        .apply("WriteRenameUntriggered",
+            ParDo.of(
+                new WriteRename(
+                    bigQueryServices,
+                    jobIdTokenView,
+                    writeDisposition,
+                    createDisposition))
+                .withSideInputs(jobIdTokenView));
+    writeSinglePartition(partitions.get(singlePartitionTag), jobIdTokenView);
+    return writeResult(p);
+  }
+
+  // Generate the base job id string.
+  private PCollectionView<String> createJobIdView(Pipeline p) {
+    // Create a singleton job ID token at execution time. This will be used as the base for all
+    // load jobs issued from this instance of the transform.
+    return p.apply("JobIdCreationRoot", Create.of((Void) null))
+        .apply(
+            "CreateJobId",
+            MapElements.via(
+                new SimpleFunction<Void, String>() {
+                  @Override
+                  public String apply(Void input) {
+                    return BigQueryHelpers.randomUUIDString();
+                  }
+                }))
+        .apply(View.<String>asSingleton());
+  }
+
+  // Generate the temporary-file prefix.
+  private PCollectionView<String> createTempFilePrefixView(PCollectionView<String> jobIdView) {
+    return ((PCollection<String>) jobIdView.getPCollection())
+        .apply(
+            "GetTempFilePrefix",
+            ParDo.of(
+                new DoFn<String, String>() {
+                  @ProcessElement
+                  public void getTempFilePrefix(ProcessContext c) {
+                    String tempLocation = resolveTempLocation(
+                        c.getPipelineOptions().getTempLocation(),
+                        "BigQueryWriteTemp", c.element());
+                    LOG.info("Writing BigQuery temporary files to {} before loading them.",
+                        tempLocation);
+                    c.output(tempLocation);
+                  }
+                }))
+        .apply("TempFilePrefixView", View.<String>asSingleton());
+  }
+
+  // Writes input data to dynamically-sharded, per-bundle files. Returns a PCollection of filename,
+  // file byte size, and table destination.
+  PCollection<WriteBundlesToFiles.Result<DestinationT>> writeDynamicallyShardedFiles(
+      PCollection<KV<DestinationT, TableRow>> input, PCollectionView<String> tempFilePrefix) {
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> results;
+    TupleTag<WriteBundlesToFiles.Result<DestinationT>> writtenFilesTag =
+        new TupleTag<WriteBundlesToFiles.Result<DestinationT>>("writtenFiles") {
+        };
+    TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag =
+        new TupleTag<KV<ShardedKey<DestinationT>, TableRow>>("unwrittenRecords") {
+        };
+    PCollectionTuple writeBundlesTuple = input
+        .apply("WriteBundlesToFiles",
+            ParDo.of(new WriteBundlesToFiles<>(tempFilePrefix, unwrittedRecordsTag,
+                maxNumWritersPerBundle, maxFileSize))
+                .withSideInputs(tempFilePrefix)
+                .withOutputTags(writtenFilesTag, TupleTagList.of(unwrittedRecordsTag)));
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFiles =
+        writeBundlesTuple.get(writtenFilesTag)
+            .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
+    // If the bundles contain too many output tables to be written inline to files (due to memory
+    // limits), any unwritten records will be spilled to the unwrittenRecordsTag PCollection.
+    // Group these records by key, and write the files after grouping. Since the record is grouped
+    // by key, we can ensure that only one file is open at a time in each bundle.
+    PCollection<WriteBundlesToFiles.Result<DestinationT>> writtenFilesGrouped =
+        writeBundlesTuple
+            .get(unwrittedRecordsTag)
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
+            .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
+            .apply("WriteGroupedRecords",
+                ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(
+                    tempFilePrefix, maxFileSize))
+                    .withSideInputs(tempFilePrefix))
+            .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+
+    // PCollection of filename, file byte size, and table destination.
+    return PCollectionList.of(writtenFiles).and(writtenFilesGrouped)
+        .apply("FlattenFiles", Flatten.<Result<DestinationT>>pCollections())
+        .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+  }
+
+  // Writes input data to statically-sharded files. Returns a PCollection of filename,
+  // file byte size, and table destination.
+  PCollection<WriteBundlesToFiles.Result<DestinationT>> writeShardedFiles(
+      PCollection<KV<DestinationT, TableRow>> input, PCollectionView<String> tempFilePrefix) {
+    checkState(numFileShards > 0);
+    return input
+        .apply("AddShard", ParDo.of(new DoFn<KV<DestinationT, TableRow>,
+            KV<ShardedKey<DestinationT>, TableRow>>() {
+          int shardNumber;
+          @Setup
+          public void setup() {
+            shardNumber = ThreadLocalRandom.current().nextInt(numFileShards);
+          }
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            DestinationT destination = c.element().getKey();
+            TableRow tableRow = c.element().getValue();
+            c.output(KV.of(ShardedKey.of(destination, ++shardNumber  % numFileShards),
+                tableRow));
+          }
+        }))
+        .setCoder(KvCoder.of(ShardedKeyCoder.of(destinationCoder), TableRowJsonCoder.of()))
+        .apply("GroupByDestination", GroupByKey.<ShardedKey<DestinationT>, TableRow>create())
+        .apply("WriteGroupedRecords",
+            ParDo.of(new WriteGroupedRecordsToFiles<DestinationT>(tempFilePrefix, maxFileSize))
+                .withSideInputs(tempFilePrefix))
+        .setCoder(WriteBundlesToFiles.ResultCoder.of(destinationCoder));
+  }
+
+  // Take in a list of files and write them to temporary tables.
+  private PCollection<KV<TableDestination, String>> writeTempTables(
+      PCollection<KV<ShardedKey<DestinationT>, List<String>>> input,
+    PCollectionView<String> jobIdTokenView) {
+    List<PCollectionView<?>> sideInputs = Lists.<PCollectionView<?>>newArrayList(jobIdTokenView);
+    sideInputs.addAll(dynamicDestinations.getSideInputs());
 
     Coder<KV<ShardedKey<DestinationT>, List<String>>> partitionsCoder =
-          KvCoder.of(
-              ShardedKeyCoder.of(NullableCoder.of(destinationCoder)),
-              ListCoder.of(StringUtf8Coder.of()));
+        KvCoder.of(
+            ShardedKeyCoder.of(NullableCoder.of(destinationCoder)),
+            ListCoder.of(StringUtf8Coder.of()));
 
     // If WriteBundlesToFiles produced more than MAX_NUM_FILES files or MAX_SIZE_BYTES bytes, then
     // the import needs to be split into multiple partitions, and those partitions will be
     // specified in multiPartitionsTag.
-    PCollection<KV<TableDestination, String>> tempTables =
-        partitions
-            .get(multiPartitionsTag)
+    return input
             .setCoder(partitionsCoder)
             // Reshuffle will distribute this among multiple workers, and also guard against
             // reexecution of the WritePartitions step once WriteTables has begun.
@@ -411,54 +469,28 @@ class BatchLoads<DestinationT>
             .apply(
                 "MultiPartitionsWriteTables",
                 ParDo.of(
-                        new WriteTables<>(
-                            false,
-                            bigQueryServices,
-                            jobIdTokenView,
-                            WriteDisposition.WRITE_EMPTY,
-                            CreateDisposition.CREATE_IF_NEEDED,
-                            dynamicDestinations))
-                    .withSideInputs(writeTablesSideInputs));
+                    new WriteTables<>(
+                        false,
+                        bigQueryServices,
+                        jobIdTokenView,
+                        WriteDisposition.WRITE_EMPTY,
+                        CreateDisposition.CREATE_IF_NEEDED,
+                        dynamicDestinations))
+                    .withSideInputs(sideInputs));
+  }
 
-    if (triggeringFrequency == null) {
-      // This view maps each final table destination to the set of temporary partitioned tables
-      // the PCollection was loaded into.
-      PCollectionView<Map<TableDestination, Iterable<String>>> tempTablesView =
-          tempTables.apply("TempTablesView", View.<TableDestination, String>asMultimap());
-
-      PCollection<KV<TableDestination, Iterable<String>>> singleton = p
-          .apply("singletonRename", Create.<KV<TableDestination, Iterable<String>>>of(
-              (KV<TableDestination, Iterable<String>>) null)
-              .withCoder(NullableCoder.of(KvCoder.of(TableDestinationCoder.of(), IterableCoder.of
-                  (StringUtf8Coder.of())))));
-      singleton.apply(
-          "WriteRenameUntriggered",
-          ParDo.of(
-              new WriteRename(
-                  bigQueryServices,
-                  jobIdTokenView,
-                  writeDisposition,
-                  createDisposition,
-                  tempTablesView))
-              .withSideInputs(tempTablesView, jobIdTokenView));
-    } else {
-      tempTables
-          .setCoder(KvCoder.of(TableDestinationCoder.of(), StringUtf8Coder.of()))
-          .apply(GroupByKey.<TableDestination, String>create())
-          .apply("WriteRenameTriggered",
-              ParDo.of(
-                  new WriteRename(
-                      bigQueryServices,
-                      jobIdTokenView,
-                      writeDisposition,
-                      createDisposition,
-                      null))
-                  .withSideInputs(jobIdTokenView));
-    }
-
+  // In the case where the files fit into a single load job, there's no need to write temporary
+  // tables and rename. We can load these files directly into the target BigQuery table.
+  void writeSinglePartition(PCollection<KV<ShardedKey<DestinationT>, List<String>>> input,
+      PCollectionView<String> jobIdTokenView) {
+    List<PCollectionView<?>> sideInputs = Lists.<PCollectionView<?>>newArrayList(jobIdTokenView);
+    sideInputs.addAll(dynamicDestinations.getSideInputs());
+    Coder<KV<ShardedKey<DestinationT>, List<String>>> partitionsCoder =
+        KvCoder.of(
+            ShardedKeyCoder.of(NullableCoder.of(destinationCoder)),
+            ListCoder.of(StringUtf8Coder.of()));
     // Write single partition to final table
-    partitions
-        .get(singlePartitionTag)
+    input
         .setCoder(partitionsCoder)
         // Reshuffle will distribute this among multiple workers, and also guard against
         // reexecution of the WritePartitions step once WriteTables has begun.
@@ -467,17 +499,23 @@ class BatchLoads<DestinationT>
         .apply(
             "SinglePartitionWriteTables",
             ParDo.of(
-                    new WriteTables<>(
-                        true,
-                        bigQueryServices,
-                        jobIdTokenView,
-                        writeDisposition,
-                        createDisposition,
-                        dynamicDestinations))
-                .withSideInputs(writeTablesSideInputs));
+                new WriteTables<>(
+                    true,
+                    bigQueryServices,
+                    jobIdTokenView,
+                    writeDisposition,
+                    createDisposition,
+                    dynamicDestinations))
+                .withSideInputs(sideInputs));
+  }
 
+  private WriteResult writeResult(Pipeline p) {
     PCollection<TableRow> empty =
         p.apply("CreateEmptyFailedInserts", Create.empty(TypeDescriptor.of(TableRow.class)));
-    return WriteResult.in(input.getPipeline(), new TupleTag<TableRow>("failedInserts"), empty);
+    return WriteResult.in(p, new TupleTag<TableRow>("failedInserts"), empty);
+  }
+  @Override
+  public WriteResult expand(PCollection<KV<DestinationT, TableRow>> input) {
+    return (triggeringFrequency != null) ? expandTriggered(input) : expandUntriggered(input);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -229,6 +229,14 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Please see <a href="https://cloud.google.com/bigquery/access-control">BigQuery Access Control
  * </a> for security and permission related information specific to BigQuery.
+ *
+ * <h3>Insertion Method</h3>
+ * {@link BigQueryIO.Write} supports two methods of inserting data into BigQuery specified using
+ * {@link BigQueryIO.Write#withMethod}. If no method is supplied, then a default method will be
+ * chosen based on the input PCollection. See {@link BigQueryIO.Write.Method} for more information
+ * about the methods. The different insertion methods provide different tradeoffs of cost, quota,
+ * and data consistency; please see BigQuery documentation for more information about these
+ * tradeoffs.
  */
 public class BigQueryIO {
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryIO.class);
@@ -787,7 +795,7 @@ public class BigQueryIO {
     public enum Method {
       /**
        * The default behavior if no method is explicitly set. If the input is bounded, then file
-       * loads will be use. If the input is unbounded, then streaming inserts will be used.
+       * loads will be used. If the input is unbounded, then streaming inserts will be used.
        */
       DEFAULT,
 
@@ -797,7 +805,8 @@ public class BigQueryIO {
        * This method can be chosen for unbounded inputs as well, as long as a triggering frequency
        * is also set using {@link #withTriggeringFrequency}. BigQuery has daily quotas on the number
        * of load jobs allowed per day, so be careful not to set the triggering frequency too
-       * frequent.
+       * frequent. For more information, see
+       * https://cloud.google.com/bigquery/docs/loading-data-cloud-storage
        */
       FILE_LOADS,
 
@@ -809,7 +818,8 @@ public class BigQueryIO {
        * https://cloud.google.com/bigquery/streaming-data-into-bigquery). A query can be run over
        * the output table to periodically clean these rare duplicates. Alternatively, using the
        * {@link #FILE_LOADS} insert method does guarantee no duplicates, though the latency for the
-       * insert into BigQuery will be much higher.
+       * insert into BigQuery will be much higher. For more information, see
+       * https://cloud.google.com/bigquery/streaming-data-into-bigquery
        */
       STREAMING_INSERTS
     }
@@ -1052,7 +1062,7 @@ public class BigQueryIO {
      *
      * <p>This is only applicable when the write method is set to {@link Method#FILE_LOADS}.
      * Every triggeringFrequency duration, a BigQuery load job will be generated for all
-     * the files written in the last pane. BigQuery has limits on how many load jobs can be
+     * the data written since the last load job. BigQuery has limits on how many load jobs can be
      * triggered per day, so be careful not to set this duration too low, or you may exceed daily
      * quota. Often this is set to 5 or 10 minutes to ensure that the project stays well under the
      * BigQuery quota. See https://cloud.google.com/bigquery/quota-policy for more information about

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ExtractSideInput.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/ExtractSideInput.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * This transforms turns a side input into a singleton PCollection that can be used as the main
+ * input for another transform.
+ */
+public class ExtractSideInput<T> extends PTransform<PBegin, PCollection<T>> {
+  @Nullable
+  private PCollectionView<T> view;
+
+  private ExtractSideInput(PCollectionView<T> view) {
+    this.view = view;
+  }
+
+  public static <T> ExtractSideInput<T> fromSideInput(PCollectionView<T> view) {
+    return new ExtractSideInput<>(view);
+  }
+
+  @Override
+  public PCollection<T> expand(PBegin input) {
+    return input.getPipeline().apply(Create.of((Void) null).withCoder(VoidCoder.of()))
+        .apply(ParDo.of(new DoFn<Void, T>() {
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            c.output(c.sideInput(view));
+          }
+        }).withSideInputs(view));
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -179,7 +179,7 @@ class WriteBundlesToFiles<DestinationT>
         // into the output. It will be grouped and written to a file in a subsequent stage.
         c.output(unwrittenRecordsTag,
             KV.of(ShardedKey.of(destination,
-                (spilledShardNumber + 1) % SPILLED_RECORD_SHARDING_FACTOR),
+                (++spilledShardNumber) % SPILLED_RECORD_SHARDING_FACTOR),
                 c.element().getValue()));
         return;
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -66,9 +66,11 @@ class WriteBundlesToFiles<DestinationT>
   private transient Map<DestinationT, TableRowWriter> writers;
   private transient Map<DestinationT, BoundedWindow> writerWindows;
   private final PCollectionView<String> tempFilePrefixView;
-  private final TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag;
+  private final TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittenRecordsTag;
   private int maxNumWritersPerBundle;
   private long maxFileSize;
+  private int spilledShardNumber;
+
 
   /**
    * The result of the {@link WriteBundlesToFiles} transform. Corresponds to a single output file,
@@ -133,11 +135,11 @@ class WriteBundlesToFiles<DestinationT>
 
   WriteBundlesToFiles(
       PCollectionView<String> tempFilePrefixView,
-      TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittedRecordsTag,
+      TupleTag<KV<ShardedKey<DestinationT>, TableRow>> unwrittenRecordsTag,
       int maxNumWritersPerBundle,
       long maxFileSize) {
     this.tempFilePrefixView = tempFilePrefixView;
-    this.unwrittedRecordsTag = unwrittedRecordsTag;
+    this.unwrittenRecordsTag = unwrittenRecordsTag;
     this.maxNumWritersPerBundle = maxNumWritersPerBundle;
     this.maxFileSize = maxFileSize;
   }
@@ -148,6 +150,7 @@ class WriteBundlesToFiles<DestinationT>
     // bundles.
     this.writers = Maps.newHashMap();
     this.writerWindows = Maps.newHashMap();
+    this.spilledShardNumber = ThreadLocalRandom.current().nextInt(SPILLED_RECORD_SHARDING_FACTOR);
   }
 
   TableRowWriter createAndInsertWriter(DestinationT destination, String tempFilePrefix,
@@ -174,9 +177,9 @@ class WriteBundlesToFiles<DestinationT>
       } else {
         // This means that we already had too many writers open in this bundle. "spill" this record
         // into the output. It will be grouped and written to a file in a subsequent stage.
-        c.output(unwrittedRecordsTag,
+        c.output(unwrittenRecordsTag,
             KV.of(ShardedKey.of(destination,
-                ThreadLocalRandom.current().nextInt(SPILLED_RECORD_SHARDING_FACTOR)),
+                (spilledShardNumber + 1) % SPILLED_RECORD_SHARDING_FACTOR),
                 c.element().getValue()));
         return;
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WritePartition.java
@@ -41,7 +41,6 @@ class WritePartition<DestinationT>
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
   private final PCollectionView<String> tempFilePrefix;
   @Nullable
-  private final PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView;
   private TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag;
   private TupleTag<KV<ShardedKey<DestinationT>, List<String>>> singlePartitionTag;
 
@@ -107,12 +106,10 @@ class WritePartition<DestinationT>
       boolean singletonTable,
       DynamicDestinations<?, DestinationT> dynamicDestinations,
       PCollectionView<String> tempFilePrefix,
-      @Nullable PCollectionView<Iterable<WriteBundlesToFiles.Result<DestinationT>>> resultsView,
       TupleTag<KV<ShardedKey<DestinationT>, List<String>>> multiPartitionsTag,
       TupleTag<KV<ShardedKey<DestinationT>, List<String>>> singlePartitionTag) {
     this.singletonTable = singletonTable;
     this.dynamicDestinations = dynamicDestinations;
-    this.resultsView = resultsView;
     this.tempFilePrefix = tempFilePrefix;
     this.multiPartitionsTag = multiPartitionsTag;
     this.singlePartitionTag = singlePartitionTag;
@@ -120,8 +117,7 @@ class WritePartition<DestinationT>
 
   @ProcessElement
   public void processElement(ProcessContext c) throws Exception {
-    List<WriteBundlesToFiles.Result<DestinationT>> results =
-        Lists.newArrayList((resultsView != null) ? c.sideInput(this.resultsView) : c.element());
+    List<WriteBundlesToFiles.Result<DestinationT>> results = Lists.newArrayList(c.element());
 
     // If there are no elements to write _and_ the user specified a constant output table, then
     // generate an empty table of that name.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -23,13 +23,11 @@ import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -71,7 +69,7 @@ class WriteTables<DestinationT>
   private final WriteDisposition firstPaneWriteDisposition;
   private final CreateDisposition firstPaneCreateDisposition;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
-  private Map<DestinationT, String> jsonSchemas = Maps.newConcurrentMap();
+  private Map<DestinationT, String> jsonSchemas = Maps.newHashMap();
 
   public WriteTables(
       boolean singlePartition,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -26,6 +26,7 @@ import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
@@ -65,35 +66,45 @@ class WriteTables<DestinationT>
   private final boolean singlePartition;
   private final BigQueryServices bqServices;
   private final PCollectionView<String> jobIdToken;
-  private final PCollectionView<Map<DestinationT, String>> schemasView;
-  private final WriteDisposition writeDisposition;
-  private final CreateDisposition createDisposition;
+  private final WriteDisposition firstPaneWriteDisposition;
+  private final CreateDisposition firstPaneCreateDisposition;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
+  private Map<DestinationT, TableSchema> schemas = Maps.newConcurrentMap();
 
   public WriteTables(
       boolean singlePartition,
       BigQueryServices bqServices,
       PCollectionView<String> jobIdToken,
-      PCollectionView<Map<DestinationT, String>> schemasView,
       WriteDisposition writeDisposition,
       CreateDisposition createDisposition,
       DynamicDestinations<?, DestinationT> dynamicDestinations) {
     this.singlePartition = singlePartition;
     this.bqServices = bqServices;
     this.jobIdToken = jobIdToken;
-    this.schemasView = schemasView;
-    this.writeDisposition = writeDisposition;
-    this.createDisposition = createDisposition;
+    this.firstPaneWriteDisposition = writeDisposition;
+    this.firstPaneCreateDisposition = createDisposition;
     this.dynamicDestinations = dynamicDestinations;
+  }
+
+  @StartBundle
+  public void startBundle(StartBundleContext c) {
+    // Clear the map on each bundle so we can notice side-input updates.
+    // (alternative is to use a cache with a TTL).
+    schemas.clear();
   }
 
   @ProcessElement
   public void processElement(ProcessContext c) throws Exception {
     dynamicDestinations.setSideInputAccessorFromProcessContext(c);
     DestinationT destination = c.element().getKey().getKey();
-    TableSchema tableSchema =
-        BigQueryHelpers.fromJsonString(
-            c.sideInput(schemasView).get(destination), TableSchema.class);
+    TableSchema tableSchema = schemas.get(destination);
+    if (tableSchema == null) {
+      tableSchema = dynamicDestinations.getSchema(destination);
+      if (tableSchema != null) {
+        schemas.put(destination, tableSchema);
+      }
+    }
+
     TableDestination tableDestination = dynamicDestinations.getTable(destination);
     TableReference tableReference = tableDestination.getTableReference();
     if (Strings.isNullOrEmpty(tableReference.getProjectId())) {
@@ -112,6 +123,10 @@ class WriteTables<DestinationT>
       tableReference.setTableId(jobIdPrefix);
     }
 
+    WriteDisposition writeDisposition =
+        (c.pane().getIndex() == 0) ? firstPaneWriteDisposition : WriteDisposition.WRITE_APPEND;
+    CreateDisposition createDisposition =
+        (c.pane().getIndex() == 0) ? firstPaneCreateDisposition : CreateDisposition.CREATE_NEVER;
     load(
         bqServices.getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
         bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -137,7 +137,6 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.sdk.values.ShardedKey;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.hamcrest.CoreMatchers;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOTest.java
@@ -490,15 +490,20 @@ public class BigQueryIOTest implements Serializable {
 
   @Test
   public void testWriteDynamicDestinationsBatch() throws Exception {
-    writeDynamicDestinations(false);
+    writeDynamicDestinations(false, 0);
+  }
+
+  @Test
+  public void testWriteDynamicDestinationsBatchNumShards() throws Exception {
+    writeDynamicDestinations(false, 10);
   }
 
   @Test
   public void testWriteDynamicDestinationsStreaming() throws Exception {
-    writeDynamicDestinations(true);
+    writeDynamicDestinations(true, 0);
   }
 
-  public void writeDynamicDestinations(boolean streaming) throws Exception {
+  public void writeDynamicDestinations(boolean streaming, int numFileShards) throws Exception {
     BigQueryOptions bqOptions = TestPipeline.testingPipelineOptions().as(BigQueryOptions.class);
     bqOptions.setProject("project-id");
     bqOptions.setTempLocation(testFolder.newFolder("BigQueryIOTest").getAbsolutePath());
@@ -548,6 +553,7 @@ public class BigQueryIOTest implements Serializable {
             .withTestServices(fakeBqServices)
             .withMaxFilesPerBundle(5)
             .withMaxFileSize(10)
+            .withNumFileShards(numFileShards)
             .withCreateDisposition(CreateDisposition.CREATE_IF_NEEDED)
             .withFormatFunction(new SerializableFunction<String, TableRow>() {
               @Override


### PR DESCRIPTION
Allow BigQuery load jobs to be selected by the user even when using unbounded PCollections. If using unbounded PCollections, the user must specify a frequency indicating how often these load jobs will be generated.

Note: while there are some similarities between the BigQuery transform and what is done in FileBasedSink, there are a enough differences that it does not appear easy or advisable to attempt to reuse the code.

Note: a design choice is to only allow the user to specify a triggering frequency, not arbitrary windows. The reason is that this triggering frequency is merely a tuning parameter controlling the BigQuery load jobs and is usually set to keep the number of BQ load jobs under quota (ideally it wouldn't even be needed, however I don't know how to make this automatic and respect user quotas). There is no need for semantic windowing to control how often these writes happen.

R:@jkff