### PR TITLE
Fix typo in variable name: window_fn --> windowfn

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1360,7 +1360,7 @@ class Windowing(object):
     if not windowfn.get_window_coder().is_deterministic():
       raise ValueError(
           'window fn (%s) does not have a determanistic coder (%s)' % (
-              window_fn, windowfn.get_window_coder()))
+              windowfn, windowfn.get_window_coder()))
     self.windowfn = windowfn
     self.triggerfn = triggerfn
     self.accumulation_mode = accumulation_mode


### PR DESCRIPTION
`window_fn` is an undefined name in this context while `windowfn` is a parameter to this function and is used in three lines above and in the line just below.

 flake8 testing of https://github.com/apache/beam on Python 2.7.13

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sdks/python/apache_beam/transforms/core.py:1363:15: F821 undefined name 'window_fn'
              window_fn, windowfn.get_window_coder()))
              ^
```