### PR TITLE
Fix TestPipeline passing special test options to main pipeline.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -492,6 +492,10 @@ public class TestPipeline extends Pipeline implements TestRule {
           continue;
         } else if (entry.getValue().isTextual()) {
           optArrayList.add("--" + entry.getKey() + "=" + entry.getValue().asText());
+        } else if (entry.getValue().isArray()) {
+          for (JsonNode n : entry.getValue()) {
+            optArrayList.add("--" + entry.getKey() + "=" + n.asText());
+          }
         } else {
           optArrayList.add("--" + entry.getKey() + "=" + entry.getValue());
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -454,7 +454,7 @@ public class TestPipeline extends Pipeline implements TestRule {
       @Nullable
       String beamTestPipelineOptions = System.getProperty(propertyName);
       return Strings.isNullOrEmpty(beamTestPipelineOptions)
-          ? null
+          ? new String[0]
           : MAPPER.readValue(beamTestPipelineOptions, String[].class);
     } catch (IOException e) {
       throw new RuntimeException(
@@ -468,17 +468,15 @@ public class TestPipeline extends Pipeline implements TestRule {
 
   /** Creates {@link PipelineOptions} for testing. */
   public static PipelineOptions testingPipelineOptions() {
-    @Nullable
     String[] testOptionList = parseOptionsFromSysProperty(PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
 
-    PipelineOptions options =
-        testOptionList == null || testOptionList.length == 0
-            ? PipelineOptionsFactory.create()
-            : PipelineOptionsFactory.fromArgs(testOptionList)
-                .as(TestPipelineOptions.class);
+    PipelineOptions options = testOptionList.length == 0
+        ? PipelineOptionsFactory.create()
+        : PipelineOptionsFactory.fromArgs(testOptionList)
+            .as(TestPipelineOptions.class);
 
     // If no options were specified, set some reasonable defaults
-    if (testOptionList == null || testOptionList.length == 0) {
+    if (testOptionList.length == 0) {
       // If there are no provided options, check to see if a dummy runner should be used.
       String useDefaultDummy = System.getProperty(PROPERTY_USE_DEFAULT_DUMMY_RUNNER);
       if (!Strings.isNullOrEmpty(useDefaultDummy) && Boolean.valueOf(useDefaultDummy)) {
@@ -515,7 +513,7 @@ public class TestPipeline extends Pipeline implements TestRule {
         }
       }
       String[] extraOptionList = parseOptionsFromSysProperty(PROPERTY_BEAM_TEST_EXTRA_OPTIONS);
-      if (extraOptionList != null && extraOptionList.length != 0) {
+      if (extraOptionList.length != 0) {
         optArrayList.addAll(Arrays.asList(extraOptionList));
       }
       return optArrayList.toArray(new String[optArrayList.size()]);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -131,14 +131,23 @@ public class TestPipelineTest implements Serializable {
     }
 
     @Test
-    public void testConvertToArgs() {
+    public void testConvertToArgs() throws Exception {
       String[] args = new String[] {"--tempLocation=Test_Location",
           "--listArgs=item1,item2",
           "--boolArg=true"};
       SimpleTestOptions options = PipelineOptionsFactory.fromArgs(args).as(SimpleTestOptions.class);
+      String extraOptions =
+          MAPPER.writeValueAsString(
+              new String[] {
+                  "--extraArg=true"
+              });
+      System.getProperties().put(TestPipeline.PROPERTY_BEAM_TEST_EXTRA_OPTIONS, extraOptions);
       String[] arr = TestPipeline.convertToArgs(options);
       List<String> lst = Arrays.asList(arr);
-      assertEquals(lst.size(), 6);
+      for (String s : lst) {
+        System.out.println(s);
+      }
+      assertEquals(lst.size(), 7);
       assertThat(
           lst,
           containsInAnyOrder("--tempLocation=Test_Location",
@@ -146,7 +155,8 @@ public class TestPipelineTest implements Serializable {
               "--optionsId=" + options.getOptionsId(),
               "--listArgs=item1",
               "--listArgs=item2",
-              "--boolArg=true"));
+              "--boolArg=true",
+              "--extraArg=true"));
     }
 
     @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -119,18 +119,34 @@ public class TestPipelineTest implements Serializable {
           pipeline.toString());
     }
 
+    /** Test options with various types used to verify
+     * {@link TestPipeline#convertToArgs(PipelineOptions)}.
+     */
+    public interface SimpleTestOptions extends PipelineOptions {
+      List<String> getListArgs();
+      void setListArgs(List<String> value);
+
+      boolean getBoolArg();
+      void setBoolArg(boolean value);
+    }
+
     @Test
     public void testConvertToArgs() {
-      String[] args = new String[] {"--tempLocation=Test_Location"};
-      PipelineOptions options = PipelineOptionsFactory.fromArgs(args).as(PipelineOptions.class);
+      String[] args = new String[] {"--tempLocation=Test_Location",
+          "--listArgs=item1,item2",
+          "--boolArg=true"};
+      SimpleTestOptions options = PipelineOptionsFactory.fromArgs(args).as(SimpleTestOptions.class);
       String[] arr = TestPipeline.convertToArgs(options);
       List<String> lst = Arrays.asList(arr);
-      assertEquals(lst.size(), 3);
+      assertEquals(lst.size(), 6);
       assertThat(
           lst,
           containsInAnyOrder("--tempLocation=Test_Location",
               "--appName=TestPipelineCreationTest",
-              "--optionsId=" + options.getOptionsId()));
+              "--optionsId=" + options.getOptionsId(),
+              "--listArgs=item1",
+              "--listArgs=item2",
+              "--boolArg=true"));
     }
 
     @Test


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

IT(Integration Tests) are using `TestPipeline.convertToArgs` to convert well-defined options to list of pipeline-recognizable arguments and pass to pipeline main function. Incorrect arguments format will be returned if an option attribute type is `List`. 

One solution is that IT can use `beamTestExtraOptions` to pass options directly to pipeline main function without passing through `TestPipeline.converToArgs`.

For example, when a test option have a attribute called `listArgs` with value `["item1","item2"]`, `TestPipeline.convertToArgs(options)` will return:
before fix: `--listArgs=["item1", "item2"]` (which cannot be parsed)
after fix: `--listArgs=item1, --listArgs=item2`