### PR TITLE
Fix a function serialization bug in AvroIO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -762,15 +762,22 @@ public class AvroIO {
       return toResource(StaticValueProvider.of(outputPrefix));
     }
 
+    private static class OutputPrefixToResourceId
+        implements SerializableFunction<String, ResourceId> {
+      @Override
+      public ResourceId apply(String input) {
+        return FileBasedSink.convertToFileResourceIfPossible(input);
+      }
+    }
+
     /** Like {@link #to(String)}. */
     public TypedWrite<UserT, OutputT> to(ValueProvider<String> outputPrefix) {
-      return toResource(NestedValueProvider.of(outputPrefix,
-          new SerializableFunction<String, ResourceId>() {
-            @Override
-            public ResourceId apply(String input) {
-              return FileBasedSink.convertToFileResourceIfPossible(input);
-            }
-          }));
+      return toResource(
+          NestedValueProvider.of(
+              outputPrefix,
+              // The function cannot be created as an anonymous class here since the enclosed class
+              // may contain unserializable members.
+              new OutputPrefixToResourceId()));
     }
 
     /** Like {@link #to(ResourceId)}. */


### PR DESCRIPTION
Hi @jkff , can you please take a look?

If ValueProvider<String> is specified as outputPrefix, a NestedValueProvider is created with a SerializableFunction enclosed to perform some translation work.
However, in the original codes the function is created as an anonymous class, capturing the enclosing class TypedWrite as "this", which contains a un-serializable member Schema. An exception is thrown from expand() if run because the function is not serializable.