### PR TITLE
[BEAM-3174] If parse_version just gives us a regular tuple use that for formatting

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -544,20 +544,7 @@ def _get_required_container_version(job_type=None):
   """
   # TODO(silviuc): Handle apache-beam versions when we have official releases.
   try:
-    version = pkg_resources.get_distribution(GOOGLE_PACKAGE_NAME).version
-    # We drop any pre/post parts of the version and we keep only the X.Y.Z
-    # format.  For instance the 0.3.0rc2 SDK version translates into 0.3.0.
-    parsed_version = pkg_resources.parse_version(version)
-    # Fall through for different results from parse_version.
-    try:
-      container_version = (
-        '%s.%s.%s' % parsed_version._version.release)
-    except AttributeError:
-      container_version = ('%s.%s.%s' % parsed_version)
-    # We do, however, keep the ".dev" suffix if it is present.
-    if re.match(r'.*\.dev[0-9]*$', version):
-      container_version += '.dev'
-    return container_version
+    return pkg_resources.get_distribution(GOOGLE_PACKAGE_NAME).version
   except pkg_resources.DistributionNotFound:
     # This case covers Apache Beam end-to-end testing scenarios. All these tests
     # will run with a special container version.

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -54,7 +54,6 @@ import functools
 import glob
 import logging
 import os
-import re
 import shutil
 import sys
 import tempfile

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -548,10 +548,10 @@ def _get_required_container_version(job_type=None):
     # We drop any pre/post parts of the version and we keep only the X.Y.Z
     # format.  For instance the 0.3.0rc2 SDK version translates into 0.3.0.
     parsed_version = pkg_resources.parse_version(version)
-    if "_version" in parsed_version:
+    try:
       container_version = (
         '%s.%s.%s' % parsed_version._version.release)
-    else:
+    except:
       container_version = ('%s.%s.%s' % parsed_version)
     # We do, however, keep the ".dev" suffix if it is present.
     if re.match(r'.*\.dev[0-9]*$', version):

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -548,10 +548,11 @@ def _get_required_container_version(job_type=None):
     # We drop any pre/post parts of the version and we keep only the X.Y.Z
     # format.  For instance the 0.3.0rc2 SDK version translates into 0.3.0.
     parsed_version = pkg_resources.parse_version(version)
+    # Fall through for different results from parse_version.
     try:
       container_version = (
         '%s.%s.%s' % parsed_version._version.release)
-    except:
+    except AttributeError:
       container_version = ('%s.%s.%s' % parsed_version)
     # We do, however, keep the ".dev" suffix if it is present.
     if re.match(r'.*\.dev[0-9]*$', version):

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -547,8 +547,12 @@ def _get_required_container_version(job_type=None):
     version = pkg_resources.get_distribution(GOOGLE_PACKAGE_NAME).version
     # We drop any pre/post parts of the version and we keep only the X.Y.Z
     # format.  For instance the 0.3.0rc2 SDK version translates into 0.3.0.
-    container_version = (
-        '%s.%s.%s' % pkg_resources.parse_version(version)._version.release)
+    parsed_version = pkg_resources.parse_version(version)
+    if "_version" in parsed_version:
+      container_version = (
+        '%s.%s.%s' % parsed_version._version.release)
+    else:
+      container_version = ('%s.%s.%s' % parsed_version)
     # We do, however, keep the ".dev" suffix if it is present.
     if re.match(r'.*\.dev[0-9]*$', version):
       container_version += '.dev'


### PR DESCRIPTION
parse_version seems to also sometimes directly return the tuple (presumably depending on package utils version) so support both formats in dependency.py