### PR TITLE
Add RemoteGrpcPort[Read/Write] abstractions

### DIFF
--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortRead.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortRead.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.fn.data;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+
+/**
+ * An execution-time only {@link PTransform} which represents an SDK harness reading from a
+ * {@link RemoteGrpcPort}.
+ */
+@AutoValue
+public abstract class RemoteGrpcPortRead {
+  public static final String URN = "urn:org.apache.beam:source:runner:0.1";
+  private static final String LOCAL_OUTPUT_ID = "local_output";
+
+  public static RemoteGrpcPortRead readFromPort(RemoteGrpcPort port, String outputPCollectionId) {
+    return new AutoValue_RemoteGrpcPortRead(port, outputPCollectionId);
+  }
+
+  public static RemoteGrpcPortRead fromPTransform(PTransform pTransform)
+      throws InvalidProtocolBufferException {
+    checkArgument(
+        URN.equals(pTransform.getSpec().getUrn()),
+        "Expected URN for %s, got %s",
+        RemoteGrpcPortRead.class.getSimpleName(),
+        pTransform.getSpec().getUrn());
+    checkArgument(
+        pTransform.getOutputsCount() == 1,
+        "Expected exactly one output, got %s",
+        pTransform.getOutputsCount());
+    RemoteGrpcPort port = RemoteGrpcPort.parseFrom(pTransform.getSpec().getPayload());
+    String outputPcollection = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+    return readFromPort(port, outputPcollection);
+  }
+
+  public PTransform toPTransform() {
+    return PTransform.newBuilder()
+        .setSpec(FunctionSpec.newBuilder().setUrn(URN).setPayload(getPort().toByteString()).build())
+        .putOutputs(LOCAL_OUTPUT_ID, getOutputPCollectionId())
+        .build();
+  }
+
+  public abstract RemoteGrpcPort getPort();
+  abstract String getOutputPCollectionId();
+}

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortWrite.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortWrite.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.fn.data;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.Iterables;
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+
+/**
+ * An execution-time only {@link PTransform} which represents a write from within an SDK harness to
+ * a {@link RemoteGrpcPort}.
+ */
+@AutoValue
+public abstract class RemoteGrpcPortWrite {
+  public static final String URN = "urn:org.apache.beam:sink:runner:0.1";
+  private static final String LOCAL_INPUT_ID = "local_input";
+
+  /**
+   * Create a {@link RemoteGrpcPortWrite} which writes the {@link PCollection} with the provided
+   * Pipeline id to the provided {@link RemoteGrpcPort}.
+   */
+  public static RemoteGrpcPortWrite writeToPort(String inputPCollectionId, RemoteGrpcPort port) {
+    return new AutoValue_RemoteGrpcPortWrite(inputPCollectionId, port);
+  }
+
+  public static RemoteGrpcPortWrite fromPTransform(PTransform pTransform)
+      throws InvalidProtocolBufferException {
+    checkArgument(
+        URN.equals(pTransform.getSpec().getUrn()),
+        "Expected URN for %s, got %s",
+        RemoteGrpcPortWrite.class.getSimpleName(),
+        pTransform.getSpec().getUrn());
+    checkArgument(
+        pTransform.getInputsCount() == 1,
+        "Expected exactly one output, got %s",
+        pTransform.getOutputsCount());
+    RemoteGrpcPort port = RemoteGrpcPort.parseFrom(pTransform.getSpec().getPayload());
+    String inputPCollectionId = Iterables.getOnlyElement(pTransform.getInputsMap().values());
+    return writeToPort(inputPCollectionId, port);
+  }
+
+  abstract String getInputPCollectionId();
+  public abstract RemoteGrpcPort getPort();
+
+  public PTransform toPTransform() {
+    return PTransform.newBuilder()
+        .setSpec(FunctionSpec.newBuilder().setUrn(URN).setPayload(getPort().toByteString()).build())
+        .putInputs(LOCAL_INPUT_ID, getInputPCollectionId())
+        .build();
+  }
+}

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortReadTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortReadTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.fn.data;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.apache.beam.model.pipeline.v1.Endpoints.OAuth2ClientCredentialsGrant;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link RemoteGrpcPortRead}.
+ */
+@RunWith(JUnit4.class)
+public class RemoteGrpcPortReadTest {
+  @Test
+  public void getPortSucceeds() {
+    RemoteGrpcPort port =
+        RemoteGrpcPort.newBuilder()
+            .setApiServiceDescriptor(
+                ApiServiceDescriptor.newBuilder()
+                    .setUrl("foo")
+                    .setOauth2ClientCredentialsGrant(
+                        OAuth2ClientCredentialsGrant.getDefaultInstance())
+                    .build())
+            .build();
+
+    RemoteGrpcPortRead read = RemoteGrpcPortRead.readFromPort(port, "myPort");
+    assertThat(read.getPort(), equalTo(port));
+  }
+
+  @Test
+  public void toFromPTransform() throws InvalidProtocolBufferException {
+    RemoteGrpcPort port =
+        RemoteGrpcPort.newBuilder()
+            .setApiServiceDescriptor(
+                ApiServiceDescriptor.newBuilder()
+                    .setUrl("foo")
+                    .setOauth2ClientCredentialsGrant(
+                        OAuth2ClientCredentialsGrant.getDefaultInstance())
+                    .build())
+            .build();
+
+    RemoteGrpcPortRead read = RemoteGrpcPortRead.readFromPort(port, "myPort");
+    PTransform ptransform = PTransform.parseFrom(read.toPTransform().toByteArray());
+    RemoteGrpcPortRead serDeRead =
+        RemoteGrpcPortRead.fromPTransform(ptransform);
+
+    assertThat(serDeRead, equalTo(read));
+    assertThat(serDeRead.getPort(), equalTo(read.getPort()));
+    assertThat(serDeRead.toPTransform(), equalTo(ptransform));
+  }
+}

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortWriteTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/RemoteGrpcPortWriteTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.fn.data;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.apache.beam.model.pipeline.v1.Endpoints.OAuth2ClientCredentialsGrant;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RemoteGrpcPortWrite}. */
+@RunWith(JUnit4.class)
+public class RemoteGrpcPortWriteTest {
+  @Test
+  public void getPortSucceeds() {
+    RemoteGrpcPort port =
+        RemoteGrpcPort.newBuilder()
+            .setApiServiceDescriptor(
+                ApiServiceDescriptor.newBuilder()
+                    .setUrl("foo")
+                    .setOauth2ClientCredentialsGrant(
+                        OAuth2ClientCredentialsGrant.getDefaultInstance())
+                    .build())
+            .build();
+
+    RemoteGrpcPortWrite write = RemoteGrpcPortWrite.writeToPort("myPort", port);
+    assertThat(write.getPort(), equalTo(port));
+  }
+
+  @Test
+  public void toFromPTransform() throws InvalidProtocolBufferException {
+    RemoteGrpcPort port =
+        RemoteGrpcPort.newBuilder()
+            .setApiServiceDescriptor(
+                ApiServiceDescriptor.newBuilder()
+                    .setUrl("foo")
+                    .setOauth2ClientCredentialsGrant(
+                        OAuth2ClientCredentialsGrant.getDefaultInstance())
+                    .build())
+            .build();
+
+    RemoteGrpcPortWrite write = RemoteGrpcPortWrite.writeToPort("myPort", port);
+    PTransform ptransform = PTransform.parseFrom(write.toPTransform().toByteArray());
+    RemoteGrpcPortWrite serDeWrite = RemoteGrpcPortWrite.fromPTransform(ptransform);
+
+    assertThat(serDeWrite, equalTo(write));
+    assertThat(serDeWrite.getPort(), equalTo(write.getPort()));
+    assertThat(serDeWrite.toPTransform(), equalTo(ptransform));
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
@@ -20,7 +20,6 @@ package org.apache.beam.fn.harness;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
@@ -44,6 +43,7 @@ import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
+import org.apache.beam.sdk.fn.data.RemoteGrpcPortRead;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.slf4j.Logger;
@@ -60,17 +60,17 @@ import org.slf4j.LoggerFactory;
 public class BeamFnDataReadRunner<OutputT> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BeamFnDataReadRunner.class);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  private static final String URN = "urn:org.apache.beam:source:runner:0.1";
 
-  /** A registrar which provides a factory to handle reading from the Fn Api Data Plane. */
+  /**
+   * A registrar which provides a factory to handle reading from the Fn Api Data
+   * Plane.
+   */
   @AutoService(PTransformRunnerFactory.Registrar.class)
-  public static class Registrar implements
-      PTransformRunnerFactory.Registrar {
+  public static class Registrar implements PTransformRunnerFactory.Registrar {
 
     @Override
     public Map<String, PTransformRunnerFactory> getPTransformRunnerFactories() {
-      return ImmutableMap.of(URN, new Factory());
+      return ImmutableMap.of(RemoteGrpcPortRead.URN, new Factory());
     }
   }
 
@@ -105,7 +105,7 @@ public class BeamFnDataReadRunner<OutputT> {
               getOnlyElement(pTransform.getOutputsMap().values()));
 
       BeamFnDataReadRunner<OutputT> runner = new BeamFnDataReadRunner<>(
-          pTransform.getSpec(),
+          pTransform,
           processBundleInstructionId,
           target,
           coderSpec,
@@ -128,7 +128,7 @@ public class BeamFnDataReadRunner<OutputT> {
   private CompletableFuture<Void> readFuture;
 
   BeamFnDataReadRunner(
-      RunnerApi.FunctionSpec functionSpec,
+      RunnerApi.PTransform grpcReadNode,
       Supplier<String> processBundleInstructionIdSupplier,
       BeamFnApi.Target inputTarget,
       RunnerApi.Coder coderSpec,
@@ -137,7 +137,7 @@ public class BeamFnDataReadRunner<OutputT> {
       Collection<FnDataReceiver<WindowedValue<OutputT>>> consumers)
           throws IOException {
     this.apiServiceDescriptor =
-        BeamFnApi.RemoteGrpcPort.parseFrom(functionSpec.getPayload()).getApiServiceDescriptor();
+        RemoteGrpcPortRead.fromPTransform(grpcReadNode).getPort().getApiServiceDescriptor();
     this.inputTarget = inputTarget;
     this.processBundleInstructionIdSupplier = processBundleInstructionIdSupplier;
     this.beamFnDataClientFactory = beamFnDataClientFactory;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -57,6 +57,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
+import org.apache.beam.sdk.fn.data.RemoteGrpcPortRead;
 import org.apache.beam.sdk.fn.test.TestExecutors;
 import org.apache.beam.sdk.fn.test.TestExecutors.TestExecutorService;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -79,14 +80,11 @@ public class BeamFnDataReadRunnerTest {
 
   private static final BeamFnApi.RemoteGrpcPort PORT_SPEC = BeamFnApi.RemoteGrpcPort.newBuilder()
       .setApiServiceDescriptor(Endpoints.ApiServiceDescriptor.getDefaultInstance()).build();
-  private static final RunnerApi.FunctionSpec FUNCTION_SPEC = RunnerApi.FunctionSpec.newBuilder()
-      .setPayload(PORT_SPEC.toByteString()).build();
   private static final Coder<WindowedValue<String>> CODER =
       WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE);
   private static final String CODER_SPEC_ID = "string-coder-id";
   private static final RunnerApi.Coder CODER_SPEC;
   private static final RunnerApi.Components COMPONENTS;
-  private static final String URN = "urn:org.apache.beam:source:runner:0.1";
 
   static {
     try {
@@ -119,25 +117,18 @@ public class BeamFnDataReadRunnerTest {
   @Test
   public void testCreatingAndProcessingBeamFnDataReadRunner() throws Exception {
     String bundleId = "57";
-    String outputId = "101";
 
     List<WindowedValue<String>> outputValues = new ArrayList<>();
 
     Multimap<String, FnDataReceiver<WindowedValue<?>>> consumers = HashMultimap.create();
-    consumers.put("outputPC",
+    String localOutputId = "outputPC";
+    consumers.put(localOutputId,
         (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) outputValues::add);
     List<ThrowingRunnable> startFunctions = new ArrayList<>();
     List<ThrowingRunnable> finishFunctions = new ArrayList<>();
 
-    RunnerApi.FunctionSpec functionSpec = RunnerApi.FunctionSpec.newBuilder()
-        .setUrn("urn:org.apache.beam:source:runner:0.1")
-        .setPayload(PORT_SPEC.toByteString())
-        .build();
-
-    RunnerApi.PTransform pTransform = RunnerApi.PTransform.newBuilder()
-        .setSpec(functionSpec)
-        .putOutputs(outputId, "outputPC")
-        .build();
+    RunnerApi.PTransform pTransform =
+        RemoteGrpcPortRead.readFromPort(PORT_SPEC, localOutputId).toPTransform();
 
     new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(
         PipelineOptionsFactory.create(),
@@ -146,7 +137,7 @@ public class BeamFnDataReadRunnerTest {
         "pTransformId",
         pTransform,
         Suppliers.ofInstance(bundleId)::get,
-        ImmutableMap.of("outputPC",
+        ImmutableMap.of(localOutputId,
             RunnerApi.PCollection.newBuilder().setCoderId(CODER_SPEC_ID).build()),
         COMPONENTS.getCodersMap(),
         COMPONENTS.getWindowingStrategiesMap(),
@@ -164,7 +155,7 @@ public class BeamFnDataReadRunnerTest {
         eq(PORT_SPEC.getApiServiceDescriptor()),
         eq(LogicalEndpoint.of(bundleId, BeamFnApi.Target.newBuilder()
             .setPrimitiveTransformReference("pTransformId")
-            .setName(outputId)
+            .setName(Iterables.getOnlyElement(pTransform.getOutputsMap().keySet()))
             .build())),
         eq(CODER),
         consumerCaptor.capture());
@@ -173,7 +164,7 @@ public class BeamFnDataReadRunnerTest {
     assertThat(outputValues, contains(valueInGlobalWindow("TestValue")));
     outputValues.clear();
 
-    assertThat(consumers.keySet(), containsInAnyOrder("outputPC"));
+    assertThat(consumers.keySet(), containsInAnyOrder(localOutputId));
 
     completionFuture.complete(null);
     Iterables.getOnlyElement(finishFunctions).run();
@@ -195,7 +186,7 @@ public class BeamFnDataReadRunnerTest {
 
     AtomicReference<String> bundleId = new AtomicReference<>("0");
     BeamFnDataReadRunner<String> readRunner = new BeamFnDataReadRunner<>(
-        FUNCTION_SPEC,
+        RemoteGrpcPortRead.readFromPort(PORT_SPEC, "localOutput").toPTransform(),
         bundleId::get,
         INPUT_TARGET,
         CODER_SPEC,
@@ -272,7 +263,9 @@ public class BeamFnDataReadRunnerTest {
     for (Registrar registrar :
         ServiceLoader.load(Registrar.class)) {
       if (registrar instanceof BeamFnDataReadRunner.Registrar) {
-        assertThat(registrar.getPTransformRunnerFactories(), IsMapContaining.hasKey(URN));
+        assertThat(
+            registrar.getPTransformRunnerFactories(),
+            IsMapContaining.hasKey(RemoteGrpcPortRead.URN));
         return;
       }
     }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.CloseableFnDataReceiver;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.data.LogicalEndpoint;
+import org.apache.beam.sdk.fn.data.RemoteGrpcPortWrite;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -74,14 +75,11 @@ public class BeamFnDataWriteRunnerTest {
 
   private static final BeamFnApi.RemoteGrpcPort PORT_SPEC = BeamFnApi.RemoteGrpcPort.newBuilder()
       .setApiServiceDescriptor(Endpoints.ApiServiceDescriptor.getDefaultInstance()).build();
-  private static final RunnerApi.FunctionSpec FUNCTION_SPEC = RunnerApi.FunctionSpec.newBuilder()
-      .setPayload(PORT_SPEC.toByteString()).build();
   private static final String CODER_ID = "string-coder-id";
   private static final Coder<WindowedValue<String>> CODER =
       WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE);
   private static final RunnerApi.Coder CODER_SPEC;
   private static final RunnerApi.Components COMPONENTS;
-  private static final String URN = "urn:org.apache.beam:sink:runner:0.1";
 
   static {
     try {
@@ -109,21 +107,14 @@ public class BeamFnDataWriteRunnerTest {
   @Test
   public void testCreatingAndProcessingBeamFnDataWriteRunner() throws Exception {
     String bundleId = "57L";
-    String inputId = "100L";
 
     Multimap<String, FnDataReceiver<WindowedValue<?>>> consumers = HashMultimap.create();
     List<ThrowingRunnable> startFunctions = new ArrayList<>();
     List<ThrowingRunnable> finishFunctions = new ArrayList<>();
 
-    RunnerApi.FunctionSpec functionSpec = RunnerApi.FunctionSpec.newBuilder()
-        .setUrn("urn:org.apache.beam:sink:runner:0.1")
-        .setPayload(PORT_SPEC.toByteString())
-        .build();
-
-    RunnerApi.PTransform pTransform = RunnerApi.PTransform.newBuilder()
-        .setSpec(functionSpec)
-        .putInputs(inputId, "inputPC")
-        .build();
+    String localInputId = "inputPC";
+    RunnerApi.PTransform pTransform =
+        RemoteGrpcPortWrite.writeToPort(localInputId, PORT_SPEC).toPTransform();
 
     new BeamFnDataWriteRunner.Factory<String>().createRunnerForPTransform(
         PipelineOptionsFactory.create(),
@@ -132,7 +123,7 @@ public class BeamFnDataWriteRunnerTest {
         "ptransformId",
         pTransform,
         Suppliers.ofInstance(bundleId)::get,
-        ImmutableMap.of("inputPC",
+        ImmutableMap.of(localInputId,
             RunnerApi.PCollection.newBuilder().setCoderId(CODER_ID).build()),
         COMPONENTS.getCodersMap(),
         COMPONENTS.getWindowingStrategiesMap(),
@@ -164,14 +155,19 @@ public class BeamFnDataWriteRunnerTest {
     Iterables.getOnlyElement(startFunctions).run();
     verify(mockBeamFnDataClient).send(
         eq(PORT_SPEC.getApiServiceDescriptor()),
-        eq(LogicalEndpoint.of(bundleId, BeamFnApi.Target.newBuilder()
-            .setPrimitiveTransformReference("ptransformId")
-            .setName(inputId)
-            .build())),
+        eq(
+            LogicalEndpoint.of(
+                bundleId,
+                BeamFnApi.Target.newBuilder()
+                    .setPrimitiveTransformReference("ptransformId")
+                    // The local input name is arbitrary, so use whatever the
+                    // RemoteGrpcPortWrite uses
+                    .setName(Iterables.getOnlyElement(pTransform.getInputsMap().keySet()))
+                    .build())),
         eq(CODER));
 
-    assertThat(consumers.keySet(), containsInAnyOrder("inputPC"));
-    Iterables.getOnlyElement(consumers.get("inputPC")).accept(valueInGlobalWindow("TestValue"));
+    assertThat(consumers.keySet(), containsInAnyOrder(localInputId));
+    Iterables.getOnlyElement(consumers.get(localInputId)).accept(valueInGlobalWindow("TestValue"));
     assertThat(outputValues, contains(valueInGlobalWindow("TestValue")));
     outputValues.clear();
 
@@ -192,7 +188,7 @@ public class BeamFnDataWriteRunnerTest {
         Matchers.<Coder<WindowedValue<String>>>any())).thenReturn(valuesA).thenReturn(valuesB);
     AtomicReference<String> bundleId = new AtomicReference<>("0");
     BeamFnDataWriteRunner<String> writeRunner = new BeamFnDataWriteRunner<>(
-        FUNCTION_SPEC,
+        RemoteGrpcPortWrite.writeToPort("myWrite", PORT_SPEC).toPTransform(),
         bundleId::get,
         OUTPUT_TARGET,
         CODER_SPEC,
@@ -256,7 +252,9 @@ public class BeamFnDataWriteRunnerTest {
     for (Registrar registrar :
         ServiceLoader.load(Registrar.class)) {
       if (registrar instanceof BeamFnDataWriteRunner.Registrar) {
-        assertThat(registrar.getPTransformRunnerFactories(), IsMapContaining.hasKey(URN));
+        assertThat(
+            registrar.getPTransformRunnerFactories(),
+            IsMapContaining.hasKey(RemoteGrpcPortWrite.URN));
         return;
       }
     }


### PR DESCRIPTION
These are utility classes to create portability-layer PTransforms which
represent an execution-time port read or write.

Use the classes in FnDataReadRunner and WriteRunner.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
