### PR TITLE
[BEAM-1936] Add ability to provide function to extract timestamp from payload in …

### DIFF
--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/GameStats.java
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubTimestampExtractor;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.Default;
@@ -253,7 +254,8 @@ public class GameStats extends LeaderBoard {
     // Read Events from Pub/Sub using custom timestamps
     PCollection<GameActionInfo> rawEvents = pipeline
         .apply(PubsubIO.readStrings()
-            .withTimestampAttribute(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
+            .withTimestampExtractor(new PubsubTimestampExtractor(TIMESTAMP_ATTRIBUTE))
+            .fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     // Extract username/score pairs from the event stream

--- a/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
+++ b/examples/java8/src/main/java/org/apache/beam/examples/complete/game/LeaderBoard.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubTimestampExtractor;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -218,7 +219,8 @@ public class LeaderBoard extends HourlyTeamScore {
     // data elements, and parse the data.
     PCollection<GameActionInfo> gameEvents = pipeline
         .apply(PubsubIO.readStrings()
-            .withTimestampAttribute(TIMESTAMP_ATTRIBUTE).fromTopic(options.getTopic()))
+            .withTimestampExtractor(new PubsubTimestampExtractor(TIMESTAMP_ATTRIBUTE))
+            .fromTopic(options.getTopic()))
         .apply("ParseGameEvent", ParDo.of(new ParseEventFn()));
 
     gameEvents

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -902,9 +902,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
               ((NestedValueProvider) overriddenTransform.getSubscriptionProvider()).propertyName());
         }
       }
-      if (overriddenTransform.getTimestampAttribute() != null) {
+      if (overriddenTransform.getTimestampExtractor().getTimestampAttribute() != null) {
         stepContext.addInput(
-            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE, overriddenTransform.getTimestampAttribute());
+            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE,
+            overriddenTransform.getTimestampExtractor().getTimestampAttribute());
       }
       if (overriddenTransform.getIdAttribute() != null) {
         stepContext.addInput(
@@ -992,9 +993,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             PropertyNames.PUBSUB_TOPIC_OVERRIDE,
             ((NestedValueProvider) overriddenTransform.getTopicProvider()).propertyName());
       }
-      if (overriddenTransform.getTimestampAttribute() != null) {
+      if (overriddenTransform.getTimestampExtractor().getTimestampAttribute() != null) {
         stepContext.addInput(
-            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE, overriddenTransform.getTimestampAttribute());
+            PropertyNames.PUBSUB_TIMESTAMP_ATTRIBUTE,
+            overriddenTransform.getTimestampExtractor().getTimestampAttribute());
       }
       if (overriddenTransform.getIdAttribute() != null) {
         stepContext.addInput(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
@@ -136,7 +136,8 @@ class PubsubTestClient extends PubsubClient implements Serializable {
     return new PubsubTestClientFactory() {
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
+          @Nullable PubsubTimestampExtractor timestampExtractor,
+          @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient();
       }
@@ -182,7 +183,8 @@ class PubsubTestClient extends PubsubClient implements Serializable {
     return new PubsubTestClientFactory() {
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
+          @Nullable PubsubTimestampExtractor timestampExtractor,
+          @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient();
       }
@@ -226,7 +228,8 @@ class PubsubTestClient extends PubsubClient implements Serializable {
 
       @Override
       public PubsubClient newClient(
-          @Nullable String timestampAttribute, @Nullable String idAttribute, PubsubOptions options)
+          @Nullable PubsubTimestampExtractor timestampExtractor,
+          @Nullable String idAttribute, PubsubOptions options)
           throws IOException {
         return new PubsubTestClient() {
           @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTimestampExtractor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTimestampExtractor.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.api.client.util.DateTime;
+import com.google.common.base.Strings;
+import java.io.Serializable;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+
+/**
+ *  When reading from Cloud Pub/Sub where record timestamps are provided as Pub/Sub message
+ * attributes, specifies the way to extract timestamps from the message. This extraction
+ * is either done by providing the name of the attribute that contains the timestamp,
+ * or a function that takes a {@link String} payload, parses the payload, and returns a
+ * timestamp.
+ */
+public class PubsubTimestampExtractor implements Serializable{
+
+  /**
+   * Interface for user to define a function that takes a Pubsub message payload and
+   * extracts the timestamp.
+   */
+  public interface TimestampExtractorFn extends Serializable{
+
+    /**
+     * Extract the message timestamp out of the message payload.
+     */
+    String extractTimestamp(String messagePaylod);
+  }
+
+  /**
+   * Attribute to use for custom timestamps, or {@literal null} if should use
+   * {@code functionExtractor}. If {@code functionExtractor} is also null, use Pubsub publish time
+   * instead.
+   */
+  @Nullable
+  private String timestampAttribute;
+  /**
+   * Function extractor to use for custom timestamps from message payload, or {@literal null}
+   * if should use {@code timestampAttribute}. If {@code timestampAttribute} is also null,
+   * use Pubsub publish time instead.
+   */
+  @Nullable
+  private TimestampExtractorFn functionExtractor;
+
+  /**
+   * Used to specify using Pubsub publish time as timestamp.
+   */
+  public PubsubTimestampExtractor() {
+
+  }
+
+  /**
+   * Used to specify timestamp attribute as extraction method for timestamp.
+   */
+  public PubsubTimestampExtractor(String timestampAttribute) {
+    this.timestampAttribute = timestampAttribute;
+  }
+
+  /**
+   * Used to specify function from message payload to timestamp as extraction method for timestamp.
+   */
+  public PubsubTimestampExtractor(TimestampExtractorFn functionExtractor) {
+    this.functionExtractor = functionExtractor;
+  }
+
+  /**
+   * Whether this extractor uses a timestamp attribute to extract timestamps.
+   */
+  public boolean hasTimestampAttribute() {
+    return !Strings.isNullOrEmpty(timestampAttribute);
+  }
+
+  /**
+   * The timestamp attribute used to extract timestamps.
+   */
+  public String getTimestampAttribute() {
+    return timestampAttribute;
+  }
+
+  /**
+   * Return timestamp as ms-since-unix-epoch corresponding to {@code timestamp}.
+   * Return {@literal null} if no timestamp could be found. Throw {@link IllegalArgumentException}
+   * if timestamp cannot be recognized.
+   */
+  @Nullable
+  private Long asMsSinceEpoch(@Nullable String timestamp) {
+    if (Strings.isNullOrEmpty(timestamp)) {
+      return null;
+    }
+    try {
+      // Try parsing as milliseconds since epoch. Note there is no way to parse a
+      // string in RFC 3339 format here.
+      // Expected IllegalArgumentException if parsing fails; we use that to fall back
+      // to RFC 3339.
+      return Long.parseLong(timestamp);
+    } catch (IllegalArgumentException e1) {
+      // Try parsing as RFC3339 string. DateTime.parseRfc3339 will throw an
+      // IllegalArgumentException if parsing fails, and the caller should handle.
+      return DateTime.parseRfc3339(timestamp).getValue();
+    }
+  }
+
+  /**
+   * Return the timestamp (in ms since unix epoch) to use for a Pubsub message with payload
+   * {@code message}, {@code attributes} and {@code pubsubTimestamp}.
+   *
+   * <p>If {@code timestampAttribute} is non-{@literal null} then the message attributes must
+   * contain that attribute, and the value of that attribute will be taken as the timestamp.
+   * Otherwise, if {@code functionExtractor} is non-{@literal null} then the message paylod must
+   * contain the timestamp, which is parsed out by {@code functionExtractor}.
+   * Otherwise the timestamp will be taken from the Pubsub publish timestamp {@code
+   * pubsubTimestamp}.
+   *
+   * @throws IllegalArgumentException if the timestamp cannot be recognized as a ms-since-unix-epoch
+   *     or RFC3339 time.
+   */
+  public long extractTimestamp(@Nullable String message, @Nullable String pubsubTimestamp,
+      @Nullable Map<String, String> attributes) {
+    Long timestampMsSinceEpoch;
+    if (Strings.isNullOrEmpty(timestampAttribute)) {
+      if (functionExtractor != null) {
+        String timestampStr = functionExtractor.extractTimestamp(message);
+        timestampMsSinceEpoch = asMsSinceEpoch(timestampStr);
+        checkArgument(timestampMsSinceEpoch != null,
+            "Cannot interpret timestamp from function extractor: %s", timestampStr);
+      } else {
+        timestampMsSinceEpoch = asMsSinceEpoch(pubsubTimestamp);
+        checkArgument(timestampMsSinceEpoch != null,
+            "Cannot interpret PubSub publish timestamp: %s", pubsubTimestamp);
+      }
+    } else {
+      String value = attributes == null ? null : attributes.get(timestampAttribute);
+      checkArgument(value != null, "PubSub message is missing a value for timestamp attribute %s",
+          timestampAttribute);
+      timestampMsSinceEpoch = asMsSinceEpoch(value);
+      checkArgument(timestampMsSinceEpoch != null,
+          "Cannot interpret value of attribute %s as timestamp: %s", timestampAttribute, value);
+    }
+    return timestampMsSinceEpoch;
+  }
+
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClientTest.java
@@ -20,15 +20,10 @@ package org.apache.beam.sdk.io.gcp.pubsub;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Map;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.ProjectPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
-import org.joda.time.Instant;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -37,131 +32,6 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class PubsubClientTest {
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
-
-  //
-  // Timestamp handling
-  //
-
-  private long parse(String timestamp) {
-    Map<String, String> map = ImmutableMap.of("myAttribute", timestamp);
-    return PubsubClient.extractTimestamp("myAttribute", null, map);
-  }
-
-  private void roundTripRfc339(String timestamp) {
-    assertEquals(Instant.parse(timestamp).getMillis(), parse(timestamp));
-  }
-
-  private void truncatedRfc339(String timestamp, String truncatedTimestmap) {
-    assertEquals(Instant.parse(truncatedTimestmap).getMillis(), parse(timestamp));
-  }
-
-  @Test
-  public void noTimestampAttributeReturnsPubsubPublish() {
-    final long time = 987654321L;
-    long timestamp = PubsubClient.extractTimestamp(null, String.valueOf(time), null);
-    assertEquals(time, timestamp);
-  }
-
-  @Test
-  public void noTimestampAttributeAndInvalidPubsubPublishThrowsError() {
-    thrown.expect(NumberFormatException.class);
-    PubsubClient.extractTimestamp(null, "not-a-date", null);
-  }
-
-  @Test
-  public void timestampAttributeWithNullAttributesThrowsError() {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
-    PubsubClient.extractTimestamp("myAttribute", null, null);
-  }
-
-  @Test
-  public void timestampAttributeSetWithMissingAttributeThrowsError() {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
-    Map<String, String> map = ImmutableMap.of("otherLabel", "whatever");
-    PubsubClient.extractTimestamp("myAttribute", null, map);
-  }
-
-  @Test
-  public void timestampAttributeParsesMillisecondsSinceEpoch() {
-    long time = 1446162101123L;
-    Map<String, String> map = ImmutableMap.of("myAttribute", String.valueOf(time));
-    long timestamp = PubsubClient.extractTimestamp("myAttribute", null, map);
-    assertEquals(time, timestamp);
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339Seconds() {
-    roundTripRfc339("2015-10-29T23:41:41Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339Tenths() {
-    roundTripRfc339("2015-10-29T23:41:41.1Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339Hundredths() {
-    roundTripRfc339("2015-10-29T23:41:41.12Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339Millis() {
-    roundTripRfc339("2015-10-29T23:41:41.123Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339Micros() {
-    // Note: micros part 456/1000 is dropped.
-    truncatedRfc339("2015-10-29T23:41:41.123456Z", "2015-10-29T23:41:41.123Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339MicrosRounding() {
-    // Note: micros part 999/1000 is dropped, not rounded up.
-    truncatedRfc339("2015-10-29T23:41:41.123999Z", "2015-10-29T23:41:41.123Z");
-  }
-
-  @Test
-  public void timestampAttributeWithInvalidFormatThrowsError() {
-    thrown.expect(NumberFormatException.class);
-    parse("not-a-timestamp");
-  }
-
-  @Test
-  public void timestampAttributeWithInvalidFormat2ThrowsError() {
-    thrown.expect(NumberFormatException.class);
-    parse("null");
-  }
-
-  @Test
-  public void timestampAttributeWithInvalidFormat3ThrowsError() {
-    thrown.expect(NumberFormatException.class);
-    parse("2015-10");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339WithSmallYear() {
-    // Google and JodaTime agree on dates after 1582-10-15, when the Gregorian Calendar was adopted
-    // This is therefore a "small year" until this difference is reconciled.
-    roundTripRfc339("1582-10-15T01:23:45.123Z");
-  }
-
-  @Test
-  public void timestampAttributeParsesRfc3339WithLargeYear() {
-    // Year 9999 in range.
-    roundTripRfc339("9999-10-29T23:41:41.123999Z");
-  }
-
-  @Test
-  public void timestampAttributeRfc3339WithTooLargeYearThrowsError() {
-    thrown.expect(NumberFormatException.class);
-    // Year 10000 out of range.
-    parse("10000-10-29T23:41:41.123999Z");
-  }
 
   //
   // Paths

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClientTest.java
@@ -72,7 +72,8 @@ public class PubsubGrpcClientTest {
   private static final long REQ_TIME = 1234L;
   private static final long PUB_TIME = 3456L;
   private static final long MESSAGE_TIME = 6789L;
-  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final PubsubTimestampExtractor TIMESTAMP_EXTRACTOR =
+      new PubsubTimestampExtractor("timestamp");
   private static final String ID_ATTRIBUTE = "id";
   private static final String MESSAGE_ID = "testMessageId";
   private static final String DATA = "testData";
@@ -89,7 +90,7 @@ public class PubsubGrpcClientTest {
     testCredentials = new TestCredential();
     client =
         new PubsubGrpcClient(
-            TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, 10, inProcessChannel, testCredentials);
+            TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE, 10, inProcessChannel, testCredentials);
   }
 
   @After
@@ -119,7 +120,7 @@ public class PubsubGrpcClientTest {
                      .setPublishTime(timestamp)
                      .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
-                         ImmutableMap.of(TIMESTAMP_ATTRIBUTE,
+                         ImmutableMap.of(TIMESTAMP_EXTRACTOR.getTimestampAttribute(),
                                          String.valueOf(MESSAGE_TIME),
                              ID_ATTRIBUTE, RECORD_ID))
                      .build();
@@ -169,7 +170,8 @@ public class PubsubGrpcClientTest {
                      .setData(ByteString.copyFrom(DATA.getBytes()))
                      .putAllAttributes(ATTRIBUTES)
                      .putAllAttributes(
-                         ImmutableMap.of(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME),
+                         ImmutableMap.of(TIMESTAMP_EXTRACTOR.getTimestampAttribute(),
+                             String.valueOf(MESSAGE_TIME),
                                          ID_ATTRIBUTE, RECORD_ID))
                      .build();
     final PublishRequest expectedRequest =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -98,16 +98,18 @@ public class PubsubIOTest {
   public void testReadTopicDisplayData() {
     String topic = "projects/project/topics/topic";
     String subscription = "projects/project/subscriptions/subscription";
+    PubsubTimestampExtractor timestampExtractor =
+        new PubsubTimestampExtractor("mytimestamp");
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromTopic(StaticValueProvider.of(topic))
-        .withTimestampAttribute("myTimestamp")
+        .withTimestampExtractor(timestampExtractor)
         .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("topic", topic));
-    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("timestampExtractor", timestampExtractor.toString()));
     assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 
@@ -115,16 +117,18 @@ public class PubsubIOTest {
   public void testReadSubscriptionDisplayData() {
     String topic = "projects/project/topics/topic";
     String subscription = "projects/project/subscriptions/subscription";
+    PubsubTimestampExtractor timestampExtractor =
+        new PubsubTimestampExtractor("mytimestamp");
     Duration maxReadTime = Duration.standardMinutes(5);
     PubsubIO.Read<String> read = PubsubIO.readStrings()
         .fromSubscription(StaticValueProvider.of(subscription))
-        .withTimestampAttribute("myTimestamp")
+        .withTimestampExtractor(timestampExtractor)
         .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(read);
 
     assertThat(displayData, hasDisplayItem("subscription", subscription));
-    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("timestampExtractor", timestampExtractor.toString()));
     assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 
@@ -221,15 +225,17 @@ public class PubsubIOTest {
   @Test
   public void testWriteDisplayData() {
     String topic = "projects/project/topics/topic";
+    PubsubTimestampExtractor timestampExtractor =
+        new PubsubTimestampExtractor("mytimestamp");
     PubsubIO.Write<?> write = PubsubIO.writeStrings()
         .to(topic)
-        .withTimestampAttribute("myTimestamp")
+        .withTimestampExtractor(timestampExtractor)
         .withIdAttribute("myId");
 
     DisplayData displayData = DisplayData.from(write);
 
     assertThat(displayData, hasDisplayItem("topic", topic));
-    assertThat(displayData, hasDisplayItem("timestampAttribute", "myTimestamp"));
+    assertThat(displayData, hasDisplayItem("timestampExtractor", timestampExtractor.toString()));
     assertThat(displayData, hasDisplayItem("idAttribute", "myId"));
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClientTest.java
@@ -58,7 +58,8 @@ public class PubsubJsonClientTest {
   private static final long REQ_TIME = 1234L;
   private static final long PUB_TIME = 3456L;
   private static final long MESSAGE_TIME = 6789L;
-  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final PubsubTimestampExtractor TIMESTAMP_EXTRACTOR =
+      new PubsubTimestampExtractor("timestamp");
   private static final String ID_ATTRIBUTE = "id";
   private static final String MESSAGE_ID = "testMessageId";
   private static final String DATA = "testData";
@@ -68,7 +69,7 @@ public class PubsubJsonClientTest {
   @Before
   public void setup() throws IOException {
     mockPubsub = Mockito.mock(Pubsub.class, Mockito.RETURNS_DEEP_STUBS);
-    client = new PubsubJsonClient(TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, mockPubsub);
+    client = new PubsubJsonClient(TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE, mockPubsub);
   }
 
   @After
@@ -88,7 +89,8 @@ public class PubsubJsonClientTest {
         .encodeData(DATA.getBytes())
         .setPublishTime(String.valueOf(PUB_TIME))
         .setAttributes(
-            ImmutableMap.of(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME),
+            ImmutableMap.of(TIMESTAMP_EXTRACTOR.getTimestampAttribute(),
+                String.valueOf(MESSAGE_TIME),
                 ID_ATTRIBUTE, RECORD_ID));
     ReceivedMessage expectedReceivedMessage =
         new ReceivedMessage().setMessage(expectedPubsubMessage)
@@ -117,7 +119,7 @@ public class PubsubJsonClientTest {
         .encodeData(DATA.getBytes())
         .setAttributes(
             ImmutableMap.<String, String> builder()
-                    .put(TIMESTAMP_ATTRIBUTE, String.valueOf(MESSAGE_TIME))
+                    .put(TIMESTAMP_EXTRACTOR.getTimestampAttribute(), String.valueOf(MESSAGE_TIME))
                     .put(ID_ATTRIBUTE, RECORD_ID)
                     .put("k", "v").build());
     PublishRequest expectedRequest = new PublishRequest()

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTimestampExtractorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTimestampExtractorTest.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubTimestampExtractor.TimestampExtractorFn;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for timestamp methods in PubsubTimestampExtractor.
+ */
+@RunWith(JUnit4.class)
+public class PubsubTimestampExtractorTest {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  //
+  // Timestamp handling
+  //
+
+  private long parse(String timestamp) {
+    Map<String, String> map = ImmutableMap.of("myAttribute", timestamp);
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor("myAttribute");
+    return timestampExtractor.extractTimestamp(null, null, map);
+  }
+
+  private void roundTripRfc339(String timestamp) {
+    assertEquals(Instant.parse(timestamp).getMillis(), parse(timestamp));
+  }
+
+  private void truncatedRfc339(String timestamp, String truncatedTimestmap) {
+    assertEquals(Instant.parse(truncatedTimestmap).getMillis(), parse(timestamp));
+  }
+
+  @Test
+  public void noTimestampAttributeOrFunctionExtractorReturnsPubsubPublish() {
+    final long time = 987654321L;
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor();
+    long timestamp = timestampExtractor.extractTimestamp(null, String.valueOf(time), null);
+    assertEquals(time, timestamp);
+  }
+
+  @Test
+  public void noTimestampAttributeOrFunctionExtractorAndInvalidPubsubPublishThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor();
+    timestampExtractor.extractTimestamp(null, "not-a-date", null);
+  }
+
+  @Test
+  public void timestampAttributeWithNullAttributesThrowsError() {
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor("myAttribute");
+    timestampExtractor.extractTimestamp(null, null, null);
+  }
+
+  @Test
+  public void timestampAttributeSetWithMissingAttributeThrowsError() {
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("PubSub message is missing a value for timestamp attribute myAttribute");
+    Map<String, String> map = ImmutableMap.of("otherLabel", "whatever");
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor("myAttribute");
+    timestampExtractor.extractTimestamp(null, null, map);
+  }
+
+  @Test
+  public void timestampAttributeParsesMillisecondsSinceEpoch() {
+    long time = 1446162101123L;
+    Map<String, String> map = ImmutableMap.of("myAttribute", String.valueOf(time));
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor("myAttribute");
+    long timestamp = timestampExtractor.extractTimestamp(null, null, map);
+    assertEquals(time, timestamp);
+  }
+
+  @Test
+  public void timestampFunctionExtractorReturnedNullThrowsError() {
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("Cannot interpret timestamp from function extractor: null");
+    final long time = 987654321L;
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor(
+        new TimestampExtractorFn() {
+          @Override public String extractTimestamp(String messagePaylod) {
+            return null;
+          }
+        });
+    long timestamp = timestampExtractor.extractTimestamp("2015-10-29T23:45:41Z", null, null);
+  }
+
+  @Test
+  public void timestampFunctionExtractorReturnedInvalidTimeThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor(
+        new TimestampExtractorFn() {
+          @Override public String extractTimestamp(String messagePaylod) {
+            return "invalid-time";
+          }
+        });
+    long timestamp = timestampExtractor.extractTimestamp("2015-10-29T23:45:41Z", null, null);
+  }
+
+  @Test
+  public void timestampFunctionExtractorParsesMillisecondsSinceEpoch() {
+    final long time = 1446162341000L;
+    PubsubTimestampExtractor timestampExtractor = new PubsubTimestampExtractor(
+        new TimestampExtractorFn() {
+          @Override public String extractTimestamp(String messagePaylod) {
+            return messagePaylod;
+          }
+        });
+    long timestamp = timestampExtractor.extractTimestamp("2015-10-29T23:45:41Z", null, null);
+    assertEquals(time, timestamp);
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339Seconds() {
+    roundTripRfc339("2015-10-29T23:41:41Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339Tenths() {
+    roundTripRfc339("2015-10-29T23:41:41.1Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339Hundredths() {
+    roundTripRfc339("2015-10-29T23:41:41.12Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339Millis() {
+    roundTripRfc339("2015-10-29T23:41:41.123Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339Micros() {
+    // Note: micros part 456/1000 is dropped.
+    truncatedRfc339("2015-10-29T23:41:41.123456Z", "2015-10-29T23:41:41.123Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339MicrosRounding() {
+    // Note: micros part 999/1000 is dropped, not rounded up.
+    truncatedRfc339("2015-10-29T23:41:41.123999Z", "2015-10-29T23:41:41.123Z");
+  }
+
+  @Test
+  public void timestampAttributeWithInvalidFormatThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    parse("not-a-timestamp");
+  }
+
+  @Test
+  public void timestampAttributeWithInvalidFormat2ThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    parse("null");
+  }
+
+  @Test
+  public void timestampAttributeWithInvalidFormat3ThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    parse("2015-10");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339WithSmallYear() {
+    // Google and JodaTime agree on dates after 1582-10-15, when the Gregorian Calendar was adopted
+    // This is therefore a "small year" until this difference is reconciled.
+    roundTripRfc339("1582-10-15T01:23:45.123Z");
+  }
+
+  @Test
+  public void timestampAttributeParsesRfc3339WithLargeYear() {
+    // Year 9999 in range.
+    roundTripRfc339("9999-10-29T23:41:41.123999Z");
+  }
+
+  @Test
+  public void timestampAttributeRfc3339WithTooLargeYearThrowsError() {
+    thrown.expect(NumberFormatException.class);
+    // Year 10000 out of range.
+    parse("10000-10-29T23:41:41.123999Z");
+  }
+
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
@@ -54,7 +54,8 @@ public class PubsubUnboundedSinkTest implements Serializable {
   private static final Map<String, String> ATTRIBUTES =
           ImmutableMap.<String, String>builder().put("a", "b").put("c", "d").build();
   private static final long TIMESTAMP = 1234L;
-  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final PubsubTimestampExtractor TIMESTAMP_EXTRACTOR =
+      new PubsubTimestampExtractor("timestamp");
   private static final String ID_ATTRIBUTE = "id";
   private static final int NUM_SHARDS = 10;
 
@@ -107,7 +108,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink sink =
           new PubsubUnboundedSink(factory, StaticValueProvider.of(TOPIC),
-              TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
+              TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
               Duration.standardSeconds(2),
               RecordIdMethod.DETERMINISTIC);
       p.apply(Create.of(ImmutableList.of(DATA)))
@@ -132,7 +133,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
           new PubsubUnboundedSink(
               factory,
               StaticValueProvider.of(TOPIC),
-              TIMESTAMP_ATTRIBUTE,
+              TIMESTAMP_EXTRACTOR,
               ID_ATTRIBUTE,
               NUM_SHARDS,
               1 /* batchSize */,
@@ -165,7 +166,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink sink =
           new PubsubUnboundedSink(factory, StaticValueProvider.of(TOPIC),
-              TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
+              TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE, NUM_SHARDS, batchSize, batchBytes,
               Duration.standardSeconds(2), RecordIdMethod.DETERMINISTIC);
       p.apply(Create.of(data))
        .apply(ParDo.of(new Stamp()))
@@ -199,7 +200,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                                                       ImmutableList.<OutgoingMessage>of())) {
       PubsubUnboundedSink sink =
           new PubsubUnboundedSink(factory, StaticValueProvider.of(TOPIC),
-              TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE,
+              TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE,
               NUM_SHARDS, batchSize, batchBytes, Duration.standardSeconds(2),
               RecordIdMethod.DETERMINISTIC);
       p.apply(Create.of(data))

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSourceTest.java
@@ -70,7 +70,8 @@ public class PubsubUnboundedSourceTest {
   private static final String DATA = "testData";
   private static final long TIMESTAMP = 1234L;
   private static final long REQ_TIME = 6373L;
-  private static final String TIMESTAMP_ATTRIBUTE = "timestamp";
+  private static final PubsubTimestampExtractor TIMESTAMP_EXTRACTOR =
+      new PubsubTimestampExtractor("timestamp");
   private static final String ID_ATTRIBUTE = "id";
   private static final String ACK_ID = "testAckId";
   private static final String RECORD_ID = "testRecordId";
@@ -96,7 +97,7 @@ public class PubsubUnboundedSourceTest {
     PubsubUnboundedSource source =
         new PubsubUnboundedSource(
             clock, factory, null, null, StaticValueProvider.of(SUBSCRIPTION),
-            TIMESTAMP_ATTRIBUTE, ID_ATTRIBUTE, true /* needsAttributes */);
+            TIMESTAMP_EXTRACTOR, ID_ATTRIBUTE, true /* needsAttributes */);
     primSource = new PubsubSource(source);
   }
 

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -42,6 +42,7 @@ import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubTimestampExtractor;
 import org.apache.beam.sdk.metrics.DistributionResult;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -728,7 +729,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         PubsubIO.readMessagesWithAttributes().fromSubscription(shortSubscription)
             .withIdAttribute(NexmarkUtils.PUBSUB_ID);
     if (!configuration.usePubsubPublishTime) {
-      io = io.withTimestampAttribute(NexmarkUtils.PUBSUB_TIMESTAMP);
+      io = io.withTimestampExtractor(new PubsubTimestampExtractor(NexmarkUtils.PUBSUB_TIMESTAMP));
     }
 
     return p
@@ -773,7 +774,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         PubsubIO.writeMessages().to(shortTopic)
             .withIdAttribute(NexmarkUtils.PUBSUB_ID);
     if (!configuration.usePubsubPublishTime) {
-      io = io.withTimestampAttribute(NexmarkUtils.PUBSUB_TIMESTAMP);
+      io = io.withTimestampExtractor(new PubsubTimestampExtractor(NexmarkUtils.PUBSUB_TIMESTAMP));
     }
 
     events.apply(queryName + ".EventToPubsubMessage",
@@ -803,7 +804,7 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
         PubsubIO.writeStrings().to(shortTopic)
             .withIdAttribute(NexmarkUtils.PUBSUB_ID);
     if (!configuration.usePubsubPublishTime) {
-      io = io.withTimestampAttribute(NexmarkUtils.PUBSUB_TIMESTAMP);
+      io = io.withTimestampExtractor(new PubsubTimestampExtractor(NexmarkUtils.PUBSUB_TIMESTAMP));
     }
     formattedResults.apply(queryName + ".WritePubsubResults", io);
   }


### PR DESCRIPTION

What: This pull request adds the ability to extract timestamps from Pubsub message bodies. 
Why: Currently an attribute name containing timestamps can be provided, but in the case where message publisher isn't controlled by the user, correct windowing requires a way to pull timestamps from the message payload.
How: Instead of passing a timestamp attribute (String) through PubsubIO -> PubsubClient, this has been generalized to a PubsubTimestampExtractor which is instantiated 3 ways: 
1) empty constructor. This means the default publish time is used as the message timestamp
2) with a String timestamp attribute name. This works the same as the current approach.
3) with a Function<String, String> extractor. This function extractor takes in the message payload as a string, and returns the parsed timestamp. In the case the returned timestamp isn't a timestamp, an exception is thrown saying the timestamp cannot be interpreted (same behavior as when a timestamp attribute can't be interpreted as a timestamp)

