### PR TITLE
[BEAM-2742] change Field type from primitives to boxed types

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
@@ -57,7 +57,7 @@ public class BeamRecordCoder extends CustomCoder<BeamRecord> {
       throws CoderException, IOException {
     nullListCoder.encode(scanNullFields(value), outStream);
     for (int idx = 0; idx < value.size(); ++idx) {
-      if (value.isNull(idx)) {
+      if (value.getFieldValue(idx) == null) {
         continue;
       }
 
@@ -87,7 +87,7 @@ public class BeamRecordCoder extends CustomCoder<BeamRecord> {
   private BitSet scanNullFields(BeamRecord record){
     BitSet nullFields = new BitSet(record.size());
     for (int idx = 0; idx < record.size(); ++idx) {
-      if (record.isNull(idx)) {
+      if (record.getFieldValue(idx) == null) {
         nullFields.set(idx);
       }
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
@@ -63,27 +63,27 @@ public class BeamRecord implements Serializable {
     return getFieldValue(dataType.getFieldsName().indexOf(fieldName));
   }
 
-  public byte getByte(String fieldName) {
+  public Byte getByte(String fieldName) {
     return (Byte) getFieldValue(fieldName);
   }
 
-  public short getShort(String fieldName) {
+  public Short getShort(String fieldName) {
     return (Short) getFieldValue(fieldName);
   }
 
-  public int getInteger(String fieldName) {
+  public Integer getInteger(String fieldName) {
     return (Integer) getFieldValue(fieldName);
   }
 
-  public float getFloat(String fieldName) {
+  public Float getFloat(String fieldName) {
     return (Float) getFieldValue(fieldName);
   }
 
-  public double getDouble(String fieldName) {
+  public Double getDouble(String fieldName) {
     return (Double) getFieldValue(fieldName);
   }
 
-  public long getLong(String fieldName) {
+  public Long getLong(String fieldName) {
     return (Long) getFieldValue(fieldName);
   }
 
@@ -103,35 +103,35 @@ public class BeamRecord implements Serializable {
     return (BigDecimal) getFieldValue(fieldName);
   }
 
-  public boolean getBoolean(String fieldName) {
-    return (boolean) getFieldValue(fieldName);
+  public Boolean getBoolean(String fieldName) {
+    return (Boolean) getFieldValue(fieldName);
   }
 
   public Object getFieldValue(int fieldIdx) {
     return dataValues.get(fieldIdx);
   }
 
-  public byte getByte(int idx) {
+  public Byte getByte(int idx) {
     return (Byte) getFieldValue(idx);
   }
 
-  public short getShort(int idx) {
+  public Short getShort(int idx) {
     return (Short) getFieldValue(idx);
   }
 
-  public int getInteger(int idx) {
+  public Integer getInteger(int idx) {
     return (Integer) getFieldValue(idx);
   }
 
-  public float getFloat(int idx) {
+  public Float getFloat(int idx) {
     return (Float) getFieldValue(idx);
   }
 
-  public double getDouble(int idx) {
+  public Double getDouble(int idx) {
     return (Double) getFieldValue(idx);
   }
 
-  public long getLong(int idx) {
+  public Long getLong(int idx) {
     return (Long) getFieldValue(idx);
   }
 
@@ -151,7 +151,7 @@ public class BeamRecord implements Serializable {
     return (BigDecimal) getFieldValue(idx);
   }
 
-  public boolean getBoolean(int idx) {
+  public Boolean getBoolean(int idx) {
     return (boolean) getFieldValue(idx);
   }
 
@@ -169,13 +169,6 @@ public class BeamRecord implements Serializable {
 
   public BeamRecordType getDataType() {
     return dataType;
-  }
-
-  /**
-   * is the specified field NULL?
-   */
-  public boolean isNull(int idx) {
-    return null ==  getFieldValue(idx);
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
@@ -152,7 +152,7 @@ public class BeamRecord implements Serializable {
   }
 
   public Boolean getBoolean(int idx) {
-    return (boolean) getFieldValue(idx);
+    return (Boolean) getFieldValue(idx);
   }
 
   public int size() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -195,11 +195,13 @@ public class BeamSortRel extends Sort implements BeamRelNode {
             BeamSqlRecordHelper.getSqlRecordType(row1), fieldIndex);
         // whether NULL should be ordered first or last(compared to non-null values) depends on
         // what user specified in SQL(NULLS FIRST/NULLS LAST)
-        if (row1.isNull(fieldIndex) && row2.isNull(fieldIndex)) {
+        boolean isValue1Null = (row1.getFieldValue(fieldIndex) == null);
+        boolean isValue2Null = (row2.getFieldValue(fieldIndex) == null);
+        if (isValue1Null && isValue2Null) {
           continue;
-        } else if (row1.isNull(fieldIndex) && !row2.isNull(fieldIndex)) {
+        } else if (isValue1Null && !isValue2Null) {
           fieldRet = -1 * (nullsFirst.get(i) ? -1 : 1);
-        } else if (!row1.isNull(fieldIndex) && row2.isNull(fieldIndex)) {
+        } else if (!isValue1Null && isValue2Null) {
           fieldRet = 1 * (nullsFirst.get(i) ? -1 : 1);
         } else {
           switch (fieldType) {


### PR DESCRIPTION
change Field type of `BeamRecord` from primitive types to boxed types, and removed `isNull` method.