### PR TITLE
[BEAM-3171] convert a join into lookup

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.values.BeamRecord;
+
+/**
+ * A seekable table converts a JOIN operator to an inline lookup.
+ * It's triggered by {@code SELECT * FROM FACT_TABLE JOIN LOOKUP_TABLE ON ...}.
+ */
+@Experimental
+public interface BeamSqlSeekableTable extends Serializable{
+  /**
+   * return a list of {@code BeamRecord} with given key set.
+   */
+  List<BeamRecord> seekRecord(BeamRecord lookupSubRecord);
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlApiSurfaceTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlApiSurfaceTest.java
@@ -52,6 +52,7 @@ public class BeamSqlApiSurfaceTest {
         .includingClass(BeamSqlUdf.class)
         .includingClass(BeamRecordSqlType.class)
         .includingClass(BeamSqlRecordHelper.class)
+        .includingClass(BeamSqlSeekableTable.class)
         .pruningPrefix("java")
         .pruningPattern("org[.]apache[.]beam[.]sdk[.]extensions[.]sql[.].*Test")
         .pruningPattern("org[.]apache[.]beam[.]sdk[.]extensions[.]sql[.].*TestBase");


### PR DESCRIPTION
This is an experimental feature which can convert a JOIN operation into LOOKUP operation. 
It's triggered by query `SELECT * FROM FACT_TABLE JOIN LOOKUP_TABLE ON ...` when `LOOKUP_TABLE` implements `BeamSqlSeekableTable`. 