### PR TITLE
[BEAM-3294] Make Go SDK external transform a primitive

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -42,7 +42,7 @@ func (c Coder) IsValid() bool {
 // Type returns the full type 'A' of elements the coder can encode and decode.
 // 'A' must be a concrete Windowed Value type, such as W<int> or
 // W<KV<int,string>>.
-func (c Coder) Type() typex.FullType {
+func (c Coder) Type() FullType {
 	if !c.IsValid() {
 		panic("Invalid Coder")
 	}
@@ -73,7 +73,7 @@ func UnwrapCoder(c Coder) *coder.Coder {
 }
 
 // NewCoder infers a Coder for any bound full type.
-func NewCoder(t typex.FullType) Coder {
+func NewCoder(t FullType) Coder {
 	c, err := inferCoder(t)
 	if err != nil {
 		panic(err) // for now
@@ -81,7 +81,7 @@ func NewCoder(t typex.FullType) Coder {
 	return Coder{c}
 }
 
-func inferCoder(t typex.FullType) (*coder.Coder, error) {
+func inferCoder(t FullType) (*coder.Coder, error) {
 	switch t.Class() {
 	case typex.Concrete, typex.Container:
 		switch t.Type() {
@@ -122,7 +122,7 @@ func inferCoder(t typex.FullType) (*coder.Coder, error) {
 	}
 }
 
-func inferCoders(list []typex.FullType) ([]*coder.Coder, error) {
+func inferCoders(list []FullType) ([]*coder.Coder, error) {
 	var ret []*coder.Coder
 	for _, t := range list {
 		c, err := inferCoder(t)
@@ -148,7 +148,7 @@ func JSONEnc(in typex.T) ([]byte, error) {
 }
 
 // JSONDec decodes the supplied JSON into an instance of the supplied type.
-func JSONDec(t reflect.Type, in []byte) (typex.T, error) {
+func JSONDec(t reflect.Type, in []byte) (T, error) {
 	val := reflect.New(t)
 	if err := json.Unmarshal(in, val.Interface()); err != nil {
 		return nil, err

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package coder contains coder representation and utilities. Coders describe
+// how to serialize and deserialize pipeline data and may be provided by users.
 package coder
 
 import (

--- a/sdks/go/pkg/beam/core/graph/window/window.go
+++ b/sdks/go/pkg/beam/core/graph/window/window.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package window contains window representation and utilities.
 package window
 
 import "fmt"

--- a/sdks/go/pkg/beam/core/runtime/exec/exec.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/exec.go
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package exec contains runtime plan representation and execution. A pipeline
+// must be translated to a runtime plan to be executed.
 package exec
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/init.go
+++ b/sdks/go/pkg/beam/core/runtime/init.go
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package runtime contains runtime hooks and utilities for pipeline options
+// and type registration. Most functionality done in init and hence is
+// available both during pipeline-submission and at runtime.
 package runtime
 
 var (

--- a/sdks/go/pkg/beam/core/typex/fulltype.go
+++ b/sdks/go/pkg/beam/core/typex/fulltype.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package typex contains full type representation and utilities for type checking.
 package typex
 
 import (

--- a/sdks/go/pkg/beam/external.go
+++ b/sdks/go/pkg/beam/external.go
@@ -17,11 +17,9 @@ package beam
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
 // External defines a Beam external transform. The interpretation of this primitive is runner
@@ -29,89 +27,38 @@ import (
 // spec provided to implement the behavior of the operation. Transform
 // libraries should expose an API that captures the user's intent and serialize
 // the payload as a byte slice that the runner will deserialize.
-func External(s Scope, spec string, payload []byte, in []PCollection, out []reflect.Type) []PCollection {
+func External(s Scope, spec string, payload []byte, in []PCollection, out []FullType) []PCollection {
 	return MustN(TryExternal(s, spec, payload, in, out))
 }
 
 // TryExternal attempts to perform the work of External, returning an error indicating why the operation
-// failed. Failure reasons include the use of side inputs, or an external transform that has both inputs
-// and outputs.
-func TryExternal(s Scope, spec string, payload []byte, in []PCollection, out []reflect.Type) ([]PCollection, error) {
-	switch {
-	case len(in) == 0 && len(out) == 0:
-		return []PCollection{}, fmt.Errorf("External node not well-formed: out and in both empty")
-	case len(in) > 0 && len(out) > 0:
-		return []PCollection{}, fmt.Errorf("External DoFns are not currently supported")
-	case len(in) > 1:
-		return []PCollection{}, fmt.Errorf("External operations with side inputs are not currently supported")
-	case len(out) > 1:
-		return []PCollection{}, fmt.Errorf("External operations with side outputs are not currently supported")
-	case len(out) == 1:
-		return tryExternalSource(s, spec, payload, out[0])
-	case len(in) == 1:
-		return tryExternalSink(s, in[0], spec, payload)
-	}
-
-	panic(fmt.Errorf("Impossible case: len[in]=%d, len[out]=%d", len(in), len(out)))
-}
-
-// TODO(wcn): the use of dynamic functions was a creative hack to minimize changes to the runtime
-// while we design aspects of this feature. While the public API is locked down as above, the details
-// here about how the payload is conveyed to the runner will certainly change, as this is a top-level
-// primitive. Runners depending on this coding do so AT THEIR OWN RISK and will be broken when we convert
-// this implementation to its final internal representation.
-
-func tryExternalSource(s Scope, spec string, payload []byte, out reflect.Type) ([]PCollection, error) {
+// failed.
+func TryExternal(s Scope, spec string, payload []byte, in []PCollection, out []FullType) ([]PCollection, error) {
 	if !s.IsValid() {
 		return nil, fmt.Errorf("invalid scope")
 	}
-	emit := reflect.FuncOf([]reflect.Type{out}, nil, false)
-	fnT := reflect.FuncOf([]reflect.Type{emit}, []reflect.Type{reflectx.Error}, false)
-
-	gen := makeGenWithErrorMessage("ExternalSource node cannot be directly executed")
-	g := &graph.DynFn{Name: "ExternalSource", Data: payload, T: fnT, Gen: gen}
-	fn, err := graph.NewDoFn(g)
-
-	if err != nil {
-		return []PCollection{}, err
-	}
-	edge, err := graph.NewSource(s.real, s.scope, fn, nil)
-	if err != nil {
-		return []PCollection{}, err
-	}
-	ret := PCollection{edge.Output[0].To}
-	ret.SetCoder(NewCoder(ret.Type()))
-	return []PCollection{ret}, nil
-}
-
-func tryExternalSink(s Scope, in PCollection, spec string, payload []byte) ([]PCollection, error) {
-	if !s.IsValid() {
-		return nil, fmt.Errorf("invalid scope")
-	}
-	if !in.IsValid() {
-		return []PCollection{}, fmt.Errorf("invalid main pcollection")
-	}
-
-	fnT := reflect.FuncOf([]reflect.Type{typex.SkipW(in.n.Type()).Type()}, []reflect.Type{reflectx.Error}, false)
-	gen := makeGenWithErrorMessage("ExternalSink node cannot be directly executed")
-	g := &graph.DynFn{Name: "ExternalSink", Data: payload, T: fnT, Gen: gen}
-	fn, err := graph.NewDoFn(g)
-
-	if err != nil {
-		return []PCollection{}, err
-	}
-	_, err = graph.NewSink(s.real, s.scope, fn, in.n)
-	if err != nil {
-		return []PCollection{}, err
-	}
-	return []PCollection{}, nil
-}
-
-func makeGenWithErrorMessage(msg string) func([]byte) func([]reflect.Value) []reflect.Value {
-	return func(in []byte) func([]reflect.Value) []reflect.Value {
-		return func(args []reflect.Value) []reflect.Value {
-			ret := reflect.ValueOf(fmt.Errorf(msg))
-			return []reflect.Value{ret.Convert(reflectx.Error)}
+	for i, col := range in {
+		if !col.IsValid() {
+			return nil, fmt.Errorf("invalid pcollection to external: index %v", i)
 		}
 	}
+	for _, t := range out {
+		if !typex.IsW(t) {
+			return nil, fmt.Errorf("output type to external must be windowed: %v", t)
+		}
+	}
+
+	var ins []*graph.Node
+	for _, col := range in {
+		ins = append(ins, col.n)
+	}
+	edge := graph.NewExternal(s.real, s.scope, &graph.Payload{URN: spec, Data: payload}, ins, out)
+
+	var ret []PCollection
+	for _, out := range edge.Output {
+		c := PCollection{out.To}
+		c.SetCoder(NewCoder(c.Type()))
+		ret = append(ret, c)
+	}
+	return ret, nil
 }

--- a/sdks/go/pkg/beam/forward.go
+++ b/sdks/go/pkg/beam/forward.go
@@ -63,6 +63,8 @@ var PipelineOptions = runtime.GlobalOptions
 // We forward typex types used in UserFn signatures to avoid having such code
 // depend on the typex package directly.
 
+type FullType = typex.FullType
+
 type T = typex.T
 type U = typex.U
 type V = typex.V

--- a/sdks/go/pkg/beam/pcollection.go
+++ b/sdks/go/pkg/beam/pcollection.go
@@ -54,7 +54,7 @@ func (p PCollection) IsValid() bool {
 
 // Type returns the full type 'A' of the elements. 'A' must be a concrete
 // Windowed Value type, such as W<int> or W<KV<int,string>>.
-func (p PCollection) Type() typex.FullType {
+func (p PCollection) Type() FullType {
 	if !p.IsValid() {
 		panic("Invalid PCollection")
 	}

--- a/sdks/go/pkg/beam/runners/dataflow/translate.go
+++ b/sdks/go/pkg/beam/runners/dataflow/translate.go
@@ -181,17 +181,6 @@ func translateEdge(edge *graph.MultiEdge) (string, properties, error) {
 			Element:  []string{url.QueryEscape(value)},
 		}, nil
 
-	case graph.Source:
-		fn, err := serializeFn(edge)
-		if err != nil {
-			return "", properties{}, err
-		}
-		return "ParallelRead", properties{
-			CustomSourceInputStep: newCustomSourceInputStep(fn),
-			UserName:              buildName(edge.Scope(), edge.DoFn.Name()),
-			Format:                "custom_source",
-		}, nil
-
 	case graph.ParDo:
 		fn, err := serializeFn(edge)
 		if err != nil {
@@ -225,11 +214,6 @@ func translateEdge(edge *graph.MultiEdge) (string, properties, error) {
 			UserName:                buildName(edge.Scope(), "group"), // TODO: user-defined
 			DisallowCombinerLifting: true,
 			SerializedFn:            sfn,
-		}, nil
-
-	case graph.Sink:
-		return "ParallelWrite", properties{
-		// TODO
 		}, nil
 
 	case graph.Flatten:

--- a/sdks/go/pkg/beam/runners/direct/direct.go
+++ b/sdks/go/pkg/beam/runners/direct/direct.go
@@ -89,10 +89,6 @@ func build(mgr exec.DataManager, instID string, list []*graph.MultiEdge) ([]exec
 			unit := &Impulse{UID: idgen.New(), Edge: edge}
 			units = append(units, unit)
 
-		case graph.Source:
-			unit := &exec.Source{UID: idgen.New(), Edge: edge}
-			units = append(units, unit)
-
 		case graph.ParDo:
 			unit := &exec.ParDo{UID: idgen.New(), Edge: edge}
 			units = append(units, unit)
@@ -226,8 +222,6 @@ func build(mgr exec.DataManager, instID string, list []*graph.MultiEdge) ([]exec
 
 func getEdge(unit exec.Unit) (*graph.MultiEdge, bool) {
 	switch unit.(type) {
-	case *exec.Source:
-		return unit.(*exec.Source).Edge, true
 	case *exec.ParDo:
 		return unit.(*exec.ParDo).Edge, true
 	case *exec.Combine:
@@ -247,8 +241,6 @@ func getEdge(unit exec.Unit) (*graph.MultiEdge, bool) {
 
 func setOut(unit exec.Unit, out []exec.Node) {
 	switch unit.(type) {
-	case *exec.Source:
-		unit.(*exec.Source).Out = out
 	case *exec.ParDo:
 		unit.(*exec.ParDo).Out = out
 	case *exec.Combine:

--- a/sdks/go/pkg/beam/util/syscallx/syscall.go
+++ b/sdks/go/pkg/beam/util/syscallx/syscall.go
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 // Package syscallx provides system call utilities that attempt to hide platform
-// differences. Operations return UnsupportedErr if not implemented on the
+// differences. Operations return ErrUnsupported if not implemented on the
 // given platform. Consumers of this package should generally treat that
 // error specially.
 package syscallx
@@ -23,5 +23,5 @@ import (
 	"errors"
 )
 
-// UnsupportedErr is the error returned for unsupported operations.
-var UnsupportedErr = errors.New("not supported on platform")
+// ErrUnsupported is the error returned for unsupported operations.
+var ErrUnsupported = errors.New("not supported on platform")

--- a/sdks/go/pkg/beam/util/syscallx/syscall_default.go
+++ b/sdks/go/pkg/beam/util/syscallx/syscall_default.go
@@ -19,10 +19,10 @@ package syscallx
 
 // PhysicalMemorySize returns the total physical memory size.
 func PhysicalMemorySize() (uint64, error) {
-	return 0, UnsupportedErr
+	return 0, ErrUnsupported
 }
 
 // FreeDiskSpace returns the free disk space for a given path.
 func FreeDiskSpace(path string) (uint64, error) {
-	return 0, UnsupportedErr
+	return 0, ErrUnsupported
 }


### PR DESCRIPTION
This change allows the removal of the last source/sink remnants. Also included minor cleanup.