### PR TITLE
[BEAM-2899] Port DataBufferingOutboundObserver

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
-import org.apache.beam.runners.fnexecution.data.FnDataReceiver;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
 
 /**
  * A high-level client for an SDK harness.

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/FnDataService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/FnDataService.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.fnexecution.data;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
 import org.apache.beam.sdk.util.WindowedValue;
 

--- a/sdks/java/fn-execution/build.gradle
+++ b/sdks/java/fn-execution/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   shadow project(path: ":beam-model-parent:beam-model-pipeline", configuration: "shadow")
   shadow project(path: ":beam-model-parent:beam-model-fn-execution", configuration: "shadow")
   shadow project(path: ":beam-sdks-parent:beam-sdks-java-parent:beam-sdks-java-core", configuration: "shadow")
+  shadow library.java.slf4j_api
   shadow library.java.grpc_core
   shadow library.java.grpc_stub
   shadow library.java.grpc_netty

--- a/sdks/java/fn-execution/pom.xml
+++ b/sdks/java/fn-execution/pom.xml
@@ -45,6 +45,8 @@
       <artifactId>beam-model-fn-execution</artifactId>
     </dependency>
 
+      <!-- The Core SDK is used for utility code and concepts shared between runner and SDK. It
+      should not be used to refer to any user-defined functions. -->
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-sdks-java-core</artifactId>
@@ -79,6 +81,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Build dependencies -->

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A buffering outbound {@link FnDataReceiver} for the Beam Fn Data API.
+ *
+ * <p>Encodes individually consumed elements with the provided {@link Coder} producing
+ * a single {@link BeamFnApi.Elements} message when the buffer threshold
+ * is surpassed.
+ *
+ * <p>The default buffer threshold can be overridden by specifying the experiment
+ * {@code beam_fn_api_data_buffer_limit=<bytes>}
+ *
+ * <p>TODO: Handle outputting large elements (&gt; 2GiBs). Note that this also applies to the
+ * input side as well.
+ *
+ * <p>TODO: Handle outputting elements that are zero bytes by outputting a single byte as
+ * a marker, detect on the input side that no bytes were read and force reading a single byte.
+ */
+public class BeamFnDataBufferingOutboundObserver<T>
+    implements FnDataReceiver<WindowedValue<T>> {
+  // TODO: Consider moving this constant out of this class
+  public static final String BEAM_FN_API_DATA_BUFFER_LIMIT = "beam_fn_api_data_buffer_limit=";
+  @VisibleForTesting
+  static final int DEFAULT_BUFFER_LIMIT_BYTES = 1_000_000;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BeamFnDataBufferingOutboundObserver.class);
+
+  public static <T> BeamFnDataBufferingOutboundObserver<T> forLocation(
+      LogicalEndpoint endpoint,
+      Coder<WindowedValue<T>> coder,
+      StreamObserver<BeamFnApi.Elements> outboundObserver) {
+    return forLocationWithBufferLimit(
+        DEFAULT_BUFFER_LIMIT_BYTES, endpoint, coder, outboundObserver);
+  }
+
+  public static <T> BeamFnDataBufferingOutboundObserver<T> forLocationWithBufferLimit(
+      int bufferLimit,
+      LogicalEndpoint endpoint,
+      Coder<WindowedValue<T>> coder,
+      StreamObserver<BeamFnApi.Elements> outboundObserver) {
+    return new BeamFnDataBufferingOutboundObserver<>(
+        bufferLimit, endpoint, coder, outboundObserver);
+  }
+
+  private long byteCounter;
+  private long counter;
+  private final int bufferLimit;
+  private final Coder<WindowedValue<T>> coder;
+  private final LogicalEndpoint outputLocation;
+  private final StreamObserver<BeamFnApi.Elements> outboundObserver;
+  private final ByteString.Output bufferedElements;
+
+  private BeamFnDataBufferingOutboundObserver(
+      int bufferLimit,
+      LogicalEndpoint outputLocation,
+      Coder<WindowedValue<T>> coder,
+      StreamObserver<BeamFnApi.Elements> outboundObserver) {
+    this.bufferLimit = bufferLimit;
+    this.outputLocation = outputLocation;
+    this.coder = coder;
+    this.outboundObserver = outboundObserver;
+    this.bufferedElements = ByteString.newOutput();
+  }
+
+  @Override
+  public void close() throws Exception {
+    BeamFnApi.Elements.Builder elements = convertBufferForTransmission();
+    // This will add an empty data block representing the end of stream.
+    elements.addDataBuilder()
+        .setInstructionReference(outputLocation.getInstructionId())
+        .setTarget(outputLocation.getTarget());
+
+    LOG.debug("Closing stream for instruction {} and "
+        + "target {} having transmitted {} values {} bytes",
+        outputLocation.getInstructionId(),
+        outputLocation.getTarget(),
+        counter,
+        byteCounter);
+    outboundObserver.onNext(elements.build());
+  }
+
+  @Override
+  public void accept(WindowedValue<T> t) throws IOException {
+    coder.encode(t, bufferedElements);
+    counter += 1;
+    if (bufferedElements.size() >= bufferLimit) {
+      outboundObserver.onNext(convertBufferForTransmission().build());
+    }
+  }
+
+  private BeamFnApi.Elements.Builder convertBufferForTransmission() {
+    BeamFnApi.Elements.Builder elements = BeamFnApi.Elements.newBuilder();
+    if (bufferedElements.size() == 0) {
+      return elements;
+    }
+
+    elements.addDataBuilder()
+        .setInstructionReference(outputLocation.getInstructionId())
+        .setTarget(outputLocation.getTarget())
+        .setData(bufferedElements.toByteString());
+
+    byteCounter += bufferedElements.size();
+    bufferedElements.reset();
+    return elements;
+  }
+}

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/FnDataReceiver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/FnDataReceiver.java
@@ -15,13 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.fnexecution.data;
-
-import java.io.Closeable;
+package org.apache.beam.sdk.fn.data;
 
 /**
  * A receiver of streamed data.
+ *
+ * <p>A {@link FnDataReceiver} should have an idempotent {@link #close()} method.
  */
-public interface FnDataReceiver<T> extends Closeable {
+public interface FnDataReceiver<T> extends AutoCloseable {
   void accept(T input) throws Exception;
+
+  /**
+   * {@inheritDoc}.
+   *
+   * <p>{@link #close()} must be idempotent.
+   */
+  void close() throws Exception;
 }

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserverTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserverTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Elements;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.LengthPrefixCoder;
+import org.apache.beam.sdk.fn.test.Consumer;
+import org.apache.beam.sdk.fn.test.TestStreams;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link BeamFnDataBufferingOutboundObserver}. */
+@RunWith(JUnit4.class)
+public class BeamFnDataBufferingOutboundObserverTest {
+  private static final LogicalEndpoint OUTPUT_LOCATION =
+      LogicalEndpoint.of(
+          "777L",
+          Target.newBuilder()
+              .setPrimitiveTransformReference("555L")
+              .setName("Test")
+              .build());
+  private static final Coder<WindowedValue<byte[]>> CODER =
+      LengthPrefixCoder.of(WindowedValue.getValueOnlyCoder(ByteArrayCoder.of()));
+
+  @Test
+  public void testWithDefaultBuffer() throws Exception {
+    final Collection<BeamFnApi.Elements> values = new ArrayList<>();
+    final AtomicBoolean onCompletedWasCalled = new AtomicBoolean();
+    FnDataReceiver<WindowedValue<byte[]>> consumer =
+        BeamFnDataBufferingOutboundObserver.forLocation(
+            OUTPUT_LOCATION,
+            CODER,
+            TestStreams.withOnNext(addToValuesConsumer(values))
+                .withOnCompleted(setBooleanToTrue(onCompletedWasCalled))
+                .build());
+
+    // Test that nothing is emitted till the default buffer size is surpassed.
+    consumer.accept(
+        valueInGlobalWindow(
+            new byte[BeamFnDataBufferingOutboundObserver.DEFAULT_BUFFER_LIMIT_BYTES - 50]));
+    assertThat(values, empty());
+
+    // Test that when we cross the buffer, we emit.
+    consumer.accept(valueInGlobalWindow(new byte[50]));
+    assertEquals(
+        messageWithData(
+            new byte[BeamFnDataBufferingOutboundObserver.DEFAULT_BUFFER_LIMIT_BYTES - 50],
+            new byte[50]),
+        Iterables.get(values, 0));
+
+    // Test that nothing is emitted till the default buffer size is surpassed after a reset
+    consumer.accept(
+        valueInGlobalWindow(
+            new byte[BeamFnDataBufferingOutboundObserver.DEFAULT_BUFFER_LIMIT_BYTES - 50]));
+    assertEquals(1, values.size());
+
+    // Test that when we cross the buffer, we emit.
+    consumer.accept(valueInGlobalWindow(new byte[50]));
+    assertEquals(
+        messageWithData(
+            new byte[BeamFnDataBufferingOutboundObserver.DEFAULT_BUFFER_LIMIT_BYTES - 50],
+            new byte[50]),
+        Iterables.get(values, 1));
+
+    // Test that when we close with an empty buffer we only have one end of stream
+    consumer.close();
+    assertEquals(messageWithData(),
+        Iterables.get(values, 2));
+  }
+
+  @Test
+  public void testConfiguredBufferLimit() throws Exception {
+    Collection<BeamFnApi.Elements> values = new ArrayList<>();
+    AtomicBoolean onCompletedWasCalled = new AtomicBoolean();
+    FnDataReceiver<WindowedValue<byte[]>> consumer =
+        BeamFnDataBufferingOutboundObserver.forLocationWithBufferLimit(
+            100,
+            OUTPUT_LOCATION,
+            CODER,
+            TestStreams.withOnNext(addToValuesConsumer(values))
+                .withOnCompleted(setBooleanToTrue(onCompletedWasCalled))
+                .build());
+
+    // Test that nothing is emitted till the default buffer size is surpassed.
+    consumer.accept(valueInGlobalWindow(new byte[51]));
+    assertThat(values, empty());
+
+    // Test that when we cross the buffer, we emit.
+    consumer.accept(valueInGlobalWindow(new byte[49]));
+    assertEquals(
+        messageWithData(new byte[51], new byte[49]),
+        Iterables.get(values, 0));
+
+    // Test that when we close we empty the value, and then the stream terminator as part
+    // of the same message
+    consumer.accept(valueInGlobalWindow(new byte[1]));
+    consumer.close();
+    assertEquals(
+        BeamFnApi.Elements.newBuilder(messageWithData(new byte[1]))
+            .addData(BeamFnApi.Elements.Data.newBuilder()
+                .setInstructionReference(OUTPUT_LOCATION.getInstructionId())
+                .setTarget(OUTPUT_LOCATION.getTarget()))
+            .build(),
+        Iterables.get(values, 1));
+  }
+
+  private static BeamFnApi.Elements messageWithData(byte[] ... datum) throws IOException {
+    ByteString.Output output = ByteString.newOutput();
+    for (byte[] data : datum) {
+      CODER.encode(valueInGlobalWindow(data), output);
+    }
+    return BeamFnApi.Elements.newBuilder()
+        .addData(BeamFnApi.Elements.Data.newBuilder()
+            .setInstructionReference(OUTPUT_LOCATION.getInstructionId())
+            .setTarget(OUTPUT_LOCATION.getTarget())
+            .setData(output.toByteString()))
+        .build();
+  }
+
+  private Consumer<Elements> addToValuesConsumer(final Collection<Elements> values) {
+    return new Consumer<Elements>() {
+      @Override
+      public void accept(Elements item) {
+        values.add(item);
+      }
+    };
+  }
+
+  private Runnable setBooleanToTrue(final AtomicBoolean onCompletedWasCalled) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        onCompletedWasCalled.set(true);
+      }
+    };
+  }
+}


### PR DESCRIPTION
Move to sdks/java/fn-execution. The outbound observers are generally the
same on both ends.

Introduce a CloseableFnDataReceiver, and remove 'Closeable' from the
default FnDataReceiver.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
