### PR TITLE
[BEAM-3041] Add support for --save_main_session flag

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount_fnapi.py
+++ b/sdks/python/apache_beam/examples/wordcount_fnapi.py
@@ -26,7 +26,6 @@ from __future__ import absolute_import
 
 import argparse
 import logging
-import re
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText
@@ -36,7 +35,6 @@ from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PipelineOptions
-from apache_beam.options.pipeline_options import SetupOptions
 
 
 class WordExtractingDoFn(beam.DoFn):
@@ -61,6 +59,12 @@ class WordExtractingDoFn(beam.DoFn):
     Returns:
       The processed element.
     """
+
+    # TODO(BEAM-3041): Move this import to top of the file after the fix.
+    # Portable containers does not support save main session, and importing here
+    # is required. This is only needed for running experimental jobs with FnApi.
+    import re
+
     text_line = element.strip()
     if not text_line:
       self.empty_line_counter.inc(1)
@@ -85,10 +89,7 @@ def run(argv=None):
                       help='Output file to write results to.')
   known_args, pipeline_args = parser.parse_known_args(argv)
 
-  # We use the save_main_session option because one or more DoFn's in this
-  # workflow rely on global context (e.g., a module imported at module level).
   pipeline_options = PipelineOptions(pipeline_args)
-  pipeline_options.view_as(SetupOptions).save_main_session = True
   p = beam.Pipeline(options=pipeline_options)
 
   # Ensure that the experiment flag is set explicitly by the user.

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -17,7 +17,7 @@
 
 """Various names for properties, transforms, etc."""
 
-
+# TODO (altay): Move shared names to a common location.
 # Standard file names used for staging files.
 PICKLED_MAIN_SESSION_FILE = 'pickled_main_session'
 DATAFLOW_SDK_TARBALL_FILE = 'dataflow_python_sdk.tar'

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -86,10 +86,11 @@ def main(unused_argv):
       fn_log_handler.close()
 
 
-def _load_main_session(session_path):
+def _load_main_session(semi_persistent_directory):
   """Loads a pickled main session from the path specified."""
-  if session_path:
-    session_file = os.path.join(session_path, names.PICKLED_MAIN_SESSION_FILE)
+  if semi_persistent_directory:
+    session_file = os.path.join(
+        semi_persistent_directory, 'staged', names.PICKLED_MAIN_SESSION_FILE)
     if os.path.isfile(session_file):
       pickler.load_session(session_file)
     else:
@@ -98,7 +99,7 @@ def _load_main_session(session_path):
           '(interactive session) may fail.', session_file)
   else:
     logging.warning(
-        'No session_path found: Functions defined in __main__ '
+        'No semi_persistent_directory found: Functions defined in __main__ '
         '(interactive session) may fail.')
 
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -17,13 +17,17 @@
 
 """SDK Fn Harness entry point."""
 
+import json
 import logging
 import os
 import sys
+import traceback
 
 from google.protobuf import text_format
 
+from apache_beam.internal import pickler
 from apache_beam.portability.api import endpoints_pb2
+from apache_beam.runners.dataflow.internal import names
 from apache_beam.runners.worker.log_handler import FnApiLogRecordHandler
 from apache_beam.runners.worker.sdk_worker import SdkHarness
 
@@ -45,8 +49,28 @@ def main(unused_argv):
   else:
     fn_log_handler = None
 
+  if 'PIPELINE_OPTIONS' in os.environ:
+    sdk_pipeline_options = json.loads(os.environ['PIPELINE_OPTIONS'])
+  else:
+    sdk_pipeline_options = {}
+
+  if 'SEMI_PERSISTENT_DIRECTORY' in os.environ:
+    semi_persistent_directory = os.environ['SEMI_PERSISTENT_DIRECTORY']
+  else:
+    semi_persistent_directory = None
+
+  logging.info('semi_persistent_directory: %s', semi_persistent_directory)
+
   try:
-    logging.info('Python sdk harness started.')
+    _load_main_session(semi_persistent_directory)
+  except Exception:  # pylint: disable=broad-except
+    exception_details = traceback.format_exc()
+    logging.error(
+        'Could not load main session: %s', exception_details, exc_info=True)
+
+  try:
+    logging.info('Python sdk harness started with pipeline_options: %s',
+                 sdk_pipeline_options)
     service_descriptor = endpoints_pb2.ApiServiceDescriptor()
     text_format.Merge(os.environ['CONTROL_API_SERVICE_DESCRIPTOR'],
                       service_descriptor)
@@ -60,6 +84,22 @@ def main(unused_argv):
   finally:
     if fn_log_handler:
       fn_log_handler.close()
+
+
+def _load_main_session(session_path):
+  """Loads a pickled main session from the path specified."""
+  if session_path:
+    session_file = os.path.join(session_path, names.PICKLED_MAIN_SESSION_FILE)
+    if os.path.isfile(session_file):
+      pickler.load_session(session_file)
+    else:
+      logging.warning(
+          'No session file found: %s. Functions defined in __main__ '
+          '(interactive session) may fail.', session_file)
+  else:
+    logging.warning(
+        'No session_path found: Functions defined in __main__ '
+        '(interactive session) may fail.')
 
 
 if __name__ == '__main__':

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -95,7 +95,7 @@ func main() {
 	// (3) Invoke python
 
 	os.Setenv("PIPELINE_OPTIONS", options)
-	os.Setenv("SEMI_PERSISTENT_DIRECTORY", dir)
+	os.Setenv("SEMI_PERSISTENT_DIRECTORY", *semiPersistDir)
 	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *loggingEndpoint}))
 	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *controlEndpoint}))
 

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -95,6 +95,7 @@ func main() {
 	// (3) Invoke python
 
 	os.Setenv("PIPELINE_OPTIONS", options)
+	os.Setenv("SEMI_PERSISTENT_DIRECTORY", dir)
 	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *loggingEndpoint}))
 	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *controlEndpoint}))
 


### PR DESCRIPTION
This change does two things:
- Loads the pickled main session file
- Parses the passed pipeline option from the environment. (To be passed to the sdk worker in a follow up change.)

I will revert the changes to `wordcount_fnapi.py` because the post commit test is still using a pre-built container, and would not pick up the container changes.

R: @robertwb @herohde 