### PR TITLE
[BEAM-3060] added support for passing extra mvn properties to pkb

### DIFF
--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -124,6 +124,11 @@
                                 <argument>-beam_it_class=${fileBasedIoItClass}</argument>
                                 <!-- arguments typically defined by user -->
                                 <argument>-beam_it_options=${integrationTestPipelineOptions}</argument>
+                                <!--
+                                optional array of key=value items. It will be passed to
+                                target mvn command by pkb. eg. -DpkbExtraProperties='["filesystem=local"]'
+                                -->
+                                <argument>-beam_extra_mvn_properties=${pkbExtraProperties}</argument>
                             </arguments>
                         </configuration>
                     </plugin>

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -37,6 +37,7 @@
     <integrationTestPipelineOptions />
     <pkbBeamRunnerProfile />
     <pkbBeamRunnerOption />
+    <pkbExtraProperties />
   </properties>
 
   <modules>


### PR DESCRIPTION
Since [this PR on in PerfKit](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/pull/1544) was merged, it's now possible to pass extra properties to be included into target mvn command when running tests with PerfKit.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
