### PR TITLE
[BEAM-1487, BEAM-3016] Address termination correctness issues in BufferingStreamObserver & BeamFnLoggingClient

### DIFF
--- a/sdks/java/harness/pom.xml
+++ b/sdks/java/harness/pom.xml
@@ -112,13 +112,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <!-- Flaky in Precommit. See BEAM-1487 https://issues.apache.org/jira/browse/BEAM-1487 -->
-            <exclude>org.apache.beam.fn.harness.logging.BeamFnLoggingClientTest</exclude>
-            <exclude>org.apache.beam.fn.harness.stream.BufferingStreamObserverTest</exclude>
-          </excludes>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/BufferingStreamObserver.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/BufferingStreamObserver.java
@@ -105,10 +105,10 @@ public final class BufferingStreamObserver<T> implements StreamObserver<T> {
         // We check to see if we were able to successfully insert the poison pill at the front of
         // the queue to cancel the processing thread eagerly or if the processing thread is done.
         try {
-          // The order of these checks is important because short circuiting will cause us to
-          // insert into the queue first and only if it fails do we check that the thread is done.
-          while (!queue.offerFirst((T) POISON_PILL, 60, TimeUnit.SECONDS)
-              || !queueDrainer.isDone()) {
+          // We shouldn't attempt to insert into the queue if the queue drainer thread is done
+          // since the queue may be full and nothing will be emptying it.
+          while (!queueDrainer.isDone()
+              && !queue.offerFirst((T) POISON_PILL, 60, TimeUnit.SECONDS)) {
           }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
@@ -130,10 +130,10 @@ public final class BufferingStreamObserver<T> implements StreamObserver<T> {
         // the queue forcing the remainder of the elements to be processed or if the processing
         // thread is done.
         try {
-          // The order of these checks is important because short circuiting will cause us to
-          // insert into the queue first and only if it fails do we check that the thread is done.
-          while (!queue.offer((T) POISON_PILL, 60, TimeUnit.SECONDS)
-              || !queueDrainer.isDone()) {
+          // We shouldn't attempt to insert into the queue if the queue drainer thread is done
+          // since the queue may be full and nothing will be emptying it.
+          while (!queueDrainer.isDone()
+              && !queue.offerLast((T) POISON_PILL, 60, TimeUnit.SECONDS)) {
           }
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/BufferingStreamObserverTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/BufferingStreamObserverTest.java
@@ -61,7 +61,7 @@ public class BufferingStreamObserverTest {
                     // critical section. Any thread that enters purposefully blocks by sleeping
                     // to increase the contention between threads artificially.
                     assertFalse(isCriticalSectionShared.getAndSet(true));
-                    Uninterruptibles.sleepUninterruptibly(50, TimeUnit.MILLISECONDS);
+                    Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MILLISECONDS);
                     onNextValues.add(t);
                     assertTrue(isCriticalSectionShared.getAndSet(false));
                   }
@@ -134,7 +134,7 @@ public class BufferingStreamObserverTest {
     }
 
     // Have them wait and then flip that we do allow elements and wake up those awaiting
-    Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+    Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
     elementsAllowed.set(true);
     phaser.arrive();
 


### PR DESCRIPTION
The issue with BeamFnLoggingClient is that we can't arriveAndDeregister during termination since
the onReadyHandler may also arrive at the same time which is why we swap to using forced termination.
Also, I added code that would guarantee that log messages produced by the thread which is shutting
down are guaranteed to make it (this was being caught occassionally by the testLogging test).

The BufferingStreamObserver was incorrectly shutting down since it may attempt to enqueue something
into a full queue with a reading thread that has already exitted for some reason so it would loop
forever attempting to insert the poison pill.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
