### PR TITLE
[BEAM-3054] Uses locale-insensitive number formatting in ESIO and tests

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -60,7 +60,7 @@ public class ElasticsearchIOTest extends ESIntegTestCase implements Serializable
   private String[] fillAddresses(){
     ArrayList<String> result = new ArrayList<>();
     for (InetSocketAddress address : cluster().httpAddresses()){
-      result.add(String.format("http://%s:%d", address.getHostString(), address.getPort()));
+      result.add(String.format("http://%s:%s", address.getHostString(), address.getPort()));
     }
     return result.toArray(new String[result.size()]);
   }

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticSearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticSearchIOTestUtils.java
@@ -64,7 +64,7 @@ class ElasticSearchIOTestUtils {
     int i = 0;
     for (String document : data) {
       bulkRequest.append(String.format(
-          "{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\", \"_id\" : \"%d\" } }%n%s%n",
+          "{ \"index\" : { \"_index\" : \"%s\", \"_type\" : \"%s\", \"_id\" : \"%s\" } }%n%s%n",
           connectionConfiguration.getIndex(), connectionConfiguration.getType(), i++, document));
     }
     String endPoint = String.format("/%s/%s/_bulk", connectionConfiguration.getIndex(),
@@ -131,9 +131,9 @@ class ElasticSearchIOTestUtils {
       int index = i % scientists.length;
       // insert 2 malformed documents
       if (InjectionMode.INJECT_SOME_INVALID_DOCS.equals(injectionMode) && (i == 6 || i == 7)) {
-        data.add(String.format("{\"scientist\";\"%s\", \"id\":%d}", scientists[index], i));
+        data.add(String.format("{\"scientist\";\"%s\", \"id\":%s}", scientists[index], i));
       } else {
-        data.add(String.format("{\"scientist\":\"%s\", \"id\":%d}", scientists[index], i));
+        data.add(String.format("{\"scientist\":\"%s\", \"id\":%s}", scientists[index], i));
       }
     }
     return data;

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -620,7 +620,7 @@ public class ElasticsearchIO {
         if (source.numSlices != null && source.numSlices > 1){
           // add slice to the user query
           String sliceQuery = String
-              .format("\"slice\": {\"id\": %d,\"max\": %d}", source.sliceId,
+              .format("\"slice\": {\"id\": %s,\"max\": %s}", source.sliceId,
                   source.numSlices);
           query = query.replaceFirst("\\{", "{" + sliceQuery + ",");
         }


### PR DESCRIPTION
The ESIO5 test framework will randomly switch the locale of the current test, and hence it discovered this bug: this is an actual bug.

This commit switches %d to %s where appropriate, i.e. where a machine-readable decimal number in US locale is required.

R: @echauchot 