### PR TITLE
Fix test name in apache_beam/io/localfilesystem_test.py

### DIFF
--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -146,7 +146,7 @@ class LocalFileSystemTest(unittest.TestCase):
         error.exception.message.startswith('Match operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [None])
 
-  def test_match_directory(self):
+  def test_match_glob(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
     open(path1, 'a').close()


### PR DESCRIPTION
There were 2 test methods named "test_match_directory".