### PR TITLE
Combine globally

### DIFF
--- a/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
@@ -41,12 +41,16 @@ class AdaptiveThrottler(object):
   MIN_REQUESTS = 1
 
   def __init__(self, window_ms, bucket_ms, overload_ratio):
-    """Args:
-      window_ms: int, length of history to consider, in ms, to set throttling.
-      bucket_ms: int, granularity of time buckets that we store data in, in ms.
-      overload_ratio: float, the target ratio between requests sent and
-          successful requests. This is "K" in the formula in
-          https://landing.google.com/sre/book/chapters/handling-overload.html
+    """Initializes AdaptiveThrottler.
+
+      Args:
+        window_ms: int, length of history to consider, in ms, to set
+                   throttling.
+        bucket_ms: int, granularity of time buckets that we store data in, in
+                   ms.
+        overload_ratio: float, the target ratio between requests sent and
+                        successful requests. This is "K" in the formula in
+                        https://landing.google.com/sre/book/chapters/handling-overload.html.
     """
     self._all_requests = util.MovingSum(window_ms, bucket_ms)
     self._successful_requests = util.MovingSum(window_ms, bucket_ms)

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/adaptive_throttler.py
@@ -41,16 +41,12 @@ class AdaptiveThrottler(object):
   MIN_REQUESTS = 1
 
   def __init__(self, window_ms, bucket_ms, overload_ratio):
-    """Initializes AdaptiveThrottler.
-
-      Args:
-        window_ms: int, length of history to consider, in ms, to set
-                   throttling.
-        bucket_ms: int, granularity of time buckets that we store data in, in
-                   ms.
-        overload_ratio: float, the target ratio between requests sent and
-                        successful requests. This is "K" in the formula in
-                        https://landing.google.com/sre/book/chapters/handling-overload.html.
+    """Args:
+      window_ms: int, length of history to consider, in ms, to set throttling.
+      bucket_ms: int, granularity of time buckets that we store data in, in ms.
+      overload_ratio: float, the target ratio between requests sent and
+          successful requests. This is "K" in the formula in
+          https://landing.google.com/sre/book/chapters/handling-overload.html
     """
     self._all_requests = util.MovingSum(window_ms, bucket_ms)
     self._successful_requests = util.MovingSum(window_ms, bucket_ms)

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -57,9 +57,17 @@ class Mean(object):
 
   class Globally(ptransform.PTransform):
     """combiners.Mean.Globally computes the arithmetic mean of the elements."""
+    def __init__(self, label=None, as_view=False, has_defaults=True):
+      super(self.__class__, self).__init__(label)
+      self.as_view = as_view
+      self.has_defaults = has_defaults
 
     def expand(self, pcoll):
-      return pcoll | core.CombineGlobally(MeanCombineFn())
+      combine = core.CombineGlobally(MeanCombineFn())\
+          .with_defaults(self.has_defaults)
+      if self.as_view:
+        combine = combine.as_singleton_view()
+      return pcoll | combine
 
   class PerKey(ptransform.PTransform):
     """combiners.Mean.PerKey finds the means of the values for each key."""
@@ -103,9 +111,17 @@ class Count(object):
 
   class Globally(ptransform.PTransform):
     """combiners.Count.Globally counts the total number of elements."""
+    def __init__(self, label=None, as_view=False, has_defaults=True):
+      super(self.__class__, self).__init__(label)
+      self.as_view = as_view
+      self.has_defaults = has_defaults
 
     def expand(self, pcoll):
-      return pcoll | core.CombineGlobally(CountCombineFn())
+      combine = core.CombineGlobally(CountCombineFn())\
+          .with_defaults(self.has_defaults)
+      if self.as_view:
+        combine = combine.as_singleton_view()
+      return pcoll | combine
 
   class PerKey(ptransform.PTransform):
     """combiners.Count.PerKey counts how many elements each unique key has."""
@@ -471,11 +487,18 @@ class SingleInputTupleCombineFn(_TupleCombineFnBase):
 class ToList(ptransform.PTransform):
   """A global CombineFn that condenses a PCollection into a single list."""
 
-  def __init__(self, label='ToList'):  # pylint: disable=useless-super-delegation
+  # pylint: disable=useless-super-delegation
+  def __init__(self, label='ToList', as_view=False, has_defaults=True):
     super(ToList, self).__init__(label)
+    self.as_view = as_view
+    self.has_defaults = has_defaults
 
   def expand(self, pcoll):
-    return pcoll | self.label >> core.CombineGlobally(ToListCombineFn())
+    combine = core.CombineGlobally(ToListCombineFn())\
+        .with_defaults(self.has_defaults)
+    if self.as_view:
+      combine = combine.as_singleton_view()
+    return pcoll | combine
 
 
 @with_input_types(T)
@@ -505,11 +528,18 @@ class ToDict(ptransform.PTransform):
   will be present in the resulting dict.
   """
 
-  def __init__(self, label='ToDict'):  # pylint: disable=useless-super-delegation
+  # pylint: disable=useless-super-delegation
+  def __init__(self, label='ToDict', as_view=False, has_defaults=True):
     super(ToDict, self).__init__(label)
+    self.as_view = as_view
+    self.has_defaults = has_defaults
 
   def expand(self, pcoll):
-    return pcoll | self.label >> core.CombineGlobally(ToDictCombineFn())
+    combine = core.CombineGlobally(ToDictCombineFn())\
+        .with_defaults(self.has_defaults)
+    if self.as_view:
+      combine = combine.as_singleton_view()
+    return pcoll | combine
 
 
 @with_input_types(Tuple[K, V])

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -57,8 +57,8 @@ class Mean(object):
 
   class Globally(ptransform.PTransform):
     """combiners.Mean.Globally computes the arithmetic mean of the elements."""
-    def __init__(self, label=None, as_view=False, has_defaults=True):
-      super(self.__class__, self).__init__(label)
+    def __init__(self, as_view=False, has_defaults=True):
+      super(self.__class__, self).__init__()
       self.as_view = as_view
       self.has_defaults = has_defaults
 
@@ -111,8 +111,8 @@ class Count(object):
 
   class Globally(ptransform.PTransform):
     """combiners.Count.Globally counts the total number of elements."""
-    def __init__(self, label=None, as_view=False, has_defaults=True):
-      super(self.__class__, self).__init__(label)
+    def __init__(self, as_view=False, has_defaults=True):
+      super(self.__class__, self).__init__()
       self.as_view = as_view
       self.has_defaults = has_defaults
 
@@ -488,8 +488,8 @@ class ToList(ptransform.PTransform):
   """A global CombineFn that condenses a PCollection into a single list."""
 
   # pylint: disable=useless-super-delegation
-  def __init__(self, label='ToList', as_view=False, has_defaults=True):
-    super(ToList, self).__init__(label)
+  def __init__(self, as_view=False, has_defaults=True):
+    super(ToList, self).__init__()
     self.as_view = as_view
     self.has_defaults = has_defaults
 
@@ -529,8 +529,8 @@ class ToDict(ptransform.PTransform):
   """
 
   # pylint: disable=useless-super-delegation
-  def __init__(self, label='ToDict', as_view=False, has_defaults=True):
-    super(ToDict, self).__init__(label)
+  def __init__(self, as_view=False, has_defaults=True):
+    super(ToDict, self).__init__()
     self.as_view = as_view
     self.has_defaults = has_defaults
 


### PR DESCRIPTION
Hi @aaltay,

This just gives a more convenient way to call global combiners when needed as views or without defaults.

e.g.
``beam.combiners.Mean.Globally(as_view=True)``
``beam.combiners.Mean.Globally(has_defaults=False)``

instead of:

``beam.CombineGlobally(beam.combiners.MeanCombineFn()).as_singleton_view()``
``beam.CombineGlobally(beam.combiners.MeanCombineFn()).without_defaults()``