### PR TITLE
[BEAM-3060] FIX: remove overriding Google project in file-based IOs performance tests

### DIFF
--- a/.test-infra/jenkins/job_beam_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_FileBasedIO_IT.groovy
@@ -42,7 +42,6 @@ job('beam_PerformanceTests_FileBasedIO_IT') {
 
     def pipelineArgs = [
             tempRoot: 'gs://temp-storage-for-perf-tests',
-            project: 'apache-beam-io-testing',
             numberOfRecords: '1000000',
             filenamePrefix: 'gs://temp-storage-for-perf-tests/filebased/${BUILD_ID}/TESTIOIT',
     ]


### PR DESCRIPTION
In #4267 I've accidentally committed own google project name therefore tests are failing on Jenkins. This change removes it so test relies on default one.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
