### PR TITLE
Fix Jenkins presubmits by reverting #3255

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -95,7 +95,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
+          <artifactId>beam-runners-flink_2.10</artifactId>
           <scope>runtime</scope>
           <exclusions>
             <exclusion>

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -95,7 +95,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
+          <artifactId>beam-runners-flink_2.10</artifactId>
           <scope>runtime</scope>
           <exclusions>
             <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
     <snappy-java.version>1.1.4</snappy-java.version>
     <kafka.clients.version>0.10.1.0</kafka.clients.version>
     <commons.csv.version>1.4</commons.csv.version>
-    <flink.scala.version>2.11</flink.scala.version>
 
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
     <groovy-maven-plugin.version>2.0</groovy-maven-plugin.version>
@@ -364,19 +363,6 @@
         </pluginManagement>
       </build>
     </profile>
-
-    <profile>
-      <id>flink-scala-2.10</id>
-      <activation>
-        <property>
-          <name>flink-scala-2.10</name>
-        </property>
-      </activation>
-      <properties>
-        <flink.scala.version>2.10</flink.scala.version>
-      </properties>
-    </profile>
-
   </profiles>
 
   <dependencyManagement>
@@ -620,7 +606,7 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
+        <artifactId>beam-runners-flink_2.10</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
+  <artifactId>beam-runners-flink_2.10</artifactId>
   <name>Apache Beam :: Runners :: Flink</name>
   <packaging>jar</packaging>
 
@@ -165,7 +165,7 @@
     <!-- Flink dependencies -->
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-clients_${flink.scala.version}</artifactId>
+      <artifactId>flink-clients_2.10</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -189,13 +189,13 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
+      <artifactId>flink-runtime_2.10</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
+      <artifactId>flink-streaming-java_2.10</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -210,7 +210,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
+      <artifactId>flink-runtime_2.10</artifactId>
       <version>${flink.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -336,7 +336,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
+      <artifactId>flink-streaming-java_2.10</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
@@ -344,7 +344,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-test-utils_${flink.scala.version}</artifactId>
+      <artifactId>flink-test-utils_2.10</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/sdks/java/javadoc/pom.xml
+++ b/sdks/java/javadoc/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
+      <artifactId>beam-runners-flink_2.10</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -215,7 +215,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_@flink.scala.version@</artifactId>
+          <artifactId>beam-runners-flink_2.10</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -214,7 +214,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_@flink.scala.version@</artifactId>
+          <artifactId>beam-runners-flink_2.10</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Currently, presubmits at head are broken with the following error:

```
[EnvInject] - Variables injected successfully.
Parsing POMs
Downloaded artifact http://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom
ERROR: Failed to parse POMs
java.io.IOException: remote file operation failed: /home/jenkins/jenkins-slave/workspace/beam_PreCommit_Java_MavenInstall@2 at hudson.remoting.Channel@7b1b4155:beam7: hudson.remoting.ProxyException: hudson.maven.MavenModuleSetBuild$MavenExecutionException: org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[ERROR] 'dependencies.dependency.version' for org.apache.beam:beam-runners-flink_2.10:jar is missing. @ line 68, column 21
[WARNING] 'artifactId' contains an expression but should be a constant. @ org.apache.beam:beam-runners-flink_${flink.scala.version}:2.2.0-SNAPSHOT, /home/jenkins/jenkins-slave/workspace/beam_PreCommit_Java_MavenInstall@2/runners/flink/pom.xml, line 29, column 15

	at hudson.FilePath.act(FilePath.java:993)
	at hudson.FilePath.act(FilePath.java:975)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.parsePoms(MavenModuleSetBuild.java:985)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.doRun(MavenModuleSetBuild.java:690)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:490)
	at hudson.model.Run.execute(Run.java:1735)
	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:542)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:405)
Caused by: hudson.remoting.ProxyException: hudson.maven.MavenModuleSetBuild$MavenExecutionException: org.apache.maven.project.ProjectBuildingException: Some problems were encountered while processing the POMs:
[...]
```

https://builds.apache.org/job/beam_PreCommit_Java_MavenInstall/14503/console

This change reverts the suspected cause #3255 to unbreak development at head.