### PR TITLE
[BEAM-2718] Add improved bundle retry code for the DirectRunner

### DIFF
--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -320,6 +320,8 @@ class DirectUnmergedState(InMemoryUnmergedState):
   def __init__(self):
     super(DirectUnmergedState, self).__init__(defensive_copy=False)
 
+  # TODO(mariagh): make a selective deepcopy of just what is needed
+  # to preserve the state while a bundle is processed.
   def clone(self):
     return copy.deepcopy(self)
 

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -20,8 +20,8 @@
 from __future__ import absolute_import
 
 import collections
-import threading
 import copy
+import threading
 
 from apache_beam.runners.direct.clock import Clock
 from apache_beam.runners.direct.direct_metrics import DirectMetrics

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -538,7 +538,7 @@ class _ExecutorServiceParallelExecutor(object):
                 update.unprocessed_bundle)
           else:
             assert update.exception
-            logging.warning('A task failed with exception.\n %s',
+            logging.warning('A task failed with exception: %s',
                             update.exception)
             self._executor.visible_updates.offer(
                 _ExecutorServiceParallelExecutor._VisibleExecutorUpdate(

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -648,7 +648,9 @@ class _GroupByKeyOnlyEvaluator(_TransformEvaluator):
           None, '', TimeDomain.WATERMARK, WatermarkManager.WATERMARK_POS_INF)
 
     return TransformResult(
-        self._applied_ptransform, bundles, [], None, {None: hold})
+        self._applied_ptransform, bundles, [], None, {None: hold},
+        partial_keyed_state=self.step_context.partial_keyed_state,
+        keyed_existing_state=self.step_context.keyed_existing_state)
 
 
 class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
@@ -703,7 +705,6 @@ class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
 
     return TransformResult(
         self._applied_ptransform, bundles, [], None, None)
-
 
 class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
   """TransformEvaluator for the _StreamingGroupAlsoByWindow transform.

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -302,8 +302,7 @@ class _BoundedReadEvaluator(_TransformEvaluator):
       with self._source.reader() as reader:
         bundles = _read_values_to_bundles(reader)
 
-    return TransformResult(
-        self._applied_ptransform, bundles, [], None, None)
+    return TransformResult(self, bundles, [], None, None)
 
 
 class _TestStreamEvaluator(_TransformEvaluator):
@@ -356,9 +355,9 @@ class _TestStreamEvaluator(_TransformEvaluator):
           self.current_index + 1, timestamp=self.watermark))
       unprocessed_bundles.append(unprocessed_bundle)
       hold = self.watermark
+
     return TransformResult(
-        self._applied_ptransform, self.bundles, unprocessed_bundles, None,
-        {None: hold})
+        self, self.bundles, unprocessed_bundles, None, {None: hold})
 
 
 class _PubSubSubscriptionWrapper(object):
@@ -442,9 +441,9 @@ class _PubSubReadEvaluator(_TransformEvaluator):
       input_pvalue = pvalue.PBegin(self._applied_ptransform.transform.pipeline)
     unprocessed_bundle = self._evaluation_context.create_bundle(
         input_pvalue)
-    return TransformResult(
-        self._applied_ptransform, bundles,
-        [unprocessed_bundle], None, {None: Timestamp.of(time.time())})
+
+    return TransformResult(self, bundles, [unprocessed_bundle], None,
+                           {None: Timestamp.of(time.time())})
 
 
 class _FlattenEvaluator(_TransformEvaluator):
@@ -467,8 +466,7 @@ class _FlattenEvaluator(_TransformEvaluator):
 
   def finish_bundle(self):
     bundles = [self.bundle]
-    return TransformResult(
-        self._applied_ptransform, bundles, [], None, None)
+    return TransformResult(self, bundles, [], None, None)
 
 
 class _TaggedReceivers(dict):
@@ -557,7 +555,7 @@ class _ParDoEvaluator(_TransformEvaluator):
     bundles = self._tagged_receivers.values()
     result_counters = self._counter_factory.get_counters()
     return TransformResult(
-        self._applied_ptransform, bundles, [], result_counters, None,
+        self, bundles, [], result_counters, None,
         self._tagged_receivers.undeclared_in_memory_tag_values)
 
 
@@ -647,10 +645,7 @@ class _GroupByKeyOnlyEvaluator(_TransformEvaluator):
       self.global_state.set_timer(
           None, '', TimeDomain.WATERMARK, WatermarkManager.WATERMARK_POS_INF)
 
-    return TransformResult(
-        self._applied_ptransform, bundles, [], None, {None: hold},
-        partial_keyed_state=self.step_context.partial_keyed_state,
-        keyed_existing_state=self.step_context.keyed_existing_state)
+    return TransformResult(self, bundles, [], None, {None: hold})
 
 
 class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
@@ -703,8 +698,7 @@ class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
       kwi = KeyedWorkItem(encoded_k, elements=vs)
       bundle.add(GlobalWindows.windowed_value(kwi))
 
-    return TransformResult(
-        self._applied_ptransform, bundles, [], None, None)
+    return TransformResult(self, bundles, [], None, None)
 
 class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
   """TransformEvaluator for the _StreamingGroupAlsoByWindow transform.
@@ -763,8 +757,7 @@ class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
         bundle.add(item)
       bundles.append(bundle)
 
-    return TransformResult(
-        self._applied_ptransform, bundles, [], None, self.keyed_holds)
+    return TransformResult(self, bundles, [], None, self.keyed_holds)
 
 
 class _NativeWriteEvaluator(_TransformEvaluator):
@@ -828,5 +821,4 @@ class _NativeWriteEvaluator(_TransformEvaluator):
       self.global_state.set_timer(
           None, '', TimeDomain.WATERMARK, WatermarkManager.WATERMARK_POS_INF)
 
-    return TransformResult(
-        self._applied_ptransform, [], [], None, {None: hold})
+    return TransformResult(self, [], [], None, {None: hold})

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -700,6 +700,7 @@ class _StreamingGroupByKeyOnlyEvaluator(_TransformEvaluator):
 
     return TransformResult(self, bundles, [], None, None)
 
+
 class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
   """TransformEvaluator for the _StreamingGroupAlsoByWindow transform.
 

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -619,7 +619,7 @@ class _GroupByKeyOnlyEvaluator(_TransformEvaluator):
         gbk_result = []
         # TODO(ccy): perhaps we can clean this up to not use this
         # internal attribute of the DirectStepContext.
-        for encoded_k in self.step_context.keyed_existing_state:
+        for encoded_k in self.step_context.existing_keyed_state:
           # Ignore global state.
           if encoded_k is None:
             continue

--- a/sdks/python/apache_beam/runners/direct/util.py
+++ b/sdks/python/apache_beam/runners/direct/util.py
@@ -28,7 +28,8 @@ class TransformResult(object):
 
   def __init__(self, applied_ptransform, uncommitted_output_bundles,
                unprocessed_bundles, counters, keyed_watermark_holds,
-               undeclared_tag_values=None):
+               undeclared_tag_values=None,
+               partial_keyed_state={}, keyed_existing_state={}):
     self.transform = applied_ptransform
     self.uncommitted_output_bundles = uncommitted_output_bundles
     self.unprocessed_bundles = unprocessed_bundles
@@ -46,6 +47,8 @@ class TransformResult(object):
     self.undeclared_tag_values = undeclared_tag_values
     # Populated by the TransformExecutor.
     self.logical_metric_updates = None
+    self.partial_keyed_state = partial_keyed_state
+    self.keyed_existing_state = keyed_existing_state
 
 
 class TimerFiring(object):

--- a/sdks/python/apache_beam/runners/direct/util.py
+++ b/sdks/python/apache_beam/runners/direct/util.py
@@ -28,9 +28,8 @@ class TransformResult(object):
 
   def __init__(self, transform_evaluator, uncommitted_output_bundles,
                unprocessed_bundles, counters, keyed_watermark_holds,
-               undeclared_tag_values=None,
-               partial_keyed_state=None, keyed_existing_state=None):
-    self.transform = transform_evaluator._applied_ptransform # mgh
+               undeclared_tag_values=None):
+    self.transform = transform_evaluator._applied_ptransform
     self.uncommitted_output_bundles = uncommitted_output_bundles
     self.unprocessed_bundles = unprocessed_bundles
     self.counters = counters
@@ -48,11 +47,8 @@ class TransformResult(object):
     # Populated by the TransformExecutor.
     self.logical_metric_updates = None
 
-    self.step_context = (
-        transform_evaluator._execution_context.get_step_context()
-        )
-    self.partial_keyed_state = self.step_context.partial_keyed_state or {}
-    self.keyed_existing_state = self.step_context.keyed_existing_state or {}
+    step_context = transform_evaluator._execution_context.get_step_context()
+    self.partial_keyed_state = step_context.partial_keyed_state
 
 
 class TimerFiring(object):

--- a/sdks/python/apache_beam/runners/direct/util.py
+++ b/sdks/python/apache_beam/runners/direct/util.py
@@ -26,11 +26,11 @@ from __future__ import absolute_import
 class TransformResult(object):
   """Result of evaluating an AppliedPTransform with a TransformEvaluator."""
 
-  def __init__(self, applied_ptransform, uncommitted_output_bundles,
+  def __init__(self, transform_evaluator, uncommitted_output_bundles,
                unprocessed_bundles, counters, keyed_watermark_holds,
                undeclared_tag_values=None,
-               partial_keyed_state={}, keyed_existing_state={}):
-    self.transform = applied_ptransform
+               partial_keyed_state=None, keyed_existing_state=None):
+    self.transform = transform_evaluator._applied_ptransform # mgh
     self.uncommitted_output_bundles = uncommitted_output_bundles
     self.unprocessed_bundles = unprocessed_bundles
     self.counters = counters
@@ -47,8 +47,12 @@ class TransformResult(object):
     self.undeclared_tag_values = undeclared_tag_values
     # Populated by the TransformExecutor.
     self.logical_metric_updates = None
-    self.partial_keyed_state = partial_keyed_state
-    self.keyed_existing_state = keyed_existing_state
+
+    self.step_context = (
+        transform_evaluator._execution_context.get_step_context()
+        )
+    self.partial_keyed_state = self.step_context.partial_keyed_state or {}
+    self.keyed_existing_state = self.step_context.keyed_existing_state or {}
 
 
 class TimerFiring(object):


### PR DESCRIPTION
When processing of a bundle fails, the bundle should be retried.
- [x] Make state mutations atomically committed per bundle.
- [ ] Improve performance by doing selective deepcopy of the partial states.