### PR TITLE
[BEAM-2733] update javadoc for BeamSql

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSql.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSql.java
@@ -71,6 +71,7 @@ outputTableB.apply(...).apply(TextIO.write().to("/my/output/path"));
 p.run().waitUntilFinish();
  * }
  * </pre>
+ *
  */
 @Experimental
 public class BeamSql {
@@ -82,8 +83,14 @@ public class BeamSql {
    * table. The {@link PCollectionTuple} contains the mapping from {@code table names} to
    * {@code PCollection<BeamSqlRow>}, each representing an input table.
    *
-   * <p>It is an error to apply a {@link PCollectionTuple} missing any {@code table names}
-   * referenced within the query.
+   * <ul>
+   * <li>If the sql query only use a subset of tables from the upstream {@link PCollectionTuple},
+   *     it succeed;</li>
+   * <li>If sql query use a table which is not covered by upstream {@link PCollectionTuple},
+   *     an {@code IllegalStateException} is thrown during query validation;</li>
+   * <li>Always, tables from upstream {@link PCollectionTuple} are only valid in the scope
+   *     of the current query call.</li>
+   * </ul>
    */
   public static QueryTransform query(String sqlQuery) {
     return QueryTransform.builder()
@@ -100,7 +107,7 @@ public class BeamSql {
    *
    * <p>Make sure to query it from a static table name <em>PCOLLECTION</em>.
    */
-  public static SimpleQueryTransform simpleQuery(String sqlQuery) throws Exception {
+  public static SimpleQueryTransform simpleQuery(String sqlQuery) {
     return SimpleQueryTransform.builder()
         .setSqlEnv(new BeamSqlEnv())
         .setSqlQuery(sqlQuery)
@@ -109,6 +116,9 @@ public class BeamSql {
 
   /**
    * A {@link PTransform} representing an execution plan for a SQL query.
+   *
+   * <p>The lifetime of tables in the input {@code PCollectionTuple} are only valid during current
+   * query.
    */
   @AutoValue
   public abstract static class QueryTransform extends


### PR DESCRIPTION
Summary:

* `Exception` declaration are removed from `BeamSql.query ()`
* Added javadoc to explain when the sql query use a non-exist table、a subset of tables from upstream, what happens.
* Added javadoc for BeamSql.query and QueryTransform to describe the lifetime of tables in PCollectionTuple.
* SimpleQueryTransform and QueryTransform are actually user-facing (they are return types of query() and simpleQuery()), so they are kept `public`.