### PR TITLE
[BEAM-3355] Diagnostic interfaces

### DIFF
--- a/sdks/go/pkg/beam/core/util/hooks/hooks.go
+++ b/sdks/go/pkg/beam/core/util/hooks/hooks.go
@@ -1,0 +1,186 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hooks allows runners to tailor execution of the worker harness.
+//
+// Examples of customization:
+//
+// gRPC integration
+// session recording
+// profile recording
+//
+// Registration methods for hooks must be called prior to calling beam.Init()
+// Request methods for hooks must be called as part of building the pipeline
+// request for the runner's Execute method.
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+)
+
+var (
+	hookRegistry = make(map[string]HookFactory)
+	enabledHooks = make(map[string][]string)
+	activeHooks  = make(map[string]Hook)
+)
+
+// A Hook is a set of hooks to run at various stages of executing a
+// pipeline.
+type Hook struct {
+	// Init is called once at the startup of the worker prior to
+	// connecting to the FnAPI services.
+	Init InitHook
+	// Req is called each time the worker handles a FnAPI instruction request.
+	Req RequestHook
+	// Resp is called each time the worker generates a FnAPI instruction response.
+	Resp ResponseHook
+}
+
+// InitHook is a hook that is called when the harness
+// initializes.
+type InitHook func(context.Context) error
+
+// HookFactory is a function that produces a Hook from the supplied arguments.
+type HookFactory func([]string) Hook
+
+// RegisterHook registers a Hook for the
+// supplied identifier.
+func RegisterHook(name string, h HookFactory) {
+	hookRegistry[name] = h
+}
+
+// RunInitHooks runs the init hooks.
+func RunInitHooks(ctx context.Context) error {
+	// If an init hook fails to complete, the invariants of the
+	// system are compromised and we can't run a workflow.
+	// The hooks can run in any order. They should not be
+	// interdependent or interfere with each other.
+	for _, h := range activeHooks {
+		if h.Init != nil {
+			if err := h.Init(ctx); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// RequestHook is called when handling a FnAPI instruction.
+type RequestHook func(context.Context, *fnpb.InstructionRequest) error
+
+// RunRequestHooks runs the hooks that handle a FnAPI request.
+func RunRequestHooks(ctx context.Context, req *fnpb.InstructionRequest) {
+	// The request hooks should not modify the request.
+	for n, h := range activeHooks {
+		if h.Req != nil {
+			if err := h.Req(ctx, req); err != nil {
+				log.Infof(ctx, "request hook %s failed: %v", n, err)
+			}
+		}
+	}
+}
+
+// ResponseHook is called when sending a FnAPI instruction response.
+type ResponseHook func(context.Context, *fnpb.InstructionRequest, *fnpb.InstructionResponse) error
+
+// RunResponseHooks runs the hooks that handle a FnAPI response.
+func RunResponseHooks(ctx context.Context, req *fnpb.InstructionRequest, resp *fnpb.InstructionResponse) {
+	for n, h := range activeHooks {
+		if h.Resp != nil {
+			if err := h.Resp(ctx, req, resp); err != nil {
+				log.Infof(ctx, "response hook %s failed: %v", n, err)
+			}
+		}
+	}
+}
+
+// SerializeHooksToOptions serializes the activated hooks and their configuration into a JSON string
+// that can be deserialized later by the runner.
+func SerializeHooksToOptions() {
+	data, err := json.Marshal(enabledHooks)
+	if err != nil {
+		// Shouldn't happen, since all the data is strings.
+		panic(fmt.Sprintf("Couldn't serialize hooks: %v", err))
+	}
+	runtime.GlobalOptions.Set("hooks", string(data))
+}
+
+// DeserializeHooksFromOptions extracts the hook configuration information from the options and configures
+// the hooks with the supplied options.
+func DeserializeHooksFromOptions() {
+	cfg := runtime.GlobalOptions.Get("hooks")
+	if err := json.Unmarshal([]byte(cfg), &enabledHooks); err != nil {
+		// Shouldn't happen, since all the data is strings.
+		panic(fmt.Sprintf("DeserializeHooks failed on input %q: %v", cfg, err))
+	}
+
+	for h, opts := range enabledHooks {
+		activeHooks[h] = hookRegistry[h](opts)
+	}
+}
+
+// EnableHook enables the hook to be run for the pipline. It will be
+// receive the supplied args when the pipeline executes. It is safe
+// to enable the same hook with different options, as this is necessary
+// if a hook wants to compose behavior.
+func EnableHook(name string, args ...string) error {
+	if _, ok := hookRegistry[name]; !ok {
+		return fmt.Errorf("EnableHook: hook %s not found", name)
+	}
+	enabledHooks[name] = args
+	return nil
+}
+
+// IsEnabled returns true and the registered options if the hook is
+// already enabled.
+func IsEnabled(name string) (bool, []string) {
+	opts, ok := enabledHooks[name]
+	return ok, opts
+}
+
+// Encode encodes a hook name and its arguments into a single string.
+// This is a convenience function for users of this package that are composing
+// hooks.
+func Encode(name string, opts []string) string {
+	var cfg bytes.Buffer
+	w := csv.NewWriter(&cfg)
+	// This should never happen since a bytes.Buffer doesn't fail to write.
+	if err := w.Write(append([]string{name}, opts...)); err != nil {
+		panic(fmt.Sprintf("error encoding arguments: %v", err))
+	}
+	w.Flush()
+	return cfg.String()
+}
+
+// Decode decodes a hook name and its arguments from a single string.
+// This is a convenience function for users of this package that are composing
+// hooks.
+func Decode(in string) (string, []string) {
+	r := csv.NewReader(strings.NewReader(in))
+	s, err := r.Read()
+	if err != nil {
+		panic(fmt.Sprintf("malformed input for decoding: %s %v", in, err))
+	}
+	return s[0], s[1:]
+}

--- a/sdks/go/pkg/beam/runners/dataflow/messages.go
+++ b/sdks/go/pkg/beam/runners/dataflow/messages.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
 	"google.golang.org/api/googleapi"
 )
@@ -34,8 +35,9 @@ func newMsg(msg interface{}) googleapi.RawMessage {
 
 // pipelineOptions models Job/Environment/SdkPipelineOptions
 type pipelineOptions struct {
-	DisplayData []*displayData `json:"display_data,omitempty"`
-	Options     interface{}    `json:"options,omitempty"`
+	DisplayData []*displayData     `json:"display_data,omitempty"`
+	Options     interface{}        `json:"options,omitempty"`
+	GoOptions   runtime.RawOptions `json:"beam:option:go_options:v1,omitempty"`
 }
 
 // NOTE(herohde) 2/9/2017: most of the v1b3 messages are weakly-typed json

--- a/sdks/go/pkg/beam/runners/session/session.go
+++ b/sdks/go/pkg/beam/runners/session/session.go
@@ -51,7 +51,7 @@ func init() {
 
 var sessionFile = flag.String("session_file", "", "Session file for the runner")
 
-// controlServer manages the Fn API control channel.
+// controlServer manages the FnAPI control channel.
 type controlServer struct {
 	filename   string
 	wg         *sync.WaitGroup // used to signal when the session is completed
@@ -207,7 +207,7 @@ func extractPortSpec(spec *rapi_pb.FunctionSpec) string {
 	panic("unable to extract port")
 }
 
-// dataServer manages the Fn API data channel.
+// dataServer manages the FnAPI data channel.
 type dataServer struct {
 	ctrl *controlServer
 }
@@ -235,7 +235,7 @@ func (d *dataServer) Data(stream fnapi_pb.BeamFnData_DataServer) error {
 	}
 }
 
-// loggingServer manages the Fn API logging channel.
+// loggingServer manages the FnAPI logging channel.
 type loggingServer struct{} // no data content
 
 func (l *loggingServer) Logging(stream fnapi_pb.BeamFnLogging_LoggingServer) error {

--- a/sdks/go/pkg/beam/util/grpcx/hook.go
+++ b/sdks/go/pkg/beam/util/grpcx/hook.go
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcx
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/hooks"
+	"google.golang.org/grpc"
+)
+
+// Hook allow a runner to customize various aspects of gRPC
+// communication with the FnAPI harness. Each member of the struct
+// is optional; the default behavior will be used if a value is not
+// supplied.
+type Hook struct {
+	// Dialer allows the runner to customize the gRPC dialing behavior.
+	Dialer func(context.Context, string, time.Duration) (*grpc.ClientConn, error)
+	// TODO(wcn): expose other hooks here.
+}
+
+type HookFactory func([]string) Hook
+
+var hookRegistry = make(map[string]HookFactory)
+
+// RegisterHook registers a HookFactory for the
+// supplied identifier. It panics if the same identifier is
+// registered twice.
+func RegisterHook(name string, c HookFactory) {
+	if _, exists := hookRegistry[name]; exists {
+		panic(fmt.Sprintf("grpc.Hook: %s registered twice", name))
+	}
+	hookRegistry[name] = c
+
+	hf := func(opts []string) hooks.Hook {
+		return hooks.Hook{
+			Init: func(_ context.Context) error {
+				if len(opts) == 0 {
+					return nil
+				}
+
+				name, opts := hooks.Decode(opts[0])
+				grpcHook := hookRegistry[name](opts)
+				if grpcHook.Dialer != nil {
+					Dial = grpcHook.Dialer
+				}
+				return nil
+			},
+		}
+	}
+	hooks.RegisterHook("grpc", hf)
+}
+
+// EnableHook is called to request the use of the gRPC
+// hook in a pipeline.
+func EnableHook(name string, opts ...string) {
+	_, exists := hookRegistry[name]
+	if !exists {
+		panic(fmt.Sprintf("EnableHook: %s not registered", name))
+	}
+	// Only one hook can be enabled. If the pipeline has two conflicting views about how to use gRPC
+	// that won't end well.
+	if exists, opts := hooks.IsEnabled("grpc"); exists {
+		n, _ := hooks.Decode(opts[0])
+		if n != name {
+			panic(fmt.Sprintf("EnableHook: can't enable hook %s, hook %s already enabled", name, n))
+		}
+	}
+
+	hooks.EnableHook("grpc", hooks.Encode(name, opts))
+}

--- a/sdks/go/pkg/beam/x/hooks/perf/perf.go
+++ b/sdks/go/pkg/beam/x/hooks/perf/perf.go
@@ -1,0 +1,170 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package perf is to add performance measuring hooks to a runner, such as cpu, or trace profiles.
+package perf
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"runtime/pprof"
+	"runtime/trace"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/hooks"
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+)
+
+// CaptureHook is used by the harness to have the runner
+// persist a trace record with the supplied name and comment.
+// The type of trace can be determined by the prefix of the string.
+//
+// * prof: A profile compatible with traces produced by runtime/pprof
+// * trace: A trace compatible with traces produced by runtime/trace
+type CaptureHook func(context.Context, string, io.Reader) error
+
+// CaptureHookFactory creates a CaptureHook from the supplied options.
+type CaptureHookFactory func([]string) CaptureHook
+
+var profCaptureHookRegistry = make(map[string]CaptureHookFactory)
+
+var enabledProfCaptureHooks []string
+
+func init() {
+	hf := func(opts []string) hooks.Hook {
+		enabledProfCaptureHooks = opts
+		enabled := len(enabledProfCaptureHooks) > 0
+		var cpuProfBuf bytes.Buffer
+		return hooks.Hook{
+			Req: func(_ context.Context, _ *fnpb.InstructionRequest) error {
+				if !enabled {
+					return nil
+				}
+				cpuProfBuf.Reset()
+				return pprof.StartCPUProfile(&cpuProfBuf)
+			},
+			Resp: func(ctx context.Context, req *fnpb.InstructionRequest, _ *fnpb.InstructionResponse) error {
+				if !enabled {
+					return nil
+				}
+				pprof.StopCPUProfile()
+				for _, h := range enabledProfCaptureHooks {
+					name, opts := hooks.Decode(h)
+					if err := profCaptureHookRegistry[name](opts)(ctx, fmt.Sprintf("prof%s", req.InstructionId), &cpuProfBuf); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		}
+	}
+	hooks.RegisterHook("prof", hf)
+
+	hf = func(opts []string) hooks.Hook {
+		var traceProfBuf bytes.Buffer
+		enabledTraceCaptureHooks = opts
+		enabled := len(enabledTraceCaptureHooks) > 0
+		return hooks.Hook{
+			Req: func(_ context.Context, _ *fnpb.InstructionRequest) error {
+				if !enabled {
+					return nil
+				}
+				traceProfBuf.Reset()
+				return trace.Start(&traceProfBuf)
+			},
+			Resp: func(ctx context.Context, req *fnpb.InstructionRequest, _ *fnpb.InstructionResponse) error {
+				if !enabled {
+					return nil
+				}
+				trace.Stop()
+				for _, h := range enabledTraceCaptureHooks {
+					name, opts := hooks.Decode(h)
+					if err := traceCaptureHookRegistry[name](opts)(ctx, fmt.Sprintf("trace_prof%s", req.InstructionId), &traceProfBuf); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		}
+	}
+	hooks.RegisterHook("trace", hf)
+}
+
+// RegisterProfCaptureHook registers a CaptureHookFactory for the
+// supplied identifier. It panics if the same identifier is
+// registered twice.
+func RegisterProfCaptureHook(name string, c CaptureHookFactory) {
+	if _, exists := profCaptureHookRegistry[name]; exists {
+		panic(fmt.Sprintf("RegisterProfCaptureHook: %s registered twice", name))
+	}
+	profCaptureHookRegistry[name] = c
+}
+
+// EnableProfCaptureHook actives a registered profile capture hook for a given pipeline.
+func EnableProfCaptureHook(name string, opts ...string) {
+	_, exists := profCaptureHookRegistry[name]
+	if !exists {
+		panic(fmt.Sprintf("EnableProfCaptureHook: %s not registered", name))
+	}
+
+	enc := hooks.Encode(name, opts)
+
+	for i, h := range enabledProfCaptureHooks {
+		n, _ := hooks.Decode(h)
+		if h == n {
+			// Rewrite the registration with the current arguments
+			enabledProfCaptureHooks[i] = enc
+			hooks.EnableHook("prof", enabledProfCaptureHooks...)
+			return
+		}
+	}
+
+	enabledProfCaptureHooks = append(enabledProfCaptureHooks, enc)
+	hooks.EnableHook("prof", enabledProfCaptureHooks...)
+}
+
+var traceCaptureHookRegistry = make(map[string]CaptureHookFactory)
+var enabledTraceCaptureHooks []string
+
+// RegisterTraceCaptureHook registers a CaptureHookFactory for the
+// supplied identifier. It panics if the same identifier is
+// registered twice.
+func RegisterTraceCaptureHook(name string, c CaptureHookFactory) {
+	if _, exists := traceCaptureHookRegistry[name]; exists {
+		panic(fmt.Sprintf("RegisterTraceCaptureHook: %s registered twice", name))
+	}
+	traceCaptureHookRegistry[name] = c
+}
+
+// EnableTraceCaptureHook actives a registered profile capture hook for a given pipeline.
+func EnableTraceCaptureHook(name string, opts ...string) {
+	if _, exists := traceCaptureHookRegistry[name]; !exists {
+		panic(fmt.Sprintf("EnableTraceCaptureHook: %s not registered", name))
+	}
+
+	enc := hooks.Encode(name, opts)
+	for i, h := range enabledTraceCaptureHooks {
+		n, _ := hooks.Decode(h)
+		if h == n {
+			// Rewrite the registration with the current arguments
+			enabledTraceCaptureHooks[i] = enc
+			hooks.EnableHook("trace", enabledTraceCaptureHooks...)
+			return
+		}
+	}
+	enabledTraceCaptureHooks = append(enabledTraceCaptureHooks, enc)
+	hooks.EnableHook("trace", enabledTraceCaptureHooks...)
+}


### PR DESCRIPTION
The current logic only works on local filesystems, which is
unnecessarily prescriptive for runners. Reworking the code in terms of
interfaces allows the runner to control how these artifacts are
recorded.