### PR TITLE
[BEAM-2804] support TIMESTAMP in Sort

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -213,6 +213,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
             case DOUBLE:
             case VARCHAR:
             case DATE:
+            case TIMESTAMP:
               Comparable v1 = (Comparable) row1.getFieldValue(fieldIndex);
               Comparable v2 = (Comparable) row2.getFieldValue(fieldIndex);
               fieldRet = v1.compareTo(v2);


### PR DESCRIPTION
This PR enables beam-sql clause : order by [TIMESTAMP]. 

One test case is added to sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java. 