### PR TITLE
[BEAM-3142] Apply futurize on gen_protos

### DIFF
--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -112,11 +112,12 @@ def generate_proto_files(force=False):
             '%s' % ret_code)
 
 
-    ret_code = subprocess.call(
+    if sys.version_info[0] >= 3:
+      ret_code = subprocess.call(
         ["futurize", "-0", "-wv", "--no-diff", out_dir])
 
-    if ret_code:
-      raise RuntimeError(
+      if ret_code:
+        raise RuntimeError(
           'Error applying futurize to generated protobuf python files.')
 
 

--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -110,6 +110,12 @@ def generate_proto_files(force=False):
         raise RuntimeError(
             'Protoc returned non-zero status (see logs for details): '
             '%s' % ret_code)
+      ret_code = subprocess.call(
+          ["futurize", "-0", "-wv", "--no-diff", out_dir])
+
+      if ret_code:
+        raise RuntimeError(
+            'Error applying futurize to pb2 files.')
 
 
 # Though wheels are available for grpcio-tools, setup_requires uses

--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -114,7 +114,7 @@ def generate_proto_files(force=False):
 
     if sys.version_info[0] >= 3:
       ret_code = subprocess.call(
-        ["futurize", "-0", "-wv", "--no-diff", out_dir])
+        ["futurize", "--both-stages", "--write", "--verbose", "--no-diff", out_dir])
 
       if ret_code:
         raise RuntimeError(

--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -110,12 +110,14 @@ def generate_proto_files(force=False):
         raise RuntimeError(
             'Protoc returned non-zero status (see logs for details): '
             '%s' % ret_code)
-      ret_code = subprocess.call(
-          ["futurize", "-0", "-wv", "--no-diff", out_dir])
 
-      if ret_code:
-        raise RuntimeError(
-            'Error applying futurize to pb2 files.')
+
+    ret_code = subprocess.call(
+        ["futurize", "-0", "-wv", "--no-diff", out_dir])
+
+    if ret_code:
+      raise RuntimeError(
+          'Error applying futurize to generated protobuf python files.')
 
 
 # Though wheels are available for grpcio-tools, setup_requires uses


### PR DESCRIPTION
Python 3 removes relative import support, we can apply futurize on the generated protos to fix the imports. It's less than ideal, but it works.