### PR TITLE
[BEAM-2807] Fixes NPE exception on CoderTypeSerializerConfigSnapshot serialization

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -162,7 +162,6 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
 
     public CoderTypeSerializerConfigSnapshot(Coder<T> coder) {
       this.coderName = coder.getClass().getName();
-      System.out.println(this.coderName);
     }
 
     @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -161,7 +161,8 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
     }
 
     public CoderTypeSerializerConfigSnapshot(Coder<T> coder) {
-      this.coderName = coder.getClass().getCanonicalName();
+      this.coderName = coder.getClass().getName();
+      System.out.println(this.coderName);
     }
 
     @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -17,6 +17,10 @@
  */
 package org.apache.beam.runners.flink.translation.types;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -25,14 +29,13 @@ import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
+/**
+ * Tests CoderTypeSerializer.
+ */
 public class CoderTypeSerializerTest {
 
-  @Test
-  public void shouldBeAbleToWriteSnapshotForAnonymousClassCoder() throws Exception {
+  @Test public void shouldBeAbleToWriteSnapshotForAnonymousClassCoder() throws Exception {
     AtomicCoder<String> anonymousClassCoder = new AtomicCoder<String>() {
 
       @Override public void encode(String value, OutputStream outStream)
@@ -51,8 +54,7 @@ public class CoderTypeSerializerTest {
     configSnapshot.write(new ComparatorTestBase.TestOutputView());
   }
 
-  @Test
-  public void shouldBeAbleToWriteSnapshotForConcreteClassCoder() throws Exception {
+  @Test public void shouldBeAbleToWriteSnapshotForConcreteClassCoder() throws Exception {
     Coder<String> concreteClassCoder = StringUtf8Coder.of();
     CoderTypeSerializer<String> coderTypeSerializer = new CoderTypeSerializer<>(concreteClassCoder);
     TypeSerializerConfigSnapshot typeSerializerConfigSnapshot = coderTypeSerializer

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -1,0 +1,46 @@
+package org.apache.beam.runners.flink.translation.types;
+
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.flink.api.common.typeutils.ComparatorTestBase;
+import org.apache.flink.api.common.typeutils.TypeSerializerConfigSnapshot;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class CoderTypeSerializerTest {
+
+  @Test
+  public void shouldBeAbleToWriteSnapshotForAnonymousClassCoder() throws Exception {
+    AtomicCoder<String> anonymousClassCoder = new AtomicCoder<String>() {
+
+      @Override public void encode(String value, OutputStream outStream)
+          throws CoderException, IOException {
+
+      }
+
+      @Override public String decode(InputStream inStream) throws CoderException, IOException {
+        return "";
+      }
+    };
+
+    CoderTypeSerializer<String> serializer = new CoderTypeSerializer<>(anonymousClassCoder);
+
+    TypeSerializerConfigSnapshot configSnapshot = serializer.snapshotConfiguration();
+    configSnapshot.write(new ComparatorTestBase.TestOutputView());
+  }
+
+  @Test
+  public void shouldBeAbleToWriteSnapshotForConcreteClassCoder() throws Exception { //passes
+    Coder<String> concreteClassCoder = StringUtf8Coder.of();
+    CoderTypeSerializer<String> coderTypeSerializer = new CoderTypeSerializer<>(concreteClassCoder);
+    TypeSerializerConfigSnapshot typeSerializerConfigSnapshot = coderTypeSerializer
+        .snapshotConfiguration();
+    typeSerializerConfigSnapshot.write(new ComparatorTestBase.TestOutputView());
+  }
+}
+

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 
 /**
- * Tests CoderTypeSerializer.
+ * Tests {@link CoderTypeSerializer}.
  */
 public class CoderTypeSerializerTest {
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -35,7 +35,7 @@ public class CoderTypeSerializerTest {
   }
 
   @Test
-  public void shouldBeAbleToWriteSnapshotForConcreteClassCoder() throws Exception { //passes
+  public void shouldBeAbleToWriteSnapshotForConcreteClassCoder() throws Exception {
     Coder<String> concreteClassCoder = StringUtf8Coder.of();
     CoderTypeSerializer<String> coderTypeSerializer = new CoderTypeSerializer<>(concreteClassCoder);
     TypeSerializerConfigSnapshot typeSerializerConfigSnapshot = coderTypeSerializer

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.flink.translation.types;
 
 import org.apache.beam.sdk.coders.AtomicCoder;


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

https://issues.apache.org/jira/browse/BEAM-2807

When a Coder is created as an anonymous class, passing it to `CoderTypeSerializer` will cause a NullPointerException when the `write` call is called on `CoderTypeSerializerConfigSnapshot` 

This is because the `coderName` field is being set by calling `getCanonicalName`, which will always return `null` for anonymous classes. 

*Note*: I am not sure if this change is destructive or not, but it appears to me the `coderName` is just metadata that is written to the stream, and is not used for anything else? 