### PR TITLE
[BEAM-1347] Convert an InputStream into an Iterable<T> using the Beam Fn data specification

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.coders.Coder;
 
 /**
  * {@link #inbound(Iterator)} treats multiple {@link ByteString}s as a single input stream and
- * {@link #outbound(CloseableThrowingConsumer)} treats a single {@link OutputStream} as mulitple
+ * {@link #outbound(CloseableThrowingConsumer)} treats a single {@link OutputStream} as multiple
  * {@link ByteString}s.
  */
 public class DataStreams {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
@@ -107,7 +107,7 @@ public class DataStreams {
    * using the specified {@link Coder}. Note that this adapter follows the Beam Fn API specification
    * for forcing values that decode consuming zero bytes to consuming exactly one byte.
    *
-   * Note that access to the underlying {@link InputStream} is lazy and will only be invoked on
+   * <p>Note that access to the underlying {@link InputStream} is lazy and will only be invoked on
    * first access to {@link #next()} or {@link #hasNext()}.
    */
   public static class DataStreamDecoder<T> implements Iterator<T> {
@@ -128,8 +128,6 @@ public class DataStreams {
     @Override
     public boolean hasNext() {
       switch (currentState) {
-        case HAS_NEXT:
-          return true;
         case EOF:
           return false;
         case READ_REQUIRED:
@@ -148,13 +146,14 @@ public class DataStreams {
               countingInputStream.skip(1);
             }
             currentState = State.HAS_NEXT;
-            return true;
           } catch (IOException e) {
             throw new IllegalStateException(e);
           }
-        default:
-          throw new IllegalStateException(String.format("Unknown state %s", currentState));
+          // fall through expected
+        case HAS_NEXT:
+          return true;
       }
+      throw new IllegalStateException(String.format("Unknown state %s", currentState));
     }
 
     @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.fn.harness.stream;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CountingInputStream;
 import com.google.protobuf.ByteString;
@@ -143,7 +145,7 @@ public class DataStreams {
             next = coder.decode(countingInputStream);
             // Skip one byte if decoding the value consumed 0 bytes.
             if (countingInputStream.getCount() - count == 0) {
-              countingInputStream.skip(1);
+              checkState(countingInputStream.read() != -1, "Unexpected EOF reached");
             }
             currentState = State.HAS_NEXT;
           } catch (IOException e) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/DataStreams.java
@@ -106,8 +106,10 @@ public class DataStreams {
 
   /**
    * An adapter which converts an {@link InputStream} to an {@link Iterator} of {@code T} values
-   * using the specified {@link Coder}. Note that this adapter follows the Beam Fn API specification
-   * for forcing values that decode consuming zero bytes to consuming exactly one byte.
+   * using the specified {@link Coder}.
+   *
+   * <p>Note that this adapter follows the Beam Fn API specification for forcing values that decode
+   * consuming zero bytes to consuming exactly one byte.
    *
    * <p>Note that access to the underlying {@link InputStream} is lazy and will only be invoked on
    * first access to {@link #next()} or {@link #hasNext()}.

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/DataStreamsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/DataStreamsTest.java
@@ -52,7 +52,7 @@ import org.junit.runners.JUnit4;
 @RunWith(Enclosed.class)
 public class DataStreamsTest {
 
-  /** Tests for {@link DataStreams.Inbound} */
+  /** Tests for {@link DataStreams.Inbound}. */
   @RunWith(JUnit4.class)
   public static class InboundTest {
     private static final ByteString BYTES_A = ByteString.copyFromUtf8("TestData");
@@ -77,7 +77,7 @@ public class DataStreamsTest {
     }
   }
 
-  /** Tests for {@link DataStreams.BlockingQueueIterator} */
+  /** Tests for {@link DataStreams.BlockingQueueIterator}. */
   @RunWith(JUnit4.class)
   public static class BlockingQueueIteratorTest {
     @Test(timeout = 10_000)

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/DataStreamsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/DataStreamsTest.java
@@ -17,76 +17,151 @@
  */
 package org.apache.beam.fn.harness.stream;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.collect.Iterators;
+import com.google.common.io.ByteStreams;
+import com.google.common.io.CountingOutputStream;
 import com.google.protobuf.ByteString;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.SynchronousQueue;
 import org.apache.beam.fn.harness.stream.DataStreams.BlockingQueueIterator;
+import org.apache.beam.fn.harness.stream.DataStreams.DataStreamDecoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link DataStreams}. */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class DataStreamsTest {
-  private static final ByteString BYTES_A = ByteString.copyFromUtf8("TestData");
-  private static final ByteString BYTES_B = ByteString.copyFromUtf8("SomeOtherTestData");
 
-  @Test
-  public void testEmptyRead() throws Exception {
-    assertEquals(ByteString.EMPTY, read());
-    assertEquals(ByteString.EMPTY, read(ByteString.EMPTY));
-    assertEquals(ByteString.EMPTY, read(ByteString.EMPTY, ByteString.EMPTY));
+  /** Tests for {@link DataStreams.Inbound} */
+  @RunWith(JUnit4.class)
+  public static class InboundTest {
+    private static final ByteString BYTES_A = ByteString.copyFromUtf8("TestData");
+    private static final ByteString BYTES_B = ByteString.copyFromUtf8("SomeOtherTestData");
+
+    @Test
+    public void testEmptyRead() throws Exception {
+      assertEquals(ByteString.EMPTY, read());
+      assertEquals(ByteString.EMPTY, read(ByteString.EMPTY));
+      assertEquals(ByteString.EMPTY, read(ByteString.EMPTY, ByteString.EMPTY));
+    }
+
+    @Test
+    public void testRead() throws Exception {
+      assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, BYTES_B));
+      assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, ByteString.EMPTY, BYTES_B));
+      assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, BYTES_B, ByteString.EMPTY));
+    }
+
+    private static ByteString read(ByteString... bytes) throws IOException {
+      return ByteString.readFrom(DataStreams.inbound(Arrays.asList(bytes).iterator()));
+    }
   }
 
-  @Test
-  public void testRead() throws Exception {
-    assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, BYTES_B));
-    assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, ByteString.EMPTY, BYTES_B));
-    assertEquals(BYTES_A.concat(BYTES_B), read(BYTES_A, BYTES_B, ByteString.EMPTY));
+  /** Tests for {@link DataStreams.BlockingQueueIterator} */
+  @RunWith(JUnit4.class)
+  public static class BlockingQueueIteratorTest {
+    @Test(timeout = 10_000)
+    public void testBlockingQueueIteratorWithoutBlocking() throws Exception {
+      BlockingQueueIterator<String> iterator =
+          new BlockingQueueIterator<>(new ArrayBlockingQueue<>(3));
+
+      iterator.accept("A");
+      iterator.accept("B");
+      iterator.close();
+
+      assertEquals(Arrays.asList("A", "B"),
+          Arrays.asList(Iterators.toArray(iterator, String.class)));
+    }
+
+    @Test(timeout = 10_000)
+    public void testBlockingQueueIteratorWithBlocking() throws Exception {
+      // The synchronous queue only allows for one element to transfer at a time and blocks
+      // the sending/receiving parties until both parties are there.
+      final BlockingQueueIterator<String> iterator =
+          new BlockingQueueIterator<>(new SynchronousQueue<>());
+      final CompletableFuture<List<String>> valuesFuture = new CompletableFuture<>();
+      Thread appender = new Thread() {
+        @Override
+        public void run() {
+          valuesFuture.complete(Arrays.asList(Iterators.toArray(iterator, String.class)));
+        }
+      };
+      appender.start();
+      iterator.accept("A");
+      iterator.accept("B");
+      iterator.close();
+      assertEquals(Arrays.asList("A", "B"), valuesFuture.get());
+      appender.join();
+    }
   }
 
-  @Test(timeout = 10_000)
-  public void testBlockingQueueIteratorWithoutBlocking() throws Exception {
-    BlockingQueueIterator<String> iterator =
-        new BlockingQueueIterator<>(new ArrayBlockingQueue<>(3));
+  /** Tests for {@link DataStreams.DataStreamDecoder}. */
+  @RunWith(JUnit4.class)
+  public static class DataStreamDecoderTest {
+    @Rule public ExpectedException thrown = ExpectedException.none();
 
-    iterator.accept("A");
-    iterator.accept("B");
-    iterator.close();
+    @Test
+    public void testEmptyInputStream() throws Exception {
+      testDecoderWith(StringUtf8Coder.of());
+    }
 
-    assertEquals(Arrays.asList("A", "B"),
-        Arrays.asList(Iterators.toArray(iterator, String.class)));
-  }
+    @Test
+    public void testNonEmptyInputStream() throws Exception {
+      testDecoderWith(StringUtf8Coder.of(), "A", "BC", "DEF", "GHIJ");
+    }
 
-  @Test(timeout = 10_000)
-  public void testBlockingQueueIteratorWithBlocking() throws Exception {
-    // The synchronous queue only allows for one element to transfer at a time and blocks
-    // the sending/receiving parties until both parties are there.
-    final BlockingQueueIterator<String> iterator =
-        new BlockingQueueIterator<>(new SynchronousQueue<>());
-    final CompletableFuture<List<String>> valuesFuture = new CompletableFuture<>();
-    Thread appender = new Thread() {
-      @Override
-      public void run() {
-        valuesFuture.complete(Arrays.asList(Iterators.toArray(iterator, String.class)));
+    @Test
+    public void testNonEmptyInputStreamWithZeroLengthCoder() throws Exception {
+      CountingOutputStream countingOutputStream =
+          new CountingOutputStream(ByteStreams.nullOutputStream());
+      GlobalWindow.Coder.INSTANCE.encode(GlobalWindow.INSTANCE, countingOutputStream);
+      assumeTrue(countingOutputStream.getCount() == 0);
+
+      testDecoderWith(GlobalWindow.Coder.INSTANCE, GlobalWindow.INSTANCE, GlobalWindow.INSTANCE);
+    }
+
+    private <T> void testDecoderWith(Coder<T> coder, T... expected) throws IOException {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      for (T value : expected) {
+        int size = baos.size();
+        coder.encode(value, baos);
+        // Pad an arbitrary byte when values encode to zero bytes
+        if (baos.size() - size == 0) {
+          baos.write(0);
+        }
       }
-    };
-    appender.start();
-    iterator.accept("A");
-    iterator.accept("B");
-    iterator.close();
-    assertEquals(Arrays.asList("A", "B"), valuesFuture.get());
-    appender.join();
-  }
 
-  private static ByteString read(ByteString... bytes) throws IOException {
-    return ByteString.readFrom(DataStreams.inbound(Arrays.asList(bytes).iterator()));
+      Iterator<T> decoder =
+          new DataStreamDecoder<>(coder, new ByteArrayInputStream(baos.toByteArray()));
+
+      Object[] actual = Iterators.toArray(decoder, Object.class);
+      assertArrayEquals(expected, actual);
+
+      assertFalse(decoder.hasNext());
+      assertFalse(decoder.hasNext());
+
+      thrown.expect(NoSuchElementException.class);
+      decoder.next();
+    }
   }
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This is towards sharing common code that supports the Beam Fn State API and the Beam Fn Data API.
