### PR TITLE
Shut down executor when spark runner finishes

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
@@ -190,6 +190,7 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
                   jssc.start();
                 }
               });
+      executorService.shutdown();
 
       result = new SparkPipelineResult.StreamingMode(startPipeline, jssc);
     } else {
@@ -214,6 +215,7 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
                   LOG.info("Batch pipeline execution complete.");
                 }
               });
+      executorService.shutdown();
 
       result = new SparkPipelineResult.BatchMode(startPipeline, jsc);
     }


### PR DESCRIPTION
The Spark runner previously left the JVM process hanging after
completion because its one-time use executor service was never shut
down. This change shuts down the executor after jobs have been
submitted, allowing graceful JVM termination.