### PR TITLE
[BEAM-2684] Fix flaky AmqpIOTest

### DIFF
--- a/sdks/java/io/amqp/pom.xml
+++ b/sdks/java/io/amqp/pom.xml
@@ -30,6 +30,10 @@
   <name>Apache Beam :: SDKs :: Java :: IO :: AMQP</name>
   <description>IO to read and write using AMQP 1.0 protocol (http://www.amqp.org).</description>
 
+  <properties>
+    <activemq.version>5.13.1</activemq.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>
@@ -94,6 +98,24 @@
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-direct-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-broker</artifactId>
+      <version>${activemq.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>activemq-amqp</artifactId>
+      <version>${activemq.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq.tooling</groupId>
+      <artifactId>activemq-junit</artifactId>
+      <version>${activemq.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/sdks/java/io/amqp/src/test/java/org/apache/beam/sdk/io/amqp/AmqpIOTest.java
+++ b/sdks/java/io/amqp/src/test/java/org/apache/beam/sdk/io/amqp/AmqpIOTest.java
@@ -20,11 +20,11 @@ package org.apache.beam.sdk.io.amqp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.activemq.junit.EmbeddedActiveMQBroker;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
@@ -33,7 +33,6 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.messenger.Messenger;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,99 +48,76 @@ public class AmqpIOTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(AmqpIOTest.class);
 
-  private int port;
-
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
-  @Before
-  public void findFreeNetworkPort() throws Exception {
-    LOG.info("Finding free network port");
-    ServerSocket socket = new ServerSocket(0);
-    port = socket.getLocalPort();
-    socket.close();
-  }
+  @Rule public EmbeddedAmqpBroker broker = new EmbeddedAmqpBroker();
 
   @Test
   public void testRead() throws Exception {
     PCollection<Message> output = pipeline.apply(AmqpIO.read()
         .withMaxNumRecords(100)
-        .withAddresses(Collections.singletonList("amqp://~localhost:" + port)));
+        .withAddresses(Collections.singletonList(broker.getQueueUri("testRead"))));
     PAssert.thatSingleton(output.apply(Count.<Message>globally())).isEqualTo(100L);
 
-    Thread sender = new Thread() {
-      public void run() {
-        try {
-          Thread.sleep(500);
-          Messenger sender = Messenger.Factory.create();
-          sender.start();
-          for (int i = 0; i < 100; i++) {
-            Message message = Message.Factory.create();
-            message.setAddress("amqp://localhost:" + port);
-            message.setBody(new AmqpValue("Test " + i));
-            sender.put(message);
-            sender.send();
-          }
-          sender.stop();
-        } catch (Exception e) {
-          LOG.error("Sender error", e);
-        }
-      }
-    };
-    try {
-      sender.start();
-      pipeline.run();
-    } finally {
-      sender.join();
+    Messenger sender = Messenger.Factory.create();
+    sender.start();
+    for (int i = 0; i < 100; i++) {
+      Message message = Message.Factory.create();
+      message.setAddress(broker.getQueueUri("testRead"));
+      message.setBody(new AmqpValue("Test " + i));
+      sender.put(message);
+      sender.send();
     }
+    sender.stop();
+
+    pipeline.run();
   }
 
   @Test
   public void testWrite() throws Exception {
-    final List<String> received = new ArrayList<>();
-    Thread receiver = new Thread() {
-      @Override
-      public void run() {
-        try {
-          Messenger messenger = Messenger.Factory.create();
-          messenger.start();
-          messenger.subscribe("amqp://~localhost:" + port);
-          while (received.size() < 100) {
-            messenger.recv();
-            while (messenger.incoming() > 0) {
-              Message message = messenger.get();
-              LOG.info("Received: " + message.getBody().toString());
-              received.add(message.getBody().toString());
-            }
-          }
-          messenger.stop();
-        } catch (Exception e) {
-          LOG.error("Receiver error", e);
-        }
-      }
-    };
-    LOG.info("Starting AMQP receiver");
-    receiver.start();
-
     List<Message> data = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
       Message message = Message.Factory.create();
       message.setBody(new AmqpValue("Test " + i));
-      message.setAddress("amqp://localhost:" + port);
+      message.setAddress(broker.getQueueUri("testWrite"));
       message.setSubject("test");
       data.add(message);
     }
     pipeline.apply(Create.of(data).withCoder(AmqpMessageCoder.of())).apply(AmqpIO.write());
-    LOG.info("Starting pipeline");
-    try {
-      pipeline.run();
-    } finally {
-      LOG.info("Join receiver thread");
-      receiver.join();
+    pipeline.run().waitUntilFinish();
+
+    List<String> received = new ArrayList<>();
+    Messenger messenger = Messenger.Factory.create();
+    messenger.start();
+    messenger.subscribe(broker.getQueueUri("testWrite"));
+    while (received.size() < 100) {
+      messenger.recv();
+      while (messenger.incoming() > 0) {
+        Message message = messenger.get();
+        LOG.info("Received: " + message.getBody().toString());
+        received.add(message.getBody().toString());
+      }
     }
+    messenger.stop();
 
     assertEquals(100, received.size());
     for (int i = 0; i < 100; i++) {
       assertTrue(received.contains("AmqpValue{Test " + i + "}"));
+    }
+  }
+
+  private static class EmbeddedAmqpBroker extends EmbeddedActiveMQBroker {
+    @Override
+    protected void configure() {
+      try {
+        getBrokerService().addConnector("amqp://localhost:0");
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    public String getQueueUri(String queueName) {
+      return getBrokerService().getDefaultSocketURIString() + "/" + queueName;
     }
   }
 


### PR DESCRIPTION
Source of the flakiness is a race between sender and receiver. In a peer-to-peer mode receiver must be running before sender starts sending messages. When this's not the case sender gets stuck in a 'send' method. AMQP broker solves the problem by eliminating sender/receiver startup order requirement.

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
