### PR TITLE
BEAM-3361 Increase Go gRPC message size

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -243,7 +243,8 @@ func fail(id, format string, args ...interface{}) *fnpb.InstructionResponse {
 func dial(ctx context.Context, endpoint string, timeout time.Duration) (*grpc.ClientConn, error) {
 	log.Infof(ctx, "Connecting via grpc @ %s ...", endpoint)
 
-	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock()}
+	opts := []grpc.DialOption{grpc.WithInsecure(), grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50 << 20))}
 
 	// TODO(wcn): Update this code to not use deprecated grpc.WithTimeout
 	if timeout > 0 {

--- a/sdks/go/pkg/beam/util/grpcx/dial.go
+++ b/sdks/go/pkg/beam/util/grpcx/dial.go
@@ -29,7 +29,8 @@ func Dial(ctx context.Context, endpoint string, timeout time.Duration) (*grpc.Cl
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cc, err := grpc.DialContext(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock())
+	cc, err := grpc.DialContext(ctx, endpoint, grpc.WithInsecure(), grpc.WithBlock(),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(50<<20)))
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial server at %v: %v", endpoint, err)
 	}


### PR DESCRIPTION
Increases the buffer for gRPC messages from 4M to 50M.

