### PR TITLE
CoGroupByKey snippet with concrete example

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1148,8 +1148,8 @@ def model_co_group_by_key_tuple(email_list, phone_list, output_path):
     # multiple possible values for each key.
     # The phone_list contains values such as: ('mary': '111-222-3333') with
     # multiple possible values for each key.
-    emails_pcoll = p | beam.Create(email_list)
-    phones_pcoll = p | beam.Create(phone_list)
+    emails_pcoll = p | 'create emails' >> beam.Create(email_list)
+    phones_pcoll = p | 'create phones' >> beam.Create(phone_list)
 
     # The result PCollection contains one key-value element for each key in the
     # input PCollections. The key of the pair will be the key from the input and

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1148,24 +1148,23 @@ def model_co_group_by_key_tuple(email_list, phone_list, output_path):
     # multiple possible values for each key.
     # The phone_list contains values such as: ('mary': '111-222-3333') with
     # multiple possible values for each key.
-    emails = p | 'email' >> beam.Create(email_list)
-    phones = p | 'phone' >> beam.Create(phone_list)
+    emails_pcoll = p | beam.Create(email_list)
+    phones_pcoll = p | beam.Create(phone_list)
+
     # The result PCollection contains one key-value element for each key in the
     # input PCollections. The key of the pair will be the key from the input and
     # the value will be a dictionary with two entries: 'emails' - an iterable of
     # all values for the current key in the emails PCollection and 'phones': an
     # iterable of all values for the current key in the phones PCollection.
     # For instance, if 'emails' contained ('joe', 'joe@example.com') and
-    # ('joe', 'joe@gmail.com'), then 'result' will contain the element
+    # ('joe', 'joe@gmail.com'), then 'result' will contain the element:
     # ('joe', {'emails': ['joe@example.com', 'joe@gmail.com'], 'phones': ...})
-    result = {'emails': emails, 'phones': phones} | beam.CoGroupByKey()
+    result = ({'emails': emails_pcoll, 'phones': phones_pcoll}
+              | beam.CoGroupByKey())
 
-    def join_info((name, info)):
-      return '; '.join(['%s' % name,
-                        '%s' % ','.join(info['emails']),
-                        '%s' % ','.join(info['phones'])])
-
-    contact_lines = result | beam.Map(join_info)
+    contact_lines = result | beam.Map(
+        lambda (name, info):\
+           '%s; %s; %s' % (name, info['emails'], info['phones']))
     # [END model_group_by_key_cogroupbykey_tuple]
     contact_lines | beam.io.WriteToText(output_path)
 

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1164,7 +1164,8 @@ def model_co_group_by_key_tuple(email_list, phone_list, output_path):
 
     contact_lines = result | beam.Map(
         lambda (name, info):\
-           '%s; %s; %s' % (name, info['emails'], info['phones']))
+           '%s; %s; %s' %\
+           (name, sorted(info['emails']), sorted(info['phones'])))
     # [END model_group_by_key_cogroupbykey_tuple]
     contact_lines | beam.io.WriteToText(output_path)
 

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -713,7 +713,7 @@ class SnippetsTest(unittest.TestCase):
     # [START model_group_by_key_cogroupbykey_tuple_outputs]
     contact_lines = [
         "amy; ['amy@example.com']; ['111-222-3333', '333-444-5555']",
-        "carl; ['carl@example.com', 'carl@email.com']; ['444-555-6666']",
+        "carl; ['carl@email.com', 'carl@example.com']; ['444-555-6666']",
         "james; []; ['222-333-4444']",
         "julia; ['julia@example.com']; []",
     ]

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -694,12 +694,31 @@ class SnippetsTest(unittest.TestCase):
     self.assertEqual([str(s) for s in expected], self.get_output(result_path))
 
   def test_model_co_group_by_key_tuple(self):
-    email_list = [['a', 'a@example.com'], ['b', 'b@example.com']]
-    phone_list = [['a', 'x4312'], ['b', 'x8452']]
+    # [START model_group_by_key_cogroupbykey_tuple_inputs]
+    email_list = [
+        ('amy', 'amy@example.com'),
+        ('carl', 'carl@example.com'),
+        ('julia', 'julia@example.com'),
+        ('carl', 'carl@email.com'),
+    ]
+    phone_list = [
+        ('amy', '111-222-3333'),
+        ('james', '222-333-4444'),
+        ('amy', '333-444-5555'),
+        ('carl', '444-555-6666'),
+    ]
+    # [END model_group_by_key_cogroupbykey_tuple_inputs]
     result_path = self.create_temp_file()
     snippets.model_co_group_by_key_tuple(email_list, phone_list, result_path)
-    expect = ['a; a@example.com; x4312', 'b; b@example.com; x8452']
-    self.assertEqual(expect, self.get_output(result_path))
+    # [START model_group_by_key_cogroupbykey_tuple_outputs]
+    contact_lines = [
+        'amy; amy@example.com; 111-222-3333,333-444-5555',
+        'carl; carl@example.com,carl@email.com; 444-555-6666',
+        'james; ; 222-333-4444',
+        'julia; julia@example.com; ',
+    ]
+    # [END model_group_by_key_cogroupbykey_tuple_outputs]
+    self.assertEqual(contact_lines, self.get_output(result_path))
 
   def test_model_use_and_query_metrics(self):
     """DebuggingWordCount example snippets."""

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -712,10 +712,10 @@ class SnippetsTest(unittest.TestCase):
     snippets.model_co_group_by_key_tuple(email_list, phone_list, result_path)
     # [START model_group_by_key_cogroupbykey_tuple_outputs]
     contact_lines = [
-        'amy; amy@example.com; 111-222-3333,333-444-5555',
-        'carl; carl@example.com,carl@email.com; 444-555-6666',
-        'james; ; 222-333-4444',
-        'julia; julia@example.com; ',
+        "amy; ['amy@example.com']; ['111-222-3333', '333-444-5555']",
+        "carl; ['carl@example.com', 'carl@email.com']; ['444-555-6666']",
+        "james; []; ['222-333-4444']",
+        "julia; ['julia@example.com']; []",
     ]
     # [END model_group_by_key_cogroupbykey_tuple_outputs]
     self.assertEqual(contact_lines, self.get_output(result_path))


### PR DESCRIPTION
R: @aaltay 
R: @melap 

Having a concrete common example for the docs, Python, and Java will allow referencing the same example on every language. This is more consistent and also allows tests to validate what is described in the docs. See [[BEAM-1934]](https://github.com/apache/beam-site/pull/302)

This PR creates new tags `model_group_by_key_cogroupbykey_tuple_inputs` and `model_group_by_key_cogroupbykey_tuple_outputs`, in `snippets_test.py`, to be used as a concrete example for `CoGroupByKey` snippet.

It also slightly changes the output formatting to make more evident how to use the results of the transform.