### PR TITLE
[BEAM-3037] Relocate sdks.common.v1 and portability.v1 in Java direct runner

### DIFF
--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -88,6 +88,20 @@
                     </shadedPattern>
                   </relocation>
                   <relocation>
+                    <!-- portability protos currently contain a typo, to be fixed later -->
+                    <pattern>org.apache.beam.sdks.common</pattern>
+                    <shadedPattern>
+                      org.apache.beam.runners.direct.repackaged.sdks.common
+                    </shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <!-- portability protos also invent this namespace -->
+                    <pattern>org.apache.beam.portability</pattern>
+                    <shadedPattern>
+                      org.apache.beam.runners.direct.repackaged.portability
+                    </shadedPattern>
+                  </relocation>
+                  <relocation>
                     <pattern>com.google.common</pattern>
                     <excludes>
                       <!-- com.google.common is too generic, need to exclude guava-testlib -->


### PR DESCRIPTION
Currently these two namespaces are mistakenly left as-is, even though they link
to other relocated proto libraries that make them incompatible when used
outside the direct runner.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

R: @tgroh 