### PR TITLE
Add @FunctionalInterface annotation to several JdbcIO interfaces

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -172,6 +172,7 @@ public class JdbcIO {
    * An interface used by {@link JdbcIO.Read} for converting each row of the {@link ResultSet} into
    * an element of the resulting {@link PCollection}.
    */
+  @FunctionalInterface
   public interface RowMapper<T> extends Serializable {
     T mapRow(ResultSet resultSet) throws Exception;
   }
@@ -271,6 +272,7 @@ public class JdbcIO {
    * An interface used by the JdbcIO Write to set the parameters of the {@link PreparedStatement}
    * used to setParameters into the database.
    */
+  @FunctionalInterface
   public interface StatementPreparator extends Serializable {
     void setParameters(PreparedStatement preparedStatement) throws Exception;
   }
@@ -502,6 +504,7 @@ public class JdbcIO {
    * An interface used by the JdbcIO Write to set the parameters of the {@link PreparedStatement}
    * used to setParameters into the database.
    */
+  @FunctionalInterface
   public interface PreparedStatementSetter<T> extends Serializable {
     void setParameters(T element, PreparedStatement preparedStatement) throws Exception;
   }


### PR DESCRIPTION
By adding the `@FunctionalInterface` to `RowMapper`, `StatementPreperator` and
`PreparedStatementSetter` it's possible to write a `JdbcIO` source in a
more concise and functional style:
```
pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  .withQuery("select id,name from Person where name = ?")
  .withRowMapper(resultSet -> KV.of(resultSet.getInt(1), resultSet.getString(2)))
  .withStatementPreparator(preparedStatement -> preparedStatement.setString(1, "Darwin"))
);
```

This change is backwards compatible with existing `JdbcIO` sources.