### PR TITLE
Add Nullable Metric getter to MetricsContainerImpl.

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -99,14 +99,40 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
     return counters.tryGet(metricName);
   }
 
+  /**
+   * Return a {@code DistributionCell} named {@code metricName}. If it doesn't exist, create a
+   * {@code Metric} with the specified name.
+   */
   @Override
   public DistributionCell getDistribution(MetricName metricName) {
     return distributions.get(metricName);
   }
 
+  /**
+   * Return a {@code DistributionCell} named {@code metricName}. If it doesn't exist, return
+   * {@code null}.
+   */
+  @Nullable
+  public DistributionCell tryGetDistribution(MetricName metricName) {
+    return distributions.tryGet(metricName);
+  }
+
+  /**
+   * Return a {@code GaugeCell} named {@code metricName}. If it doesn't exist, create a
+   * {@code Metric} with the specified name.
+   */
   @Override
   public GaugeCell getGauge(MetricName metricName) {
     return gauges.get(metricName);
+  }
+
+  /**
+   * Return a {@code GaugeCell} named {@code metricName}. If it doesn't exist, return
+   * {@code null}.
+   */
+  @Nullable
+  public GaugeCell tryGetGauge(MetricName metricName) {
+    return gauges.tryGet(metricName);
   }
 
   private <UpdateT, CellT extends MetricCell<UpdateT>>

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -95,7 +95,9 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
    * {@code null}.
    */
   @Nullable
-  public CounterCell tryGetCounter(MetricName metricName) { return counters.tryGet(metricName); }
+  public CounterCell tryGetCounter(MetricName metricName) {
+    return counters.tryGet(metricName);
+  }
 
   @Override
   public DistributionCell getDistribution(MetricName metricName) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -84,6 +85,9 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
   public CounterCell getCounter(MetricName metricName) {
     return counters.get(metricName);
   }
+
+  @Nullable
+  public CounterCell tryGetCounter(MetricName metricName) { return counters.tryGet(metricName); }
 
   @Override
   public DistributionCell getDistribution(MetricName metricName) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/MetricsContainerImpl.java
@@ -81,11 +81,19 @@ public class MetricsContainerImpl implements Serializable, MetricsContainer {
     this.stepName = stepName;
   }
 
+  /**
+   * Return a {@code CounterCell} named {@code metricName}. If it doesn't exist, create a
+   * {@code Metric} with the specified name.
+   */
   @Override
   public CounterCell getCounter(MetricName metricName) {
     return counters.get(metricName);
   }
 
+  /**
+   * Return a {@code CounterCell} named {@code metricName}. If it doesn't exist, return
+   * {@code null}.
+   */
   @Nullable
   public CounterCell tryGetCounter(MetricName metricName) { return counters.tryGet(metricName); }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
@@ -22,8 +22,8 @@ import static org.apache.beam.runners.core.metrics.MetricUpdateMatchers.metricUp
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.apache.beam.sdk.metrics.MetricName;
 import org.junit.Test;
@@ -73,7 +73,7 @@ public class MetricsContainerImplTest {
     assertEquals(dne, null);
 
     CounterCell readC1 = container.tryGetCounter(MetricName.named("ns", "name1"));
-    assertEquals((long)readC1.getCumulative(), 13L);
+    assertEquals((long) readC1.getCumulative(), 13L);
   }
 
   @Test

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
@@ -71,9 +71,6 @@ public class MetricsContainerImplTest {
 
     CounterCell dne = container.tryGetCounter(MetricName.named("ns", "dne"));
     assertEquals(dne, null);
-
-    CounterCell readC1 = container.tryGetCounter(MetricName.named("ns", "name1"));
-    assertEquals((long) readC1.getCumulative(), 13L);
   }
 
   @Test
@@ -96,6 +93,9 @@ public class MetricsContainerImplTest {
     assertThat(container.getCumulative().counterUpdates(), containsInAnyOrder(
         metricUpdate("name1", 13L),
         metricUpdate("name2", 4L)));
+
+    CounterCell readC1 = container.tryGetCounter(MetricName.named("ns", "name1"));
+    assertEquals((long) readC1.getCumulative(), 13L);
   }
 
   @Test
@@ -133,5 +133,8 @@ public class MetricsContainerImplTest {
     assertThat(container.getUpdates().distributionUpdates(), contains(
         metricUpdate("name1", DistributionData.create(17, 3, 4, 8))));
     container.commitUpdates();
+
+    DistributionCell dne = container.tryGetDistribution(MetricName.named("ns", "dne"));
+    assertEquals(dne, null);
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
@@ -71,6 +71,9 @@ public class MetricsContainerImplTest {
 
     CounterCell dne = container.tryGetCounter(MetricName.named("ns", "dne"));
     assertEquals(dne, null);
+
+    CounterCell readC1 = container.tryGetCounter(MetricName.named("ns", "name1"));
+    assertEquals((long)readC1.getCumulative(), 13L);
   }
 
   @Test

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/MetricsContainerImplTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import org.apache.beam.sdk.metrics.MetricName;
 import org.junit.Test;
@@ -67,6 +68,9 @@ public class MetricsContainerImplTest {
     c1.inc(8L);
     assertThat(container.getUpdates().counterUpdates(), contains(
         metricUpdate("name1", 13L)));
+
+    CounterCell dne = container.tryGetCounter(MetricName.named("ns", "dne"));
+    assertEquals(dne, null);
   }
 
   @Test


### PR DESCRIPTION
MetricsContainerImpl currently creates a Counter with a given name when attempting to read that Counter. In order to read potentially non-existent Counters, a getter that doesn't create a Counter on behalf of the reader is necessary. 'tryGetCounter' introduces a way to retrieve null Counter values.