### PR TITLE
Extend nightly build timeout to 4 hours

### DIFF
--- a/.test-infra/jenkins/job_beam_Release_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_beam_Release_NightlySnapshot.groovy
@@ -27,8 +27,12 @@ mavenJob('beam_Release_NightlySnapshot') {
   // Execute concurrent builds if necessary.
   concurrentBuild()
 
-  // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(delegate)
+  // Set common parameters. Huge timeout because we really do need to
+  // run all the ITs and release the artifacts.
+  common_job_properties.setTopLevelMainJobProperties(
+      delegate,
+      'master',
+      240)
 
   // Set maven paramaters.
   common_job_properties.setMavenConfig(delegate)
@@ -41,5 +45,16 @@ mavenJob('beam_Release_NightlySnapshot') {
       'dev@beam.apache.org')
 
   // Maven goals for this job.
-  goals('-B -e clean deploy -P release,dataflow-runner -DskipITs=false -DintegrationTestPipelineOptions=\'[ "--project=apache-beam-testing", "--tempRoot=gs://temp-storage-for-end-to-end-tests", "--runner=TestDataflowRunner" ]\'')
+  goals('''\
+      clean deploy
+      --batch-mode \
+      --errors \
+      -P release,dataflow-runner \
+      -D skipITs=false \
+      -D integrationTestPipelineOptions=\'[ \
+        "--project=apache-beam-testing", \
+        "--tempRoot=gs://temp-storage-for-end-to-end-tests", \
+        "--runner=TestDataflowRunner" \
+      ]\'\
+  ''')
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

The last successful nightly build was Sept 17, and it took 89 minutes. Since then, we have had test failures but we also know that the build time has increased to exceed the 100 minute timeout. For the nightly build, we should have very liberal timeouts since it builds everything and does additional work. And anyhow if it takes a long time to push a working snapshot, that is OK.