### PR TITLE
[BEAM-2958] Adding a top-level user agent string to PipelineOptions

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -297,6 +297,12 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       dataflowOptions.setGcsUploadBufferSizeBytes(GCS_UPLOAD_BUFFER_SIZE_BYTES_DEFAULT);
     }
 
+    DataflowRunnerInfo dataflowRunnerInfo = DataflowRunnerInfo.getDataflowRunnerInfo();
+    String userAgent = String
+        .format("%s/%s", dataflowRunnerInfo.getName(), dataflowRunnerInfo.getVersion())
+        .replace(" ", "_");
+    dataflowOptions.setUserAgent(userAgent);
+
     return new DataflowRunner(dataflowOptions);
   }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -341,6 +341,18 @@ public class DataflowRunnerTest implements Serializable {
   }
 
   @Test
+  public void testFromOptionsUserAgentFromPipelineInfo() throws Exception {
+    DataflowPipelineOptions options = buildPipelineOptions();
+    DataflowRunner.fromOptions(options);
+
+    String expectedName = DataflowRunnerInfo.getDataflowRunnerInfo().getName().replace(" ", "_");
+    assertThat(options.getUserAgent(), containsString(expectedName));
+
+    String expectedVersion = DataflowRunnerInfo.getDataflowRunnerInfo().getVersion();
+    assertThat(options.getUserAgent(), containsString(expectedVersion));
+  }
+
+  @Test
   public void testRun() throws IOException {
     DataflowPipelineOptions options = buildPipelineOptions();
     Pipeline p = buildDataflowPipeline(options);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -361,8 +361,8 @@ public interface PipelineOptions extends HasDisplayData {
    * <p>The string defaults to "[name]/[version]" based on the properties of the Beam release.
    */
   @Description("A user agent string describing the pipeline to external services. "
-      + "The default name is \"[name]/[version]\""
-      + " where name and version are properties of the Beam release.")
+      + "The default name is {@code [name]/[version]}"
+      + " where name and version are properties of the Apache Beam release.")
   @Default.InstanceFactory(UserAgentFactory.class)
   String getUserAgent();
   void setUserAgent(String userAgent);
@@ -375,9 +375,7 @@ public interface PipelineOptions extends HasDisplayData {
     @Override
     public String create(PipelineOptions options) {
       ReleaseInfo info = ReleaseInfo.getReleaseInfo();
-      return
-          String.format("%s/%s", info.getName(), info.getVersion())
-              .replace(" ", "_");
+      return String.format("%s/%s", info.getName(), info.getVersion()).replace(" ", "_");
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -35,6 +35,7 @@ import org.apache.beam.sdk.options.ProxyInvocationHandler.Deserializer;
 import org.apache.beam.sdk.options.ProxyInvocationHandler.Serializer;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
+import org.apache.beam.sdk.util.ReleaseInfo;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -351,6 +352,32 @@ public interface PipelineOptions extends HasDisplayData {
     @Override
     public Long create(PipelineOptions options) {
       return NEXT_ID.getAndIncrement();
+    }
+  }
+
+  /**
+   * A user agent string describing the pipeline to external services.
+   *
+   * <p>The string defaults to "[name]/[version]" based on the properties of the Beam release.
+   */
+  @Description("A user agent string describing the pipeline to external services. "
+      + "The default name is \"[name]/[version]\""
+      + " where name and version are properties of the Beam release.")
+  @Default.InstanceFactory(UserAgentFactory.class)
+  String getUserAgent();
+  void setUserAgent(String userAgent);
+
+  /**
+   * Returns a user agent string constructed from {@link ReleaseInfo#getName()} and
+   * {@link ReleaseInfo#getVersion()}, in the format "[name]/[version]".
+   */
+  class UserAgentFactory implements DefaultValueFactory<String> {
+    @Override
+    public String create(PipelineOptions options) {
+      ReleaseInfo info = ReleaseInfo.getReleaseInfo();
+      return
+          String.format("%s/%s", info.getName(), info.getVersion())
+              .replace(" ", "_");
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -366,9 +366,10 @@ public interface PipelineOptions extends HasDisplayData {
    * product            = token ["/" product-version]
    * product-version    = token
    * </code></pre>
-   * Where a token is a series of without a separator.
+   * Where a token is a series of characters without a separator.
    *
-   * <p>The string defaults to {@code [name]/[version]} based on the properties of the Beam release.
+   * <p>The string defaults to {@code [name]/[version]} based on the properties of the Apache Beam
+   * release.
    */
   @Description("A user agent string describing the pipeline to external services."
       + " The format should follow RFC2616. This option defaults to \"[name]/[version]\""

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -356,12 +356,22 @@ public interface PipelineOptions extends HasDisplayData {
   }
 
   /**
-   * A user agent string describing the pipeline to external services.
+   * A user agent string as per RFC2616, describing the pipeline to external services.
+   *
+   * <p>https://www.ietf.org/rfc/rfc2616.txt
+   *
+   * <p>It should follow the BNF Form:
+   * <pre><code>
+   * user agent         = 1*(product | comment)
+   * product            = token ["/" product-version]
+   * product-version    = token
+   * </code></pre>
+   * Where a token is a series of without a separator.
    *
    * <p>The string defaults to {@code [name]/[version]} based on the properties of the Beam release.
    */
-  @Description("A user agent string describing the pipeline to external services. "
-      + "The default name is \"[name]/[version]\""
+  @Description("A user agent string describing the pipeline to external services."
+      + " The format should follow RFC2616. This option defaults to \"[name]/[version]\""
       + " where name and version are properties of the Apache Beam release.")
   @Default.InstanceFactory(UserAgentFactory.class)
   String getUserAgent();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -380,7 +380,7 @@ public interface PipelineOptions extends HasDisplayData {
 
   /**
    * Returns a user agent string constructed from {@link ReleaseInfo#getName()} and
-   * {@link ReleaseInfo#getVersion()}, in the format "[name]/[version]".
+   * {@link ReleaseInfo#getVersion()}, in the format {@code [name]/[version]}.
    */
   class UserAgentFactory implements DefaultValueFactory<String> {
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -358,10 +358,10 @@ public interface PipelineOptions extends HasDisplayData {
   /**
    * A user agent string describing the pipeline to external services.
    *
-   * <p>The string defaults to "[name]/[version]" based on the properties of the Beam release.
+   * <p>The string defaults to {@code [name]/[version]} based on the properties of the Beam release.
    */
   @Description("A user agent string describing the pipeline to external services. "
-      + "The default name is {@code [name]/[version]}"
+      + "The default name is \"[name]/[version]\""
       + " where name and version are properties of the Apache Beam release.")
   @Default.InstanceFactory(UserAgentFactory.class)
   String getUserAgent();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.options;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -36,6 +37,8 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link PipelineOptions}. */
 @RunWith(JUnit4.class)
 public class PipelineOptionsTest {
+  private static final String DEFAULT_USER_AGENT_NAME = "Apache_Beam_SDK_for_Java";
+
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
   /** Interfaces used for testing that {@link PipelineOptions#as(Class)} functions. */
@@ -105,5 +108,13 @@ public class PipelineOptionsTest {
         fail(String.format("Generated duplicate id %s, existing generated ids %s", id, ids));
       }
     }
+  }
+
+  @Test
+  public void testUserAgentFactory() {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    String userAgent = options.getUserAgent();
+    assertNotNull(userAgent);
+    assertTrue(userAgent.contains(DEFAULT_USER_AGENT_NAME));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -60,7 +60,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.util.ReleaseInfo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -279,10 +278,9 @@ public class BigtableIO {
 
       BigtableOptions.Builder clonedBuilder = options.toBuilder()
           .setUseCachedDataPool(true);
-      BigtableOptions optionsWithAgent =
-          clonedBuilder.setUserAgent(getBeamSdkPartOfUserAgent()).build();
+      BigtableOptions clonedOptions = clonedBuilder.build();
 
-      return toBuilder().setBigtableOptions(optionsWithAgent).build();
+      return toBuilder().setBigtableOptions(clonedOptions).build();
     }
 
     /**
@@ -477,9 +475,8 @@ public class BigtableIO {
                   .setUseBulkApi(true)
                   .build())
           .setUseCachedDataPool(true);
-      BigtableOptions optionsWithAgent =
-          clonedBuilder.setUserAgent(getBeamSdkPartOfUserAgent()).build();
-      return toBuilder().setBigtableOptions(optionsWithAgent).build();
+      BigtableOptions clonedOptions = clonedBuilder.build();
+      return toBuilder().setBigtableOptions(clonedOptions).build();
     }
 
     /**
@@ -567,6 +564,7 @@ public class BigtableIO {
         return getBigtableService();
       }
       BigtableOptions.Builder clonedOptions = getBigtableOptions().toBuilder();
+      clonedOptions.setUserAgent(pipelineOptions.getUserAgent());
       if (getBigtableOptions().getCredentialOptions()
           .getCredentialType() == CredentialType.DefaultCredentials) {
         clonedOptions.setCredentialOptions(
@@ -1071,19 +1069,5 @@ public class BigtableIO {
               record.getValue()),
           cause);
     }
-  }
-
-  /**
-   * A helper function to produce a Cloud Bigtable user agent string. This need only include
-   * information about the Apache Beam SDK itself, because Bigtable will automatically append
-   * other relevant system and Bigtable client-specific version information.
-   *
-   * @see com.google.cloud.bigtable.config.BigtableVersionInfo
-   */
-  private static String getBeamSdkPartOfUserAgent() {
-    ReleaseInfo info = ReleaseInfo.getReleaseInfo();
-    return
-        String.format("%s/%s", info.getName(), info.getVersion())
-            .replace(" ", "_");
   }
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Adding a string to PipelineOptions that can be used for setting a user agent string with information about the distribution of Beam being used. That string can be sent to external services too.

This PR is probably not completely done yet. While the actual user agent string is in and working, more might have to be done to replace BigTableIO and DataflowRunner usages of user agents to use this new one. I'm still working on that right now.