### PR TITLE
[BEAM-2734] Unbreaks some Dataflow ValidatesRunner tests

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UnboundedReadFromBoundedSource.java
@@ -91,6 +91,11 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
   }
 
   @Override
+  protected Coder<T> getDefaultOutputCoder() {
+    return source.getDefaultOutputCoder();
+  }
+
+  @Override
   public String getKindString() {
     return String.format("Read(%s)", NameUtils.approximateSimpleName(source));
   }
@@ -161,14 +166,14 @@ public class UnboundedReadFromBoundedSource<T> extends PTransform<PBegin, PColle
     }
 
     @Override
-    public Coder<T> getOutputCoder() {
-      return boundedSource.getOutputCoder();
+    public Coder<T> getDefaultOutputCoder() {
+      return boundedSource.getDefaultOutputCoder();
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     public Coder<Checkpoint<T>> getCheckpointMarkCoder() {
-      return new CheckpointCoder<>(boundedSource.getOutputCoder());
+      return new CheckpointCoder<>(boundedSource.getDefaultOutputCoder());
     }
 
     @VisibleForTesting

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Source.java
@@ -64,11 +64,23 @@ public abstract class Source<T> implements Serializable, HasDisplayData {
   /** @deprecated Override {@link #getOutputCoder()} instead. */
   @Deprecated
   public Coder<T> getDefaultOutputCoder() {
-    throw new UnsupportedOperationException("Source needs to override getOutputCoder()");
+    // If the subclass doesn't override getDefaultOutputCoder(), hopefully it overrides the proper
+    // version - getOutputCoder(). Check that it does, before calling the method (if subclass
+    // doesn't override it, we'll call the default implementation and get infinite recursion).
+    try {
+      if (getClass().getMethod("getOutputCoder").getDeclaringClass().equals(Source.class)) {
+        throw new UnsupportedOperationException(
+            getClass() + " needs to override getOutputCoder().");
+      }
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+    return getOutputCoder();
   }
 
   /** Returns the {@code Coder} to use for the data read from this source. */
   public Coder<T> getOutputCoder() {
+    // Call the old method for compatibility.
     return getDefaultOutputCoder();
   }
 


### PR DESCRIPTION
This is a partial revert of https://github.com/apache/beam/pull/3649, changing UnboundedReadFromBoundedSource to be identical to the version before that PR.

The Source is serialized in the pipeline and deserialized on the worker using the worker's different (fixed per-worker) version of runners-core-construction so the serialVersionUID has to match.

This Source does not declare a serialVersionUID, so one is computed by the JVM automatically, and in practice that means the class needs to be completely identical.

The current PR is a quick emergency fix. The right solution is I suppose to declare a serialVersionUID for everything serializable in runners-core-construction, or to make the worker not contain a fixed version of runners-core-construction (not sure if it's feasible) - but it's outside the scope of this PR.

R: @tgroh 