### PR TITLE
Use the same termination logic in different places in DataflowRunner

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -949,7 +949,9 @@ class DataflowPipelineResult(PipelineResult):
       while thread.isAlive():
         time.sleep(5.0)
 
-      terminated = self._is_in_terminal_state()
+      # TODO: Merge the termination code in poll_for_job_completion and
+      # _is_in_terminal_state.
+      terminated = (str(self._job.currentState) != 'JOB_STATE_RUNNING')
       assert duration or terminated, (
           'Job did not reach to a terminal state after waiting indefinitely.')
 


### PR DESCRIPTION
Use the same termination check for `wait_until_finish` and `_is_in_terminal_state`. Note that this only affects an `assert` with a TODO to improve it.

The change is required for having clean fail messages instead of this assert for cases similar to: https://builds.apache.org/view/A-D/view/Beam/job/beam_PostCommit_Python_Verify/3013/consoleFull

(https://console.cloud.google.com/dataflow/jobsDetail/locations/us-central1/jobs/2017-08-28_11_08_56-17324181904913254210?project=apache-beam-testing)

R: @charlesccychen 