### PR TITLE
[BEAM-3169] Fixes a data loss bug in WriteFiles when used with fire-once triggers

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
@@ -213,7 +213,7 @@ class ParDoTranslator<InputT, OutputT>
             sideInputCollection.getWindowingStrategy());
       }
       if (!sideInputCollection.getCoder().equals(firstSideInput.getCoder())) {
-        String msg = "Multiple side inputs with different coders.";
+        String msg = context.getFullName() + ": Multiple side inputs with different coders.";
         throw new UnsupportedOperationException(msg);
       }
       sourceCollections.add(context.<PCollection<Object>>getViewInput(sideInput));

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/WordCountTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/WordCountTest.java
@@ -108,7 +108,7 @@ public class WordCountTest {
       .apply(ParDo.of(new ExtractWordsFn()))
       .apply(Count.<String>perElement())
       .apply(ParDo.of(new FormatAsStringFn()))
-      .apply("WriteCounts", TextIO.write().to(options.getOutput()))
+      .apply("WriteCounts", TextIO.write().to(options.getOutput()).withNumShards(2))
       ;
     p.run().waitUntilFinish();
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/WriteFilesTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/WriteFilesTranslationTest.java
@@ -64,7 +64,6 @@ public class WriteFilesTranslationTest {
     public static Iterable<WriteFiles<Object, Void, Object>> data() {
       return ImmutableList.of(
           WriteFiles.to(new DummySink()),
-          WriteFiles.to(new DummySink()).withWindowedWrites(),
           WriteFiles.to(new DummySink()).withNumShards(17),
           WriteFiles.to(new DummySink()).withWindowedWrites().withNumShards(42));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileBasedSink.java
@@ -44,6 +44,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
@@ -74,6 +75,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo.PaneInfoCoder;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors.TypeVariableExtractor;
@@ -123,6 +125,7 @@ import org.slf4j.LoggerFactory;
 public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     implements Serializable, HasDisplayData {
   private static final Logger LOG = LoggerFactory.getLogger(FileBasedSink.class);
+  static final String TEMP_DIRECTORY_PREFIX = ".temp-beam";
 
   /** @deprecated use {@link Compression}. */
   @Deprecated
@@ -511,7 +514,7 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
         implements SerializableFunction<ResourceId, ResourceId> {
       private static final AtomicLong TEMP_COUNT = new AtomicLong(0);
       private static final DateTimeFormatter TEMPDIR_TIMESTAMP =
-          DateTimeFormat.forPattern("yyyy-MM-DD_HH-mm-ss");
+          DateTimeFormat.forPattern("yyyy-MM-dd_HH-mm-ss");
       // The intent of the code is to have a consistent value of tempDirectory across
       // all workers, which wouldn't happen if now() was called inline.
       private final String timestamp = Instant.now().toString(TEMPDIR_TIMESTAMP);
@@ -522,7 +525,7 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
       @Override
       public ResourceId apply(ResourceId tempDirectory) {
         // Temp directory has a timestamp and a unique ID
-        String tempDirName = String.format(".temp-beam-%s-%s", timestamp, tempId);
+        String tempDirName = String.format(TEMP_DIRECTORY_PREFIX + "-%s-%s", timestamp, tempId);
         return tempDirectory
             .getCurrentDirectory()
             .resolve(tempDirName, StandardResolveOptions.RESOLVE_DIRECTORY);
@@ -558,30 +561,6 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
       this.windowedWrites = windowedWrites;
     }
 
-    /**
-     * Finalizes writing by copying temporary output files to their final location.
-     *
-     * <p>Finalization may be overridden by subclass implementations to perform customized
-     * finalization (e.g., initiating some operation on output bundles, merging them, etc.). {@code
-     * writerResults} contains the filenames of written bundles.
-     *
-     * <p>If subclasses override this method, they must guarantee that its implementation is
-     * idempotent, as it may be executed multiple times in the case of failure or for redundancy. It
-     * is a best practice to attempt to try to make this method atomic.
-     *
-     * <p>Returns the map of temporary files generated to final filenames. Callers must call {@link
-     * #removeTemporaryFiles(Set)} to cleanup the temporary files.
-     *
-     * @param writerResults the results of writes (FileResult).
-     */
-    public Map<ResourceId, ResourceId> finalize(Iterable<FileResult<DestinationT>> writerResults)
-        throws Exception {
-      // Collect names of temporary files and copies them.
-      Map<ResourceId, ResourceId> outputFilenames = buildOutputFilenames(writerResults);
-      copyToOutputFiles(outputFilenames);
-      return outputFilenames;
-    }
-
     /*
      * Remove temporary files after finalization.
      *
@@ -603,34 +582,52 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
     }
 
     @Experimental(Kind.FILESYSTEM)
-    protected final Map<ResourceId, ResourceId> buildOutputFilenames(
+    protected final List<KV<FileResult<DestinationT>, ResourceId>> buildOutputFilenames(
+        @Nullable DestinationT dest,
+        @Nullable BoundedWindow window,
+        @Nullable Integer numShards,
         Iterable<FileResult<DestinationT>> writerResults) {
-      int numShards = Iterables.size(writerResults);
-      Map<ResourceId, ResourceId> outputFilenames = Maps.newHashMap();
+      for (FileResult<DestinationT> res : writerResults) {
+        checkArgument(
+            Objects.equals(dest, res.getDestination()),
+            "File result has wrong destination: expected %s, got %s",
+            dest, res.getDestination());
+        checkArgument(
+            Objects.equals(window, res.getWindow()),
+            "File result has wrong window: expected %s, got %s",
+            window, res.getWindow());
+      }
+      List<KV<FileResult<DestinationT>, ResourceId>> outputFilenames = Lists.newArrayList();
 
-      // Either all results have a shard number set (if the sink is configured with a fixed
-      // number of shards), or they all don't (otherwise).
-      Boolean isShardNumberSetEverywhere = null;
-      for (FileResult<DestinationT> result : writerResults) {
-        boolean isShardNumberSetHere = (result.getShard() != UNKNOWN_SHARDNUM);
-        if (isShardNumberSetEverywhere == null) {
-          isShardNumberSetEverywhere = isShardNumberSetHere;
-        } else {
+      final int effectiveNumShards;
+      if (numShards != null) {
+        effectiveNumShards = numShards;
+        for (FileResult<DestinationT> res : writerResults) {
           checkArgument(
-              isShardNumberSetEverywhere == isShardNumberSetHere,
-              "Found a mix of files with and without shard number set: %s",
-              result);
+              res.getShard() != UNKNOWN_SHARDNUM,
+              "Fixed sharding into %s shards was specified, "
+                  + "but file result %s does not specify a shard",
+              numShards,
+              res);
+        }
+      } else {
+        effectiveNumShards = Iterables.size(writerResults);
+        for (FileResult<DestinationT> res : writerResults) {
+          checkArgument(
+              res.getShard() == UNKNOWN_SHARDNUM,
+              "Runner-chosen sharding was specified, "
+                  + "but file result %s explicitly specifies a shard",
+              res);
         }
       }
 
-      if (isShardNumberSetEverywhere == null) {
-        isShardNumberSetEverywhere = true;
-      }
-
       List<FileResult<DestinationT>> resultsWithShardNumbers = Lists.newArrayList();
-      if (isShardNumberSetEverywhere) {
+      if (numShards != null) {
         resultsWithShardNumbers = Lists.newArrayList(writerResults);
       } else {
+        checkState(
+            !windowedWrites,
+            "When doing windowed writes, shards should have been assigned when writing");
         // Sort files for idempotence. Sort by temporary filename.
         // Note that this codepath should not be used when processing triggered windows. In the
         // case of triggers, the list of FileResult objects in the Finalize iterable is not
@@ -653,23 +650,24 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
         }
       }
 
+      Map<ResourceId, FileResult<DestinationT>> distinctFilenames = Maps.newHashMap();
       for (FileResult<DestinationT> result : resultsWithShardNumbers) {
         checkArgument(
             result.getShard() != UNKNOWN_SHARDNUM, "Should have set shard number on %s", result);
-        outputFilenames.put(
-            result.getTempFilename(),
-            result.getDestinationFile(
-                getSink().getDynamicDestinations(),
-                numShards,
-                getSink().getWritableByteChannelFactory()));
+        ResourceId finalFilename = result.getDestinationFile(
+            getSink().getDynamicDestinations(),
+            effectiveNumShards,
+            getSink().getWritableByteChannelFactory());
+        checkArgument(
+            !distinctFilenames.containsKey(finalFilename),
+            "Filename policy must generate unique filenames, but generated the same name %s "
+                + "for file results %s and %s",
+            finalFilename,
+            result,
+            distinctFilenames.get(finalFilename));
+        distinctFilenames.put(finalFilename, result);
+        outputFilenames.add(KV.of(result, finalFilename));
       }
-
-      int numDistinctShards = new HashSet<>(outputFilenames.values()).size();
-      checkState(
-          numDistinctShards == outputFilenames.size(),
-          "Only generated %s distinct file names for %s files.",
-          numDistinctShards,
-          outputFilenames.size());
       return outputFilenames;
     }
 
@@ -684,24 +682,23 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
      * the policy) is "dir/file", the extension is ".txt", and the fileNamingTemplate is
      * "-SSS-of-NNN", the contents of A will be copied to dir/file-000-of-003.txt, the contents of B
      * will be copied to dir/file-001-of-003.txt, etc.
-     *
-     * @param filenames the filenames of temporary files.
      */
     @VisibleForTesting
     @Experimental(Kind.FILESYSTEM)
-    final void copyToOutputFiles(Map<ResourceId, ResourceId> filenames) throws IOException {
-      int numFiles = filenames.size();
+    final void copyToOutputFiles(
+        List<KV<FileResult<DestinationT>, ResourceId>> resultsToFinalFilenames) throws IOException {
+      int numFiles = resultsToFinalFilenames.size();
       if (numFiles > 0) {
         LOG.debug("Copying {} files.", numFiles);
-        List<ResourceId> srcFiles = new ArrayList<>(filenames.size());
-        List<ResourceId> dstFiles = new ArrayList<>(filenames.size());
-        for (Map.Entry<ResourceId, ResourceId> srcDestPair : filenames.entrySet()) {
-          srcFiles.add(srcDestPair.getKey());
-          dstFiles.add(srcDestPair.getValue());
+        List<ResourceId> srcFiles = new ArrayList<>(resultsToFinalFilenames.size());
+        List<ResourceId> dstFiles = new ArrayList<>(resultsToFinalFilenames.size());
+        for (KV<FileResult<DestinationT>, ResourceId> entry : resultsToFinalFilenames) {
+          srcFiles.add(entry.getKey().getTempFilename());
+          dstFiles.add(entry.getValue());
           LOG.info(
               "Will copy temporary file {} to final location {}",
-              srcDestPair.getKey(),
-              srcDestPair.getValue());
+              entry.getKey().getTempFilename(),
+              entry.getValue());
         }
         // During a failure case, files may have been deleted in an earlier step. Thus
         // we ignore missing files here.
@@ -732,7 +729,10 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
 
       // This may still fail to remove temporary outputs of some failed bundles, but at least
       // the common case (where all bundles succeed) is guaranteed to be fully addressed.
-      Set<ResourceId> matches = new HashSet<>();
+      Set<ResourceId> allMatches = new HashSet<>(knownFiles);
+      for (ResourceId match : allMatches) {
+        LOG.info("Will remove known temporary file {}", match);
+      }
       // TODO: Windows OS cannot resolves and matches '*' in the path,
       // ignore the exception for now to avoid failing the pipeline.
       if (shouldRemoveTemporaryDirectory) {
@@ -741,29 +741,24 @@ public abstract class FileBasedSink<UserT, DestinationT, OutputT>
               Iterables.getOnlyElement(
                   FileSystems.match(Collections.singletonList(tempDir.toString() + "*")));
           for (Metadata matchResult : singleMatch.metadata()) {
-            matches.add(matchResult.resourceId());
-            LOG.info("Will remove temporary file {}", matchResult.resourceId());
+            if (allMatches.add(matchResult.resourceId())) {
+              LOG.info("Will also remove unknown temporary file {}", matchResult.resourceId());
+            }
           }
         } catch (Exception e) {
           LOG.warn("Failed to match temporary files under: [{}].", tempDir);
         }
       }
-      Set<ResourceId> allMatches = new HashSet<>(matches);
-      allMatches.addAll(knownFiles);
-      LOG.debug(
-          "Removing {} temporary files found under {} ({} matched glob, {} known files)",
-          allMatches.size(),
-          tempDir,
-          matches.size(),
-          allMatches.size() - matches.size());
       FileSystems.delete(allMatches, StandardMoveOptions.IGNORE_MISSING_FILES);
 
-      // Deletion of the temporary directory might fail, if not all temporary files are removed.
-      try {
-        FileSystems.delete(
-            Collections.singletonList(tempDir), StandardMoveOptions.IGNORE_MISSING_FILES);
-      } catch (Exception e) {
-        LOG.warn("Failed to remove temporary directory: [{}].", tempDir);
+      if (shouldRemoveTemporaryDirectory) {
+        // Deletion of the temporary directory might fail, if not all temporary files are removed.
+        try {
+          FileSystems.delete(
+              Collections.singletonList(tempDir), StandardMoveOptions.IGNORE_MISSING_FILES);
+        } catch (Exception e) {
+          LOG.warn("Failed to remove temporary directory: [{}].", tempDir);
+        }
       }
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteFilesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/WriteFilesTest.java
@@ -21,11 +21,14 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.includesDisplayDataFor;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -35,7 +38,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,6 +85,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.commons.compress.utils.Sets;
+import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
@@ -156,10 +159,6 @@ public class WriteFilesTest {
     }
   }
 
-  private String appendToTempFolder(String filename) {
-    return Paths.get(tmpFolder.getRoot().getPath(), filename).toString();
-  }
-
   private String getBaseOutputFilename() {
     return getBaseOutputDirectory().resolve("file", StandardResolveOptions.RESOLVE_FILE).toString();
   }
@@ -187,7 +186,11 @@ public class WriteFilesTest {
         IDENTITY_MAP,
         getBaseOutputFilename(),
         WriteFiles.to(makeSimpleSink()));
-    checkFileContents(getBaseOutputFilename(), Collections.<String>emptyList(), Optional.of(1));
+    checkFileContents(
+        getBaseOutputFilename(),
+        Collections.<String>emptyList(),
+        Optional.of(1),
+        true /* expectRemovedTempDirectory */);
   }
 
   /**
@@ -241,7 +244,8 @@ public class WriteFilesTest {
 
     p.run();
 
-    checkFileContents(getBaseOutputFilename(), inputs, Optional.of(3));
+    checkFileContents(
+        getBaseOutputFilename(), inputs, Optional.of(3), true /* expectRemovedTempDirectory */);
   }
 
   /**
@@ -314,7 +318,10 @@ public class WriteFilesTest {
         inputs,
         Window.<String>into(FixedWindows.of(Duration.millis(2))),
         getBaseOutputFilename(),
-        WriteFiles.to(makeSimpleSink()).withMaxNumWritersPerBundle(2).withWindowedWrites());
+        WriteFiles.to(makeSimpleSink())
+            .withMaxNumWritersPerBundle(2)
+            .withWindowedWrites()
+            .withNumShards(1));
   }
 
   public void testBuildWrite() {
@@ -379,11 +386,10 @@ public class WriteFilesTest {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testUnboundedNeedsSharding() {
+  public void testWindowedWritesNeedSharding() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(
-        "When applying WriteFiles to an unbounded PCollection, "
-            + "must specify number of output shards explicitly");
+        "When using windowed writes, must specify number of output shards explicitly");
 
     SimpleSink<Void> sink = makeSimpleSink();
     p.apply(Create.of("foo"))
@@ -491,7 +497,11 @@ public class WriteFilesTest {
       for (int j = i; j < numInputs; j += 5) {
         expected.add("record_" + j);
       }
-      checkFileContents(base.toString(), expected, Optional.of(numShards));
+      checkFileContents(
+          base.toString(),
+          expected,
+          Optional.of(numShards),
+          bounded /* expectRemovedTempDirectory */);
     }
   }
 
@@ -659,14 +669,15 @@ public class WriteFilesTest {
     p.run();
 
     Optional<Integer> numShards =
-        (write.getNumShards() != null)
+        (write.getNumShards() != null && !write.isWindowedWrites())
             ? Optional.of(write.getNumShards().get())
             : Optional.<Integer>absent();
-    checkFileContents(baseName, inputs, numShards);
+    checkFileContents(baseName, inputs, numShards, !write.isWindowedWrites());
   }
 
   static void checkFileContents(
-      String baseName, List<String> inputs, Optional<Integer> numExpectedShards)
+      String baseName, List<String> inputs, Optional<Integer> numExpectedShards,
+      boolean expectRemovedTempDirectory)
       throws IOException {
     List<File> outputFiles = Lists.newArrayList();
     final String pattern = baseName + "*";
@@ -675,6 +686,7 @@ public class WriteFilesTest {
     for (Metadata meta : metadata) {
       outputFiles.add(new File(meta.resourceId().toString()));
     }
+    assertFalse("Should have produced at least 1 output file", outputFiles.isEmpty());
     if (numExpectedShards.isPresent()) {
       assertEquals(numExpectedShards.get().intValue(), outputFiles.size());
       Pattern shardPattern = Pattern.compile("\\d{4}-of-\\d{4}");
@@ -710,6 +722,11 @@ public class WriteFilesTest {
       }
     }
     assertThat(actual, containsInAnyOrder(inputs.toArray()));
+    if (expectRemovedTempDirectory) {
+      assertThat(
+          Lists.newArrayList(new File(baseName).getParentFile().list()),
+          Matchers.everyItem(not(containsString(FileBasedSink.TEMP_DIRECTORY_PREFIX))));
+    }
   }
 
   /** Options for test, exposed for PipelineOptionsFactory. */


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-3169

This required a bit of twiddling with shard assignment logic too. The gist of the change is changing the pre-finalize GBK to Reshuffle. I audited all other usages of GBK in the SDK and it appears that only this one is buggy: others either explicitly set a repeated trigger before applying the GBK, or are directly applied to the user's input and the user's trigger firing behavior is WAI.