### PR TITLE
Avoid importing testing hierarchy for Javadoc comments.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProvider.java
@@ -41,7 +41,6 @@ import java.lang.reflect.Proxy;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Internal;
-import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
@@ -57,7 +56,7 @@ import org.apache.beam.sdk.values.PCollection;
  * For that, use {@link Create#ofProvider}.
  *
  * <p>For unit-testing a transform against a {@link ValueProvider} that only becomes available
- * at runtime, use {@link TestPipeline#newProvider}.
+ * at runtime, use {@link org.apache.beam.sdk.testing.TestPipeline#newProvider}.
  */
 @JsonSerialize(using = ValueProvider.Serializer.class)
 @JsonDeserialize(using = ValueProvider.Deserializer.class)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProviders.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ValueProviders.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Map;
-import org.apache.beam.sdk.testing.TestPipeline;
 
 /** Utilities for working with the {@link ValueProvider} interface. */
 public class ValueProviders {
@@ -32,7 +31,8 @@ public class ValueProviders {
    * Given {@code serializedOptions} as a JSON-serialized {@link PipelineOptions}, updates the
    * values according to the provided values in {@code runtimeValues}.
    *
-   * @deprecated Use {@link TestPipeline#newProvider} for testing {@link ValueProvider} code.
+   * @deprecated Use {@link org.apache.beam.sdk.testing.TestPipeline#newProvider}
+   * for testing {@link ValueProvider} code.
    */
   @Deprecated
   public static String updateSerializedOptions(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardedFile.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ShardedFile.java
@@ -21,13 +21,12 @@ package org.apache.beam.sdk.util;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
-import org.apache.beam.sdk.testing.SerializableMatcher;
 
 /**
  * Bare-bones class for using sharded files.
  *
  * <p>For internal use only; used only in SDK tests. Must be {@link Serializable} so it can be
- * shipped as a {@link SerializableMatcher}.
+ * shipped as a {@link org.apache.beam.sdk.testing.SerializableMatcher}.
  */
 public interface ShardedFile extends Serializable {
 


### PR DESCRIPTION
These files import from the testing hierarchy solely to provide
Javadoc comments. This blurs the line a bit between operational and
test code. This is just a cleanup to make it more clear the
references are documentation and not actual code dependencies.
