### PR TITLE
[BEAM-2796] Actually wait for exector service to shutdown

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner_test.py
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import threading
+import unittest
+
+import apache_beam as beam
+from apache_beam.testing import test_pipeline
+
+
+class DirectPipelineResultTest(unittest.TestCase):
+
+  def test_waiting_on_result_stops_executor_threads(self):
+    pre_test_threads = set(t.ident for t in threading.enumerate())
+
+    pipeline = test_pipeline.TestPipeline()
+    _ = (pipeline | beam.Create([{'foo': 'bar'}]))
+    result = pipeline.run()
+    result.wait_until_finish()
+
+    post_test_threads = set(t.ident for t in threading.enumerate())
+    new_threads = post_test_threads - pre_test_threads
+    self.assertEqual(len(new_threads), 0)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -415,6 +415,7 @@ class _ExecutorServiceParallelExecutor(object):
         raise t, v, tb
     finally:
       self.executor_service.shutdown()
+      self.executor_service.await_completion()
 
   def schedule_consumers(self, committed_bundle):
     if committed_bundle.pcollection in self.value_to_consumers:


### PR DESCRIPTION
Currently executor service is leaking threads, which eventually complete, but may complicate writing integration tests in frameworks that check for leaked threads. There is await_for_completion in the _ExecutorService class, but it's not invoked from the _ExecutorServiceParallelExecutor.await_for_completion, which is fixed in this pull request.