### PR TITLE
[BEAM-2728] Extension for sketch-based statistics : HyperLogLog

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,12 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
+        <artifactId>beam-sdks-java-extensions-sketching</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-java-extensions-sorter</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/sdks/java/extensions/pom.xml
+++ b/sdks/java/extensions/pom.xml
@@ -36,6 +36,7 @@
     <module>jackson</module>
     <module>join-library</module>
     <module>protobuf</module>
+    <module>sketching</module>
     <module>sorter</module>
     <module>sql</module>
   </modules>

--- a/sdks/java/extensions/sketching/pom.xml
+++ b/sdks/java/extensions/sketching/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-extensions-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>beam-sdks-java-extensions-sketching</artifactId>
+  <name>Apache Beam :: SDKs :: Java :: Extensions :: Sketching</name>
+
+  <properties>
+    <streamlib.version>2.9.5</streamlib.version>
+    <t-digest.version>3.2</t-digest.version>
+    <commons-math3.version>3.2</commons-math3.version>
+    <spark-sketch.version>2.2.0</spark-sketch.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.clearspring.analytics</groupId>
+      <artifactId>stream</artifactId>
+      <version>${streamlib.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305 -->
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
+
+    <!-- test dependencies -->
+    <!-- https://mvnrepository.com/artifact/org.apache.avro/avro -->
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <version>1.8.2</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+      <version>${commons-math3.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/sdks/java/extensions/sketching/pom.xml
+++ b/sdks/java/extensions/sketching/pom.xml
@@ -64,13 +64,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305 -->
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-
     <!-- test dependencies -->
     <!-- https://mvnrepository.com/artifact/org.apache.avro/avro -->
     <dependency>

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
@@ -1,0 +1,533 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sketching;
+
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.MoreObjects;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.annotation.Nullable;
+
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Combine.CombineFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * {@link PTransform}s for computing the approximate number of distinct elements in a stream.
+ *
+ * <p>This class relies on the HyperLogLog algorithm, and more precisely HyperLogLog+,
+ * the improved version of Google.
+ *
+ * <p>The {@link CombineFn} is also exposed directly so it can be used as a state cell in a
+ * stateful {@link org.apache.beam.sdk.transforms.ParDo}. See {@link ApproximateDistinctFn}.
+ *
+ * <p>Three parameters can be tuned according to the processing context :
+ * <ul>
+ *    <li> Input Coder : The coder of the objects to combine.
+ *    <li> Precision : Controls the accuracy of the estimation. In general one can expect a
+ *    relative error of about {@code 1.1 / sqrt(2^p)}.
+ *    <li> Sparse Precision : Used to create a sparse representation in order to optimize memory
+ *    and improve accuracy at small cardinalities ({@code < 12000}).
+ * </ul>
+ *
+ * <h2>Using the Transforms</h2>
+ *
+ * <p>By default the Input Coder is inferred at runtime. One should specify a coder only if
+ * custom type is used.
+ * <br>By default the precision is set to {@code 12} for a relative error of around {@code 2%}.
+ * <br>By default the sparse representation is not used. One should use it if the number of
+ * distinct elements in the stream may be less than {@code 12000}.
+ *
+ * <h4>Example 1 : globally default use</h4>
+ * <pre>{@code
+ * PCollection<Integer> input = ...;
+ * PCollection<HyperLogLogPlus> hllSketch = input.apply(ApproximateDistinct.<Integer>globally());
+ * }</pre>
+ *
+ * <h4>Example 2 : per key default use</h4>
+ * <pre>{@code
+ * PCollection<Integer, String> input = ...;
+ * PCollection<Integer, HyperLogLogPlus> hllSketches = input.apply(ApproximateDistinct
+ *                .<Integer, String>perKey());
+ * }</pre>
+ *
+ * <h4>Example 3 : tune precision and use sparse representation</h4>
+ * <pre>{@code
+ * int precision = 15;
+ * int sparsePrecision = 25;
+ * PCollection<Double> input = ...;
+ * PCollection<HyperLogLogPlus> hllSketch = input.apply(ApproximateDistinct
+ *                .<Double>globally()
+ *                .withPrecision(precision)
+ *                .withSparsePrecision(sparsePrecision));
+ * }</pre>
+ *
+ * <h4>Example 4 : use a custom object and tune precision</h4>
+ * <pre>{@code
+ * int precision = 18;
+ * PCollection<MyClass> input = ...;
+ * PCollection<HyperLogLogPlus> hllSketch = input.apply(ApproximateDistinct.<MyClass>globally()
+ *                  .withInputCoder(MyClassCoder.of())
+ *                  .withPrecision(precision));
+ * }</pre>
+ *
+ * <p>The tuning works exactly the same with {@link #perKey()}.
+ *
+ * <h2>Using the CombineFn</h2>
+ *
+ * <p>See examples at {@link ApproximateDistinctFn}
+ *
+ * <h2>References</h2>
+ *
+ * <p>The implementation comes from Addthis' Stream-lib library :
+ * <a>https://github.com/addthis/stream-lib</a>
+ *
+ * <br>The original paper of the HyperLogLog is available here :
+ * <a>http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf</a>
+ *
+ * <br>A paper from the same authors to have a clearer view of the algorithm is available here :
+ * <a>http://cscubs.cs.uni-bonn.de/2016/proceedings/paper-03.pdf</a>
+ *
+ * <br>Google's HyperLogLog+ version is detailed in this paper :
+ * <a>https://research.google.com/pubs/pub40671.html</a>
+ */
+public final class ApproximateDistinct {
+
+  /**
+   * The {@link PTransform} takes an input {@link PCollection} of objects and returns a
+   * {@link PCollection} whose contents is a sketch that can be queried in order to retrieve
+   * the approximate number of distinct elements in the input {@link PCollection}.
+   *
+   * @param <InputT>    the type of the elements in the input {@link PCollection}
+   */
+  public static <InputT> GloballyDistinct<InputT> globally() {
+    return GloballyDistinct.<InputT>builder()
+            .build();
+  }
+
+  /**
+   * A {@link PTransform} that takes an input {@code PCollection<KV<K, V>}
+   * and returns a {@code PCollection<KV<K, HyperLogLogPlus>>} that contains an
+   * output element mapping each distinct key in the input {@link PCollection}
+   * to a structure wrapping a {@link HyperLogLogPlus}. It can be queried in
+   * order to retrieve the approximate number of distinct values associated with
+   * each key in the input {@link PCollection}.
+   *
+   * @param <K>         type of the keys mapping the elements
+   * @param <V>         type of the values being combined per key
+   */
+  public static <K, V> PerKeyDistinct<K, V> perKey() {
+    return PerKeyDistinct.<K, V>builder()
+            .build();
+  }
+
+  /**
+   * Implementation of {@link #globally()}.
+   *
+   * @param <InputT>    the type of the elements in the input {@link PCollection}
+   */
+  @AutoValue
+  public abstract static class GloballyDistinct<InputT>
+          extends PTransform<PCollection<InputT>, PCollection<HyperLogLogPlus>> {
+
+    @Nullable abstract Coder<InputT> inputCoder();
+    abstract int precision();
+    abstract int sparsePrecision();
+    abstract Builder<InputT> toBuilder();
+
+    static <InputT> Builder<InputT> builder() {
+      return new AutoValue_ApproximateDistinct_GloballyDistinct.Builder<InputT>()
+              .setInputCoder(null)
+              .setPrecision(12)
+              .setSparsePrecision(0);
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<InputT> {
+      abstract Builder<InputT> setInputCoder(Coder<InputT> coder);
+      abstract Builder<InputT> setPrecision(int p);
+      abstract Builder<InputT> setSparsePrecision(int sp);
+      abstract GloballyDistinct<InputT> build();
+    }
+
+
+    public GloballyDistinct<InputT> withInputCoder(Coder<InputT> coder) {
+      return toBuilder().setInputCoder(coder).build();
+    }
+
+    public GloballyDistinct<InputT> withPrecision(int p) {
+      return toBuilder().setPrecision(p).build();
+    }
+
+    public GloballyDistinct<InputT> withSparsePrecision(int sp) {
+      return toBuilder().setSparsePrecision(sp).build();
+    }
+
+    @Override
+    public PCollection<HyperLogLogPlus> expand(PCollection<InputT> input) {
+      return input.apply(Combine.globally(ApproximateDistinctFn
+              .<InputT>create(MoreObjects.firstNonNull(this.inputCoder(), input.getCoder()))
+              .withPrecision(this.precision())
+              .withSparseRepresentation(this.sparsePrecision())));
+    }
+  }
+
+  /**
+   * Implementation of {@link #perKey()}.
+   *
+   * @param <K>       type of the keys mapping the elements
+   * @param <V>       type of the values being combined per key
+   */
+  @AutoValue
+  public abstract static class PerKeyDistinct<K, V>
+          extends PTransform<PCollection<KV<K, V>>, PCollection<KV<K, HyperLogLogPlus>>> {
+
+    @Nullable abstract Coder<V> inputCoder();
+    abstract int precision();
+    abstract int sparsePrecision();
+    abstract Builder<K, V> toBuilder();
+
+    static <K, V> Builder<K, V> builder() {
+      return new AutoValue_ApproximateDistinct_PerKeyDistinct.Builder<K, V>()
+              .setInputCoder(null)
+              .setPrecision(12)
+              .setSparsePrecision(0);
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<K, V> {
+      abstract Builder<K, V> setInputCoder(Coder<V> coder);
+      abstract Builder<K, V> setPrecision(int p);
+      abstract Builder<K, V> setSparsePrecision(int sp);
+      abstract PerKeyDistinct<K, V> build();
+    }
+
+    public PerKeyDistinct<K, V> withInputCoder(Coder<V> coder) {
+      return toBuilder().setInputCoder(coder).build();
+    }
+
+    public PerKeyDistinct<K, V> withPrecision(int p) {
+      return toBuilder().setPrecision(p).build();
+    }
+
+    public PerKeyDistinct<K, V> withSparsePrecision(int sp) {
+      return toBuilder().setSparsePrecision(sp).build();
+    }
+
+    @Override
+    public PCollection<KV<K, HyperLogLogPlus>> expand(PCollection<KV<K, V>> input) {
+      KvCoder<K, V> inputCoder = (KvCoder<K, V>) input.getCoder();
+      return input.apply(Combine.<K, V, HyperLogLogPlus>perKey(ApproximateDistinctFn
+              .<V>create(MoreObjects.firstNonNull(this.inputCoder(), inputCoder.getValueCoder()))
+              .withPrecision(this.precision())
+              .withSparseRepresentation(this.sparsePrecision())));
+    }
+  }
+
+  /**
+   * A {@link CombineFn} that computes the stream into a {@link HyperLogLogPlus}
+   * sketch. Can be used as a state cell using stateful transforms such as
+   * {@link org.apache.beam.sdk.transforms.ParDo}s.
+   *
+   * <p>For more information about the parameters, see {@link ApproximateDistinct}.
+   *
+   * <h2>Examples using the {@link CombineFn}</h2>
+   *
+   * <p>By default, one must always specify a coder, using the {@link #create(Coder)} method.
+   * <br>By default, the precision is set to {@code 12} for a relative error of around {@code 2%}.
+   * <br>By default, the sparse representation is not used. One should use it if the cardinality
+   * may be less than {@code 12000}.
+   *
+   * <h4>Example 1 : default use</h4>
+   * <pre>{@code
+   * PCollection<Integer> input = ...;
+   * PCollection<HyperLogLogPlus> output = input.apply(Combine.globally(ApproximateDistinctFn
+   *                .<Integer>create(BigEndianIntegerCoder.of()));
+   * }</pre>
+   *
+   * <h4>Example 2 : tune the parameters</h4>
+   *
+   * <p>You can tune the precision and sparse precision by successively calling
+   * {@link #withPrecision(int)} and {@link #withSparseRepresentation(int)} methods.
+   *
+   * <pre>{@code
+   * PCollection<Object> input = ...;
+   * PCollection<HyperLogLogPlus> output = input.apply(Combine.globally(ApproximateDistinctFn
+   *                .<Object>create(new ObjectCoder())
+   *                .withPrecision(18)
+   *                .withSparseRepresentation(24)));
+   * }</pre>
+   *
+   * <h4>Example 3 : using the {@link CombineFn} in a stateful
+   * {@link org.apache.beam.sdk.transforms.ParDo}</h4>
+   *
+   * <p>One may want to use the {@link ApproximateDistinctFn} in a stateful ParDo in order to
+   * make some processing depending on the current cardinality of the stream.
+   * <br>For more information about stateful processing see :
+   * <a>https://beam.apache.org/blog/2017/02/13/stateful-processing.html</a>
+   *
+   * <p>Here is an example of {@link org.apache.beam.sdk.transforms.DoFn} using an
+   * {@link ApproximateDistinctFn} as a {@link org.apache.beam.sdk.state.CombiningState} :
+   *
+   * <pre>{@code
+   * class StatefulCardinality<V> extends DoFn<V>, OutputT>> {
+   *   {@literal @}StateId("hyperloglog")
+   *   private final StateSpec<CombiningState<V, HyperLogLogPlus, HyperLogLogPlus>> indexSpec;
+   *
+   *   public StatefulCardinality(ApproximateDistinctFn<V> fn) {
+   *     indexSpec = StateSpecs.combining(fn);
+   *   }
+   *
+   *   {@literal @}ProcessElement
+   *   public void processElement(
+   *      ProcessContext context,
+   *      {@literal @}StateId("hllSketch")
+   *      CombiningState<V, HyperLogLogPlus, HyperLogLogPlus> hllSketch) {
+   *     long current = MoreObjects.firstNonNull(hllSketch.getAccum().cardinality(), 0L);
+   *     hllSketch.add(context.element());
+   *     context.output(...);
+   *     }
+   * }
+   * }</pre>
+   *
+   * <p>Then the {@link org.apache.beam.sdk.transforms.DoFn} can be called like this :
+   * <pre>{@code
+   * PCollection<Object> input = ...;
+   * ApproximateDistinctFn myFn = ApproximateDistinctFn.create(new ObjectCoder());
+   * PCollection<OutputT> = input.apply(ParDo.of(new StatefulCardinality(myFn)));
+   * }</pre>
+   *
+   * @param <InputT>      the type of the elements in the input {@link PCollection}
+   */
+  public static class ApproximateDistinctFn<InputT>
+      extends CombineFn<InputT, HyperLogLogPlus, HyperLogLogPlus> {
+
+    private final int p;
+
+    private final int sp;
+
+    private final Coder<InputT> inputCoder;
+
+    private ApproximateDistinctFn(int p, int sp, Coder<InputT> coder) {
+      this.p = p;
+      this.sp = sp;
+      inputCoder = coder;
+    }
+
+    /**
+     * Returns an {@link ApproximateDistinctFn} combiner with the given input coder.
+     *
+     * @param <InputT>    the type of the elements in the input {@link PCollection}
+     * @param coder       the coder that encodes the elements' type
+     */
+    public static <InputT> ApproximateDistinctFn<InputT> create(Coder<InputT> coder) {
+      try {
+        coder.verifyDeterministic();
+      } catch (Coder.NonDeterministicException e) {
+        throw new IllegalArgumentException("Coder is not deterministic ! " + e.getMessage(), e);
+      }
+      return new ApproximateDistinctFn<>(12, 0, coder);
+    }
+
+    /**
+     * Returns a new {@link ApproximateDistinctFn} combiner with a new precision p but
+     * the other parameters remain unchanged.
+     *
+     * @param p           the precision value for the normal representation
+     */
+    public ApproximateDistinctFn<InputT> withPrecision(int p) {
+      if (p < 4) {
+        throw new IllegalArgumentException(String.format("Expected : p >= 4. Actual : p = %s", p));
+      }
+      return new ApproximateDistinctFn<>(p, this.sp, this.inputCoder);
+    }
+
+    /**
+     * Returns a new {@link ApproximateDistinctFn} combiner with a sparse representation
+     * of precision sp but the other parameters remain unchanged.
+     *
+     * @param sp          the precision of HyperLogLog+' sparse representation
+     */
+    public ApproximateDistinctFn<InputT> withSparseRepresentation(int sp) {
+      if ((sp < this.p || sp > 32) && (sp != 0)) {
+          throw new IllegalArgumentException(String.format("Expected : p <= sp <= 32."
+                  + "Actual : p = %s, sp = %s", this.p, sp));
+      }
+      return new ApproximateDistinctFn<>(this.p, sp, this.inputCoder);
+    }
+
+    @Override
+    public HyperLogLogPlus createAccumulator() {
+      return new HyperLogLogPlus(p, sp);
+    }
+
+    @Override
+    public HyperLogLogPlus addInput(HyperLogLogPlus acc, InputT record) {
+      acc.offer(getBytes(record));
+      return acc;
+    }
+
+    private byte[] getBytes(InputT input) {
+      ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      try {
+        inputCoder.encode(input, baos);
+        } catch (IOException e) {
+        throw new IllegalStateException(
+                "The input value cannot be encoded : " + e.getMessage(), e);
+        }
+      return baos.toByteArray();
+      }
+
+    /**
+     * Output the whole structure so it can be queried, reused or stored easily.
+     */
+    @Override
+    public HyperLogLogPlus extractOutput(HyperLogLogPlus accumulator) {
+      return accumulator;
+    }
+
+    @Override
+    public HyperLogLogPlus mergeAccumulators(Iterable<HyperLogLogPlus> accumulators) {
+      HyperLogLogPlus mergedAccum = createAccumulator();
+      for (HyperLogLogPlus accum : accumulators) {
+        try {
+          mergedAccum.addAll(accum);
+        } catch (CardinalityMergeException e) {
+          // Should never happen because only HyperLogLogPlus accumulators are instantiated.
+          throw new IllegalStateException("The accumulators cannot be merged : " + e.getMessage());
+        }
+      }
+      return mergedAccum;
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder
+              .add(DisplayData.item("inputCoder", inputCoder.getEncodedTypeDescriptor().toString())
+                      .withLabel("coder"))
+              .add(DisplayData.item("p", p)
+                      .withLabel("precision"))
+              .add(DisplayData.item("sp", sp)
+                      .withLabel("sparse representation precision"));
+      }
+  }
+
+  /**
+   * Coder for {@link HyperLogLogPlus} class.
+   */
+  public static class HyperLogLogPlusCoder extends CustomCoder<HyperLogLogPlus> {
+
+    private static final HyperLogLogPlusCoder INSTANCE = new HyperLogLogPlusCoder();
+
+    private static final ByteArrayCoder BYTE_ARRAY_CODER = ByteArrayCoder.of();
+
+    public static HyperLogLogPlusCoder of() {
+      return INSTANCE;
+    }
+
+    @Override public void encode(HyperLogLogPlus value, OutputStream outStream)
+            throws IOException {
+      if (value == null) {
+        throw new CoderException("cannot encode a null HyperLogLogPlus sketch");
+      }
+      BYTE_ARRAY_CODER.encode(value.getBytes(), outStream);
+    }
+
+    @Override public HyperLogLogPlus decode(InputStream inStream) throws IOException {
+      return HyperLogLogPlus.Builder.build(BYTE_ARRAY_CODER.decode(inStream));
+    }
+
+    @Override public boolean isRegisterByteSizeObserverCheap(HyperLogLogPlus value) {
+      return true;
+    }
+
+    @Override protected long getEncodedElementByteSize(HyperLogLogPlus value) throws IOException {
+      if (value == null) {
+        throw new CoderException("cannot encode a null HyperLogLogPlus sketch");
+      }
+      return value.sizeof();
+    }
+  }
+
+  /**
+   * Computes the precision based on the desired relative error.
+   *
+   * <p>According to the paper, the mean squared error is bounded by the following formula :
+   * <pre>b(m) / sqrt(m)
+   * Where m is the number of buckets used ({@code p = log2(m)})
+   * and {@code b(m) < 1.106} for {@code m > 16 (and p > 4)}.
+   * </pre>
+   *
+   * <br><b>WARNING:</b>
+   * <br>This does not mean relative error in the estimation <b>can't</b> be higher.
+   * <br>This only means that on average the relative error will be
+   * lower than the desired relative error.
+   * <br>Nevertheless, the more elements arrive in the {@link PCollection}, the lower
+   * the variation will be.
+   * <br>Indeed, this is like when you throw a dice millions of time : the relative frequency of
+   * each different result <code>{1,2,3,4,5,6}</code> will get closer to {@code 1/6}.
+   *
+   * @param relativeError   the mean squared error should be in the interval ]0,1]
+   * @return  the minimum precision p in order to have the desired relative error on average.
+   */
+  static long precisionForRelativeError(double relativeError) {
+    return Math.round(Math.ceil(Math.log(
+            Math.pow(1.106, 2.0)
+                    / Math.pow(relativeError, 2.0))
+            / Math.log(2)));
+  }
+
+  /**
+   * @param p              the precision i.e. the number of bits used for indexing the buckets
+   * @return  the Mean squared error of the Estimation of cardinality to expect
+   * for the given value of p.
+   */
+  static double relativeErrorForPrecision(int p) {
+    if (p < 4) {
+      return 1.0;
+    }
+    double betaM;
+    switch(p) {
+      case 4 : betaM = 1.156;
+        break;
+      case 5 : betaM = 1.2;
+        break;
+      case 6 : betaM = 1.104;
+        break;
+      case 7 : betaM = 1.096;
+        break;
+      default : betaM = 1.05;
+        break;
+    }
+    return betaM / Math.sqrt(Math.exp(p * Math.log(2)));
+  }
+}

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/package-info.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities for computing statistical indicators using probabilistic sketches.
+ */
+package org.apache.beam.sdk.extensions.sketching;

--- a/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
+++ b/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
@@ -151,7 +151,6 @@ public class ApproximateDistinctTest implements Serializable {
       PCollection<Long> results = tp
               .apply("Create stream", Create.of(users).withCoder(AvroCoder.of(schema)))
               .apply("Test custom object", ApproximateDistinct.<GenericRecord>globally()
-                      .withInputCoder(AvroCoder.of(schema))
                       .withPrecision(p));
 
       PAssert.that("Verify Accuracy for custom object", results)

--- a/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
+++ b/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
@@ -65,7 +65,7 @@ public class ApproximateDistinctTest implements Serializable {
   public void smallCardinality() {
     final int smallCard = 1000;
     final int p = 6;
-    final Double expectedErr = 1.104 / Math.sqrt(p);
+    final double expectedErr = 1.104 / Math.sqrt(p);
 
     List<Integer> small = new ArrayList<>();
     for (int i = 0; i < smallCard; i++) {
@@ -77,17 +77,8 @@ public class ApproximateDistinctTest implements Serializable {
             .apply("small cardinality", ApproximateDistinct.<Integer>globally().withPrecision(p))
             .apply("retrieve small cardinality", ParDo.of(new RetrieveDistinct()));
 
-    PAssert.thatSingleton("Not Accurate Enough", cardinality)
-            .satisfies(new SerializableFunction<Long, Void>() {
-              @Override
-              public Void apply(Long input) {
-                boolean isAccurate = Math.abs(input - smallCard) / smallCard < expectedErr;
-                Assert.assertTrue("not accurate enough : \nExpected Cardinality : "
-                                + smallCard + "\nComputed Cardinality : " + input,
-                        isAccurate);
-                return null;
-              }
-            });
+    PAssert.that("Not Accurate Enough", cardinality)
+            .satisfies(new VerifyAccuracy(smallCard, expectedErr));
     tp.run();
 
     }
@@ -97,7 +88,7 @@ public class ApproximateDistinctTest implements Serializable {
     final int cardinality = 15000;
     final int p = 15;
     final int sp = 20;
-    final Double expectedErr = 1.04 / Math.sqrt(p);
+    final double expectedErr = 1.04 / Math.sqrt(p);
 
     List<Integer> stream = new ArrayList<>();
     for (int i = 1; i <= cardinality; i++) {
@@ -122,7 +113,7 @@ public class ApproximateDistinctTest implements Serializable {
   public void perKey() {
     final int cardinality = 1000;
     final int p = 15;
-    final Double expectedErr = 1.04 / Math.sqrt(p);
+    final double expectedErr = 1.04 / Math.sqrt(p);
 
     List<Integer> stream = new ArrayList<>();
     for (int i = 1; i <= cardinality; i++) {
@@ -148,7 +139,7 @@ public class ApproximateDistinctTest implements Serializable {
   public void customObject() {
     final int cardinality = 500;
     final int p = 15;
-    final Double expectedErr = 1.04 / Math.sqrt(p);
+    final double expectedErr = 1.04 / Math.sqrt(p);
 
     Schema schema = SchemaBuilder.record("User").fields()
             .requiredString("Pseudo")
@@ -188,8 +179,6 @@ public class ApproximateDistinctTest implements Serializable {
     final ApproximateDistinctFn<Integer> fnWithPrecision =
             ApproximateDistinctFn.create(BigEndianIntegerCoder.of()).withPrecision(23);
 
-    assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("inputCoder",
-            BigEndianIntegerCoder.of().getEncodedTypeDescriptor().toString()));
     assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("p", 23));
     assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("sp", 0));
 

--- a/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
+++ b/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
@@ -22,9 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,9 +33,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.coders.AvroCoder;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
-import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.CustomCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.extensions.sketching.ApproximateDistinct.ApproximateDistinctFn;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.testing.PAssert;

--- a/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
+++ b/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinctTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sketching;
+
+import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.extensions.sketching.ApproximateDistinct.ApproximateDistinctFn;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link ApproximateDistinct}.
+ */
+public class ApproximateDistinctTest implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApproximateDistinctTest.class);
+
+  @Rule
+  public final transient TestPipeline tp = TestPipeline.create();
+
+  @Test
+  public void smallCardinality() {
+    final int smallCard = 1000;
+    final int p = 6;
+    final Double expectedErr = 1.104 / Math.sqrt(p);
+
+    List<Integer> small = new ArrayList<>();
+    for (int i = 0; i < smallCard; i++) {
+      small.add(i);
+    }
+
+    PCollection<Long> cardinality = tp
+            .apply("small stream", Create.<Integer> of(small))
+            .apply("small cardinality", ApproximateDistinct.<Integer>globally().withPrecision(p))
+            .apply("retrieve small cardinality", ParDo.of(new RetrieveDistinct()));
+
+    PAssert.thatSingleton("Not Accurate Enough", cardinality)
+            .satisfies(new SerializableFunction<Long, Void>() {
+              @Override
+              public Void apply(Long input) {
+                boolean isAccurate = Math.abs(input - smallCard) / smallCard < expectedErr;
+                Assert.assertTrue("not accurate enough : \nExpected Cardinality : "
+                                + smallCard + "\nComputed Cardinality : " + input,
+                        isAccurate);
+                return null;
+              }
+            });
+    tp.run();
+
+    }
+
+  @Test
+  public void bigCardinality() {
+    final int cardinality = 15000;
+    final int p = 15;
+    final int sp = 20;
+    final Double expectedErr = 1.04 / Math.sqrt(p);
+
+    List<Integer> stream = new ArrayList<>();
+    for (int i = 1; i <= cardinality; i++) {
+      stream.addAll(Collections.nCopies(2, i));
+    }
+    Collections.shuffle(stream);
+
+    PCollection<Long> res = tp
+            .apply("big stream", Create.<Integer>of(stream))
+            .apply("big cardinality", ApproximateDistinct.<Integer>globally()
+                    .withPrecision(p)
+                    .withSparsePrecision(sp))
+            .apply("retrieve big cardinality", ParDo.of(new RetrieveDistinct()));
+
+    PAssert.that("Verify Accuracy for big cardinality", res)
+            .satisfies(new VerifyAccuracy(cardinality, expectedErr));
+
+    tp.run();
+  }
+
+  @Test
+  public void perKey() {
+    final int cardinality = 1000;
+    final int p = 15;
+    final Double expectedErr = 1.04 / Math.sqrt(p);
+
+    List<Integer> stream = new ArrayList<>();
+    for (int i = 1; i <= cardinality; i++) {
+      stream.addAll(Collections.nCopies(2, i));
+    }
+    Collections.shuffle(stream);
+
+    PCollection<Long> results = tp
+            .apply("per key stream", Create.of(stream))
+            .apply("create keys", WithKeys.<Integer, Integer>of(1))
+            .apply("per key cardinality", ApproximateDistinct
+                    .<Integer, Integer>perKey()
+                    .withPrecision(p))
+            .apply("extract values", Values.<HyperLogLogPlus>create())
+            .apply("retrieve per key cardinality", ParDo.of(new RetrieveDistinct()));
+
+    PAssert.that("Verify Accuracy for cardinality per key", results)
+            .satisfies(new VerifyAccuracy(cardinality, expectedErr));
+    tp.run();
+  }
+
+  @Test
+  public void customObject() {
+    final int cardinality = 500;
+    final int p = 15;
+    final Double expectedErr = 1.04 / Math.sqrt(p);
+
+    Schema schema = SchemaBuilder.record("User").fields()
+            .requiredString("Pseudo")
+            .requiredInt("Age")
+            .endRecord();
+    List<GenericRecord> users = new ArrayList<>();
+    for (int i = 1; i <= cardinality; i++) {
+      GenericData.Record newRecord = new GenericData.Record(schema);
+      newRecord.put("Pseudo", "User" + i);
+      newRecord.put("Age", i);
+      users.add(newRecord);
+    }
+      PCollection<Long> results = tp
+              .apply("Create stream", Create.of(users).withCoder(AvroCoder.of(schema)))
+              .apply("Test custom object", ApproximateDistinct.<GenericRecord>globally()
+                      .withInputCoder(AvroCoder.of(schema))
+                      .withPrecision(p))
+              .apply("Retrieve cardinality of custom object", ParDo.of(new RetrieveDistinct()));
+
+      PAssert.that("Verify Accuracy for custom object", results)
+              .satisfies(new VerifyAccuracy(cardinality, expectedErr));
+      tp.run();
+  }
+
+  @Test
+  public void testCoder() throws Exception {
+    HyperLogLogPlus hllp = new HyperLogLogPlus(12, 18);
+    for (int i = 0; i < 10; i++) {
+      hllp.offer(i);
+    }
+    CoderProperties.<HyperLogLogPlus>coderDecodeEncodeEqual(
+            ApproximateDistinct.HyperLogLogPlusCoder.of(), hllp);
+  }
+
+  @Test
+  public void testDisplayData() {
+    final ApproximateDistinctFn<Integer> fnWithPrecision =
+            ApproximateDistinctFn.create(BigEndianIntegerCoder.of()).withPrecision(23);
+
+    assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("inputCoder",
+            BigEndianIntegerCoder.of().getEncodedTypeDescriptor().toString()));
+    assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("p", 23));
+    assertThat(DisplayData.from(fnWithPrecision), hasDisplayItem("sp", 0));
+
+  }
+
+  static class RetrieveDistinct extends DoFn<HyperLogLogPlus, Long> {
+    @ProcessElement
+    public void apply(ProcessContext c) {
+      Long card = c.element().cardinality();
+      LOG.debug("Number of distinct Elements : " + card);
+      c.output(card);
+    }
+  }
+
+  class VerifyAccuracy implements SerializableFunction<Iterable<Long>, Void> {
+
+    private final int expectedCard;
+
+    private final double expectedError;
+
+    VerifyAccuracy(int expectedCard, double expectedError) {
+      this.expectedCard = expectedCard;
+      this.expectedError = expectedError;
+    }
+
+    @Override
+    public Void apply(Iterable<Long> input) {
+      for (Long estimate : input) {
+        boolean isAccurate = Math.abs(estimate - expectedCard) / expectedCard < expectedError;
+        Assert.assertTrue(
+                "not accurate enough : \nExpected Cardinality : " + expectedCard
+                        + "\nComputed Cardinality : " + estimate,
+                isAccurate);
+      }
+      return null;
+    }
+  }
+}

--- a/sdks/java/javadoc/pom.xml
+++ b/sdks/java/javadoc/pom.xml
@@ -94,6 +94,11 @@
 
     <dependency>
       <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-extensions-sketching</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-extensions-sorter</artifactId>
     </dependency>
 


### PR DESCRIPTION
Extension for computing approximate statistics with the use of probabilistic data structures aka sketches.

For now the extension is composed of one sketch, HyperLogLog+ for computing the approximate number of distinct elements in a stream.
It takes the form of a Combiner with the CombineFn exposed directly so it can be used as a state cell in stateful ParDos.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
