### PR TITLE
Build output redirection option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <external.build.directory>${project.basedir}/target</external.build.directory>
     <beam.javadoc_opts />
 
     <!-- Disable integration tests by default -->
@@ -286,8 +285,6 @@
             <artifactId>reproducible-build-maven-plugin</artifactId>
           </plugin>
         </plugins>
-
-        <directory>${external.build.directory}</directory>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <external.build.directory>${project.basedir}/target</external.build.directory>
     <beam.javadoc_opts />
 
     <!-- Disable integration tests by default -->
@@ -2174,6 +2175,7 @@
         </executions>
       </plugin>
     </plugins>
+    <directory>${external.build.directory}</directory>
   </build>
 
   <reporting>


### PR DESCRIPTION
This is a fix to https://github.com/apache/beam/pull/4085

The property should apply to the base configuration, not just the release profile. This would allow the property to be used by any profile.
