### PR TITLE
KafkaIO readme

### DIFF
--- a/sdks/java/io/kafka/README.md
+++ b/sdks/java/io/kafka/README.md
@@ -1,0 +1,36 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+KafkaIO is a beam connector to [Apache Kafka](http://kafka.apache.org/)'s messaging framework. It enables using kafka as an unbounded source or sink in your pipeline.
+
+## Dependencies
+
+To use KafkaIO you must first add a dependency on `beam-sdks-java-io-kafka`
+
+```maven
+<dependency>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-io-kafka</artifactId>
+    <version>...</version>
+</dependency>
+```
+
+## Documentation
+
+- [KafkaIO class](https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java)


### PR DESCRIPTION
Following Beam's [Documentation page](https://beam.apache.org/documentation/io/built-in/), (which you get to from header -> documentation -> pipeline i/o -> built in i/o transforms) leads to  [Kafka in the IO directory](https://github.com/apache/beam/tree/master/sdks/java/io/kafka), but there is no docs there.

I've added a short readme to make it easier for new users that need Kafka as their source/sink.