### PR TITLE
Fix inversion between namespace and doc arguments

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
@@ -256,8 +256,8 @@ class BigQueryAvroUtils {
     }
     return Schema.createRecord(
         schemaName,
-        "org.apache.beam.sdk.io.gcp.bigquery",
         "Translated Avro Schema for " + schemaName,
+        "org.apache.beam.sdk.io.gcp.bigquery",      
         false,
         avroFields);
   }


### PR DESCRIPTION
Hey,

It seems the `doc` and `namespace` arguments are mixed up, the method signature being `public static Schema createRecord(String name, String doc, String namespace, boolean isError, List<Schema.Field> fields)`.
```
