### PR TITLE
 Add custom gcs temp location support to BigQueryIO.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -364,10 +364,10 @@ class BatchLoads<DestinationT>
                   @ProcessElement
                   public void getTempFilePrefix(ProcessContext c) {
                     String tempLocationRoot;
-                    if (customGcsTempLocation.isAccessible()) {
-                      tempLocationRoot = c.getPipelineOptions().getTempLocation();
-                    } else {
+                    if (customGcsTempLocation != null && customGcsTempLocation.isAccessible()) {
                       tempLocationRoot = customGcsTempLocation.get();
+                    } else {
+                      tempLocationRoot = c.getPipelineOptions().getTempLocation();
                     }
                     String tempLocation =
                         resolveTempLocation(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -364,7 +364,7 @@ class BatchLoads<DestinationT>
                   @ProcessElement
                   public void getTempFilePrefix(ProcessContext c) {
                     String tempLocationRoot;
-                    if (customGcsTempLocation != null && customGcsTempLocation.isAccessible()) {
+                    if (customGcsTempLocation != null) {
                       tempLocationRoot = customGcsTempLocation.get();
                     } else {
                       tempLocationRoot = c.getPipelineOptions().getTempLocation();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteBundlesToFiles.Result;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
@@ -127,11 +128,13 @@ class BatchLoads<DestinationT>
   private long maxFileSize;
   private int numFileShards;
   private Duration triggeringFrequency;
+  private ValueProvider<String> customTempLocation;
 
   BatchLoads(WriteDisposition writeDisposition, CreateDisposition createDisposition,
              boolean singletonTable,
              DynamicDestinations<?, DestinationT> dynamicDestinations,
-             Coder<DestinationT> destinationCoder) {
+             Coder<DestinationT> destinationCoder,
+             ValueProvider<String> customTempLocation) {
     bigQueryServices = new BigQueryServicesImpl();
     this.writeDisposition = writeDisposition;
     this.createDisposition = createDisposition;
@@ -142,6 +145,7 @@ class BatchLoads<DestinationT>
     this.maxFileSize = DEFAULT_MAX_FILE_SIZE;
     this.numFileShards = DEFAULT_NUM_FILE_SHARDS;
     this.triggeringFrequency = null;
+    this.customTempLocation = customTempLocation;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
@@ -359,9 +363,15 @@ class BatchLoads<DestinationT>
                 new DoFn<String, String>() {
                   @ProcessElement
                   public void getTempFilePrefix(ProcessContext c) {
+                    String tempLocationRoot;
+                    if (customTempLocation == null) {
+                      tempLocationRoot = c.getPipelineOptions().getTempLocation();
+                    } else {
+                      tempLocationRoot = customTempLocation.get();
+                    }
                     String tempLocation =
                         resolveTempLocation(
-                            c.getPipelineOptions().getTempLocation(),
+                            tempLocationRoot,
                             "BigQueryWriteTemp",
                             c.element());
                     LOG.info(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -128,13 +128,13 @@ class BatchLoads<DestinationT>
   private long maxFileSize;
   private int numFileShards;
   private Duration triggeringFrequency;
-  private ValueProvider<String> customTempLocation;
+  private ValueProvider<String> customGcsTempLocation;
 
   BatchLoads(WriteDisposition writeDisposition, CreateDisposition createDisposition,
              boolean singletonTable,
              DynamicDestinations<?, DestinationT> dynamicDestinations,
              Coder<DestinationT> destinationCoder,
-             ValueProvider<String> customTempLocation) {
+             ValueProvider<String> customGcsTempLocation) {
     bigQueryServices = new BigQueryServicesImpl();
     this.writeDisposition = writeDisposition;
     this.createDisposition = createDisposition;
@@ -145,7 +145,7 @@ class BatchLoads<DestinationT>
     this.maxFileSize = DEFAULT_MAX_FILE_SIZE;
     this.numFileShards = DEFAULT_NUM_FILE_SHARDS;
     this.triggeringFrequency = null;
-    this.customTempLocation = customTempLocation;
+    this.customGcsTempLocation = customGcsTempLocation;
   }
 
   void setTestServices(BigQueryServices bigQueryServices) {
@@ -364,10 +364,10 @@ class BatchLoads<DestinationT>
                   @ProcessElement
                   public void getTempFilePrefix(ProcessContext c) {
                     String tempLocationRoot;
-                    if (customTempLocation == null) {
+                    if (customGcsTempLocation.isAccessible()) {
                       tempLocationRoot = c.getPipelineOptions().getTempLocation();
                     } else {
-                      tempLocationRoot = customTempLocation.get();
+                      tempLocationRoot = customGcsTempLocation.get();
                     }
                     String tempLocation =
                         resolveTempLocation(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1035,7 +1035,7 @@ public class BigQueryIO {
 
     @Nullable abstract InsertRetryPolicy getFailedInsertRetryPolicy();
 
-    @Nullable abstract ValueProvider<String> getCustomTempLocation();
+    @Nullable abstract ValueProvider<String> getCustomGcsTempLocation();
 
     abstract Builder<T> toBuilder();
 
@@ -1065,7 +1065,7 @@ public class BigQueryIO {
 
       abstract Builder<T> setFailedInsertRetryPolicy(InsertRetryPolicy retryPolicy);
 
-      abstract Builder<T> setCustomTempLocation(ValueProvider<String> customTempLocation);
+      abstract Builder<T> setCustomGcsTempLocation(ValueProvider<String> customGcsTempLocation);
 
       abstract Write<T> build();
     }
@@ -1311,6 +1311,15 @@ public class BigQueryIO {
       return toBuilder().setNumFileShards(numFileShards).build();
     }
 
+    public Write<T> withCustomGcsTempLocation(ValueProvider<String> customGcsTempLocation) {
+      return toBuilder().setCustomGcsTempLocation(customGcsTempLocation).build();
+    }
+
+    public Write<T> withCustomGcsTempLocation(String customGcsTempLocation) {
+      return toBuilder().setCustomGcsTempLocation(
+          StaticValueProvider.of(customGcsTempLocation)).build();
+    }
+
     @VisibleForTesting
     Write<T> withTestServices(BigQueryServices testServices) {
       return toBuilder().setBigQueryServices(testServices).build();
@@ -1324,16 +1333,6 @@ public class BigQueryIO {
     @VisibleForTesting
     Write<T> withMaxFileSize(long maxFileSize) {
       return toBuilder().setMaxFileSize(maxFileSize).build();
-    }
-
-    @VisibleForTesting
-    Write<T> withCustomTempLocation(ValueProvider<String> customTempLocation) {
-      return toBuilder().setCustomTempLocation(customTempLocation).build();
-    }
-
-    @VisibleForTesting
-    Write<T> withCustomTempLocation(String customTempLocation) {
-      return toBuilder().setCustomTempLocation(StaticValueProvider.of(customTempLocation)).build();
     }
 
     @Override
@@ -1498,7 +1497,7 @@ public class BigQueryIO {
             getJsonTableRef() != null,
             dynamicDestinations,
             destinationCoder,
-            getCustomTempLocation());
+            getCustomGcsTempLocation());
         batchLoads.setTestServices(getBigQueryServices());
         if (getMaxFilesPerBundle() != null) {
           batchLoads.setMaxNumWritersPerBundle(getMaxFilesPerBundle());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1035,6 +1035,8 @@ public class BigQueryIO {
 
     @Nullable abstract InsertRetryPolicy getFailedInsertRetryPolicy();
 
+    @Nullable abstract ValueProvider<String> getCustomTempLocation();
+
     abstract Builder<T> toBuilder();
 
     @AutoValue.Builder
@@ -1062,6 +1064,8 @@ public class BigQueryIO {
       abstract Builder<T> setMethod(Method method);
 
       abstract Builder<T> setFailedInsertRetryPolicy(InsertRetryPolicy retryPolicy);
+
+      abstract Builder<T> setCustomTempLocation(ValueProvider<String> customTempLocation);
 
       abstract Write<T> build();
     }
@@ -1322,6 +1326,16 @@ public class BigQueryIO {
       return toBuilder().setMaxFileSize(maxFileSize).build();
     }
 
+    @VisibleForTesting
+    Write<T> withCustomTempLocation(ValueProvider<String> customTempLocation) {
+      return toBuilder().setCustomTempLocation(customTempLocation).build();
+    }
+
+    @VisibleForTesting
+    Write<T> withCustomTempLocation(String customTempLocation) {
+      return toBuilder().setCustomTempLocation(StaticValueProvider.of(customTempLocation)).build();
+    }
+
     @Override
     public void validate(PipelineOptions pipelineOptions) {
       BigQueryOptions options = pipelineOptions.as(BigQueryOptions.class);
@@ -1483,7 +1497,8 @@ public class BigQueryIO {
             getCreateDisposition(),
             getJsonTableRef() != null,
             dynamicDestinations,
-            destinationCoder);
+            destinationCoder,
+            getCustomTempLocation());
         batchLoads.setTestServices(getBigQueryServices());
         if (getMaxFilesPerBundle() != null) {
           batchLoads.setMaxNumWritersPerBundle(getMaxFilesPerBundle());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1311,13 +1311,22 @@ public class BigQueryIO {
       return toBuilder().setNumFileShards(numFileShards).build();
     }
 
+    /**
+     * Provides a custom temp location on GCS for temp files generated in BigQuery writes in
+     * batch jobs.
+     *
+     * <p>A custom GCS temp location is mantatory if BigQueryIO is used in dataflow templates.
+     * Otherwise, the temp location is not configurable at the time launching templates.
+     */
     public Write<T> withCustomGcsTempLocation(ValueProvider<String> customGcsTempLocation) {
       return toBuilder().setCustomGcsTempLocation(customGcsTempLocation).build();
     }
 
+    /**
+     * The same as {@link #withCustomGcsTempLocation}, but takes a String.
+     */
     public Write<T> withCustomGcsTempLocation(String customGcsTempLocation) {
-      return toBuilder().setCustomGcsTempLocation(
-          StaticValueProvider.of(customGcsTempLocation)).build();
+      return withCustomGcsTempLocation(StaticValueProvider.of(customGcsTempLocation));
     }
 
     @VisibleForTesting


### PR DESCRIPTION
BigQueryIO currently writes temp files to PipelineOptions.tempLocation, which is not ValueProvider-wrapped. Which makes the generated dataflow templates cannot be used across projects.
In this PR, a new method withCustomGcsTempLocation() is introduced to solve the problem.
---
