### PR TITLE
[BEAM-3060] TextIOIT: DataFlow and PerfKit profiles + big hash

### DIFF
--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -59,7 +59,8 @@
 
             mvn verify -Dio-it-suite -pl sdks/java/io/file-based-io-tests
                 -DpkbLocation="path-to-pkb.py" \
-                -DintegrationTestPipelineOptions='["&ndash;&ndash;numberOfRecords=100000"]'
+                -DintegrationTestPipelineOptions='["&ndash;&ndash;numberOfRecords=100000"]' \
+                -DfileBasedIoItClass=file-based IO IT class, eg. org.apache.beam.sdk.io.text.TextIOIT
 
             For DirectRunner, please use -DforceDirectRunner=true argument
             For other runners please check doc in BEAM-3060 and https://beam.apache.org/documentation/io/testing/
@@ -120,7 +121,7 @@
                                 <argument>${pkbBeamRunnerOption}</argument>
                                 <!-- specific to this IO -->
                                 <argument>-beam_it_module=sdks/java/io/file-based-io-tests</argument>
-                                <argument>-beam_it_class=org.apache.beam.sdk.io.text.TextIOIT</argument>
+                                <argument>-beam_it_class=${fileBasedIoItClass}</argument>
                                 <!-- arguments typically defined by user -->
                                 <argument>-beam_it_options=${integrationTestPipelineOptions}</argument>
                             </arguments>

--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -31,6 +31,112 @@
     <name>Apache Beam :: SDKs :: Java :: IO :: File-based-io-tests</name>
     <description>Integration tests for reading/writing using file-based sources/sinks.</description>
 
+    <profiles>
+        <!-- Include the Google Cloud Dataflow runner activated by -DintegrationTestRunner=dataflow -->
+        <profile>
+            <id>dataflow-runner</id>
+            <activation>
+                <property>
+                    <name>integrationTestRunner</name>
+                    <value>dataflow</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.beam</groupId>
+                    <artifactId>beam-runners-google-cloud-dataflow-java</artifactId>
+                    <scope>runtime</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!--
+            This profile invokes PerfKitBenchmarker, which does benchmarking of
+            the IO ITs. The arguments passed to it allow it to invoke mvn again
+            with the desired benchmark.
+
+            To invoke this, run:
+
+            mvn verify -Dio-it-suite -pl sdks/java/io/file-based-io-tests
+                -DpkbLocation="path-to-pkb.py" \
+                -DintegrationTestPipelineOptions='["&ndash;&ndash;numberOfRecords=100000"]'
+        -->
+        <profile>
+            <id>io-it-suite</id>
+            <activation>
+                <property><name>io-it-suite</name></property>
+            </activation>
+            <properties>
+                <!-- This is based on the location of the current pom relative to the root
+                     See discussion in BEAM-2460 -->
+                <beamRootProjectDir>${project.parent.parent.parent.parent.basedir}</beamRootProjectDir>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>${groovy-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>find-supported-python-for-compile</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${beamRootProjectDir}/sdks/python/findSupportedPython.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${maven-exec-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>${python.interpreter.bin}</executable>
+                            <arguments>
+                                <argument>${pkbLocation}</argument>
+                                <argument>-benchmarks=beam_integration_benchmark</argument>
+                                <argument>-beam_it_profile=io-it</argument>
+                                <argument>-beam_location=${beamRootProjectDir}</argument>
+                                <argument>-beam_prebuilt=true</argument>
+                                <argument>-beam_sdk=java</argument>
+                                <!-- runner overrides, controlled via forceDirectRunner -->
+                                <argument>${pkbBeamRunnerProfile}</argument>
+                                <argument>${pkbBeamRunnerOption}</argument>
+                                <!-- specific to this IO -->
+                                <argument>-beam_it_module=sdks/java/io/file-based-io-tests</argument>
+                                <argument>-beam_it_class=org.apache.beam.sdk.io.text.TextIOIT</argument>
+                                <!-- arguments typically defined by user -->
+                                <argument>-beam_it_options=${integrationTestPipelineOptions}</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${surefire-plugin.version}</version>
+                        <configuration>
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.beam</groupId>

--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -60,6 +60,9 @@
             mvn verify -Dio-it-suite -pl sdks/java/io/file-based-io-tests
                 -DpkbLocation="path-to-pkb.py" \
                 -DintegrationTestPipelineOptions='["&ndash;&ndash;numberOfRecords=100000"]'
+
+            For DirectRunner, please use -DforceDirectRunner=true argument
+            For other runners please check doc in BEAM-3060 and https://beam.apache.org/documentation/io/testing/
         -->
         <profile>
             <id>io-it-suite</id>

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -54,7 +54,7 @@ import org.junit.runners.JUnit4;
  *
  * <p>Run this test using the command below. Pass in connection information via PipelineOptions:
  * <pre>
- *  mvn -e -Pio-it verify -pl sdks/java/io/text -DintegrationTestPipelineOptions='[
+ *  mvn -e -Pio-it verify -pl sdks/java/io/file-based-io-tests -DintegrationTestPipelineOptions='[
  *  "--numberOfRecords=100000",
  *  "--filenamePrefix=TEXTIOIT"
  *  ]'
@@ -107,7 +107,8 @@ public class TextIOIT {
   private static String getExpectedHashForLineCount(Long lineCount) {
     Map<Long, String> expectedHashes = ImmutableMap.of(
         100_000L, "4c8bb3b99dcc59459b20fefba400d446",
-        1_000_000L, "9796db06e7a7960f974d5a91164afff1"
+        1_000_000L, "9796db06e7a7960f974d5a91164afff1",
+        100_000_000L, "6ce05f456e2fdc846ded2abd0ec1de95"
     );
 
     String hash = expectedHashes.get(lineCount);

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -59,6 +59,9 @@ import org.junit.runners.JUnit4;
  *  "--filenamePrefix=TEXTIOIT"
  *  ]'
  * </pre>
+ * </p>
+ * <p>Please see 'sdks/java/io/file-based-io-tests/pom.xml' for instructions regarding
+ * running this test using Beam performance testing framework.</p>
  * */
 @RunWith(JUnit4.class)
 public class TextIOIT {

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -54,7 +54,9 @@ import org.junit.runners.JUnit4;
  *
  * <p>Run this test using the command below. Pass in connection information via PipelineOptions:
  * <pre>
- *  mvn -e -Pio-it verify -pl sdks/java/io/file-based-io-tests -DintegrationTestPipelineOptions='[
+ *  mvn -e -Pio-it verify -pl sdks/java/io/file-based-io-tests
+ *  -Dit.test=org.apache.beam.sdk.io.text.TextIOIT
+ *  -DintegrationTestPipelineOptions='[
  *  "--numberOfRecords=100000",
  *  "--filenamePrefix=TEXTIOIT"
  *  ]'


### PR DESCRIPTION
This PR adds Maven profiles for DataFlow runner and PerfKit to `file-based-io-tests`
Additionally hash for large dataset is added and doc for `TextIOIT` is fixed. 

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
