### PR TITLE
[BEAM-413] Created local annotation for floating point equality warning.

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -332,12 +332,6 @@
     <!--[BEAM-410] Class defines compareTo(...) and uses Object.equals()-->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.transforms.Mean$CountSum"/>
-    <Method name="equals"/>
-    <Bug pattern="FE_FLOATING_POINT_EQUALITY"/>
-    <!--[BEAM-413] Test for floating point equality-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.util.CombineFnUtil$NonSerializableBoundedCombineFn"/>
     <Field name="context"/>
     <Bug pattern="SE_BAD_FIELD"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Mean.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Mean.java
@@ -156,6 +156,10 @@ public class Mean {
     }
 
     @Override
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(
+        value = "FE_FLOATING_POINT_EQUALITY",
+        justification = "Comparing doubles directly since equals method is only used in coder test."
+    )
     public boolean equals(Object other) {
       if (!(other instanceof CountSum)) {
         return false;


### PR DESCRIPTION
Equals method for the CountSum is used in a test that makes sure encoding and decoding CountSum object results in an equal object. Since coderDecodeEncodeEqual method below takes an object and does the equality check automatically, it is easier to keep the equals() function with annotation than removing it and writing custom method instead of coderDecodeEncodeEqual. 

CoderProperties.coderDecodeEncodeEqual(coder, countSumObject);