### PR TITLE
[BEAM-2970] Add contains_in_any_order matcher

### DIFF
--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -70,35 +70,38 @@ def contains_in_any_order(predicates):
   Args:
     predicates: a list of predicate functions that take a value from the
       iterable as argument and return True to indicate a match and False to
-      indicate a non-match. Each of the predicates will only be used once, so
-      be careful when specifying predicates that may be satisfied by more
-      than one entry in an iterable.
+      indicate a non-match.
 
   Returns:
     A matcher that operates on iterables and raises an error if any of the
     following are true:
     - the length of the list of predicates is not equal to the length of the
       iterable.
-    - an item in the iterable matches no predicate in the list of predicates.
+    - there isn't a way to create a one-to-one mapping from items i in the
+      iterable to predicates p such that p(i) == True for all i.
   """
-  predicates = copy.copy(predicates)
+  def _contains_in_any_order(all_items, all_predicates):
+    stack = [(all_items, all_predicates)]
 
-  def _matches(item):
-    for i, predicate in enumerate(predicates):
-      if predicate(item):
-        del predicates[i]
-        return True
+    # Perform a depth-first search to find a mapping from items in the
+    # iterable to predicates they satisfy.
+    while len(stack) > 0:
+      items, predicates = stack[0]
+      stack = stack[1:]
+      if items == []:
+        return predicates == []
+      for i, p in enumerate(predicates):
+        remaining_predicates = copy.copy(predicates)
+        del remaining_predicates[i]
+        if p(items[0]):
+          stack = [(items[1:], remaining_predicates)] + stack
     return False
 
-  def _contains_in_any_order(actual):
-    e = BeamAssertException('Failed assert: %r contains_in_any_order %r' %
-                            (actual, predicates))
-    if len(actual) != len(predicates):
-      raise e
-    for item in actual:
-      if not _matches(item):
-        raise e
-  return _contains_in_any_order
+  def _matcher(actual):
+    if not _contains_in_any_order(actual, predicates):
+      raise BeamAssertException('Failed assert: %r contains_in_any_order %r' %
+                                (actual, predicates))
+  return _matcher
 
 
 def is_empty():

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -27,10 +27,6 @@ from apache_beam.testing.util import equal_to
 from apache_beam.testing.util import is_empty
 
 
-def equals_int(number):
-  return lambda n: n == number
-
-
 class UtilTest(unittest.TestCase):
 
   def test_assert_that_equal_to_passes(self):
@@ -49,14 +45,25 @@ class UtilTest(unittest.TestCase):
 
   def test_assert_that_contains_in_any_order_passes(self):
     with TestPipeline() as p:
-      assert_that(p | Create([2, 3, 1]), contains_in_any_order(
-          [equals_int(1), equals_int(2), equals_int(3)]))
+      assert_that(p | Create([5, 50]), contains_in_any_order(
+          [lambda x: x > 0, lambda x: x < 10]))
 
   def test_assert_that_contains_in_any_order_fails(self):
     with self.assertRaises(Exception):
       with TestPipeline() as p:
-        assert_that(p | Create([1, 10, 100]), contains_in_any_order(
-            [equals_int(1), equals_int(2), equals_int(3)]))
+        assert_that(p | Create([5, 50]), contains_in_any_order(
+            [lambda x: x > 0, lambda x: x < 0]))
+
+  def test_assert_that_contains_in_any_order_fails_on_empty_predicates(self):
+    with self.assertRaises(Exception):
+      with TestPipeline() as p:
+        assert_that(p | Create([5, 50]), contains_in_any_order([]))
+
+  def test_assert_that_contains_in_any_order_fails_on_too_many_predicates(self):
+    with self.assertRaises(Exception):
+      with TestPipeline() as p:
+        assert_that(p | Create([5, 50]), contains_in_any_order(
+            [lambda x: x > 0, lambda x: x < 10, lambda x: x == 5]))
 
   def test_assert_that_is_empty_passes(self):
     with TestPipeline() as p:

--- a/sdks/python/apache_beam/testing/util_test.py
+++ b/sdks/python/apache_beam/testing/util_test.py
@@ -22,27 +22,47 @@ import unittest
 from apache_beam import Create
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import contains_in_any_order
 from apache_beam.testing.util import equal_to
 from apache_beam.testing.util import is_empty
 
 
+def equals_int(number):
+  return lambda n: n == number
+
+
 class UtilTest(unittest.TestCase):
 
-  def test_assert_that_passes(self):
+  def test_assert_that_equal_to_passes(self):
     with TestPipeline() as p:
       assert_that(p | Create([1, 2, 3]), equal_to([1, 2, 3]))
 
-  def test_assert_that_fails(self):
+  def test_assert_that_equal_to_fails(self):
     with self.assertRaises(Exception):
       with TestPipeline() as p:
         assert_that(p | Create([1, 10, 100]), equal_to([1, 2, 3]))
 
-  def test_assert_that_fails_on_empty_input(self):
+  def test_assert_that_equal_to_fails_on_empty_input(self):
     with self.assertRaises(Exception):
       with TestPipeline() as p:
         assert_that(p | Create([]), equal_to([1, 2, 3]))
 
-  def test_assert_that_fails_on_empty_expected(self):
+  def test_assert_that_contains_in_any_order_passes(self):
+    with TestPipeline() as p:
+      assert_that(p | Create([2, 3, 1]), contains_in_any_order(
+          [equals_int(1), equals_int(2), equals_int(3)]))
+
+  def test_assert_that_contains_in_any_order_fails(self):
+    with self.assertRaises(Exception):
+      with TestPipeline() as p:
+        assert_that(p | Create([1, 10, 100]), contains_in_any_order(
+            [equals_int(1), equals_int(2), equals_int(3)]))
+
+  def test_assert_that_is_empty_passes(self):
+    with TestPipeline() as p:
+      assert_that(p | Create([]), is_empty())
+
+  def test_assert_that_is_empty_fails(self):
     with self.assertRaises(Exception):
       with TestPipeline() as p:
         assert_that(p | Create([1, 2, 3]), is_empty())


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

The Python testing utilities already provide an equal_to matcher, but the equal_to matcher assumes that the lists it's comparing contain objects which can be compared using < and ==. In particular, classes don't always define < and ==. contains_in_any_order is more general than equal_to: it doesn't rely on < and ==; instead, it takes as an argument a list of matcher functions, allowing the caller to provide its own definition of equality.