### PR TITLE
Ignore HTTP 404 when deleting GCS files

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
@@ -767,7 +767,11 @@ public class GcsUtil {
 
       @Override
       public void onFailure(GoogleJsonError e, HttpHeaders responseHeaders) throws IOException {
-        throw new IOException(String.format("Error trying to delete %s: %s", file, e));
+        if (e.getCode() == 404) {
+          LOG.info("Ignoring failed deletion of file {} which already does not exist: {}", file, e);
+        } else {
+          throw new IOException(String.format("Error trying to delete %s: %s", file, e));
+        }
       }
     });
   }


### PR DESCRIPTION
You can get a 404 if a previous delete RPC actually succeeded
but returned a failed response due to some network issues,
so the next attempt gets a 404.

R: @chamikaramj 