### PR TITLE
Introduces Reshuffle.viaRandomKey()

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -152,6 +152,11 @@ public class FileIO {
     public String readFullyAsUTF8String() throws IOException {
       return new String(readFullyAsBytes(), StandardCharsets.UTF_8);
     }
+
+    @Override
+    public String toString() {
+      return "ReadableFile{metadata=" + metadata + ", compression=" + compression + '}';
+    }
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PaneExtractors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PaneExtractors.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.testing;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -42,8 +40,9 @@ final class PaneExtractors {
   private PaneExtractors() {
   }
 
-  static <T> SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> onlyPane() {
-    return new ExtractOnlyPane<>();
+  static <T> SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> onlyPane(
+      PAssert.PAssertionSite site) {
+    return new ExtractOnlyPane<>(site);
   }
 
   static <T> SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> onTimePane() {
@@ -68,15 +67,23 @@ final class PaneExtractors {
 
   private static class ExtractOnlyPane<T>
       extends SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> {
+    private final PAssert.PAssertionSite site;
+
+    private ExtractOnlyPane(PAssert.PAssertionSite site) {
+      this.site = site;
+    }
+
     @Override
     public Iterable<T> apply(Iterable<ValueInSingleWindow<T>> input) {
       List<T> outputs = new ArrayList<>();
       for (ValueInSingleWindow<T> value : input) {
-        checkState(value.getPane().isFirst() && value.getPane().isLast(),
-            "Expected elements to be produced by a trigger that fires at most once, but got"
-                + "a value in a pane that is %s. Actual Pane Info: %s",
-            value.getPane().isFirst() ? "not the last pane" : "not the first pane",
-            value.getPane());
+        if (!value.getPane().isFirst() || !value.getPane().isLast()) {
+          throw site.wrap(
+              String.format(
+                  "Expected elements to be produced by a trigger that fires at most once, but got "
+                      + "a value %s in a pane that is %s.",
+                  value, value.getPane().isFirst() ? "not the last pane" : "not the first pane"));
+        }
         outputs.add(value.getValue());
       }
       return outputs;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PaneExtractorsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PaneExtractorsTest.java
@@ -43,7 +43,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneNoFiring() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane();
+        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> noFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(
@@ -56,7 +56,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneOnlyOneFiring() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane();
+        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> onlyFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(
@@ -70,7 +70,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneMultiplePanesFails() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane();
+        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> multipleFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(
@@ -89,7 +89,6 @@ public class PaneExtractorsTest {
                 GlobalWindow.INSTANCE,
                 PaneInfo.createPane(false, false, Timing.LATE, 2L, 1L)));
 
-    thrown.expect(IllegalStateException.class);
     thrown.expectMessage("trigger that fires at most once");
     extractor.apply(multipleFiring);
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -81,9 +81,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
-import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.View;
-import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.util.Transport;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
@@ -600,15 +598,7 @@ public class BigQueryIO {
         rows =
             tuple
                 .get(filesTag)
-                .apply(
-                    WithKeys.of(
-                        new SerializableFunction<String, String>() {
-                          public String apply(String s) {
-                            return s;
-                          }
-                        }))
-                .apply(Reshuffle.<String, String>of())
-                .apply(Values.<String>create())
+                .apply(Reshuffle.<String>viaRandomKey())
                 .apply(
                     "ReadFiles",
                     ParDo.of(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingWriteTables.java
@@ -79,10 +79,11 @@ public class StreamingWriteTables extends PTransform<
     // get good batching into BigQuery's insert calls, and enough that we can max out the
     // streaming insert quota.
     PCollection<KV<ShardedKey<String>, TableRowInfo>> tagged =
-        input.apply("ShardTableWrites", ParDo.of
-        (new GenerateShardedTable(50)))
-        .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowJsonCoder.of()))
-        .apply("TagWithUniqueIds", ParDo.of(new TagWithUniqueIds()));
+        input
+            .apply("ShardTableWrites", ParDo.of(new GenerateShardedTable(50)))
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowJsonCoder.of()))
+            .apply("TagWithUniqueIds", ParDo.of(new TagWithUniqueIds()))
+            .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()));
 
     // To prevent having the same TableRow processed more than once with regenerated
     // different unique ids, this implementation relies on "checkpointing", which is
@@ -91,7 +92,6 @@ public class StreamingWriteTables extends PTransform<
     TupleTag<Void> mainOutputTag = new TupleTag<>("mainOutput");
     TupleTag<TableRow> failedInsertsTag = new TupleTag<>("failedInserts");
     PCollectionTuple tuple = tagged
-        .setCoder(KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()))
         .apply(Reshuffle.<ShardedKey<String>, TableRowInfo>of())
         // Put in the global window to ensure that DynamicDestinations side inputs are accessed
         // correctly.

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
@@ -611,7 +611,7 @@ public class DatastoreV1Test {
         .thenReturn(splitQuery(QUERY, numSplits));
 
     SplitQueryFn splitQueryFn = new SplitQueryFn(V_1_OPTIONS, numSplits, mockDatastoreFactory);
-    DoFnTester<Query, KV<Integer, Query>> doFnTester = DoFnTester.of(splitQueryFn);
+    DoFnTester<Query, Query> doFnTester = DoFnTester.of(splitQueryFn);
     /**
      * Although Datastore client is marked transient in {@link SplitQueryFn}, when injected through
      * mock factory using a when clause for unit testing purposes, it is not serializable
@@ -619,10 +619,9 @@ public class DatastoreV1Test {
      * doFn from being serialized.
      */
     doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
-    List<KV<Integer, Query>> queries = doFnTester.processBundle(QUERY);
+    List<Query> queries = doFnTester.processBundle(QUERY);
 
     assertEquals(queries.size(), numSplits);
-    verifyUniqueKeys(queries);
     verify(mockQuerySplitter, times(1)).getSplits(
         eq(QUERY), any(PartitionId.class), eq(numSplits), any(Datastore.class));
     verifyZeroInteractions(mockDatastore);
@@ -657,12 +656,11 @@ public class DatastoreV1Test {
         .thenReturn(splitQuery(QUERY, expectedNumSplits));
 
     SplitQueryFn splitQueryFn = new SplitQueryFn(V_1_OPTIONS, numSplits, mockDatastoreFactory);
-    DoFnTester<Query, KV<Integer, Query>> doFnTester = DoFnTester.of(splitQueryFn);
+    DoFnTester<Query, Query> doFnTester = DoFnTester.of(splitQueryFn);
     doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
-    List<KV<Integer, Query>> queries = doFnTester.processBundle(QUERY);
+    List<Query> queries = doFnTester.processBundle(QUERY);
 
     assertEquals(queries.size(), expectedNumSplits);
-    verifyUniqueKeys(queries);
     verify(mockQuerySplitter, times(1)).getSplits(
         eq(QUERY), any(PartitionId.class), eq(expectedNumSplits), any(Datastore.class));
     verify(mockDatastore, times(1)).runQuery(latestTimestampRequest);
@@ -679,12 +677,11 @@ public class DatastoreV1Test {
         .build();
 
     SplitQueryFn splitQueryFn = new SplitQueryFn(V_1_OPTIONS, 10, mockDatastoreFactory);
-    DoFnTester<Query, KV<Integer, Query>> doFnTester = DoFnTester.of(splitQueryFn);
+    DoFnTester<Query, Query> doFnTester = DoFnTester.of(splitQueryFn);
     doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
-    List<KV<Integer, Query>> queries = doFnTester.processBundle(queryWithLimit);
+    List<Query> queries = doFnTester.processBundle(queryWithLimit);
 
     assertEquals(queries.size(), 1);
-    verifyUniqueKeys(queries);
     verifyNoMoreInteractions(mockDatastore);
     verifyNoMoreInteractions(mockQuerySplitter);
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/SplitQueryFnIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/SplitQueryFnIT.java
@@ -27,7 +27,6 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.gcp.datastore.DatastoreV1.Read.SplitQueryFn;
 import org.apache.beam.sdk.io.gcp.datastore.DatastoreV1.Read.V1Options;
 import org.apache.beam.sdk.transforms.DoFnTester;
-import org.apache.beam.sdk.values.KV;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -87,9 +86,9 @@ public class SplitQueryFnIT {
 
     SplitQueryFn splitQueryFn = new SplitQueryFn(
         V1Options.from(projectId, namespace, null), 0);
-    DoFnTester<Query, KV<Integer, Query>> doFnTester = DoFnTester.of(splitQueryFn);
+    DoFnTester<Query, Query> doFnTester = DoFnTester.of(splitQueryFn);
 
-    List<KV<Integer, Query>> queries = doFnTester.processBundle(query.build());
+    List<Query> queries = doFnTester.processBundle(query.build());
     assertEquals(queries.size(), expectedNumSplits);
   }
 


### PR DESCRIPTION
It's a commonly used pattern for breaking fusion https://cloud.google.com/dataflow/service/dataflow-service-desc#fusion-optimization

viaRandomKey() only abstracts away the current commonly used pattern. It has the same caveats as using Reshuffle.of() directly - the semantics are technically not guaranteed by the Beam model, but it works in practice, and this is the pattern we keep recommending to users.

The naming is deliberately operational rather than semantic, to emphasize that we don't have the semantics figured out, and the transform promises only that it expands into exactly the sequence "pair with random key, reshuffle, drop key". The goal of this change is just to reduce copy-paste.

See prior discussion at https://lists.apache.org/thread.html/ac34c9ac665a8d9f67b0254015e44c59ea65ecc1360d4014b95d3b2e@%3Cdev.beam.apache.org%3E

This change also converts several existing usages to use it, and adds another one in Match.

R: @bjchambers 