### PR TITLE
[BEAM-3060] Allow to specify timeout for FileBasedIOIT ran via PerfKit

### DIFF
--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -113,6 +113,7 @@
                                 <argument>${pkbLocation}</argument>
                                 <argument>-benchmarks=beam_integration_benchmark</argument>
                                 <argument>-beam_it_profile=io-it</argument>
+                                <argument>-beam_it_timeout=${pkbTimeout}</argument>
                                 <argument>-beam_location=${beamRootProjectDir}</argument>
                                 <argument>-beam_prebuilt=true</argument>
                                 <argument>-beam_sdk=java</argument>

--- a/sdks/java/io/pom.xml
+++ b/sdks/java/io/pom.xml
@@ -38,6 +38,7 @@
     <pkbBeamRunnerProfile />
     <pkbBeamRunnerOption />
     <pkbExtraProperties />
+    <pkbTimeout>600</pkbTimeout>
   </properties>
 
   <modules>


### PR DESCRIPTION
with default set to 10 mins (which is PerfKit's timeout).

Background: large-scale tests run via PerfKit were failing. this PR allows to specify timeout so tests are passing.

--------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
