### PR TITLE
[BEAM-2861] Fix tests which fail with google credential

### DIFF
--- a/sdks/python/apache_beam/io/gcp/tests/utils.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils.py
@@ -50,13 +50,13 @@ def delete_bq_table(project, dataset, table):
                'table: %s.', project, dataset, table)
   bq_dataset = bigquery.Client(project=project).dataset(dataset)
   if not bq_dataset.exists():
-    raise GcpTestIOError('Failed to cleanup. Bigquery dataset %s doesn\'t'
-                         'exist in project %s.' % dataset, project)
+    raise GcpTestIOError('Failed to cleanup. Bigquery dataset %s doesn\'t '
+                         'exist in project %s.' % (dataset, project))
   bq_table = bq_dataset.table(table)
   if not bq_table.exists():
-    raise GcpTestIOError('Failed to cleanup. Biqeury table %s doesn\'t '
+    raise GcpTestIOError('Failed to cleanup. Bigquery table %s doesn\'t '
                          'exist in project %s, dataset %s.' %
-                         table, project, dataset)
+                         (table, project, dataset))
   bq_table.delete()
   if bq_table.exists():
     raise RuntimeError('Failed to cleanup. Bigquery table %s still exists '

--- a/sdks/python/apache_beam/io/gcp/tests/utils_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils_test.py
@@ -20,8 +20,7 @@
 import logging
 import unittest
 
-from mock import Mock
-from mock import patch
+from mock import Mock, patch
 
 from apache_beam.io.gcp.tests import utils
 from apache_beam.testing.test_utils import patch_retry
@@ -40,31 +39,69 @@ class UtilsTest(unittest.TestCase):
     self._mock_result = Mock()
     patch_retry(self, utils)
 
-  @patch('google.cloud.bigquery.Table.delete')
-  @patch('google.cloud.bigquery.Table.exists', side_effect=[True, False])
-  @patch('google.cloud.bigquery.Dataset.exists', return_value=True)
-  def test_delete_bq_table_succeeds(self, *_):
+  @patch.object(bigquery, 'Client')
+  def test_delete_table_succeeds(self, mock_client):
+    mock_dataset = Mock()
+    mock_client.return_value.dataset = mock_dataset
+    mock_dataset.return_value.exists.return_value = True
+
+    mock_table = Mock()
+    mock_dataset.return_value.table = mock_table
+    mock_table.return_value.exists.side_effect = [True, False]
+
     utils.delete_bq_table('unused_project',
                           'unused_dataset',
                           'unused_table')
 
-  @patch('google.cloud.bigquery.Table.delete', side_effect=Exception)
-  @patch('google.cloud.bigquery.Table.exists', return_value=True)
-  @patch('google.cloud.bigquery.Dataset.exists', return_vaue=True)
-  def test_delete_bq_table_fails_with_server_error(self, *_):
-    with self.assertRaises(Exception):
-      utils.delete_bq_table('unused_project',
-                            'unused_dataset',
-                            'unused_table')
+  @patch.object(bigquery, 'Client')
+  def test_delete_table_fails_dataset_not_exist(self, mock_client):
+    mock_dataset = Mock()
+    mock_client.return_value.dataset = mock_dataset
+    mock_dataset.return_value.exists.return_value = False
 
-  @patch('google.cloud.bigquery.Table.delete')
-  @patch('google.cloud.bigquery.Table.exists', return_value=[True, True])
-  @patch('google.cloud.bigquery.Dataset.exists', return_vaue=True)
-  def test_delete_bq_table_fails_with_delete_error(self, *_):
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(Exception) as e:
       utils.delete_bq_table('unused_project',
                             'unused_dataset',
                             'unused_table')
+    self.assertTrue(
+      e.exception.message.startswith('Failed to cleanup. Bigquery dataset '
+                                     'unused_dataset doesn\'t exist'))
+
+  @patch.object(bigquery, 'Client')
+  def test_delete_table_fails_table_not_exist(self, mock_client):
+    mock_dataset = Mock()
+    mock_client.return_value.dataset = mock_dataset
+    mock_dataset.return_value.exists.return_value = True
+
+    mock_table = Mock()
+    mock_dataset.return_value.table = mock_table
+    mock_table.return_value.exists.return_value = False
+
+    with self.assertRaises(Exception) as e:
+      utils.delete_bq_table('unused_project',
+                            'unused_dataset',
+                            'unused_table')
+    self.assertTrue(
+      e.exception.message.startswith('Failed to cleanup. Bigquery table '
+                                     'unused_table doesn\'t exist'))
+
+  @patch.object(bigquery, 'Client')
+  def test_delete_table_fails_service_error(self, mock_client):
+    mock_dataset = Mock()
+    mock_client.return_value.dataset = mock_dataset
+    mock_dataset.return_value.exists.return_value = True
+
+    mock_table = Mock()
+    mock_dataset.return_value.table = mock_table
+    mock_table.return_value.exists.return_value = True
+
+    with self.assertRaises(Exception) as e:
+      utils.delete_bq_table('unused_project',
+                            'unused_dataset',
+                            'unused_table')
+    self.assertTrue(
+      e.exception.message.startswith('Failed to cleanup. Bigquery table '
+                                     'unused_table still exists'))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/gcp/tests/utils_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils_test.py
@@ -20,7 +20,8 @@
 import logging
 import unittest
 
-from mock import Mock, patch
+from mock import Mock
+from mock import patch
 
 from apache_beam.io.gcp.tests import utils
 from apache_beam.testing.test_utils import patch_retry
@@ -64,8 +65,8 @@ class UtilsTest(unittest.TestCase):
                             'unused_dataset',
                             'unused_table')
     self.assertTrue(
-      e.exception.message.startswith('Failed to cleanup. Bigquery dataset '
-                                     'unused_dataset doesn\'t exist'))
+        e.exception.message.startswith('Failed to cleanup. Bigquery dataset '
+                                       'unused_dataset doesn\'t exist'))
 
   @patch.object(bigquery, 'Client')
   def test_delete_table_fails_table_not_exist(self, mock_client):
@@ -82,8 +83,8 @@ class UtilsTest(unittest.TestCase):
                             'unused_dataset',
                             'unused_table')
     self.assertTrue(
-      e.exception.message.startswith('Failed to cleanup. Bigquery table '
-                                     'unused_table doesn\'t exist'))
+        e.exception.message.startswith('Failed to cleanup. Bigquery table '
+                                       'unused_table doesn\'t exist'))
 
   @patch.object(bigquery, 'Client')
   def test_delete_table_fails_service_error(self, mock_client):
@@ -100,8 +101,8 @@ class UtilsTest(unittest.TestCase):
                             'unused_dataset',
                             'unused_table')
     self.assertTrue(
-      e.exception.message.startswith('Failed to cleanup. Bigquery table '
-                                     'unused_table still exists'))
+        e.exception.message.startswith('Failed to cleanup. Bigquery table '
+                                       'unused_table still exists'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

A workaround way to fix tests in `utils_test.py` which fail if GCP dependencies are installed but no GOOGLE_APPLICATION_CREDENTIAL.