### PR TITLE
[BEAM-3189] Sdk worker multithreading

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -850,7 +850,7 @@ class FnApiRunner(runner.PipelineRunner):
       self.data_plane_handler = data_plane.InMemoryDataChannel()
       self.worker = sdk_worker.SdkWorker(
           self.state_handler, data_plane.InMemoryDataChannelFactory(
-              self.data_plane_handler.inverse()))
+              self.data_plane_handler.inverse()), {})
 
     def push(self, request):
       logging.debug('CONTROL REQUEST %s', request)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -902,8 +902,11 @@ class FnApiRunner(runner.PipelineRunner):
       self.data_server.start()
       self.control_server.start()
 
-      self.worker = (self.sdk_harness_factory or sdk_worker.SdkHarness)(
-          'localhost:%s' % self.control_port)
+      self.worker = self.sdk_harness_factory(
+          'localhost:%s' % self.control_port
+      ) if self.sdk_harness_factory else sdk_worker.SdkHarness(
+          'localhost:%s' % self.control_port, worker_count=1)
+
       self.worker_thread = threading.Thread(
           name='run_worker', target=self.worker.run)
       logging.info('starting worker')

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+import functools
 import logging
 import time
 import unittest
@@ -22,6 +22,7 @@ import unittest
 import apache_beam as beam
 from apache_beam.runners.portability import fn_api_runner
 from apache_beam.runners.portability import maptask_executor_runner_test
+from apache_beam.runners.worker import sdk_worker
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms import window
@@ -153,6 +154,16 @@ class FnApiRunnerTestWithGrpc(FnApiRunnerTest):
   def create_pipeline(self):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(use_grpc=True))
+
+
+class FnApiRunnerTestWithGrpcMultiThreaded(FnApiRunnerTest):
+
+  def create_pipeline(self):
+    return beam.Pipeline(
+        runner=fn_api_runner.FnApiRunner(
+            use_grpc=True,
+            sdk_harness_factory=functools.partial(
+                sdk_worker.SdkHarness, worker_count=2)))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -22,7 +22,6 @@ from __future__ import print_function
 
 import logging
 import Queue as queue
-import re
 import sys
 import threading
 import traceback
@@ -39,26 +38,8 @@ from apache_beam.runners.worker import data_plane
 class SdkHarness(object):
   REQUEST_METHOD_PREFIX = '_request_'
 
-  def __init__(self, control_address, pipeline_options=None):
-    def _get_worker_count(pipeline_options):
-      pipeline_options = pipeline_options.get(
-          'options'
-      ) if pipeline_options and pipeline_options.has_key('options') else {}
-      experiments = pipeline_options.get(
-          'experiments'
-      ) if pipeline_options and pipeline_options.has_key('experiments') else []
-
-      experiments = experiments if experiments else []
-
-      for experiment in experiments:
-        # There should only be 1 match so returning from the loop
-        s = re.findall('^(worker_threads=[0-9]+)', experiment)
-        if len(s) > 0:
-          return int(s.pop()[len('worker_threads='):])
-
-      return 1
-
-    self._worker_count = _get_worker_count(pipeline_options)
+  def __init__(self, control_address, worker_count=1):
+    self._worker_count = worker_count
     self._worker_index = 0
     self._control_channel = grpc.insecure_channel(control_address)
     self._data_channel_factory = data_plane.GrpcClientDataChannelFactory()

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -38,9 +38,17 @@ from apache_beam.runners.worker import data_plane
 
 class SdkHarness(object):
 
-  def __init__(self, control_address):
+  def __init__(self, control_address, pipeline_options=None):
     # TODO: angoenka make worker_count an experimental parameter
-    self._worker_count = 2
+    if pipeline_options and pipeline_options.has_key(
+        'experiments') and pipeline_options.get('experiments').has_key(
+            'worker_threads'):
+      self._worker_count = int(
+          pipeline_options.get('experiments').get('worker_threads'))
+    else:
+      self._worker_count = 1
+
+    logging.info('Initializing SDKHarness with %i workers.', self._worker_count)
     self._worker_index = 0
     self._lock = threading.Lock()
     self._control_channel = grpc.insecure_channel(control_address)

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -38,7 +38,7 @@ from apache_beam.runners.worker import data_plane
 class SdkHarness(object):
   REQUEST_METHOD_PREFIX = '_request_'
 
-  def __init__(self, control_address, worker_count=1):
+  def __init__(self, control_address, worker_count):
     self._worker_count = worker_count
     self._worker_index = 0
     self._control_channel = grpc.insecure_channel(control_address)

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -20,6 +20,7 @@ import BaseHTTPServer
 import json
 import logging
 import os
+import re
 import sys
 import threading
 import traceback
@@ -130,7 +131,7 @@ def main(unused_argv):
     assert not service_descriptor.oauth2_client_credentials_grant.url
     SdkHarness(
         control_address=service_descriptor.url,
-        pipeline_options=sdk_pipeline_options).run()
+        worker_count=_get_worker_count(sdk_pipeline_options)).run()
     logging.info('Python sdk harness exiting.')
   except:  # pylint: disable=broad-except
     logging.exception('Python sdk harness failed: ')
@@ -138,6 +139,39 @@ def main(unused_argv):
   finally:
     if fn_log_handler:
       fn_log_handler.close()
+
+
+def _get_worker_count(pipeline_options):
+  """Extract worker count from the pipeline_options.
+
+  This defines how many SdkWorkers will be started in this Python process.
+  And each SdkWorker will have its own thread to process data. Name of the
+  experimental parameter is 'worker_threads'
+  Example Usage in the Command Line:
+    --experimental worker_threads=1
+
+  Note: worker_threads is an experimental flag and might not be available in
+  future releases.
+
+  Returns:
+    an int containing the worker_threads to use. Default is 1
+  """
+  pipeline_options = pipeline_options.get(
+      'options') if pipeline_options.has_key('options') else {}
+  experiments = pipeline_options.get(
+      'experiments'
+  ) if pipeline_options and pipeline_options.has_key('experiments') else []
+
+  experiments = experiments if experiments else []
+
+  for experiment in experiments:
+    # There should only be 1 match so returning from the loop
+    if re.match(r'worker_threads=', experiment):
+      return int(
+          re.match(r'worker_threads=(?P<worker_threads>.*)',
+                   experiment).group('worker_threads'))
+
+  return 1
 
 
 def _load_main_session(semi_persistent_directory):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -128,7 +128,9 @@ def main(unused_argv):
                       service_descriptor)
     # TODO(robertwb): Support credentials.
     assert not service_descriptor.oauth2_client_credentials_grant.url
-    SdkHarness(service_descriptor.url).run()
+    SdkHarness(
+        control_address=service_descriptor.url,
+        pipeline_options=sdk_pipeline_options).run()
     logging.info('Python sdk harness exiting.')
   except:  # pylint: disable=broad-except
     logging.exception('Python sdk harness failed: ')

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -20,10 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import functools
-import httplib
 import logging
-import threading
 import unittest
 
 from apache_beam.runners.worker import sdk_worker_main

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -20,7 +20,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import functools
+import httplib
 import logging
+import threading
 import unittest
 
 from apache_beam.runners.worker import sdk_worker_main

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import json
 import logging
 import unittest
 from concurrent import futures
@@ -71,10 +70,8 @@ class SdkWorkerTest(unittest.TestCase):
             }) for ix in range(size)
     ]
 
-  def _check_fn_registration_multi_request(self,
-                                           request_count,
-                                           process_bundles_per_request,
-                                           pipeline_options=None):
+  def _check_fn_registration_multi_request(self, request_count,
+                                           process_bundles_per_request):
     requests = []
     process_bundle_descriptors = []
 
@@ -95,8 +92,7 @@ class SdkWorkerTest(unittest.TestCase):
     test_port = server.add_insecure_port("[::]:0")
     server.start()
 
-    harness = sdk_worker.SdkHarness(
-        "localhost:%s" % test_port, pipeline_options=pipeline_options)
+    harness = sdk_worker.SdkHarness("localhost:%s" % test_port, worker_count=1)
     harness.run()
 
     for worker in harness.workers.queue:
@@ -112,15 +108,6 @@ class SdkWorkerTest(unittest.TestCase):
   def test_fn_registration_multiple_request(self):
     self._check_fn_registration_multi_request(
         request_count=4, process_bundles_per_request=4)
-
-  def test_work_count_default_value(self):
-    harness = self._check_fn_registration_multi_request(1, 1, {})
-    self.assertEquals(len(harness.workers.queue), 1)
-
-  def test_work_count_custom_value(self):
-    harness = self._check_fn_registration_multi_request(
-        1, 1, json.loads('{"options": {"experiments":["worker_threads=4"]}}'))
-    self.assertEquals(harness.workers.qsize(), 4)
 
 
 if __name__ == "__main__":

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -119,7 +119,7 @@ class SdkWorkerTest(unittest.TestCase):
 
   def test_work_count_custom_value(self):
     harness = self._check_fn_registration_multi_request(
-        1, 1, json.loads('{"experiments":{"worker_threads":4}}'))
+        1, 1, json.loads('{"experiments":["worker_threads=4"]}'))
     self.assertEquals(len(harness.worker_wrappers), 4)
 
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -91,7 +91,7 @@ class SdkWorkerTest(unittest.TestCase):
     harness = sdk_worker.SdkHarness("localhost:%s" % test_port)
     harness.run()
     self.assertEqual(
-      harness.worker.fns,
+      harness.worker_wrapper.worker.fns,
       {item.id: item for item in process_bundle_descriptors})
 
   def test_fn_registration(self):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -70,44 +70,44 @@ class SdkWorkerTest(unittest.TestCase):
             }) for ix in range(size)
     ]
 
-  def _check_fn_registration_multi_request(self, request_count,
-                                           process_bundles_per_request):
-    requests = []
-    process_bundle_descriptors = []
+  def _check_fn_registration_multi_request(self, *args):
+    """Check the function registration calls to the sdk_harness.
 
-    for i in range(request_count):
-      pbd = self._get_process_bundles(i, process_bundles_per_request)
-      process_bundle_descriptors.extend(pbd)
-      requests.append(
-          beam_fn_api_pb2.InstructionRequest(
-              instruction_id=str(i),
-              register=beam_fn_api_pb2.RegisterRequest(
-                  process_bundle_descriptor=process_bundle_descriptors)))
+    Args:
+     tuple of request_count, number of process_bundles per request and workers counts to process the request.
+    """
+    for (request_count, process_bundles_per_request, worker_count) in args:
+      requests = []
+      process_bundle_descriptors = []
 
-    test_controller = BeamFnControlServicer(requests)
+      for i in range(request_count):
+        pbd = self._get_process_bundles(i, process_bundles_per_request)
+        process_bundle_descriptors.extend(pbd)
+        requests.append(
+            beam_fn_api_pb2.InstructionRequest(
+                instruction_id=str(i),
+                register=beam_fn_api_pb2.RegisterRequest(
+                    process_bundle_descriptor=process_bundle_descriptors)))
 
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    beam_fn_api_pb2_grpc.add_BeamFnControlServicer_to_server(
-        test_controller, server)
-    test_port = server.add_insecure_port("[::]:0")
-    server.start()
+      test_controller = BeamFnControlServicer(requests)
 
-    harness = sdk_worker.SdkHarness("localhost:%s" % test_port, worker_count=1)
-    harness.run()
+      server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+      beam_fn_api_pb2_grpc.add_BeamFnControlServicer_to_server(
+          test_controller, server)
+      test_port = server.add_insecure_port("[::]:0")
+      server.start()
 
-    for worker in harness.workers.queue:
-      self.assertEqual(worker.fns,
-                       {item.id: item
-                        for item in process_bundle_descriptors})
-    return harness
+      harness = sdk_worker.SdkHarness(
+          "localhost:%s" % test_port, worker_count=worker_count)
+      harness.run()
+
+      for worker in harness.workers.queue:
+        self.assertEqual(worker.fns,
+                         {item.id: item
+                          for item in process_bundle_descriptors})
 
   def test_fn_registration(self):
-    self._check_fn_registration_multi_request(
-        request_count=1, process_bundles_per_request=4)
-
-  def test_fn_registration_multiple_request(self):
-    self._check_fn_registration_multi_request(
-        request_count=4, process_bundles_per_request=4)
+    self._check_fn_registration_multi_request((1, 4, 1), (4, 4, 1), (4, 4, 2))
 
 
 if __name__ == "__main__":

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -99,8 +99,8 @@ class SdkWorkerTest(unittest.TestCase):
         "localhost:%s" % test_port, pipeline_options=pipeline_options)
     harness.run()
 
-    for worker_wrapper in harness.worker_wrappers:
-      self.assertEqual(worker_wrapper.worker.fns,
+    for worker in harness.workers.queue:
+      self.assertEqual(worker.fns,
                        {item.id: item
                         for item in process_bundle_descriptors})
     return harness
@@ -115,12 +115,12 @@ class SdkWorkerTest(unittest.TestCase):
 
   def test_work_count_default_value(self):
     harness = self._check_fn_registration_multi_request(1, 1, {})
-    self.assertEquals(len(harness.worker_wrappers), 1)
+    self.assertEquals(len(harness.workers.queue), 1)
 
   def test_work_count_custom_value(self):
     harness = self._check_fn_registration_multi_request(
-        1, 1, json.loads('{"experiments":["worker_threads=4"]}'))
-    self.assertEquals(len(harness.worker_wrappers), 4)
+        1, 1, json.loads('{"options": {"experiments":["worker_threads=4"]}}'))
+    self.assertEquals(harness.workers.qsize(), 4)
 
 
 if __name__ == "__main__":

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -74,7 +74,8 @@ class SdkWorkerTest(unittest.TestCase):
     """Check the function registration calls to the sdk_harness.
 
     Args:
-     tuple of request_count, number of process_bundles per request and workers counts to process the request.
+     tuple of request_count, number of process_bundles per request and workers
+     counts to process the request.
     """
     for (request_count, process_bundles_per_request, worker_count) in args:
       requests = []


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
Beam Python SDK is couple of magnitude slower than Java SDK when it comes to stream processing.
In this PR we are going to address the following issue.
Given a single core, currently we are not fully utilizing the core because the single thread spends a lot of time on the IO. This is more of a limitation of our implementation rather than a limitation of Python.
