### PR TITLE
[BEAM-2750][BEAM-2751] Implement WholeFileIO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io;
 
 import static com.google.common.base.Preconditions.checkNotNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
@@ -1,0 +1,224 @@
+package org.apache.beam.sdk.io;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY;
+import static org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions.RESOLVE_FILE;
+import static org.apache.beam.sdk.util.MimeTypes.BINARY;
+
+import com.google.auto.value.AutoValue;
+import com.google.protobuf.ByteString;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PDone;
+
+/**
+ * WholeFileIO.
+ */
+public class WholeFileIO {
+
+  public static Read read() {
+    return new AutoValue_WholeFileIO_Read.Builder().build();
+  }
+
+  public static Write write() {
+    return new AutoValue_WholeFileIO_Write.Builder().build();
+  }
+
+  /**
+   * Implements read().
+   */
+  @AutoValue
+  public abstract static class Read extends PTransform<PBegin, PCollection<KV<String, byte[]>>> {
+    @Nullable
+    abstract ValueProvider<String> getFilePattern();
+
+    abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setFilePattern(ValueProvider<String> filePattern);
+
+      abstract Read build();
+    }
+
+    public Read from(String filePattern) {
+      checkNotNull(filePattern, "FilePattern cannot be empty.");
+      return from(ValueProvider.StaticValueProvider.of(filePattern));
+    }
+
+    public Read from(ValueProvider<String> filePattern) {
+      checkNotNull(filePattern, "FilePattern cannot be empty.");
+      return toBuilder().setFilePattern(filePattern).build();
+    }
+
+    @Override
+    public PCollection<KV<String, byte[]>> expand(PBegin input) {
+      checkNotNull(
+          getFilePattern(),
+          "Need to set the filePattern of a WholeFileIO.Read transform."
+      );
+
+      String filePattern = getFilePattern().get();
+
+      PCollection<String> filePatternPCollection = input.apply(Create.of(filePattern));
+
+      PCollection<ResourceId> resourceIds = filePatternPCollection.apply(
+          ParDo.of(
+              new DoFn<String, ResourceId>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  String filePattern = c.element();
+                  try {
+                    List<MatchResult> matchResults = FileSystems.match(
+                        Collections.singletonList(filePattern));
+                    for (MatchResult matchResult : matchResults) {
+                      List<MatchResult.Metadata> metadataList = matchResult.metadata();
+                      for (MatchResult.Metadata metadata : metadataList) {
+                        ResourceId resourceId = metadata.resourceId();
+                        c.output(resourceId);
+                      }
+                    }
+                  } catch (IOException e) {
+                    e.printStackTrace();
+                  }
+                }
+              }
+          )
+      );
+
+      PCollection<KV<String, byte[]>> files = resourceIds.apply(
+          ParDo.of(
+              new DoFn<ResourceId, KV<String, byte[]>>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  ResourceId resourceId = c.element();
+
+                  try {
+                    ReadableByteChannel channel = FileSystems.open(resourceId);
+                    ByteBuffer byteBuffer = ByteBuffer.allocate(8192);
+                    ByteString byteString = ByteString.EMPTY;
+
+                    while (channel.read(byteBuffer) != -1) {
+                      byteBuffer.flip();
+                      byteString = byteString.concat(ByteString.copyFrom(byteBuffer));
+                      byteBuffer.clear();
+                    }
+
+                    KV<String, byte[]> kv = KV.of(
+                        resourceId.getFilename(),
+                        byteString.toByteArray()
+                    );
+
+                    c.output(kv);
+                  } catch (IOException e) {
+                    e.printStackTrace();
+                  }
+                }
+              }
+          )
+      );
+
+      return files;
+    }
+  }
+
+  /**
+   * Implements write().
+   */
+  @AutoValue
+  public abstract static class Write extends PTransform<PCollection<KV<String, byte[]>>, PDone> {
+
+    @Nullable abstract ValueProvider<ResourceId> getOutputDir();
+
+    abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setOutputDir(ValueProvider<ResourceId> outputDir);
+
+      abstract Write build();
+    }
+
+    public Write to(String outputDir) {
+      return to(FileBasedSink.convertToFileResourceIfPossible(outputDir));
+    }
+
+    public Write to(ResourceId outputDir) {
+      return toResource(ValueProvider.StaticValueProvider.of(outputDir));
+    }
+
+    public Write toResource(ValueProvider<ResourceId> outputDir) {
+      return toBuilder().setOutputDir(outputDir).build();
+    }
+
+    @Override
+    public PDone expand(PCollection<KV<String, byte[]>> input) {
+      checkNotNull(
+          getOutputDir(),
+          "Need to set the output directory of a WholeFileIO.Write transform."
+      );
+
+      ResourceId outputDir = getOutputDir().get();
+      if (!outputDir.isDirectory()) {
+        outputDir = outputDir.getCurrentDirectory()
+                             .resolve(outputDir.getFilename(), RESOLVE_DIRECTORY);
+      }
+      final PCollectionView<ResourceId> outputDirView = input.getPipeline()
+          .apply(Create.of(outputDir))
+          .apply(View.<ResourceId>asSingleton());
+
+      input.apply(
+          ParDo.of(
+              new DoFn<KV<String, byte[]>, Void>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  KV<String, byte[]> kv = c.element();
+
+                  ResourceId outputDir = c.sideInput(outputDirView);
+                  String filename = kv.getKey();
+                  ResourceId outputFile = outputDir.resolve(filename, RESOLVE_FILE);
+
+                  byte[] bytes = kv.getValue();
+                  try {
+                    WritableByteChannel channel = FileSystems.create(outputFile, BINARY);
+                    OutputStream os = Channels.newOutputStream(channel);
+                    os.write(bytes);
+                    os.flush();
+                    os.close();
+                  } catch (IOException e) {
+                    e.printStackTrace();
+                  }
+                }
+              }
+          ).withSideInputs(outputDirView)
+      );
+
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /** Disable construction of utility class. */
+  private WholeFileIO() {}
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
@@ -27,22 +27,32 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.channels.Channels;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Nullable;
 
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MoveOptions;
+import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.StreamUtils;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.joda.time.Instant;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // TODO: Write comment on what this is and how to use it.
 // TODO: Mention that if multiple files have the same filename at write, only one will survive.
@@ -128,6 +138,7 @@ public class WholeFileIO {
    */
   @AutoValue
   public abstract static class Write extends PTransform<PCollection<KV<String, byte[]>>, PDone> {
+    private static final Logger LOG = LoggerFactory.getLogger(Write.class);
 
     @Nullable abstract ValueProvider<ResourceId> getOutputDir();
 
@@ -162,26 +173,57 @@ public class WholeFileIO {
       input.apply(
           ParDo.of(
               new DoFn<KV<String, byte[]>, Void>() {
+                ValueProvider<ResourceId> tmpDir;
+
+                @Setup
+                public void setup() {
+                  tmpDir = ValueProvider.NestedValueProvider.of(
+                      getOutputDir(),
+                      new TemporaryDirectoryBuilder()
+                  );
+                }
+
                 @ProcessElement
                 public void processElement(ProcessContext c) throws IOException {
                   KV<String, byte[]> kv = c.element();
 
-                  ResourceId outputDir = getOutputDir().get();
                   String filename = kv.getKey();
-                  // TODO: Write to tmp files. Once tmp file write finished, rename to filename.
-                  // TODO: ^ Alternative (faster): setup() create tmp dir, processElement()
-                  //    write each file to tmp dir, teardown() rename tmp dir to outputDir
-                  // (Or, instead of setup() and teardown(), use startBundle() and finishBundle()
-                  //    except that you mv all files inside tmp dir to inside the outputDir
-                  ResourceId outputFile = outputDir.resolve(filename, RESOLVE_FILE);
+                  ResourceId tmpFile = tmpDir.get().resolve(filename, RESOLVE_FILE);
 
                   byte[] bytes = kv.getValue();
                   try (
                       OutputStream outStream =
-                          Channels.newOutputStream(FileSystems.create(outputFile, BINARY))
+                          Channels.newOutputStream(FileSystems.create(tmpFile, BINARY))
                   ) {
                     outStream.write(bytes);
                     outStream.flush();
+                  } catch (IOException e) {
+                    LOG.error(
+                        "Failed to write to temporary file [{}] for [{}].",
+                        tmpFile,
+                        getOutputDir().get().resolve(filename, RESOLVE_FILE)
+                    );
+                    FileSystems.delete(
+                        Collections.singletonList(tmpFile),
+                        MoveOptions.StandardMoveOptions.IGNORE_MISSING_FILES
+                    );
+                    throw e;
+                  }
+                }
+
+                @Teardown
+                public void teardown() throws IOException {
+                  try {
+                    FileSystems.rename(
+                        Collections.singletonList(tmpDir.get()),
+                        Collections.singletonList(getOutputDir().get())
+                    );
+                  } catch (IOException e) {
+                    LOG.error(
+                        "Failed to rename temporary directory [{}] to [{}].",
+                        tmpDir.get(), getOutputDir().get()
+                    );
+                    throw e;
                   }
                 }
               }
@@ -189,6 +231,28 @@ public class WholeFileIO {
       );
 
       return PDone.in(input.getPipeline());
+    }
+
+    private static class TemporaryDirectoryBuilder
+        implements SerializableFunction<ResourceId, ResourceId> {
+      private static final AtomicLong TEMP_COUNT = new AtomicLong(0);
+      private static final DateTimeFormatter TEMPDIR_TIMESTAMP =
+          DateTimeFormat.forPattern("yyyy-MM-DD_HH-mm-ss");
+      // The intent of the code is to have a consistent value of tempDirectory across
+      // all workers, which wouldn't happen if now() was called inline.
+      private final String timestamp = Instant.now().toString(TEMPDIR_TIMESTAMP);
+      // Multiple different sinks may be used in the same output directory; use tempId to create a
+      // separate temp directory for each.
+      private final Long tempId = TEMP_COUNT.getAndIncrement();
+
+      @Override
+      public ResourceId apply(ResourceId tempDirectory) {
+        // Temp directory has a timestamp and a unique ID
+        String tempDirName = String.format(".temp-beam-%s-%s", timestamp, tempId);
+        return tempDirectory
+            .getCurrentDirectory()
+            .resolve(tempDirName, ResolveOptions.StandardResolveOptions.RESOLVE_DIRECTORY);
+      }
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
@@ -137,7 +137,7 @@ public class WholeFileIO {
   }
 
   /**
-   * A {@link PTransform} that takes a {@link PCollection} of {@link KV {@code KV<String, byte[]>}}
+   * A {@link PTransform} that takes a {@link PCollection} of {@code KV<String, byte[]>}
    * and writes each {@code byte[]} to the corresponding filename (i.e. the {@link String} of the
    * {@link KV}).
    */
@@ -217,7 +217,7 @@ public class WholeFileIO {
     }
   }
 
-  /** Implementation of {@Link #write()}. */
+  /** Implementation of {@link #write()}. */
   @AutoValue
   public abstract static class Write extends PTransform<PCollection<KV<String, byte[]>>, PDone> {
     private static final Logger LOG = LoggerFactory.getLogger(Write.class);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/WholeFileIO.java
@@ -60,7 +60,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>To read a {@link PCollection} of one or more files as {@link KV}s, use
  * {@code WholeFileIO.read()} to instantiate a transform and use
- * {@link WholeFileIO.Read#from(String)} to specify the path of the file(s) to be read.</p>
+ * {@link WholeFileIO.Read#from(String)} to specify the path of the file(s) to be read.
+ * Alternatively, if the filenames to be read are themselves in a {@link
+ * PCollection}, apply {@link WholeFileIO#readAll()}.
  *
  * <p>Method {@link #read} returns a {@link PCollection} of {@code  KV<String, byte[]>}s,
  * each corresponding to one file's filename and contents.</p>
@@ -85,6 +87,19 @@ import org.slf4j.LoggerFactory;
  *                                        WholeFileIO.read().from("/local/path/to/nested/dirs/**"));
  * // ^ The KV's String corresponding to filename retains only the last term of the file path
  * //   (i.e. it retains the filename and ignores intermediate directory names)
+ * }</pre>
+ *
+ * <p>Example 2: reading a PCollection of filenames (whole paths, not just the last term).
+ *
+ * <pre>{@code
+ * Pipeline p = ...;
+ *
+ * // E.g. the filenames might be computed from other data in the pipeline, or
+ * // read from a data source.
+ * PCollection<String> filenames = ...;
+ *
+ * // Read all files in the collection.
+ * PCollection<KV<String, byte[]>> files = filenames.apply(WholeFileIO.readAll());
  * }</pre>
  *
  * <p>To write the byte array of a {@link PCollection} of {@code KV<String, byte[]>} to an output
@@ -128,9 +143,7 @@ public class WholeFileIO {
     return new AutoValue_WholeFileIO_Write.Builder().build();
   }
 
-  /**
-   * Implements read().
-   */
+  /** Implementation of {@link #read()}. */
   @AutoValue
   public abstract static class Read extends PTransform<PBegin, PCollection<KV<String, byte[]>>> {
     @Nullable
@@ -202,9 +215,7 @@ public class WholeFileIO {
     }
   }
 
-  /**
-   * Implements write().
-   */
+  /** Implementation of {@Link #write()}. */
   @AutoValue
   public abstract static class Write extends PTransform<PCollection<KV<String, byte[]>>, PDone> {
     private static final Logger LOG = LoggerFactory.getLogger(Write.class);


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

## Narrative

WholeFileIO fulfills the requests of [BEAM-2750] and [BEAM-2751] for a way to read and write individual files as individual elements of a PCollection to and from specific filenames.

## Description

`WholeFileIO.Read` receives a file pattern (glob) of input files. The file pattern is expanded into a `PCollection` of `ResourceId`s, each pointing to a single file. The bytes at the file location specified by the `ResourceId`s are read in and attached to their originating filename in a `KV`.

`WholeFileIO.Write` receives a `PCollection` of `KV`s containing byte arrays and their corresponding filenames. The byte arrays are written to the output directory with their corresponding filename.

## Example Usage

This example pipeline will read in files according to a given file glob and write them to the specified output directory unmodified other than "-copy" appended to their filenames. If the input file glob specifies files spread through a directory hierarchy, they will still be written out all into the same flat output directory.

Example pipeline:
```java
public class WholeFileIOPipeline {

    public interface FileIOOptions extends PipelineOptions {
        @Description("File glob of the files to read from")
        @Validation.Required
        String getInputFiles();
        void setInputFiles(String value);

        @Description("Path of the directory to write files to")
        @Validation.Required
        String getOutputDir();
        void setOutputDir(String value);
    }

    public static void main(String[] args) {
        final FileIOOptions options = PipelineOptionsFactory.fromArgs(args).withValidation()
                .as(FileIOOptions.class);
        Pipeline p = Pipeline.create(options);

        PCollection<KV<String, byte[]>> files = p.apply(
            "Read Bytes and filenames of input files",
            WholeFileIO.read().from(options.getInputFiles())
        );

        PCollection<KV<String, byte[]>> renamedFiles = files.apply(
                ParDo.of(
                        new DoFn<KV<String, byte[]>, KV<String, byte[]>>() {
                            @ProcessElement
                            public void processElement(ProcessContext c) {
                                KV<String, byte[]> file = c.element();
                                c.output(KV.of(file.getKey() + "-copy", file.getValue()));
                            }
                        }
                )
        );

        renamedFiles.apply(
                "Write Bytes to filenames in Output Directory",
                WholeFileIO.write().to(options.getOutputDir())
        );

        p.run().waitUntilFinish();
    }
}
```

Example command to run example pipeline:
```bash
mvn clean compile exec:java -Dexec.mainClass=com.example.WholeFileIOPipeline \
  -Dexec.args=" \
    --inputFiles=/path/to/input/files/** \
    --outputDir=/path/to/output/directory/ \
    " \
  -Pdirect-runner
```

## ToDo

- [x] Add comments
- [ ] Add unit tests
- [ ] Scale test for performance
- [x] Find out if `FileSystems.resolve()` will resolve multiple intermediary directories if a user provides a path that doesn't fully exist yet. (`WholeFileIO -> Write -> expand() -> ParDo -> ResourceId logic`)
- [x] Make sure that the `OutputStream` automatically closes when an `Exception` occurs in `WholeFileIO -> Write -> expand() -> ParDo -> try/catch`. If not, close it in a `finally` statement.