### PR TITLE
Set save_main_session to True for csv module

### DIFF
--- a/sdks/python/apache_beam/examples/complete/game/user_score.py
+++ b/sdks/python/apache_beam/examples/complete/game/user_score.py
@@ -61,6 +61,8 @@ import logging
 
 import apache_beam as beam
 from apache_beam.metrics.metric import Metrics
+from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam.options.pipeline_options import SetupOptions
 
 
 class ParseGameEventFn(beam.DoFn):
@@ -136,6 +138,12 @@ def run(argv=None):
                       help='Path to the output file(s).')
 
   args, pipeline_args = parser.parse_known_args(argv)
+
+  options = PipelineOptions(pipeline_args)
+
+  # We use the save_main_session option because one or more DoFn's in this
+  # workflow rely on global context (e.g., a module imported at module level).
+  options.view_as(SetupOptions).save_main_session = True
 
   with beam.Pipeline(argv=pipeline_args) as p:
     def format_user_score_sums(user_score):


### PR DESCRIPTION
Parsing the game events requires the `csv` module, so we also needed to set `save_main_session` to True for this to work in Dataflow.

R: @aaltay 