### PR TITLE
[BEAM-2963] Pass portable transform IDs in Dataflow translation

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CombineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CombineTranslation.java
@@ -177,7 +177,7 @@ public class CombineTranslation {
             Map<String, SideInput> sideInputs = new HashMap<>();
             for (PCollectionView<?> sideInput : combine.getTransform().getSideInputs()) {
               sideInputs.put(
-                  sideInput.getTagInternal().getId(), ParDoTranslation.toProto(sideInput));
+                  sideInput.getTagInternal().getId(), ParDoTranslation.translateView(sideInput));
             }
             return sideInputs;
           }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -70,6 +70,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignature.StateDeclaration;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.TimerDeclaration;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
+import org.apache.beam.sdk.util.DoFnAndMainOutput;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -470,16 +471,6 @@ public class ParDoTranslation {
     }
   }
 
-  @AutoValue
-  abstract static class DoFnAndMainOutput implements Serializable {
-    public static DoFnAndMainOutput of(DoFn<?, ?> fn, TupleTag<?> tag) {
-      return new AutoValue_ParDoTranslation_DoFnAndMainOutput(fn, tag);
-    }
-
-    abstract DoFn<?, ?> getDoFn();
-
-    abstract TupleTag<?> getMainOutputTag();
-  }
 
   private static SdkFunctionSpec toProto(DoFn<?, ?> fn, TupleTag<?> tag) {
     return SdkFunctionSpec.newBuilder()

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
@@ -49,8 +49,12 @@ import org.apache.beam.sdk.values.TupleTag;
 /** Utilities for going to/from Runner API pipelines. */
 public class PipelineTranslation {
 
-  public static RunnerApi.Pipeline toProto(final Pipeline pipeline) {
-    final SdkComponents components = SdkComponents.create();
+  public static RunnerApi.Pipeline toProto(Pipeline pipeline) {
+    return toProto(pipeline, SdkComponents.create());
+  }
+
+  public static RunnerApi.Pipeline toProto(
+      final Pipeline pipeline, final SdkComponents components) {
     final Collection<String> rootIds = new HashSet<>();
     pipeline.traverseTopologically(
         new PipelineVisitor.Defaults() {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/RehydratedComponents.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/RehydratedComponents.java
@@ -59,8 +59,15 @@ public class RehydratedComponents {
               new CacheLoader<String, WindowingStrategy<?, ?>>() {
                 @Override
                 public WindowingStrategy<?, ?> load(String id) throws Exception {
+                  @Nullable
+                  RunnerApi.WindowingStrategy windowingStrategyProto =
+                      components.getWindowingStrategiesOrDefault(id, null);
+                  checkState(
+                      windowingStrategyProto != null,
+                      "No WindowingStrategy with id '%s' in serialized components",
+                      id);
                   return WindowingStrategyTranslation.fromProto(
-                      components.getWindowingStrategiesOrThrow(id), RehydratedComponents.this);
+                      windowingStrategyProto, RehydratedComponents.this);
                 }
               });
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
@@ -113,6 +113,12 @@ public class SdkComponents {
     return transformIds.get(appliedPTransform);
   }
 
+  public String getPTransformIdOrThrow(AppliedPTransform<?, ?, ?> appliedPTransform) {
+    String existing = transformIds.get(appliedPTransform);
+    checkArgument(existing != null, "PTransform id not found for: %s", appliedPTransform);
+    return existing;
+  }
+
   /**
    * Registers the provided {@link PCollection} into this {@link SdkComponents}, returning a unique
    * ID for the {@link PCollection}. Multiple registrations of the same {@link PCollection} will

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
@@ -78,7 +78,7 @@ public class WriteFilesTranslation {
             Map<String, SideInput> sideInputs = new HashMap<>();
             for (PCollectionView<?> view :
                 transform.getSink().getDynamicDestinations().getSideInputs()) {
-              sideInputs.put(view.getTagInternal().getId(), ParDoTranslation.toProto(view));
+              sideInputs.put(view.getTagInternal().getId(), ParDoTranslation.translateView(view));
             }
             return sideInputs;
           }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
@@ -124,7 +124,7 @@ public class ParDoTranslationTest {
     @Test
     public void testToAndFromProto() throws Exception {
       SdkComponents components = SdkComponents.create();
-      ParDoPayload payload = ParDoTranslation.toProto(parDo, components);
+      ParDoPayload payload = ParDoTranslation.translateParDo(parDo, components);
 
       assertThat(ParDoTranslation.getDoFn(payload), Matchers.<DoFn<?, ?>>equalTo(parDo.getFn()));
       assertThat(
@@ -208,7 +208,8 @@ public class ParDoTranslationTest {
     public void testStateSpecToFromProto() throws Exception {
       // Encode
       SdkComponents sdkComponents = SdkComponents.create();
-      RunnerApi.StateSpec stateSpecProto = ParDoTranslation.toProto(stateSpec, sdkComponents);
+      RunnerApi.StateSpec stateSpecProto =
+          ParDoTranslation.translateStateSpec(stateSpec, sdkComponents);
 
       // Decode
       RehydratedComponents rehydratedComponents =

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -383,6 +383,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
@@ -52,6 +52,8 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 
 /**
@@ -109,6 +111,11 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
 
     public List<PCollectionView<?>> getSideInputs() {
       return original.getSideInputs();
+    }
+
+    @Override
+    public Map<TupleTag<?>, PValue> getAdditionalInputs() {
+      return PCollectionViews.toAdditionalInputs(getSideInputs());
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
@@ -18,11 +18,29 @@
 
 package org.apache.beam.runners.dataflow;
 
+import static org.apache.beam.runners.core.construction.PTransformTranslation.PAR_DO_TRANSFORM_URN;
+import static org.apache.beam.runners.core.construction.ParDoTranslation.translateTimerSpec;
+import static org.apache.beam.sdk.transforms.reflect.DoFnSignatures.getStateSpecOrThrow;
+import static org.apache.beam.sdk.transforms.reflect.DoFnSignatures.getTimerSpecOrThrow;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.Iterables;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.DisplayData;
 import org.apache.beam.runners.core.construction.ForwardingPTransform;
 import org.apache.beam.runners.core.construction.PTransformReplacements;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.ParDoTranslation;
+import org.apache.beam.runners.core.construction.RehydratedComponents;
+import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.core.construction.SingleInputOutputOverrideFactory;
+import org.apache.beam.runners.core.construction.TransformPayloadTranslatorRegistrar;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
@@ -30,8 +48,11 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.ParDo.SingleOutput;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
 
 /**
  * A {@link PTransformOverrideFactory} that produces {@link ParDoSingle} instances from {@link
@@ -52,31 +73,38 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
         PTransformReplacements.getSingletonMainInput(transform),
         new ParDoSingle<>(
             transform.getTransform(),
+            Iterables.getOnlyElement(transform.getOutputs().keySet()),
             PTransformReplacements.getSingletonMainOutput(transform).getCoder()));
   }
 
-  /**
-   * A single-output primitive {@link ParDo}.
-   */
+  /** A single-output primitive {@link ParDo}. */
   public static class ParDoSingle<InputT, OutputT>
       extends ForwardingPTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
     private final ParDo.SingleOutput<InputT, OutputT> original;
+    private final TupleTag<?> onlyOutputTag;
     private final Coder<OutputT> outputCoder;
 
-    private ParDoSingle(SingleOutput<InputT, OutputT> original, Coder<OutputT> outputCoder) {
+    private ParDoSingle(
+        SingleOutput<InputT, OutputT> original,
+        TupleTag<?> onlyOutputTag,
+        Coder<OutputT> outputCoder) {
       this.original = original;
+      this.onlyOutputTag = onlyOutputTag;
       this.outputCoder = outputCoder;
     }
 
     @Override
     public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
       return PCollection.createPrimitiveOutputInternal(
-          input.getPipeline(), input.getWindowingStrategy(), input.isBounded(),
-          outputCoder);
+          input.getPipeline(), input.getWindowingStrategy(), input.isBounded(), outputCoder);
     }
 
     public DoFn<InputT, OutputT> getFn() {
       return original.getFn();
+    }
+
+    public TupleTag<?> getMainOutputTag() {
+      return onlyOutputTag;
     }
 
     public List<PCollectionView<?>> getSideInputs() {
@@ -86,6 +114,131 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
     @Override
     protected PTransform<PCollection<? extends InputT>, PCollection<OutputT>> delegate() {
       return original;
+    }
+  }
+
+  /** A translator for {@link ParDoSingle}. */
+  public static class PayloadTranslator
+      implements PTransformTranslation.TransformPayloadTranslator<ParDoSingle<?, ?>> {
+    public static PTransformTranslation.TransformPayloadTranslator create() {
+      return new PayloadTranslator();
+    }
+
+    private PayloadTranslator() {}
+
+    @Override
+    public String getUrn(ParDoSingle<?, ?> transform) {
+      return PTransformTranslation.PAR_DO_TRANSFORM_URN;
+    }
+
+    @Override
+    public RunnerApi.FunctionSpec translate(
+        AppliedPTransform<?, ?, ParDoSingle<?, ?>> transform, SdkComponents components)
+        throws IOException {
+      RunnerApi.ParDoPayload payload = payloadForParDoSingle(transform.getTransform(), components);
+      return RunnerApi.FunctionSpec.newBuilder()
+          .setUrn(PAR_DO_TRANSFORM_URN)
+          .setPayload(payload.toByteString())
+          .build();
+    }
+
+    @Override
+    public PTransformTranslation.RawPTransform<?, ?> rehydrate(
+        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
+        throws IOException {
+      throw new UnsupportedOperationException(
+          String.format(
+              "%s.rehydrate should never be called; the serialized form is that of a ParDo",
+              getClass().getCanonicalName()));
+    }
+
+    private static RunnerApi.ParDoPayload payloadForParDoSingle(
+        final ParDoSingle<?, ?> parDo, SdkComponents components) throws IOException {
+
+      final DoFn<?, ?> doFn = parDo.getFn();
+      final DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
+
+      return ParDoTranslation.payloadForParDoLike(
+          new ParDoTranslation.ParDoLike() {
+            @Override
+            public RunnerApi.SdkFunctionSpec translateDoFn(SdkComponents newComponents) {
+              return ParDoTranslation.translateDoFn(parDo.getFn(), parDo.getMainOutputTag());
+            }
+
+            @Override
+            public List<RunnerApi.Parameter> translateParameters() {
+              List<RunnerApi.Parameter> parameters = new ArrayList<>();
+              for (DoFnSignature.Parameter parameter :
+                  signature.processElement().extraParameters()) {
+                RunnerApi.Parameter protoParameter = ParDoTranslation.translateParameter(parameter);
+                if (protoParameter != null) {
+                  parameters.add(protoParameter);
+                }
+              }
+              return parameters;
+            }
+
+            @Override
+            public Map<String, RunnerApi.SideInput> translateSideInputs(SdkComponents components) {
+              Map<String, RunnerApi.SideInput> sideInputs = new HashMap<>();
+              for (PCollectionView<?> sideInput : parDo.getSideInputs()) {
+                sideInputs.put(
+                    sideInput.getTagInternal().getId(), ParDoTranslation.translateView(sideInput));
+              }
+              return sideInputs;
+            }
+
+            @Override
+            public Map<String, RunnerApi.StateSpec> translateStateSpecs(SdkComponents components)
+                throws IOException {
+              Map<String, RunnerApi.StateSpec> stateSpecs = new HashMap<>();
+              for (Map.Entry<String, DoFnSignature.StateDeclaration> state :
+                  signature.stateDeclarations().entrySet()) {
+                RunnerApi.StateSpec spec =
+                    ParDoTranslation.translateStateSpec(
+                        getStateSpecOrThrow(state.getValue(), doFn), components);
+                stateSpecs.put(state.getKey(), spec);
+              }
+              return stateSpecs;
+            }
+
+            @Override
+            public Map<String, RunnerApi.TimerSpec> translateTimerSpecs(
+                SdkComponents newComponents) {
+              Map<String, RunnerApi.TimerSpec> timerSpecs = new HashMap<>();
+              for (Map.Entry<String, DoFnSignature.TimerDeclaration> timer :
+                  signature.timerDeclarations().entrySet()) {
+                RunnerApi.TimerSpec spec =
+                    translateTimerSpec(getTimerSpecOrThrow(timer.getValue(), doFn));
+                timerSpecs.put(timer.getKey(), spec);
+              }
+              return timerSpecs;
+            }
+
+            @Override
+            public boolean isSplittable() {
+              return signature.processElement().isSplittable();
+            }
+          },
+          components);
+    }
+  }
+
+  /** Registers {@link PayloadTranslator}. */
+  @AutoService(TransformPayloadTranslatorRegistrar.class)
+  public static class Registrar implements TransformPayloadTranslatorRegistrar {
+    @Override
+    public Map<
+            ? extends Class<? extends PTransform>,
+            ? extends PTransformTranslation.TransformPayloadTranslator>
+        getTransformPayloadTranslators() {
+      return Collections.singletonMap(ParDoSingle.class, new PayloadTranslator());
+    }
+
+    @Override
+    public Map<String, ? extends PTransformTranslation.TransformPayloadTranslator>
+        getTransformRehydrators() {
+      return Collections.emptyMap();
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.util.OutputReference;
 import org.apache.beam.sdk.Pipeline;
@@ -70,6 +71,10 @@ public interface TransformTranslator<TransformT extends PTransform> {
 
     /** Encode a PValue reference as an output reference. */
     OutputReference asOutputReference(PValue value, AppliedPTransform<?, ?, ?> producer);
+
+    SdkComponents getSdkComponents();
+
+    AppliedPTransform<?, ?, ?> getCurrentTransform();
 
     /**
      * Get the {@link AppliedPTransform} that produced the provided {@link PValue}.

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.dataflow;
 import static org.apache.beam.runners.dataflow.util.Structs.getString;
 import static org.apache.beam.sdk.util.StringUtils.jsonStringToByteArray;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -35,23 +34,11 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.api.services.dataflow.Dataflow;
 import com.google.api.services.dataflow.model.DataflowPackage;
 import com.google.api.services.dataflow.model.Job;
 import com.google.api.services.dataflow.model.Step;
 import com.google.api.services.dataflow.model.WorkerPool;
-import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -80,11 +67,9 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
-import org.apache.beam.sdk.extensions.gcp.storage.GcsPathValidator;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.range.OffsetRange;
-import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.state.StateSpec;
@@ -159,7 +144,7 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     FileSystems.setDefaultPipelineOptions(options);
 
     p.apply("ReadMyFile", TextIO.read().from("gs://bucket/object"))
-     .apply("WriteMyFile", TextIO.write().to("gs://bucket/object"));
+        .apply("WriteMyFile", TextIO.write().to("gs://bucket/object"));
     DataflowRunner runner = DataflowRunner.fromOptions(options);
     runner.replaceTransforms(p);
 
@@ -206,107 +191,6 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     options.setDataflowClient(buildMockDataflow(new IsValidCreateRequest()));
     options.setGcsUtil(mockGcsUtil);
     return options;
-  }
-
-  @Test
-  public void testSettingOfSdkPipelineOptions() throws IOException {
-    DataflowPipelineOptions options = buildPipelineOptions();
-    options.setRunner(DataflowRunner.class);
-
-    Pipeline p = Pipeline.create(options);
-    p.traverseTopologically(new RecordingPipelineVisitor());
-    Job job =
-        DataflowPipelineTranslator.fromOptions(options)
-            .translate(
-                p, DataflowRunner.fromOptions(options), Collections.<DataflowPackage>emptyList())
-            .getJob();
-
-    Map<String, Object> sdkPipelineOptions = job.getEnvironment().getSdkPipelineOptions();
-    assertThat(sdkPipelineOptions, hasKey("options"));
-    Map<String, Object> optionsMap = (Map<String, Object>) sdkPipelineOptions.get("options");
-
-    assertThat(optionsMap, hasEntry("appName", (Object) "DataflowPipelineTranslatorTest"));
-    assertThat(optionsMap, hasEntry("project", (Object) "some-project"));
-    assertThat(optionsMap,
-        hasEntry("pathValidatorClass", (Object) GcsPathValidator.class.getName()));
-    assertThat(optionsMap, hasEntry("runner", (Object) DataflowRunner.class.getName()));
-    assertThat(optionsMap, hasEntry("jobName", (Object) "some-job-name"));
-    assertThat(optionsMap, hasEntry("tempLocation", (Object) "gs://somebucket/some/path"));
-    assertThat(optionsMap,
-        hasEntry("stagingLocation", (Object) "gs://somebucket/some/path/staging/"));
-    assertThat(optionsMap, hasEntry("stableUniqueNames", (Object) "WARNING"));
-    assertThat(optionsMap, hasEntry("streaming", (Object) false));
-    assertThat(optionsMap, hasEntry("numberOfWorkerHarnessThreads", (Object) 0));
-  }
-
-  /** PipelineOptions used to test auto registration of Jackson modules. */
-  public interface JacksonIncompatibleOptions extends PipelineOptions {
-    JacksonIncompatible getJacksonIncompatible();
-    void setJacksonIncompatible(JacksonIncompatible value);
-  }
-
-  /** A Jackson {@link Module} to test auto-registration of modules. */
-  @AutoService(Module.class)
-  public static class RegisteredTestModule extends SimpleModule {
-    public RegisteredTestModule() {
-      super("RegisteredTestModule");
-      setMixInAnnotation(JacksonIncompatible.class, JacksonIncompatibleMixin.class);
-    }
-  }
-
-  /** A class which Jackson does not know how to serialize/deserialize. */
-  public static class JacksonIncompatible {
-    private final String value;
-    public JacksonIncompatible(String value) {
-      this.value = value;
-    }
-  }
-
-  /** A Jackson mixin used to add annotations to other classes. */
-  @JsonDeserialize(using = JacksonIncompatibleDeserializer.class)
-  @JsonSerialize(using = JacksonIncompatibleSerializer.class)
-  public static final class JacksonIncompatibleMixin {}
-
-  /** A Jackson deserializer for {@link JacksonIncompatible}. */
-  public static class JacksonIncompatibleDeserializer extends
-      JsonDeserializer<JacksonIncompatible> {
-
-    @Override
-    public JacksonIncompatible deserialize(JsonParser jsonParser,
-        DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
-      return new JacksonIncompatible(jsonParser.readValueAs(String.class));
-    }
-  }
-
-  /** A Jackson serializer for {@link JacksonIncompatible}. */
-  public static class JacksonIncompatibleSerializer extends JsonSerializer<JacksonIncompatible> {
-
-    @Override
-    public void serialize(JacksonIncompatible jacksonIncompatible, JsonGenerator jsonGenerator,
-        SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
-      jsonGenerator.writeString(jacksonIncompatible.value);
-    }
-  }
-
-  @Test
-  public void testSettingOfPipelineOptionsWithCustomUserType() throws IOException {
-    DataflowPipelineOptions options = buildPipelineOptions();
-    options.setRunner(DataflowRunner.class);
-    options.as(JacksonIncompatibleOptions.class).setJacksonIncompatible(
-        new JacksonIncompatible("userCustomTypeTest"));
-
-    Pipeline p = Pipeline.create(options);
-    p.traverseTopologically(new RecordingPipelineVisitor());
-    Job job =
-        DataflowPipelineTranslator.fromOptions(options)
-            .translate(
-                p, DataflowRunner.fromOptions(options), Collections.<DataflowPackage>emptyList())
-            .getJob();
-
-    Map<String, Object> sdkPipelineOptions = job.getEnvironment().getSdkPipelineOptions();
-    assertThat(sdkPipelineOptions, hasKey("options"));
-    Map<String, Object> optionsMap = (Map<String, Object>) sdkPipelineOptions.get("options");
-    assertThat(optionsMap, hasEntry("jacksonIncompatible", (Object) "userCustomTypeTest"));
   }
 
   @Test

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -21,6 +21,7 @@ import static org.apache.beam.runners.dataflow.DataflowRunner.getContainerImageF
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
@@ -42,11 +43,23 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.api.services.dataflow.Dataflow;
 import com.google.api.services.dataflow.model.DataflowPackage;
 import com.google.api.services.dataflow.model.Job;
 import com.google.api.services.dataflow.model.ListJobsResponse;
 import com.google.api.services.storage.model.StorageObject;
+import com.google.auto.service.AutoService;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -397,6 +410,118 @@ public class DataflowRunnerTest implements Serializable {
 
     String expectedVersion = DataflowRunnerInfo.getDataflowRunnerInfo().getVersion();
     assertThat(options.getUserAgent(), containsString(expectedVersion));
+  }
+
+  /**
+   * Invasive mock-based test for checking that the JSON generated for the pipeline options has
+   * not had vital fields pruned.
+   */
+  @Test
+  public void testSettingOfSdkPipelineOptions() throws IOException {
+    DataflowPipelineOptions options = buildPipelineOptions();
+
+    // These options are important only for this test, and need not be global to the test class
+    options.setAppName(DataflowRunnerTest.class.getSimpleName());
+    options.setJobName("some-job-name");
+
+    Pipeline p = Pipeline.create(options);
+    p.run();
+
+    ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+    Mockito.verify(mockJobs).create(eq(PROJECT_ID), eq(REGION_ID), jobCaptor.capture());
+
+    Map<String, Object> sdkPipelineOptions =
+        jobCaptor.getValue().getEnvironment().getSdkPipelineOptions();
+
+    assertThat(sdkPipelineOptions, hasKey("options"));
+    Map<String, Object> optionsMap = (Map<String, Object>) sdkPipelineOptions.get("options");
+
+    assertThat(optionsMap, hasEntry("appName", (Object) options.getAppName()));
+    assertThat(optionsMap, hasEntry("project", (Object) options.getProject()));
+    assertThat(
+        optionsMap,
+        hasEntry("pathValidatorClass", (Object) options.getPathValidatorClass().getName()));
+    assertThat(optionsMap, hasEntry("runner", (Object) options.getRunner().getName()));
+    assertThat(optionsMap, hasEntry("jobName", (Object) options.getJobName()));
+    assertThat(optionsMap, hasEntry("tempLocation", (Object) options.getTempLocation()));
+    assertThat(
+        optionsMap, hasEntry("stagingLocation", (Object) options.getStagingLocation()));
+    assertThat(
+        optionsMap,
+        hasEntry("stableUniqueNames", (Object) options.getStableUniqueNames().toString()));
+    assertThat(optionsMap, hasEntry("streaming", (Object) options.isStreaming()));
+    assertThat(
+        optionsMap,
+        hasEntry(
+            "numberOfWorkerHarnessThreads", (Object) options.getNumberOfWorkerHarnessThreads()));
+  }
+
+  /** PipelineOptions used to test auto registration of Jackson modules. */
+  public interface JacksonIncompatibleOptions extends PipelineOptions {
+    JacksonIncompatible getJacksonIncompatible();
+    void setJacksonIncompatible(JacksonIncompatible value);
+  }
+
+  /** A Jackson {@link Module} to test auto-registration of modules. */
+  @AutoService(Module.class)
+  public static class RegisteredTestModule extends SimpleModule {
+    public RegisteredTestModule() {
+      super("RegisteredTestModule");
+      setMixInAnnotation(JacksonIncompatible.class, JacksonIncompatibleMixin.class);
+    }
+  }
+
+  /** A class which Jackson does not know how to serialize/deserialize. */
+  public static class JacksonIncompatible {
+    private final String value;
+    public JacksonIncompatible(String value) {
+      this.value = value;
+    }
+  }
+
+  /** A Jackson mixin used to add annotations to other classes. */
+  @JsonDeserialize(using = JacksonIncompatibleDeserializer.class)
+  @JsonSerialize(using = JacksonIncompatibleSerializer.class)
+  public static final class JacksonIncompatibleMixin {}
+
+  /** A Jackson deserializer for {@link JacksonIncompatible}. */
+  public static class JacksonIncompatibleDeserializer extends
+      JsonDeserializer<JacksonIncompatible> {
+
+    @Override
+    public JacksonIncompatible deserialize(JsonParser jsonParser,
+        DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+      return new JacksonIncompatible(jsonParser.readValueAs(String.class));
+    }
+  }
+
+  /** A Jackson serializer for {@link JacksonIncompatible}. */
+  public static class JacksonIncompatibleSerializer extends JsonSerializer<JacksonIncompatible> {
+
+    @Override
+    public void serialize(JacksonIncompatible jacksonIncompatible, JsonGenerator jsonGenerator,
+        SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+      jsonGenerator.writeString(jacksonIncompatible.value);
+    }
+  }
+
+  @Test
+  public void testSettingOfPipelineOptionsWithCustomUserType() throws IOException {
+    DataflowPipelineOptions options = buildPipelineOptions();
+    options.as(JacksonIncompatibleOptions.class).setJacksonIncompatible(
+        new JacksonIncompatible("userCustomTypeTest"));
+
+    Pipeline p = Pipeline.create(options);
+    p.run();
+
+    ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
+    Mockito.verify(mockJobs).create(eq(PROJECT_ID), eq(REGION_ID), jobCaptor.capture());
+
+    Map<String, Object> sdkPipelineOptions =
+        jobCaptor.getValue().getEnvironment().getSdkPipelineOptions();
+    assertThat(sdkPipelineOptions, hasKey("options"));
+    Map<String, Object> optionsMap = (Map<String, Object>) sdkPipelineOptions.get("options");
+    assertThat(optionsMap, hasEntry("jacksonIncompatible", (Object) "userCustomTypeTest"));
   }
 
   @Test

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -580,6 +580,9 @@ public class ParDo {
    */
   public static class SingleOutput<InputT, OutputT>
       extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
+
+    private static final String MAIN_OUTPUT_TAG = "output";
+
     private final List<PCollectionView<?>> sideInputs;
     private final DoFn<InputT, OutputT> fn;
     private final DisplayData.ItemSpec<? extends Class<?>> fnDisplayData;
@@ -638,7 +641,7 @@ public class ParDo {
     public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
       CoderRegistry registry = input.getPipeline().getCoderRegistry();
       finishSpecifyingStateSpecs(fn, registry, input.getCoder());
-      TupleTag<OutputT> mainOutput = new TupleTag<>();
+      TupleTag<OutputT> mainOutput = new TupleTag<>(MAIN_OUTPUT_TAG);
       PCollection<OutputT> res =
           input.apply(withOutputTags(mainOutput, TupleTagList.empty())).get(mainOutput);
       try {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -1381,4 +1381,51 @@ public class DoFnSignatures {
       }
     }
   }
+
+  public static StateSpec<?> getStateSpecOrThrow(
+      StateDeclaration stateDeclaration, DoFn<?, ?> target) {
+    try {
+      Object fieldValue = stateDeclaration.field().get(target);
+      checkState(
+          fieldValue instanceof StateSpec,
+          "Malformed %s class %s: state declaration field %s does not have type %s.",
+          DoFn.class.getSimpleName(),
+          target.getClass().getName(),
+          stateDeclaration.field().getName(),
+          StateSpec.class);
+
+      return (StateSpec<?>) stateDeclaration.field().get(target);
+    } catch (IllegalAccessException exc) {
+      throw new RuntimeException(
+          String.format(
+              "Malformed %s class %s: state declaration field %s is not accessible.",
+              DoFn.class.getSimpleName(),
+              target.getClass().getName(),
+              stateDeclaration.field().getName()));
+    }
+  }
+
+  public static TimerSpec getTimerSpecOrThrow(
+      TimerDeclaration timerDeclaration, DoFn<?, ?> target) {
+    try {
+      Object fieldValue = timerDeclaration.field().get(target);
+      checkState(
+          fieldValue instanceof TimerSpec,
+          "Malformed %s class %s: timer declaration field %s does not have type %s.",
+          DoFn.class.getSimpleName(),
+          target.getClass().getName(),
+          timerDeclaration.field().getName(),
+          TimerSpec.class);
+
+      return (TimerSpec) timerDeclaration.field().get(target);
+    } catch (IllegalAccessException exc) {
+      throw new RuntimeException(
+          String.format(
+              "Malformed %s class %s: timer declaration field %s is not accessible.",
+              DoFn.class.getSimpleName(),
+              target.getClass().getName(),
+              timerDeclaration.field().getName()));
+    }
+  }
+
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnAndMainOutput.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/DoFnAndMainOutput.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.TupleTag;
+
+/**
+ * The data that the Java SDK harness needs to execute a DoFn.
+ */
+@AutoValue
+public abstract class DoFnAndMainOutput implements Serializable {
+  public static DoFnAndMainOutput of(DoFn<?, ?> fn, TupleTag<?> tag) {
+    return new AutoValue_DoFnAndMainOutput(fn, tag);
+  }
+
+  public abstract DoFn<?, ?> getDoFn();
+
+  public abstract TupleTag<?> getMainOutputTag();
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
+import com.google.protobuf.TextFormat;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -141,9 +142,10 @@ public class ProcessBundleHandler {
           Consumer<ThrowingRunnable> addStartFunction,
           Consumer<ThrowingRunnable> addFinishFunction) {
         throw new IllegalStateException(String.format(
-            "No factory registered for %s, known factories %s",
+            "No factory registered for %s, known factories %s, whole transform was: %s",
             pTransform.getSpec().getUrn(),
-            urnToPTransformRunnerFactoryMap.keySet()));
+            urnToPTransformRunnerFactoryMap.keySet(),
+            TextFormat.printToString(pTransform)));
       }
     };
   }
@@ -180,6 +182,18 @@ public class ProcessBundleHandler {
             addStartFunction,
             addFinishFunction);
       }
+    }
+
+    if (!pTransform.hasSpec()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot process transform with no spec: %s", TextFormat.printToString(pTransform)));
+    }
+
+    if (pTransform.getSubtransformsCount() > 0) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot process composite transform: %s", TextFormat.printToString(pTransform)));
     }
 
     urnToPTransformRunnerFactoryMap.getOrDefault(


### PR DESCRIPTION
This changes the Dataflow translation to reference the portable pipeline by id rather than putting serialized Java bits directly in the Dataflow job.

----

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
