### PR TITLE
[BEAM-2829] Add ability to set job labels for Dataflow runners in BEAM Java SDK

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -345,6 +345,9 @@ public class DataflowPipelineTranslator {
       workerPool.setPackages(packages);
       workerPool.setNumWorkers(options.getNumWorkers());
 
+      if (options.getLabels() != null) {
+        job.setLabels(options.getLabels());
+      }
       if (options.isStreaming()
           && !DataflowRunner.hasExperiment(options, "enable_windmill_service")) {
         // Use separate data disk for streaming.

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.options;
 
+import java.util.Map;
+
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
@@ -114,6 +116,13 @@ public interface DataflowPipelineOptions
   @Default.String("us-central1")
   String getRegion();
   void setRegion(String region);
+
+  /**
+   * Labels that will be applied to the billing records for this job.
+   */
+  @Description("Labels that will be applied to the billing records for this job.")
+  Map<String, String> getLabels();
+  void setLabels(Map<String, String> labels);
 
   /**
    * Returns a default staging location under {@link GcpOptions#getGcpTempLocation}.


### PR DESCRIPTION
Dataflow runner supports job labels specified by users and the labels will be populated to billing records and make query easier. This change enables BEAM Java SDK to use job labels on Dataflow runners. 