### PR TITLE
Move StreamObserverFactory to java fn-execution

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -29,13 +29,14 @@ import org.apache.beam.fn.harness.data.BeamFnDataGrpcClient;
 import org.apache.beam.fn.harness.fn.ThrowingFunction;
 import org.apache.beam.fn.harness.logging.BeamFnLoggingClient;
 import org.apache.beam.fn.harness.state.BeamFnStateGrpcClientCache;
-import org.apache.beam.fn.harness.stream.StreamObserverFactory;
+import org.apache.beam.fn.harness.stream.HarnessStreamObserverFactories;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionResponse.Builder;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.fn.channel.ManagedChannelFactory;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
@@ -101,7 +102,8 @@ public class FnHarness {
     } else {
       channelFactory = ManagedChannelFactory.createDefault();
     }
-    StreamObserverFactory streamObserverFactory = StreamObserverFactory.fromOptions(options);
+    StreamObserverFactory streamObserverFactory =
+        HarnessStreamObserverFactories.fromOptions(options);
     try (BeamFnLoggingClient logging = new BeamFnLoggingClient(
         options,
         loggingApiServiceDescriptor,

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BeamFnControlClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BeamFnControlClient.java
@@ -33,8 +33,10 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.apache.beam.fn.harness.fn.ThrowingFunction;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnControlGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,13 +70,15 @@ public class BeamFnControlClient {
   public BeamFnControlClient(
       Endpoints.ApiServiceDescriptor apiServiceDescriptor,
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory,
-      BiFunction<Function<StreamObserver<BeamFnApi.InstructionRequest>,
-                          StreamObserver<BeamFnApi.InstructionResponse>>,
-                 StreamObserver<BeamFnApi.InstructionRequest>,
-                 StreamObserver<BeamFnApi.InstructionResponse>> streamObserverFactory,
-      EnumMap<BeamFnApi.InstructionRequest.RequestCase,
-              ThrowingFunction<BeamFnApi.InstructionRequest,
-                               BeamFnApi.InstructionResponse.Builder>> handlers) {
+      BiFunction<
+              StreamObserverClientFactory<InstructionRequest, BeamFnApi.InstructionResponse>,
+              StreamObserver<BeamFnApi.InstructionRequest>,
+              StreamObserver<BeamFnApi.InstructionResponse>>
+          streamObserverFactory,
+      EnumMap<
+              BeamFnApi.InstructionRequest.RequestCase,
+              ThrowingFunction<BeamFnApi.InstructionRequest, BeamFnApi.InstructionResponse.Builder>>
+          handlers) {
     this.bufferedInstructions = new LinkedBlockingDeque<>();
     this.outboundObserver = streamObserverFactory.apply(
         BeamFnControlGrpc.newStub(channelFactory.apply(apiServiceDescriptor))::control,

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
@@ -32,6 +32,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnDataGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.slf4j.Logger;
@@ -47,18 +48,19 @@ public class BeamFnDataGrpcClient implements BeamFnDataClient {
 
   private final ConcurrentMap<Endpoints.ApiServiceDescriptor, BeamFnDataGrpcMultiplexer> cache;
   private final Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory;
-  private final BiFunction<Function<StreamObserver<BeamFnApi.Elements>,
-                                    StreamObserver<BeamFnApi.Elements>>,
-                           StreamObserver<BeamFnApi.Elements>,
-                           StreamObserver<BeamFnApi.Elements>> streamObserverFactory;
+  private final BiFunction<
+          StreamObserverClientFactory<BeamFnApi.Elements, BeamFnApi.Elements>,
+          StreamObserver<BeamFnApi.Elements>, StreamObserver<BeamFnApi.Elements>>
+      streamObserverFactory;
   private final PipelineOptions options;
 
   public BeamFnDataGrpcClient(
       PipelineOptions options,
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory,
-      BiFunction<Function<StreamObserver<BeamFnApi.Elements>, StreamObserver<BeamFnApi.Elements>>,
-                 StreamObserver<BeamFnApi.Elements>,
-                 StreamObserver<BeamFnApi.Elements>> streamObserverFactory) {
+      BiFunction<
+              StreamObserverClientFactory<BeamFnApi.Elements, BeamFnApi.Elements>,
+              StreamObserver<BeamFnApi.Elements>, StreamObserver<BeamFnApi.Elements>>
+          streamObserverFactory) {
     this.options = options;
     this.channelFactory = channelFactory;
     this.streamObserverFactory = streamObserverFactory;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/BeamFnStateGrpcClientCache.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/BeamFnStateGrpcClientCache.java
@@ -33,6 +33,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnStateGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,10 +48,10 @@ public class BeamFnStateGrpcClientCache {
 
   private final ConcurrentMap<ApiServiceDescriptor, BeamFnStateClient> cache;
   private final Function<ApiServiceDescriptor, ManagedChannel> channelFactory;
-  private final BiFunction<Function<StreamObserver<StateResponse>,
-      StreamObserver<StateRequest>>,
-      StreamObserver<StateResponse>,
-      StreamObserver<StateRequest>> streamObserverFactory;
+  private final BiFunction<
+          StreamObserverClientFactory<StateResponse, StateRequest>, StreamObserver<StateResponse>,
+          StreamObserver<StateRequest>>
+      streamObserverFactory;
   private final PipelineOptions options;
   private final Supplier<String> idGenerator;
 
@@ -58,7 +59,7 @@ public class BeamFnStateGrpcClientCache {
       PipelineOptions options,
       Supplier<String> idGenerator,
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory,
-      BiFunction<Function<StreamObserver<StateResponse>, StreamObserver<StateRequest>>,
+      BiFunction<StreamObserverClientFactory<StateResponse, StateRequest>,
           StreamObserver<StateResponse>,
           StreamObserver<StateRequest>> streamObserverFactory) {
     this.options = options;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactories.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactories.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.fn.harness.stream;
+
+import io.grpc.stub.StreamObserver;
+import java.util.List;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory;
+import org.apache.beam.sdk.options.ExperimentalOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * Uses {@link PipelineOptions} to configure which underlying {@link StreamObserver} implementation
+ * to use in the java SDK harness.
+ */
+public abstract class HarnessStreamObserverFactories {
+  public static org.apache.beam.sdk.fn.stream.StreamObserverFactory fromOptions(
+      PipelineOptions options) {
+    List<String> experiments = options.as(ExperimentalOptions.class).getExperiments();
+    if (experiments != null && experiments.contains("beam_fn_api_buffered_stream")) {
+      int bufferSize = getBufferSize(experiments);
+      if (bufferSize > 0) {
+        return StreamObserverFactory.buffered(
+            options.as(GcsOptions.class).getExecutorService(), bufferSize);
+      }
+      return StreamObserverFactory.buffered(
+          options.as(GcsOptions.class).getExecutorService());
+    }
+    return StreamObserverFactory.direct();
+  }
+
+  private static int getBufferSize(List<String> experiments) {
+    for (String experiment : experiments) {
+      if (experiment.startsWith("beam_fn_api_buffered_stream_buffer_size=")) {
+        return Integer.parseInt(
+            experiment.substring("beam_fn_api_buffered_stream_buffer_size=".length()));
+      }
+    }
+    return -1;
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/BeamFnControlClientTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/BeamFnControlClientTest.java
@@ -37,11 +37,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
 import org.apache.beam.fn.harness.fn.ThrowingFunction;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnControlGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.apache.beam.sdk.fn.test.TestStreams;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -176,8 +176,7 @@ public class BeamFnControlClientTest {
   }
 
   private <ReqT, RespT> StreamObserver<RespT> createStreamForTest(
-      Function<StreamObserver<ReqT>, StreamObserver<RespT>> clientFactory,
-      StreamObserver<ReqT> handler) {
-    return clientFactory.apply(handler);
+      StreamObserverClientFactory<ReqT, RespT> clientFactory, StreamObserver<ReqT> handler) {
+    return clientFactory.outboundObserverFor(handler);
   }
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClientTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClientTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 import org.apache.beam.fn.harness.fn.CloseableThrowingConsumer;
 import org.apache.beam.fn.harness.fn.ThrowingConsumer;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
@@ -53,6 +52,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.LengthPrefixCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.apache.beam.sdk.fn.test.Consumer;
 import org.apache.beam.sdk.fn.test.TestStreams;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -313,8 +313,8 @@ public class BeamFnDataGrpcClientTest {
   }
 
   private <ReqT, RespT> StreamObserver<RespT> createStreamForTest(
-      Function<StreamObserver<ReqT>, StreamObserver<RespT>> clientFactory,
+      StreamObserverClientFactory<ReqT, RespT> clientFactory,
       StreamObserver<ReqT> handler) {
-    return clientFactory.apply(handler);
+    return clientFactory.outboundObserverFor(handler);
   }
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/BeamFnStateGrpcClientCacheTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/BeamFnStateGrpcClientCacheTest.java
@@ -38,12 +38,12 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.function.Function;
 import org.apache.beam.fn.harness.IdGenerator;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnStateGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory.StreamObserverClientFactory;
 import org.apache.beam.sdk.fn.test.TestStreams;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.After;
@@ -227,8 +227,7 @@ public class BeamFnStateGrpcClientCacheTest {
   }
 
   private <ReqT, RespT> StreamObserver<RespT> createStreamForTest(
-      Function<StreamObserver<ReqT>, StreamObserver<RespT>> clientFactory,
-      StreamObserver<ReqT> handler) {
-    return clientFactory.apply(handler);
+      StreamObserverClientFactory<ReqT, RespT> clientFactory, StreamObserver<ReqT> handler) {
+    return clientFactory.outboundObserverFor(handler);
   }
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactoriesTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactoriesTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.fn.harness.stream;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import io.grpc.stub.CallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import org.apache.beam.sdk.fn.stream.BufferingStreamObserver;
+import org.apache.beam.sdk.fn.stream.DirectStreamObserver;
+import org.apache.beam.sdk.fn.stream.ForwardingClientResponseObserver;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Tests for {@link HarnessStreamObserverFactoriesTest}. */
+@RunWith(JUnit4.class)
+public class HarnessStreamObserverFactoriesTest {
+  @Mock private StreamObserver<Integer> mockRequestObserver;
+  @Mock private CallStreamObserver<String> mockResponseObserver;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testDefaultInstantiation() {
+    StreamObserver<String> observer =
+        HarnessStreamObserverFactories.fromOptions(PipelineOptionsFactory.create())
+            .from(this::fakeFactory, mockRequestObserver);
+    assertThat(observer, instanceOf(DirectStreamObserver.class));
+  }
+
+  @Test
+  public void testBufferedStreamInstantiation() {
+    StreamObserver<String> observer =
+        HarnessStreamObserverFactories.fromOptions(
+                PipelineOptionsFactory.fromArgs(
+                        new String[] {"--experiments=beam_fn_api_buffered_stream"})
+                    .create())
+            .from(this::fakeFactory, mockRequestObserver);
+    assertThat(observer, instanceOf(BufferingStreamObserver.class));
+  }
+
+  @Test
+  public void testBufferedStreamWithLimitInstantiation() {
+    StreamObserver<String> observer =
+        HarnessStreamObserverFactories.fromOptions(
+                PipelineOptionsFactory.fromArgs(
+                        new String[] {
+                          "--experiments=beam_fn_api_buffered_stream,"
+                              + "beam_fn_api_buffered_stream_buffer_size=1"
+                        })
+                    .create())
+            .from(this::fakeFactory, mockRequestObserver);
+    assertThat(observer, instanceOf(BufferingStreamObserver.class));
+    assertEquals(1, ((BufferingStreamObserver<String>) observer).getBufferSize());
+  }
+
+  private StreamObserver<String> fakeFactory(StreamObserver<Integer> observer) {
+    assertThat(observer, instanceOf(ForwardingClientResponseObserver.class));
+    return mockResponseObserver;
+  }
+}


### PR DESCRIPTION

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
The abstract type can be used by both servers and clients.

Create an interface (not java.util.function.Function) for creating outbound observers from
inbound observers.
