### PR TITLE
[BEAM-3042] Tracking of time spent reading side inputs, and bytes read in Dataflow.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -21,13 +21,13 @@ cimport libc.stdint
 from apache_beam.utils.counters cimport Counter
 
 
-cdef class TransformIoCounter(object):
+cdef class TransformIOCounter(object):
   cpdef add_bytes_read(self, libc.stdint.int64_t n)
   cpdef __enter__(self)
   cpdef __exit__(self, exc_type, exc_value, traceback)
   
 
-cdef class SideInputReadCounter(TransformIoCounter):
+cdef class SideInputReadCounter(TransformIOCounter):
   cdef readonly object _counter_factory
   cdef readonly object _state_sampler
   cdef readonly object declaring_step

--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -21,6 +21,22 @@ cimport libc.stdint
 from apache_beam.utils.counters cimport Counter
 
 
+cdef class TransformIoCounter(object):
+  cpdef add_bytes_read(self, libc.stdint.int64_t n)
+  cpdef __enter__(self)
+  cpdef __exit__(self, exc_type, exc_value, traceback)
+  
+
+
+cdef class SideInputReadCounter(TransformIoCounter):
+  cdef readonly object _counter_factory
+  cdef readonly object declaring_step
+  cdef readonly object input_index
+
+  cdef Counter bytes_read_counter
+  cdef object scoped_state
+
+
 cdef class SumAccumulator(object):
   cdef libc.stdint.int64_t _value
   cpdef update(self, libc.stdint.int64_t value)

--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -30,6 +30,7 @@ cdef class TransformIoCounter(object):
 
 cdef class SideInputReadCounter(TransformIoCounter):
   cdef readonly object _counter_factory
+  cdef readonly object _state_sampler
   cdef readonly object declaring_step
   cdef readonly object input_index
 

--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -27,7 +27,6 @@ cdef class TransformIoCounter(object):
   cpdef __exit__(self, exc_type, exc_value, traceback)
   
 
-
 cdef class SideInputReadCounter(TransformIoCounter):
   cdef readonly object _counter_factory
   cdef readonly object _state_sampler

--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -22,10 +22,11 @@ from apache_beam.utils.counters cimport Counter
 
 
 cdef class TransformIOCounter(object):
+  cpdef update_current_step(self)
   cpdef add_bytes_read(self, libc.stdint.int64_t n)
   cpdef __enter__(self)
   cpdef __exit__(self, exc_type, exc_value, traceback)
-  
+
 
 cdef class SideInputReadCounter(TransformIOCounter):
   cdef readonly object _counter_factory

--- a/sdks/python/apache_beam/runners/worker/opcounters.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters.py
@@ -66,8 +66,7 @@ class SideInputReadCounter(TransformIOCounter):
   """Tracks time and bytes consumed while reading from side inputs.
 
   This class is designed to track consumption of side inputs across fused steps.
-  We represent a side input as a declaring step, and an input index, which are
-  represented as an io_target.
+  We represent a side input as a declaring step, and an input index.
 
   The declaring step is the step that originally receives the side input for
   consumption, and the input index in which the declaring step receives the side
@@ -91,8 +90,8 @@ class SideInputReadCounter(TransformIOCounter):
 
     The side input is uniquely identified by (declaring_step, input_index);
     where declaring_step is the step that receives the PCollectionView as a
-    side input, and input_index is the index of the PCView within the list of
-    inputs.
+    side input, and input_index is the index of the PCollectionView within
+    the list of inputs.
     """
     self._counter_factory = counter_factory
     self._state_sampler = state_sampler
@@ -110,6 +109,9 @@ class SideInputReadCounter(TransformIOCounter):
     structure that holds side inputs (Iterable, Dict, or others). This call
     updates the current step, to attribute the data consumption to the step
     that is responsible for actual consumption.
+
+    CounterName uses the io_target field for information pertinent to the
+    consumption of side inputs.
     """
     current_state = self._state_sampler.current_state()
     operation_name = current_state.name.step_name

--- a/sdks/python/apache_beam/runners/worker/opcounters.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters.py
@@ -41,13 +41,16 @@ class TransformIOCounter(object):
   Some examples of IO can be side inputs, shuffle, or streaming state.
   """
 
-  def check_step(self):
-    """Check the current step within a stage as it may have changed.
+  def update_current_step(self):
+    """Update the current step within a stage as it may have changed.
 
     If the state changed, it would mean that an initial step passed a
     data-accessor (such as a side input / shuffle Iterable) down to the
     next step in a stage.
     """
+    pass
+
+  def add_bytes_read(self, count):
     pass
 
   def __exit__(self, exc_type, exc_value, traceback):
@@ -56,9 +59,6 @@ class TransformIOCounter(object):
 
   def __enter__(self):
     """Enter the IO state. This should track time spent blocked on IO."""
-    pass
-
-  def add_bytes_read(self, count):
     pass
 
 
@@ -100,11 +100,10 @@ class SideInputReadCounter(TransformIOCounter):
     self.input_index = input_index
 
     # Side inputs are set up within the start state of the first receiving
-    # state.
-    # We check the current state to create the internal counters.
-    self.check_step()
+    # step. We check the current state to create the internal counters.
+    self.update_current_step()
 
-  def check_step(self):
+  def update_current_step(self):
     """Update the current running step.
 
     Due to the fusion optimization, user code may choose to emit the data

--- a/sdks/python/apache_beam/runners/worker/opcounters.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters.py
@@ -71,9 +71,10 @@ class SideInputReadCounter(TransformIoCounter):
   def check_step(self):
     """Update the current running step.
 
-    Due to the fusion optimization, user code may choose to emit the data structure
-    that holds side inputs (Iterable, Dict, or others). This call updates the current
-    step, to attribute the data consumption to the step that is responsible for it.
+    Due to the fusion optimization, user code may choose to emit the data
+    structure that holds side inputs (Iterable, Dict, or others). This call
+    updates the current step, to attribute the data consumption to the step
+    that is responsible for it.
     """
     current_state = self._state_sampler.current_state()
     operation_name = current_state.name.step_name

--- a/sdks/python/apache_beam/runners/worker/opcounters.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters.py
@@ -63,9 +63,16 @@ class SideInputReadCounter(TransformIoCounter):
   not be the only step that spends time reading from this side input.
   """
 
-  def __init__(self, counter_factory, state_sampler,
-               declaring_step, input_index):
+  def __init__(self, counter_factory, state_sampler, declaring_step,
+               input_index):
     """Create a side input read counter.
+
+    Args:
+      counter_factory: A counters.CounterFactory to create byte counters.
+      state_sampler: A statesampler.StateSampler to transition into read states.
+      declaring_step: The step that directly receives the side input initially.
+      input_index: The index of the side input in the list of inputs of the
+        declaring step.
 
     The side input is uniquely identified by (declaring_step, input_index);
     where declaring_step is the step that receives the PCollectionView as a
@@ -89,14 +96,14 @@ class SideInputReadCounter(TransformIoCounter):
     current_state = self._state_sampler.current_state()
     operation_name = current_state.name.step_name
     self.scoped_state = self._state_sampler.scoped_state(
-        self.declaring_step, 'read-sideinput',
+        self.declaring_step,
+        'read-sideinput',
         io_target=counters.side_input_id(operation_name, self.input_index))
     self.bytes_read_counter = self._counter_factory.get_counter(
         CounterName(
             'read-sideinput-byte-count',
             step_name=self.declaring_step,
-            io_target=counters.side_input_id(
-                operation_name, self.input_index)),
+            io_target=counters.side_input_id(operation_name, self.input_index)),
         Counter.SUM)
 
   def add_bytes_read(self, n):

--- a/sdks/python/apache_beam/runners/worker/opcounters_test.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters_test.py
@@ -18,8 +18,8 @@
 import logging
 import math
 import random
-from time import sleep
 import unittest
+from time import sleep
 
 from nose.plugins.skip import SkipTest
 

--- a/sdks/python/apache_beam/runners/worker/opcounters_test.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters_test.py
@@ -18,10 +18,7 @@
 import logging
 import math
 import random
-import time
 import unittest
-
-from nose.plugins.skip import SkipTest
 
 from apache_beam import coders
 from apache_beam.runners.worker import opcounters
@@ -49,11 +46,6 @@ class ObjectThatDoesNotImplementLen(object):
 
 class TransformIoCounterTest(unittest.TestCase):
 
-  def setUp(self):
-    if not statesampler.FAST_SAMPLER:
-      raise SkipTest('State sampler not compiled.')
-    super(TransformIoCounterTest, self).setUp()
-
   def test_basic_counters(self):
     counter_factory = CounterFactory()
     sampler = statesampler.StateSampler('stage1', counter_factory)
@@ -66,7 +58,6 @@ class TransformIoCounterTest(unittest.TestCase):
     with sampler.scoped_state('step2', 'stateB'):
       with counter:
         counter.add_bytes_read(10)
-        time.sleep(0.1)  # An arbitrary short interval.
 
       counter.update_current_step()
 

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -287,6 +287,10 @@ class DoOperation(Operation):
     # provided directly.
     assert self.side_input_maps is None
 
+    # Get experiments active in the worker to check for side input metrics exp.
+    experiments = RuntimeValueProvider(
+        'experiments', str, '').get().split(',')
+
     # We will read the side inputs in the order prescribed by the
     # tags_and_types argument because this is exactly the order needed to
     # replace the ArgumentPlaceholder objects in the args/kwargs of the DoFn
@@ -308,9 +312,7 @@ class DoOperation(Operation):
           raise NotImplementedError('Unknown side input type: %r' % si)
         sources.append(si.source)
         # The tracking of time spend reading and bytes read from side inputs is
-        # behind an experiment flag to test performance impact.
-        experiments = RuntimeValueProvider(
-            'experiments', str, '').get().split(',')
+        # behind an experiment flag to test its performance impact.
         if 'sideinput_io_metrics' in experiments:
           si_counter = opcounters.SideInputReadCounter(
               self.counter_factory,

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -288,8 +288,8 @@ class DoOperation(Operation):
     assert self.side_input_maps is None
 
     # Get experiments active in the worker to check for side input metrics exp.
-    experiments = RuntimeValueProvider(
-        'experiments', str, '').get().split(',')
+    experiments = set(RuntimeValueProvider(
+        'experiments', str, '').get().split(','))
 
     # We will read the side inputs in the order prescribed by the
     # tags_and_types argument because this is exactly the order needed to

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -42,7 +42,6 @@ from apache_beam.transforms import core
 from apache_beam.transforms.combiners import PhasedCombineFnExecutor
 from apache_beam.transforms.combiners import curry_combine_fn
 from apache_beam.transforms.window import GlobalWindows
-from apache_beam.utils import counters
 from apache_beam.utils.windowed_value import WindowedValue
 
 # Allow some "pure mode" declarations.
@@ -310,8 +309,9 @@ class DoOperation(Operation):
       si_counter = opcounters.SideInputReadCounter(
           self.counter_factory,
           self.state_sampler,
+          declaring_step=self.operation_name,
           # Inputs are 1-indexed, so we add 1 to i in the side input id
-          counters.side_input_id(self.operation_name, i + 1))
+          input_index=i + 1)
       iterator_fn = sideinputs.get_iterator_fn_for_sources(
           sources, read_counter=si_counter)
 

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -93,7 +93,7 @@ class PrefetchingSourceSetIterable(object):
       if is_record_size:
         self.read_counter.add_bytes_read(record_size)
 
-    if self.read_counter and isinstance(reader, observable.ObservableMixin):
+    if isinstance(reader, observable.ObservableMixin):
       reader.register_observer(update_bytes_read)
 
   def _start_reader_threads(self):

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -92,10 +92,10 @@ class PrefetchingSourceSetIterable(object):
         bytes tracked.
     """
 
-    def update_bytes_read(record, is_encoded=True):
-      # Observe records, and count bytes from encoded records.
-      if is_encoded:
-        self.read_counter.add_bytes_read(len(record))
+    def update_bytes_read(record_size, is_record_size=False, **kwargs):
+      # Let the reader report block size.
+      if is_record_size:
+        self.read_counter.add_bytes_read(record_size)
 
     if self.read_counter and isinstance(reader, observable.ObservableMixin):
       reader.register_observer(update_bytes_read)

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -73,7 +73,11 @@ class PrefetchingSourceSetIterable(object):
     # Whether an error was encountered in any source reader.
     self.has_errored = False
 
-    self.read_counter = read_counter or opcounters.TransformIoCounter()
+    experiments = RuntimeValueProvider('experiments', str, '').get().split(',')
+    if 'sideinput_io_metrics' in experiments:
+      self.read_counter = read_counter or opcounters.TransformIOCounter()
+    else:
+      self.read_counter = opcounters.TransformIOCounter()
 
     self.reader_threads = []
     self._start_reader_threads()

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -88,13 +88,6 @@ class PrefetchingSourceSetIterable(object):
       reader: A reader that should inherit from ObservableMixin to have
         bytes tracked.
     """
-
-    # The tracking of time spend reading and bytes read from side inputs is kept
-    # behind an experiment flag to test performance impact.
-    experiments = RuntimeValueProvider('experiments', str, '').get().split(',')
-    if 'sideinput_io_metrics' not in experiments:
-      return
-
     def update_bytes_read(record_size, is_record_size=False, **kwargs):
       # Let the reader report block size.
       if is_record_size:
@@ -112,6 +105,8 @@ class PrefetchingSourceSetIterable(object):
 
   def _reader_thread(self):
     # pylint: disable=too-many-nested-blocks
+    experiments = set(
+        RuntimeValueProvider('experiments', str, '').get().split(','))
     try:
       while True:
         try:
@@ -128,7 +123,11 @@ class PrefetchingSourceSetIterable(object):
           else:
             # Native dataflow source.
             with source.reader() as reader:
-              self.add_byte_counter(reader)
+              # The tracking of time spend reading and bytes read from side
+              # inputs is kept behind an experiment flag to test performance
+              # impact.
+              if 'sideinput_io_metrics' in experiments:
+                self.add_byte_counter(reader)
               returns_windowed_values = reader.returns_windowed_values
               for value in reader:
                 if self.has_errored:

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -73,11 +73,7 @@ class PrefetchingSourceSetIterable(object):
     # Whether an error was encountered in any source reader.
     self.has_errored = False
 
-    experiments = RuntimeValueProvider('experiments', str, '').get().split(',')
-    if 'sideinput_io_metrics' in experiments:
-      self.read_counter = read_counter or opcounters.TransformIOCounter()
-    else:
-      self.read_counter = opcounters.TransformIOCounter()
+    self.read_counter = read_counter or opcounters.TransformIOCounter()
 
     self.reader_threads = []
     self._start_reader_threads()
@@ -167,14 +163,7 @@ class PrefetchingSourceSetIterable(object):
     try:
       while True:
         try:
-          if self.element_queue.empty():
-            # We check the current step only when the Queue is empty because we
-            # will likely block waiting (if the queue is not empty, then we'll
-            # be able to get from it instantly). This allows us to limit how
-            # much we check the current step.
-            self.read_counter.check_step()
-          with self.read_counter:
-            element = self.element_queue.get()
+          element = self.element_queue.get()
           if element is READER_THREAD_IS_DONE_SENTINEL:
             num_readers_finished += 1
             if num_readers_finished == self.num_reader_threads:

--- a/sdks/python/apache_beam/runners/worker/sideinputs_test.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs_test.py
@@ -24,8 +24,8 @@ import unittest
 import mock
 
 from apache_beam.coders import observable
-from apache_beam.runners.worker import sideinputs
 from apache_beam.options.value_provider import RuntimeValueProvider
+from apache_beam.runners.worker import sideinputs
 
 
 def strip_windows(iterator):

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -94,7 +94,12 @@ cdef class StateSampler(object):
     self.current_state_index = 0
     self.time_since_transition = 0
     self.state_transition_count = 0
-    unknown_state = ScopedState(self, 'unknown', self.current_state_index)
+    unknown_state = ScopedState(self,
+                                CounterName('unknown',
+                                            'unknown',
+                                            'unknown',
+                                            'unknown'),
+                                self.current_state_index)
     pythread.PyThread_acquire_lock(self.lock, pythread.WAIT_LOCK)
     self.scoped_states_by_index = [unknown_state]
     pythread.PyThread_release_lock(self.lock)

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -36,6 +36,8 @@ runtime profile to be produced.
 """
 import threading
 
+from apache_beam.utils.counters import CounterName
+
 cimport cython
 from cpython cimport pythread
 from libc.stdint cimport int32_t, int64_t
@@ -94,12 +96,8 @@ cdef class StateSampler(object):
     self.current_state_index = 0
     self.time_since_transition = 0
     self.state_transition_count = 0
-    unknown_state = ScopedState(self,
-                                CounterName('unknown',
-                                            'unknown',
-                                            'unknown',
-                                            'unknown'),
-                                self.current_state_index)
+    unknown_state = ScopedState(
+        self, CounterName('unknown'), self.current_state_index)
     pythread.PyThread_acquire_lock(self.lock, pythread.WAIT_LOCK)
     self.scoped_states_by_index = [unknown_state]
     pythread.PyThread_release_lock(self.lock)

--- a/sdks/python/apache_beam/utils/counters.py
+++ b/sdks/python/apache_beam/utils/counters.py
@@ -28,6 +28,8 @@ from collections import namedtuple
 
 from apache_beam.transforms import cy_combiners
 
+# Information identifying the IO being measured by a counter.
+#
 # A CounterName with IOTarget helps identify the IO being measured by a
 # counter.
 #


### PR DESCRIPTION
This pull request adds changes the PrefetchingSourceReader used to fetch side input data. 

Specifically, this change helps it track how long was spent blocked waiting to fetch side inputs; and for the Dataflow runner (which uses NativeAvroSource), it also helps track how many bytes were read.