### PR TITLE
[BEAM-2549] Remove Queue based 60 seconds timeout for GCS io.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -26,7 +26,6 @@ import fnmatch
 import logging
 import multiprocessing
 import os
-import Queue
 import re
 import threading
 import time
@@ -427,14 +426,12 @@ class GcsBufferedReader(object):
                client,
                path,
                mode='r',
-               buffer_size=DEFAULT_READ_BUFFER_SIZE,
-               segment_timeout=DEFAULT_READ_SEGMENT_TIMEOUT_SECONDS):
+               buffer_size=DEFAULT_READ_BUFFER_SIZE):
     self.client = client
     self.path = path
     self.bucket, self.name = parse_gcs_path(path)
     self.mode = mode
     self.buffer_size = buffer_size
-    self.segment_timeout = segment_timeout
 
     # Get object state.
     self.get_request = (storage.StorageObjectsGetRequest(
@@ -575,47 +572,18 @@ class GcsBufferedReader(object):
         self.buffer_start_position + len(self.buffer) <= self.position):
       bytes_to_request = min(self._remaining(), self.buffer_size)
       self.buffer_start_position = self.position
-      retry_count = 0
-      while retry_count <= 10:
-        queue = Queue.Queue()
-        t = threading.Thread(target=self._fetch_to_queue,
-                             args=(queue, self._get_segment,
-                                   (self.position, bytes_to_request)))
-        t.daemon = True
-        t.start()
-        try:
-          result, exn, tb = queue.get(timeout=self.segment_timeout)
-        except Queue.Empty:
-          logging.warning(
-              ('Timed out fetching %d bytes from position %d of %s after %f '
-               'seconds; retrying...'), bytes_to_request, self.position,
-              self.path, self.segment_timeout)
-          retry_count += 1
-          # Reinitialize download objects.
-          self.download_stream = cStringIO.StringIO()
-          self.downloader = transfer.Download(
-              self.download_stream, auto_transfer=False,
-              chunksize=self.buffer_size)
-          self.client.objects.Get(self.get_request, download=self.downloader)
-          continue
-        if exn:
-          logging.error(
-              ('Exception while fetching %d bytes from position %d of %s: '
-               '%s\n%s'),
-              bytes_to_request, self.position, self.path, exn, tb)
-          raise exn
-        self.buffer = result
-        return
-      raise GcsIOError(
-          'Reached retry limit for _fetch_next_if_buffer_exhausted.')
+      try:
+        result = self._get_segment(self.position, bytes_to_request)
+      except Exception as e:  # pylint: disable=broad-except
+        tb = traceback.format_exc()
+        logging.error(
+            ('Exception while fetching %d bytes from position %d of %s: '
+             '%s\n%s'),
+            bytes_to_request, self.position, self.path, e, tb)
+        raise
 
-  def _fetch_to_queue(self, queue, func, args):
-    try:
-      value = func(*args)
-      queue.put((value, None, None))
-    except Exception as e:  # pylint: disable=broad-except
-      tb = traceback.format_exc()
-      queue.put((None, e, tb))
+      self.buffer = result
+      return
 
   def _remaining(self):
     return self.size - self.position


### PR DESCRIPTION
This was introduced as a workaround, and it should not be needed any
more since we introduced a global timeout for http cliend
(`DEFAULT_HTTP_TIMEOUT_SECONDS`).

Do we need this mechanism any more? Is it safe to remove it?

R: @charlesccychen
cc: @chamikaramj 