### PR TITLE
[BEAM-3052] Set end-of-window timer in AfterWatermarkStateMachine

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import java.util.NavigableSet;
+import java.util.NoSuchElementException;
 import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.state.TimeDomain;
@@ -71,21 +72,20 @@ public class InMemoryTimerInternals implements TimerInternals {
    */
   @Nullable
   public Instant getNextTimer(TimeDomain domain) {
-    final TimerData data;
-    switch (domain) {
-      case EVENT_TIME:
-        data = watermarkTimers.first();
-        break;
-      case PROCESSING_TIME:
-        data = processingTimers.first();
-        break;
-      case SYNCHRONIZED_PROCESSING_TIME:
-        data = synchronizedProcessingTimers.first();
-        break;
-      default:
-        throw new IllegalArgumentException("Unexpected time domain: " + domain);
+    try {
+      switch (domain) {
+        case EVENT_TIME:
+          return watermarkTimers.first().getTimestamp();
+        case PROCESSING_TIME:
+          return processingTimers.first().getTimestamp();
+        case SYNCHRONIZED_PROCESSING_TIME:
+          return synchronizedProcessingTimers.first().getTimestamp();
+        default:
+          throw new IllegalArgumentException("Unexpected time domain: " + domain);
+      }
+    } catch (NoSuchElementException exc) {
+      return null;
     }
-    return (data == null) ? null : data.getTimestamp();
   }
 
   private NavigableSet<TimerData> timersForDomain(TimeDomain domain) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -100,6 +100,10 @@ public class AfterWatermarkStateMachine {
 
     @Override
     public void onElement(OnElementContext c) throws Exception {
+      if (!endOfWindowReached(c)) {
+        c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
+      }
+
       if (!c.trigger().isMerging()) {
         // If merges can never happen, we just run the unfinished subtrigger
         c.trigger().firstUnfinishedSubTrigger().invokeOnElement(c);
@@ -270,7 +274,9 @@ public class AfterWatermarkStateMachine {
       // We're interested in knowing when the input watermark passes the end of the window.
       // (It is possible this has already happened, in which case the timer will be fired
       // almost immediately).
-      c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
+      if (!endOfWindowReached(c)) {
+        c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
+      }
     }
 
     @Override

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachineTest.java
@@ -17,8 +17,11 @@
  */
 package org.apache.beam.runners.core.triggers;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
@@ -26,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import org.apache.beam.runners.core.triggers.TriggerStateMachine.OnMergeContext;
 import org.apache.beam.runners.core.triggers.TriggerStateMachineTester.SimpleTriggerStateMachineTester;
+import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
@@ -101,6 +105,31 @@ public class AfterWatermarkStateMachineTest {
     assertTrue(tester.shouldFire(window));
     tester.fireIfShouldFire(window);
     assertTrue(tester.isMarkedFinished(window));
+  }
+
+  @Test
+  public void testTimerForEndOfWindow() throws Exception {
+    tester = TriggerStateMachineTester.forTrigger(
+        AfterWatermarkStateMachine.pastEndOfWindow(),
+        FixedWindows.of(Duration.millis(100)));
+
+    assertThat(tester.getNextTimer(TimeDomain.EVENT_TIME), nullValue());
+    injectElements(1);
+    IntervalWindow window = new IntervalWindow(new Instant(0), new Instant(100));
+    assertThat(tester.getNextTimer(TimeDomain.EVENT_TIME), equalTo(window.maxTimestamp()));
+  }
+
+  @Test
+  public void testTimerForEndOfWindowCompound() throws Exception {
+    tester =
+        TriggerStateMachineTester.forTrigger(
+            AfterWatermarkStateMachine.pastEndOfWindow().withEarlyFirings(NeverStateMachine.ever()),
+            FixedWindows.of(Duration.millis(100)));
+
+    assertThat(tester.getNextTimer(TimeDomain.EVENT_TIME), nullValue());
+    injectElements(1);
+    IntervalWindow window = new IntervalWindow(new Instant(0), new Instant(100));
+    assertThat(tester.getNextTimer(TimeDomain.EVENT_TIME), equalTo(window.maxTimestamp()));
   }
 
   @Test

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
@@ -198,6 +198,12 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
     }
   }
 
+  /** Retrieves the next timer for this time domain, if any, for use in assertions. */
+  @Nullable
+  public Instant getNextTimer(TimeDomain domain) {
+    return timerInternals.getNextTimer(domain);
+  }
+
   /**
    * Returns {@code true} if the {@link TriggerStateMachine} under test is finished for the given
    * window.

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
@@ -269,11 +269,6 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
 
         for (W window : assignedWindows) {
           activeWindows.addActiveForTesting(window);
-
-          // Today, triggers assume onTimer firing at the watermark time, whether or not they
-          // explicitly set the timer themselves. So this tester must set it.
-          timerInternals.setTimer(
-              TimerData.of(windowNamespace(window), window.maxTimestamp(), TimeDomain.EVENT_TIME));
         }
 
         windowedValues.add(WindowedValue.of(value, timestamp, assignedWindows, PaneInfo.NO_FIRING));
@@ -357,8 +352,6 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
         executableTrigger.invokeOnMerge(contextFactory.createOnMergeContext(mergeResult,
             new TestTimers(windowNamespace(mergeResult)), executableTrigger,
             getFinishedSet(mergeResult), mergingFinishedSets));
-        timerInternals.setTimer(TimerData.of(
-            windowNamespace(mergeResult), mergeResult.maxTimestamp(), TimeDomain.EVENT_TIME));
       }
     });
   }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

The state machines for the variants of `AfterWatermark.pastEndOfWindow()` were inconsistent in when they set a timer or not. Since this state machine should be decoupled from whatever context it is being run in, it should set a timer for the time it is interested in.

This is deliberately peeled off #3988 since it is simpler and more definitely correct. The other bits in that PR are under further revision.

R: @bjchambers 