### PR TITLE
[BEAM-2500] Add S3 FileSystem to Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -546,6 +546,12 @@
 
       <dependency>
         <groupId>org.apache.beam</groupId>
+        <artifactId>beam-sdks-java-io-amazon-web-services</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.beam</groupId>
         <artifactId>beam-sdks-java-io-amqp</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/sdks/java/io/amazon-web-services/pom.xml
+++ b/sdks/java/io/amazon-web-services/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.apache.beam</groupId>
     <artifactId>beam-sdks-java-extensions-parent</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/sdks/java/io/amazon-web-services/pom.xml
+++ b/sdks/java/io/amazon-web-services/pom.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.beam</groupId>
+    <artifactId>beam-sdks-java-extensions-parent</artifactId>
+    <version>2.2.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>beam-sdks-java-io-amazon-web-services</artifactId>
+  <name>Apache Beam :: SDKs :: Java :: IO :: Amazon Web Services</name>
+  <description>IO library to read and write Amazon Web Services services from Beam.</description>
+
+  <packaging>jar</packaging>
+
+  <properties>
+    <aws-java-sdk.version>1.11.194</aws-java-sdk.version>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <excludedGroups>
+            org.apache.beam.sdk.testing.NeedsRunner
+          </excludedGroups>
+          <systemPropertyVariables>
+            <beamUseDummyRunner>true</beamUseDummyRunner>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+
+      <!-- Coverage analysis for unit tests. -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <!-- build dependencies -->
+    <dependency>
+      <groupId>com.google.auto.service</groupId>
+      <artifactId>auto-service</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- test dependencies -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-core</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
@@ -1,0 +1,21 @@
+package org.apache.beam.sdk.io.aws.options;
+
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * Options used to configure Amazon Web Services specific options such as credentials and region.
+ */
+public interface AwsOptions extends PipelineOptions {
+  @Description("AWS access key ID")
+  String getAwsAccessKeyId();
+  void setAwsAccessKeyId(String value);
+
+  @Description("AWS secret access key")
+  String getAwsSecretAccessKey();
+  void setAwsSecretAccessKey(String value);
+
+  @Description("AWS region used by the AWS client")
+  String getAwsRegion();
+  void setAwsRegion(String value);
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsPipelineOptionsRegistrar.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsPipelineOptionsRegistrar.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.options;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsRegistrar;
+
+/**
+ * A registrar containing the default AWS options.
+ */
+@AutoService(PipelineOptionsRegistrar.class)
+public class AwsPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+
+  @Override
+  public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
+    return ImmutableList.<Class<? extends PipelineOptions>>builder()
+        .add(AwsOptions.class)
+        .add(S3Options.class)
+        .build();
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3Options.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3Options.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.options;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.aws.util.S3Util;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.Hidden;
+
+/** Options used to configure Amazon Web Services S3. */
+public interface S3Options extends AwsOptions {
+
+  @JsonIgnore
+  @Description("The S3Util instance that should be used to communicate with AWS S3")
+  @Default.InstanceFactory(S3Util.S3UtilFactory.class)
+  @Hidden
+  S3Util getS3Util();
+
+  void setS3Util(S3Util value);
+
+  @Description("AWS S3 storage class used for creating S3 objects")
+  @Default.String("STANDARD")
+  String getS3StorageClass();
+
+  void setS3StorageClass(String value);
+
+  @Description("Size of S3 upload chunks; max upload object size is this value multiplied by 10000")
+  @Nullable
+  Integer getS3UploadBufferSizeBytes();
+
+  void setS3UploadBufferSizeBytes(Integer value);
+
+  @Description("Thread pool size, limiting max concurrent S3 operations")
+  @Default.Integer(50)
+  int getS3ThreadPoolSize();
+
+  void setS3ThreadPoolSize(int value);
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Defines {@link org.apache.beam.sdk.options.PipelineOptions} for
+ * configuring pipeline execution for Amazon Web Services components.
+ */
+package org.apache.beam.sdk.io.aws.options;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.s3;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.Collection;
+import java.util.List;
+import org.apache.beam.sdk.io.FileSystem;
+import org.apache.beam.sdk.io.aws.options.S3Options;
+import org.apache.beam.sdk.io.fs.CreateOptions;
+import org.apache.beam.sdk.io.fs.MatchResult;
+
+class S3FileSystem extends FileSystem<S3ResourceId> {
+
+  private final S3Options options;
+
+  S3FileSystem(S3Options options) {
+    this.options = checkNotNull(options, "options");
+  }
+
+  @Override
+  protected String getScheme() {
+    return S3Path.SCHEME;
+  }
+
+  @Override
+  protected List<MatchResult> match(List<String> specs) throws IOException {
+    List<S3Path> paths =
+        FluentIterable.from(specs)
+            .transform(
+                new Function<String, S3Path>() {
+                  @Override
+                  public S3Path apply(String spec) {
+                    return S3Path.fromUri(spec);
+                  }
+                })
+            .toList();
+    return options.getS3Util().match(paths);
+  }
+
+  @Override
+  protected WritableByteChannel create(S3ResourceId resourceId, CreateOptions createOptions)
+      throws IOException {
+    return options.getS3Util().create(resourceId.getS3Path());
+  }
+
+  @Override
+  protected ReadableByteChannel open(S3ResourceId resourceId) throws IOException {
+    return options.getS3Util().open(resourceId.getS3Path());
+  }
+
+  @Override
+  protected void copy(
+      List<S3ResourceId> sourceResourceIds, List<S3ResourceId> destinationResourceIds)
+      throws IOException {
+    List<S3Path> sourcePaths = S3ResourceId.getS3Paths(sourceResourceIds);
+    List<S3Path> destinationPaths = S3ResourceId.getS3Paths(destinationResourceIds);
+    options.getS3Util().copy(sourcePaths, destinationPaths);
+  }
+
+  @Override
+  protected void rename(
+      List<S3ResourceId> sourceResourceIds, List<S3ResourceId> destinationResourceIds)
+      throws IOException {
+    copy(sourceResourceIds, destinationResourceIds);
+    delete(sourceResourceIds);
+  }
+
+  @Override
+  protected void delete(Collection<S3ResourceId> resourceIds) throws IOException {
+    List<S3ResourceId> nonDirectoryResourceIds =
+        S3ResourceId.getNonDirectoryResourceIds(resourceIds);
+    List<S3Path> paths = S3ResourceId.getS3Paths(nonDirectoryResourceIds);
+    options.getS3Util().delete(paths);
+  }
+
+  @Override
+  protected S3ResourceId matchNewResource(String singleResourceSpec, boolean isDirectory) {
+    if (isDirectory) {
+      if (!singleResourceSpec.endsWith("/")) {
+        singleResourceSpec += "/";
+      }
+    } else {
+      checkArgument(
+          !singleResourceSpec.endsWith("/"),
+          "Expected a file path, but [%s] ends with '/'. This is unsupported in S3FileSystem.",
+          singleResourceSpec);
+    }
+    S3Path path = S3Path.fromUri(singleResourceSpec);
+    return S3ResourceId.fromS3Path(path);
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemRegistrar.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemRegistrar.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.s3;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.io.FileSystem;
+import org.apache.beam.sdk.io.FileSystemRegistrar;
+import org.apache.beam.sdk.io.aws.options.S3Options;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * {@link AutoService} registrar for the {@link S3FileSystem}.
+ */
+@AutoService(FileSystemRegistrar.class)
+@Experimental(Experimental.Kind.FILESYSTEM)
+public class S3FileSystemRegistrar implements FileSystemRegistrar {
+
+  @Override
+  public Iterable<FileSystem> fromOptions(@Nullable PipelineOptions options) {
+    checkNotNull(options, "Expect the runner have called FileSystems.setDefaultPipelineOptions().");
+    return ImmutableList.<FileSystem>of(new S3FileSystem(options.as(S3Options.class)));
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3Path.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3Path.java
@@ -1,0 +1,559 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.s3;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.Inet4Address;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.nio.file.FileSystem;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.WatchEvent.Kind;
+import java.nio.file.WatchEvent.Modifier;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/** Implements the Java NIO {@link Path} API for AWS S3 paths. */
+public class S3Path implements Path, Serializable {
+
+  public static final String SCHEME = "s3";
+
+  /** Matches a glob containing a wildcard, capturing the portion before the first wildcard. */
+  private static final Pattern GLOB_PREFIX = Pattern.compile("(?<PREFIX>[^\\[*?]*)[\\[*?].*");
+
+  public static S3Path fromUri(URI uri) {
+    checkArgument(uri.getScheme().equals(SCHEME), "URI: %s is not an S3 URI", uri);
+    checkArgument(uri.getPort() == -1, "S3 URI may not specify port: %s (%i)", uri, uri.getPort());
+    checkArgument(
+        Strings.isNullOrEmpty(uri.getUserInfo()),
+        "S3 URI may not specify userInfo: %s (%s)",
+        uri,
+        uri.getUserInfo());
+    checkArgument(
+        Strings.isNullOrEmpty(uri.getQuery()),
+        "S3 URI may not specify query: %s (%s)",
+        uri,
+        uri.getQuery());
+    checkArgument(
+        Strings.isNullOrEmpty(uri.getFragment()),
+        "S3 URI may not specify fragment: %s (%s)",
+        uri,
+        uri.getFragment());
+
+    String bucket = uri.getHost();
+    String key = uri.getPath();
+    if (key.startsWith("/")) {
+      key = key.substring(1);
+    }
+    return fromComponents(bucket, key);
+  }
+
+  private static final Pattern S3_URI =
+      Pattern.compile("(?<SCHEME>[^:]+)://(?<BUCKET>[^/]+)(/(?<OBJECT>.*))?");
+
+  public static S3Path fromUri(String uri) {
+    Matcher m = S3_URI.matcher(uri);
+    checkArgument(m.matches(), "Invalid S3 URI: %s", uri);
+
+    checkArgument(m.group("SCHEME").equalsIgnoreCase(SCHEME), "URI: %s is not an S3 URI", uri);
+    return new S3Path(null, m.group("BUCKET"), m.group("OBJECT"));
+  }
+
+  public static S3Path fromComponents(String bucket, String key) {
+    return new S3Path(null, bucket, key);
+  }
+
+  @Nullable private transient FileSystem fileSystem;
+  @Nonnull private final String bucket;
+  @Nonnull private final String key;
+
+  private S3Path(FileSystem fileSystem, String bucket, String key) {
+    // Bucket name rules:
+    // http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
+    // - Bucket name length must be [3~63] characters.
+    // - "Labels" are defined as bucket name parts separated by single period delimiter.
+    // - Each label starts and ends with lowercase letter or number.
+    // - Bucket name cannot be formatted as an IP address.
+    if (bucket == null) {
+      bucket = "";
+    }
+    if (!bucket.isEmpty()) {
+      checkArgument(
+          3 <= bucket.length() && bucket.length() <= 63,
+          "S3 bucket name length must be 3 to 63 characters");
+      // Is this a valid IPv4 address?
+      try {
+        checkArgument(
+            !(bucket.matches("[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}")
+                && bucket.equals(Inet4Address.getByName(bucket).getHostAddress())),
+            "S3 bucket name cannot be formatted as an IP address");
+      } catch (UnknownHostException e) {
+        // Expected; fall through.
+      }
+
+      String[] labels = bucket.split("\\.");
+      for (String label : labels) {
+        checkArgument(
+            !label.isEmpty(),
+            "S3 bucket name cannot start or end with a period, or have two consecutive periods");
+        checkArgument(
+            label.matches("[a-z0-9][-a-z0-9]+[a-z0-9]"),
+            "S3 bucket name may contain lowercase letters, numbers, and hyphens. "
+                + "Labels may not start or end with hyphen. 's3://%s/%s'",
+            bucket,
+            key);
+      }
+    }
+
+    // Key name rules:
+    // http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+    // - Length must be [1~1024] UTF-8 bytes.
+    // - No character is explicitly prohibited (some are suggested to avoid).
+    if (key == null) {
+      key = "";
+    }
+    checkArgument(
+        Charsets.UTF_8.encode(key).limit() <= 1024,
+        "S3 key length must be <= 1024 bytes when UTF-8 encoded");
+
+    this.fileSystem = fileSystem;
+    this.bucket = Strings.nullToEmpty(bucket);
+    this.key = Strings.nullToEmpty(key);
+  }
+
+  @Override
+  public FileSystem getFileSystem() {
+    return fileSystem;
+  }
+
+  public void setFileSystem(FileSystem fileSystem) {
+    this.fileSystem = fileSystem;
+  }
+
+  public String getBucket() {
+    return bucket;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  @Override
+  public boolean isAbsolute() {
+    return !bucket.isEmpty() || key.isEmpty();
+  }
+
+  public boolean isWildcard() {
+    return GLOB_PREFIX.matcher(this.getKey()).matches();
+  }
+
+  @Override
+  public S3Path getRoot() {
+    return new S3Path(fileSystem, "", "");
+  }
+
+  @Override
+  public S3Path getFileName() {
+    int nameCount = getNameCount();
+    if (nameCount < 2) {
+      throw new UnsupportedOperationException(
+          "Can't get filename from root path in the bucket: " + this);
+    }
+    return getName(nameCount - 1);
+  }
+
+  @Override
+  public S3Path getParent() {
+    if (bucket.isEmpty() && key.isEmpty()) {
+      // The root path has no parent, by definition.
+      return null;
+    }
+
+    if (key.isEmpty()) {
+      // An S3 bucket. All buckets come from a common root.
+      return getRoot();
+    }
+
+    // Skip last character, in case it is a trailing slash.
+    int i = key.lastIndexOf('/', key.length() - 2);
+    if (i <= 0) {
+      if (bucket.isEmpty()) {
+        // Relative paths are not attached to the root node.
+        return null;
+      }
+      return new S3Path(fileSystem, bucket, "");
+    }
+
+    // Retain trailing slash.
+    return new S3Path(fileSystem, bucket, key.substring(0, i + 1));
+  }
+
+  @Override
+  public int getNameCount() {
+    int count = bucket.isEmpty() ? 0 : 1;
+    if (key.isEmpty()) {
+      return count;
+    }
+
+    // Add another for each separator found.
+    int index = -1;
+    while ((index = key.indexOf('/', index + 1)) != -1) {
+      count++;
+    }
+
+    return key.endsWith("/") ? count : count + 1;
+  }
+
+  @Override
+  public S3Path getName(int index) {
+    checkArgument(index >= 0);
+
+    Iterator<Path> iterator = iterator();
+    for (int i = 0; i < index; ++i) {
+      checkArgument(iterator.hasNext());
+      iterator.next();
+    }
+
+    checkArgument(iterator.hasNext());
+    return (S3Path) iterator.next();
+  }
+
+  @Override
+  public S3Path subpath(int beginIndex, int endIndex) {
+    checkArgument(beginIndex >= 0);
+    checkArgument(endIndex > beginIndex);
+
+    Iterator<Path> iterator = iterator();
+    for (int i = 0; i < beginIndex; ++i) {
+      checkArgument(iterator.hasNext());
+      iterator.next();
+    }
+
+    S3Path path = null;
+    while (beginIndex < endIndex) {
+      checkArgument(iterator.hasNext());
+      if (path == null) {
+        path = (S3Path) iterator.next();
+      } else {
+        path = path.resolve(iterator.next());
+      }
+      ++beginIndex;
+    }
+
+    return path;
+  }
+
+  @Override
+  public boolean startsWith(Path other) {
+    if (other instanceof S3Path) {
+      S3Path otherS3Path = (S3Path) other;
+      return startsWith(otherS3Path.bucketAndKey());
+    }
+    return startsWith(other.toString());
+  }
+
+  @Override
+  public boolean startsWith(String prefix) {
+    return bucketAndKey().startsWith(prefix);
+  }
+
+  @Override
+  public boolean endsWith(Path other) {
+    if (other instanceof S3Path) {
+      S3Path otherS3Path = (S3Path) other;
+      return endsWith(otherS3Path.bucketAndKey());
+    }
+    return endsWith(other.toString());
+  }
+
+  @Override
+  public boolean endsWith(String suffix) {
+    return bucketAndKey().endsWith(suffix);
+  }
+
+  @Override
+  public S3Path normalize() {
+    return this;
+  }
+
+  @Override
+  public S3Path resolve(Path other) {
+    if (other instanceof S3Path) {
+      S3Path otherS3Path = (S3Path) other;
+      if (otherS3Path.isAbsolute()) {
+        return otherS3Path;
+      }
+      return resolve(otherS3Path.getKey());
+    }
+    return resolve(other.toString());
+  }
+
+  @Override
+  public S3Path resolve(String other) {
+    if (bucket.isEmpty() && key.isEmpty()) {
+      // Resolve on a root path is equivalent to looking up a bucket and object.
+      other = SCHEME + "://" + other;
+    }
+
+    if (other.startsWith(SCHEME + "://")) {
+      S3Path otherS3Path = fromUri(other);
+      otherS3Path.setFileSystem(getFileSystem());
+      return otherS3Path;
+    }
+
+    if (other.isEmpty()) {
+      // An empty component MUST refer to a directory.
+      other = "/";
+    }
+
+    if (key.isEmpty()) {
+      return new S3Path(fileSystem, bucket, other);
+    } else if (key.endsWith("/")) {
+      return new S3Path(fileSystem, bucket, key + other);
+    } else {
+      return new S3Path(fileSystem, bucket, key + "/" + other);
+    }
+  }
+
+  @Override
+  public S3Path resolveSibling(Path other) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public S3Path resolveSibling(String other) {
+    if (getNameCount() < 2) {
+      throw new UnsupportedOperationException("Can't resolve the sibling of a root path: " + this);
+    }
+    S3Path parent = getParent();
+    return (parent == null) ? fromUri(other) : parent.resolve(other);
+  }
+
+  @Override
+  public S3Path relativize(Path other) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public URI toUri() {
+    try {
+      return new URI(SCHEME, "//" + bucketAndKey(), null);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Unable to create URI for S3 path " + this);
+    }
+  }
+
+  @Override
+  public S3Path toAbsolutePath() {
+    return this;
+  }
+
+  @Override
+  public S3Path toRealPath(LinkOption... options) throws IOException {
+    return this;
+  }
+
+  @Override
+  public File toFile() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WatchKey register(WatchService watcher, Kind<?>[] events, Modifier... modifiers)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public WatchKey register(WatchService watcher, Kind<?>... events) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Iterator<Path> iterator() {
+    return new NameIterator(fileSystem, !bucket.isEmpty(), bucketAndKey());
+  }
+
+  private static class NameIterator implements Iterator<Path> {
+
+    private final FileSystem innerFileSystem;
+    private boolean fullPath;
+    private String name;
+
+    NameIterator(FileSystem innerFileSystem, boolean fullPath, String name) {
+      this.innerFileSystem = innerFileSystem;
+      this.fullPath = fullPath;
+      this.name = name;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !Strings.isNullOrEmpty(name);
+    }
+
+    @Override
+    public S3Path next() {
+      int i = name.indexOf('/');
+      String component;
+      if (i >= 0) {
+        component = name.substring(0, i);
+        name = name.substring(i + 1);
+      } else {
+        component = name;
+        name = null;
+      }
+      if (fullPath) {
+        fullPath = false;
+        return new S3Path(innerFileSystem, component, "");
+      } else {
+        // Relative paths have no bucket.
+        return new S3Path(innerFileSystem, "", component);
+      }
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  public S3Path commonKeyPrefix(S3Path other) {
+    checkArgument(getBucket().equals(other.getBucket()), "buckets equal");
+
+    int minLength = Math.min(getKey().length(), other.getKey().length());
+    String commonKeyPrefix = getKey().substring(0, minLength);
+    for (int i = 0; i < minLength; i++) {
+      if (getKey().charAt(i) != other.getKey().charAt(i)) {
+        commonKeyPrefix = getKey().substring(0, i);
+        break;
+      }
+    }
+
+    return new S3Path(null, getBucket(), commonKeyPrefix);
+  }
+
+  @Override
+  public int compareTo(Path other) {
+    if (!(other instanceof S3Path)) {
+      throw new ClassCastException();
+    }
+
+    S3Path path = (S3Path) other;
+    int b = bucket.compareTo(path.bucket);
+    if (b != 0) {
+      return b;
+    }
+
+    // Compare a component at a time, so that the separator char doesn't
+    // get compared against component contents.  Eg, "a/b" < "a-1/b".
+    Iterator<Path> left = iterator();
+    Iterator<Path> right = path.iterator();
+
+    while (left.hasNext() && right.hasNext()) {
+      String leftStr = left.next().toString();
+      String rightStr = right.next().toString();
+      int c = leftStr.compareTo(rightStr);
+      if (c != 0) {
+        return c;
+      }
+    }
+
+    if (!left.hasNext() && !right.hasNext()) {
+      return 0;
+    } else {
+      return left.hasNext() ? 1 : -1;
+    }
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+
+    S3Path otherS3Path = (S3Path) other;
+    return bucket.equals(otherS3Path.bucket) && key.equals(otherS3Path.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return 31 * bucket.hashCode() + key.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    if (!isAbsolute()) {
+      return key;
+    }
+    StringBuilder sb = new StringBuilder();
+    sb.append(SCHEME).append("://");
+    if (!bucket.isEmpty()) {
+      sb.append(bucket).append('/');
+    }
+    sb.append(key);
+    return sb.toString();
+  }
+
+  private String bucketAndKey() {
+    if (bucket.isEmpty()) {
+      return key;
+    }
+    return bucket + "/" + key;
+  }
+
+  public String getKeyNonWildcardPrefix() {
+    Matcher m = GLOB_PREFIX.matcher(getKey());
+    checkArgument(m.matches(), String.format("Glob expression: [%s] is not expandable.", getKey()));
+    return m.group("PREFIX");
+  }
+
+  /** A coder for {@link S3Path}. */
+  public static class Coder extends SerializableCoder<S3Path> {
+
+    private static final Coder CODER_INSTANCE = new Coder();
+
+    public static Coder of() {
+      return CODER_INSTANCE;
+    }
+
+    private Coder() {
+      super(S3Path.class, TypeDescriptor.of(S3Path.class));
+    }
+
+    @Override
+    public void verifyDeterministic() {}
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3ResourceId.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3ResourceId.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.s3;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.fs.ResolveOptions;
+import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
+import org.apache.beam.sdk.io.fs.ResourceId;
+
+/** {@link ResourceId} implementation for Amazon Web Services S3. */
+public class S3ResourceId implements ResourceId {
+
+  private final S3Path s3Path;
+
+  public static S3ResourceId fromS3Path(S3Path s3Path) {
+    checkNotNull(s3Path, "s3Path");
+    return new S3ResourceId(s3Path);
+  }
+
+  private S3ResourceId(S3Path s3Path) {
+    this.s3Path = s3Path;
+  }
+
+  public S3Path getS3Path() {
+    return s3Path;
+  }
+
+  static List<S3ResourceId> getNonDirectoryResourceIds(Collection<S3ResourceId> resourceIds) {
+    return FluentIterable.from(resourceIds)
+        .filter(
+            new Predicate<S3ResourceId>() {
+              @Override
+              public boolean apply(S3ResourceId resourceId) {
+                return !resourceId.isDirectory();
+              }
+            })
+        .toList();
+  }
+
+  static List<S3Path> getS3Paths(Collection<S3ResourceId> resourceIds) {
+    return FluentIterable.from(resourceIds)
+        .transform(
+            new Function<S3ResourceId, S3Path>() {
+              @Override
+              public S3Path apply(S3ResourceId resourceId) {
+                return resourceId.getS3Path();
+              }
+            })
+        .toList();
+  }
+
+  @Override
+  public ResourceId resolve(String other, ResolveOptions resolveOptions) {
+    checkState(
+        isDirectory(), String.format("Expected the s3Path is a directory, but had [%s].", s3Path));
+    checkArgument(
+        resolveOptions.equals(StandardResolveOptions.RESOLVE_FILE)
+            || resolveOptions.equals(StandardResolveOptions.RESOLVE_DIRECTORY),
+        String.format("ResolveOptions: [%s] is not supported.", resolveOptions));
+    if (resolveOptions.equals(StandardResolveOptions.RESOLVE_FILE)) {
+      checkArgument(
+          !other.endsWith("/"), "The resolved file: [%s] should not end with '/'.", other);
+      return fromS3Path(s3Path.resolve(other));
+    }
+
+    // StandardResolveOptions.RESOLVE_DIRECTORY
+    if (other.endsWith("/")) {
+      // other already contains the delimiter for S3.
+      // It is not recommended for callers to set the delimiter.
+      // However, we consider it as a valid input.
+      return fromS3Path(s3Path.resolve(other));
+    }
+    return fromS3Path(s3Path.resolve(other + "/"));
+  }
+
+  @Override
+  public ResourceId getCurrentDirectory() {
+    if (isDirectory()) {
+      return this;
+    }
+    S3Path parent = s3Path.getParent();
+    checkState(
+        parent != null,
+        String.format("Failed to get the current directory for path: [%s].", s3Path));
+    return fromS3Path(parent);
+  }
+
+  @Nullable
+  @Override
+  public String getFilename() {
+    if (s3Path.getNameCount() <= 1) {
+      return null;
+    }
+    S3Path s3Filename = s3Path.getFileName();
+    return s3Filename == null ? null : s3Filename.toString();
+  }
+
+  @Override
+  public boolean isDirectory() {
+    return s3Path.endsWith("/");
+  }
+
+  @Override
+  public String getScheme() {
+    return S3Path.SCHEME;
+  }
+
+  @Override
+  public String toString() {
+    return s3Path.toString();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof S3ResourceId)) {
+      return false;
+    }
+    S3ResourceId otherS3ResourceId = (S3ResourceId) other;
+    return s3Path.equals(otherS3ResourceId.s3Path);
+  }
+
+  @Override
+  public int hashCode() {
+    return s3Path.hashCode();
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Defines IO connectors for Amazon Web Services S3.
+ */
+package org.apache.beam.sdk.io.aws.s3;

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3ReadableSeekableByteChannel.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3ReadableSeekableByteChannel.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import org.apache.beam.sdk.io.aws.s3.S3Path;
+
+/** A readable S3 object, as a {@link SeekableByteChannel}. */
+class S3ReadableSeekableByteChannel implements SeekableByteChannel {
+
+  private final AmazonS3 amazonS3;
+  private final S3Path path;
+  private final long contentLength;
+  private long position = 0;
+  private boolean open = true;
+  private S3Object s3Object;
+  private ReadableByteChannel s3ObjectContentChannel;
+
+   S3ReadableSeekableByteChannel(AmazonS3 amazonS3, S3Path path) throws IOException {
+    this.amazonS3 = checkNotNull(amazonS3, "amazonS3");
+    this.path = checkNotNull(path, "path");
+    try {
+      contentLength = amazonS3.getObjectMetadata(path.getBucket(), path.getKey())
+          .getContentLength();
+    } catch (AmazonServiceException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public int read(ByteBuffer destinationBuffer) throws IOException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+    if (!destinationBuffer.hasArray()) {
+      throw new UnsupportedOperationException("ByteBuffer.hasArray() must be true");
+    }
+    if (!destinationBuffer.hasRemaining()) {
+      return 0;
+    }
+    if (position == contentLength) {
+      return -1;
+    }
+
+    if (s3Object == null) {
+      GetObjectRequest request = new GetObjectRequest(path.getBucket(), path.getKey());
+      if (position > 0) {
+        request.setRange(position, contentLength);
+      }
+      try {
+        s3Object = amazonS3.getObject(request);
+      } catch (AmazonServiceException e) {
+        throw new IOException(e);
+      }
+      s3ObjectContentChannel = Channels.newChannel(
+          new BufferedInputStream(s3Object.getObjectContent(), 1024 * 1024));
+    }
+
+    int totalBytesRead = 0;
+    int bytesRead = 0;
+
+    do {
+      totalBytesRead += bytesRead;
+      bytesRead = s3ObjectContentChannel.read(destinationBuffer);
+    } while (bytesRead > 0);
+
+    position += totalBytesRead;
+    return totalBytesRead;
+  }
+
+  @Override
+  public long position() throws ClosedChannelException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+    return position;
+  }
+
+  @Override
+  public SeekableByteChannel position(long newPosition) throws IOException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+    checkArgument(newPosition >= 0, "newPosition too low");
+    checkArgument(newPosition < contentLength, "new position too high");
+    if (s3Object != null) {
+      s3Object.close();
+    }
+    position = newPosition;
+    return this;
+  }
+
+  @Override
+  public long size() throws ClosedChannelException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+    return contentLength;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (s3Object != null) {
+      s3Object.close();
+    }
+    open = false;
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public int write(ByteBuffer src) {
+    throw new NonWritableChannelException();
+  }
+
+  @Override
+  public SeekableByteChannel truncate(long size) {
+    throw new NonWritableChannelException();
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3Util.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3Util.java
@@ -1,0 +1,565 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CopyPartRequest;
+import com.amazonaws.services.s3.model.CopyPartResult;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest.KeyVersion;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Strings;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Multimap;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.regex.Pattern;
+import org.apache.beam.sdk.io.aws.options.S3Options;
+import org.apache.beam.sdk.io.aws.s3.S3Path;
+import org.apache.beam.sdk.io.aws.s3.S3ResourceId;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.options.DefaultValueFactory;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** S3Util wraps the Amazon Web Services client library. */
+public class S3Util {
+
+  private static final Logger LOG = LoggerFactory.getLogger(S3Util.class);
+
+  /**
+   * This is a {@link DefaultValueFactory} able to create an {@link S3Util} using any transport
+   * flags specified on the {@link PipelineOptions}.
+   */
+  public static class S3UtilFactory implements DefaultValueFactory<S3Util> {
+
+    @Override
+    public S3Util create(PipelineOptions options) {
+      S3Options s3Options = options.as(S3Options.class);
+
+      checkArgument(
+          !Strings.isNullOrEmpty(s3Options.getAwsAccessKeyId()), "AWS access key ID is required");
+      checkArgument(
+          !Strings.isNullOrEmpty(s3Options.getAwsSecretAccessKey()),
+          "AWS secret access key is required");
+      checkArgument(!Strings.isNullOrEmpty(s3Options.getAwsRegion()), "AWS region is required");
+
+      return new S3Util(
+          s3Options.getAwsAccessKeyId(),
+          s3Options.getAwsSecretAccessKey(),
+          s3Options.getAwsRegion(),
+          s3Options.getS3StorageClass(),
+          s3Options.getS3UploadBufferSizeBytes(),
+          s3Options.getS3ThreadPoolSize());
+    }
+  }
+
+  // Amazon S3 API docs: Each part must be at least 5 MB in size, except the last part.
+  private static final int MINIMUM_UPLOAD_BUFFER_SIZE_BYTES = 5 * 1024 * 1024;
+  private static final int DEFAULT_UPLOAD_BUFFER_SIZE_BYTES =
+      Runtime.getRuntime().maxMemory() < 512 * 1024 * 1024
+          ? MINIMUM_UPLOAD_BUFFER_SIZE_BYTES
+          : 64 * 1024 * 1024;
+  private static final int MAX_THREADS_PER_CONCURRENT_COPY = 3;
+
+  // Non-final for testing.
+  private AmazonS3 amazonS3;
+  private final String storageClass;
+  private final int s3UploadBufferSizeBytes;
+  private final ExecutorService executorService;
+
+  private S3Util(
+      String awsAccessKeyId,
+      String awsSecretAccessKey,
+      String region,
+      String storageClass,
+      Integer uploadBufferSizeBytes,
+      int threadPoolSize) {
+    AWSStaticCredentialsProvider credentialsProvider =
+        new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(awsAccessKeyId, awsSecretAccessKey));
+    amazonS3 =
+        AmazonS3ClientBuilder.standard()
+            .withCredentials(credentialsProvider)
+            .withRegion(region)
+            .build();
+
+    this.storageClass = checkNotNull(storageClass, "storageClass");
+
+    if (uploadBufferSizeBytes == null) {
+      uploadBufferSizeBytes = DEFAULT_UPLOAD_BUFFER_SIZE_BYTES;
+    }
+    this.s3UploadBufferSizeBytes =
+        Math.max(MINIMUM_UPLOAD_BUFFER_SIZE_BYTES, uploadBufferSizeBytes);
+
+    checkArgument(threadPoolSize > 0, "threadPoolSize");
+    this.executorService = Executors.newFixedThreadPool(threadPoolSize);
+  }
+
+  @VisibleForTesting
+  public void setAmazonS3Client(AmazonS3 amazonS3) {
+    this.amazonS3 = amazonS3;
+  }
+
+  @VisibleForTesting
+  public int getS3UploadBufferSizeBytes() {
+    return s3UploadBufferSizeBytes;
+  }
+
+  @Override
+  protected void finalize() {
+    executorService.shutdownNow();
+  }
+
+  /**
+   * Calls executorService.invokeAll() with tasks, then unwraps the resulting {@link Future
+   * Futures}.
+   *
+   * <p>Any task exception is wrapped in {@link IOException}.
+   */
+  private static <T> List<T> invokeAllAndUnwrapResults(
+      Collection<Callable<T>> tasks, ExecutorService executorService) throws IOException {
+    List<Future<T>> futures;
+    try {
+      futures = executorService.invokeAll(tasks);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("executor service task was interrupted");
+    }
+
+    List<T> results = new ArrayList<>(tasks.size());
+    try {
+      for (Future<T> future : futures) {
+        results.add(future.get());
+      }
+
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("executor service future.get() was interrupted");
+
+    } catch (ExecutionException e) {
+      if (e.getCause() != null) {
+        if (e.getCause() instanceof IOException) {
+          throw ((IOException) e.getCause());
+        }
+        throw new IOException(e.getCause());
+      }
+      throw new IOException(e);
+    }
+
+    return results;
+  }
+
+  public WritableByteChannel create(S3Path path) throws IOException {
+    return new S3WritableByteChannel(amazonS3, path, storageClass, s3UploadBufferSizeBytes);
+  }
+
+  public ReadableByteChannel open(S3Path path) throws IOException {
+    return new S3ReadableSeekableByteChannel(amazonS3, path);
+  }
+
+  public void copy(List<S3Path> sourcePaths, List<S3Path> destinationPaths) throws IOException {
+    checkArgument(
+        sourcePaths.size() == destinationPaths.size(),
+        "sizes of sourcePaths and destinationPaths do not match");
+
+    List<Callable<Void>> tasks = new ArrayList<>(sourcePaths.size());
+
+    Iterator<S3Path> sourcePathsIterator = sourcePaths.iterator();
+    Iterator<S3Path> destinationPathsIterator = destinationPaths.iterator();
+    while (sourcePathsIterator.hasNext()) {
+      final S3Path sourcePath = sourcePathsIterator.next();
+      final S3Path destinationPath = destinationPathsIterator.next();
+
+      tasks.add(
+          new Callable<Void>() {
+            @Override
+            public Void call() throws IOException {
+              copy(sourcePath, destinationPath);
+              return null;
+            }
+          });
+    }
+
+    invokeAllAndUnwrapResults(tasks, executorService);
+  }
+
+  @VisibleForTesting
+  void copy(S3Path sourcePath, S3Path destinationPath) throws IOException {
+    InitiateMultipartUploadRequest initiateUploadRequest =
+        new InitiateMultipartUploadRequest(destinationPath.getBucket(), destinationPath.getKey())
+            .withStorageClass(storageClass);
+    String uploadId;
+    long objectSize;
+    try {
+      InitiateMultipartUploadResult initiateUploadResult =
+          amazonS3.initiateMultipartUpload(initiateUploadRequest);
+      uploadId = initiateUploadResult.getUploadId();
+
+      ObjectMetadata objectMetadata =
+          amazonS3.getObjectMetadata(sourcePath.getBucket(), sourcePath.getKey());
+      objectSize = objectMetadata.getContentLength();
+
+    } catch (AmazonClientException e) {
+      throw new IOException(e);
+    }
+
+    List<Callable<PartETag>> tasks =
+        new ArrayList<>((int) Math.ceil((double) objectSize / (double) s3UploadBufferSizeBytes));
+
+    long bytePosition = 0;
+
+    // Amazon parts are 1-indexed, not zero-indexed.
+    for (int partNumber = 1; bytePosition < objectSize; partNumber++) {
+      final CopyPartRequest copyPartRequest =
+          new CopyPartRequest()
+              .withSourceBucketName(sourcePath.getBucket())
+              .withSourceKey(sourcePath.getKey())
+              .withDestinationBucketName(destinationPath.getBucket())
+              .withDestinationKey(destinationPath.getKey())
+              .withUploadId(uploadId)
+              .withPartNumber(partNumber)
+              .withFirstByte(bytePosition)
+              .withLastByte(Math.min(objectSize - 1, bytePosition + s3UploadBufferSizeBytes - 1));
+
+      tasks.add(
+          new Callable<PartETag>() {
+            @Override
+            public PartETag call() throws IOException {
+              CopyPartResult copyPartResult;
+              try {
+                copyPartResult = amazonS3.copyPart(copyPartRequest);
+              } catch (AmazonClientException e) {
+                throw new IOException(e);
+              }
+              return copyPartResult.getPartETag();
+            }
+          });
+
+      bytePosition += s3UploadBufferSizeBytes;
+    }
+
+    ExecutorService executorService;
+    if (tasks.size() > 1) {
+      // Don't pollute the main thread pool, which this was called from.
+      // Instead, create a small thread pool just for this copy operation.
+      int threadQuantity = Math.min(MAX_THREADS_PER_CONCURRENT_COPY, tasks.size());
+      executorService = Executors.newFixedThreadPool(threadQuantity);
+    } else {
+      // Don't create a thread pool if there is only one task.
+      executorService = MoreExecutors.newDirectExecutorService();
+    }
+    List<PartETag> eTags;
+    try {
+      eTags = invokeAllAndUnwrapResults(tasks, executorService);
+    } finally {
+      executorService.shutdown();
+    }
+
+    CompleteMultipartUploadRequest completeUploadRequest =
+        new CompleteMultipartUploadRequest()
+            .withBucketName(destinationPath.getBucket())
+            .withKey(destinationPath.getKey())
+            .withUploadId(uploadId)
+            .withPartETags(eTags);
+
+    try {
+      amazonS3.completeMultipartUpload(completeUploadRequest);
+    } catch (AmazonClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public void delete(List<S3Path> paths) throws IOException {
+    Multimap<String, String> keysByBucket = ArrayListMultimap.create();
+    for (S3Path path : paths) {
+      keysByBucket.put(path.getBucket(), path.getKey());
+    }
+
+    List<Callable<Void>> tasks = new ArrayList<>();
+    for (final String bucket : keysByBucket.keySet()) {
+      for (final List<String> keysPartition : Iterables.partition(keysByBucket.get(bucket), 1000)) {
+        tasks.add(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws IOException {
+                delete(bucket, keysPartition);
+                return null;
+              }
+            });
+      }
+    }
+
+    invokeAllAndUnwrapResults(tasks, executorService);
+  }
+
+  private void delete(String bucket, Collection<String> keys) throws IOException {
+    // S3 SDK: "You may specify up to 1000 keys."
+    checkArgument(keys.size() <= 1000, "only 1000 keys can be deleted per request");
+    List<KeyVersion> deleteKeyVersions =
+        FluentIterable.from(keys)
+            .transform(
+                new Function<String, KeyVersion>() {
+                  @Override
+                  public KeyVersion apply(String key) {
+                    return new KeyVersion(key);
+                  }
+                })
+            .toList();
+    DeleteObjectsRequest request = new DeleteObjectsRequest(bucket).withKeys(deleteKeyVersions);
+    try {
+      amazonS3.deleteObjects(request);
+    } catch (AmazonClientException e) {
+      throw new IOException(e);
+    }
+  }
+
+  public List<MatchResult> match(Collection<S3Path> paths) throws IOException {
+    List<S3Path> globs = Lists.newArrayList();
+    List<S3Path> nonGlobs = Lists.newArrayList();
+    List<Boolean> isGlobBooleans = Lists.newArrayList();
+
+    for (S3Path path : paths) {
+      if (path.isWildcard()) {
+        globs.add(path);
+        isGlobBooleans.add(true);
+      } else {
+        nonGlobs.add(path);
+        isGlobBooleans.add(false);
+      }
+    }
+
+    Iterator<MatchResult> globMatches = matchGlobPaths(globs).iterator();
+    Iterator<MatchResult> nonGlobMatches = matchNonGlobPaths(nonGlobs).iterator();
+
+    ImmutableList.Builder<MatchResult> matchResults = ImmutableList.builder();
+    for (Boolean isGlob : isGlobBooleans) {
+      if (isGlob) {
+        checkState(globMatches.hasNext(), "Expect globMatches has next.");
+        matchResults.add(globMatches.next());
+      } else {
+        checkState(nonGlobMatches.hasNext(), "Expect nonGlobMatches has next.");
+        matchResults.add(nonGlobMatches.next());
+      }
+    }
+    checkState(!globMatches.hasNext(), "Expect no more elements in globMatches.");
+    checkState(!nonGlobMatches.hasNext(), "Expect no more elements in nonGlobMatches.");
+
+    return matchResults.build();
+  }
+
+  private List<MatchResult> matchGlobPaths(Collection<S3Path> paths) throws IOException {
+    List<Callable<MatchResult>> tasks = new ArrayList<>(paths.size());
+    for (final S3Path path : paths) {
+      tasks.add(
+          new Callable<MatchResult>() {
+            @Override
+            public MatchResult call() {
+              return matchGlobPath(path);
+            }
+          });
+    }
+
+    return invokeAllAndUnwrapResults(tasks, executorService);
+  }
+
+  /** Gets {@link MatchResult} representing all objects that match wildcard-containing path. */
+  @VisibleForTesting
+  MatchResult matchGlobPath(S3Path path) {
+    // The S3 API can list objects, filtered by prefix, but not by wildcard.
+    // Here, we find the longest prefix without wildcard "*",
+    // then filter the results with a regex.
+    checkArgument(path.isWildcard(), "isWildcard");
+    String keyPrefix = path.getKeyNonWildcardPrefix();
+    Pattern wildcardRegexp = Pattern.compile(S3Util.wildcardToRegexp(path.getKey()));
+
+    LOG.debug(
+        "matching files in bucket {}, prefix {} against pattern {}",
+        path.getBucket(),
+        keyPrefix,
+        wildcardRegexp.toString());
+
+    ImmutableList.Builder<MatchResult.Metadata> results = ImmutableList.builder();
+    String continuationToken = null;
+
+    do {
+      ListObjectsV2Request request =
+          new ListObjectsV2Request()
+              .withBucketName(path.getBucket())
+              .withPrefix(keyPrefix)
+              .withContinuationToken(continuationToken);
+      ListObjectsV2Result result;
+      try {
+        result = amazonS3.listObjectsV2(request);
+      } catch (AmazonClientException e) {
+        return MatchResult.create(MatchResult.Status.ERROR, new IOException(e));
+      }
+      continuationToken = result.getNextContinuationToken();
+
+      for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+        // Filter against regex.
+        if (wildcardRegexp.matcher(objectSummary.getKey()).matches()) {
+          S3Path objectPath =
+              S3Path.fromComponents(objectSummary.getBucketName(), objectSummary.getKey());
+          LOG.debug("Matched S3 object: {}", objectPath);
+          results.add(createBeamMetadata(objectPath, objectSummary.getSize()));
+        }
+      }
+    } while (continuationToken != null);
+
+    return MatchResult.create(MatchResult.Status.OK, results.build());
+  }
+
+  private List<MatchResult> matchNonGlobPaths(Collection<S3Path> paths) throws IOException {
+    List<Callable<MatchResult>> tasks = new ArrayList<>(paths.size());
+    for (final S3Path path : paths) {
+      tasks.add(
+          new Callable<MatchResult>() {
+            @Override
+            public MatchResult call() {
+              return matchNonGlobPath(path);
+            }
+          });
+    }
+
+    return invokeAllAndUnwrapResults(tasks, executorService);
+  }
+
+  @VisibleForTesting
+  MatchResult matchNonGlobPath(S3Path path) {
+    ObjectMetadata s3Metadata;
+    try {
+      s3Metadata = amazonS3.getObjectMetadata(path.getBucket(), path.getKey());
+    } catch (AmazonClientException e) {
+      if (e instanceof AmazonS3Exception && ((AmazonS3Exception) e).getStatusCode() == 404) {
+        return MatchResult.create(MatchResult.Status.NOT_FOUND, new FileNotFoundException());
+      }
+      return MatchResult.create(MatchResult.Status.ERROR, new IOException(e));
+    }
+    return MatchResult.create(
+        MatchResult.Status.OK,
+        ImmutableList.of(createBeamMetadata(path, s3Metadata.getContentLength())));
+  }
+
+  private static MatchResult.Metadata createBeamMetadata(S3Path path, long sizeBytes) {
+    // TODO: Address https://issues.apache.org/jira/browse/BEAM-1494
+    // It is incorrect to set IsReadSeekEfficient true for files with content encoding set to gzip.
+    return MatchResult.Metadata.builder()
+        .setIsReadSeekEfficient(true)
+        .setResourceId(S3ResourceId.fromS3Path(path))
+        .setSizeBytes(sizeBytes)
+        .build();
+  }
+
+  /**
+   * Expands glob expressions to regular expressions.
+   *
+   * @param globExp the glob expression to expand
+   * @return a string with the regular expression this glob expands to
+   */
+  @VisibleForTesting
+  static String wildcardToRegexp(String globExp) {
+    StringBuilder dst = new StringBuilder();
+    char[] src = globExp.replace("**/*", "**").toCharArray();
+    int i = 0;
+    while (i < src.length) {
+      char c = src[i++];
+      switch (c) {
+        case '*':
+          // One char lookahead for **
+          if (i < src.length && src[i] == '*') {
+            dst.append(".*");
+            ++i;
+          } else {
+            dst.append("[^/]*");
+          }
+          break;
+        case '?':
+          dst.append("[^/]");
+          break;
+        case '.':
+        case '+':
+        case '{':
+        case '}':
+        case '(':
+        case ')':
+        case '|':
+        case '^':
+        case '$':
+          // These need to be escaped in regular expressions
+          dst.append('\\').append(c);
+          break;
+        case '\\':
+          i = doubleSlashes(dst, src, i);
+          break;
+        default:
+          dst.append(c);
+          break;
+      }
+    }
+    return dst.toString();
+  }
+
+  private static int doubleSlashes(StringBuilder dst, char[] src, int i) {
+    // Emit the next character without special interpretation
+    dst.append('\\');
+    if ((i - 1) != src.length) {
+      dst.append(src[i]);
+      i++;
+    } else {
+      // A backslash at the very end is treated like an escaped backslash
+      dst.append('\\');
+    }
+    return i;
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3WritableByteChannel.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/S3WritableByteChannel.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.io.aws.s3.S3Path;
+
+/** A writable S3 object, as a {@link WritableByteChannel}. */
+class S3WritableByteChannel implements WritableByteChannel {
+
+  private final AmazonS3 amazonS3;
+  private final S3Path path;
+  private final String uploadId;
+  private final ByteArrayOutputStream uploadStream;
+  private final WritableByteChannel uploadChannel;
+  private final List<PartETag> eTags;
+
+  // Amazon parts are 1-indexed, not zero-indexed.
+  private int partNumber = 1;
+  private boolean open = true;
+
+  S3WritableByteChannel(
+      AmazonS3 amazonS3, S3Path path, String storageClass, int uploadBufferSizeBytes)
+      throws IOException {
+    this.amazonS3 = checkNotNull(amazonS3, "amazonS3");
+    this.path = checkNotNull(path, "path");
+    checkArgument(uploadBufferSizeBytes > 0, "uploadBufferSizeBytes");
+    this.uploadStream = new ByteArrayOutputStream(uploadBufferSizeBytes);
+    this.uploadChannel = Channels.newChannel(uploadStream);
+    eTags = new ArrayList<>();
+
+    InitiateMultipartUploadRequest request =
+        new InitiateMultipartUploadRequest(path.getBucket(), path.getKey())
+            .withStorageClass(storageClass);
+    InitiateMultipartUploadResult result;
+    try {
+      result = amazonS3.initiateMultipartUpload(request);
+    } catch (AmazonServiceException e) {
+      throw new IOException(e);
+    }
+    uploadId = result.getUploadId();
+  }
+
+  @Override
+  public int write(ByteBuffer sourceBuffer) throws IOException {
+    if (!isOpen()) {
+      throw new ClosedChannelException();
+    }
+    if (!sourceBuffer.hasArray()) {
+      throw new IllegalArgumentException("sourceBuffer is expected to have a backing array");
+    }
+
+    int totalBytesWritten = 0;
+    while (sourceBuffer.hasRemaining()) {
+      int bytesWritten = uploadChannel.write(sourceBuffer);
+      totalBytesWritten += bytesWritten;
+      if (sourceBuffer.hasRemaining()) {
+        flush();
+      }
+    }
+
+    return totalBytesWritten;
+  }
+
+  private void flush() throws IOException {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(uploadStream.toByteArray());
+
+    UploadPartRequest request =
+        new UploadPartRequest()
+            .withBucketName(path.getBucket())
+            .withKey(path.getKey())
+            .withUploadId(uploadId)
+            .withPartNumber(partNumber++)
+            .withPartSize(uploadStream.size())
+            .withInputStream(inputStream);
+    UploadPartResult result;
+    try {
+      result = amazonS3.uploadPart(request);
+    } catch (AmazonServiceException e) {
+      throw new IOException(e);
+    }
+    uploadStream.reset();
+    eTags.add(result.getPartETag());
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public void close() throws IOException {
+    open = false;
+    if (uploadStream.size() > 0) {
+      flush();
+    }
+    CompleteMultipartUploadRequest request =
+        new CompleteMultipartUploadRequest()
+            .withBucketName(path.getBucket())
+            .withKey(path.getKey())
+            .withUploadId(uploadId)
+            .withPartETags(eTags);
+    try {
+      amazonS3.completeMultipartUpload(request);
+    } catch (AmazonServiceException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/package-info.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/util/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Defines Amazon Web Services component utilities that can be used by Beam runners. */
+package org.apache.beam.sdk.io.aws.util;

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3PathTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3PathTest.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.aws.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests {@link S3Path}. */
+@RunWith(JUnit4.class)
+public class S3PathTest {
+
+  static final class TestCase {
+
+    final String uri;
+    final String expectedBucket;
+    final String expectedKey;
+    final String[] namedComponents;
+
+    TestCase(String uri, String... namedComponents) {
+      this.uri = uri;
+      this.expectedBucket = namedComponents[0];
+      this.namedComponents = namedComponents;
+      this.expectedKey = uri.substring(expectedBucket.length() + 6);
+    }
+  }
+
+  // Each test case is an expected URL, then the components used to build it.
+  // Empty components result in a double slash.
+  static final List<TestCase> PATH_TEST_CASES =
+      Arrays.asList(
+          new TestCase("s3://bucket/then/object", "bucket", "then", "object"),
+          new TestCase("s3://bucket//then/object", "bucket", "", "then", "object"),
+          new TestCase("s3://bucket/then//object", "bucket", "then", "", "object"),
+          new TestCase("s3://bucket/then///object", "bucket", "then", "", "", "object"),
+          new TestCase("s3://bucket/then/object/", "bucket", "then", "object/"),
+          new TestCase("s3://bucket/then/object/", "bucket", "then/", "object/"),
+          new TestCase("s3://bucket/then/object//", "bucket", "then", "object", ""),
+          new TestCase("s3://bucket/then/object//", "bucket", "then", "object/", ""),
+          new TestCase("s3://bucket/09azAZ!-_.*'()", "bucket", "09azAZ!-_.*'()"),
+          new TestCase("s3://bucket/then--object", "bucket", "then--object"),
+          new TestCase("s3://bucket-hyphenated/object", "bucket-hyphenated", "object"),
+          new TestCase("s3://sub.bucket/object", "sub.bucket", "object"),
+          new TestCase("s3://bucket/", "bucket"));
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testS3PathParsing() throws Exception {
+    for (TestCase testCase : PATH_TEST_CASES) {
+      String uriString = testCase.uri;
+
+      S3Path path = S3Path.fromUri(URI.create(uriString));
+      // Deconstruction - check bucket, key, and components.
+      assertEquals(testCase.expectedBucket, path.getBucket());
+      assertEquals(testCase.expectedKey, path.getKey());
+      assertEquals(testCase.uri, testCase.namedComponents.length, path.getNameCount());
+
+      // Construction - check that the path can be built from components.
+      S3Path built = S3Path.fromComponents(null, null);
+      for (String component : testCase.namedComponents) {
+        built = built.resolve(component);
+      }
+      assertEquals(testCase.uri, built.toString());
+    }
+  }
+
+  @Test
+  public void testParentRelationship() throws Exception {
+    S3Path path = S3Path.fromComponents("bucket", "then/object");
+    assertEquals("bucket", path.getBucket());
+    assertEquals("then/object", path.getKey());
+    assertEquals(3, path.getNameCount());
+    assertTrue(path.endsWith("object"));
+    assertTrue(path.startsWith("bucket/then"));
+
+    S3Path parent = path.getParent(); // s3://bucket/then/
+    assertEquals("bucket", parent.getBucket());
+    assertEquals("then/", parent.getKey());
+    assertEquals(2, parent.getNameCount());
+    assertThat(path, Matchers.not(Matchers.equalTo(parent)));
+    assertTrue(path.startsWith(parent));
+    assertFalse(parent.startsWith(path));
+    assertTrue(parent.endsWith("then/"));
+    assertTrue(parent.startsWith("bucket/then"));
+    assertTrue(parent.isAbsolute());
+
+    S3Path root = path.getRoot();
+    assertEquals(0, root.getNameCount());
+    assertEquals("s3://", root.toString());
+    assertEquals("", root.getBucket());
+    assertEquals("", root.getKey());
+    assertTrue(root.isAbsolute());
+    assertThat(root, Matchers.equalTo(parent.getRoot()));
+
+    S3Path grandParent = parent.getParent(); // s3://bucket/
+    assertEquals(1, grandParent.getNameCount());
+    assertEquals("s3://bucket/", grandParent.toString());
+    assertTrue(grandParent.isAbsolute());
+    assertThat(root, Matchers.equalTo(grandParent.getParent()));
+    assertThat(root.getParent(), Matchers.nullValue());
+
+    assertTrue(path.startsWith(path.getRoot()));
+    assertTrue(parent.startsWith(path.getRoot()));
+  }
+
+  @Test
+  public void testRelativeParent() throws Exception {
+    S3Path path = S3Path.fromComponents(null, "a/b");
+    S3Path parent = path.getParent();
+    assertEquals("a/", parent.toString());
+
+    S3Path grandParent = parent.getParent();
+    assertNull(grandParent);
+  }
+
+  @Test
+  public void testUriSupport() throws Exception {
+    URI uri = URI.create("s3://bucket/some/path");
+
+    S3Path path = S3Path.fromUri(uri);
+    assertEquals("bucket", path.getBucket());
+    assertEquals("some/path", path.getKey());
+
+    URI reconstructed = path.toUri();
+    assertEquals(uri, reconstructed);
+
+    path = S3Path.fromUri("s3://bucket");
+    assertEquals("s3://bucket/", path.toString());
+  }
+
+  @Test
+  public void testBucketParsing() throws Exception {
+    S3Path path = S3Path.fromUri("s3://bucket");
+    S3Path path2 = S3Path.fromUri("s3://bucket/");
+
+    assertEquals(path, path2);
+    assertEquals(path.toString(), path2.toString());
+    assertEquals(path.toUri(), path2.toUri());
+  }
+
+  @Test
+  public void testS3PathToString() throws Exception {
+    String filename = "s3://some-bucket/some/file.txt";
+    S3Path path = S3Path.fromUri(filename);
+    assertEquals(filename, path.toString());
+  }
+
+  @Test
+  public void testEquals() {
+    S3Path a = S3Path.fromComponents(null, "a/b/c");
+    S3Path a2 = S3Path.fromComponents(null, "a/b/c");
+    assertFalse(a.isAbsolute());
+    assertFalse(a2.isAbsolute());
+
+    S3Path b = S3Path.fromComponents("bucket", "a/b/c");
+    S3Path b2 = S3Path.fromComponents("bucket", "a/b/c");
+    assertTrue(b.isAbsolute());
+    assertTrue(b2.isAbsolute());
+
+    assertEquals(a, a);
+    assertThat(a, Matchers.not(Matchers.equalTo(b)));
+    assertThat(b, Matchers.not(Matchers.equalTo(a)));
+
+    assertEquals(a, a2);
+    assertEquals(a2, a);
+    assertEquals(b, b2);
+    assertEquals(b2, b);
+
+    assertThat(a, Matchers.not(Matchers.equalTo(Paths.get("/tmp/foo"))));
+    assertTrue(a != null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidS3Path() {
+    @SuppressWarnings("unused")
+    S3Path filename = S3Path.fromUri("file://invalid/s3/path");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidBucket() {
+    S3Path.fromComponents("invalid/", "");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidBucketWithUnderscore() {
+    S3Path.fromComponents("invalid_bucket", "");
+  }
+
+  @Test
+  public void testResolveUri() {
+    S3Path path = S3Path.fromComponents("bucket", "a/b/c");
+    S3Path d = path.resolve("s3://bucket2/d");
+    assertEquals("s3://bucket2/d", d.toString());
+  }
+
+  @Test
+  public void testResolveOther() {
+    S3Path a = S3Path.fromComponents("bucket", "a");
+    S3Path b = a.resolve(Paths.get("b"));
+    assertEquals("a/b", b.getKey());
+  }
+
+  @Test
+  public void testGetFileName() {
+    assertEquals("foo", S3Path.fromUri("s3://bucket/bar/foo").getFileName().toString());
+    assertEquals("foo", S3Path.fromUri("s3://bucket/foo").getFileName().toString());
+    thrown.expect(UnsupportedOperationException.class);
+    S3Path.fromUri("s3://bucket/").getFileName();
+  }
+
+  @Test
+  public void testResolveSibling() {
+    assertEquals(
+        "s3://bucket/bar/moo",
+        S3Path.fromUri("s3://bucket/bar/foo").resolveSibling("moo").toString());
+    assertEquals(
+        "s3://bucket/moo", S3Path.fromUri("s3://bucket/foo").resolveSibling("moo").toString());
+    thrown.expect(UnsupportedOperationException.class);
+    S3Path.fromUri("s3://bucket/").resolveSibling("moo");
+  }
+
+  @Test
+  public void testCompareTo() {
+    S3Path a = S3Path.fromComponents("bucket", "a");
+    S3Path b = S3Path.fromComponents("bucket", "b");
+    S3Path b2 = S3Path.fromComponents("bucket2", "b");
+    S3Path brel = S3Path.fromComponents(null, "b");
+    S3Path a2 = S3Path.fromComponents("bucket", "a");
+    S3Path arel = S3Path.fromComponents(null, "a");
+
+    assertThat(a.compareTo(b), Matchers.lessThan(0));
+    assertThat(b.compareTo(a), Matchers.greaterThan(0));
+    assertThat(a.compareTo(a2), Matchers.equalTo(0));
+
+    assertThat(a.hashCode(), Matchers.equalTo(a2.hashCode()));
+    assertThat(a.hashCode(), Matchers.not(Matchers.equalTo(b.hashCode())));
+    assertThat(b.hashCode(), Matchers.not(Matchers.equalTo(brel.hashCode())));
+
+    assertThat(brel.compareTo(b), Matchers.lessThan(0));
+    assertThat(b.compareTo(brel), Matchers.greaterThan(0));
+    assertThat(arel.compareTo(brel), Matchers.lessThan(0));
+    assertThat(brel.compareTo(arel), Matchers.greaterThan(0));
+
+    assertThat(b.compareTo(b2), Matchers.lessThan(0));
+    assertThat(b2.compareTo(b), Matchers.greaterThan(0));
+  }
+
+  @Test
+  public void testCompareTo_ordering() {
+    S3Path ab = S3Path.fromComponents("bucket", "a/b");
+    S3Path abc = S3Path.fromComponents("bucket", "a/b/c");
+    S3Path a1b = S3Path.fromComponents("bucket", "a-1/b");
+
+    assertThat(ab.compareTo(a1b), Matchers.lessThan(0));
+    assertThat(a1b.compareTo(ab), Matchers.greaterThan(0));
+
+    assertThat(ab.compareTo(abc), Matchers.lessThan(0));
+    assertThat(abc.compareTo(ab), Matchers.greaterThan(0));
+  }
+
+  @Test
+  public void testCompareTo_buckets() {
+    S3Path a = S3Path.fromComponents(null, "a/b/c");
+    S3Path b = S3Path.fromComponents("bucket", "a/b/c");
+
+    assertThat(a.compareTo(b), Matchers.lessThan(0));
+    assertThat(b.compareTo(a), Matchers.greaterThan(0));
+  }
+
+  @Test
+  public void testIterator() {
+    S3Path a = S3Path.fromComponents("bucket", "a/b/c");
+    Iterator<Path> it = a.iterator();
+
+    assertTrue(it.hasNext());
+    assertEquals("s3://bucket/", it.next().toString());
+    assertTrue(it.hasNext());
+    assertEquals("a", it.next().toString());
+    assertTrue(it.hasNext());
+    assertEquals("b", it.next().toString());
+    assertTrue(it.hasNext());
+    assertEquals("c", it.next().toString());
+    assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void testSubpath() {
+    S3Path a = S3Path.fromComponents("bucket", "a/b/c/d");
+    assertThat(a.subpath(0, 1).toString(), Matchers.equalTo("s3://bucket/"));
+    assertThat(a.subpath(0, 2).toString(), Matchers.equalTo("s3://bucket/a"));
+    assertThat(a.subpath(0, 3).toString(), Matchers.equalTo("s3://bucket/a/b"));
+    assertThat(a.subpath(0, 4).toString(), Matchers.equalTo("s3://bucket/a/b/c"));
+    assertThat(a.subpath(1, 2).toString(), Matchers.equalTo("a"));
+    assertThat(a.subpath(2, 3).toString(), Matchers.equalTo("b"));
+    assertThat(a.subpath(2, 4).toString(), Matchers.equalTo("b/c"));
+    assertThat(a.subpath(2, 5).toString(), Matchers.equalTo("b/c/d"));
+  }
+
+  @Test
+  public void testGetName() {
+    S3Path a = S3Path.fromComponents("bucket", "a/b/c/d");
+    assertEquals(5, a.getNameCount());
+    assertThat(a.getName(0).toString(), Matchers.equalTo("s3://bucket/"));
+    assertThat(a.getName(1).toString(), Matchers.equalTo("a"));
+    assertThat(a.getName(2).toString(), Matchers.equalTo("b"));
+    assertThat(a.getName(3).toString(), Matchers.equalTo("c"));
+    assertThat(a.getName(4).toString(), Matchers.equalTo("d"));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testSubPathError() {
+    S3Path a = S3Path.fromComponents("bucket", "a/b/c/d");
+    a.subpath(1, 1); // throws IllegalArgumentException
+    fail();
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/util/MatchResultMatcher.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/util/MatchResultMatcher.java
@@ -1,0 +1,100 @@
+package org.apache.beam.sdk.io.aws.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.List;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.ResourceId;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+/**
+ * Hamcrest {@link Matcher} to match {@link MatchResult}. Necessary because {@link
+ * MatchResult#metadata()} throws an exception under normal circumstances.
+ */
+public class MatchResultMatcher extends BaseMatcher<MatchResult> {
+
+  private final MatchResult.Status expectedStatus;
+  private final List<MatchResult.Metadata> expectedMetadata;
+  private final IOException expectedException;
+
+  private MatchResultMatcher(
+      MatchResult.Status expectedStatus,
+      List<MatchResult.Metadata> expectedMetadata,
+      IOException expectedException) {
+    this.expectedStatus = checkNotNull(expectedStatus);
+    checkArgument((expectedMetadata == null) ^ (expectedException == null));
+    this.expectedMetadata = expectedMetadata;
+    this.expectedException = expectedException;
+  }
+
+  static MatchResultMatcher create(List<MatchResult.Metadata> expectedMetadata) {
+    return new MatchResultMatcher(MatchResult.Status.OK, expectedMetadata, null);
+  }
+
+  static MatchResultMatcher create(MatchResult.Metadata expectedMetadata) {
+    return create(ImmutableList.of(expectedMetadata));
+  }
+
+  static MatchResultMatcher create(
+      long sizeBytes, ResourceId resourceId, boolean isReadSeekEfficient) {
+    return create(
+        MatchResult.Metadata.builder()
+            .setSizeBytes(sizeBytes)
+            .setResourceId(resourceId)
+            .setIsReadSeekEfficient(isReadSeekEfficient)
+            .build());
+  }
+
+  static MatchResultMatcher create(
+      MatchResult.Status expectedStatus, IOException expectedException) {
+    return new MatchResultMatcher(expectedStatus, null, expectedException);
+  }
+
+  static MatchResultMatcher create(MatchResult expected) {
+    MatchResult.Status expectedStatus = expected.status();
+    List<MatchResult.Metadata> expectedMetadata = null;
+    IOException expectedException = null;
+    try {
+      expectedMetadata = expected.metadata();
+    } catch (IOException e) {
+      expectedException = e;
+    }
+    return new MatchResultMatcher(expectedStatus, expectedMetadata, expectedException);
+  }
+
+  @Override
+  public boolean matches(Object actual) {
+    if (actual == null) {
+      return false;
+    }
+    if (!(actual instanceof MatchResult)) {
+      return false;
+    }
+    MatchResult actualResult = (MatchResult) actual;
+    if (!expectedStatus.equals(actualResult.status())) {
+      return false;
+    }
+
+    List<MatchResult.Metadata> actualMetadata;
+    try {
+      actualMetadata = actualResult.metadata();
+    } catch (IOException e) {
+      return expectedException != null && expectedException.toString().equals(e.toString());
+    }
+    return expectedMetadata != null && expectedMetadata.equals(actualMetadata);
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    if (expectedMetadata != null) {
+      description.appendText(MatchResult.create(expectedStatus, expectedMetadata).toString());
+    } else {
+      description.appendText(MatchResult.create(expectedStatus, expectedException).toString());
+    }
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/util/S3UtilTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/util/S3UtilTest.java
@@ -1,0 +1,351 @@
+package org.apache.beam.sdk.io.aws.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.notNull;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CopyPartRequest;
+import com.amazonaws.services.s3.model.CopyPartResult;
+import com.amazonaws.services.s3.model.DeleteObjectsRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.google.common.collect.ImmutableList;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.io.aws.options.S3Options;
+import org.apache.beam.sdk.io.aws.s3.S3Path;
+import org.apache.beam.sdk.io.aws.s3.S3ResourceId;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+
+/** Test case for {@link S3Util}. */
+@RunWith(JUnit4.class)
+public class S3UtilTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testGlobTranslation() {
+    assertEquals("foo", S3Util.wildcardToRegexp("foo"));
+    assertEquals("fo[^/]*o", S3Util.wildcardToRegexp("fo*o"));
+    assertEquals("f[^/]*o\\.[^/]", S3Util.wildcardToRegexp("f*o.?"));
+    assertEquals("foo-[0-9][^/]*", S3Util.wildcardToRegexp("foo-[0-9]*"));
+    assertEquals("foo-[0-9].*", S3Util.wildcardToRegexp("foo-[0-9]**"));
+    assertEquals(".*foo", S3Util.wildcardToRegexp("**/*foo"));
+    assertEquals(".*foo", S3Util.wildcardToRegexp("**foo"));
+    assertEquals("foo/[^/]*", S3Util.wildcardToRegexp("foo/*"));
+    assertEquals("foo[^/]*", S3Util.wildcardToRegexp("foo*"));
+    assertEquals("foo/[^/]*/[^/]*/[^/]*", S3Util.wildcardToRegexp("foo/*/*/*"));
+    assertEquals("foo/[^/]*/.*", S3Util.wildcardToRegexp("foo/*/**"));
+    assertEquals("foo.*baz", S3Util.wildcardToRegexp("foo**baz"));
+  }
+
+  private static S3Options s3Options() {
+    S3Options options = PipelineOptionsFactory.as(S3Options.class);
+    options.setAwsAccessKeyId("mock");
+    options.setAwsSecretAccessKey("mock");
+    options.setAwsRegion("mock");
+    return options;
+  }
+
+  @Test
+  public void testCopyMultipleParts() throws IOException {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    S3Path sourcePath = S3Path.fromUri("s3://bucket/from");
+    S3Path destinationPath = S3Path.fromUri("s3://bucket/to");
+
+    InitiateMultipartUploadResult initiateMultipartUploadResult =
+        new InitiateMultipartUploadResult();
+    initiateMultipartUploadResult.setUploadId("upload-id");
+    when(mockAmazonS3.initiateMultipartUpload(
+            argThat(notNullValue(InitiateMultipartUploadRequest.class))))
+        .thenReturn(initiateMultipartUploadResult);
+
+    ObjectMetadata sourceS3ObjectMetadata = new ObjectMetadata();
+    sourceS3ObjectMetadata.setContentLength((long) (s3Util.getS3UploadBufferSizeBytes() * 1.5));
+    when(mockAmazonS3.getObjectMetadata(sourcePath.getBucket(), sourcePath.getKey()))
+        .thenReturn(sourceS3ObjectMetadata);
+
+    CopyPartResult copyPartResult1 = new CopyPartResult();
+    copyPartResult1.setETag("etag-1");
+    CopyPartResult copyPartResult2 = new CopyPartResult();
+    copyPartResult1.setETag("etag-2");
+    when(mockAmazonS3.copyPart(argThat(notNullValue(CopyPartRequest.class))))
+        .thenReturn(copyPartResult1)
+        .thenReturn(copyPartResult2);
+
+    s3Util.copy(sourcePath, destinationPath);
+
+    verify(mockAmazonS3, times(1))
+        .completeMultipartUpload(argThat(notNullValue(CompleteMultipartUploadRequest.class)));
+  }
+
+  @Test
+  public void deleteThousandsOfObjectsInMultipleBuckets() throws IOException {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    List<String> buckets = ImmutableList.of("bucket1", "bucket2");
+    List<String> keys = new ArrayList<>();
+    for (int i = 0; i < 2500; i++) {
+      keys.add(String.format("key-%d", i));
+    }
+    List<S3Path> paths = new ArrayList<>();
+    for (String bucket : buckets) {
+      for (String key : keys) {
+        paths.add(S3Path.fromComponents(bucket, key));
+      }
+    }
+
+    s3Util.delete(paths);
+
+    // Should require 6 calls to delete 2500 objects in each of 2 buckets.
+    verify(mockAmazonS3, times(6)).deleteObjects(argThat(notNullValue(DeleteObjectsRequest.class)));
+  }
+
+  @Test
+  public void matchNonGlob() {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    S3Path path = S3Path.fromUri("s3://testbucket/testdirectory/filethatexists");
+    ObjectMetadata s3ObjectMetadata = new ObjectMetadata();
+    s3ObjectMetadata.setContentLength(100);
+    when(mockAmazonS3.getObjectMetadata(path.getBucket(), path.getKey()))
+        .thenReturn(s3ObjectMetadata);
+
+    MatchResult result = s3Util.matchNonGlobPath(path);
+    assertThat(
+        result,
+        MatchResultMatcher.create(
+            ImmutableList.of(
+                MatchResult.Metadata.builder()
+                    .setSizeBytes(100)
+                    .setResourceId(S3ResourceId.fromS3Path(path))
+                    .setIsReadSeekEfficient(true)
+                    .build())));
+  }
+
+  @Test
+  public void matchNonGlobNotFound() throws IOException {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    S3Path path = S3Path.fromUri("s3://testbucket/testdirectory/nonexistentfile");
+    AmazonS3Exception exception = new AmazonS3Exception("mock exception");
+    exception.setStatusCode(404);
+    when(mockAmazonS3.getObjectMetadata(path.getBucket(), path.getKey())).thenThrow(exception);
+
+    MatchResult result = s3Util.matchNonGlobPath(path);
+    assertThat(
+        result,
+        MatchResultMatcher.create(MatchResult.Status.NOT_FOUND, new FileNotFoundException()));
+  }
+
+  @Test
+  public void matchNonGlobForbidden() throws IOException {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    AmazonS3Exception exception = new AmazonS3Exception("mock exception");
+    exception.setStatusCode(403);
+    S3Path path = S3Path.fromUri("s3://testbucket/testdirectory/keyname");
+    when(mockAmazonS3.getObjectMetadata(path.getBucket(), path.getKey())).thenThrow(exception);
+
+    assertThat(
+        s3Util.matchNonGlobPath(path),
+        MatchResultMatcher.create(MatchResult.Status.ERROR, new IOException(exception)));
+  }
+
+  static class ListObjectsV2RequestArgumentMatches extends ArgumentMatcher<ListObjectsV2Request> {
+
+    private final ListObjectsV2Request expected;
+
+    ListObjectsV2RequestArgumentMatches(ListObjectsV2Request expected) {
+      this.expected = checkNotNull(expected);
+    }
+
+    @Override
+    public boolean matches(Object argument) {
+      if (argument != null && argument instanceof ListObjectsV2Request) {
+        ListObjectsV2Request actual = (ListObjectsV2Request) argument;
+        return expected.getBucketName().equals(actual.getBucketName())
+            && expected.getPrefix().equals(actual.getPrefix())
+            && (expected.getContinuationToken() == null
+                ? actual.getContinuationToken() == null
+                : expected.getContinuationToken().equals(actual.getContinuationToken()));
+      }
+      return false;
+    }
+  }
+
+  @Test
+  public void matchGlob() {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    S3Path path = S3Path.fromUri("s3://testbucket/foo/bar*baz");
+
+    ListObjectsV2Request firstRequest =
+        new ListObjectsV2Request()
+            .withBucketName(path.getBucket())
+            .withPrefix(path.getKeyNonWildcardPrefix())
+            .withContinuationToken(null);
+
+    // Expected to be returned; prefix and wildcard/regex match
+    S3ObjectSummary firstMatch = new S3ObjectSummary();
+    firstMatch.setBucketName(path.getBucket());
+    firstMatch.setKey("foo/bar0baz");
+    firstMatch.setSize(100);
+
+    // Expected to not be returned; prefix matches, but substring after wildcard does not
+    S3ObjectSummary secondMatch = new S3ObjectSummary();
+    secondMatch.setBucketName(path.getBucket());
+    secondMatch.setKey("foo/bar1qux");
+    secondMatch.setSize(200);
+
+    // Expected first request returns continuation token
+    ListObjectsV2Result firstResult = new ListObjectsV2Result();
+    firstResult.setNextContinuationToken("token");
+    firstResult.getObjectSummaries().add(firstMatch);
+    firstResult.getObjectSummaries().add(secondMatch);
+    when(mockAmazonS3.listObjectsV2(argThat(new ListObjectsV2RequestArgumentMatches(firstRequest))))
+        .thenReturn(firstResult);
+
+    // Expect second request with continuation token
+    ListObjectsV2Request secondRequest =
+        new ListObjectsV2Request()
+            .withBucketName(path.getBucket())
+            .withPrefix(path.getKeyNonWildcardPrefix())
+            .withContinuationToken("token");
+
+    // Expected to be returned; prefix and wildcard/regex match
+    S3ObjectSummary thirdMatch = new S3ObjectSummary();
+    thirdMatch.setBucketName(path.getBucket());
+    thirdMatch.setKey("foo/bar2baz");
+    thirdMatch.setSize(300);
+
+    // Expected second request returns third prefix match and no continuation token
+    ListObjectsV2Result secondResult = new ListObjectsV2Result();
+    secondResult.setNextContinuationToken(null);
+    secondResult.getObjectSummaries().add(thirdMatch);
+    when(mockAmazonS3.listObjectsV2(
+            argThat(new ListObjectsV2RequestArgumentMatches(secondRequest))))
+        .thenReturn(secondResult);
+
+    assertThat(
+        s3Util.matchGlobPath(path),
+        MatchResultMatcher.create(
+            ImmutableList.of(
+                MatchResult.Metadata.builder()
+                    .setIsReadSeekEfficient(true)
+                    .setResourceId(
+                        S3ResourceId.fromS3Path(
+                            S3Path.fromComponents(firstMatch.getBucketName(), firstMatch.getKey())))
+                    .setSizeBytes(firstMatch.getSize())
+                    .build(),
+                MatchResult.Metadata.builder()
+                    .setIsReadSeekEfficient(true)
+                    .setResourceId(
+                        S3ResourceId.fromS3Path(
+                            S3Path.fromComponents(thirdMatch.getBucketName(), thirdMatch.getKey())))
+                    .setSizeBytes(thirdMatch.getSize())
+                    .build())));
+  }
+
+  @Test
+  public void matchVariousInvokeThreadPool() throws IOException {
+    S3Options pipelineOptions = s3Options();
+    S3Util s3Util = pipelineOptions.getS3Util();
+
+    AmazonS3 mockAmazonS3 = Mockito.mock(AmazonS3.class);
+    s3Util.setAmazonS3Client(mockAmazonS3);
+
+    AmazonS3Exception notFoundException = new AmazonS3Exception("mock exception");
+    notFoundException.setStatusCode(404);
+    S3Path pathNotExist = S3Path.fromUri("s3://testbucket/testdirectory/nonexistentfile");
+    when(mockAmazonS3.getObjectMetadata(pathNotExist.getBucket(), pathNotExist.getKey()))
+        .thenThrow(notFoundException);
+
+    AmazonS3Exception forbiddenException = new AmazonS3Exception("mock exception");
+    forbiddenException.setStatusCode(403);
+    S3Path pathForbidden = S3Path.fromUri("s3://testbucket/testdirectory/forbiddenfile");
+    when(mockAmazonS3.getObjectMetadata(pathForbidden.getBucket(), pathForbidden.getKey()))
+        .thenThrow(forbiddenException);
+
+    S3Path pathExist = S3Path.fromUri("s3://testbucket/testdirectory/filethatexists");
+    ObjectMetadata s3ObjectMetadata = new ObjectMetadata();
+    s3ObjectMetadata.setContentLength(100);
+    when(mockAmazonS3.getObjectMetadata(pathExist.getBucket(), pathExist.getKey()))
+        .thenReturn(s3ObjectMetadata);
+
+    S3Path pathGlob = S3Path.fromUri("s3://testbucket/path/part*");
+
+    S3ObjectSummary foundListObject = new S3ObjectSummary();
+    foundListObject.setBucketName(pathGlob.getBucket());
+    foundListObject.setKey("path/part-0");
+    foundListObject.setSize(200);
+
+    ListObjectsV2Result listObjectsResult = new ListObjectsV2Result();
+    listObjectsResult.setNextContinuationToken(null);
+    listObjectsResult.getObjectSummaries().add(foundListObject);
+    when(mockAmazonS3.listObjectsV2(notNull(ListObjectsV2Request.class)))
+        .thenReturn(listObjectsResult);
+
+    assertThat(
+        s3Util.match(ImmutableList.of(pathNotExist, pathForbidden, pathExist, pathGlob)),
+        contains(
+            MatchResultMatcher.create(MatchResult.Status.NOT_FOUND, new FileNotFoundException()),
+            MatchResultMatcher.create(
+                MatchResult.Status.ERROR, new IOException(forbiddenException)),
+            MatchResultMatcher.create(100, S3ResourceId.fromS3Path(pathExist), true),
+            MatchResultMatcher.create(
+                200,
+                S3ResourceId.fromS3Path(
+                    S3Path.fromComponents(pathGlob.getBucket(), foundListObject.getKey())),
+                true)));
+  }
+}

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -40,6 +40,7 @@
   </properties>
 
   <modules>
+    <module>amazon-web-services</module>
     <module>amqp</module>
     <module>cassandra</module>
     <module>common</module>


### PR DESCRIPTION
My first contribution, will submit ICLA later today.

Ran `mvn clean verify` against sdks/java/io only, because I'm currently in a place with limited power and bandwidth.

There is some technical discussion in the JIRA.
https://issues.apache.org/jira/browse/BEAM-2500

Please notice that there is one persistent thread pool, and that copy operations can create a new thread pool per copy. Happy to hear feedback and discuss.