### PR TITLE
Fix storagePath variable.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/session.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/session.go
@@ -60,7 +60,7 @@ func setupDiagnosticRecording() error {
 
 	var err error
 
-	storagePath := runtime.GlobalOptions.Get("storage_path")
+	storagePath = runtime.GlobalOptions.Get("storage_path")
 	// Any form of recording requires the destination directory to exist.
 	if err = os.MkdirAll(storagePath, 0755); err != nil {
 		return fmt.Errorf("Unable to create session directory: %v", err)


### PR DESCRIPTION
The code incorrectly sets a local variable from the property, so the
value queried in the session code will always be an empty string.

