### PR TITLE
[BEAM-3028] Fixes a bug in DatastoreIO query splitting.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -807,7 +807,7 @@ public class DatastoreV1 {
 
         // assign unique keys to query splits.
         for (Query subquery : querySplits) {
-          c.output(query);
+          c.output(subquery);
         }
       }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
@@ -623,30 +623,15 @@ public class DatastoreV1Test {
     List<Query> queries = doFnTester.processBundle(QUERY);
 
     assertEquals(queries.size(), numSplits);
-    verify(mockQuerySplitter, times(1)).getSplits(
-        eq(QUERY), any(PartitionId.class), eq(numSplits), any(Datastore.class));
-    verifyZeroInteractions(mockDatastore);
-  }
 
-  /**
-   * Tests {@link SplitQueryFn} to make sure that sub-queries are different from the original query
-   * when there is more than one split.
-   */
-  @Test
-  public void testSplitsNotEqualToOriginal() throws Exception {
-    int numSplits = 5;
-    when(mockQuerySplitter.getSplits(
-            eq(QUERY), any(PartitionId.class), eq(numSplits), any(Datastore.class)))
-            .thenReturn(splitQuery(QUERY, numSplits));
-
-    SplitQueryFn splitQueryFn = new SplitQueryFn(V_1_OPTIONS, numSplits, mockDatastoreFactory);
-    DoFnTester<Query, Query> doFnTester = DoFnTester.of(splitQueryFn);
-    doFnTester.setCloningBehavior(CloningBehavior.DO_NOT_CLONE);
-    List<Query> queries = doFnTester.processBundle(QUERY);
-
+    // Confirms that sub-queries are not equal to original when there is more than one split.
     for (Query subQuery : queries) {
       assertNotEquals(subQuery, QUERY);
     }
+
+    verify(mockQuerySplitter, times(1)).getSplits(
+        eq(QUERY), any(PartitionId.class), eq(numSplits), any(Datastore.class));
+    verifyZeroInteractions(mockDatastore);
   }
 
   /**


### PR DESCRIPTION
We were returning original query instead of the sub-queries resulting in data duplication when reading.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
