### PR TITLE
[BEAM-2718] Add initial bundle retry code for the DirectRunner

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -314,6 +314,13 @@ class DirectOptions(PipelineOptions):
         help='DirectRunner uses stacked WindowedValues within a Bundle for '
         'memory optimization. Set --no_direct_runner_use_stacked_bundle to '
         'avoid it.')
+    parser.add_argument(
+        '--direct_runner_bundle_retry',
+        action='store_true',
+        default=False,
+        help=
+        ('Whether to allow bundle retries. If True the maximum'
+         'number of attempts to process a bundle is 4. '))
 
 
 class GoogleCloudOptions(PipelineOptions):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -27,6 +27,7 @@ import unittest
 import apache_beam as beam
 from apache_beam.io import Read
 from apache_beam.metrics import Metrics
+from apache_beam.options.pipeline_options import DirectOptions
 from apache_beam.pipeline import Pipeline
 from apache_beam.pipeline import PTransformOverride
 from apache_beam.pipeline import PipelineOptions
@@ -501,7 +502,9 @@ class RunnerApiTest(unittest.TestCase):
 class DirectRunnerRetryTests(unittest.TestCase):
 
   def test_retry_fork_graph(self):
-    p = beam.Pipeline('DirectRunner')
+    pipeline_options = PipelineOptions(['--direct_runner_bundle_retry'])
+    p = beam.Pipeline(options=pipeline_options)
+
     # TODO(mariagh): Remove the use of globals from the test.
     global count_b, count_c
     count_b, count_c = 0, 0
@@ -524,6 +527,7 @@ class DirectRunnerRetryTests(unittest.TestCase):
     with self.assertRaises(Exception):
       p.run().wait_until_finish()
     assert count_b == count_c == 4
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.DEBUG)

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -502,6 +502,7 @@ class DirectRunnerRetryTests(unittest.TestCase):
 
   def test_retry_fork_graph(self):
     p = beam.Pipeline('DirectRunner')
+    # TODO(mariagh): Remove the use of globals from the test.
     global count_b, count_c
     count_b, count_c = 0, 0
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -499,6 +499,7 @@ class RunnerApiTest(unittest.TestCase):
     p.to_runner_api()
     self.assertEqual(MyPTransform.pickle_count[0], 20)
 
+
 class DirectRunnerRetryTests(unittest.TestCase):
 
   def test_retry_fork_graph(self):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -27,7 +27,7 @@ import unittest
 import apache_beam as beam
 from apache_beam.io import Read
 from apache_beam.metrics import Metrics
-from apache_beam.options.pipeline_options import DirectOptions
+# from apache_beam.options.pipeline_options import DirectOptions
 from apache_beam.pipeline import Pipeline
 from apache_beam.pipeline import PTransformOverride
 from apache_beam.pipeline import PipelineOptions
@@ -506,23 +506,23 @@ class DirectRunnerRetryTests(unittest.TestCase):
     p = beam.Pipeline(options=pipeline_options)
 
     # TODO(mariagh): Remove the use of globals from the test.
-    global count_b, count_c
+    global count_b, count_c # pylint: disable=global-variable-undefined
     count_b, count_c = 0, 0
 
     def f_b(x):
-      global count_b
+      global count_b  # pylint: disable=global-variable-undefined
       count_b += 1
       raise Exception('exception in f_b')
 
     def f_c(x):
-      global count_c
+      global count_c  # pylint: disable=global-variable-undefined
       count_c += 1
       raise Exception('exception in f_c')
 
     names = p | 'CreateNodeA' >> beam.Create(['Ann', 'Joe'])
 
-    fork_b = names | 'SendToB' >> beam.Map(f_b)
-    fork_c = names | 'SendToC' >> beam.Map(f_c)
+    fork_b = names | 'SendToB' >> beam.Map(f_b) # pylint: disable=unused-variable
+    fork_c = names | 'SendToC' >> beam.Map(f_c) # pylint: disable=unused-variable
 
     with self.assertRaises(Exception):
       p.run().wait_until_finish()

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -520,10 +520,9 @@ class DirectRunnerRetryTests(unittest.TestCase):
     fork_b = names | 'SendToB' >> beam.Map(f_b)
     fork_c = names | 'SendToC' >> beam.Map(f_c)
 
-    try:
+    with self.assertRaises(Exception):
       p.run().wait_until_finish()
-    except Exception as e:  # pylint: disable=broad-except
-      assert count_b == count_c == 4
+    assert count_b == count_c == 4
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.DEBUG)

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -27,7 +27,6 @@ import unittest
 import apache_beam as beam
 from apache_beam.io import Read
 from apache_beam.metrics import Metrics
-# from apache_beam.options.pipeline_options import DirectOptions
 from apache_beam.pipeline import Pipeline
 from apache_beam.pipeline import PTransformOverride
 from apache_beam.pipeline import PipelineOptions

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -489,7 +489,6 @@ class _ExecutorServiceParallelExecutor(object):
         # Not the right exception.
         self.exc_info = (exception, None, None)
 
-
   class _VisibleExecutorUpdate(object):
     """An update of interest to the user.
 

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -105,7 +105,6 @@ REQUIRED_PACKAGES = [
     'protobuf>=3.2.0,<=3.3.0',
     'pyyaml>=3.12,<4.0.0',
     'typing>=3.6.0,<3.7.0',
-    'retrying==1.3.3',
     ]
 
 REQUIRED_SETUP_PACKAGES = [

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -105,6 +105,7 @@ REQUIRED_PACKAGES = [
     'protobuf>=3.2.0,<=3.3.0',
     'pyyaml>=3.12,<4.0.0',
     'typing>=3.6.0,<3.7.0',
+    'retrying==1.3.3',
     ]
 
 REQUIRED_SETUP_PACKAGES = [


### PR DESCRIPTION
When processing of a bundle fails, the bundle should be retried.
- [x] Retry bundle 3 times when --direct_runner_bundle_retry is specified.
- [ ] Make state mutations atomically committed per bundle.
