### PR TITLE
[BEAM-2808] Improve error message when DoFn @ProcessElement has the wrong window type

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -537,7 +537,8 @@ public class ParDo {
     if (methodSignature.windowT() != null) {
       checkArgument(
           methodSignature.windowT().isSupertypeOf(actualWindowT),
-          "%s expects window type %s, which is not a supertype of actual window type %s",
+          "%s unable to provide window -- expected window type from parameter (%s) is not a"
+              + "supertype of actual window type assigned by windowing (%s)",
           methodSignature.targetMethod(),
           methodSignature.windowT(),
           actualWindowT);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -537,7 +537,7 @@ public class ParDo {
     if (methodSignature.windowT() != null) {
       checkArgument(
           methodSignature.windowT().isSupertypeOf(actualWindowT),
-          "%s unable to provide window -- expected window type from parameter (%s) is not a"
+          "%s unable to provide window -- expected window type from parameter (%s) is not a "
               + "supertype of actual window type assigned by windowing (%s)",
           methodSignature.targetMethod(),
           methodSignature.windowT(),


### PR DESCRIPTION
Modifying the error message from this:

<Method> expects window type <Type>, which is not a supertype of actual window type <Other Type>

to this:

<Method> unable to provide window -- expected window type from parameter (<Type>) is not a supertype of actual window type assigned by windowing (<Other Type>)

@lukecwik, can you review?