### PR TITLE
[BEAM-2803, BEAM-2706] JdbcIO improvements

### DIFF
--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -38,7 +38,6 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.common.TestRow;
-import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Count;
@@ -52,7 +51,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -206,7 +204,6 @@ public class JdbcIOTest implements Serializable {
   }
 
   @Test
-  @Category(NeedsRunner.class)
   public void testRead() throws Exception {
     PCollection<TestRow> rows = pipeline.apply(
         JdbcIO.<TestRow>read()
@@ -226,7 +223,6 @@ public class JdbcIOTest implements Serializable {
   }
 
    @Test
-   @Category(NeedsRunner.class)
    public void testReadWithSingleStringParameter() throws Exception {
      PCollection<TestRow> rows = pipeline.apply(
              JdbcIO.<TestRow>read()
@@ -254,7 +250,6 @@ public class JdbcIOTest implements Serializable {
    }
 
   @Test
-  @Category(NeedsRunner.class)
   public void testWrite() throws Exception {
     final long rowsToAdd = 1000L;
 
@@ -300,7 +295,6 @@ public class JdbcIOTest implements Serializable {
   }
 
   @Test
-  @Category(NeedsRunner.class)
   public void testWriteWithEmptyPCollection() throws Exception {
     pipeline
         .apply(Create.empty(KvCoder.of(VarIntCoder.of(), StringUtf8Coder.of())))


### PR DESCRIPTION
This solves two issues:

* https://issues.apache.org/jira/browse/BEAM-2803 by changing the strategy of breaking fusion: instead of a regular reshuffle, materializes via side input first.
* https://issues.apache.org/jira/browse/BEAM-2706 by introducing JdbcIO.readAll().

Also brings the validation messages in accordance with the updated guidance in PTransform Style Guide.

R: @jbonofre 