### PR TITLE
[BEAM-2999] Move ValidatesRunner test out of Python postcommit

### DIFF
--- a/.test-infra/jenkins/job_beam_PostCommit_Python_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Python_ValidatesRunner_Dataflow.groovy
@@ -20,7 +20,7 @@ import common_job_properties
 
 // This job runs the suite of Python ValidatesRunner tests against the
 // Dataflow runner.
-Job('beam_PostCommit_Python_ValidatesRunner_Dataflow') {
+job('beam_PostCommit_Python_ValidatesRunner_Dataflow') {
   description('Runs Python ValidatesRunner suite on the Dataflow runner.')
 
   // Set common parameters.

--- a/.test-infra/jenkins/job_beam_PostCommit_Python_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Python_ValidatesRunner_Dataflow.groovy
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common_job_properties
+
+// This job runs the suite of Python ValidatesRunner tests against the
+// Dataflow runner.
+Job('beam_PostCommit_Python_ValidatesRunner_Dataflow') {
+  description('Runs Python ValidatesRunner suite on the Dataflow runner.')
+
+  // Set common parameters.
+  common_job_properties.setTopLevelMainJobProperties(delegate)
+
+  // Sets that this is a PostCommit job.
+  common_job_properties.setPostCommit(delegate, '0 3-22/6 * * *')
+
+  // Allows triggering this build against pull requests.
+  common_job_properties.enablePhraseTriggeringFromPullRequest(
+      delegate,
+      'Google Cloud Dataflow Runner Python ValidatesRunner Tests',
+      'Run Python Dataflow ValidatesRunner')
+
+  // Allow the test to only run on particular nodes
+  // TODO(BEAM-1817): Remove once the tests can run on all nodes
+  parameters {
+    nodeParam('TEST_HOST') {
+      description('select test host as either beam1, 2 or 3')
+      defaultNodes(['beam3'])
+      allowedNodes(['beam1', 'beam2', 'beam3'])
+      trigger('multiSelectionDisallowed')
+      eligibility('IgnoreOfflineNodeEligibility')
+    }
+  }
+
+  // Execute shell command to test Python SDK.
+  steps {
+    shell('bash sdks/python/run_validatesrunner.sh')
+  }
+}

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -66,10 +66,6 @@ python setup.py sdist
 
 SDK_LOCATION=$(find dist/apache-beam-*.tar.gz)
 
-# Install test dependencies for ValidatesRunner tests.
-echo "pyhamcrest" > postcommit_requirements.txt
-echo "mock" >> postcommit_requirements.txt
-
 # Run integration tests on the Google Cloud Dataflow service
 # and validate that jobs finish successfully.
 echo ">>> RUNNING TEST DATAFLOW RUNNER it tests"

--- a/sdks/python/run_validatesrunner.sh
+++ b/sdks/python/run_validatesrunner.sh
@@ -37,22 +37,12 @@ rm -rf sdks/python/target/.tox
 # INFRA does not install virtualenv
 pip install virtualenv --user
 
-# INFRA does not install tox
-pip install tox --user
-
-# Tox runs unit tests in a virtual environment
-${LOCAL_PATH}/tox -e ALL -c sdks/python/tox.ini
-
 # Virtualenv for the rest of the script to run setup & e2e tests
 ${LOCAL_PATH}/virtualenv sdks/python
 . sdks/python/bin/activate
 cd sdks/python
 pip install -e .[gcp,test]
 
-# Run wordcount in the Direct Runner and validate output.
-echo ">>> RUNNING DIRECT RUNNER py-wordcount"
-python -m apache_beam.examples.wordcount --output /tmp/py-wordcount-direct
-# TODO: check that output file is generated for Direct Runner.
 
 # Run tests on the service.
 
@@ -70,20 +60,18 @@ SDK_LOCATION=$(find dist/apache-beam-*.tar.gz)
 echo "pyhamcrest" > postcommit_requirements.txt
 echo "mock" >> postcommit_requirements.txt
 
-# Run integration tests on the Google Cloud Dataflow service
-# and validate that jobs finish successfully.
-echo ">>> RUNNING TEST DATAFLOW RUNNER it tests"
+# Run ValidatesRunner tests on Google Cloud Dataflow service
+echo ">>> RUNNING DATAFLOW RUNNER VALIDATESRUNNER TESTS"
 python setup.py nosetests \
-  --attr IT \
+  --attr ValidatesRunner \
   --nocapture \
   --processes=4 \
   --process-timeout=900 \
   --test-pipeline-options=" \
     --runner=TestDataflowRunner \
     --project=$PROJECT \
-    --staging_location=$GCS_LOCATION/staging-it \
-    --temp_location=$GCS_LOCATION/temp-it \
-    --output=$GCS_LOCATION/py-it-cloud/output \
+    --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
+    --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
     --sdk_location=$SDK_LOCATION \
-    --num_workers=1 \
-    --sleep_secs=20"
+    --requirements_file=postcommit_requirements.txt \
+    --num_workers=1"

--- a/sdks/python/run_validatesrunner.sh
+++ b/sdks/python/run_validatesrunner.sh
@@ -31,9 +31,6 @@ set -v
 # pip install --user installation location.
 LOCAL_PATH=$HOME/.local/bin/
 
-# Remove any tox cache from previous workspace
-rm -rf sdks/python/target/.tox
-
 # INFRA does not install virtualenv
 pip install virtualenv --user
 
@@ -42,9 +39,6 @@ ${LOCAL_PATH}/virtualenv sdks/python
 . sdks/python/bin/activate
 cd sdks/python
 pip install -e .[gcp,test]
-
-
-# Run tests on the service.
 
 # Where to store integration test outputs.
 GCS_LOCATION=gs://temp-storage-for-end-to-end-tests

--- a/sdks/python/run_validatesrunner.sh
+++ b/sdks/python/run_validatesrunner.sh
@@ -50,10 +50,6 @@ python setup.py sdist
 
 SDK_LOCATION=$(find dist/apache-beam-*.tar.gz)
 
-# Install test dependencies for ValidatesRunner tests.
-echo "pyhamcrest" > postcommit_requirements.txt
-echo "mock" >> postcommit_requirements.txt
-
 # Run ValidatesRunner tests on Google Cloud Dataflow service
 echo ">>> RUNNING DATAFLOW RUNNER VALIDATESRUNNER TESTS"
 python setup.py nosetests \
@@ -67,5 +63,4 @@ python setup.py nosetests \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
     --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
     --sdk_location=$SDK_LOCATION \
-    --requirements_file=postcommit_requirements.txt \
     --num_workers=1"

--- a/sdks/python/run_validatesrunner.sh
+++ b/sdks/python/run_validatesrunner.sh
@@ -50,6 +50,10 @@ python setup.py sdist
 
 SDK_LOCATION=$(find dist/apache-beam-*.tar.gz)
 
+# Install test dependencies for ValidatesRunner tests.
+echo "pyhamcrest" > postcommit_requirements.txt
+echo "mock" >> postcommit_requirements.txt
+
 # Run ValidatesRunner tests on Google Cloud Dataflow service
 echo ">>> RUNNING DATAFLOW RUNNER VALIDATESRUNNER TESTS"
 python setup.py nosetests \
@@ -63,4 +67,5 @@ python setup.py nosetests \
     --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
     --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
     --sdk_location=$SDK_LOCATION \
+    --requirements_file=postcommit_requirements.txt \
     --num_workers=1"


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Create separate Jenkins build for Python validatesrunner tests and move them out of `beam_PostCommit_Python_Verify`. 

`beam_PostCommit_Python_Verify` is pretty heavy combining with unit tests, validatesrunner tests and end-to-end tests, and the total time increase to 1 hour recently. This change can reduce the load of `beam_PostCommit_Python_Verify` and log will be cleaner for debugging if either build failed.