### PR TITLE
[BEAM-419] Fixing SE_BAD_FIELD FindBug in CombineFnUtil

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -337,7 +337,10 @@
     <Class name="org.apache.beam.sdk.util.CombineFnUtil$NonSerializableBoundedCombineFn"/>
     <Field name="context"/>
     <Bug pattern="SE_BAD_FIELD"/>
-    <!--[BEAM-419] Non-transient non-serializable instance field in serializable class-->
+    <!--
+      The class is not meant to be serializable, writeObject() just throws an exception. Therefore
+      it's reasonable for this field to also not be serializable.
+    -->
   </Match>
   <Match>
     <Class name="org.apache.beam.runners.core.WatermarkHold"/>


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

FindBugs detected that the `context` member in `NonSerializableBoundedKeyedCombineFn` (now `NonSerializableBoundedCombineFn`) was not serializable although the class was. Seeing as the class has "`NonSerializable`" right in the name, to fix the FindBug I marked the member as transient to make it explicitly non-serializable.