### PR TITLE
 [BEAM-2993] AvroIO.write without specifying a schema

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -385,7 +385,7 @@ public class AvroIO {
             .build());
   }
 
-  /** Writes Avro records determining the schema from the input collection. */
+  /** Writes Avro {@link GenericRecord}s.  */
   public static Write<GenericRecord> writeGenericRecords() {
     return new Write<>(
         AvroIO.<GenericRecord, GenericRecord>defaultWriteBuilder()
@@ -418,8 +418,10 @@ public class AvroIO {
 
   /**
    * Similar to {@link #writeCustomType()}, but specialized for the case where the output type is
-   * {@link GenericRecord}. A schema can be specified in {@link DynamicAvroDestinations#getSchema}.
-   * If it is not specified then, it will be determined out of the input elements
+   * {@link GenericRecord}. A schema can be specified in {@link DynamicAvroDestinations#getSchema}
+   * for example to write objects with different schemas depending on the destination
+   * (see Writing data to multiple destinations in {@link AvroIO}.
+   * If the schema is not specified, then it will be determined out of the input elements
    */
   public static <UserT> TypedWrite<UserT, Void, GenericRecord> writeCustomTypeToGenericRecords() {
     return AvroIO.<UserT, GenericRecord>defaultWriteBuilder().setGenericRecords(true).build();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -181,23 +181,19 @@ import org.joda.time.Duration;
  *
  * <h3>Writing specific or generic records</h3>
  *
- * <p>To write specific records, such as Avro-generated classes, use {@link #write(Class)}. To write
- * {@link GenericRecord GenericRecords}, use either {@link #writeGenericRecords(Schema)} which takes
- * a {@link Schema} object, or {@link #writeGenericRecords(String)} which takes a schema in a
- * JSON-encoded string form. An exception will be thrown if a record doesn't match the specified
- * schema.
+ * <p>To write specific records, such as Avro-generated classes, use {@link #write()}. To write
+ * {@link GenericRecord GenericRecords}, use {@link #writeGenericRecords()}
  *
  * <p>For example:
  *
  * <pre>{@code
  * // A simple Write to a local file (only runs locally):
  * PCollection<AvroAutoGenClass> records = ...;
- * records.apply(AvroIO.write(AvroAutoGenClass.class).to("/path/to/file.avro"));
+ * records.apply(AvroIO.write().to("/path/to/file.avro"));
  *
  * // A Write to a sharded GCS file (runs locally and using remote execution):
- * Schema schema = new Schema.Parser().parse(new File("schema.avsc"));
  * PCollection<GenericRecord> records = ...;
- * records.apply("WriteToAvro", AvroIO.writeGenericRecords(schema)
+ * records.apply("WriteToAvro", AvroIO.writeGenericRecords()
  *     .to("gs://my_bucket/path/to/numbers")
  *     .withSuffix(".avro"));
  * }</pre>
@@ -355,6 +351,7 @@ public class AvroIO {
    * Writes a {@link PCollection} to an Avro file (or multiple Avro files matching a sharding
    * pattern).
    */
+  @Deprecated
   public static <T> Write<T> write(Class<T> recordClass) {
     return new Write<>(
         AvroIO.<T, T>defaultWriteBuilder()
@@ -363,12 +360,32 @@ public class AvroIO {
             .build());
   }
 
+  /**
+   * Writes a {@link PCollection} to an Avro file (or multiple Avro files matching a sharding
+   * pattern).
+   */
+  public static <T> Write<T> write() {
+    return new Write<>(
+        AvroIO.<T, T>defaultWriteBuilder()
+            .setGenericRecords(false)
+            .build());
+  }
+
+  @Deprecated
   /** Writes Avro records of the specified schema. */
   public static Write<GenericRecord> writeGenericRecords(Schema schema) {
     return new Write<>(
         AvroIO.<GenericRecord, GenericRecord>defaultWriteBuilder()
             .setGenericRecords(true)
             .setSchema(schema)
+            .build());
+  }
+
+  /** Writes Avro records determining the schema from the input collection. */
+  public static Write<GenericRecord> writeGenericRecords() {
+    return new Write<>(
+        AvroIO.<GenericRecord, GenericRecord>defaultWriteBuilder()
+            .setGenericRecords(true)
             .build());
   }
 
@@ -397,9 +414,8 @@ public class AvroIO {
 
   /**
    * Similar to {@link #writeCustomType()}, but specialized for the case where the output type is
-   * {@link GenericRecord}. A schema must be specified either in {@link
-   * DynamicAvroDestinations#getSchema} or if not using dynamic destinations, by using {@link
-   * TypedWrite#withSchema(Schema)}.
+   * {@link GenericRecord}. A schema can be specified in {@link DynamicAvroDestinations#getSchema}.
+   * If it is not specified then, it will be determined out of the input elements
    */
   public static <UserT> TypedWrite<UserT, Void, GenericRecord> writeCustomTypeToGenericRecords() {
     return AvroIO.<UserT, GenericRecord>defaultWriteBuilder().setGenericRecords(true).build();
@@ -408,6 +424,7 @@ public class AvroIO {
   /**
    * Writes Avro records of the specified schema. The schema is specified as a JSON-encoded string.
    */
+  @Deprecated
   public static Write<GenericRecord> writeGenericRecords(String schema) {
     return writeGenericRecords(new Schema.Parser().parse(schema));
   }
@@ -1003,6 +1020,7 @@ public class AvroIO {
      * Sets the the output schema. Can only be used when the output type is {@link GenericRecord}
      * and when not using {@link #to(DynamicAvroDestinations)}.
      */
+    @Deprecated
     public TypedWrite<UserT, DestinationT, OutputT> withSchema(Schema schema) {
       return toBuilder().setSchema(schema).build();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -350,6 +350,7 @@ public class AvroIO {
   /**
    * Writes a {@link PCollection} to an Avro file (or multiple Avro files matching a sharding
    * pattern).
+   * @deprecated Use {@link #write()} that will determine the schema out of the elements
    */
   @Deprecated
   public static <T> Write<T> write(Class<T> recordClass) {
@@ -371,8 +372,11 @@ public class AvroIO {
             .build());
   }
 
+  /** Writes Avro records of the specified schema.
+   * @deprecated Use {@link #writeGenericRecords()} that will determine the schema
+   * out of the elements
+   * */
   @Deprecated
-  /** Writes Avro records of the specified schema. */
   public static Write<GenericRecord> writeGenericRecords(Schema schema) {
     return new Write<>(
         AvroIO.<GenericRecord, GenericRecord>defaultWriteBuilder()
@@ -423,7 +427,10 @@ public class AvroIO {
 
   /**
    * Writes Avro records of the specified schema. The schema is specified as a JSON-encoded string.
-   */
+   * @deprecated Use {@link #writeGenericRecords()} that will determine the schema
+   * out of the elements
+   * */
+
   @Deprecated
   public static Write<GenericRecord> writeGenericRecords(String schema) {
     return writeGenericRecords(new Schema.Parser().parse(schema));
@@ -1019,6 +1026,7 @@ public class AvroIO {
     /**
      * Sets the the output schema. Can only be used when the output type is {@link GenericRecord}
      * and when not using {@link #to(DynamicAvroDestinations)}.
+     * @deprecated the schema can be determined out of the elements. See {@link #write()}
      */
     @Deprecated
     public TypedWrite<UserT, DestinationT, OutputT> withSchema(Schema schema) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -105,10 +105,13 @@ class AvroSink<UserT, DestinationT, OutputT> extends FileBasedSink<UserT, Destin
 
 
       if (schema != null) {
-        datumWriter = genericRecords ? new GenericDatumWriter<OutputT>(schema) : new ReflectDatumWriter<OutputT>(
-            schema);
+        datumWriter = genericRecords
+            ? new GenericDatumWriter<OutputT>(schema) :
+            new ReflectDatumWriter<OutputT>(schema);
       } else { // lazy init
-        datumWriter = genericRecords ? new GenericDatumWriter<OutputT>() : new ReflectDatumWriter<OutputT>();
+        datumWriter = genericRecords
+            ? new GenericDatumWriter<OutputT>() :
+            new ReflectDatumWriter<OutputT>();
       }
       dataFileWriter = new DataFileWriter<>(datumWriter).setCodec(codec);
       for (Map.Entry<String, Object> entry : metadata.entrySet()) {
@@ -144,8 +147,8 @@ class AvroSink<UserT, DestinationT, OutputT> extends FileBasedSink<UserT, Destin
     }
 
     private void lazyInitDataFileWriter(OutputT value) throws java.io.IOException {
-      schema = genericRecords ?
-            ((GenericRecord) value).getSchema() :
+      schema = genericRecords
+            ? ((GenericRecord) value).getSchema() :
             ReflectData.get().getSchema(value.getClass());
         datumWriter.setSchema(schema);
         dataFileWriter.create(schema, Channels.newOutputStream(channel));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
@@ -111,11 +111,7 @@ class ConstantAvroDestination<UserT, OutputT>
 
   @Override
   public Schema getSchema(Void destination) {
-    if (schema != null) {
-      return schema.get();
-    } else {
-      return null;
-    }
+    return schema != null ? schema.get() : null;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
@@ -79,7 +79,8 @@ class ConstantAvroDestination<UserT, OutputT>
       SerializableFunction<UserT, OutputT> formatFunction) {
     this.filenamePolicy = filenamePolicy;
     if (schema != null) {
-      this.schema = Suppliers.compose(new SchemaFunction(), Suppliers.ofInstance(schema.toString()));
+      this.schema = Suppliers
+          .compose(new SchemaFunction(), Suppliers.ofInstance(schema.toString()));
     } else {
       this.schema = null;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ConstantAvroDestination.java
@@ -46,6 +46,7 @@ class ConstantAvroDestination<UserT, OutputT>
   // This should be a multiple of 4 to not get a partial encoded byte.
   private static final int METADATA_BYTES_MAX_LENGTH = 40;
   private final FilenamePolicy filenamePolicy;
+  @Nullable
   private final Supplier<Schema> schema;
   private final Map<String, Object> metadata;
   private final SerializableAvroCodecFactory codec;
@@ -77,7 +78,11 @@ class ConstantAvroDestination<UserT, OutputT>
       CodecFactory codec,
       SerializableFunction<UserT, OutputT> formatFunction) {
     this.filenamePolicy = filenamePolicy;
-    this.schema = Suppliers.compose(new SchemaFunction(), Suppliers.ofInstance(schema.toString()));
+    if (schema != null) {
+      this.schema = Suppliers.compose(new SchemaFunction(), Suppliers.ofInstance(schema.toString()));
+    } else {
+      this.schema = null;
+    }
     this.metadata = metadata;
     this.codec = new SerializableAvroCodecFactory(codec);
     this.formatFunction = formatFunction;
@@ -105,7 +110,11 @@ class ConstantAvroDestination<UserT, OutputT>
 
   @Override
   public Schema getSchema(Void destination) {
-    return schema.get();
+    if (schema != null) {
+      return schema.get();
+    } else {
+      return null;
+    }
   }
 
   @Override
@@ -121,7 +130,9 @@ class ConstantAvroDestination<UserT, OutputT>
   @Override
   public void populateDisplayData(DisplayData.Builder builder) {
     filenamePolicy.populateDisplayData(builder);
-    builder.add(DisplayData.item("schema", schema.get().toString()).withLabel("Record Schema"));
+    if (schema != null) {
+      builder.add(DisplayData.item("schema", schema.get().toString()).withLabel("Record Schema"));
+    }
     builder.addIfNotDefault(
         DisplayData.item("codec", codec.getCodec().toString()).withLabel("Avro Compression Codec"),
         AvroIO.TypedWrite.DEFAULT_SERIALIZABLE_CODEC.toString());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -281,11 +281,11 @@ public class AvroIOTransformTest {
   public static class AvroIOWriteTransformTest extends AvroIOTransformTest {
 
     public final transient TestPipeline pipeline = TestPipeline.create();
-    public ExpectedException expectedException = ExpectedException.none();
+    public ExpectedException thrown = ExpectedException.none();
 
-    // the expectedException must stop the pipeline
+    // the ExpectedException must stop the pipeline
     @Rule
-    public final transient RuleChain chain = RuleChain.outerRule(expectedException).around(pipeline);
+    public final transient RuleChain chain = RuleChain.outerRule(thrown).around(pipeline);
 
     private static final String WRITE_TRANSFORM_NAME = "AvroIO.Write";
 
@@ -406,7 +406,7 @@ public class AvroIOTransformTest {
       final AvroIO.Write<T> write = writeBuilder.to(avroFile.getPath());
 
       if (expectAvroException) {
-        expectedException.expect(isA(UnresolvedUnionException.class));
+        thrown.expect(isA(UnresolvedUnionException.class));
       }
       @SuppressWarnings("unchecked") final
       PCollection<T> input =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -41,11 +41,18 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Sample;
+import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -271,6 +278,17 @@ public class AvroIOTransformTest {
         }
         return (List<T>) genericRecords;
       }
+    }
+
+    private List<GenericRecord> readAvroFileWithGenericRecords(final File avroFile) throws IOException {
+      final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(SCHEMA);
+      final List<GenericRecord> genericRecords = new ArrayList<>();
+      try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(avroFile, datumReader)) {
+        while (dataFileReader.hasNext()) {
+          genericRecords.add(dataFileReader.next());
+        }
+      }
+      return genericRecords;
     }
 
     @Parameterized.Parameters(name = "{0}_with_{1}")

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -41,18 +41,11 @@ import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.Sample;
-import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionView;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -280,17 +273,6 @@ public class AvroIOTransformTest {
       }
     }
 
-    private List<GenericRecord> readAvroFileWithGenericRecords(final File avroFile) throws IOException {
-      final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(SCHEMA);
-      final List<GenericRecord> genericRecords = new ArrayList<>();
-      try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(avroFile, datumReader)) {
-        while (dataFileReader.hasNext()) {
-          genericRecords.add(dataFileReader.next());
-        }
-      }
-      return genericRecords;
-    }
-
     @Parameterized.Parameters(name = "{0}_with_{1}")
     public static Iterable<Object[]> data() throws IOException {
 
@@ -313,10 +295,21 @@ public class AvroIOTransformTest {
                       AvroIOTransformTest.generateAvroGenericRecords(),
                       true
                   },
-
                   new Object[] {
                       AvroIO.writeGenericRecords(SCHEMA_STRING),
                       genericRecordsfromSchemaString,
+                      AvroIOTransformTest.generateAvroGenericRecords(),
+                      true
+                  },
+                  new Object[] {
+                      AvroIO.write(),
+                      generatedClass,
+                      AvroIOTransformTest.generateAvroObjects(),
+                      false
+                  },
+                  new Object[] {
+                      AvroIO.writeGenericRecords(),
+                      genericRecordsfromSchema,
                       AvroIOTransformTest.generateAvroGenericRecords(),
                       true
                   })

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -279,6 +279,8 @@ public class AvroIOTransformTest {
       final String generatedClass = "GeneratedClass";
       final String genericRecordsfromSchema = "GenericRecordsFromSchemaObject";
       final String genericRecordsfromSchemaString = "GenericRecordsFromSchemaString";
+      final String generatedClassWithoutSchema = "GeneratedClassWithoutSchema";
+      final String genericRecordsWithoutSchema = "GenericRecordsWithoutSchema";
 
       return
           ImmutableList.<Object[]>builder()
@@ -303,13 +305,13 @@ public class AvroIOTransformTest {
                   },
                   new Object[] {
                       AvroIO.write(),
-                      generatedClass,
+                      generatedClassWithoutSchema,
                       AvroIOTransformTest.generateAvroObjects(),
                       false
                   },
                   new Object[] {
                       AvroIO.writeGenericRecords(),
-                      genericRecordsfromSchema,
+                      genericRecordsWithoutSchema,
                       AvroIOTransformTest.generateAvroGenericRecords(),
                       true
                   })

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTransformTest.java
@@ -33,6 +33,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DatumWriter;
@@ -102,27 +103,27 @@ public class AvroIOTransformTest {
     return new AvroGeneratedUser[] { user1, user2, user3 };
   }
 
+  private static GenericRecord[] generateAvroGenericRecords() {
+    final GenericRecord user1 = new GenericData.Record(SCHEMA);
+    user1.put("name", "Bob");
+    user1.put("favorite_number", 256);
+
+    final GenericRecord user2 = new GenericData.Record(SCHEMA);
+    user2.put("name", "Alice");
+    user2.put("favorite_number", 128);
+
+    final GenericRecord user3 = new GenericData.Record(SCHEMA);
+    user3.put("name", "Ted");
+    user3.put("favorite_color", "white");
+
+    return new GenericRecord[] { user1, user2, user3 };
+  }
+
   /**
    * Tests for AvroIO Read transforms, using classes generated from {@code user.avsc}.
    */
   @RunWith(Parameterized.class)
   public static class AvroIOReadTransformTest extends AvroIOTransformTest {
-
-    private static GenericRecord[] generateAvroGenericRecords() {
-      final GenericRecord user1 = new GenericData.Record(SCHEMA);
-      user1.put("name", "Bob");
-      user1.put("favorite_number", 256);
-
-      final GenericRecord user2 = new GenericData.Record(SCHEMA);
-      user2.put("name", "Alice");
-      user2.put("favorite_number", 128);
-
-      final GenericRecord user3 = new GenericData.Record(SCHEMA);
-      user3.put("name", "Ted");
-      user3.put("favorite_color", "white");
-
-      return new GenericRecord[] { user1, user2, user3 };
-    }
 
     private void generateAvroFile(final AvroGeneratedUser[] elements,
                                   final File avroFile) throws IOException {
@@ -247,41 +248,59 @@ public class AvroIOTransformTest {
 
     private static final String WRITE_TRANSFORM_NAME = "AvroIO.Write";
 
-    private List<AvroGeneratedUser> readAvroFile(final File avroFile) throws IOException {
-      final DatumReader<AvroGeneratedUser> userDatumReader =
-          new SpecificDatumReader<>(AvroGeneratedUser.class);
-      final List<AvroGeneratedUser> users = new ArrayList<>();
-      try (DataFileReader<AvroGeneratedUser> dataFileReader =
-          new DataFileReader<>(avroFile, userDatumReader)) {
-        while (dataFileReader.hasNext()) {
-          users.add(dataFileReader.next());
+    private <T> List<T> readAvroFile(final File avroFile, boolean generic) throws IOException {
+      if (!generic) {
+        final DatumReader<AvroGeneratedUser> datumReader = new SpecificDatumReader<>(
+            AvroGeneratedUser.class);
+        final List<AvroGeneratedUser> output = new ArrayList<>();
+        try (DataFileReader<AvroGeneratedUser> dataFileReader = new DataFileReader<>(avroFile,
+            datumReader)) {
+          while (dataFileReader.hasNext()) {
+            output.add(dataFileReader.next());
+          }
         }
+        return (List<T>) output;
+      } else {
+        final DatumReader<GenericRecord> datumReader = new GenericDatumReader<>(SCHEMA);
+        final List<GenericRecord> genericRecords = new ArrayList<>();
+        try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(avroFile,
+            datumReader)) {
+          while (dataFileReader.hasNext()) {
+            genericRecords.add(dataFileReader.next());
+          }
+        }
+        return (List<T>) genericRecords;
       }
-      return users;
     }
 
     @Parameterized.Parameters(name = "{0}_with_{1}")
     public static Iterable<Object[]> data() throws IOException {
 
       final String generatedClass = "GeneratedClass";
-      final String fromSchema = "SchemaObject";
-      final String fromSchemaString = "SchemaString";
+      final String genericRecordsfromSchema = "GenericRecordsFromSchemaObject";
+      final String genericRecordsfromSchemaString = "GenericRecordsFromSchemaString";
 
       return
           ImmutableList.<Object[]>builder()
               .add(
                   new Object[] {
                       AvroIO.write(AvroGeneratedUser.class),
-                      generatedClass
+                      generatedClass,
+                      AvroIOTransformTest.generateAvroObjects(),
+                      false
                   },
                   new Object[] {
                       AvroIO.writeGenericRecords(SCHEMA),
-                      fromSchema
+                      genericRecordsfromSchema,
+                      AvroIOTransformTest.generateAvroGenericRecords(),
+                      true
                   },
 
                   new Object[] {
                       AvroIO.writeGenericRecords(SCHEMA_STRING),
-                      fromSchemaString
+                      genericRecordsfromSchemaString,
+                      AvroIOTransformTest.generateAvroGenericRecords(),
+                      true
                   })
               .build();
     }
@@ -293,29 +312,33 @@ public class AvroIOTransformTest {
     @Parameterized.Parameter(1)
     public String testAlias;
 
-    private <T> void runTestWrite(final AvroIO.Write<T> writeBuilder)
-        throws Exception {
+    @Parameterized.Parameter(2)
+    public Object[] inputData;
 
+    @Parameterized.Parameter(3)
+    public Boolean generic;
+
+    private <T> void runTestWrite(final AvroIO.Write<T> writeBuilder, T[] inputData,
+        boolean generic) throws Exception {
       final File avroFile = tmpFolder.newFile("file.avro");
-      final AvroGeneratedUser[] users = generateAvroObjects();
       final AvroIO.Write<T> write = writeBuilder.to(avroFile.getPath());
 
       @SuppressWarnings("unchecked") final
       PCollection<T> input =
-          pipeline.apply(Create.of(Arrays.asList((T[]) users))
+          pipeline.apply(Create.of(Arrays.asList(inputData))
                                .withCoder((Coder<T>) AvroCoder.of(AvroGeneratedUser.class)));
       input.apply(write.withoutSharding());
 
       pipeline.run();
 
       assertEquals(WRITE_TRANSFORM_NAME, write.getName());
-      assertThat(readAvroFile(avroFile), containsInAnyOrder(users));
+      assertThat(readAvroFile(avroFile, generic), containsInAnyOrder((Object[]) inputData));
     }
 
     @Test
     @Category(NeedsRunner.class)
     public void testWrite() throws Exception {
-      runTestWrite(writeTransform);
+      runTestWrite(writeTransform, inputData, generic);
     }
 
     // TODO: for Write only, test withSuffix, withNumShards,


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This PR adds the ability to use `AvroIO.write()` and related methods without specifying a schema. 
The schema is determined at the first call of `AvroSink.write()`: the `DataFileWriter` is lazy initialized (at first write) once we have the value to get the schema from.  
This PR also makes the schema optional in `ConstantAvroDestination` and depreciate write methods that take schema as parameter. Tell me if I'm missing something that prevents deprecation of these methods.

To use `AvoIO.write()` with no schema, all the elements of the input PCollection must have the same schema, but it is the same with current AvroIO.write(schema) implementation because this schema instance is passed to the `TypedWrite` then to the `ConstantAvroDestination` that is used in `AvroSink`. Please tell me if I'm missing something here.

My only concern is with empty bundles, `AvroSink.write()` will not be called resulting in the `DataFileWriter` not being initialized.  

Please merge the PR bellow before this one because it is used as a base for the tests
https://github.com/apache/beam/pull/3948

R: @jkff 
R: @reuvenlax 
CC: @lukecwik 
