### PR TITLE
[BEAM-2770] Add @Experimental and ImmutableList.copyOf

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
@@ -17,12 +17,12 @@
  */
 package org.apache.beam.sdk.coders;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.values.BeamRecord;
@@ -106,6 +106,6 @@ public class BeamRecordCoder extends CustomCoder<BeamRecord> {
   }
 
   public List<Coder> getCoders() {
-    return ImmutableList.copyOf(coders);
+    return Collections.unmodifiableList(coders);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BeamRecordCoder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.coders;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -105,6 +106,6 @@ public class BeamRecordCoder extends CustomCoder<BeamRecord> {
   }
 
   public List<Coder> getCoders() {
-    return coders;
+    return ImmutableList.copyOf(coders);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.values;
 
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -282,7 +283,7 @@ public class BeamRecord implements Serializable {
    * Return the list of data values.
    */
   public List<Object> getDataValues() {
-    return dataValues;
+    return ImmutableList.copyOf(dataValues);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/BeamRecord.java
@@ -17,11 +17,11 @@
  */
 package org.apache.beam.sdk.values;
 
-import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
@@ -283,7 +283,7 @@ public class BeamRecord implements Serializable {
    * Return the list of data values.
    */
   public List<Object> getDataValues() {
-    return ImmutableList.copyOf(dataValues);
+    return Collections.unmodifiableList(dataValues);
   }
 
   /**

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamRecordSqlType.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamRecordSqlType.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
+import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.sql.Types;
 import java.util.ArrayList;
@@ -155,7 +156,7 @@ public class BeamRecordSqlType extends BeamRecordType {
   }
 
   public List<Integer> getFieldTypes() {
-    return fieldTypes;
+    return ImmutableList.copyOf(fieldTypes);
   }
 
   public Integer getFieldTypeByIndex(int index){

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamRecordSqlType.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamRecordSqlType.java
@@ -17,10 +17,10 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
-import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -156,7 +156,7 @@ public class BeamRecordSqlType extends BeamRecordType {
   }
 
   public List<Integer> getFieldTypes() {
-    return ImmutableList.copyOf(fieldTypes);
+    return Collections.unmodifiableList(fieldTypes);
   }
 
   public Integer getFieldTypeByIndex(int index){

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlUdf.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlUdf.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.extensions.sql;
 
 import java.io.Serializable;
+import org.apache.beam.sdk.annotations.Experimental;
 
 /**
  * Interface to create a UDF in Beam SQL.
@@ -36,6 +37,7 @@ import java.io.Serializable;
  * <p>The first parameter is named "s" and is mandatory,
  * and the second parameter is named "n" and is optional.
  */
+@Experimental
 public interface BeamSqlUdf extends Serializable {
   String UDF_METHOD = "eval";
 }


### PR DESCRIPTION
Some final API polish, making sure \@Experimental annotations are on all the public SQL API classes, and immutable objects always return ImmutableLists for private members instead of the mutable members themselves.