### PR TITLE
[BEAM-2377] Allow cross compilation (2.10,2.11) for flink runner

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -95,7 +95,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <scope>runtime</scope>
           <exclusions>
             <exclusion>

--- a/examples/java8/pom.xml
+++ b/examples/java8/pom.xml
@@ -95,7 +95,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <scope>runtime</scope>
           <exclusions>
             <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <snappy-java.version>1.1.4</snappy-java.version>
     <kafka.clients.version>0.10.1.0</kafka.clients.version>
     <commons.csv.version>1.4</commons.csv.version>
+    <flink.scala.version>2.11</flink.scala.version>
 
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
     <groovy-maven-plugin.version>2.0</groovy-maven-plugin.version>
@@ -363,6 +364,19 @@
         </pluginManagement>
       </build>
     </profile>
+
+    <profile>
+      <id>flink-scala-2.10</id>
+      <activation>
+        <property>
+          <name>flink-scala-2.10</name>
+        </property>
+      </activation>
+      <properties>
+        <flink.scala.version>2.10</flink.scala.version>
+      </properties>
+    </profile>
+
   </profiles>
 
   <dependencyManagement>
@@ -606,7 +620,7 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
-        <artifactId>beam-runners-flink_2.10</artifactId>
+        <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -26,7 +26,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>beam-runners-flink_2.10</artifactId>
+  <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
   <name>Apache Beam :: Runners :: Flink</name>
   <packaging>jar</packaging>
 
@@ -165,7 +165,7 @@
     <!-- Flink dependencies -->
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-clients_2.10</artifactId>
+      <artifactId>flink-clients_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -189,13 +189,13 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_2.10</artifactId>
+      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_2.10</artifactId>
+      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
     </dependency>
 
@@ -210,7 +210,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-runtime_2.10</artifactId>
+      <artifactId>flink-runtime_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
@@ -336,7 +336,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_2.10</artifactId>
+      <artifactId>flink-streaming-java_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
@@ -344,7 +344,7 @@
 
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-test-utils_2.10</artifactId>
+      <artifactId>flink-test-utils_${flink.scala.version}</artifactId>
       <version>${flink.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/sdks/java/javadoc/pom.xml
+++ b/sdks/java/javadoc/pom.xml
@@ -64,7 +64,7 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-flink_2.10</artifactId>
+      <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
     </dependency>
 
     <dependency>

--- a/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples-java8/src/main/resources/archetype-resources/pom.xml
@@ -215,7 +215,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_@flink.scala.version@</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>

--- a/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
+++ b/sdks/java/maven-archetypes/examples/src/main/resources/archetype-resources/pom.xml
@@ -214,7 +214,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_@flink.scala.version@</artifactId>
           <version>${beam.version}</version>
           <scope>runtime</scope>
         </dependency>

--- a/sdks/java/nexmark/pom.xml
+++ b/sdks/java/nexmark/pom.xml
@@ -67,7 +67,7 @@
       <dependencies>
         <dependency>
           <groupId>org.apache.beam</groupId>
-          <artifactId>beam-runners-flink_2.10</artifactId>
+          <artifactId>beam-runners-flink_${flink.scala.version}</artifactId>
           <scope>runtime</scope>
         </dependency>
       </dependencies>


### PR DESCRIPTION
This is a fixed version of #3255 which was reverted in #3875. The problem was that `flink.scala.version` was not set in the nexmark pom.