### PR TITLE
[BEAM-2701] ensure objectinputstream uses the right classloader for serialization

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ApiSurface.java
@@ -834,6 +834,8 @@ public class ApiSurface {
         .pruningPattern("org[.]apache[.]beam[.].*Test")
         // Exposes Guava, but not intended for users
         .pruningClassName("org.apache.beam.sdk.util.common.ReflectHelpers")
+         // test only
+        .pruningClassName("org.apache.beam.sdk.testing.InterceptingUrlClassLoader")
         .pruningPrefix("java");
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
@@ -88,7 +88,7 @@ public class SerializableUtils {
 
   public static <T extends Serializable> T clone(T value) {
     final Thread thread = Thread.currentThread();
-    final ClassLoader tccl = ReflectHelpers.findClassLoader();
+    final ClassLoader tccl = thread.getContextClassLoader();
     ClassLoader loader = tccl;
     try {
       if (tccl.loadClass(value.getClass().getName()) != value.getClass()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/SerializableUtils.java
@@ -33,6 +33,7 @@ import java.lang.reflect.Proxy;
 import java.util.Arrays;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.xerial.snappy.SnappyInputStream;
 import org.xerial.snappy.SnappyOutputStream;
 
@@ -89,7 +90,7 @@ public class SerializableUtils {
     final Thread thread = Thread.currentThread();
     final ClassLoader loader = value == null
             ? thread.getContextClassLoader() : value.getClass().getClassLoader();
-    final ClassLoader pushedLoader = thread.getContextClassLoader();
+    final ClassLoader pushedLoader = ReflectHelpers.findClassLoader();
     thread.setContextClassLoader(loader);
     @SuppressWarnings("unchecked")
     final T copy;
@@ -164,7 +165,7 @@ public class SerializableUtils {
             throws IOException, ClassNotFoundException {
       // note: staying aligned on JVM default but can need class filtering here to avoid 0day issue
       final String n = classDesc.getName();
-      final ClassLoader classloader = getClassloader();
+      final ClassLoader classloader = ReflectHelpers.findClassLoader();
       try {
         return Class.forName(n, false, classloader);
       } catch (final ClassNotFoundException e) {
@@ -175,7 +176,7 @@ public class SerializableUtils {
     @Override
     protected Class resolveProxyClass(final String[] interfaces)
             throws IOException, ClassNotFoundException {
-      final ClassLoader classloader = getClassloader();
+      final ClassLoader classloader = ReflectHelpers.findClassLoader();
 
       final Class[] cinterfaces = new Class[interfaces.length];
       for (int i = 0; i < interfaces.length; i++) {
@@ -187,11 +188,6 @@ public class SerializableUtils {
       } catch (final IllegalArgumentException e) {
         throw new ClassNotFoundException(null, e);
       }
-    }
-
-    private ClassLoader getClassloader() {
-      final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-      return contextClassLoader == null ? ClassLoader.getSystemClassLoader() : contextClassLoader;
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import com.google.common.collect.Sets;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Custom classloader behaving as a child first for a set of defined classes.
+ */
+public class InterceptingUrlClassLoader extends ClassLoader {
+    private final Set<String> ownedClasses;
+
+    public InterceptingUrlClassLoader(final ClassLoader parent, final String... ownedClasses) {
+        super(parent);
+        this.ownedClasses = Sets.newHashSet(ownedClasses);
+    }
+
+    @Override
+    public Class<?> loadClass(final String name) throws ClassNotFoundException {
+        if (name != null && ownedClasses.contains(name)) {
+            try {
+                final String classAsResource = name.replace('.', '/') + ".class";
+                final byte[] classBytes =
+                        ByteStreams.toByteArray(getParent().getResourceAsStream(classAsResource));
+                return defineClass(name, classBytes, 0, classBytes.length);
+            } catch (final IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return getParent().loadClass(name);
+    }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.util.Set;
 
 /**
- * Custom classloader behaving as a child first for a set of defined classes.
+ * A classloader that intercepts loading of specifically named classes. This classloader copies
+ * the original classes definition and is useful for testing code which needs to validate usage
+ * with multiple classloaders..
  */
 public class InterceptingUrlClassLoader extends ClassLoader {
     private final Set<String> ownedClasses;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/InterceptingUrlClassLoader.java
@@ -37,6 +37,11 @@ public class InterceptingUrlClassLoader extends ClassLoader {
 
     @Override
     public Class<?> loadClass(final String name) throws ClassNotFoundException {
+        final Class<?> alreadyLoaded = super.findLoadedClass(name);
+        if (alreadyLoaded != null) {
+            return alreadyLoaded;
+        }
+
         if (name != null && ownedClasses.contains(name)) {
             try {
                 final String classAsResource = name.replace('.', '/') + ".class";


### PR DESCRIPTION
When the PTransform are not loaded with the app classloader the ensureSerializable code can end up through ObjectInputStream on vmLatestUserDefinedClassLoader which likely falls back on app classloader whereas it should use the TCCL in resolveClass.

This PR ensures:

1. we use the TCCL as expected to deserialize an instance
2. uses the serialized instance classloader contextually in ensureSerializable to tolerate cross classloader usage