### PR TITLE
[BEAM-2989] Fixed error when using Void type in WithKeys.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
@@ -41,7 +41,7 @@ public class VoidCoder extends AtomicCoder<Void> {
   @Override
   public void encode(Void value, OutputStream outStream) throws IOException {
     if (value != null) {
-      throw (new IOException("Attempting to encode non-null value with VoidCoder."));
+      throw new IOException("Attempting to encode non-null value with VoidCoder.");
     }
     // Nothing to write!
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.coders;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -38,7 +39,10 @@ public class VoidCoder extends AtomicCoder<Void> {
   private VoidCoder() {}
 
   @Override
-  public void encode(Void value, OutputStream outStream) {
+  public void encode(Void value, OutputStream outStream) throws IOException {
+    if (value != null) {
+      throw (new IOException("Attempting to encode non-null value with VoidCoder."));
+    }
     // Nothing to write!
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithKeys.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -64,6 +66,8 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>,
    * be called on the result {@link PTransform}.
    */
   public static <K, V> WithKeys<K, V> of(SerializableFunction<V, K> fn) {
+    checkNotNull(fn,
+        "WithKeys constructed with null function. Did you mean WithKeys.of((Void) null)?");
     return new WithKeys<>(fn, null);
   }
 
@@ -82,7 +86,7 @@ public class WithKeys<K, V> extends PTransform<PCollection<V>,
             return key;
           }
         },
-        (Class<K>) (key == null ? null : key.getClass()));
+        (Class<K>) (key == null ? Void.class : key.getClass()));
   }
 
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
@@ -39,7 +39,7 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class WithKeysTest {
-  static final String[] COLLECTION = new String[] {
+  private static final String[] COLLECTION = new String[] {
     "a",
     "aa",
     "b",
@@ -47,7 +47,7 @@ public class WithKeysTest {
     "bbb"
   };
 
-  static final List<KV<Integer, String>> WITH_KEYS = Arrays.asList(
+  private static final List<KV<Integer, String>> WITH_KEYS = Arrays.asList(
     KV.of(1, "a"),
     KV.of(2, "aa"),
     KV.of(1, "b"),
@@ -55,12 +55,20 @@ public class WithKeysTest {
     KV.of(3, "bbb")
   );
 
-  static final List<KV<Integer, String>> WITH_CONST_KEYS = Arrays.asList(
+  private static final List<KV<Integer, String>> WITH_CONST_KEYS = Arrays.asList(
     KV.of(100, "a"),
     KV.of(100, "aa"),
     KV.of(100, "b"),
     KV.of(100, "bb"),
     KV.of(100, "bbb")
+  );
+
+  private static final List<KV<Void, String>> WITH_CONST_KEYS_NULL = Arrays.asList(
+      KV.of((Void) null, "a"),
+      KV.of((Void) null, "aa"),
+      KV.of((Void) null, "b"),
+      KV.of((Void) null, "bb"),
+      KV.of((Void) null, "bbb")
   );
 
   @Rule
@@ -94,6 +102,22 @@ public class WithKeysTest {
         input.apply(WithKeys.<Integer, String>of(100));
     PAssert.that(output)
         .containsInAnyOrder(WITH_CONST_KEYS);
+
+    p.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testConstantVoidKeys() {
+
+    PCollection<String> input =
+        p.apply(Create.of(Arrays.asList(COLLECTION)).withCoder(
+            StringUtf8Coder.of()));
+
+    PCollection<KV<Void, String>> output =
+        input.apply(WithKeys.<Void, String>of((Void) null));
+    PAssert.that(output)
+        .containsInAnyOrder(WITH_CONST_KEYS_NULL);
 
     p.run();
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
@@ -63,7 +63,7 @@ public class WithKeysTest {
     KV.of(100, "bbb")
   );
 
-  private static final List<KV<Void, String>> WITH_CONST_KEYS_NULL = Arrays.asList(
+  private static final List<KV<Void, String>> WITH_CONST_NULL_KEYS = Arrays.asList(
       KV.of((Void) null, "a"),
       KV.of((Void) null, "aa"),
       KV.of((Void) null, "b"),
@@ -117,7 +117,7 @@ public class WithKeysTest {
     PCollection<KV<Void, String>> output =
         input.apply(WithKeys.<Void, String>of((Void) null));
     PAssert.that(output)
-        .containsInAnyOrder(WITH_CONST_KEYS_NULL);
+        .containsInAnyOrder(WITH_CONST_NULL_KEYS);
 
     p.run();
   }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

`WithKeys` had trouble correctly getting a `VoidCoder` when called with a null input before. This fix makes it so that it now functions when the input is `(Void) null`. This is done by passing Void.class as the key's class type instead of null, if the inputted key was null. Note that a null input that isn't cast to Void calls the `WithKeys.of` taking a `SerializableFunction` instead, so I added a precondition with a warning message to that one.

Also added a unit test to confirm that the fix works as intended, a quick change to `VoidCoder` to ensure that it doesn't get used inappropriately, and fixed a few warnings in `WithKeysTest`.