### PR TITLE
[BEAM-2713] Support Python native types in Beam typehints

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -105,10 +105,6 @@ def convert_to_beam_type(typ):
           arity=1,
           beam_type=typehints.List),
       _TypeMapEntry(
-          match=_match_issubclass(typing.Optional),
-          arity=1,
-          beam_type=typehints.Optional),
-      _TypeMapEntry(
           match=_match_issubclass(typing.Set),
           arity=1,
           beam_type=typehints.Set),
@@ -145,7 +141,7 @@ def convert_to_beam_type(typ):
     # Nullary types (e.g. Any) don't accept empty tuples as arguments.
     return matched_entry.beam_type
   elif arity == 1:
-    # Unary types (e.g. Optional) don't accept 1-tuples as arguments
+    # Unary types (e.g. Set) don't accept 1-tuples as arguments
     return matched_entry.beam_type[typs[0]]
   else:
     return matched_entry.beam_type[tuple(typs)]

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -17,16 +17,8 @@
 
 """Module to convert Python's native typing types to Beam types."""
 
-try:
-  import typing
-except ImportError:
-  # If the typing module is not importable, then the only types we should
-  # see in the typehints are Beam types, so no conversion is required.
-  def convert_to_beam_types(args):
-    return args
-
-
 import collections
+import typing
 from apache_beam.typehints import typehints
 
 # Describes an entry in the type map in convert_to_beam_type.
@@ -59,8 +51,8 @@ def _safe_issubclass(derived, parent):
   e.g. typing.Union isn't actually a class.
 
   Args:
-    derived: As in issubclass
-    parent: As in issubclass
+    derived: As in issubclass.
+    parent: As in issubclass.
 
   Returns:
     issubclass(derived, parent), or False if a TypeError was raised.
@@ -93,7 +85,7 @@ def convert_to_beam_type(typ):
     typ: typing type.
 
   Returns:
-    The given type converted to a Beam type as far as we can do the converion.
+    The given type converted to a Beam type as far as we can do the conversion.
 
   Raises:
     ValueError: The type was malformed.

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -1,0 +1,176 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Module to convert Python's native typing types to Beam types."""
+
+try:
+  import typing
+except ImportError:
+  # If the typing module is not importable, then the only types we should
+  # see in the typehints are Beam types, so no conversion is required.
+  def convert_to_beam_types(args):
+    return args
+
+
+import collections
+from apache_beam.typehints import typehints
+
+# Describes an entry in the type map in convert_to_beam_type.
+# match is a function that takes a user type and returns whether the conversion
+# should trigger.
+# arity is the expected arity of the user type. -1 means it's variadic.
+# beam_type is the Beam type the user type should map to.
+_TypeMapEntry = collections.namedtuple(
+    '_TypeMapEntry', ['match', 'arity', 'beam_type'])
+
+
+def _get_arg(typ, index):
+  """Returns the index-th argument to the given type."""
+  return typ.__args__[index]
+
+
+def _len_arg(typ):
+  """Returns the length of the arguments to the given type."""
+  try:
+    return len(typ.__args__)
+  except AttributeError:
+    # For Any type, which takes no arguments.
+    return 0
+
+
+def _safe_issubclass(derived, parent):
+  """Like issubclass, but swallows TypeErrors.
+
+  This is useful for when either parameter might not actually be a class,
+  e.g. typing.Union isn't actually a class.
+
+  Args:
+    derived: As in issubclass
+    parent: As in issubclass
+
+  Returns:
+    issubclass(derived, parent), or False if a TypeError was raised.
+  """
+  try:
+    return issubclass(derived, parent)
+  except TypeError:
+    return False
+
+
+def _match_issubclass(match_against):
+  return lambda user_type: _safe_issubclass(user_type, match_against)
+
+
+def _match_same_type(match_against):
+  # For Union types. They can't be compared with isinstance either, so we
+  # have to compare their types directly.
+  return lambda user_type: type(user_type) == type(match_against)
+
+
+def _match_is_named_tuple(user_type):
+  return (_safe_issubclass(user_type, typing.Tuple) and
+          hasattr(user_type, '_field_types'))
+
+
+def convert_to_beam_type(typ):
+  """Convert a given typing type to a Beam type.
+
+  Args:
+    typ: typing type.
+
+  Returns:
+    The given type converted to a Beam type as far as we can do the converion.
+
+  Raises:
+    ValueError: The type was malformed.
+  """
+
+  type_map = [
+      _TypeMapEntry(
+          match=_match_same_type(typing.Any),
+          arity=0,
+          beam_type=typehints.Any),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.Dict),
+          arity=2,
+          beam_type=typehints.Dict),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.List),
+          arity=1,
+          beam_type=typehints.List),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.Optional),
+          arity=1,
+          beam_type=typehints.Optional),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.Set),
+          arity=1,
+          beam_type=typehints.Set),
+      # NamedTuple is a subclass of Tuple, but it needs special handling.
+      # We just convert it to Any for now.
+      # This MUST appear before the entry for the normal Tuple.
+      _TypeMapEntry(
+          match=_match_is_named_tuple, arity=0, beam_type=typehints.Any),
+      _TypeMapEntry(
+          match=_match_issubclass(typing.Tuple),
+          arity=-1,
+          beam_type=typehints.Tuple),
+      _TypeMapEntry(
+          match=_match_same_type(typing.Union),
+          arity=-1,
+          beam_type=typehints.Union)
+  ]
+
+  # Find the first matching entry.
+  matched_entry = next((entry for entry in type_map if entry.match(typ)), None)
+  if not matched_entry:
+    # No match: return original type.
+    return typ
+
+  if matched_entry.arity == -1:
+    arity = _len_arg(typ)
+  else:
+    arity = matched_entry.arity
+    if _len_arg(typ) != arity:
+      raise ValueError('expecting type %s to have arity %d, had arity %d '
+                       'instead' % (str(typ), arity, _len_arg(typ)))
+  typs = [convert_to_beam_type(_get_arg(typ, i)) for i in xrange(arity)]
+  if arity == 0:
+    # Nullary types (e.g. Any) don't accept empty tuples as arguments.
+    return matched_entry.beam_type
+  elif arity == 1:
+    # Unary types (e.g. Optional) don't accept 1-tuples as arguments
+    return matched_entry.beam_type[typs[0]]
+  else:
+    return matched_entry.beam_type[tuple(typs)]
+
+
+def convert_to_beam_types(args):
+  """Convert the given list or dictionary of args to Beam types.
+
+  Args:
+    args: Either an iterable of types, or a dictionary where the values are
+    types.
+
+  Returns:
+    If given an iterable, a list of converted types. If given a dictionary,
+    a dictionary with the same keys, and values which have been converted.
+  """
+  if isinstance(args, dict):
+    return {k: convert_to_beam_type(v) for k, v in args.iteritems()}
+  else:
+    return [convert_to_beam_type(v) for v in args]

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -50,10 +50,7 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
         ('simple dict', typing.Dict[bytes, int],
          typehints.Dict[bytes, int]),
         ('simple list', typing.List[int], typehints.List[int]),
-        # Bug in Beam: None and NoneType should be interchangeable
-        # (see PEP484, "Using None")
-        # ('simple optional', typing.Optional[int],
-        #  typehints.Optional[int]),
+        ('simple optional', typing.Optional[int], typehints.Optional[int]),
         ('simple set', typing.Set[float], typehints.Set[float]),
         ('simple unary tuple', typing.Tuple[bytes],
          typehints.Tuple[bytes]),

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -17,13 +17,7 @@
 
 """Test for Beam type compatibility library."""
 
-import sys
-
-try:
-  import typing
-except ImportError:
-  sys.exit(1)
-
+import typing
 import unittest
 
 from apache_beam.typehints import typehints

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -1,0 +1,101 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Test for Beam type compatibility library."""
+
+import sys
+
+try:
+  import typing
+except ImportError:
+  sys.exit(1)
+
+import unittest
+
+from apache_beam.typehints import typehints
+from apache_beam.typehints import native_type_compatibility
+
+_TestNamedTuple = typing.NamedTuple('_TestNamedTuple',
+                                    [('age', int), ('name', bytes)])
+_TestFlatAlias = typing.Tuple[bytes, float]
+_TestNestedAlias = typing.List[_TestFlatAlias]
+
+
+class _TestClass(object):
+  pass
+
+
+class NativeTypeCompatibilityTest(unittest.TestCase):
+
+  def test_convert_to_beam_type(self):
+    test_cases = [
+        ('raw bytes', bytes, bytes),
+        ('raw int', int, int),
+        ('raw float', float, float),
+        ('any', typing.Any, typehints.Any),
+        ('simple dict', typing.Dict[bytes, int],
+         typehints.Dict[bytes, int]),
+        ('simple list', typing.List[int], typehints.List[int]),
+        # Bug in Beam: None and NoneType should be interchangeable
+        # (see PEP484, "Using None")
+        # ('simple optional', typing.Optional[int],
+        #  typehints.Optional[int]),
+        ('simple set', typing.Set[float], typehints.Set[float]),
+        ('simple unary tuple', typing.Tuple[bytes],
+         typehints.Tuple[bytes]),
+        ('simple union', typing.Union[int, bytes, float],
+         typehints.Union[int, bytes, float]),
+        ('namedtuple', _TestNamedTuple, typehints.Any),
+        ('test class', _TestClass, _TestClass),
+        ('test class in list', typing.List[_TestClass],
+         typehints.List[_TestClass]),
+        ('complex tuple', typing.Tuple[bytes, typing.List[typing.Tuple[
+            bytes, typing.Union[int, bytes, float]]]],
+         typehints.Tuple[bytes, typehints.List[typehints.Tuple[
+             bytes, typehints.Union[int, bytes, float]]]]),
+        ('flat alias', _TestFlatAlias, typehints.Tuple[bytes, float]),
+        ('nested alias', _TestNestedAlias,
+         typehints.List[typehints.Tuple[bytes, float]]),
+        ('complex dict',
+         typing.Dict[bytes, typing.List[typing.Tuple[bytes, _TestClass]]],
+         typehints.Dict[bytes, typehints.List[typehints.Tuple[
+             bytes, _TestClass]]])
+    ]
+
+    for test_case in test_cases:
+      # Unlike typing types, Beam types are guaranteed to compare equal.
+      description = test_case[0]
+      typing_type = test_case[1]
+      beam_type = test_case[2]
+      self.assertEqual(
+          native_type_compatibility.convert_to_beam_type(typing_type),
+          beam_type, description)
+
+  def test_convert_to_beam_types(self):
+    typing_types = [bytes, typing.List[bytes],
+                    typing.List[typing.Tuple[bytes, int]],
+                    typing.Union[int, typing.List[int]]]
+    beam_types = [bytes, typehints.List[bytes],
+                  typehints.List[typehints.Tuple[bytes, int]],
+                  typehints.Union[int, typehints.List[int]]]
+    self.assertEqual(
+        native_type_compatibility.convert_to_beam_types(typing_types),
+        beam_types)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/typed_pipeline_test.py
+++ b/sdks/python/apache_beam/typehints/typed_pipeline_test.py
@@ -17,8 +17,8 @@
 
 """Unit tests for the type-hint objects and decorators."""
 import inspect
+import typing
 import unittest
-
 
 import apache_beam as beam
 from apache_beam import pvalue
@@ -98,36 +98,29 @@ class MainInputTest(unittest.TestCase):
       [1, 2, 3] | (beam.ParDo(my_do_fn) | 'again' >> beam.ParDo(my_do_fn))
 
 
-# NativeTypesTest is only run if the typing module is available.
-try:
-  import typing
+class NativeTypesTest(unittest.TestCase):
 
-  class NativeTypesTest(unittest.TestCase):
+  def test_good_main_input(self):
+    @typehints.with_input_types(typing.Tuple[str, int])
+    def munge((s, i)):
+      return (s + 's', i * 2)
+    result = [('apple', 5), ('pear', 3)] | beam.Map(munge)
+    self.assertEqual([('apples', 10), ('pears', 6)], sorted(result))
 
-    def test_good_main_input(self):
-      @typehints.with_input_types(typing.Tuple[str, int])
-      def munge((s, i)):
-        return (s + 's', i * 2)
-      result = [('apple', 5), ('pear', 3)] | beam.Map(munge)
-      self.assertEqual([('apples', 10), ('pears', 6)], sorted(result))
+  def test_bad_main_input(self):
+    @typehints.with_input_types(typing.Tuple[str, str])
+    def munge((s, i)):
+      return (s + 's', i * 2)
+    with self.assertRaises(typehints.TypeCheckError):
+      [('apple', 5), ('pear', 3)] | beam.Map(munge)
 
-    def test_bad_main_input(self):
-      @typehints.with_input_types(typing.Tuple[str, str])
-      def munge((s, i)):
-        return (s + 's', i * 2)
-      with self.assertRaises(typehints.TypeCheckError):
-        [('apple', 5), ('pear', 3)] | beam.Map(munge)
-
-    def test_bad_main_output(self):
-      @typehints.with_input_types(typing.Tuple[int, int])
-      @typehints.with_output_types(typing.Tuple[str, str])
-      def munge((a, b)):
-        return (str(a), str(b))
-      with self.assertRaises(typehints.TypeCheckError):
-        [(5, 4), (3, 2)] | beam.Map(munge) | 'Again' >> beam.Map(munge)
-
-except ImportError:
-  pass
+  def test_bad_main_output(self):
+    @typehints.with_input_types(typing.Tuple[int, int])
+    @typehints.with_output_types(typing.Tuple[str, str])
+    def munge((a, b)):
+      return (str(a), str(b))
+    with self.assertRaises(typehints.TypeCheckError):
+      [(5, 4), (3, 2)] | beam.Map(munge) | 'Again' >> beam.Map(munge)
 
 
 class SideInputTest(unittest.TestCase):

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -498,7 +498,7 @@ UnionConstraint = UnionHint.UnionConstraint
 class OptionalHint(UnionHint):
   """An Option type-hint. Optional[X] accepts instances of X or None.
 
-  The Optional[X] factory function proxies to Union[X, None]
+  The Optional[X] factory function proxies to Union[X, type(None)]
   """
 
   def __getitem__(self, py_type):
@@ -507,7 +507,7 @@ class OptionalHint(UnionHint):
       raise TypeError('An Option type-hint only accepts a single type '
                       'parameter.')
 
-    return Union[py_type, None]
+    return Union[py_type, type(None)]
 
 
 class TupleHint(CompositeTypeHint):

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -104,6 +104,7 @@ REQUIRED_PACKAGES = [
     'oauth2client>=2.0.1,<4.0.0',
     'protobuf>=3.2.0,<=3.3.0',
     'pyyaml>=3.12,<4.0.0',
+    'typing>=3.6.0,<3.7.0',
     ]
 
 REQUIRED_SETUP_PACKAGES = [


### PR DESCRIPTION
Add support for Python native types in Beam typehints.