### PR TITLE
[BEAM-2790] Use byte[] instead of ByteBuffer to read from HadoopFilesystem

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -189,7 +189,21 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
       if (closed) {
         throw new IOException("Channel is closed");
       }
-      return inputStream.read(dst);
+      // O length read must be supported
+      int read = 0;
+      // We avoid using the ByteBuffer based read for Hadoop because some FSDataInputStream
+      // implementations are not ByteBufferReadable,
+      // See https://issues.apache.org/jira/browse/HADOOP-14603
+      if (dst.hasArray()){
+        // does the same as inputStream.read(dst):
+        // stores up to dst.remaining() bytes into dst.array() starting at dst.position().
+        // But dst can have an offset with its backing array hence the + dst.arrayOffset()
+        read = inputStream.read(dst.array(), dst.position() + dst.arrayOffset(), dst.remaining());
+      }
+      if (read > 0) {
+        dst.position(dst.position() + read);
+      }
+      return read;
     }
 
     @Override

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -194,11 +194,13 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
       // We avoid using the ByteBuffer based read for Hadoop because some FSDataInputStream
       // implementations are not ByteBufferReadable,
       // See https://issues.apache.org/jira/browse/HADOOP-14603
-      if (dst.hasArray()){
+      if (dst.hasArray()) {
         // does the same as inputStream.read(dst):
         // stores up to dst.remaining() bytes into dst.array() starting at dst.position().
         // But dst can have an offset with its backing array hence the + dst.arrayOffset()
         read = inputStream.read(dst.array(), dst.position() + dst.arrayOffset(), dst.remaining());
+      } else {
+        read = inputStream.read(dst);
       }
       if (read > 0) {
         dst.position(dst.position() + read);

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
@@ -293,9 +293,7 @@ public class HadoopFileSystemTest {
     try (ReadableByteChannel channel = fileSystem.open(testPath(relativePath))) {
       InputStream inputStream = Channels.newInputStream(channel);
       if (bytesToSkip > 0) {
-        long bytesSkip = inputStream.skip(bytesToSkip);
-        // might skip less than bytesToSkip
-        assertEquals(bytesSkip, bytesToSkip);
+        ByteStreams.skipFully(inputStream, bytesToSkip);
       }
       return ByteStreams.toByteArray(inputStream);
     }

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
@@ -28,11 +28,13 @@ import static org.junit.Assert.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.io.ByteStreams;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.TextIO;
@@ -86,8 +88,28 @@ public class HadoopFileSystemTest {
 
   @Test
   public void testCreateAndReadFile() throws Exception {
-    create("testFile", "testData".getBytes());
-    assertArrayEquals("testData".getBytes(), read("testFile"));
+    byte[] bytes = "testData".getBytes();
+    create("testFile", bytes);
+    assertArrayEquals(bytes, read("testFile", 0));
+  }
+
+  @Test
+  public void testCreateAndReadFileWithShift() throws Exception {
+    byte[] bytes = "testData".getBytes();
+    create("testFile", bytes);
+    int bytesToSkip = 3;
+    byte[] expected = Arrays.copyOfRange(bytes, bytesToSkip, bytes.length);
+    byte[] actual = read("testFile", bytesToSkip);
+    assertArrayEquals(expected, actual);
+  }
+
+  @Test
+  public void testCreateAndReadFileWithShiftToEnd() throws Exception {
+    byte[] bytes = "testData".getBytes();
+    create("testFile", bytes);
+    int bytesToSkip = bytes.length;
+    byte[] expected = Arrays.copyOfRange(bytes, bytesToSkip, bytes.length);
+    assertArrayEquals(expected, read("testFile", bytesToSkip));
   }
 
   @Test
@@ -101,10 +123,10 @@ public class HadoopFileSystemTest {
         ImmutableList.of(
             testPath("copyTestFileA"),
             testPath("copyTestFileB")));
-    assertArrayEquals("testDataA".getBytes(), read("testFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB"));
-    assertArrayEquals("testDataA".getBytes(), read("copyTestFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("copyTestFileB"));
+    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
+    assertArrayEquals("testDataA".getBytes(), read("copyTestFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("copyTestFileB", 0));
   }
 
   @Test
@@ -114,9 +136,9 @@ public class HadoopFileSystemTest {
     create("testFileC", "testDataC".getBytes());
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("testFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB"));
-    assertArrayEquals("testDataC".getBytes(), read("testFileC"));
+    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
+    assertArrayEquals("testDataC".getBytes(), read("testFileC", 0));
 
     fileSystem.delete(ImmutableList.of(
         testPath("testFileA"),
@@ -139,9 +161,9 @@ public class HadoopFileSystemTest {
     create("testFileB", "testDataB".getBytes());
 
     // ensure files exist
-    assertArrayEquals("testDataAA".getBytes(), read("testFileAA"));
-    assertArrayEquals("testDataA".getBytes(), read("testFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB"));
+    assertArrayEquals("testDataAA".getBytes(), read("testFileAA", 0));
+    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
 
     List<MatchResult> results =
         fileSystem.match(ImmutableList.of(testPath("testFileA*").toString()));
@@ -165,8 +187,8 @@ public class HadoopFileSystemTest {
     create("testFileBB", "testDataBB".getBytes());
 
     // ensure files exist
-    assertArrayEquals("testDataAA".getBytes(), read("testFileAA"));
-    assertArrayEquals("testDataBB".getBytes(), read("testFileBB"));
+    assertArrayEquals("testDataAA".getBytes(), read("testFileAA", 0));
+    assertArrayEquals("testDataBB".getBytes(), read("testFileBB", 0));
 
     List<MatchResult> matchResults = fileSystem.match(ImmutableList.of(
         testPath("testFileAA").toString(),
@@ -196,8 +218,8 @@ public class HadoopFileSystemTest {
     create("testFileB", "testDataB".getBytes());
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("testFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB"));
+    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
 
     fileSystem.rename(
         ImmutableList.of(
@@ -221,8 +243,8 @@ public class HadoopFileSystemTest {
             .build()));
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("renameFileA"));
-    assertArrayEquals("testDataB".getBytes(), read("renameFileB"));
+    assertArrayEquals("testDataA".getBytes(), read("renameFileA", 0));
+    assertArrayEquals("testDataB".getBytes(), read("renameFileB", 0));
   }
 
   @Test
@@ -267,9 +289,15 @@ public class HadoopFileSystemTest {
     }
   }
 
-  private byte[] read(String relativePath) throws Exception {
+  private byte[] read(String relativePath, long bytesToSkip) throws Exception {
     try (ReadableByteChannel channel = fileSystem.open(testPath(relativePath))) {
-      return ByteStreams.toByteArray(Channels.newInputStream(channel));
+      InputStream inputStream = Channels.newInputStream(channel);
+      if (bytesToSkip > 0) {
+        long bytesSkip = inputStream.skip(bytesToSkip);
+        // might skip less than bytesToSkip
+        assertEquals(bytesSkip, bytesToSkip);
+      }
+      return ByteStreams.toByteArray(inputStream);
     }
   }
 


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This is the continuation of PR https://github.com/apache/beam/pull/3744. It fixes the code to deal with the offsets/limits to have the same behavior than `read(ByteBuffer)` and it adds corner cases tests.
R: @lukecwik @steveloughran
CC: @iemejia 