### PR TITLE
[BEAM-3195] Specifies numShards on windowed writes examples, as it is now required

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -161,9 +161,10 @@ public class WindowedWordCount {
     Long getMaxTimestampMillis();
     void setMaxTimestampMillis(Long value);
 
-    @Description("Fixed number of shards to produce per window, or null for runner-chosen sharding")
-    Integer getNumShards();
-    void setNumShards(Integer numShards);
+    @Description("Fixed number of shards to produce per window")
+    @Default.Integer(3)
+    int getNumShards();
+    void setNumShards(int numShards);
   }
 
   public static void main(String[] args) throws IOException {

--- a/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/common/WriteOneFilePerWindow.java
@@ -19,7 +19,6 @@ package org.apache.beam.examples.common;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.io.FileBasedSink.FilenamePolicy;
 import org.apache.beam.sdk.io.FileBasedSink.OutputFileHints;
@@ -46,10 +45,9 @@ import org.joda.time.format.ISODateTimeFormat;
 public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone> {
   private static final DateTimeFormatter FORMATTER = ISODateTimeFormat.hourMinute();
   private String filenamePrefix;
-  @Nullable
-  private Integer numShards;
+  private int numShards;
 
-  public WriteOneFilePerWindow(String filenamePrefix, Integer numShards) {
+  public WriteOneFilePerWindow(String filenamePrefix, int numShards) {
     this.filenamePrefix = filenamePrefix;
     this.numShards = numShards;
   }
@@ -61,10 +59,8 @@ public class WriteOneFilePerWindow extends PTransform<PCollection<String>, PDone
         TextIO.write()
             .to(new PerWindowFiles(resource))
             .withTempDirectory(resource.getCurrentDirectory())
-            .withWindowedWrites();
-    if (numShards != null) {
-      write = write.withNumShards(numShards);
-    }
+            .withWindowedWrites()
+            .withNumShards(numShards);
     return input.apply(write);
   }
 

--- a/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/WindowedWordCountIT.java
@@ -87,14 +87,6 @@ public class WindowedWordCountIT {
   }
 
   @Test
-  public void testWindowedWordCountInBatchDynamicSharding() throws Exception {
-    WindowedWordCountITOptions options = batchOptions();
-    // This is the default value, but make it explicit
-    options.setNumShards(null);
-    testWindowedWordCountPipeline(options);
-  }
-
-  @Test
   public void testWindowedWordCountInBatchStaticSharding() throws Exception {
     WindowedWordCountITOptions options = batchOptions();
     options.setNumShards(3);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-3195

When doing windowed writes, one now must specify the number of shards, because it's not possible to assign shard numbers automatically and deterministically. Before https://github.com/apache/beam/pull/4124 it was allowed to not specify number of shards for bounded PCollection's when doing windowed writes, but a streaming runner writing a bounded PCollection could technically produce non-deterministic results, so now we prohibit this.

R: @kennknowles 