### PR TITLE
[BEAM-3060] Add Compressed TextIOIT

### DIFF
--- a/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOTestPipelineOptions.java
+++ b/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOTestPipelineOptions.java
@@ -100,4 +100,10 @@ public interface IOTestPipelineOptions extends TestPipelineOptions {
   String getFilenamePrefix();
 
   void setFilenamePrefix(String prefix);
+
+  @Description("File compression type for writing and reading test files")
+  @Default.String("UNCOMPRESSED")
+  String getCompressionType();
+
+  void setCompressionType(String compressionType);
 }

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -15,24 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.beam.sdk.io.text;
 
 import static org.apache.beam.sdk.io.Compression.AUTO;
-import static org.apache.beam.sdk.io.Compression.BZIP2;
-import static org.apache.beam.sdk.io.Compression.DEFLATE;
-import static org.apache.beam.sdk.io.Compression.GZIP;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.GenerateSequence;
@@ -53,28 +52,32 @@ import org.apache.beam.sdk.values.PCollection;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.junit.runners.Parameterized;
-
 
 /**
  * Integration tests for {@link org.apache.beam.sdk.io.TextIO}.
  *
  * <p>Run this test using the command below. Pass in connection information via PipelineOptions:
  * <pre>
- *  mvn -e -Pio-it verify -pl sdks/java/io/text -DintegrationTestPipelineOptions='[
+ *  mvn -e -Pio-it verify -pl sdks/java/io/file-based-io-tests
+ *  -Dit.test=org.apache.beam.sdk.io.text.TextIOIT
+ *  -DintegrationTestPipelineOptions='[
  *  "--numberOfRecords=100000",
  *  "--filenamePrefix=TEXTIOIT"
+ *  "--compressionType=GZIP"
  *  ]'
  * </pre>
  * */
-@RunWith(Enclosed.class)
+@RunWith(JUnit4.class)
 public class TextIOIT {
 
   private static String filenamePrefix;
   private static Long numberOfTextLines;
+  private static Compression compressionType;
+
+  @Rule
+  public TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void setup() throws ParseException {
@@ -84,94 +87,54 @@ public class TextIOIT {
 
     numberOfTextLines = options.getNumberOfRecords();
     filenamePrefix = appendTimestamp(options.getFilenamePrefix());
+    compressionType = parseCompressionType(options.getCompressionType());
+  }
+
+  private static Compression parseCompressionType(String compressionType) {
+    try {
+      return Compression.valueOf(compressionType.toUpperCase());
+    } catch (IllegalArgumentException ex) {
+      throw new IllegalArgumentException(
+          String.format("Unsupported compression type: %s", compressionType));
+    }
   }
 
   private static String appendTimestamp(String filenamePrefix) {
     return String.format("%s_%s", filenamePrefix, new Date().getTime());
   }
 
-  /** IO IT with no compression. */
-  @RunWith(JUnit4.class)
-  public static class UncompressedTextIOIT {
+  @Test
+  public void writeThenReadAll() {
+    TextIO.TypedWrite<String, Object> write = TextIO
+        .write()
+        .to(filenamePrefix)
+        .withOutputFilenames()
+        .withCompression(compressionType);
 
-    @Rule
-    public TestPipeline pipeline = TestPipeline.create();
+    PCollection<String> testFilenames = pipeline
+        .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
+        .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
+        .apply("Write content to files", write)
+        .getPerDestinationOutputFilenames().apply(Values.<String>create());
 
-    @Test
-    public void writeThenReadAll() {
-      PCollection<String> testFilenames = pipeline
-          .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
-          .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
-          .apply("Write content to files", TextIO.write().to(filenamePrefix).withOutputFilenames())
-          .getPerDestinationOutputFilenames().apply(Values.<String>create());
+    PCollection<String> consolidatedHashcode = testFilenames
+        .apply("Read all files", TextIO.readAll().withCompression(AUTO))
+        .apply("Calculate hashcode", Combine.globally(new HashingFn()));
 
-      PCollection<String> consolidatedHashcode = testFilenames
-          .apply("Read all files", TextIO.readAll())
-          .apply("Calculate hashcode", Combine.globally(new HashingFn()));
+    String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
+    PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
 
-      String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
-      PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
+    testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
+        .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
 
-      testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
-          .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
-
-      pipeline.run().waitUntilFinish();
-    }
-  }
-
-  /** IO IT with various compression types. */
-  @RunWith(Parameterized.class)
-  public static class CompressedTextIOIT {
-
-    @Rule
-    public TestPipeline pipeline = TestPipeline.create();
-
-    @Parameterized.Parameters()
-    public static Iterable<Compression> data() {
-      return ImmutableList.<Compression>builder()
-          .add(GZIP)
-          .add(DEFLATE)
-          .add(BZIP2)
-          .build();
-    }
-
-    @Parameterized.Parameter()
-    public Compression compression;
-
-    @Test
-    public void writeThenReadAllWithCompression() {
-      TextIO.TypedWrite<String, Object> write = TextIO
-          .write()
-          .to(filenamePrefix)
-          .withOutputFilenames()
-          .withCompression(compression);
-
-      TextIO.ReadAll read = TextIO.readAll().withCompression(AUTO);
-
-      PCollection<String> testFilenames = pipeline
-          .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
-          .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
-          .apply("Write content to files", write)
-          .getPerDestinationOutputFilenames().apply(Values.<String>create());
-
-      PCollection<String> consolidatedHashcode = testFilenames
-          .apply("Read all files", read)
-          .apply("Calculate hashcode", Combine.globally(new HashingFn()));
-
-      String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
-      PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
-
-      testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
-          .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
-
-      pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
   }
 
   private static String getExpectedHashForLineCount(Long lineCount) {
     Map<Long, String> expectedHashes = ImmutableMap.of(
         100_000L, "4c8bb3b99dcc59459b20fefba400d446",
-        1_000_000L, "9796db06e7a7960f974d5a91164afff1"
+        1_000_000L, "9796db06e7a7960f974d5a91164afff1",
+        100_000_000L, "6ce05f456e2fdc846ded2abd0ec1de95"
     );
 
     String hash = expectedHashes.get(lineCount);
@@ -183,6 +146,7 @@ public class TextIOIT {
   }
 
   private static class DeterministicallyConstructTestTextLineFn extends DoFn<Long, String> {
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       c.output(String.format("IO IT Test line of text. Line seed: %s", c.element()));
@@ -190,6 +154,7 @@ public class TextIOIT {
   }
 
   private static class DeleteFileFn extends DoFn<String, Void> {
+
     @ProcessElement
     public void processElement(ProcessContext c) throws IOException {
       MatchResult match = Iterables
@@ -200,6 +165,7 @@ public class TextIOIT {
     private Collection<ResourceId> toResourceIds(MatchResult match) throws IOException {
       return FluentIterable.from(match.metadata())
           .transform(new Function<MatchResult.Metadata, ResourceId>() {
+
             @Override
             public ResourceId apply(MatchResult.Metadata metadata) {
               return metadata.resourceId();

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/text/TextIOIT.java
@@ -17,8 +17,14 @@
  */
 package org.apache.beam.sdk.io.text;
 
+import static org.apache.beam.sdk.io.Compression.AUTO;
+import static org.apache.beam.sdk.io.Compression.BZIP2;
+import static org.apache.beam.sdk.io.Compression.DEFLATE;
+import static org.apache.beam.sdk.io.Compression.GZIP;
+
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
@@ -27,6 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
+import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TextIO;
@@ -46,11 +53,14 @@ import org.apache.beam.sdk.values.PCollection;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+
 
 /**
- * An integration test for {@link org.apache.beam.sdk.io.TextIO}.
+ * Integration tests for {@link org.apache.beam.sdk.io.TextIO}.
  *
  * <p>Run this test using the command below. Pass in connection information via PipelineOptions:
  * <pre>
@@ -60,14 +70,11 @@ import org.junit.runners.JUnit4;
  *  ]'
  * </pre>
  * */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class TextIOIT {
 
   private static String filenamePrefix;
   private static Long numberOfTextLines;
-
-  @Rule
-  public TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void setup() throws ParseException {
@@ -83,25 +90,82 @@ public class TextIOIT {
     return String.format("%s_%s", filenamePrefix, new Date().getTime());
   }
 
-  @Test
-  public void writeThenReadAll() {
-    PCollection<String> testFilenames = pipeline
-        .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
-        .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
-        .apply("Write content to files", TextIO.write().to(filenamePrefix).withOutputFilenames())
-        .getPerDestinationOutputFilenames().apply(Values.<String>create());
+  /** IO IT with no compression. */
+  @RunWith(JUnit4.class)
+  public static class UncompressedTextIOIT {
 
-    PCollection<String> consolidatedHashcode = testFilenames
-        .apply("Read all files", TextIO.readAll())
-        .apply("Calculate hashcode", Combine.globally(new HashingFn()));
+    @Rule
+    public TestPipeline pipeline = TestPipeline.create();
 
-    String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
-    PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
+    @Test
+    public void writeThenReadAll() {
+      PCollection<String> testFilenames = pipeline
+          .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
+          .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
+          .apply("Write content to files", TextIO.write().to(filenamePrefix).withOutputFilenames())
+          .getPerDestinationOutputFilenames().apply(Values.<String>create());
 
-    testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
-        .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
+      PCollection<String> consolidatedHashcode = testFilenames
+          .apply("Read all files", TextIO.readAll())
+          .apply("Calculate hashcode", Combine.globally(new HashingFn()));
 
-    pipeline.run().waitUntilFinish();
+      String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
+      PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
+
+      testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
+          .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
+
+      pipeline.run().waitUntilFinish();
+    }
+  }
+
+  /** IO IT with various compression types. */
+  @RunWith(Parameterized.class)
+  public static class CompressedTextIOIT {
+
+    @Rule
+    public TestPipeline pipeline = TestPipeline.create();
+
+    @Parameterized.Parameters()
+    public static Iterable<Compression> data() {
+      return ImmutableList.<Compression>builder()
+          .add(GZIP)
+          .add(DEFLATE)
+          .add(BZIP2)
+          .build();
+    }
+
+    @Parameterized.Parameter()
+    public Compression compression;
+
+    @Test
+    public void writeThenReadAllWithCompression() {
+      TextIO.TypedWrite<String, Object> write = TextIO
+          .write()
+          .to(filenamePrefix)
+          .withOutputFilenames()
+          .withCompression(compression);
+
+      TextIO.ReadAll read = TextIO.readAll().withCompression(AUTO);
+
+      PCollection<String> testFilenames = pipeline
+          .apply("Generate sequence", GenerateSequence.from(0).to(numberOfTextLines))
+          .apply("Produce text lines", ParDo.of(new DeterministicallyConstructTestTextLineFn()))
+          .apply("Write content to files", write)
+          .getPerDestinationOutputFilenames().apply(Values.<String>create());
+
+      PCollection<String> consolidatedHashcode = testFilenames
+          .apply("Read all files", read)
+          .apply("Calculate hashcode", Combine.globally(new HashingFn()));
+
+      String expectedHash = getExpectedHashForLineCount(numberOfTextLines);
+      PAssert.thatSingleton(consolidatedHashcode).isEqualTo(expectedHash);
+
+      testFilenames.apply("Delete test files", ParDo.of(new DeleteFileFn())
+          .withSideInputs(consolidatedHashcode.apply(View.<String>asSingleton())));
+
+      pipeline.run().waitUntilFinish();
+    }
   }
 
   private static String getExpectedHashForLineCount(Long lineCount) {


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

This is a parametrized test for Compressed TextIO. Only the Java code - @DariuszAniszewski is working on Perfkit support and Dataflow runner support on his separate branch. As ZIP compression type is unsupported, I skipped it in the test. 

@chamikaramj could you take a look?