### PR TITLE
[BEAM-2884] Send portable protos for ParDo in DataflowRunner

### DIFF
--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -181,6 +181,7 @@
                 <artifactSet>
                   <includes>
                     <include>com.google.guava:guava</include>
+                    <include>com.google.protobuf:protobuf-java</include>
                     <include>org.apache.beam:beam-runners-core-construction-java</include>
                   </includes>
                 </artifactSet>
@@ -205,6 +206,10 @@
                       <exclude>com.google.common.**.testing.*</exclude>
                     </excludes>
                     <shadedPattern>org.apache.beam.runners.dataflow.repackaged.com.google.common</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>com.google.protobuf</pattern>
+                    <shadedPattern>org.apache.beam.runners.dataflow.repackaged.com.google.protobuf</shadedPattern>
                   </relocation>
                   <relocation>
                     <pattern>com.google.thirdparty</pattern>
@@ -371,6 +376,11 @@
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
     </dependency>
 
     <dependency>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -33,7 +33,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.container_version>beam-master-20170918</dataflow.container_version>
+    <dataflow.container_version>beam-master-20170921</dataflow.container_version>
     <dataflow.fnapi_environment_major_version>1</dataflow.fnapi_environment_major_version>
     <dataflow.legacy_environment_major_version>6</dataflow.legacy_environment_major_version>
   </properties>

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -183,6 +183,7 @@
                     <include>com.google.guava:guava</include>
                     <include>com.google.protobuf:protobuf-java</include>
                     <include>org.apache.beam:beam-runners-core-construction-java</include>
+                    <include>org.apache.beam:beam-sdks-common-runner-api</include>
                   </includes>
                 </artifactSet>
                 <filters>
@@ -218,6 +219,10 @@
                   <relocation>
                     <pattern>org.apache.beam.runners.core</pattern>
                     <shadedPattern>org.apache.beam.runners.dataflow.repackaged.org.apache.beam.runners.core</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.apache.beam.sdk.common.runner</pattern>
+                    <shadedPattern>org.apache.beam.runners.dataflow.repackaged.org.apache.beam.sdk.common.runner</shadedPattern>
                   </relocation>
                 </relocations>
                 <transformers>

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
@@ -39,7 +40,7 @@ import org.apache.beam.sdk.values.TupleTag;
  */
 @Internal
 public interface TransformTranslator<TransformT extends PTransform> {
-  void translate(TransformT transform, TranslationContext context);
+  void translate(TransformT transform, TranslationContext context) throws IOException;
 
   /**
    * The interface provided to registered callbacks for interacting with the {@link DataflowRunner},


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Instead of just sending Dataflow a Java-serialized `DoFnInfo`, send it as part of a portable payload of the form: `PTransform` proto > `ParDoPayload` > `SdkFunctionSpec` > `FunctionSpec`

A couple notes:

 - The Java SDK harness depends on the full `DoFnInfo`. For example, the default "main" output is not part of the portable model. Later, we can refine/shrink what we put in `DoFnInfo` but that is separable.
 - There are pieces left blank, such as the environment of the `SdkFunctionSpec`. I believe this is blocked on containers.
 - It may also be possible that Dataflow doesn't need quite so much context in the protos. It only needs the pieces that the runner harness uses to construct an instruction graph for the harness - for example, Dataflow already knows coders from elsewhere, so they aren't really needed in these protos. It is just convenient to re-use the existing translation code, and perhaps any move towards getting the info from of the portable protos is good.