### PR TITLE
Included immediate results after CoGroupByKey for better readability in docs

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1159,15 +1159,15 @@ def model_co_group_by_key_tuple(email_list, phone_list, output_path):
     # For instance, if 'emails' contained ('joe', 'joe@example.com') and
     # ('joe', 'joe@gmail.com'), then 'result' will contain the element:
     # ('joe', {'emails': ['joe@example.com', 'joe@gmail.com'], 'phones': ...})
-    result = ({'emails': emails_pcoll, 'phones': phones_pcoll}
-              | beam.CoGroupByKey())
+    results = ({'emails': emails_pcoll, 'phones': phones_pcoll}
+               | beam.CoGroupByKey())
 
-    contact_lines = result | beam.Map(
+    formatted_results = results | beam.Map(
         lambda (name, info):\
            '%s; %s; %s' %\
            (name, sorted(info['emails']), sorted(info['phones'])))
     # [END model_group_by_key_cogroupbykey_tuple]
-    contact_lines | beam.io.WriteToText(output_path)
+    formatted_results | beam.io.WriteToText(output_path)
 
 
 def model_join_using_side_inputs(

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -711,14 +711,33 @@ class SnippetsTest(unittest.TestCase):
     result_path = self.create_temp_file()
     snippets.model_co_group_by_key_tuple(email_list, phone_list, result_path)
     # [START model_group_by_key_cogroupbykey_tuple_outputs]
-    contact_lines = [
+    results = [
+        ('amy', {
+            'emails': ['amy@example.com'],
+            'phones': ['111-222-3333', '333-444-5555']}),
+        ('carl', {
+            'emails': ['carl@email.com', 'carl@example.com'],
+            'phones': ['444-555-6666']}),
+        ('james', {
+            'emails': [],
+            'phones': ['222-333-4444']}),
+        ('julia', {
+            'emails': ['julia@example.com'],
+            'phones': []}),
+    ]
+    # [END model_group_by_key_cogroupbykey_tuple_outputs]
+    # [START model_group_by_key_cogroupbykey_tuple_formatted_outputs]
+    formatted_results = [
         "amy; ['amy@example.com']; ['111-222-3333', '333-444-5555']",
         "carl; ['carl@email.com', 'carl@example.com']; ['444-555-6666']",
         "james; []; ['222-333-4444']",
         "julia; ['julia@example.com']; []",
     ]
-    # [END model_group_by_key_cogroupbykey_tuple_outputs]
-    self.assertEqual(contact_lines, self.get_output(result_path))
+    # [END model_group_by_key_cogroupbykey_tuple_formatted_outputs]
+    expected_results = ['%s; %s; %s' % (name, info['emails'], info['phones'])
+                        for name, info in results]
+    self.assertEqual(expected_results, formatted_results)
+    self.assertEqual(formatted_results, self.get_output(result_path))
 
   def test_model_use_and_query_metrics(self):
     """DebuggingWordCount example snippets."""


### PR DESCRIPTION
R: @melap 
R: @aaltay 

This makes the outputs show the data structures after the `CoGroupByKey` transform. The `formatted_results` shows how the data is affected after using the data. This will make for a clearer explanation in [BEAM-1934](https://github.com/apache/beam-site/pull/302)

- Changed `snippets_test.py:model_group_by_key_cogroupbykey_tuple_outputs` to show the data structures.
- Added `snippets_test.py:model_group_by_key_cogroupbykey_tuple_formatted_outputs` to show the data after using it in another transform.