### PR TITLE
[BEAM-3027] Correctly set output type on SourceId-stripper

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -190,7 +190,7 @@ class FlinkStreamingTransformTranslators {
               new ValueWithRecordIdKeySelector<T>())
               .transform("debuping", outputTypeInfo, new DedupingOperator<T>());
         } else {
-          source = nonDedupSource.flatMap(new StripIdsMap<T>());
+          source = nonDedupSource.flatMap(new StripIdsMap<T>()).returns(outputTypeInfo);
         }
       } catch (Exception e) {
         throw new RuntimeException(


### PR DESCRIPTION
R: @peihe or @JingsongLi or @mxm 