### PR TITLE
[BEAM-2982] Use the SubscriptionProvider in PubsubUnboundedSource

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSource.java
@@ -61,6 +61,7 @@ import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.SourceMetrics;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -1097,13 +1098,14 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
     public final PubsubUnboundedSource outer;
     // The subscription to read from.
     @VisibleForTesting
-    final SubscriptionPath subscriptionPath;
+    final ValueProvider<SubscriptionPath> subscriptionPath;
 
     public PubsubSource(PubsubUnboundedSource outer) {
-      this(outer, outer.getSubscription());
+      this(outer, outer.getSubscriptionProvider());
     }
 
-    private PubsubSource(PubsubUnboundedSource outer, SubscriptionPath subscriptionPath) {
+    private PubsubSource(
+        PubsubUnboundedSource outer, ValueProvider<SubscriptionPath> subscriptionPath) {
       this.outer = outer;
       this.subscriptionPath = subscriptionPath;
     }
@@ -1114,7 +1116,9 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
       List<PubsubSource> result = new ArrayList<>(desiredNumSplits);
       PubsubSource splitSource = this;
       if (subscriptionPath == null) {
-        splitSource = new PubsubSource(outer, outer.createRandomSubscription(options));
+        splitSource =
+            new PubsubSource(
+                outer, StaticValueProvider.of(outer.createRandomSubscription(options)));
       }
       for (int i = 0; i < desiredNumSplits * SCALE_OUT; i++) {
         // Since the source is immutable and Pubsub automatically shards we simply
@@ -1129,8 +1133,8 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
         PipelineOptions options,
         @Nullable PubsubCheckpoint checkpoint) {
       PubsubReader reader;
-      SubscriptionPath subscription = subscriptionPath;
-      if (subscription == null) {
+      SubscriptionPath subscription;
+      if (subscriptionPath == null || subscriptionPath.get() == null) {
         if (checkpoint == null) {
           // This reader has never been started and there was no call to #split;
           // create a single random subscription, which will be kept in the checkpoint.
@@ -1138,6 +1142,8 @@ public class PubsubUnboundedSource extends PTransform<PBegin, PCollection<Pubsub
         } else {
           subscription = checkpoint.getSubscription();
         }
+      } else {
+        subscription = subscriptionPath.get();
       }
       try {
         reader = new PubsubReader(options.as(PubsubOptions.class), this, subscription);


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
During expansion, a ValueProvider may not be accessible. This ensures
that if the subscription is based on a value provider, it will only be
evaluated when that ValueProvider is bound, rather than at construction
time.

