### PR TITLE
BEAM-2764: Set right range for min_doc_size and max_doc_size

### DIFF
--- a/sdks/java/io/solr/src/test/java/org/apache/beam/sdk/io/solr/SolrIOTestUtils.java
+++ b/sdks/java/io/solr/src/test/java/org/apache/beam/sdk/io/solr/SolrIOTestUtils.java
@@ -28,8 +28,8 @@ import org.apache.solr.common.SolrInputDocument;
 
 /** Test utilities to use with {@link SolrIO}. */
 public class SolrIOTestUtils {
-  public static final long MIN_DOC_SIZE = 40L;
-  public static final long MAX_DOC_SIZE = 90L;
+  public static final long MIN_DOC_SIZE = 30L;
+  public static final long MAX_DOC_SIZE = 150L;
 
   static void createCollection(
       String collection, int numShards, int replicationFactor, AuthorizedSolrClient client)


### PR DESCRIPTION
Change SolrIOTestUtils.MIN_DOC_SIZE and SolrIOTestUtils.MAX_DOC_SIZE to appropriate value, beasted the test ~2000 times.