### PR TITLE
[BEAM-3061] Done notification for BigtableIO.write()

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -60,10 +60,11 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -434,7 +435,7 @@ public class BigtableIO {
   @Experimental(Experimental.Kind.SOURCE_SINK)
   @AutoValue
   public abstract static class Write
-      extends PTransform<PCollection<KV<ByteString, Iterable<Mutation>>>, PDone> {
+      extends PTransform<PCollection<KV<ByteString, Iterable<Mutation>>>, PCollection<Void>> {
 
     /** Returns the table being written to. */
     @Nullable
@@ -516,18 +517,17 @@ public class BigtableIO {
     }
 
     @Override
-    public PDone expand(PCollection<KV<ByteString, Iterable<Mutation>>> input) {
+    public PCollection<Void> expand(PCollection<KV<ByteString, Iterable<Mutation>>> input) {
       checkArgument(getBigtableOptions() != null, "withBigtableOptions() is required");
       checkArgument(getTableId() != null && !getTableId().isEmpty(), "withTableId() is required");
 
-      input.apply(ParDo.of(new BigtableWriterFn(getTableId(),
+      return input.apply(ParDo.of(new BigtableWriterFn(getTableId(),
           new SerializableFunction<PipelineOptions, BigtableService>() {
         @Override
         public BigtableService apply(PipelineOptions options) {
           return getBigtableService(options);
         }
       })));
-      return PDone.in(input.getPipeline());
     }
 
     @Override
@@ -630,10 +630,11 @@ public class BigtableIO {
       }
 
       @FinishBundle
-      public void finishBundle() throws Exception {
+      public void finishBundle(FinishBundleContext c) throws Exception {
         bigtableWriter.flush();
         checkForFailures();
         LOG.info("Wrote {} records", recordsWritten);
+        c.output(null, Instant.now(), GlobalWindow.INSTANCE);
       }
 
       @Teardown


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This adds support for "done" notification in `BigtableIO.write()`.  For each bundle that is completely written, a single "Void" is output by the PTransform.  Doing so allows flows to effectively wait for all writes to finish.

This works well for batch flows (and I've been using for a few weeks now in some large ones), but there is some limitation on the streaming side.

For streaming writes, all "done" notifications are output into the global window, rather than the window(s?) that was(were) written in that bundle.  I'm not very familiar with the interactions of bundles, windows, and panes in the streaming API, so I haven't tried to solve this at all, although for this IO specifically it seems doable.