### PR TITLE
[BEAM-2718] Improve performance of bundle retry

### DIFF
--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -336,5 +336,5 @@ class DirectStepContext(object):
       self.existing_keyed_state[key] = DirectUnmergedState()
     if not self.partial_keyed_state.get(key):
       self.partial_keyed_state[key] = (
-          self.existing_keyed_state[key].custom_copy())
+          self.existing_keyed_state[key].copy())
     return self.partial_keyed_state[key]

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -20,7 +20,6 @@
 from __future__ import absolute_import
 
 import collections
-import copy
 import threading
 
 from apache_beam.runners.direct.clock import Clock
@@ -321,11 +320,6 @@ class DirectUnmergedState(InMemoryUnmergedState):
   def __init__(self):
     super(DirectUnmergedState, self).__init__(defensive_copy=False)
 
-  # TODO(mariagh): make a selective deepcopy of just what is needed
-  # to preserve the state while a bundle is processed.
-  def clone(self):
-    return copy.deepcopy(self)
-
 
 class DirectStepContext(object):
   """Context for the currently-executing step."""
@@ -341,5 +335,6 @@ class DirectStepContext(object):
     if not self.existing_keyed_state.get(key):
       self.existing_keyed_state[key] = DirectUnmergedState()
     if not self.partial_keyed_state.get(key):
-      self.partial_keyed_state[key] = self.existing_keyed_state[key].clone()
+      self.partial_keyed_state[key] = (
+          self.existing_keyed_state[key].custom_copy())
     return self.partial_keyed_state[key]

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1064,6 +1064,17 @@ class InMemoryUnmergedState(UnmergedState):
     self.global_state = {}
     self.defensive_copy = defensive_copy
 
+  def custom_copy(self):
+    cloned_object = copy.copy(self)
+    cloned_object.timers = copy.deepcopy(self.timers)
+    cloned_object.global_state = copy.deepcopy(self.global_state)
+    cloned_object.state = copy.copy(self.state)
+    for window in self.state:
+      cloned_object.state[window] = copy.copy(self.state[window])
+      for tag in self.state[window]:
+        cloned_object.state[window][tag] = copy.copy(self.state[window][tag])
+    return cloned_object
+
   def set_global_state(self, tag, value):
     assert isinstance(tag, _ValueStateTag)
     if self.defensive_copy:

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1068,7 +1068,8 @@ class InMemoryUnmergedState(UnmergedState):
     cloned_object = copy.copy(self)
     cloned_object.timers = copy.deepcopy(self.timers)
     cloned_object.global_state = copy.deepcopy(self.global_state)
-    cloned_object.state = collections.defaultdict(lambda: collections.defaultdict(list))
+    cloned_object.state = (
+        collections.defaultdict(lambda: collections.defaultdict(list)))
     for window in self.state:
       cloned_object.state[window] = collections.defaultdict(list)
       for tag in self.state[window]:

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1065,13 +1065,10 @@ class InMemoryUnmergedState(UnmergedState):
     self.defensive_copy = defensive_copy
 
   def copy(self):
-    cloned_object = copy.copy(self)
+    cloned_object = InMemoryUnmergedState(defensive_copy=self.defensive_copy)
     cloned_object.timers = copy.deepcopy(self.timers)
     cloned_object.global_state = copy.deepcopy(self.global_state)
-    cloned_object.state = (
-        collections.defaultdict(lambda: collections.defaultdict(list)))
     for window in self.state:
-      cloned_object.state[window] = collections.defaultdict(list)
       for tag in self.state[window]:
         cloned_object.state[window][tag] = copy.copy(self.state[window][tag])
     return cloned_object

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -1064,13 +1064,13 @@ class InMemoryUnmergedState(UnmergedState):
     self.global_state = {}
     self.defensive_copy = defensive_copy
 
-  def custom_copy(self):
+  def copy(self):
     cloned_object = copy.copy(self)
     cloned_object.timers = copy.deepcopy(self.timers)
     cloned_object.global_state = copy.deepcopy(self.global_state)
-    cloned_object.state = copy.copy(self.state)
+    cloned_object.state = collections.defaultdict(lambda: collections.defaultdict(list))
     for window in self.state:
-      cloned_object.state[window] = copy.copy(self.state[window])
+      cloned_object.state[window] = collections.defaultdict(list)
       for tag in self.state[window]:
         cloned_object.state[window][tag] = copy.copy(self.state[window][tag])
     return cloned_object


### PR DESCRIPTION
In order to keep a consistent state while handling bundles, every time the state is accessed, a copy is made and kept until the bundle is committed. Here a custom copy is used replicating only the inner structures that are needed and shallow-copying the rest.
