### PR TITLE
[BEAM-3243] support multiple anonymous classes from the same enclosing class in a pipeline

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NameUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/NameUtils.java
@@ -52,8 +52,6 @@ public class NameUtils {
   private static final String ANONYMOUS_CLASS_REGEX = "\\$[0-9]+\\$";
 
   private static String approximateSimpleName(Class<?> clazz, boolean dropOuterClassNames) {
-    checkArgument(!clazz.isAnonymousClass(),
-        "Attempted to get simple name of anonymous class");
     return approximateSimpleName(clazz.getName(), dropOuterClassNames);
   }
 
@@ -93,14 +91,6 @@ public class NameUtils {
   }
 
   /**
-   * As {@link #approximateSimpleName(Object, String)} but returning {@code "Anonymous"} when
-   * {@code object} is an instance of anonymous class.
-   */
-  public static String approximateSimpleName(Object object) {
-    return approximateSimpleName(object, "Anonymous");
-  }
-
-  /**
    * Returns a simple name describing a class that is being used as a function (eg., a {@link DoFn}
    * or {@link CombineFn}, etc.).
    *
@@ -123,7 +113,7 @@ public class NameUtils {
    *   <li>{@code another.package.PairingFn} becomes "Pairing"
    * </ul>
    */
-  public static String approximateSimpleName(Object object, String anonymousValue) {
+  public static String approximateSimpleName(Object object) {
     if (object instanceof NameOverride) {
       return ((NameOverride) object).getNameOverride();
     }
@@ -134,9 +124,11 @@ public class NameUtils {
     } else {
       clazz = object.getClass();
     }
+    /* if anonymous ensure the name is unique to support multiple anonymous DoFn per class
     if (clazz.isAnonymousClass()) {
       return anonymousValue;
     }
+    */
 
     return approximateSimpleName(clazz, /* dropOuterClassNames */ true);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/NameUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/NameUtilsTest.java
@@ -77,6 +77,9 @@ public class NameUtilsTest {
    * Inner class for simple name test.
    */
   private class EmbeddedDoFn {
+    private Object anonymous() { // ensure we have a single one for the test
+      return new DeeperEmbeddedDoFn() {};
+    }
 
     private class DeeperEmbeddedDoFn extends EmbeddedDoFn {}
 
@@ -114,7 +117,7 @@ public class NameUtilsTest {
 
   @Test
   public void testAnonSimpleName() throws Exception {
-    assertEquals("Anonymous", NameUtils.approximateSimpleName(new EmbeddedDoFn() {}));
+    assertEquals("Embedded$1", NameUtils.approximateSimpleName(new EmbeddedDoFn().anonymous()));
   }
 
   @Test
@@ -179,11 +182,5 @@ public class NameUtilsTest {
       }
     };
     assertEquals("CUSTOM_NAME", NameUtils.approximateSimpleName(overriddenName));
-  }
-
-  @Test
-  public void testApproximateSimpleNameCustomAnonymous() {
-    Object overriddenName = new Object() {};
-    assertEquals("CUSTOM_NAME", NameUtils.approximateSimpleName(overriddenName, "CUSTOM_NAME"));
   }
 }


### PR DESCRIPTION
Idea is to keep the "number" (suffix) of the anonymous class for anonymous dofn to support multiple anonymous dofn in the same pipeline.

