### PR TITLE
Avoid passing extra argument to object() constructor in GcsIO

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -105,7 +105,7 @@ class GcsIO(object):
   def __new__(cls, storage_client=None):
     if storage_client:
       # This path is only used for testing.
-      return super(GcsIO, cls).__new__(cls, storage_client)
+      return super(GcsIO, cls).__new__(cls)
     else:
       # Create a single storage client for each thread.  We would like to avoid
       # creating more than one storage client for each thread, since each


### PR DESCRIPTION
This change fixes the following warning in gcsio_test:
```
apache_beam/io/gcp/gcsio.py:108: DeprecationWarning: object() takes no parameters
  return super(GcsIO, cls).__new__(cls, storage_client)
```