### PR TITLE
[BEAM-3354] Fixed a bug that prevented processing time timers to be reset

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -454,6 +454,7 @@ class WatermarkManager {
     private final Collection<CommittedBundle<?>> pendingBundles;
     private final Map<StructuralKey<?>, NavigableSet<TimerData>> processingTimers;
     private final Map<StructuralKey<?>, NavigableSet<TimerData>> synchronizedProcessingTimers;
+    private final Map<StructuralKey<?>, Table<StateNamespace, String, TimerData>> existingTimers;
 
     private final NavigableSet<TimerData> pendingTimers;
 
@@ -464,6 +465,7 @@ class WatermarkManager {
       this.pendingBundles = new HashSet<>();
       this.processingTimers = new HashMap<>();
       this.synchronizedProcessingTimers = new HashMap<>();
+      this.existingTimers = new HashMap<>();
       this.pendingTimers = new TreeSet<>();
       Instant initialHold = BoundedWindow.TIMESTAMP_MAX_VALUE;
       for (Watermark wm : inputWms) {
@@ -540,21 +542,51 @@ class WatermarkManager {
 
     private synchronized void updateTimers(TimerUpdate update) {
       Map<TimeDomain, NavigableSet<TimerData>> timerMap = timerMap(update.key);
+      Table<StateNamespace, String, TimerData> existingTimersForKey =
+          existingTimers.get(update.key);
+      if (existingTimersForKey == null) {
+        existingTimersForKey = HashBasedTable.create();
+        existingTimers.put(update.key, existingTimersForKey);
+      }
+
       for (TimerData addedTimer : update.setTimers) {
         NavigableSet<TimerData> timerQueue = timerMap.get(addedTimer.getDomain());
-        if (timerQueue != null) {
+        if (timerQueue == null) {
+          continue;
+        }
+
+        @Nullable
+        TimerData existingTimer =
+            existingTimersForKey.get(addedTimer.getNamespace(), addedTimer.getTimerId());
+        if (existingTimer == null) {
           timerQueue.add(addedTimer);
+        } else if (!existingTimer.equals(addedTimer)) {
+          timerQueue.remove(existingTimer);
+          timerQueue.add(addedTimer);
+        } // else the timer is already set identically, so noop.
+
+        existingTimersForKey.put(addedTimer.getNamespace(), addedTimer.getTimerId(), addedTimer);
+      }
+
+      for (TimerData deletedTimer : update.deletedTimers) {
+        NavigableSet<TimerData> timerQueue = timerMap.get(deletedTimer.getDomain());
+        if (timerQueue == null) {
+          continue;
+        }
+
+        @Nullable
+        TimerData existingTimer =
+            existingTimersForKey.get(deletedTimer.getNamespace(), deletedTimer.getTimerId());
+
+        if (existingTimer != null) {
+          pendingTimers.remove(deletedTimer);
+          timerQueue.remove(deletedTimer);
+          existingTimersForKey.remove(existingTimer.getNamespace(), existingTimer.getTimerId());
         }
       }
 
       for (TimerData completedTimer : update.completedTimers) {
         pendingTimers.remove(completedTimer);
-      }
-      for (TimerData deletedTimer : update.deletedTimers) {
-        NavigableSet<TimerData> timerQueue = timerMap.get(deletedTimer.getDomain());
-        if (timerQueue != null) {
-          timerQueue.remove(deletedTimer);
-        }
       }
     }
 


### PR DESCRIPTION
Timers should be resetting its timestamp when called consequently. Currently, this is the case for the event time timers due to https://github.com/apache/beam/commit/7f14c463acd2ae5b86ac81a9528ac4aa7dff765f.

However, it was not implemented for the processing time timers. As a result, processing time timers are setting new timers instead of resetting. This PR completes the implementation.


Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
