### PR TITLE
[BEAM-2524] Update the gcloud cancel command to include the --region flag.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/MonitoringUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/MonitoringUtil.java
@@ -214,8 +214,8 @@ public class MonitoringUtil {
     }
 
     // Assemble cancel command from optional prefix and project/job parameters.
-    return String.format("%s%s jobs --project=%s cancel %s",
-        dataflowApiOverridePrefix, GCLOUD_DATAFLOW_PREFIX, options.getProject(), jobId);
+    return String.format("%s%s jobs --project=%s cancel %s --region=%s",
+        dataflowApiOverridePrefix, GCLOUD_DATAFLOW_PREFIX, options.getProject(), jobId, options.getRegion());
   }
 
   public static State toState(String stateName) {

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/MonitoringUtilTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/MonitoringUtilTest.java
@@ -49,6 +49,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MonitoringUtilTest {
   private static final String PROJECT_ID = "someProject";
+  private static final String REGION_ID = "thatRegion";
   private static final String JOB_ID = "1234";
 
   @Rule public ExpectedLogs expectedLogs = ExpectedLogs.none(LoggingHandler.class);
@@ -119,9 +120,10 @@ public class MonitoringUtilTest {
     DataflowPipelineOptions options =
         PipelineOptionsFactory.create().as(DataflowPipelineOptions.class);
     options.setProject(PROJECT_ID);
+    options.setRegion(REGION_ID);
     options.setGcpCredential(new TestCredential());
     String cancelCommand = MonitoringUtil.getGcloudCancelCommand(options, JOB_ID);
-    assertEquals("gcloud dataflow jobs --project=someProject cancel 1234", cancelCommand);
+    assertEquals("gcloud dataflow jobs --project=someProject cancel 1234 --region=thatRegion", cancelCommand);
   }
 
   @Test
@@ -129,13 +131,14 @@ public class MonitoringUtilTest {
     DataflowPipelineOptions options =
         PipelineOptionsFactory.create().as(DataflowPipelineOptions.class);
     options.setProject(PROJECT_ID);
+    options.setRegion(REGION_ID);
     options.setGcpCredential(new TestCredential());
     String stagingDataflowEndpoint = "v0neverExisted";
     options.setDataflowEndpoint(stagingDataflowEndpoint);
     String cancelCommand = MonitoringUtil.getGcloudCancelCommand(options, JOB_ID);
     assertEquals(
         "CLOUDSDK_API_ENDPOINT_OVERRIDES_DATAFLOW=https://dataflow.googleapis.com/v0neverExisted/ "
-        + "gcloud dataflow jobs --project=someProject cancel 1234",
+        + "gcloud dataflow jobs --project=someProject cancel 1234 --region=thatRegion",
         cancelCommand);
   }
 


### PR DESCRIPTION
Have the cancel command provided by the Dataflow Runner specify the region for the job, so jobs started in other regions are actually cancelled.