### PR TITLE
[BEAM-3356] Add builtin varint coder for the Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -122,7 +122,8 @@ type Kind string
 // documents the usage of coders in the Beam environment.
 const (
 	Custom        Kind = "Custom" // Implicitly length-prefixed
-	Bytes         Kind = "bytes"  // Implicitly length-prefixed
+	Bytes         Kind = "bytes"  // Implicitly length-prefixed as part of the encoding
+	VarInt        Kind = "varint"
 	WindowedValue Kind = "W"
 	KV            Kind = "KV"
 	GBK           Kind = "GBK"
@@ -197,6 +198,11 @@ func (c *Coder) String() string {
 // is always nested, for now.
 func NewBytes() *Coder {
 	return &Coder{Kind: Bytes, T: typex.New(reflectx.ByteSlice)}
+}
+
+// NewVarInt returns a new int32 coder using the built-in scheme.
+func NewVarInt() *Coder {
+	return &Coder{Kind: VarInt, T: typex.New(reflectx.Int32)}
 }
 
 // Convenience methods to operate through the top-level WindowedValue.

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -78,6 +78,12 @@ func EncodeElement(c *coder.Coder, val FullValue, w io.Writer) error {
 		_, err := w.Write(data)
 		return err
 
+	case coder.VarInt:
+		// Encoding: beam varint
+
+		n := reflectx.UnderlyingType(val.Elm).Convert(reflectx.Int32).Interface().(int32)
+		return coder.EncodeVarInt(n, w)
+
 	case coder.Custom:
 		enc := c.Custom.Enc
 
@@ -131,6 +137,15 @@ func DecodeElement(c *coder.Coder, r io.Reader) (FullValue, error) {
 			return FullValue{}, err
 		}
 		return FullValue{Elm: reflect.ValueOf(data)}, nil
+
+	case coder.VarInt:
+		// Encoding: beam varint
+
+		n, err := coder.DecodeVarInt(r)
+		if err != nil {
+			return FullValue{}, err
+		}
+		return FullValue{Elm: reflect.ValueOf(n)}, nil
 
 	case coder.Custom:
 		dec := c.Custom.Dec

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -136,6 +136,9 @@ func (b *CoderUnmarshaller) makeCoder(c *pb.Coder) (*coder.Coder, error) {
 	case urnBytesCoder:
 		return coder.NewBytes(), nil
 
+	case urnVarIntCoder:
+		return coder.NewVarInt(), nil
+
 	case urnKVCoder:
 		if len(components) != 2 {
 			return nil, fmt.Errorf("bad pair: %v", c)
@@ -297,6 +300,9 @@ func (b *CoderMarshaller) Add(c *coder.Coder) string {
 	case coder.Bytes:
 		// TODO(herohde) 6/27/2017: add length-prefix and not assume nested by context?
 		return b.internBuiltInCoder(urnBytesCoder)
+
+	case coder.VarInt:
+		return b.internBuiltInCoder(urnVarIntCoder)
 
 	default:
 		panic(fmt.Sprintf("Unexpected coder kind: %v", c.Kind))

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
@@ -47,6 +47,10 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			coder.NewBytes(),
 		},
 		{
+			"varint",
+			coder.NewVarInt(),
+		},
+		{
 			"foo",
 			foo,
 		},

--- a/sdks/go/pkg/beam/core/runtime/graphx/serialize.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/serialize.go
@@ -720,6 +720,7 @@ type CoderRef struct {
 const (
 	WindowedValueType = "kind:windowed_value"
 	BytesType         = "kind:bytes"
+	VarIntType        = "kind:varint"
 	GlobalWindowType  = "kind:global_window"
 	streamType        = "kind:stream"
 	pairType          = "kind:pair"
@@ -796,6 +797,9 @@ func EncodeCoderRef(c *coder.Coder) (*CoderRef, error) {
 		// TODO(herohde) 6/27/2017: add length-prefix and not assume nested by context?
 		return &CoderRef{Type: BytesType}, nil
 
+	case coder.VarInt:
+		return &CoderRef{Type: VarIntType}, nil
+
 	default:
 		return nil, fmt.Errorf("bad coder kind: %v", c.Kind)
 	}
@@ -806,6 +810,9 @@ func DecodeCoderRef(c *CoderRef) (*coder.Coder, error) {
 	switch c.Type {
 	case BytesType:
 		return coder.NewBytes(), nil
+
+	case VarIntType:
+		return coder.NewVarInt(), nil
 
 	case pairType:
 		if len(c.Components) != 2 {


### PR DESCRIPTION
* The varint coder is a standard coder and should be supported.