### PR TITLE
[BEAM-2957] Fix flaky ElasticsearchIOTest.testSplit in beam-sdks-java-io-elasticsearch-tests-5

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-2/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-2/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -180,6 +180,6 @@ public class ElasticsearchIOTest implements Serializable {
         nonEmptySplits += 1;
       }
     }
-    assertEquals("Wrong number of empty splits", expectedNumSplits, nonEmptySplits);
+    assertEquals("Wrong number of non empty splits", expectedNumSplits, nonEmptySplits);
   }
 }

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -179,6 +179,6 @@ public class ElasticsearchIOTest extends ESIntegTestCase implements Serializable
         nonEmptySplits += 1;
       }
     }
-    assertEquals("Wrong number of empty splits", expectedNumSources, nonEmptySplits);
+    assertEquals("Wrong number of non empty splits", expectedNumSources, nonEmptySplits);
   }
 }

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/pom.xml
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/pom.xml
@@ -33,7 +33,6 @@
 
     <properties>
         <commons-io.version>1.3.2</commons-io.version>
-        <jna.version>4.1.0</jna.version>
         <log4j.version>2.6.2</log4j.version>
         <elasticsearch.client.rest.version>5.0.0</elasticsearch.client.rest.version>
         <httpcomponents.core.version>4.4.5</httpcomponents.core.version>

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticSearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticSearchIOTestUtils.java
@@ -61,8 +61,11 @@ class ElasticSearchIOTestUtils {
         ElasticSearchIOTestUtils.createDocuments(
             numDocs, ElasticSearchIOTestUtils.InjectionMode.DO_NOT_INJECT_INVALID_DOCS);
     StringBuilder bulkRequest = new StringBuilder();
+    int i = 0;
     for (String document : data) {
-      bulkRequest.append(String.format("{ \"index\" : {} }%n%s%n", document));
+      bulkRequest.append(String.format(
+          "{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\", \"_id\" : \"%d\" } }%n%s%n",
+          connectionConfiguration.getIndex(), connectionConfiguration.getType(), i++, document));
     }
     String endPoint = String.format("/%s/%s/_bulk", connectionConfiguration.getIndex(),
         connectionConfiguration.getType());

--- a/sdks/java/io/elasticsearch-tests/pom.xml
+++ b/sdks/java/io/elasticsearch-tests/pom.xml
@@ -35,7 +35,7 @@
         <commons-io.version>1.3.2</commons-io.version>
         <jna.version>4.1.0</jna.version>
         <log4j.version>2.6.2</log4j.version>
-        <elasticsearch.client.rest.version>5.0.0</elasticsearch.client.rest.version>
+        <elasticsearch.client.rest.version>5.4.0</elasticsearch.client.rest.version>
     </properties>
 
     <dependencies>

--- a/sdks/java/io/elasticsearch/pom.xml
+++ b/sdks/java/io/elasticsearch/pom.xml
@@ -33,7 +33,7 @@
     <description>IO to read and write on Elasticsearch</description>
 
     <properties>
-        <elasticsearch.client.rest.version>5.0.0</elasticsearch.client.rest.version>
+        <elasticsearch.client.rest.version>5.4.0</elasticsearch.client.rest.version>
         <httpcomponents.core.version>4.4.5</httpcomponents.core.version>
         <httpcomponents.httpasyncclient.version>4.1.2</httpcomponents.httpasyncclient.version>
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
ES Slices are based on document id. For them to be deterministic (no empty slice), ids need to be always the same.
Provide document id at insertion time rather than letting Elasticsearch generate one.
Fix assert message in `testSplit`

Unrelated:
Update ES rest client from 5.0 to 5.4
Remove unneeded jna version property
=> Tested 100 runs of `testSplit`, all passed.
R: @jkff 
CC: @jbonofre 