### PR TITLE
[BEAM-3125] Creating FlattenRunner in Java SDK Harness

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -58,7 +58,7 @@ public class FlattenRunner<InputT>{
     }
   }
 
-  /** A factory for {@link FlattenRunner}s. */
+  /** A factory for {@link FlattenRunner}. */
   static class Factory<InputT> implements
       PTransformRunnerFactory<FlattenRunner<InputT>> {
     @Override
@@ -76,9 +76,8 @@ public class FlattenRunner<InputT>{
         Consumer<ThrowingRunnable> addStartFunction,
         Consumer<ThrowingRunnable> addFinishFunction)
         throws IOException {
-      //Collection<FnDataReceiver<WindowedValue<InputT>>> consumers =
-      //    (Collection) pCollectionIdsToConsumers
-      //        .get(getOnlyElement(pTransform.getOutputsMap().values()));
+
+      // Give each input a MultiplexingFnDataReceiver to all outputs of the flatten.
       ImmutableSet.Builder<FnDataReceiver<WindowedValue<InputT>>> consumersBuilder =
           new ImmutableSet.Builder<FnDataReceiver<WindowedValue<InputT>>>();
       for (String output : pTransform.getOutputsMap().values()) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -19,21 +19,31 @@ package org.apache.beam.fn.harness;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
+import org.apache.beam.fn.harness.data.MultiplexingFnDataReceiver;
 import org.apache.beam.fn.harness.fn.ThrowingRunnable;
 import org.apache.beam.fn.harness.state.BeamFnStateClient;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
-import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.util.WindowedValue;
 
-public class FlattenRunner<InputT, OutputT>{
+/**
+ * A {@link DoFnRunner} for flatten transformations.
+ */
+public class FlattenRunner<InputT>{
   /**
    * A registrar which provides a factory to handle Java {@link DoFn}s.
    */
@@ -46,27 +56,45 @@ public class FlattenRunner<InputT, OutputT>{
       return ImmutableMap.of(
           PTransformTranslation.FLATTEN_TRANSFORM_URN, new Factory());
     }
-
-    /** A factory for {@link FlattenRunner}s. */
-    static class Factory<InputT> implements
-        PTransformRunnerFactory<FlattenRunner<InputT>> {
-      @Override
-      public FlattenRunner<InputT> createRunnerForPTransform(
-          PipelineOptions pipelineOptions,
-          BeamFnDataClient beamFnDataClient,
-          BeamFnStateClient beamFnStateClient,
-          String pTransformId,
-          PTransform pTransform,
-          Supplier<String> processBundleInstructionId,
-          Map<String, PCollection> pCollections,
-          Map<String, RunnerApi.Coder> coders,
-          Map<String, RunnerApi.WindowingStrategy> windowingStrategies,
-          Multimap<String, FnDataReceiver<WindowedValue<?>>> pCollectionIdsToConsumers,
-          Consumer<ThrowingRunnable> addStartFunction,
-          Consumer<ThrowingRunnable> addFinishFunction) {
-
-      }
-    }
   }
 
+  /** A factory for {@link FlattenRunner}s. */
+  static class Factory<InputT> implements
+      PTransformRunnerFactory<FlattenRunner<InputT>> {
+    @Override
+    public FlattenRunner<InputT> createRunnerForPTransform(
+        PipelineOptions pipelineOptions,
+        BeamFnDataClient beamFnDataClient,
+        BeamFnStateClient beamFnStateClient,
+        String pTransformId,
+        RunnerApi.PTransform pTransform,
+        Supplier<String> processBundleInstructionId,
+        Map<String, PCollection> pCollections,
+        Map<String, Coder> coders,
+        Map<String, RunnerApi.WindowingStrategy> windowingStrategies,
+        Multimap<String, FnDataReceiver<WindowedValue<?>>> pCollectionIdsToConsumers,
+        Consumer<ThrowingRunnable> addStartFunction,
+        Consumer<ThrowingRunnable> addFinishFunction)
+        throws IOException {
+      //Collection<FnDataReceiver<WindowedValue<InputT>>> consumers =
+      //    (Collection) pCollectionIdsToConsumers
+      //        .get(getOnlyElement(pTransform.getOutputsMap().values()));
+      ImmutableSet.Builder<FnDataReceiver<WindowedValue<InputT>>> consumersBuilder =
+          new ImmutableSet.Builder<FnDataReceiver<WindowedValue<InputT>>>();
+      for (String output : pTransform.getOutputsMap().values()) {
+        consumersBuilder.addAll((Iterable) pCollectionIdsToConsumers.get(output));
+      }
+      Collection<FnDataReceiver<WindowedValue<InputT>>> consumers = consumersBuilder.build();
+
+      FnDataReceiver<WindowedValue<InputT>> receiver =
+          MultiplexingFnDataReceiver.forConsumers(consumers);
+      FlattenRunner<InputT> runner = new FlattenRunner<>();
+
+      for (String pCollectionId : pTransform.getInputsMap().values()) {
+        pCollectionIdsToConsumers.put(pCollectionId, (FnDataReceiver) receiver);
+      }
+
+      return runner;
+    }
+  }
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.beam.fn.harness.data.BeamFnDataClient;
+import org.apache.beam.fn.harness.fn.ThrowingRunnable;
+import org.apache.beam.fn.harness.state.BeamFnStateClient;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.util.WindowedValue;
+
+public class FlattenRunner<InputT, OutputT>{
+  /**
+   * A registrar which provides a factory to handle Java {@link DoFn}s.
+   */
+  @AutoService(PTransformRunnerFactory.Registrar.class)
+  public static class Registrar implements
+      PTransformRunnerFactory.Registrar {
+
+    @Override
+    public Map<String, PTransformRunnerFactory> getPTransformRunnerFactories() {
+      return ImmutableMap.of(
+          PTransformTranslation.FLATTEN_TRANSFORM_URN, new Factory());
+    }
+
+    /** A factory for {@link FlattenRunner}s. */
+    static class Factory<InputT> implements
+        PTransformRunnerFactory<FlattenRunner<InputT>> {
+      @Override
+      public FlattenRunner<InputT> createRunnerForPTransform(
+          PipelineOptions pipelineOptions,
+          BeamFnDataClient beamFnDataClient,
+          BeamFnStateClient beamFnStateClient,
+          String pTransformId,
+          PTransform pTransform,
+          Supplier<String> processBundleInstructionId,
+          Map<String, PCollection> pCollections,
+          Map<String, RunnerApi.Coder> coders,
+          Map<String, RunnerApi.WindowingStrategy> windowingStrategies,
+          Multimap<String, FnDataReceiver<WindowedValue<?>>> pCollectionIdsToConsumers,
+          Consumer<ThrowingRunnable> addStartFunction,
+          Consumer<ThrowingRunnable> addFinishFunction) {
+
+      }
+    }
+  }
+
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FlattenRunner}. */
+@RunWith(JUnit4.class)
+public class FlattenRunnerTest {
+
+  /**
+   * Create a DoFn that has 4 inputs (inputATarget1, inputATarget2, inputBTarget, inputCTarget) and
+   * 2 outputs (mainOutput, output). Validate that inputs are flattened together and that outputs
+   * are directed to the correct consumers.
+   */
+  @Test
+  public void testCreatingAndProcessingDoFn() throws Exception {
+    String pTransformId = "pTransformId";
+    String mainOutputId = "101";
+    String additionalOutputId = "102";
+
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setUrn(PTransformTranslation.FLATTEN_TRANSFORM_URN)
+            .build();
+    RunnerApi.PTransform pTransform = RunnerApi.PTransform.newBuilder()
+        .setSpec(functionSpec)
+        .putInputs("inputA", "inputATarget")
+        .putInputs("inputB", "inputBTarget")
+        .putInputs("inputC", "inputCTarget")
+        .putOutputs(mainOutputId, "mainOutputTarget")
+        .putOutputs(additionalOutputId, "additionalOutputTarget")
+        .build();
+
+    List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
+    List<WindowedValue<String>> additionalOutputValues = new ArrayList<>();
+    Multimap<String, FnDataReceiver<WindowedValue<?>>> consumers = HashMultimap.create();
+    consumers.put("mainOutputTarget",
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
+    consumers.put("additionalOutputTarget",
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
+
+    new FlattenRunner.Factory<>().createRunnerForPTransform(
+        PipelineOptionsFactory.create(),
+        null /* beamFnDataClient */,
+        null /* beamFnStateClient */,
+        pTransformId,
+        pTransform,
+        Suppliers.ofInstance("57L")::get,
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        Collections.emptyMap(),
+        consumers,
+        null /* addStartFunction */,
+        null /* addFinishFunction */);
+
+    mainOutputValues.clear();
+    assertThat(consumers.keySet(), containsInAnyOrder(
+        "inputATarget", "inputBTarget", "inputCTarget", "mainOutputTarget",
+        "additionalOutputTarget"));
+
+    Iterables.getOnlyElement(consumers.get("inputATarget")).accept(valueInGlobalWindow("A1"));
+    Iterables.getOnlyElement(consumers.get("inputATarget")).accept(valueInGlobalWindow("A2"));
+    Iterables.getOnlyElement(consumers.get("inputBTarget")).accept(valueInGlobalWindow("B"));
+    Iterables.getOnlyElement(consumers.get("inputCTarget")).accept(valueInGlobalWindow("C"));
+    assertThat(mainOutputValues, contains(
+        valueInGlobalWindow("A1"),
+        valueInGlobalWindow("A2"),
+        valueInGlobalWindow("B"),
+        valueInGlobalWindow("C")));
+    assertThat(additionalOutputValues, contains(
+        valueInGlobalWindow("A1"),
+        valueInGlobalWindow("A2"),
+        valueInGlobalWindow("B"),
+        valueInGlobalWindow("C")));
+
+    mainOutputValues.clear();
+    additionalOutputValues.clear();
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
@@ -46,10 +46,10 @@ public class FlattenRunnerTest {
   /**
    * Create a DoFn that has 4 inputs (inputATarget1, inputATarget2, inputBTarget, inputCTarget) and
    * 2 outputs (mainOutput, output). Validate that inputs are flattened together and that outputs
-   * are directed to the correct consumers.
+   * are directed to all consumers.
    */
   @Test
-  public void testCreatingAndProcessingDoFn() throws Exception {
+  public void testCreatingAndProcessingDoFlatten() throws Exception {
     String pTransformId = "pTransformId";
     String mainOutputId = "101";
     String additionalOutputId = "102";

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -165,7 +165,7 @@ public class FnApiDoFnRunnerTest {
 
     Iterables.getOnlyElement(consumers.get("inputATarget")).accept(valueInGlobalWindow("A1"));
     Iterables.getOnlyElement(consumers.get("inputATarget")).accept(valueInGlobalWindow("A2"));
-    Iterables.getOnlyElement(consumers.get("inputATarget")).accept(valueInGlobalWindow("B"));
+    Iterables.getOnlyElement(consumers.get("inputBTarget")).accept(valueInGlobalWindow("B"));
     assertThat(mainOutputValues, contains(
         valueInGlobalWindow("MainOutputA1"),
         valueInGlobalWindow("MainOutputA2"),


### PR DESCRIPTION
 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

This change adds a runner to the Java SDK Harness for flattens so that if it can handle receiving pTransforms with the URN for flattens. Currently flattens are done implicitly by having DoFns with multiple inputs. This change will not remove that functionality, but will also allow explicit flattens.

R: @lukecwik 