### PR TITLE
[BEAM-3081] Findbugs: NonNull by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,7 @@
     <hamcrest.version>1.3</hamcrest.version>
     <jackson.version>2.8.9</jackson.version>
     <findbugs.version>3.0.1</findbugs.version>
+    <findbugs.annotations.version>1.3.9-1</findbugs.annotations.version>
     <joda.version>2.4</joda.version>
     <junit.version>4.12</junit.version>
     <mockito.version>1.9.5</mockito.version>
@@ -1034,6 +1035,12 @@
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${findbugs.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.stephenc.findbugs</groupId>
+        <artifactId>findbugs-annotations</artifactId>
+        <version>${findbugs.annotations.version}</version>
       </dependency>
 
       <dependency>

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
@@ -174,7 +174,7 @@ public class SideInputHandler implements ReadyCheckingSideInputReader {
     ValueState<Iterable<WindowedValue<?>>> state =
         stateInternals.state(StateNamespaces.window(windowCoder, window), stateTag);
 
-    Iterable<WindowedValue<?>> elements = state.read();
+    @Nullable Iterable<WindowedValue<?>> elements = state.read();
 
     if (elements == null) {
       elements = Collections.emptyList();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
@@ -483,9 +483,9 @@ class WatermarkHold<W extends BoundedWindow> implements Serializable {
       @Override
       public OldAndNewHolds read() {
         // Read both the element and extra holds.
-        Instant elementHold = elementHoldState.read();
-        Instant extraHold = extraHoldState.read();
-        Instant oldHold;
+        @Nullable Instant elementHold = elementHoldState.read();
+        @Nullable Instant extraHold = extraHoldState.read();
+        @Nullable Instant oldHold;
         // Find the minimum, accounting for null.
         if (elementHold == null) {
           oldHold = extraHold;

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachineRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachineRunner.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.core.MergingStateAccessor;
 import org.apache.beam.runners.core.StateAccessor;
 import org.apache.beam.runners.core.StateTag;
@@ -79,7 +80,7 @@ public class TriggerStateMachineRunner<W extends BoundedWindow> {
       return FinishedTriggersBitSet.emptyWithCapacity(rootTrigger.getFirstIndexAfterSubtree());
     }
 
-    BitSet bitSet = state.read();
+    @Nullable BitSet bitSet = state.read();
     return bitSet == null
         ? FinishedTriggersBitSet.emptyWithCapacity(rootTrigger.getFirstIndexAfterSubtree())
             : FinishedTriggersBitSet.fromBitSet(bitSet);

--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -26,13 +26,18 @@
   <!-- The uncallable method error fails on @ProcessElement style methods -->
   <Bug pattern="UMAC_UNCALLABLE_METHOD_OF_ANONYMOUS_CLASS"/>
 
+  <!-- Suppress checking of AutoValue internals -->
+  <Match>
+    <Class name="~.*AutoValue_.*"/>
+  </Match>
+
   <!--
           Suppressed findbugs issues. All new issues should include a comment why they're
           suppressed.
 
           Suppressions should go in this file rather than inline using @SuppressFBWarnings to avoid
           unapproved artifact license.
-        -->
+	-->
   <Match>
     <Class name="org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver"/>
     <Method name="onCompleted"/>

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -227,6 +227,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.stephenc.findbugs</groupId>
+      <artifactId>findbugs-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.io.Read;
@@ -393,9 +394,13 @@ public class Pipeline {
      */
     class Defaults implements PipelineVisitor {
 
-      private Pipeline pipeline;
+      @Nullable private Pipeline pipeline;
 
       protected Pipeline getPipeline() {
+        if (pipeline == null) {
+          throw new IllegalStateException(
+              "Illegal access to pipeline after visitor traversal was completed");
+        }
         return pipeline;
       }
 
@@ -484,7 +489,10 @@ public class Pipeline {
 
   private final TransformHierarchy transforms;
   private Set<String> usedFullNames = new HashSet<>();
-  private CoderRegistry coderRegistry;
+
+  /** Lazily initialized; access via {@link #getCoderRegistry()}. */
+  @Nullable private CoderRegistry coderRegistry;
+
   private final List<String> unstableNames = new ArrayList<>();
   private final PipelineOptions defaultOptions;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/annotations/package-info.java
@@ -18,4 +18,8 @@
 /**
  * Defines annotations used across the SDK.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.annotations;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DefaultCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DefaultCoder.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ import org.slf4j.LoggerFactory;
 @Target(ElementType.TYPE)
 @SuppressWarnings("rawtypes")
 public @interface DefaultCoder {
+  @CheckForNull
   Class<? extends Coder> value();
 
   /**
@@ -86,22 +88,23 @@ public @interface DefaultCoder {
                   clazz.getName()));
         }
 
-        if (defaultAnnotation.value() == null) {
+        Class<? extends Coder> defaultAnnotationValue = defaultAnnotation.value();
+        if (defaultAnnotationValue == null) {
           throw new CannotProvideCoderException(
-              String.format("Class %s has a @DefaultCoder annotation with a null value.",
-                  clazz.getName()));
+              String.format(
+                  "Class %s has a @DefaultCoder annotation with a null value.", clazz.getName()));
         }
 
         LOG.debug("DefaultCoder annotation found for {} with value {}",
-            clazz, defaultAnnotation.value());
+            clazz, defaultAnnotationValue);
 
         Method coderProviderMethod;
         try {
-          coderProviderMethod = defaultAnnotation.value().getMethod("getCoderProvider");
+          coderProviderMethod = defaultAnnotationValue.getMethod("getCoderProvider");
         } catch (NoSuchMethodException e) {
           throw new CannotProvideCoderException(String.format(
               "Unable to find 'public static CoderProvider getCoderProvider()' on %s",
-              defaultAnnotation.value()),
+              defaultAnnotationValue),
               e);
         }
 
@@ -115,7 +118,7 @@ public @interface DefaultCoder {
             | ExceptionInInitializerError e) {
           throw new CannotProvideCoderException(String.format(
               "Unable to invoke 'public static CoderProvider getCoderProvider()' on %s",
-              defaultAnnotation.value()),
+              defaultAnnotationValue),
               e);
         }
         return coderProvider.coderFor(typeDescriptor, componentCoders);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/LengthPrefixCoder.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.util.VarInt;
 
 /**
@@ -126,7 +125,7 @@ public class LengthPrefixCoder<T> extends StructuredCoder<T> {
    * {@inheritDoc}
    */
   @Override
-  public boolean isRegisterByteSizeObserverCheap(@Nullable T value) {
+  public boolean isRegisterByteSizeObserverCheap(T value) {
     return valueCoder.isRegisterByteSizeObserverCheap(value);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -25,6 +25,7 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
@@ -105,7 +106,9 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
   }
 
   private final Class<T> type;
-  private transient TypeDescriptor<T> typeDescriptor;
+
+  /** Access via {@link #getEncodedTypeDescriptor()}. */
+  @Nullable private transient TypeDescriptor<T> typeDescriptor;
 
   protected SerializableCoder(Class<T> type, TypeDescriptor<T> typeDescriptor) {
     this.type = type;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/StructuredCoder.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -46,12 +45,7 @@ public abstract class StructuredCoder<T> extends Coder<T> {
    * <p>The default components will be equal to the value returned by {@link #getCoderArguments()}.
    */
   public List<? extends Coder<?>> getComponents() {
-    List<? extends Coder<?>> coderArguments = getCoderArguments();
-    if (coderArguments == null) {
-      return Collections.emptyList();
-    } else {
-      return coderArguments;
-    }
+    return getCoderArguments();
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/VoidCoder.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.coders;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
@@ -44,6 +45,7 @@ public class VoidCoder extends AtomicCoder<Void> {
   }
 
   @Override
+  @Nullable
   public Void decode(InputStream inStream) {
     // Nothing to read!
     return null;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/package-info.java
@@ -42,4 +42,8 @@
  * types.
  *
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.coders;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/package-info.java
@@ -25,4 +25,8 @@
  * <p>Runners should look at {@link org.apache.beam.sdk.metrics.MetricsContainer} for details on
  * how to support metrics.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.metrics;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/package-info.java
@@ -31,4 +31,8 @@
  * where and how it should run after pipeline construction is complete.
  *
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/TransformHierarchy.java
@@ -309,11 +309,13 @@ public class TransformHierarchy {
    * for initialization and ordered visitation.
    */
   public class Node {
-    private final Node enclosingNode;
+    // null for the root node, otherwise the enclosing node
+    @Nullable private final Node enclosingNode;
+
     // The PTransform for this node, which may be a composite PTransform.
     // The root of a TransformHierarchy is represented as a Node
     // with a null transform field.
-    private final PTransform<?, ?> transform;
+    @Nullable private final PTransform<?, ?> transform;
 
     private final String fullName;
 
@@ -324,21 +326,22 @@ public class TransformHierarchy {
     private final Map<TupleTag<?>, PValue> inputs;
 
     // TODO: track which outputs need to be exported to parent.
-    // Output of the transform, in expanded form.
-    private Map<TupleTag<?>, PValue> outputs;
+    // Output of the transform, in expanded form. Null if not yet set.
+    @Nullable private Map<TupleTag<?>, PValue> outputs;
 
     @VisibleForTesting
     boolean finishedSpecifying = false;
 
     /**
      * Creates the root-level node. The root level node has a null enclosing node, a null transform,
-     * an empty map of inputs, and a name equal to the empty string.
+     * an empty map of inputs, an empty map of outputs, and a name equal to the empty string.
      */
     private Node() {
       this.enclosingNode = null;
       this.transform = null;
       this.fullName = "";
       this.inputs = Collections.emptyMap();
+      this.outputs = Collections.emptyMap();
     }
 
     /**
@@ -469,7 +472,7 @@ public class TransformHierarchy {
 
     /** Returns the transform input, in fully expanded form. */
     public Map<TupleTag<?>, PValue> getInputs() {
-      return inputs == null ? Collections.<TupleTag<?>, PValue>emptyMap() : inputs;
+      return inputs;
     }
 
     /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/package-info.java
@@ -20,4 +20,8 @@
 
  * <p>Internals for use by runners.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.runners;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/BagState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/BagState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.state;
 
+import javax.annotation.Nonnull;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 
@@ -31,6 +32,11 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
  */
 @Experimental(Kind.STATE)
 public interface BagState<T> extends GroupingState<T, Iterable<T>> {
+
+  @Override
+  @Nonnull
+  Iterable<T> read();
+
   @Override
   BagState<T> readLater();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/CombiningState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/CombiningState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.state;
 
+import javax.annotation.Nonnull;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
@@ -34,6 +35,10 @@ import org.apache.beam.sdk.transforms.Combine.CombineFn;
  */
 @Experimental(Kind.STATE)
 public interface CombiningState<InputT, AccumT, OutputT> extends GroupingState<InputT, OutputT> {
+
+  @Override
+  @Nonnull
+  OutputT read();
 
   /**
    * Read the merged accumulator for this state cell. It is implied that reading the state involves

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ReadableState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ReadableState.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.state;
 
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 
@@ -37,10 +38,11 @@ public interface ReadableState<T> {
    * should first call {@link #readLater} for all of them so the reads can potentially be batched
    * (depending on the underlying implementation}.
    *
-   * <p>The returned object should be independent of the underlying state.  Any direct modification
+   * <p>The returned object should be independent of the underlying state. Any direct modification
    * of the returned object should not modify state without going through the appropriate state
    * interface, and modification to the state should not be mirrored in the returned object.
    */
+  @Nullable
   T read();
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateSpecs.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateSpecs.java
@@ -131,7 +131,7 @@ public class StateSpecs {
    * @see #bag(Coder)
    */
   public static <T> StateSpec<BagState<T>> bag() {
-    return bag(null);
+    return new BagStateSpec<>(null);
   }
 
   /**
@@ -151,7 +151,7 @@ public class StateSpecs {
    * @see #set(Coder)
    */
   public static <T> StateSpec<SetState<T>> set() {
-    return set(null);
+    return new SetStateSpec<>(null);
   }
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/package-info.java
@@ -19,4 +19,8 @@
 /**
  * Classes and interfaces for interacting with state.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.state;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SuccessOrFailure.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SuccessOrFailure.java
@@ -31,10 +31,10 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 @DefaultCoder(SerializableCoder.class)
 public final class SuccessOrFailure implements Serializable {
   private static final class SerializableThrowable implements Serializable {
-    private final Throwable throwable;
-    private final StackTraceElement[] stackTrace;
+    @Nullable private final Throwable throwable;
+    @Nullable private final StackTraceElement[] stackTrace;
 
-    private SerializableThrowable(Throwable t) {
+    private SerializableThrowable(@Nullable Throwable t) {
       this.throwable = t;
       this.stackTrace = (t == null) ? null : t.getStackTrace();
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -142,7 +142,8 @@ public class TestPipeline extends Pipeline implements TestRule {
 
   private static class PipelineAbandonedNodeEnforcement extends PipelineRunEnforcement {
 
-    private List<TransformHierarchy.Node> runVisitedNodes;
+    // Null until the pipeline has been run
+    @Nullable private List<TransformHierarchy.Node> runVisitedNodes;
 
     private final Predicate<TransformHierarchy.Node> isPAssertNode =
         new Predicate<TransformHierarchy.Node>() {
@@ -172,6 +173,7 @@ public class TestPipeline extends Pipeline implements TestRule {
 
     private PipelineAbandonedNodeEnforcement(final TestPipeline pipeline) {
       super(pipeline);
+      runVisitedNodes = null;
     }
 
     private List<TransformHierarchy.Node> recordPipelineNodes(final Pipeline pipeline) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowSupplier.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowSupplier.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.Serializable;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -36,7 +37,8 @@ final class WindowSupplier implements Supplier<Collection<BoundedWindow>>, Seria
   private final Coder<? extends BoundedWindow> coder;
   private final Collection<byte[]> encodedWindows;
 
-  private transient Collection<BoundedWindow> windows;
+  /** Access via {@link #get()}.*/
+  @Nullable private transient Collection<BoundedWindow> windows;
 
   public static <W extends BoundedWindow> WindowSupplier of(Coder<W> coder, Iterable<W> windows) {
     ImmutableSet.Builder<byte[]> windowsBuilder = ImmutableSet.builder();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/package-info.java
@@ -19,4 +19,9 @@
  * Defines utilities for unit testing Apache Beam pipelines. The tests for the {@code PTransform}s
  * and examples included in the Apache Beam SDK provide examples of using these utilities.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.testing;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;
+


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

R: @jkff since you mentioned the time findbugs spent, I thought I would try to get more value out of it anyhow.

I have wondered for a while why `@Nullable` annotations didn't take care of themselves, since this is maybe the most important thing findbugs ought to be gaining us. Turns out it is simply turned off by default. It has to be turned on per-package, as far as I can tell. That is just as well, because some packages are in better shape than others.

I addressed some low-hanging fruit to demonstrate, and the changes I made were universally improvements IMO, so that's nice evidence in favor of taking this further.