### PR TITLE
[DISCUSS] add a java profile to be able to skip python/go when not relevant for current work

### DIFF
--- a/sdks/pom.xml
+++ b/sdks/pom.xml
@@ -32,15 +32,37 @@
 
   <name>Apache Beam :: SDKs</name>
 
-  <modules>
-    <module>go</module>
-    <module>java</module>
-    <module>python</module>
-  </modules>
-
   <profiles>
     <profile>
+      <id>default</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>go</module>
+        <module>java</module>
+        <module>python</module>
+      </modules>
+    </profile>
+    <profile> <!-- if you don't care of python/go put in your settings.xml the property <beam.java.only>true</beam.java.only> -->
+      <id>java</id>
+      <activation>
+        <property>
+          <name>beam.java.only</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <modules>
+        <module>java</module>
+      </modules>
+    </profile>
+    <profile>
       <id>release</id>
+      <modules>
+        <module>go</module>
+        <module>java</module>
+        <module>python</module>
+      </modules>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
Often working on a feature or even more on a fix you only care about a language - which is probably most of the time java?

When building the project, the python execution time is very important (like half of it on my machine). However you are sure you didn't affect it since the code is quite parallel and almost unrelated in term of dependency.

This PR adds a java profile which skips python/go sdk when building. It is designed to be activable through a property you can put in your settings.xml if you always only work with java part of beam.