### PR TITLE
[BEAM-2762] Python code coverage report in Postcommit

### DIFF
--- a/sdks/python/pom.xml
+++ b/sdks/python/pom.xml
@@ -226,8 +226,7 @@
                 <configuration>
                   <executable>${python.user.base}/bin/tox</executable>
                   <arguments>
-                    <argument>-e</argument>
-                    <argument>py27,py27gcp,py27cython,lint,docs</argument>
+                    <argument>envlist</argument>
                     <argument>-c</argument>
                     <argument>tox.ini</argument>
                   </arguments>

--- a/sdks/python/pom.xml
+++ b/sdks/python/pom.xml
@@ -227,7 +227,7 @@
                   <executable>${python.user.base}/bin/tox</executable>
                   <arguments>
                     <argument>-e</argument>
-                    <argument>ALL</argument>
+                    <argument>py27,py27gcp,py27cython,lint,docs</argument>
                     <argument>-c</argument>
                     <argument>tox.ini</argument>
                   </arguments>

--- a/sdks/python/pom.xml
+++ b/sdks/python/pom.xml
@@ -226,6 +226,7 @@
                 <configuration>
                   <executable>${python.user.base}/bin/tox</executable>
                   <arguments>
+                    <!--Testenv that are only defined in envlist will be triggered.-->
                     <argument>envlist</argument>
                     <argument>-c</argument>
                     <argument>tox.ini</argument>

--- a/sdks/python/pom.xml
+++ b/sdks/python/pom.xml
@@ -226,7 +226,9 @@
                 <configuration>
                   <executable>${python.user.base}/bin/tox</executable>
                   <arguments>
-                    <!--Testenv that are only defined in envlist will be triggered.-->
+                    <!-- Environments that are only defined in envlist will be triggered. New
+                         environments will be excluded by default unless explicitly added to
+                         envlist.-->
                     <argument>envlist</argument>
                     <argument>-c</argument>
                     <argument>tox.ini</argument>

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -48,7 +48,6 @@ exclude_lines =
   if self\.debug
 
   # Don't complain if tests don't hit defensive assertion code:
-  raise AssertionError
   raise NotImplementedError
 
   # Don't complain if non-runnable code isn't run:

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -26,8 +26,7 @@ verbosity=2
 # fast_coders_test and typecoders_test.
 exclude=fast_coders_test|typecoders_test
 
-# Configuration for code coverage.
-# .coveragerc to control coverage.py
+# Configurations to control coverage.py.
 [coverage:run]
 branch = True
 source = apache_beam

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -31,24 +31,28 @@ exclude=fast_coders_test|typecoders_test
 [coverage:run]
 branch = True
 source = apache_beam
+omit =
+  # Omit auto-generated files by the protocol buffer compiler.
+  apache_beam/portability/api/*_pb2.py
+  apache_beam/portability/api/*_pb2_grpc.py
 
 [coverage:report]
 # Regexes for lines to exclude from consideration
 exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-    abc.abstractmethod
+  # Have to re-enable the standard pragma
+  pragma: no cover
+  abc.abstractmethod
 
-    # Don't complain about missing debug-only code:
-    def __repr__
-    if self\.debug
+  # Don't complain about missing debug-only code:
+  def __repr__
+  if self\.debug
 
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
+  # Don't complain if tests don't hit defensive assertion code:
+  raise AssertionError
+  raise NotImplementedError
 
-    # Don't complain if non-runnable code isn't run:
-    if __name__ == .__main__.:
+  # Don't complain if non-runnable code isn't run:
+  if __name__ == .__main__.:
 
 [coverage:xml]
 output = target/site/cobertura/coverage.xml

--- a/sdks/python/setup.cfg
+++ b/sdks/python/setup.cfg
@@ -25,3 +25,30 @@ verbosity=2
 # fast_coders module which is not available when running unit tests:
 # fast_coders_test and typecoders_test.
 exclude=fast_coders_test|typecoders_test
+
+# Configuration for code coverage.
+# .coveragerc to control coverage.py
+[coverage:run]
+branch = True
+source = apache_beam
+
+[coverage:report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+    abc.abstractmethod
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+[coverage:xml]
+output = target/site/cobertura/coverage.xml

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -16,6 +16,7 @@
 ;
 
 [tox]
+# new environments will be excluded by default unless explicitly added to envlist.
 envlist = py27,py27gcp,py27cython,lint,docs
 toxworkdir = {toxinidir}/target/.tox
 

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -16,7 +16,7 @@
 ;
 
 [tox]
-envlist = py27,py27gcp,py27cython,lint,docs
+envlist = py27,py27gcp,py27cython,lint,docs,cover
 toxworkdir = {toxinidir}/target/.tox
 
 [pycodestyle]
@@ -109,4 +109,23 @@ whitelist_externals=time
 commands =
   time pip install -e .[test,gcp,docs]
   time {toxinidir}/generate_pydoc.sh
+passenv = TRAVIS*
+
+[testenv:cover]
+deps =
+  coverage==4.4.1
+  nose==1.3.7
+whitelist_externals=find
+commands =
+  python --version
+  pip install -e .[test,gcp]
+  # Clean up all previous python generated files.
+  - find apache_beam -type f -name '*.pyc' -delete
+  # Clean up previously collected data.
+  coverage erase
+  coverage run setup.py test
+  # Print coverage report to STDOUT
+  coverage report --skip-covered
+  # Generate report in xml format
+  coverage xml
 passenv = TRAVIS*

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -16,7 +16,7 @@
 ;
 
 [tox]
-envlist = py27,py27gcp,py27cython,lint,docs,cover
+envlist = py27,py27gcp,py27cython,lint,docs
 toxworkdir = {toxinidir}/target/.tox
 
 [pycodestyle]

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -112,6 +112,7 @@ commands =
 passenv = TRAVIS*
 
 [testenv:cover]
+# This is not included in envlist which is defined in [tox].
 deps =
   coverage==4.4.1
   nose==1.3.7


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Use coverage.py to run py27gcp test suite in order to generate coverage report in Python postcommit build.
 - Add `cover` env in `tox.ini` which run `py27gcp` and generate report.
 - Report will be printed to test log and also in a xml file.
 - Only enable the coverage report in python postcommit since precommit build already takes ~30mins with existing test suites. Run `py27gcp` in code coverage will add ~7mins to the build. (thoughts?)

Example report: [https://builds.apache.org/job/beam_PostCommit_Python_Verify/3183/consoleFull](https://builds.apache.org/job/beam_PostCommit_Python_Verify/3183/consoleFull)
```
Name                                                                              Stmts   Miss Branch BrPart  Cover
-------------------------------------------------------------------------------------------------------------------
apache_beam/__init__.py                                                              12      1      2      1    86%
apache_beam/coders/coder_impl.py                                                    411     17    100      9    95%
...
apache_beam/utils/timestamp.py                                                       82      3     14      0    97%
apache_beam/utils/windowed_value.py                                                  38      2      6      0    95%
-------------------------------------------------------------------------------------------------------------------
TOTAL                                                                             34291   3655   6471    689    88%
```

Future:
Send coverage report to coverage service (like `coveralls.io`). The known issue for `coveralls.io` is that reports from different languages will mix together in `coveralls.io` and record as history data.

+R: @robertwb  