### PR TITLE
Add property to control dependency poms.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <external.build.directory>${project.basedir}/target</external.build.directory>
+    <external.createDependencyReducedPom>true</external.createDependencyReducedPom>
     <beam.javadoc_opts />
 
     <!-- Disable integration tests by default -->
@@ -1857,6 +1858,7 @@
               </goals>
               <configuration>
                 <shadeTestJar>true</shadeTestJar>
+                <createDependencyReducedPom>${external.createDependencyReducedPom}</createDependencyReducedPom>
                 <artifactSet>
                   <includes>
                     <include>com.google.guava:guava</include>


### PR DESCRIPTION
The behavior of the shade plugin creates a dependency reduced POM
and places it in the basedir rather than the artifacts directory. This
behavior is unwelcome if basedir is a read-only filesystem. Adding
a property to allow this feature to be disabled in these environments.
