### PR TITLE
statesampler will not be relative-imported in test

### DIFF
--- a/sdks/python/apache_beam/runners/worker/statesampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_test.py
@@ -33,7 +33,7 @@ class StateSamplerTest(unittest.TestCase):
     try:
       # pylint: disable=global-variable-not-assigned
       global statesampler
-      from . import statesampler
+      from apache_beam.runners.worker import statesampler
     except ImportError:
       raise SkipTest('State sampler not compiled.')
     super(StateSamplerTest, self).setUp()


### PR DESCRIPTION
Relative imports make it impossible to run `python statesampler_test.py`