### PR TITLE
[BEAM-3184] Added ProxyInfoFromEnvironmentVar() & GetNewHttp() methods for GCS

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -99,9 +99,10 @@ def ProxyInfoFromEnvironmentVar(proxy_env_var):
   proxy_url = os.environ.get(proxy_env_var)
   if not proxy_url or not proxy_env_var.lower().startswith('http'):
     return httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0)
+    logging.warn("Ignoring proxy_env_var, incorrect format")
   proxy_protocol = proxy_env_var.lower().split('_')[0]
   if not proxy_url.lower().startswith('http'):
-    # proxy_info_from_url requires a protocol, which is always http or https.
+    logging.warn("proxy_info_from_url requires a protocol, which is always http or https.")
     proxy_url = proxy_protocol + '://' + proxy_url
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
@@ -113,14 +114,6 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
   Returns:
     An initialized httplib2.Http instance.
   """
-  proxy_info = httplib2.ProxyInfo(
-    proxy_type=3,
-    proxy_host=None,
-    proxy_port=None,
-    proxy_user=None,
-    proxy_pass=None,
-    proxy_rdns=None
-  )
 
   for proxy_env_var in ['http_proxy', 'https_proxy']:
     if proxy_env_var in os.environ and os.environ[proxy_env_var]:

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -97,8 +97,8 @@ def proxy_info_from_environment_var(proxy_env_var):
     httplib2.ProxyInfo constructed from the environment string.
   """
   proxy_url = os.environ.get(proxy_env_var)
-  if not proxy_url or not proxy_env_var:
-    return httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0)
+  if not proxy_url:
+    return None
   proxy_protocol = proxy_env_var.lower().split('_')[0]
   if not re.match('^https?://', proxy_url, flags=re.IGNORECASE):
     logging.warn("proxy_info_from_url requires a protocol, which is always "

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -119,7 +119,8 @@ def get_new_http():
       break
 
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
-  return httplib2.Http(proxy_info=proxy_info, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)
+  return httplib2.Http(proxy_info=proxy_info,
+                       timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 def parse_gcs_path(gcs_path):
   """Return the bucket and object names of the given gs:// path."""
@@ -268,7 +269,8 @@ class GcsIO(object):
       request = storage.StorageObjectsDeleteRequest(
           bucket=bucket, object=object_path)
       batch_request.Add(self.client.objects, 'Delete', request)
-    api_calls = batch_request.Execute(self.client._http)  # pylint: disable=protected-access
+    api_calls = batch_request.Execute(self.client._http) # pylint:
+    # disable=protected-access
     result_statuses = []
     for i, api_call in enumerate(api_calls):
       path = paths[i]
@@ -334,7 +336,8 @@ class GcsIO(object):
           destinationBucket=dest_bucket,
           destinationObject=dest_path)
       batch_request.Add(self.client.objects, 'Copy', request)
-    api_calls = batch_request.Execute(self.client._http)  # pylint: disable=protected-access
+    api_calls = batch_request.Execute(self.client._http)  # pylint:
+    # disable=protected-access
     result_statuses = []
     for i, api_call in enumerate(api_calls):
       src, dest = src_dest_pairs[i]

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -104,6 +104,7 @@ def proxy_info_from_environment_var(proxy_env_var):
     logging.warn("proxy_info_from_url requires a protocol, which is always "
                  "http or https.")
     proxy_url = proxy_protocol + '://' + proxy_url
+
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
 def get_new_http():

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -271,8 +271,7 @@ class GcsIO(object):
       request = storage.StorageObjectsDeleteRequest(
           bucket=bucket, object=object_path)
       batch_request.Add(self.client.objects, 'Delete', request)
-    api_calls = batch_request.Execute(self.client._http) # pylint:
-    # disable=protected-access
+    api_calls = batch_request.Execute(self.client._http) # pylint: disable=protected-access
     result_statuses = []
     for i, api_call in enumerate(api_calls):
       path = paths[i]
@@ -338,8 +337,7 @@ class GcsIO(object):
           destinationBucket=dest_bucket,
           destinationObject=dest_path)
       batch_request.Add(self.client.objects, 'Copy', request)
-    api_calls = batch_request.Execute(self.client._http)  # pylint:
-    # disable=protected-access
+    api_calls = batch_request.Execute(self.client._http)  # pylint: disable=protected-access
     result_statuses = []
     for i, api_call in enumerate(api_calls):
       src, dest = src_dest_pairs[i]

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -90,8 +90,9 @@ MAX_BATCH_OPERATION_SIZE = 100
 def ProxyInfoFromEnvironmentVar(proxy_env_var):
   """Reads proxy info from the environment and converts to httplib2.ProxyInfo.
   Args:
-    proxy_env_var: environment variable string to read, such as http_proxy or
-       https_proxy.
+    proxy_env_var: environment variable string to read, http_proxy or
+       https_proxy (in lower case).
+       Example: http://myproxy.domain.com:8080
   Returns:
     httplib2.ProxyInfo constructed from the environment string.
   """
@@ -121,7 +122,7 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
     proxy_rdns=None
   )
 
-  for proxy_env_var in ['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY']:
+  for proxy_env_var in ['http_proxy', 'https_proxy']:
     if proxy_env_var in os.environ and os.environ[proxy_env_var]:
       proxy_info = ProxyInfoFromEnvironmentVar(proxy_env_var)
       break

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -115,7 +115,7 @@ def get_new_http():
   """
   proxy_info = None
   for proxy_env_var in ['http_proxy', 'https_proxy']:
-    if proxy_env_var in os.environ and os.environ[proxy_env_var]:
+    if os.environ(proxy_env_var):
       proxy_info = proxy_info_from_environment_var(proxy_env_var)
       break
 

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -111,7 +111,7 @@ def get_new_http():
   Returns:
     An initialized httplib2.Http instance.
   """
-
+  proxy_info = None
   for proxy_env_var in ['http_proxy', 'https_proxy']:
     if proxy_env_var in os.environ and os.environ[proxy_env_var]:
       proxy_info = proxy_info_from_environment_var(proxy_env_var)

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -154,8 +154,8 @@ class GcsIO(object):
         credentials = auth.get_service_credentials()
         storage_client = storage.StorageV1(
             credentials=credentials,
-            http=get_new_http())
             get_credentials=False,
+            http=get_new_http())
         local_state.gcsio_instance = (
             super(GcsIO, cls).__new__(cls, storage_client))
         local_state.gcsio_instance.client = storage_client

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -107,6 +107,7 @@ def proxy_info_from_environment_var(proxy_env_var):
 
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
+
 def get_new_http():
   """Creates and returns a new httplib2.Http instance.
   Returns:
@@ -121,6 +122,7 @@ def get_new_http():
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
   return httplib2.Http(proxy_info=proxy_info,
                        timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)
+
 
 def parse_gcs_path(gcs_path):
   """Return the bucket and object names of the given gs:// path."""

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -121,7 +121,7 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
     proxy_rdns=None
   )
 
-  for proxy_env_var in ['http_proxy', 'https_proxy', 'HTTPS_PROXY']:
+  for proxy_env_var in ['http_proxy', 'HTTP_PROXY', 'https_proxy', 'HTTPS_PROXY']:
     if proxy_env_var in os.environ and os.environ[proxy_env_var]:
       proxy_info = ProxyInfoFromEnvironmentVar(proxy_env_var)
       break

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -106,11 +106,8 @@ def proxy_info_from_environment_var(proxy_env_var):
     proxy_url = proxy_protocol + '://' + proxy_url
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
-def get_new_http(http_class=httplib2.Http, **kwargs):
+def get_new_http():
   """Creates and returns a new httplib2.Http instance.
-  Args:
-    http_class: optional custom Http class to use.
-    **kwargs: arguments to pass to http_class constructor.
   Returns:
     An initialized httplib2.Http instance.
   """
@@ -121,9 +118,7 @@ def get_new_http(http_class=httplib2.Http, **kwargs):
       break
 
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
-  kwargs['timeout'] = DEFAULT_HTTP_TIMEOUT_SECONDS
-  http = http_class(proxy_info=proxy_info, **kwargs)
-  return http
+  return httplib2.Http(proxy_info=proxy_info, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)
 
 def parse_gcs_path(gcs_path):
   """Return the bucket and object names of the given gs:// path."""

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -87,7 +87,7 @@ WRITE_CHUNK_SIZE = 8 * 1024 * 1024
 MAX_BATCH_OPERATION_SIZE = 100
 
 
-def ProxyInfoFromEnvironmentVar(proxy_env_var):
+def proxy_info_from_environment_var(proxy_env_var):
   """Reads proxy info from the environment and converts to httplib2.ProxyInfo.
   Args:
     proxy_env_var: environment variable string to read, http_proxy or
@@ -106,7 +106,7 @@ def ProxyInfoFromEnvironmentVar(proxy_env_var):
     proxy_url = proxy_protocol + '://' + proxy_url
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
-def GetNewHttp(http_class=httplib2.Http, **kwargs):
+def get_new_http(http_class=httplib2.Http, **kwargs):
   """Creates and returns a new httplib2.Http instance.
   Args:
     http_class: optional custom Http class to use.
@@ -117,7 +117,7 @@ def GetNewHttp(http_class=httplib2.Http, **kwargs):
 
   for proxy_env_var in ['http_proxy', 'https_proxy']:
     if proxy_env_var in os.environ and os.environ[proxy_env_var]:
-      proxy_info = ProxyInfoFromEnvironmentVar(proxy_env_var)
+      proxy_info = proxy_info_from_environment_var(proxy_env_var)
       break
 
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
@@ -155,8 +155,8 @@ class GcsIO(object):
         credentials = auth.get_service_credentials()
         storage_client = storage.StorageV1(
             credentials=credentials,
+            http=get_new_http())
             get_credentials=False,
-            http=GetNewHttp())
         local_state.gcsio_instance = (
             super(GcsIO, cls).__new__(cls, storage_client))
         local_state.gcsio_instance.client = storage_client

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -97,12 +97,12 @@ def proxy_info_from_environment_var(proxy_env_var):
     httplib2.ProxyInfo constructed from the environment string.
   """
   proxy_url = os.environ.get(proxy_env_var)
-  if not proxy_url or not proxy_env_var.lower().startswith('http'):
+  if not proxy_url or not proxy_env_var:
     return httplib2.ProxyInfo(httplib2.socks.PROXY_TYPE_HTTP, None, 0)
-    logging.warn("Ignoring proxy_env_var, incorrect format")
   proxy_protocol = proxy_env_var.lower().split('_')[0]
-  if not proxy_url.lower().startswith('http'):
-    logging.warn("proxy_info_from_url requires a protocol, which is always http or https.")
+  if not re.match('^https?://', proxy_url, flags=re.IGNORECASE):
+    logging.warn("proxy_info_from_url requires a protocol, which is always "
+                 "http or https.")
     proxy_url = proxy_protocol + '://' + proxy_url
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -90,7 +90,7 @@ MAX_BATCH_OPERATION_SIZE = 100
 def ProxyInfoFromEnvironmentVar(proxy_env_var):
   """Reads proxy info from the environment and converts to httplib2.ProxyInfo.
   Args:
-    proxy_env_var: Environment variable string to read, such as http_proxy or
+    proxy_env_var: environment variable string to read, such as http_proxy or
        https_proxy.
   Returns:
     httplib2.ProxyInfo constructed from the environment string.
@@ -107,8 +107,8 @@ def ProxyInfoFromEnvironmentVar(proxy_env_var):
 def GetNewHttp(http_class=httplib2.Http, **kwargs):
   """Creates and returns a new httplib2.Http instance.
   Args:
-    http_class: Optional custom Http class to use.
-    **kwargs: Arguments to pass to http_class constructor.
+    http_class: optional custom Http class to use.
+    **kwargs: arguments to pass to http_class constructor.
   Returns:
     An initialized httplib2.Http instance.
   """

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -111,7 +111,7 @@ def proxy_info_from_environment_var(proxy_env_var):
 
 def get_new_http():
   """Creates and returns a new httplib2.Http instance.
-  
+
   Returns:
     An initialized httplib2.Http instance.
   """

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -89,10 +89,12 @@ MAX_BATCH_OPERATION_SIZE = 100
 
 def proxy_info_from_environment_var(proxy_env_var):
   """Reads proxy info from the environment and converts to httplib2.ProxyInfo.
+
   Args:
     proxy_env_var: environment variable string to read, http_proxy or
        https_proxy (in lower case).
        Example: http://myproxy.domain.com:8080
+
   Returns:
     httplib2.ProxyInfo constructed from the environment string.
   """
@@ -104,21 +106,20 @@ def proxy_info_from_environment_var(proxy_env_var):
     logging.warn("proxy_info_from_url requires a protocol, which is always "
                  "http or https.")
     proxy_url = proxy_protocol + '://' + proxy_url
-
   return httplib2.proxy_info_from_url(proxy_url, method=proxy_protocol)
 
 
 def get_new_http():
   """Creates and returns a new httplib2.Http instance.
+  
   Returns:
     An initialized httplib2.Http instance.
   """
   proxy_info = None
   for proxy_env_var in ['http_proxy', 'https_proxy']:
-    if os.environ(proxy_env_var):
+    if os.environ.get(proxy_env_var):
       proxy_info = proxy_info_from_environment_var(proxy_env_var)
       break
-
   # Use a non-infinite SSL timeout to avoid hangs during network flakiness.
   return httplib2.Http(proxy_info=proxy_info,
                        timeout=DEFAULT_HTTP_TIMEOUT_SECONDS)


### PR DESCRIPTION
This PR meant to fix BEAM-3184 "Not able to access GCS API when submitting Python jobs behind corporate firewall".
Added ProxyInfoFromEnvironmentVar() & GetNewHttp() methods to get proxy environment settings in gcsio.py module in Python SDK, this is to add methods to pick up proxy settings from environment variables in the httplib2 library, allowing to submit jobs from behind a corporate proxy by connecting to GCS buckets.

Note: These methods are based on GCP gsutil Python tool.