### PR TITLE
[BEAM-2304] Allow declared state to be accessed as a superclass.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -888,8 +888,8 @@ public class DoFnSignatures {
           id);
 
       paramErrors.checkArgument(
-          stateDecl.stateType().equals(stateType),
-          "reference to %s %s with different type %s",
+          stateDecl.stateType().isSubtypeOf(stateType),
+          "data type of reference to %s %s must be a supertype of %s",
           StateId.class.getSimpleName(),
           id,
           formatType(stateDecl.stateType()));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2545,7 +2545,7 @@ public class ParDoTest implements Serializable {
           @StateId(stateId)
           private final StateSpec<CombiningState<Integer, int[], Integer>> state =
               StateSpecs.combining(Sum.ofIntegers());
-      
+
           @ProcessElement
           public void processElement(ProcessContext c,
               @StateId(stateId) GroupingState<Integer, Integer> state) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2545,6 +2545,7 @@ public class ParDoTest implements Serializable {
           @StateId(stateId)
           private final StateSpec<CombiningState<Integer, int[], Integer>> state =
               StateSpecs.combining(Sum.ofIntegers());
+      
           @ProcessElement
           public void processElement(ProcessContext c,
               @StateId(stateId) GroupingState<Integer, Integer> state) {
@@ -2561,7 +2562,7 @@ public class ParDoTest implements Serializable {
             .apply(Create.of(KV.of(123, 4), KV.of(123, 7), KV.of(123, -3)))
             .apply(ParDo.of(fn));
 
-    // There should only be one moment at which the average is exactly 8
+    // There should only be one moment at which the sum is exactly 8
     PAssert.that(output).containsInAnyOrder("right on");
     pipeline.run();
   }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This is a fix to BEAM-2304: State declared with one class cannot be accessed as a superclass (applies to BagState|CombiningState <: GroupingState).

I changed the stateId check in `analyzeExtraParameter` of `DoFnSignatures.java` to check that the initial state declaration is a subtype of the state type of `processElement` instead of equal to.

I updated the corresponding error message and added a test to `DoFnSignaturesTest.java` which makes sure that the example code in the original JIRA issue instantiates a DoFn without a runtime error.

This is my first pull request. I'm excited to learn from everyone!
