### PR TITLE
[BEAM-3357] Add grpcio upper bound

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -98,7 +98,9 @@ REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0',
     'crcmod>=1.7,<2.0',
     'dill==0.2.6',
-    'grpcio>=1.0,<2.0',
+    # grpcio 1.8.1 requires protobuf >= 3.5
+    # TODO(BEAM-3357): Remove the upper bound.
+    'grpcio>=1.0,<=1.7.3',
     'httplib2>=0.8,<0.10',
     'mock>=1.0.1,<3.0.0',
     'oauth2client>=2.0.1,<4.0.0',


### PR DESCRIPTION
Latest grpcio 1.8.1 is not compatible with the protobuf version beam depends on.

R: @chamikaramj @robertwb 