### PR TITLE
Fixes TextIO and AvroIO tests of watchForNewFiles

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
@@ -60,7 +60,6 @@ import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
@@ -74,9 +73,14 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesSplittableParDo;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ToString;
 import org.apache.beam.sdk.transforms.Watch;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.DisplayDataEvaluator;
+import org.apache.beam.sdk.transforms.windowing.AfterPane;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
@@ -827,50 +831,30 @@ public class TextIOReadTest {
     public void testReadWatchForNewFiles() throws IOException, InterruptedException {
       final Path basePath = tempFolder.getRoot().toPath().resolve("readWatch");
       basePath.toFile().mkdir();
+
+      p.apply(GenerateSequence.from(0).to(10).withRate(1, Duration.millis(100)))
+          .apply(
+              Window.<Long>into(FixedWindows.of(Duration.millis(150)))
+                  .withAllowedLateness(Duration.ZERO)
+                  .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+                  .discardingFiredPanes())
+          .apply(ToString.elements())
+          .apply(
+              TextIO.write()
+                  .to(basePath.resolve("data").toString())
+                  .withNumShards(1)
+                  .withWindowedWrites());
+
       PCollection<String> lines =
           p.apply(
               TextIO.read()
                   .from(basePath.resolve("*").toString())
-                  // Make sure that compression type propagates into readAll()
-                  .withCompression(ZIP)
                   .watchForNewFiles(
                       Duration.millis(100),
                       Watch.Growth.<String>afterTimeSinceNewOutput(Duration.standardSeconds(3))));
 
-      Thread writer =
-        new Thread() {
-          @Override
-          public void run() {
-            try {
-              Thread.sleep(1000);
-              writeToFile(
-                Arrays.asList("a.1", "a.2"),
-                tempFolder,
-                basePath.resolve("fileA").toString(),
-                ZIP);
-              Thread.sleep(300);
-              writeToFile(
-                Arrays.asList("b.1", "b.2"),
-                tempFolder,
-                basePath.resolve("fileB").toString(),
-                ZIP);
-              Thread.sleep(300);
-              writeToFile(
-                Arrays.asList("c.1", "c.2"),
-                tempFolder,
-                basePath.resolve("fileC").toString(),
-                ZIP);
-            } catch (IOException | InterruptedException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        };
-      writer.start();
-
-      PAssert.that(lines).containsInAnyOrder("a.1", "a.2", "b.1", "b.2", "c.1", "c.2");
+      PAssert.that(lines).containsInAnyOrder("0", "1", "2", "3", "4", "5", "6", "7", "8", "9");
       p.run();
-
-      writer.join();
     }
   }
 }


### PR DESCRIPTION
* AvroIO: Need to specify a trigger to make sure that files are really generated continuously and testing of watchForNewFiles is non-vacuous.

* TextIO: files were generated by manual code, and sometimes writing of a file could race with TextIO reading it, and it might see the same file with two different sizes, and count it as two different files (two Metadata objects for the same filename with different sizes are not equal) and read the file twice.

It makes sense to address that separately: e.g. in the Watch transform allow specifying a key extractor - but it's outside the scope of this PR and tracked in https://issues.apache.org/jira/browse/BEAM-3030.

R: @reuvenlax 