### PR TITLE
Only fail nightly release at end, for more detailed signal

### DIFF
--- a/.test-infra/jenkins/job_beam_PostCommit_Java_MavenInstall.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_MavenInstall.groovy
@@ -51,6 +51,7 @@ mavenJob('beam_PostCommit_Java_MavenInstall') {
       --also-make-dependents \
       --batch-mode \
       --errors \
+      --fail-at-end \
       -P release,dataflow-runner \
       -DrepoToken=$COVERALLS_REPO_TOKEN \
       -DskipITs=false \

--- a/.test-infra/jenkins/job_beam_Release_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_beam_Release_NightlySnapshot.groovy
@@ -49,6 +49,7 @@ mavenJob('beam_Release_NightlySnapshot') {
       clean deploy \
       --batch-mode \
       --errors \
+      --fail-at-end \
       -P release,dataflow-runner \
       -D skipITs=false \
       -D integrationTestPipelineOptions=\'[ \


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

R: @aviemzur (since you mentioned how broken things are, sending things to you)

I think the nightly build - misnamed, since it isn't night for everyone - should gather all the failures. It hit a flake in some IO and then we lost any other signal.