### PR TITLE
[BEAM-3004] Disable testReadPdfFile

### DIFF
--- a/sdks/java/io/tika/src/test/java/org/apache/beam/sdk/io/tika/TikaIOTest.java
+++ b/sdks/java/io/tika/src/test/java/org/apache/beam/sdk/io/tika/TikaIOTest.java
@@ -72,6 +72,7 @@ public class TikaIOTest {
   @Rule
   public TestPipeline p = TestPipeline.create();
 
+  @Ignore
   @Test
   public void testReadPdfFile() throws IOException {
 

--- a/sdks/java/io/tika/src/test/java/org/apache/beam/sdk/io/tika/TikaIOTest.java
+++ b/sdks/java/io/tika/src/test/java/org/apache/beam/sdk/io/tika/TikaIOTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.tika.exception.TikaException;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 


### PR DESCRIPTION
Signed-off-by: Jason Kuster <jasonkuster@google.com>

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

R: @kennknowles 
CC: @sberyozkin 
testReadPdfFile has been failing intermittently in PRs with nothing to do with TikaIO. Disabling until it can be deflaked.

https://builds.apache.org/view/A-D/view/Beam/job/beam_PreCommit_Java_MavenInstall/14691/org.apache.beam$beam-sdks-java-io-tika/testReport/org.apache.beam.sdk.io.tika/TikaIOTest/testReadPdfFile/history/