### PR TITLE
[BEAM-2718] Integrate bundle retry code for the DirectRunner

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -313,13 +313,6 @@ class DirectOptions(PipelineOptions):
         help='DirectRunner uses stacked WindowedValues within a Bundle for '
         'memory optimization. Set --no_direct_runner_use_stacked_bundle to '
         'avoid it.')
-    parser.add_argument(
-        '--direct_runner_bundle_retry',
-        action='store_true',
-        default=False,
-        help=
-        ('Whether to allow bundle retries. If True the maximum'
-         'number of attempts to process a bundle is 4. '))
 
 
 class GoogleCloudOptions(PipelineOptions):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -506,8 +506,7 @@ class RunnerApiTest(unittest.TestCase):
 class DirectRunnerRetryTests(unittest.TestCase):
 
   def test_retry_fork_graph(self):
-    pipeline_options = PipelineOptions(['--direct_runner_bundle_retry'])
-    p = beam.Pipeline(options=pipeline_options)
+    p = beam.Pipeline()
 
     # TODO(mariagh): Remove the use of globals from the test.
     global count_b, count_c # pylint: disable=global-variable-undefined

--- a/sdks/python/run_pylint.sh
+++ b/sdks/python/run_pylint.sh
@@ -72,6 +72,7 @@ ISORT_EXCLUDED=(
   "iobase_test.py"
   "fast_coders_test.py"
   "slow_coders_test.py"
+  "executor.py"
 )
 SKIP_PARAM=""
 for file in "${ISORT_EXCLUDED[@]}"; do

--- a/sdks/python/run_pylint.sh
+++ b/sdks/python/run_pylint.sh
@@ -72,7 +72,6 @@ ISORT_EXCLUDED=(
   "iobase_test.py"
   "fast_coders_test.py"
   "slow_coders_test.py"
-  "executor.py"
 )
 SKIP_PARAM=""
 for file in "${ISORT_EXCLUDED[@]}"; do


### PR DESCRIPTION
When processing of a bundle fails, the bundle is retried.
 - [x] Remove opt-in flag, make it happen by default.
