### PR TITLE
[BEAM-2844] Introduces PCollectionView.get()

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/RunnerPCollectionView.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/RunnerPCollectionView.java
@@ -18,6 +18,8 @@
 
 package org.apache.beam.runners.core.construction;
 
+import static org.apache.beam.sdk.values.PCollectionViews.getCurrentSideInputContext;
+
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -35,6 +37,8 @@ import org.apache.beam.sdk.values.WindowingStrategy;
 
 /** A {@link PCollectionView} created from the components of a {@link SideInput}. */
 class RunnerPCollectionView<T> extends PValueBase implements PCollectionView<T> {
+  public static final long serialVersionUID = 2465466441736952633L;
+
   private final TupleTag<Iterable<WindowedValue<?>>> tag;
   private final ViewFn<Iterable<WindowedValue<?>>, T> viewFn;
   private final WindowMappingFn<?> windowMappingFn;
@@ -58,6 +62,11 @@ class RunnerPCollectionView<T> extends PValueBase implements PCollectionView<T> 
     this.windowMappingFn = windowMappingFn;
     this.windowingStrategy = windowingStrategy;
     this.coder = coder;
+  }
+
+  @Override
+  public T get() throws IllegalStateException {
+    return getCurrentSideInputContext().sideInput(this);
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.sdk.values.PCollectionViews.setCurrentSideInputContext;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
@@ -47,6 +48,8 @@ import org.apache.beam.sdk.util.SystemDoFnInternal;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PCollectionViews.ScopedSideInputContext;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.joda.time.Duration;
@@ -172,9 +175,10 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
   }
 
   private void invokeProcessElement(WindowedValue<InputT> elem) {
+    DoFnProcessContext context = new DoFnProcessContext(elem);
     // This can contain user code. Wrap it in case it throws an exception.
-    try {
-      invoker.invokeProcessElement(new DoFnProcessContext(elem));
+    try (ScopedSideInputContext sideInputContext = setCurrentSideInputContext(context)) {
+      invoker.invokeProcessElement(context);
     } catch (Exception ex) {
       throw wrapUserCodeException(ex);
     }
@@ -201,7 +205,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
   private <T> T sideInput(PCollectionView<T> view, BoundedWindow sideInputWindow) {
     if (!sideInputReader.contains(view)) {
-      throw new IllegalArgumentException("calling sideInput() with unknown view");
+      throw new IllegalArgumentException(
+          "Attempting to access undeclared side input view "
+              + view.getName()
+              + ". Please ensure that it has been wired to the current transform "
+              + "via .withSideInputs() or an equivalent method");
     }
     return sideInputReader.get(view, sideInputWindow);
   }
@@ -365,7 +373,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
    * single element.
    */
   private class DoFnProcessContext extends DoFn<InputT, OutputT>.ProcessContext
-      implements DoFnInvoker.ArgumentProvider<InputT, OutputT> {
+      implements DoFnInvoker.ArgumentProvider<InputT, OutputT>,
+      PCollectionViews.SideInputContext {
     final WindowedValue<InputT> elem;
 
     /** Lazily initialized; should only be accessed via {@link #getNamespace()}. */

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -248,6 +248,7 @@
                 org.apache.beam.sdk.testing.UsesAttemptedMetrics,
                 org.apache.beam.sdk.testing.UsesDistributionMetrics,
                 org.apache.beam.sdk.testing.UsesGaugeMetrics,
+                org.apache.beam.sdk.testing.UsesImplicitSideInputs,
                 org.apache.beam.sdk.testing.UsesSetState,
                 org.apache.beam.sdk.testing.UsesMapState,
                 org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesImplicitSideInputs.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesImplicitSideInputs.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Category for tests that use <a href="https://issues.apache.org/jira/browse/BEAM-2844">implicit
+ * side inputs</a>, i.e. {@link PCollectionView#get}.
+ */
+public interface UsesImplicitSideInputs {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionView.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionView.java
@@ -24,6 +24,8 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.ViewFn;
@@ -52,6 +54,15 @@ import org.apache.beam.sdk.util.WindowedValue;
  * @param <T> the type of the value(s) accessible via this {@link PCollectionView}
  */
 public interface PCollectionView<T> extends PValue, Serializable {
+  /**
+   * When called from user code in a pipeline at execution time, returns the value of the view in
+   * the current context, e.g. in the current {@link ProcessContext} of a {@link DoFn}.
+   *
+   * @throws IllegalStateException if not called from a context where values of side inputs are
+   *     available.
+   */
+  T get() throws IllegalStateException;
+
   /**
    * <b>For internal use only.</b>
    *

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PCollectionViewTesting.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PCollectionViewTesting.java
@@ -18,6 +18,8 @@
 
 package org.apache.beam.sdk.testing;
 
+import static org.apache.beam.sdk.values.PCollectionViews.getCurrentSideInputContext;
+
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.Iterables;
@@ -293,6 +295,11 @@ public final class PCollectionViewTesting {
       this.windowMappingFn = windowMappingFn;
       this.windowingStrategy = windowingStrategy;
       this.coder = coder;
+    }
+
+    @Override
+    public ViewT get() throws IllegalStateException {
+      return getCurrentSideInputContext().sideInput(this);
     }
 
     @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -79,6 +79,7 @@ import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.testing.UsesImplicitSideInputs;
 import org.apache.beam.sdk.testing.UsesMapState;
 import org.apache.beam.sdk.testing.UsesSetState;
 import org.apache.beam.sdk.testing.UsesStatefulParDo;
@@ -560,6 +561,111 @@ public class ParDoTest implements Serializable {
                    .forInput(inputs)
                    .andSideInputs(11, 222));
 
+    pipeline.run();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesImplicitSideInputs.class})
+  public void testParDoWithImplicitSideInputs() {
+    final PCollectionView<String> foo = pipeline
+        .apply("Create foo", Create.of("foo"))
+        .apply("Singleton", View.<String>asSingleton());
+
+    PCollection<String> output =
+        pipeline
+            .apply(Create.of(1, 2, 3))
+            .apply(
+                ParDo.of(
+                        new DoFn<Integer, String>() {
+                          @ProcessElement
+                          public void process(ProcessContext c) {
+                            c.output(foo.get() + " " + c.element());
+                          }
+                        })
+                    .withSideInputs(foo));
+
+    PAssert.that(output).containsInAnyOrder("foo 1", "foo 2", "foo 3");
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesImplicitSideInputs.class})
+  public void testParDoWithImplicitSideInputsUndeclared() {
+    final PCollectionView<String> foo = pipeline
+        .apply("Create foo", Create.of("foo"))
+        .apply("As singleton", View.<String>asSingleton());
+
+    pipeline
+        .apply(Create.of(1, 2, 3))
+        .apply(
+            ParDo.of(
+                new DoFn<Integer, String>() {
+                  @ProcessElement
+                  public void process(ProcessContext c) {
+                    c.output(foo.get() + " " + c.element());
+                  }
+                }));
+
+    thrown.expectMessage("undeclared side input view");
+    thrown.expectMessage("Create foo");
+    thrown.expectMessage("As singleton");
+    thrown.expectMessage(".withSideInputs()");
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesImplicitSideInputs.class})
+  public void testParDoWithImplicitSideInputsFromStartBundle() {
+    final PCollectionView<String> foo = pipeline
+        .apply("Create foo", Create.of("foo"))
+        .apply("Singleton", View.<String>asSingleton());
+
+    pipeline
+        .apply(Create.of(1, 2, 3))
+        .apply(
+            ParDo.of(
+                    new DoFn<Integer, String>() {
+                      @ProcessElement
+                      public void process(ProcessContext c) {}
+
+                      @StartBundle
+                      public void startBundle(StartBundleContext c) {
+                        // Should fail
+                        foo.get();
+                      }
+                    })
+                .withSideInputs(foo));
+
+    thrown.expectMessage("currently not in a context where side inputs are available");
+    pipeline.run();
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesImplicitSideInputs.class})
+  public void testParDoWithImplicitSideInputsFromFinishBundle() {
+    final PCollectionView<String> foo = pipeline
+        .apply("Create foo", Create.of("foo"))
+        .apply("Singleton", View.<String>asSingleton());
+
+    pipeline
+        .apply(Create.of(1, 2, 3))
+        .apply(
+            ParDo.of(
+                    new DoFn<Integer, String>() {
+                      @ProcessElement
+                      public void process(ProcessContext c) {}
+
+                      @FinishBundle
+                      public void finishBundle(StartBundleContext c) {
+                        // Should fail
+                        foo.get();
+                      }
+                    })
+                .withSideInputs(foo));
+
+    thrown.expectMessage("Current thread is not in a context where side inputs are available");
     pipeline.run();
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-2844

Supports it for DoFn in the various DoFnRunner's and DoFnTester. Support in CombineFn remains.

Introduces a category tag UsesImplicitSideInputs, currently excluded in Dataflow runner - that will be fixed in a follow-up PR after service-side changes, and the category will be removed.

R: @lukecwik 