### PR TITLE
BEAM-3324 improve symtab memory usage

### DIFF
--- a/sdks/go/pkg/beam/core/util/symtab/symtab.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab.go
@@ -37,6 +37,10 @@ func New(filename string) (*SymbolTable, error) {
 		return nil, err
 	}
 
+	// The interface contract for the xxx.NewFile() methods takes an
+	// io.ReaderAt which suggests the Reader needs to stay alive for the duration
+	// of the symbol table.
+
 	// First try ELF
 	ef, err := elf.NewFile(f)
 	if err == nil {

--- a/sdks/go/pkg/beam/core/util/symtab/symtab.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab.go
@@ -16,13 +16,12 @@
 package symtab
 
 import (
-	"bytes"
 	"debug/dwarf"
 	"debug/elf"
 	"debug/macho"
 	"debug/pe"
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 // SymbolTable allows for mapping between symbols and their addresses.
@@ -33,14 +32,13 @@ type SymbolTable struct {
 // New creates a new symbol table based on the debug info
 // read from the specified file.
 func New(filename string) (*SymbolTable, error) {
-	b, err := ioutil.ReadFile(filename)
+	f, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-	r := bytes.NewReader(b)
 
 	// First try ELF
-	ef, err := elf.NewFile(r)
+	ef, err := elf.NewFile(f)
 	if err == nil {
 		d, err := ef.DWARF()
 		if err != nil {
@@ -50,7 +48,7 @@ func New(filename string) (*SymbolTable, error) {
 	}
 
 	// then Mach-O
-	mf, err := macho.NewFile(r)
+	mf, err := macho.NewFile(f)
 	if err == nil {
 		d, err := mf.DWARF()
 		if err != nil {
@@ -60,7 +58,7 @@ func New(filename string) (*SymbolTable, error) {
 	}
 
 	// finally try Windows PE format
-	pf, err := pe.NewFile(r)
+	pf, err := pe.NewFile(f)
 	if err == nil {
 		d, err := pf.DWARF()
 		if err != nil {

--- a/sdks/go/pkg/beam/core/util/symtab/symtab.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab.go
@@ -42,7 +42,8 @@ func New(filename string) (*SymbolTable, error) {
 	if err == nil {
 		d, err := ef.DWARF()
 		if err != nil {
-			return nil, err
+			f.Close()
+			return nil, fmt.Errorf("No working DWARF: %v", err)
 		}
 		return &SymbolTable{d}, nil
 	}
@@ -52,6 +53,7 @@ func New(filename string) (*SymbolTable, error) {
 	if err == nil {
 		d, err := mf.DWARF()
 		if err != nil {
+			f.Close()
 			return nil, fmt.Errorf("No working DWARF: %v", err)
 		}
 		return &SymbolTable{d}, nil
@@ -62,12 +64,14 @@ func New(filename string) (*SymbolTable, error) {
 	if err == nil {
 		d, err := pf.DWARF()
 		if err != nil {
-			return nil, err
+			f.Close()
+			return nil, fmt.Errorf("No working DWARF: %v", err)
 		}
 		return &SymbolTable{d}, nil
 	}
 
 	// Give up, we don't recognize it
+	f.Close()
 	return nil, fmt.Errorf("Unknown file format")
 }
 


### PR DESCRIPTION
Change the symbol table lookup to read from a file rather than
loading the file into memory. This is a space/time tradeoff, but
lookups can be cached so we can get good speed with a much lower
memory footprint.