### PR TITLE
[BEAM-1630] Adds API for defining Splittable DoFns using Python SDK.

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1032,6 +1032,16 @@ class RestrictionTracker(object):
 
     Returns a restriction accurately describing the full range of work the
     current ``DoFn.process()`` call will do, including already completed work.
+
+    The current restriction returned by method may be updated dynamically due
+    to invocation of other methods of the ``RestrictionTracker``, For example,
+    ``checkpoint()``.
+
+    ** Thread safety **
+
+    Methods of the class ``RestrictionTracker`` including this method may get
+    invoked by different threads, hence must be made thread-safe, e.g. by using
+    a single lock object.
     """
     raise NotImplementedError
 
@@ -1050,6 +1060,12 @@ class RestrictionTracker(object):
 
     This method must be called at most once on a given ``RestrictionTracker``
     object.
+
+    ** Thread safety **
+
+    Methods of the class ``RestrictionTracker`` including this method may get
+    invoked by different threads, hence must be made thread-safe, e.g. by using
+    a single lock object.
     """
 
     raise NotImplementedError
@@ -1064,5 +1080,11 @@ class RestrictionTracker(object):
     Raises ValueError: if there is still any unclaimed work remaining in the
       restriction invoking this method. Exception raised must have an
       informative error message.
+
+    ** Thread safety **
+
+    Methods of the class ``RestrictionTracker`` including this method may get
+    invoked by different threads, hence must be made thread-safe, e.g. by using
+    a single lock object.
     """
     raise NotImplementedError

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1034,8 +1034,8 @@ class RestrictionTracker(object):
     current ``DoFn.process()`` call will do, including already completed work.
 
     The current restriction returned by method may be updated dynamically due
-    to invocation of other methods of the ``RestrictionTracker``, For example,
-    ``checkpoint()``.
+    to due to concurrent invocation of other methods of the
+    ``RestrictionTracker``, For example, ``checkpoint()``.
 
     ** Thread safety **
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1018,6 +1018,8 @@ class _RoundRobinKeyFn(core.DoFn):
 class RestrictionTracker(object):
   """Manages concurrent access to a restriction.
 
+  Experimental; no backwards-compatibility guarantees.
+
   Keeps track of the restrictions claimed part for a Splittable DoFn.
 
   See following documents for more details.

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1058,9 +1058,6 @@ class RestrictionTracker(object):
     ``current_restriction()`` and the return value of this method invocation
     combined.
 
-    This method must be called at most once on a given ``RestrictionTracker``
-    object.
-
     ** Thread safety **
 
     Methods of the class ``RestrictionTracker`` including this method may get

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -150,7 +150,7 @@ class ProcessContinuation(object):
   input element.
   """
 
-  def __init__(self, should_resume, resume_delay=0):
+  def __init__(self, resume_delay=0):
     """Initializes a ProcessContinuation object.
 
     Args:

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -181,15 +181,15 @@ class RestrictionProvider(object):
   Splittable ``DoFn``s.
 
   To denote a ``DoFn`` class to be Splittable ``DoFn``, ``DoFn.process()``
-  method of that class should have exactly one parameter of a type that is a
-  sub-class of ``RestrictionProvider``.
+  method of that class should have exactly one parameter whose default value is
+  an instance of ``RestrictionProvider``.
 
-  The provided ``RestrictionProvider`` object must provide suitable overrides
+  The provided ``RestrictionProvider`` instance must provide suitable overrides
   for the following methods.
-  * new_tracker()
+  * create_tracker()
   * initial_restriction()
 
-  Optionally, RestrictionProvider may override default implementations of
+  Optionally, ``RestrictionProvider`` may override default implementations of
   following methods.
   * restriction_coder()
   * split()
@@ -219,7 +219,7 @@ class RestrictionProvider(object):
   gives the watermark in number of seconds.
   """
 
-  def new_tracker(self, restriction):
+  def create_tracker(self, restriction):
     """Produces a new ``RestrictionTracker`` for the given restriction.
 
     Args:
@@ -230,17 +230,6 @@ class RestrictionProvider(object):
     Returns: an object of type ``RestrictionTracker``.
     """
     raise NotImplementedError
-
-  def restriction_coder(self):
-    """Returns a ``Coder`` for restrictions.
-
-    Returned``Coder`` will be used for the restrictions produced by the current
-    ``RestrictionProvider``.
-
-    Returns:
-      an object of type ``Coder``.
-    """
-    return coders.registry.get_coder(object)
 
   def initial_restriction(self, element):
     """Produces an initial restriction for the given element."""
@@ -258,6 +247,17 @@ class RestrictionProvider(object):
     number of parts or size in bytes.
     """
     yield restriction
+
+  def restriction_coder(self):
+    """Returns a ``Coder`` for restrictions.
+
+    Returned``Coder`` will be used for the restrictions produced by the current
+    ``RestrictionProvider``.
+
+    Returns:
+      an object of type ``Coder``.
+    """
+    return coders.registry.get_coder(object)
 
 
 class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
@@ -300,10 +300,8 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     ``DoFn.SideInputParam``: a side input that may be used when processing.
     ``DoFn.TimestampParam``: timestamp of the input element.
     ``DoFn.WindowParam``: ``Window`` the input element belongs to.
-    An object of type ``RestrictionProvider``: having a parameter of a type that
-    is a sub-class of ``RestrictionProvider`` identifies current ``DoFn``
-    to be a Splittable ``DoFn``. Please see documentation in class
-    ``RestrictionProvider`` for more details.
+    A ``RestrictionProvider`` instance: an ``iobase.RestrictionTracker`` will be
+    provided here to allow treatment as a Splittable `DoFn``.
     ``DoFn.WatermarkReporterParam``: a function that can be used to report
     output watermark of Splittable ``DoFn`` implementations.
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -173,6 +173,93 @@ class ProcessContinuation(object):
     return ProcessContinuation(resume_delay=resume_delay)
 
 
+class RestrictionProvider(object):
+  """Provides methods for generating and manipulating restrictions.
+
+  This class should be implemented to support Splittable ``DoFn``s in Python
+  SDK. See https://s.apache.org/splittable-do-fn for more details about
+  Splittable ``DoFn``s.
+
+  To denote a ``DoFn`` class to be Splittable ``DoFn``, ``DoFn.process()``
+  method of that class should have exactly one parameter of a type that is a
+  sub-class of ``RestrictionProvider``.
+
+  The provided ``RestrictionProvider`` object must provide suitable overrides
+  for the following methods.
+  * new_tracker()
+  * initial_restriction()
+
+  Optionally, RestrictionProvider may override default implementations of
+  following methods.
+  * restriction_coder()
+  * split()
+
+  ** Pausing and resuming processing of an element **
+
+  As the last element produced by the iterator returned by the
+  ``DoFn.process()`` method, a Splittable ``DoFn`` may return an object of type
+  ``ProcessContinuation``.
+
+  If provided, ``ProcessContinuation`` object specifies that runner should
+  later re-invoke ``DoFn.process()`` method to resume processing the current
+  element and the manner in which the re-invocation should be performed. A
+  ``ProcessContinuation`` object must only be specified as the last element of
+  the iterator. If a ``ProcessContinuation`` object is not provided the runner
+  will assume that the current input element has been fully processed.
+
+  ** Updating output watermark **
+
+  ``DoFn.process()`` method of Splittable ``DoFn``s could contain a parameter
+  with default value ``DoFn.WatermarkReporterParam``. If specified this asks the
+  runner to provide a function that can be used to give the runner a
+  (best-effort) lower bound about the timestamps of future output associated
+  with the current element processed by the ``DoFn``. If the ``DoFn`` has
+  multiple outputs, the watermark applies to all of them. Provided function must
+  be invoked with a single parameter of type ``Timestamp`` or as an integer that
+  gives the watermark in number of seconds.
+  """
+
+  def new_tracker(self, restriction):
+    """Produces a new ``RestrictionTracker`` for the given restriction.
+
+    Args:
+      restriction: an object that defines a restriction as identified by a
+        Splittable ``DoFn`` that utilizes the current ``RestrictionProvider``.
+        For example, a tuple that gives a range of positions for a Splittable
+        ``DoFn`` that reads files based on byte positions.
+    Returns: an object of type ``RestrictionTracker``.
+    """
+    raise NotImplementedError
+
+  def restriction_coder(self):
+    """Returns a ``Coder`` for restrictions.
+
+    Returned``Coder`` will be used for the restrictions produced by the current
+    ``RestrictionProvider``.
+
+    Returns:
+      an object of type ``Coder``.
+    """
+    return coders.registry.get_coder(object)
+
+  def initial_restriction(self, element):
+    """Produces an initial restriction for the given element."""
+    raise NotImplementedError
+
+  def split(self, element, restriction):
+    """Splits the given element and restriction.
+
+    Returns an iterator of restrictions. The total set of elements produced by
+    reading input element for each of the returned restrictions should be the
+    same as the total set of elements produced by reading the input element for
+    the input restriction.
+
+    TODO(chamikara): give suitable hints for performing splitting, for example
+    number of parts or size in bytes.
+    """
+    yield restriction
+
+
 class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   """A function object used by a transform with custom processing.
 
@@ -189,7 +276,6 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   SideInputParam = 'SideInputParam'
   TimestampParam = 'TimestampParam'
   WindowParam = 'WindowParam'
-  RestrictionTrackerParam = 'RestrictionTrackerParam'
   WatermarkReporterParam = 'WatermarkReporterParam'
 
   DoFnParams = [ElementParam, SideInputParam, TimestampParam, WindowParam]
@@ -207,11 +293,6 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     This is invoked by ``DoFnRunner`` for each element of a input
     ``PCollection``.
 
-    Args:
-      element: The element to be processed
-      *args: side inputs
-      **kwargs: other keyword arguments.
-
     If specified, following default arguments are used by the ``DoFnRunner`` to
     be able to pass the parameters correctly.
 
@@ -219,58 +300,17 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     ``DoFn.SideInputParam``: a side input that may be used when processing.
     ``DoFn.TimestampParam``: timestamp of the input element.
     ``DoFn.WindowParam``: ``Window`` the input element belongs to.
-    ``DoFn.RestrictionTrackerParam``: a ``RestrictionTrakcer`` to be used when
-    processing the input element. If a parameter is defined with this default
-    value, current ``DoFn`` is considered to be a Splittable ``DoFn`` and is
-    subjected to the special requirements given in the corresponding section
-    below.
-    ``DoFn.WatermarkReporterParam``: a function that can be used to give the
-    runner a (best-effort) lower bound about the timestamps of future output
-    associated with the current element. If the ``DoFn`` has multiple outputs,
-    the watermark applies to all of them. Function must be invoked with a
-    single parameter of type ``Timestamp`` or as an integer that gives the
-    watermark in number of seconds.
+    An object of type ``RestrictionProvider``: having a parameter of a type that
+    is a sub-class of ``RestrictionProvider`` identifies current ``DoFn``
+    to be a Splittable ``DoFn``. Please see documentation in class
+    ``RestrictionProvider`` for more details.
+    ``DoFn.WatermarkReporterParam``: a function that can be used to report
+    output watermark of Splittable ``DoFn`` implementations.
 
-    ** Splittable DoFns **
-
-    This feature is experimental and currently does not offer any
-    backwards-compatibility guarantees.
-
-    A ``DoFn`` is considered to be a 'Splittable DoFn' of it's ``process()``
-    method has a parameter with default value ``DoFn.RestrictionTrackerParam``.
-    This is an advanced feature and an overwhelming majority of users will never
-    need to write a Splittable DoFn.
-
-    A Splittable DoFn must provide suitable overrides for the following methods
-    of the ``DoFn`` class.
-    * new_tracker()
-    * initial_restriction()
-
-    Optionally, Splittable DoFns may override default implementations of
-    following methods.
-    * restriction_coder()
-    * split()
-
-    As the last element produced by the iterator returned by the ``process()``
-    method, a Splittable DoFn may return an object of type
-    ``ProcessContinuation``.
-
-    If provided, ``ProcessContinuation`` object specifies whether runner should
-    later re-invoke ``process()`` method to resume processing the current
-    element and the manner in which the re-invocation should be performed. A
-    ``ProcessContinuation`` object must only be specified as the last element of
-    the iterator. If a ``ProcessContinuation`` object is not provided the runner
-    will assume that the current input element has been fully processed.
-
-    Optionally, a runner may specify a parameter to the ``process()`` method
-    with default value ``DoFn.WatermarkReporterParam``. If specified, this gives
-    a function that can be used to update the watermark of the outputs produced
-    by the current Splittable DoFn. This function must be invoked with an object
-    of type ``Timestamp``.
-
-    See following documents for more details about Splittable DoFns.
-    * https://s.apache.org/splittable-do-fn
-    * https://s.apache.org/splittable-do-fn-python-sdk
+    Args:
+      element: The element to be processed
+      *args: side inputs
+      **kwargs: other keyword arguments.
     """
     raise NotImplementedError
 
@@ -287,51 +327,6 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     """Called after a bundle of elements is processed on a worker.
     """
     pass
-
-  def new_tracker(self, restriction):
-    """Produces a new ``RestrictionTracker`` for the given restriction.
-
-    This method should only be implemented by Splittable DoFns.
-
-    Args:
-      restriction: an object that defines a restriction as identified by the
-        current ``DoFn``. For example, a tuple that gives a range of positions
-        for a ``DoFn`` that reads files based on byte positions.
-    Returns: an object of type ``RestrictionTracker``.
-    """
-    raise NotImplementedError
-
-  def restriction_coder(self):
-    """Returns a ``Coder`` for restrictions produced by the current ``DoFn``.
-
-    This method may be overridden by Splittable DoFns.
-
-    Returns:
-      an object of type ``Coder``.
-    """
-    return coders.registry.get_coder(object)
-
-  def initial_restriction(self, element):
-    """Produces an initial restriction for the given element.
-
-    This method should only be implemented by Splittable DoFns.
-    """
-    raise NotImplementedError
-
-  def split(self, element, restriction):
-    """Splits the given element and restriction.
-
-    This method may be overridden by Splittable DoFns.
-
-    Returns an iterator of restrictions. The total set of elements produced by
-    reading input element for each of the returned restrictions should be the
-    same as the total set of elements produced by reading the input element for
-    the input restriction.
-
-    TODO(chamikara): give suitable hints for performing splitting, for example
-    number of parts or size in bytes.
-    """
-    yield restriction
 
   def get_function_arguments(self, func):
     """Return the function arguments based on the name provided. If they have


### PR DESCRIPTION
See https://s.apache.org/splittable-do-fn-python-sdk for the design.

This PR and the above doc were updated to reflect following recent updates to Splittable DoFn.
* Support for ProcessContinuations
* Support for dynamically updating output watermark irrespective of the output element production.

This will be followed by a PR that adds support for reading Splittable DoFns using DirectRunner.
