### PR TITLE
[BEAM-3118] Fix thread leaks in ElasticsearchIOTest.testWriteWith* when using DoFnTester

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -258,6 +258,10 @@ class ElasticsearchIOTestCommon implements Serializable {
         }
       }
     }
+    // fnTester clones the writeFn in default cloning behavior (CLOSE_ONCE).
+    // Need to explicitly close the fnTester so that it closes the underlying cloned DoFn.
+    fnTester.finishBundle();
+    fnTester.close();
   }
 
   void testWriteWithMaxBatchSizeBytes() throws Exception {
@@ -302,5 +306,9 @@ class ElasticsearchIOTestCommon implements Serializable {
         }
       }
     }
+    // fnTester clones the writeFn in default cloning behavior (CLOSE_ONCE).
+    // Need to explicitly close the fnTester so that it closes the underlying cloned DoFn.
+    fnTester.finishBundle();
+    fnTester.close();
   }
 }


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
DoFnTester is configured in CLONE_ONCE cloning behavior. So we need to explicitly call DoFnTester.close() so that doFn.tearDown() could be called and the ES Resclient properly closed causing the http leaked threads to be properly terminated.
R: @jkff 