### PR TITLE
Do not crash when RawPTransform has null spec

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -179,7 +179,13 @@ public class PTransformTranslation {
     if (transform instanceof RawPTransform) {
       // The raw transform was parsed in the context of other components; this puts it in the
       // context of our current serialization
-      transformBuilder.setSpec(((RawPTransform<?, ?>) transform).migrate(components));
+      FunctionSpec spec = ((RawPTransform<?, ?>) transform).migrate(components);
+
+      // A composite transform is permitted to have a null spec. There are also some pseudo-
+      // primitives not yet supported by the portability framework that have null specs
+      if (spec != null) {
+        transformBuilder.setSpec(spec);
+      }
     } else if (KNOWN_PAYLOAD_TRANSLATORS.containsKey(transform.getClass())) {
       transformBuilder.setSpec(
           KNOWN_PAYLOAD_TRANSLATORS

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformTranslationTest.java
@@ -31,9 +31,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.CountingSource;
 import org.apache.beam.sdk.io.GenerateSequence;
@@ -42,6 +42,7 @@ import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.KV;
@@ -49,6 +50,7 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
@@ -69,17 +71,24 @@ public class PTransformTranslationTest {
     // This pipeline exists for construction, not to run any test.
     // TODO: Leaf node with understood payload - i.e. validate payloads
     ToAndFromProtoSpec readLeaf = ToAndFromProtoSpec.leaf(read(TestPipeline.create()));
+
     ToAndFromProtoSpec readMultipleInAndOut =
         ToAndFromProtoSpec.leaf(multiMultiParDo(TestPipeline.create()));
+
     TestPipeline compositeReadPipeline = TestPipeline.create();
     ToAndFromProtoSpec compositeRead =
         ToAndFromProtoSpec.composite(
             generateSequence(compositeReadPipeline),
             ToAndFromProtoSpec.leaf(read(compositeReadPipeline)));
+
+    ToAndFromProtoSpec rawLeafNullSpec =
+        ToAndFromProtoSpec.leaf(rawPTransformWithNullSpec(TestPipeline.create()));
+
     return ImmutableList.<ToAndFromProtoSpec>builder()
         .add(readLeaf)
         .add(readMultipleInAndOut)
         .add(compositeRead)
+        .add(rawLeafNullSpec)
         // TODO: Composite with multiple children
         // TODO: Composite with a composite child
         .build();
@@ -139,7 +148,7 @@ public class PTransformTranslationTest {
       // Sanity call
       components.getExistingPTransformId(child.getTransform());
     }
-    PTransform convert = PTransformTranslation
+    RunnerApi.PTransform convert = PTransformTranslation
         .toProto(spec.getTransform(), childTransforms, components);
     // Make sure the converted transform is registered. Convert it independently, but if this is a
     // child spec, the child must be in the components.
@@ -164,6 +173,28 @@ public class PTransformTranslationTest {
     PCollection<Long> pcollection = pipeline.apply(transform);
     return AppliedPTransform.<PBegin, PCollection<Long>, Read.Unbounded<Long>>of(
         "ReadTheCount", pipeline.begin().expand(), pcollection.expand(), transform, pipeline);
+  }
+
+  private static AppliedPTransform<?, ?, ?> rawPTransformWithNullSpec(Pipeline pipeline) {
+    PTransformTranslation.RawPTransform<PBegin, PDone> rawPTransform =
+        new PTransformTranslation.RawPTransform<PBegin, PDone>() {
+          @Override
+          public String getUrn() {
+            return "fake/urn";
+          }
+
+          @Nullable
+          @Override
+          public RunnerApi.FunctionSpec getSpec() {
+            return null;
+          }
+        };
+    return AppliedPTransform.<PBegin, PDone, PTransform<PBegin, PDone>>of(
+        "RawPTransformWithNoSpec",
+        pipeline.begin().expand(),
+        PDone.in(pipeline).expand(),
+        rawPTransform,
+        pipeline);
   }
 
   private static AppliedPTransform<?, ?, ?> multiMultiParDo(Pipeline pipeline) {


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

R: @jkff or @tgroh 

Superficial issue: misuse of generated proto code. This is an obviously-correct fix that gets things green in the short term. I've confirmed this fix eliminates the NPE currently happening on `SplittableDoFnTest` in the Dataflow postcommit.

Larger issue: we stage a portable pipeline and the Dataflow job description has (or will have) pointers into that portable pipeline for the runner harness to extract portable payloads. So setting up `ProcessKeyedElements` to have a `null` payload or to be `NotSerializable` is incorrect. Instead, I think it has to be a standardized transform with a portable URN/payload specification. That will be a prerequisite to supporting SDF portably, unless we have a different implementation strategy.