### PR TITLE
[BEAM-3415] junit 5 integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,6 +169,7 @@ buildscript {
     classpath "cz.malohlava:visteg:1.0.3"                                      // Enable generating Gradle task dependencies as ".dot" files
     classpath "com.github.jengelman.gradle.plugins:shadow:2.0.1"               // Enable shading Java dependencies
     classpath "ca.coglinc:javacc-gradle-plugin:2.4.0"                          // Enable the JavaCC parser generator
+    classpath "org.junit.platform:junit-platform-gradle-plugin:1.0.2"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,6 @@ buildscript {
     classpath "cz.malohlava:visteg:1.0.3"                                      // Enable generating Gradle task dependencies as ".dot" files
     classpath "com.github.jengelman.gradle.plugins:shadow:2.0.1"               // Enable shading Java dependencies
     classpath "ca.coglinc:javacc-gradle-plugin:2.4.0"                          // Enable the JavaCC parser generator
-    classpath "org.junit.platform:junit-platform-gradle-plugin:1.0.2"
   }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1791,6 +1791,7 @@
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
             <argLine>${beamSurefireArgline}</argLine>
           </configuration>
+          <!-- let children do something else and it is the default anyway
           <dependencies>
             <dependency>
               <groupId>org.apache.maven.surefire</groupId>
@@ -1798,6 +1799,7 @@
               <version>${surefire-plugin.version}</version>
             </dependency>
           </dependencies>
+          -->
         </plugin>
 
         <plugin>

--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -114,14 +114,14 @@
   </Match>
 
   <Match>
-    <Class name="org.apache.beam.sdk.testing.PAssert$PCollectionViewAssert"/>
+    <Class name="org.apache.beam.sdk.testing.PAsserts$PCollectionViewAssert"/>
     <Method name="equals" />
     <Bug pattern="EQ_UNUSUAL"/>
     <!-- Unsupported operation -->
   </Match>
 
   <Match>
-    <Class name="org.apache.beam.sdk.testing.PAssert$PCollectionContentsAssert"/>
+    <Class name="org.apache.beam.sdk.testing.PAsserts$PCollectionContentsAssert"/>
     <Method name="equals" />
     <Bug pattern="EQ_UNUSUAL"/>
     <!-- Unsupported operation -->

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -17,6 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
+apply plugin: "org.junit.platform.gradle.plugin"
 applyJavaNature()
 applyAvroNature()
 
@@ -71,6 +72,9 @@ dependencies {
   shadowTest library.java.slf4j_jdk14
   shadowTest library.java.mockito_core
   shadowTest "com.esotericsoftware.kryo:kryo:2.21"
+
+  // for the junit 5 integration - it looks wrong but aligned on junit 4 config -> to fix when fixing gradle build?
+  shadow 'org.junit.jupiter:junit-jupiter-api:5.0.2'
 }
 
 // Shade dependencies.

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -17,7 +17,6 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-apply plugin: "org.junit.platform.gradle.plugin"
 applyJavaNature()
 applyAvroNature()
 

--- a/sdks/java/core/pom.xml
+++ b/sdks/java/core/pom.xml
@@ -37,6 +37,8 @@
   <properties>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+
+    <junit5.version>5.0.2</junit5.version>
   </properties>
 
   <build>
@@ -48,6 +50,7 @@
     </resources>
 
     <pluginManagement>
+
       <plugins>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -140,6 +143,37 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <excludes>
+                <exclude>**/junit5/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <execution>
+            <id>compile-junit5</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+              <proc>none</proc> <!-- @AutoService not compatible with j8 for now -->
+              <includes>
+                <include>**/junit5/**</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
@@ -339,6 +373,32 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit5.version}</version>
+      <scope>provided</scope>
+      <optional>true</optional> <!-- for some maven parsers which mess up provided -->
+    </dependency>
+    <dependency> <!-- workaround cause of current surefire state -->
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-runner</artifactId>
+      <version>1.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit5.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency> <!-- to avoid warning compiling against junit 5 -->
+      <groupId>org.apiguardian</groupId>
+      <artifactId>apiguardian-api</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/Jsons.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/Jsons.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+
+/**
+ * Indirection for jackson in the test pipeline handler.
+ */
+public final class Jsons {
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModules(
+        ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
+
+    private Jsons() {
+        // no-op
+    }
+
+    public static String[] toArgs(final PipelineOptions options) {
+        try {
+            byte[] opts = MAPPER.writeValueAsBytes(options);
+
+            JsonParser jsonParser = MAPPER.getFactory().createParser(opts);
+            TreeNode node = jsonParser.readValueAsTree();
+            ObjectNode optsNode = (ObjectNode) node.get("options");
+            ArrayList<String> optArrayList = new ArrayList<>();
+            Iterator<Map.Entry<String, JsonNode>> entries = optsNode.fields();
+            while (entries.hasNext()) {
+                Map.Entry<String, JsonNode> entry = entries.next();
+                if (entry.getValue().isNull()) {
+                    continue;
+                } else if (entry.getValue().isTextual()) {
+                    optArrayList.add("--" + entry.getKey() + "=" + entry.getValue().asText());
+                } else {
+                    optArrayList.add("--" + entry.getKey() + "=" + entry.getValue());
+                }
+            }
+            return optArrayList.toArray(new String[optArrayList.size()]);
+        } catch (final IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static String[] readOptions(final String beamTestPipelineOptions) {
+        try {
+            return MAPPER.readValue(beamTestPipelineOptions, String[].class);
+        } catch (final IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static PipelineOptions convertOptions(final PipelineOptions options) {
+        return MAPPER.convertValue(MAPPER.valueToTree(options), PipelineOptions.class);
+    }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/Options.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/Options.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.NoSuchElementException;
+
+/**
+ * Parsing of CLI style options.
+ */
+public final class Options {
+    private Options() {
+        // no-op
+    }
+
+    public static String[] readOptions(final String beamTestPipelineOptions) {
+        return new StringPropertiesTokenizer(beamTestPipelineOptions).tokens();
+    }
+
+    public static boolean isParseable(final String value) {
+        return value != null && value.trim().startsWith("--");
+    }
+
+    private static class StringPropertiesTokenizer {
+
+        private String input;
+
+        private char[] delim;
+
+        private int pos = 0;
+
+        private char lastDelimiter = 0;
+
+        private boolean isDelimiter = false;
+
+        private StringPropertiesTokenizer(final String str) {
+            input = str;
+            delim = " \r\n\f".toCharArray();
+        }
+
+        public String[] tokens() {
+            final Collection<String> out = new ArrayList<>();
+            while (hasMoreTokens()) {
+                out.add(nextToken());
+            }
+            return out.toArray(new String[out.size()]);
+        }
+
+        private boolean hasMoreTokens() {
+            final int oldpos = pos;
+            final char olddelim = lastDelimiter;
+            try {
+                nextToken();
+                return true;
+            } catch (final NoSuchElementException nsee) {
+                return false;
+            } finally {
+                pos = oldpos;
+                lastDelimiter = olddelim;
+            }
+        }
+
+        private String nextToken() {
+            if (pos >= input.length()) {
+                throw new NoSuchElementException();
+            }
+
+            final StringBuilder sb = new StringBuilder();
+            char prevch = 0;
+            char ch;
+            while (pos < input.length()) {
+                lastDelimiter = ch = input.charAt(pos);
+                if (isDelimiter(ch, prevch)) {
+                    break;
+                }
+                if (isDelimiter(ch, (char) 0) && prevch == '\\') {
+                    sb.setLength(sb.length() - 1);
+                }
+
+                sb.append(ch);
+                prevch = ch;
+                pos++;
+            }
+            isDelimiter = false;
+            if (sb.length() == 0) {
+                pos++;
+                return nextToken();
+            }
+
+            return sb.toString();
+        }
+
+        public boolean isDelimiter() {
+            return isDelimiter;
+        }
+
+        private boolean isDelimiter(final char ch, final char prevch) {
+            for (char currentChar : delim) {
+                if (ch == currentChar && prevch != '\\') {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -17,63 +17,15 @@
  */
 package org.apache.beam.sdk.testing;
 
-import static com.google.common.base.Preconditions.checkState;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertThat;
-
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
-import java.io.IOException;
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineRunner;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.MapCoder;
-import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.metrics.Counter;
-import org.apache.beam.sdk.metrics.Metrics;
-import org.apache.beam.sdk.runners.TransformHierarchy.Node;
-import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.Flatten;
-import org.apache.beam.sdk.transforms.GroupByKey;
-import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.transforms.SimpleFunction;
-import org.apache.beam.sdk.transforms.Values;
-import org.apache.beam.sdk.transforms.View;
-import org.apache.beam.sdk.transforms.WithKeys;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
-import org.apache.beam.sdk.transforms.windowing.Never;
-import org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing;
-import org.apache.beam.sdk.transforms.windowing.Trigger;
-import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
-import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.KV;
-import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionList;
-import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.beam.sdk.values.PDone;
-import org.apache.beam.sdk.values.ValueInSingleWindow;
-import org.apache.beam.sdk.values.WindowingStrategy;
-import org.joda.time.Duration;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
 
 /**
  * An assertion on the contents of a {@link PCollection} incorporated into the pipeline. Such an
@@ -103,1447 +55,145 @@ import org.joda.time.Duration;
  * <p>JUnit and Hamcrest must be linked in by any code that uses PAssert.
  */
 public class PAssert {
-  public static final String SUCCESS_COUNTER = "PAssertSuccess";
-  public static final String FAILURE_COUNTER = "PAssertFailure";
-  private static final Counter successCounter = Metrics.counter(
-      PAssert.class, PAssert.SUCCESS_COUNTER);
-  private static final Counter failureCounter = Metrics.counter(
-      PAssert.class, PAssert.FAILURE_COUNTER);
+  static final PAsserts.AssertBase ASSERTS = new PAsserts.AssertBase<Matcher<?>>() {
+    @Override
+    public <T> void assertThat(T actual, Matcher<?> matcher) {
+      Assert.assertThat(actual, (Matcher<? super T>) matcher);
+    }
 
-  private static int assertCount = 0;
+    @Override
+    public <T> void assertEquals(T actual, T expected) {
+      Assert.assertEquals(actual, expected);
+    }
 
-  private static String nextAssertionName() {
-    return "PAssert$" + (assertCount++);
-  }
+    @Override
+    public <T> void assertNotEquals(T actual, T expected) {
+      Assert.assertNotEquals(actual, expected);
+    }
+
+    @Override
+    public <T> Matcher<Iterable<? extends T>> containsInAnyOrder(final T[] expected) {
+      return Matchers.containsInAnyOrder(expected);
+    }
+  };
 
   // Do not instantiate.
   private PAssert() {}
 
   /**
-   * A {@link DoFn} that counts the number of successful {@link SuccessOrFailure} in the
-   * input {@link PCollection} and counts them. If a failed {@link SuccessOrFailure} is
-   * encountered, it is counted and immediately raised.
+   * Constructs an {@link PAsserts.IterableAssert} for the elements of
+   * the provided {@link PCollection}.
    */
-  private static final class DefaultConcludeFn extends DoFn<SuccessOrFailure, Void> {
-
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      SuccessOrFailure e = c.element();
-      if (e.isSuccess()) {
-        PAssert.successCounter.inc();
-      } else {
-        PAssert.failureCounter.inc();
-        throw e.assertionError();
-      }
-    }
-  }
-
-  /**
-   * Default transform to check that a PAssert was successful. This transform
-   * relies on two {@link Counter} objects from the Metrics API to count the number of
-   * successful and failed asserts.
-   * Runners that do not support the Metrics API should replace this transform with
-   * their own implementation.
-   */
-  public static class DefaultConcludeTransform
-      extends PTransform<PCollection<SuccessOrFailure>, PCollection<Void>> {
-    public PCollection<Void> expand(PCollection<SuccessOrFailure> input) {
-      return input.apply(ParDo.of(new DefaultConcludeFn()));
-    }
-  }
-
-  /**
-   * Track the place where an assertion is defined.
-   * This is necessary because the stack trace of a Throwable is a transient attribute, and can't
-   * be serialized. {@link PAssertionSite} helps track the stack trace
-   * of the place where an assertion is issued.
-   */
-  public static class PAssertionSite implements Serializable {
-    private final String message;
-    private final StackTraceElement[] creationStackTrace;
-
-    static PAssertionSite capture(String message) {
-      return new PAssertionSite(message, new Throwable().getStackTrace());
-    }
-
-    PAssertionSite(String message, StackTraceElement[] creationStackTrace) {
-      this.message = message;
-      this.creationStackTrace = creationStackTrace;
-    }
-
-    public AssertionError wrap(Throwable t) {
-      AssertionError res =
-          new AssertionError(
-              message.isEmpty() ? t.getMessage() : (message + ": " + t.getMessage()), t);
-      res.setStackTrace(creationStackTrace);
-      return res;
-    }
-
-    public AssertionError wrap(String message) {
-      String outputMessage = (this.message == null || this.message.isEmpty())
-          ? message : (this.message + ": " + message);
-      AssertionError res = new AssertionError(outputMessage);
-      res.setStackTrace(creationStackTrace);
-      return res;
-    }
-  }
-
-  /**
-   * Builder interface for assertions applicable to iterables and PCollection contents.
-   */
-  public interface IterableAssert<T> {
-    /**
-     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
-     * run on the provided window.
-     *
-     * <p>The assertion will concatenate all panes present in the provided window if the
-     * {@link Trigger} produces multiple panes. If the windowing strategy accumulates fired panes
-     * and triggers fire multple times, consider using instead {@link #inFinalPane(BoundedWindow)}
-     * or {@link #inOnTimePane(BoundedWindow)}.
-     *
-     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
-     * specified window.
-     */
-    IterableAssert<T> inWindow(BoundedWindow window);
-
-    /**
-     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
-     * run on the provided window, running the checker only on the final pane for each key.
-     *
-     * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
-     * may be executed over an empty input even if the trigger has fired previously. To ensure that
-     * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
-     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
-     * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
-     *
-     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
-     * specified window.
-     */
-    IterableAssert<T> inFinalPane(BoundedWindow window);
-
-    /**
-     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
-     * run on the provided window.
-     *
-     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
-     * specified window.
-     */
-    IterableAssert<T> inOnTimePane(BoundedWindow window);
-
-    /**
-     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
-     * run on the provided window across all panes that were not produced by the arrival of late
-     * data.
-     *
-     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
-     * specified window.
-     */
-    IterableAssert<T> inCombinedNonLatePanes(BoundedWindow window);
-
-    /**
-     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
-     * run on panes in the {@link GlobalWindow} that were emitted before the {@link GlobalWindow}
-     * closed. These panes have {@link Timing#EARLY}.
-     */
-    IterableAssert<T> inEarlyGlobalWindowPanes();
-
-    /**
-     * Asserts that the iterable in question contains the provided elements.
-     *
-     * @return the same {@link IterableAssert} builder for further assertions
-     */
-    IterableAssert<T> containsInAnyOrder(T... expectedElements);
-
-    /**
-     * Asserts that the iterable in question contains the provided elements.
-     *
-     * @return the same {@link IterableAssert} builder for further assertions
-     */
-    IterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements);
-
-    /**
-     * Asserts that the iterable in question is empty.
-     *
-     * @return the same {@link IterableAssert} builder for further assertions
-     */
-    IterableAssert<T> empty();
-
-    /**
-     * Applies the provided checking function (presumably containing assertions) to the
-     * iterable in question.
-     *
-     * @return the same {@link IterableAssert} builder for further assertions
-     */
-    IterableAssert<T> satisfies(SerializableFunction<Iterable<T>, Void> checkerFn);
-  }
-
-  /**
-   * Builder interface for assertions applicable to a single value.
-   */
-  public interface SingletonAssert<T> {
-    /**
-     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
-     * only run on the provided window.
-     *
-     * <p>The assertion will expect outputs to be produced to the provided window exactly once. If
-     * the upstream {@link Trigger} may produce output multiple times, consider instead using
-     * {@link #inFinalPane(BoundedWindow)} or {@link #inOnTimePane(BoundedWindow)}.
-     *
-     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
-     * the specified window.
-     */
-    SingletonAssert<T> inOnlyPane(BoundedWindow window);
-
-    /**
-     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
-     * only run on the provided window, running the checker only on the final pane for each key.
-     *
-     * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
-     * may be executed over an empty input even if the trigger has fired previously. To ensure that
-     * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
-     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
-     * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
-     *
-     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
-     * the specified window.
-     */
-    SingletonAssert<T> inFinalPane(BoundedWindow window);
-
-    /**
-     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
-     * only run on the provided window, running the checker only on the on-time pane for each key.
-     *
-     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
-     * the specified window.
-     */
-    SingletonAssert<T> inOnTimePane(BoundedWindow window);
-
-    /**
-     * Asserts that the value in question is equal to the provided value, according to
-     * {@link Object#equals}.
-     *
-     * @return the same {@link SingletonAssert} builder for further assertions
-     */
-    SingletonAssert<T> isEqualTo(T expected);
-
-    /**
-     * Asserts that the value in question is not equal to the provided value, according
-     * to {@link Object#equals}.
-     *
-     * @return the same {@link SingletonAssert} builder for further assertions
-     */
-    SingletonAssert<T> notEqualTo(T notExpected);
-
-    /**
-     * Applies the provided checking function (presumably containing assertions) to the
-     * value in question.
-     *
-     * @return the same {@link SingletonAssert} builder for further assertions
-     */
-    SingletonAssert<T> satisfies(SerializableFunction<T, Void> checkerFn);
-  }
-
-  /**
-   * Constructs an {@link IterableAssert} for the elements of the provided {@link PCollection}.
-   */
-  public static <T> IterableAssert<T> that(PCollection<T> actual) {
+  public static <T> PAsserts.IterableAssert<T> that(PCollection<T> actual) {
     return that(actual.getName(), actual);
   }
 
   /**
-   * Constructs an {@link IterableAssert} for the elements of the provided {@link PCollection}
+   * Constructs an {@link PAsserts.IterableAssert} for the elements of
+   * the provided {@link PCollection}
    * with the specified reason.
    */
-  public static <T> IterableAssert<T> that(String reason, PCollection<T> actual) {
-    return new PCollectionContentsAssert<>(actual, PAssertionSite.capture(reason));
+  public static <T> PAsserts.IterableAssert<T> that(String reason, PCollection<T> actual) {
+    return PAsserts.that(reason, actual, ASSERTS);
   }
 
   /**
-   * Constructs an {@link IterableAssert} for the value of the provided {@link PCollection} which
+   * Constructs an {@link PAsserts.IterableAssert} for the value of
+   * the provided {@link PCollection} which
    * must contain a single {@code Iterable<T>} value.
    */
-  public static <T> IterableAssert<T> thatSingletonIterable(
+  public static <T> PAsserts.IterableAssert<T> thatSingletonIterable(
       PCollection<? extends Iterable<T>> actual) {
     return thatSingletonIterable(actual.getName(), actual);
   }
 
   /**
-   * Constructs an {@link IterableAssert} for the value of the provided {@link PCollection } with
-   * the specified reason. The provided PCollection must contain a single {@code Iterable<T>} value.
+   * Constructs an {@link PAsserts.IterableAssert} for the value of
+   * the provided {@link PCollection } with
+   * the specified reason. The provided PCollection must contain a single
+   * {@code Iterable<T>} value.
    */
-  public static <T> IterableAssert<T> thatSingletonIterable(
+  public static <T> PAsserts.IterableAssert<T> thatSingletonIterable(
       String reason, PCollection<? extends Iterable<T>> actual) {
-    @SuppressWarnings("unchecked") // Safe covariant cast
-    PCollection<Iterable<T>> actualIterables = (PCollection<Iterable<T>>) actual;
-
-    return new PCollectionSingletonIterableAssert<>(
-        actualIterables, PAssertionSite.capture(reason));
+    return PAsserts.thatSingletonIterable(reason, actual, ASSERTS);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of the provided
    * {@code PCollection PCollection<T>}, which must be a singleton.
    */
-  public static <T> SingletonAssert<T> thatSingleton(PCollection<T> actual) {
+  public static <T> PAsserts.SingletonAssert<T> thatSingleton(PCollection<T> actual) {
     return thatSingleton(actual.getName(), actual);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of the provided
    * {@code PCollection PCollection<T>} with the specified reason. The provided PCollection must be
    * a singleton.
    */
-  public static <T> SingletonAssert<T> thatSingleton(String reason, PCollection<T> actual) {
-    return new PCollectionViewAssert<>(
-        actual, View.<T>asSingleton(), actual.getCoder(), PAssertionSite.capture(reason)
-    );
+  public static <T> PAsserts.SingletonAssert<T> thatSingleton(String reason,
+                                                              PCollection<T> actual) {
+    return PAsserts.thatSingleton(reason, actual, ASSERTS);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}.
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of
+   * the provided {@link PCollection}.
    *
    * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
    * {@code Coder<K, V>}.
    */
-  public static <K, V> SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+  public static <K, V> PAsserts.SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
       PCollection<KV<K, V>> actual) {
     return thatMultimap(actual.getName(), actual);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection} with the
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of
+   * the provided {@link PCollection} with the
    * specified reason.
    *
    * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
    * {@code Coder<K, V>}.
    */
-  public static <K, V> SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+  public static <K, V> PAsserts.SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
       String reason, PCollection<KV<K, V>> actual) {
-    @SuppressWarnings("unchecked")
-    KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
-    return new PCollectionViewAssert<>(
-        actual,
-        View.<K, V>asMultimap(),
-        MapCoder.of(kvCoder.getKeyCoder(), IterableCoder.of(kvCoder.getValueCoder())),
-        PAssertionSite.capture(reason));
+    return PAsserts.thatMultimap(reason, actual, ASSERTS);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}, which
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of
+   * the provided {@link PCollection}, which
    * must have at most one value per key.
    *
    * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
    * {@code Coder<K, V>}.
    */
-  public static <K, V> SingletonAssert<Map<K, V>> thatMap(PCollection<KV<K, V>> actual) {
+  public static <K, V> PAsserts.SingletonAssert<Map<K, V>> thatMap(PCollection<KV<K, V>> actual) {
     return thatMap(actual.getName(), actual);
   }
 
   /**
-   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection} with
+   * Constructs a {@link PAsserts.SingletonAssert} for the value of
+   * the provided {@link PCollection} with
    * the specified reason. The {@link PCollection} must have at most one value per key.
    *
    * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
    * {@code Coder<K, V>}.
    */
-  public static <K, V> SingletonAssert<Map<K, V>> thatMap(
+  public static <K, V> PAsserts.SingletonAssert<Map<K, V>> thatMap(
       String reason, PCollection<KV<K, V>> actual) {
-    @SuppressWarnings("unchecked")
-    KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
-    return new PCollectionViewAssert<>(
-        actual,
-        View.<K, V>asMap(),
-        MapCoder.of(kvCoder.getKeyCoder(), kvCoder.getValueCoder()),
-        PAssertionSite.capture(reason));
-  }
-
-  ////////////////////////////////////////////////////////////
-
-  /**
-   * An {@link IterableAssert} about the contents of a {@link PCollection}. This does not require
-   * the runner to support side inputs.
-   */
-  protected static class PCollectionContentsAssert<T> implements IterableAssert<T> {
-    private final PCollection<T> actual;
-    private final AssertionWindows rewindowingStrategy;
-    private final SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor;
-    private final PAssertionSite site;
-
-    public PCollectionContentsAssert(PCollection<T> actual, PAssertionSite site) {
-      this(actual, IntoGlobalWindow.of(), PaneExtractors.<T>allPanes(), site);
-    }
-
-    public PCollectionContentsAssert(
-        PCollection<T> actual,
-        AssertionWindows rewindowingStrategy,
-        SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor,
-        PAssertionSite site) {
-      this.actual = actual;
-      this.rewindowingStrategy = rewindowingStrategy;
-      this.paneExtractor = paneExtractor;
-      this.site = site;
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> inWindow(BoundedWindow window) {
-      return withPane(window, PaneExtractors.<T>allPanes());
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> inFinalPane(BoundedWindow window) {
-      return withPane(window, PaneExtractors.<T>finalPane());
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> inOnTimePane(BoundedWindow window) {
-      return withPane(window, PaneExtractors.<T>onTimePane());
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
-      return withPane(window, PaneExtractors.<T>nonLatePanes());
-    }
-
-    @Override
-    public IterableAssert<T> inEarlyGlobalWindowPanes() {
-      return withPane(GlobalWindow.INSTANCE, PaneExtractors.<T>earlyPanes());
-    }
-
-    private PCollectionContentsAssert<T> withPane(
-        BoundedWindow window,
-        SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor) {
-      @SuppressWarnings({"unchecked", "rawtypes"})
-      Coder<BoundedWindow> windowCoder =
-          (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder();
-      return new PCollectionContentsAssert<>(
-          actual, IntoStaticWindows.of(windowCoder, window), paneExtractor, site);
-    }
-
-    /**
-     * Checks that the {@code Iterable} contains the expected elements, in any order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    @Override
-    @SafeVarargs
-    public final PCollectionContentsAssert<T> containsInAnyOrder(T... expectedElements) {
-      return containsInAnyOrder(Arrays.asList(expectedElements));
-    }
-
-    /**
-     * Checks that the {@code Iterable} contains the expected elements, in any order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    @Override
-    public PCollectionContentsAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
-      return satisfies(new AssertContainsInAnyOrderRelation<T>(), expectedElements);
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> empty() {
-      containsInAnyOrder(Collections.<T>emptyList());
-      return this;
-    }
-
-    @Override
-    public PCollectionContentsAssert<T> satisfies(
-        SerializableFunction<Iterable<T>, Void> checkerFn) {
-      actual.apply(
-          nextAssertionName(),
-          new GroupThenAssert<>(checkerFn, rewindowingStrategy, paneExtractor, site));
-      return this;
-    }
-
-    /**
-     * Checks that the {@code Iterable} contains elements that match the provided matchers, in any
-     * order.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    @SafeVarargs
-    final PCollectionContentsAssert<T> containsInAnyOrder(
-        SerializableMatcher<? super T>... elementMatchers) {
-      return satisfies(SerializableMatchers.containsInAnyOrder(elementMatchers));
-    }
-
-    /**
-     * Applies a {@link SerializableFunction} to check the elements of the {@code Iterable}.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    private PCollectionContentsAssert<T> satisfies(
-        AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
-      return satisfies(
-          new CheckRelationAgainstExpected<>(
-              relation, expectedElements, IterableCoder.of(actual.getCoder())));
-    }
-
-    /**
-     * Applies a {@link SerializableMatcher} to check the elements of the {@code Iterable}.
-     *
-     * <p>Returns this {@code IterableAssert}.
-     */
-    PCollectionContentsAssert<T> satisfies(
-        final SerializableMatcher<Iterable<? extends T>> matcher) {
-      // Safe covariant cast. Could be elided by changing a lot of this file to use
-      // more flexible bounds.
-      @SuppressWarnings({"rawtypes", "unchecked"})
-      SerializableFunction<Iterable<T>, Void> checkerFn =
-          (SerializableFunction) new MatcherCheckerFn<>(matcher);
-      actual.apply(
-          "PAssert$" + (assertCount++),
-          new GroupThenAssert<>(checkerFn, rewindowingStrategy, paneExtractor, site));
-      return this;
-    }
-
-    /** Check that the passed-in matchers match the existing data. */
-    protected static class MatcherCheckerFn<T> implements SerializableFunction<T, Void> {
-      private SerializableMatcher<T> matcher;
-
-      public MatcherCheckerFn(SerializableMatcher<T> matcher) {
-        this.matcher = matcher;
-      }
-
-      @Override
-      @Nullable
-      public Void apply(T actual) {
-        assertThat(actual, matcher);
-        return null;
-      }
-    }
-
-    /**
-     * @throws UnsupportedOperationException always
-     * @deprecated {@link Object#equals(Object)} is not supported on PAssert objects. If you meant
-     * to test object equality, use a variant of {@link #containsInAnyOrder} instead.
-     */
-    @Deprecated
-    @Override
-    public boolean equals(Object o) {
-      throw new UnsupportedOperationException(
-          "If you meant to test object equality, use .containsInAnyOrder instead.");
-    }
-
-    /**
-     * @throws UnsupportedOperationException always.
-     * @deprecated {@link Object#hashCode()} is not supported on PAssert objects.
-     */
-    @Deprecated
-    @Override
-    public int hashCode() {
-      throw new UnsupportedOperationException(
-          String.format("%s.hashCode() is not supported.", IterableAssert.class.getSimpleName()));
-    }
+    return PAsserts.thatMap(reason, actual, ASSERTS);
   }
 
   /**
-   * An {@link IterableAssert} for an iterable that is the sole element of a {@link PCollection}.
-   * This does not require the runner to support side inputs.
-   */
-  private static class PCollectionSingletonIterableAssert<T> implements IterableAssert<T> {
-    private final PCollection<Iterable<T>> actual;
-    private final Coder<T> elementCoder;
-    private final AssertionWindows rewindowingStrategy;
-    private final SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
-        paneExtractor;
-    private final PAssertionSite site;
-
-    public PCollectionSingletonIterableAssert(
-        PCollection<Iterable<T>> actual, PAssertionSite site) {
-      this(
-          actual,
-          IntoGlobalWindow.of(),
-          PaneExtractors.<Iterable<T>>allPanes(),
-          site);
-    }
-
-    public PCollectionSingletonIterableAssert(
-        PCollection<Iterable<T>> actual,
-        AssertionWindows rewindowingStrategy,
-        SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
-            paneExtractor,
-        PAssertionSite site) {
-      this.actual = actual;
-
-      @SuppressWarnings("unchecked")
-      Coder<T> typedCoder = (Coder<T>) actual.getCoder().getCoderArguments().get(0);
-      this.elementCoder = typedCoder;
-
-      this.rewindowingStrategy = rewindowingStrategy;
-      this.paneExtractor = paneExtractor;
-      this.site = site;
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> inWindow(BoundedWindow window) {
-      return withPanes(window, PaneExtractors.<Iterable<T>>allPanes());
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> inFinalPane(BoundedWindow window) {
-      return withPanes(window, PaneExtractors.<Iterable<T>>finalPane());
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> inOnTimePane(BoundedWindow window) {
-      return withPanes(window, PaneExtractors.<Iterable<T>>onTimePane());
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
-      return withPanes(window, PaneExtractors.<Iterable<T>>nonLatePanes());
-    }
-
-    @Override
-    public IterableAssert<T> inEarlyGlobalWindowPanes() {
-      return withPanes(GlobalWindow.INSTANCE, PaneExtractors.<Iterable<T>>earlyPanes());
-    }
-
-    private PCollectionSingletonIterableAssert<T> withPanes(
-        BoundedWindow window,
-        SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
-            paneExtractor) {
-      @SuppressWarnings({"unchecked", "rawtypes"})
-      Coder<BoundedWindow> windowCoder =
-          (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder();
-      return new PCollectionSingletonIterableAssert<>(
-          actual, IntoStaticWindows.of(windowCoder, window), paneExtractor, site);
-    }
-
-    @Override
-    @SafeVarargs
-    public final PCollectionSingletonIterableAssert<T> containsInAnyOrder(T... expectedElements) {
-      return containsInAnyOrder(Arrays.asList(expectedElements));
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> empty() {
-      return containsInAnyOrder(Collections.<T>emptyList());
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
-      return satisfies(new AssertContainsInAnyOrderRelation<T>(), expectedElements);
-    }
-
-    @Override
-    public PCollectionSingletonIterableAssert<T> satisfies(
-        SerializableFunction<Iterable<T>, Void> checkerFn) {
-      actual.apply(
-          "PAssert$" + (assertCount++),
-          new GroupThenAssertForSingleton<>(
-              checkerFn, rewindowingStrategy, paneExtractor, site));
-      return this;
-    }
-
-    private PCollectionSingletonIterableAssert<T> satisfies(
-        AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
-      return satisfies(
-          new CheckRelationAgainstExpected<>(
-              relation, expectedElements, IterableCoder.of(elementCoder)));
-    }
-  }
-
-  /**
-   * An assertion about the contents of a {@link PCollection} when it is viewed as a single value
-   * of type {@code ViewT}. This requires side input support from the runner.
-   */
-  private static class PCollectionViewAssert<ElemT, ViewT> implements SingletonAssert<ViewT> {
-    private final PCollection<ElemT> actual;
-    private final PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view;
-    private final AssertionWindows rewindowActuals;
-    private final SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>>
-        paneExtractor;
-    private final Coder<ViewT> coder;
-    private final PAssertionSite site;
-
-    protected PCollectionViewAssert(
-        PCollection<ElemT> actual,
-        PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view,
-        Coder<ViewT> coder,
-        PAssertionSite site) {
-      this(
-          actual,
-          view,
-          IntoGlobalWindow.of(),
-          PaneExtractors.<ElemT>allPanes(),
-          coder,
-          site);
-    }
-
-    private PCollectionViewAssert(
-        PCollection<ElemT> actual,
-        PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view,
-        AssertionWindows rewindowActuals,
-        SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>> paneExtractor,
-        Coder<ViewT> coder,
-        PAssertionSite site) {
-      this.actual = actual;
-      this.view = view;
-      this.rewindowActuals = rewindowActuals;
-      this.paneExtractor = paneExtractor;
-      this.coder = coder;
-      this.site = site;
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> inOnlyPane(BoundedWindow window) {
-      return inPane(window, PaneExtractors.<ElemT>onlyPane(site));
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> inFinalPane(BoundedWindow window) {
-      return inPane(window, PaneExtractors.<ElemT>finalPane());
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> inOnTimePane(BoundedWindow window) {
-      return inPane(window, PaneExtractors.<ElemT>onTimePane());
-    }
-
-    private PCollectionViewAssert<ElemT, ViewT> inPane(
-        BoundedWindow window,
-        SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>> paneExtractor) {
-      return new PCollectionViewAssert<>(
-          actual,
-          view,
-          IntoStaticWindows.of(
-              (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder(), window),
-          paneExtractor,
-          coder,
-          site);
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> isEqualTo(ViewT expectedValue) {
-      return satisfies(new AssertIsEqualToRelation<ViewT>(), expectedValue);
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> notEqualTo(ViewT expectedValue) {
-      return satisfies(new AssertNotEqualToRelation<ViewT>(), expectedValue);
-    }
-
-    @Override
-    public PCollectionViewAssert<ElemT, ViewT> satisfies(
-        SerializableFunction<ViewT, Void> checkerFn) {
-      actual
-          .getPipeline()
-          .apply(
-              "PAssert$" + (assertCount++),
-              new OneSideInputAssert<>(
-                  CreateActual.from(actual, rewindowActuals, paneExtractor, view),
-                  rewindowActuals.<Integer>windowDummy(),
-                  checkerFn,
-                  site));
-      return this;
-    }
-
-    /**
-     * Applies an {@link AssertRelation} to check the provided relation against the value of this
-     * assert and the provided expected value.
-     *
-     * <p>Returns this {@code SingletonAssert}.
-     */
-    private PCollectionViewAssert<ElemT, ViewT> satisfies(
-        AssertRelation<ViewT, ViewT> relation, final ViewT expectedValue) {
-      return satisfies(new CheckRelationAgainstExpected<>(relation, expectedValue, coder));
-    }
-
-    /**
-     * @throws UnsupportedOperationException always
-     * @deprecated {@link Object#equals(Object)} is not supported on PAssert objects. If you meant
-     * to test object equality, use {@link #isEqualTo} instead.
-     */
-    @Deprecated
-    @Override
-    public boolean equals(Object o) {
-      throw new UnsupportedOperationException(
-          String.format(
-              "tests for Java equality of the %s object, not the PCollection in question. "
-                  + "Call a test method, such as isEqualTo.",
-              getClass().getSimpleName()));
-    }
-
-    /**
-     * @throws UnsupportedOperationException always.
-     * @deprecated {@link Object#hashCode()} is not supported on {@link PAssert} objects.
-     */
-    @Deprecated
-    @Override
-    public int hashCode() {
-      throw new UnsupportedOperationException(
-          String.format("%s.hashCode() is not supported.", SingletonAssert.class.getSimpleName()));
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////////////
-
-  private static class CreateActual<T, ActualT>
-      extends PTransform<PBegin, PCollectionView<ActualT>> {
-
-    private final transient PCollection<T> actual;
-    private final transient AssertionWindows rewindowActuals;
-    private final transient SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>>
-        extractPane;
-    private final transient PTransform<PCollection<T>, PCollectionView<ActualT>> actualView;
-
-    public static <T, ActualT> CreateActual<T, ActualT> from(
-        PCollection<T> actual,
-        AssertionWindows rewindowActuals,
-        SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> extractPane,
-        PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
-      return new CreateActual<>(actual, rewindowActuals, extractPane, actualView);
-    }
-
-    private CreateActual(
-        PCollection<T> actual,
-        AssertionWindows rewindowActuals,
-        SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> extractPane,
-        PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
-      this.actual = actual;
-      this.rewindowActuals = rewindowActuals;
-      this.extractPane = extractPane;
-      this.actualView = actualView;
-    }
-
-    @Override
-    public PCollectionView<ActualT> expand(PBegin input) {
-      final Coder<T> coder = actual.getCoder();
-      return actual
-          .apply("FilterActuals", rewindowActuals.<T>prepareActuals())
-          .apply("GatherPanes", GatherAllPanes.<T>globally())
-          .apply("ExtractPane", MapElements.via(extractPane))
-          .setCoder(IterableCoder.of(actual.getCoder()))
-          .apply(Flatten.<T>iterables())
-          .apply("RewindowActuals", rewindowActuals.<T>windowActuals())
-          .apply(
-              ParDo.of(
-                  new DoFn<T, T>() {
-                    @ProcessElement
-                    public void processElement(ProcessContext context) throws CoderException {
-                      context.output(CoderUtils.clone(coder, context.element()));
-                    }
-                  }))
-          .apply(actualView);
-    }
-  }
-
-  /**
-   * A partially applied {@link AssertRelation}, where one value is provided along with a coder to
-   * serialize/deserialize them.
-   */
-  private static class CheckRelationAgainstExpected<T> implements SerializableFunction<T, Void> {
-    private final AssertRelation<T, T> relation;
-    private final byte[] encodedExpected;
-    private final Coder<T> coder;
-
-    public CheckRelationAgainstExpected(AssertRelation<T, T> relation, T expected, Coder<T> coder) {
-      this.relation = relation;
-      this.coder = coder;
-
-      try {
-        this.encodedExpected = CoderUtils.encodeToByteArray(coder, expected);
-      } catch (IOException coderException) {
-        throw new RuntimeException(coderException);
-      }
-    }
-
-    @Override
-    public Void apply(T actual) {
-      try {
-        T expected = CoderUtils.decodeFromByteArray(coder, encodedExpected);
-        return relation.assertFor(expected).apply(actual);
-      } catch (IOException coderException) {
-        throw new RuntimeException(coderException);
-      }
-    }
-  }
-
-  /**
-   * A transform that gathers the contents of a {@link PCollection} into a single main input
-   * iterable in the global window. This requires a runner to support {@link GroupByKey} in the
-   * global window, but not side inputs or other windowing or triggers.
+   * @deprecated use PAsserts flavor.
    *
-   * <p>If the {@link PCollection} is empty, this transform returns a {@link PCollection} containing
-   * a single empty iterable, even though in practice most runners will not produce any element.
+   * @param pipeline the pipeline.
+   * @return the number of asserts.
    */
-  private static class GroupGlobally<T>
-      extends PTransform<PCollection<T>, PCollection<Iterable<ValueInSingleWindow<T>>>>
-      implements Serializable {
-    private final AssertionWindows rewindowingStrategy;
-
-    public GroupGlobally(AssertionWindows rewindowingStrategy) {
-      this.rewindowingStrategy = rewindowingStrategy;
-    }
-
-    @Override
-    public PCollection<Iterable<ValueInSingleWindow<T>>> expand(PCollection<T> input) {
-      final int combinedKey = 42;
-
-      // Remove the triggering on both
-      PTransform<
-              PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>,
-              PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>>
-          removeTriggering =
-              Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
-                  .triggering(Never.ever())
-                  .discardingFiredPanes()
-                  .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness());
-      // Group the contents by key. If it is empty, this PCollection will be empty, too.
-      // Then key it again with a dummy key.
-      PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>> groupedContents =
-          // TODO: Split the filtering from the rewindowing, and apply filtering before the Gather
-          // if the grouping of extra records
-          input
-              .apply(rewindowingStrategy.<T>prepareActuals())
-              .apply("GatherAllOutputs", GatherAllPanes.<T>globally())
-              .apply(
-                  "RewindowActuals",
-                  rewindowingStrategy.<Iterable<ValueInSingleWindow<T>>>windowActuals())
-              .apply(
-                  "KeyForDummy",
-                  WithKeys.<Integer, Iterable<ValueInSingleWindow<T>>>of(combinedKey))
-              .apply("RemoveActualsTriggering", removeTriggering);
-
-      // Create another non-empty PCollection that is keyed with a distinct dummy key
-      PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>> keyedDummy =
-          input
-              .getPipeline()
-              .apply(
-                  Create.of(
-                          KV.of(
-                              combinedKey,
-                              (Iterable<ValueInSingleWindow<T>>)
-                                  Collections.<ValueInSingleWindow<T>>emptyList()))
-                      .withCoder(groupedContents.getCoder()))
-              .apply(
-                  "WindowIntoDummy",
-                  rewindowingStrategy.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>windowDummy())
-              .apply("RemoveDummyTriggering", removeTriggering);
-
-      // Flatten them together and group by the combined key to get a single element
-      PCollection<KV<Integer, Iterable<Iterable<ValueInSingleWindow<T>>>>> dummyAndContents =
-          PCollectionList.of(groupedContents)
-              .and(keyedDummy)
-              .apply(
-                  "FlattenDummyAndContents",
-                  Flatten.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>pCollections())
-              .apply(
-                  "NeverTrigger",
-                  Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
-                      .triggering(Never.ever())
-                      .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness())
-                      .discardingFiredPanes())
-              .apply(
-                  "GroupDummyAndContents",
-                  GroupByKey.<Integer, Iterable<ValueInSingleWindow<T>>>create());
-
-      return dummyAndContents
-          .apply(Values.<Iterable<Iterable<ValueInSingleWindow<T>>>>create())
-          .apply(ParDo.of(new ConcatFn<ValueInSingleWindow<T>>()));
-    }
-  }
-
-  private static final class ConcatFn<T> extends DoFn<Iterable<Iterable<T>>, Iterable<T>> {
-    @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
-      c.output(Iterables.concat(c.element()));
-    }
-  }
-
-  /**
-   * A transform that applies an assertion-checking function over iterables of {@code ActualT} to
-   * the entirety of the contents of its input.
-   */
-  public static class GroupThenAssert<T> extends PTransform<PCollection<T>, PDone>
-      implements Serializable {
-    private final SerializableFunction<Iterable<T>, Void> checkerFn;
-    private final AssertionWindows rewindowingStrategy;
-    private final SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor;
-    private final PAssertionSite site;
-
-    private GroupThenAssert(
-        SerializableFunction<Iterable<T>, Void> checkerFn,
-        AssertionWindows rewindowingStrategy,
-        SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor,
-        PAssertionSite site) {
-      this.checkerFn = checkerFn;
-      this.rewindowingStrategy = rewindowingStrategy;
-      this.paneExtractor = paneExtractor;
-      this.site = site;
-    }
-
-    @Override
-    public PDone expand(PCollection<T> input) {
-      input
-          .apply("GroupGlobally", new GroupGlobally<T>(rewindowingStrategy))
-          .apply("GetPane", MapElements.via(paneExtractor))
-          .setCoder(IterableCoder.of(input.getCoder()))
-          .apply("RunChecks", ParDo.of(new GroupedValuesCheckerDoFn<>(checkerFn, site)))
-          .apply("VerifyAssertions", new DefaultConcludeTransform());
-
-      return PDone.in(input.getPipeline());
-    }
-  }
-
-  /**
-   * A transform that applies an assertion-checking function to a single iterable contained as the
-   * sole element of a {@link PCollection}.
-   */
-  public static class GroupThenAssertForSingleton<T>
-      extends PTransform<PCollection<Iterable<T>>, PDone> implements Serializable {
-    private final SerializableFunction<Iterable<T>, Void> checkerFn;
-    private final AssertionWindows rewindowingStrategy;
-    private final SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
-        paneExtractor;
-    private final PAssertionSite site;
-
-    private GroupThenAssertForSingleton(
-        SerializableFunction<Iterable<T>, Void> checkerFn,
-        AssertionWindows rewindowingStrategy,
-        SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
-            paneExtractor,
-        PAssertionSite site) {
-      this.checkerFn = checkerFn;
-      this.rewindowingStrategy = rewindowingStrategy;
-      this.paneExtractor = paneExtractor;
-      this.site = site;
-    }
-
-    @Override
-    public PDone expand(PCollection<Iterable<T>> input) {
-      input
-          .apply("GroupGlobally", new GroupGlobally<Iterable<T>>(rewindowingStrategy))
-          .apply("GetPane", MapElements.via(paneExtractor))
-          .setCoder(IterableCoder.of(input.getCoder()))
-          .apply("RunChecks", ParDo.of(new SingletonCheckerDoFn<>(checkerFn, site)))
-          .apply("VerifyAssertions", new DefaultConcludeTransform());
-
-      return PDone.in(input.getPipeline());
-    }
-  }
-
-  /**
-   * An assertion checker that takes a single {@link PCollectionView
-   * PCollectionView&lt;ActualT&gt;} and an assertion over {@code ActualT}, and checks it within a
-   * Beam pipeline.
-   *
-   * <p>Note that the entire assertion must be serializable.
-   *
-   * <p>This is generally useful for assertion functions that are serializable but whose underlying
-   * data may not have a coder.
-   */
-  public static class OneSideInputAssert<ActualT> extends PTransform<PBegin, PDone>
-      implements Serializable {
-    private final transient PTransform<PBegin, PCollectionView<ActualT>> createActual;
-    private final transient PTransform<PCollection<Integer>, PCollection<Integer>> windowToken;
-    private final SerializableFunction<ActualT, Void> checkerFn;
-    private final PAssertionSite site;
-
-    private OneSideInputAssert(
-        PTransform<PBegin, PCollectionView<ActualT>> createActual,
-        PTransform<PCollection<Integer>, PCollection<Integer>> windowToken,
-        SerializableFunction<ActualT, Void> checkerFn,
-        PAssertionSite site) {
-      this.createActual = createActual;
-      this.windowToken = windowToken;
-      this.checkerFn = checkerFn;
-      this.site = site;
-    }
-
-    @Override
-    public PDone expand(PBegin input) {
-      final PCollectionView<ActualT> actual = input.apply("CreateActual", createActual);
-
-      input
-          .apply(Create.of(0).withCoder(VarIntCoder.of()))
-          .apply("WindowToken", windowToken)
-          .apply(
-              "RunChecks",
-              ParDo.of(new SideInputCheckerDoFn<>(checkerFn, actual, site)).withSideInputs(actual))
-          .apply("VerifyAssertions", new DefaultConcludeTransform());
-      return PDone.in(input.getPipeline());
-    }
-  }
-
-  /**
-   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of a
-   * {@link PCollectionView}, and adjusts counters and thrown exceptions for use in testing.
-   *
-   * <p>The input is ignored, but is {@link Integer} to be usable on runners that do not support
-   * null values.
-   */
-  private static class SideInputCheckerDoFn<ActualT> extends DoFn<Integer, SuccessOrFailure> {
-    private final SerializableFunction<ActualT, Void> checkerFn;
-    private final PCollectionView<ActualT> actual;
-    private final PAssertionSite site;
-
-    private SideInputCheckerDoFn(
-        SerializableFunction<ActualT, Void> checkerFn,
-        PCollectionView<ActualT> actual,
-        PAssertionSite site) {
-      this.checkerFn = checkerFn;
-      this.actual = actual;
-      this.site = site;
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      ActualT actualContents = c.sideInput(actual);
-      c.output(doChecks(site, actualContents, checkerFn));
-    }
-  }
-
-  /**
-   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
-   * the single iterable element of the input {@link PCollection} and adjusts counters and
-   * thrown exceptions for use in testing.
-   *
-   * <p>The singleton property is presumed, not enforced.
-   */
-  private static class GroupedValuesCheckerDoFn<ActualT> extends DoFn<ActualT, SuccessOrFailure> {
-    private final SerializableFunction<ActualT, Void> checkerFn;
-    private final PAssertionSite site;
-
-    private GroupedValuesCheckerDoFn(
-        SerializableFunction<ActualT, Void> checkerFn, PAssertionSite site) {
-      this.checkerFn = checkerFn;
-      this.site = site;
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      c.output(doChecks(site, c.element(), checkerFn));
-    }
-  }
-
-  /**
-   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
-   * the single item contained within the single iterable on input and
-   * adjusts counters and thrown exceptions for use in testing.
-   *
-   * <p>The singleton property of the input {@link PCollection} is presumed, not enforced. However,
-   * each input element must be a singleton iterable, or this will fail.
-   */
-  private static class SingletonCheckerDoFn<ActualT>
-      extends DoFn<Iterable<ActualT>, SuccessOrFailure> {
-    private final SerializableFunction<ActualT, Void> checkerFn;
-    private final PAssertionSite site;
-
-    private SingletonCheckerDoFn(
-        SerializableFunction<ActualT, Void> checkerFn, PAssertionSite site) {
-      this.checkerFn = checkerFn;
-      this.site = site;
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      ActualT actualContents = Iterables.getOnlyElement(c.element());
-      c.output(doChecks(site, actualContents, checkerFn));
-    }
-  }
-
-  protected static <ActualT> SuccessOrFailure doChecks(
-      PAssertionSite site,
-      ActualT actualContents,
-      SerializableFunction<ActualT, Void> checkerFn) {
-    try {
-      checkerFn.apply(actualContents);
-      return SuccessOrFailure.success();
-    } catch (Throwable t) {
-      return SuccessOrFailure.failure(site, t);
-    }
-  }
-
-  /////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * A {@link SerializableFunction} that verifies that an actual value is equal to an expected
-   * value.
-   */
-  private static class AssertIsEqualTo<T> implements SerializableFunction<T, Void> {
-    private T expected;
-
-    public AssertIsEqualTo(T expected) {
-      this.expected = expected;
-    }
-
-    @Override
-    @Nullable
-    public Void apply(T actual) {
-      assertThat(actual, equalTo(expected));
-      return null;
-    }
-  }
-
-  /**
-   * A {@link SerializableFunction} that verifies that an actual value is not equal to an expected
-   * value.
-   */
-  private static class AssertNotEqualTo<T> implements SerializableFunction<T, Void> {
-    private T expected;
-
-    public AssertNotEqualTo(T expected) {
-      this.expected = expected;
-    }
-
-    @Override
-    @Nullable
-    public Void apply(T actual) {
-      assertThat(actual, not(equalTo(expected)));
-      return null;
-    }
-  }
-
-  /**
-   * A {@link SerializableFunction} that verifies that an {@code Iterable} contains expected items
-   * in any order.
-   */
-  private static class AssertContainsInAnyOrder<T>
-      implements SerializableFunction<Iterable<T>, Void> {
-    private T[] expected;
-
-    @SafeVarargs
-    public AssertContainsInAnyOrder(T... expected) {
-      this.expected = expected;
-    }
-
-    @SuppressWarnings("unchecked")
-    public AssertContainsInAnyOrder(Collection<T> expected) {
-      this((T[]) expected.toArray());
-    }
-
-    public AssertContainsInAnyOrder(Iterable<T> expected) {
-      this(Lists.newArrayList(expected));
-    }
-
-    @Override
-    @Nullable
-    public Void apply(Iterable<T> actual) {
-      assertThat(actual, containsInAnyOrder(expected));
-      return null;
-    }
-  }
-
-  ////////////////////////////////////////////////////////////
-
-  /**
-   * A binary predicate between types {@code Actual} and {@code Expected}. Implemented as a method
-   * {@code assertFor(Expected)} which returns a {@code SerializableFunction<Actual, Void>} that
-   * should verify the assertion..
-   */
-  private interface AssertRelation<ActualT, ExpectedT> extends Serializable {
-    SerializableFunction<ActualT, Void> assertFor(ExpectedT input);
-  }
-
-  /**
-   * An {@link AssertRelation} implementing the binary predicate that two objects are equal.
-   */
-  private static class AssertIsEqualToRelation<T> implements AssertRelation<T, T> {
-    @Override
-    public SerializableFunction<T, Void> assertFor(T expected) {
-      return new AssertIsEqualTo<>(expected);
-    }
-  }
-
-  /**
-   * An {@link AssertRelation} implementing the binary predicate that two objects are not equal.
-   */
-  private static class AssertNotEqualToRelation<T> implements AssertRelation<T, T> {
-    @Override
-    public SerializableFunction<T, Void> assertFor(T expected) {
-      return new AssertNotEqualTo<>(expected);
-    }
-  }
-
-  /**
-   * An {@code AssertRelation} implementing the binary predicate that two collections are equal
-   * modulo reordering.
-   */
-  private static class AssertContainsInAnyOrderRelation<T>
-      implements AssertRelation<Iterable<T>, Iterable<T>> {
-    @Override
-    public SerializableFunction<Iterable<T>, Void> assertFor(Iterable<T> expectedElements) {
-      return new AssertContainsInAnyOrder<>(expectedElements);
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////////////////////////////////////
-
-  /**
-   * A strategy for filtering and rewindowing the actual and dummy {@link PCollection PCollections}
-   * within a {@link PAssert}.
-   *
-   * <p>This must ensure that the windowing strategies of the output of {@link #windowActuals()} and
-   * {@link #windowDummy()} are compatible (and can be {@link Flatten Flattened}).
-   *
-   * <p>The {@link PCollection} produced by {@link #prepareActuals()} will be a parent (though not
-   * a direct parent) of the transform provided to {@link #windowActuals()}.
-   */
-  private interface AssertionWindows {
-    /**
-     * Returns a transform that assigns the dummy element into the appropriate
-     * {@link BoundedWindow windows}.
-     */
-    <T> PTransform<PCollection<T>, PCollection<T>> windowDummy();
-
-    /**
-     * Returns a transform that filters and reassigns windows of the actual elements if necessary.
-     */
-    <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals();
-
-    /**
-     * Returns a transform that assigns the actual elements into the appropriate
-     * {@link BoundedWindow windows}. Will be called after {@link #prepareActuals()}.
-     */
-    <T> PTransform<PCollection<T>, PCollection<T>> windowActuals();
-  }
-
-  /**
-   * An {@link AssertionWindows} which assigns all elements to the {@link GlobalWindow}.
-   */
-  private static class IntoGlobalWindow implements AssertionWindows, Serializable {
-    public static AssertionWindows of() {
-      return new IntoGlobalWindow();
-    }
-
-    private <T> PTransform<PCollection<T>, PCollection<T>> window() {
-      return Window.into(new GlobalWindows());
-    }
-
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> windowDummy() {
-      return window();
-    }
-
-    /**
-     * Rewindows all input elements into the {@link GlobalWindow}. This ensures that the result
-     * PCollection will contain all of the elements of the PCollection when the window is not
-     * specified.
-     */
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals() {
-      return window();
-    }
-
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> windowActuals() {
-      return window();
-    }
-  }
-
-  private static class IntoStaticWindows implements AssertionWindows {
-    private final StaticWindows windowFn;
-
-    public static AssertionWindows of(Coder<BoundedWindow> windowCoder, BoundedWindow window) {
-      return new IntoStaticWindows(StaticWindows.of(windowCoder, window));
-    }
-
-    private IntoStaticWindows(StaticWindows windowFn) {
-      this.windowFn = windowFn;
-    }
-
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> windowDummy() {
-      return Window.into(windowFn);
-    }
-
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals() {
-      return new FilterWindows<>(windowFn);
-    }
-
-    @Override
-    public <T> PTransform<PCollection<T>, PCollection<T>> windowActuals() {
-      return Window.into(windowFn.intoOnlyExisting());
-    }
-  }
-
-  /**
-   * A DoFn that filters elements based on their presence in a static collection of windows.
-   */
-  private static final class FilterWindows<T> extends PTransform<PCollection<T>, PCollection<T>> {
-    private final StaticWindows windows;
-
-    public FilterWindows(StaticWindows windows) {
-      this.windows = windows;
-    }
-
-    @Override
-    public PCollection<T> expand(PCollection<T> input) {
-      return input.apply("FilterWindows", ParDo.of(new Fn()));
-    }
-
-    private class Fn extends DoFn<T, T> {
-      @ProcessElement
-      public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
-        if (windows.getWindows().contains(window)) {
-          c.output(c.element());
-        }
-      }
-    }
-  }
-
+  @Deprecated
   public static int countAsserts(Pipeline pipeline) {
-    AssertionCountingVisitor visitor = new AssertionCountingVisitor();
-    pipeline.traverseTopologically(visitor);
-    return visitor.getPAssertCount();
-  }
-
-  /**
-   * A {@link PipelineVisitor} that counts the number of total {@link PAssert PAsserts} in a
-   * {@link Pipeline}.
-   */
-  private static class AssertionCountingVisitor extends PipelineVisitor.Defaults {
-    private int assertCount;
-    private boolean pipelineVisited;
-
-    private AssertionCountingVisitor() {
-      assertCount = 0;
-      pipelineVisited = false;
-    }
-
-    @Override
-    public CompositeBehavior enterCompositeTransform(Node node) {
-      if (node.isRootNode()) {
-        checkState(
-            !pipelineVisited,
-            "Tried to visit a pipeline with an already used %s",
-            AssertionCountingVisitor.class.getSimpleName());
-      }
-      if (!node.isRootNode()
-          && (node.getTransform() instanceof PAssert.OneSideInputAssert
-          || node.getTransform() instanceof PAssert.GroupThenAssert
-          || node.getTransform() instanceof PAssert.GroupThenAssertForSingleton)) {
-        assertCount++;
-      }
-      return CompositeBehavior.ENTER_TRANSFORM;
-    }
-
-    public void leaveCompositeTransform(Node node) {
-      if (node.isRootNode()) {
-        pipelineVisited = true;
-      }
-    }
-
-    @Override
-    public void visitPrimitiveTransform(Node node) {
-      if
-          (node.getTransform() instanceof PAssert.OneSideInputAssert
-          || node.getTransform() instanceof PAssert.GroupThenAssert
-          || node.getTransform() instanceof PAssert.GroupThenAssertForSingleton) {
-        assertCount++;
-      }
-    }
-
-    /**
-     * Gets the number of {@link PAssert PAsserts} in the pipeline.
-     */
-    int getPAssertCount() {
-      checkState(pipelineVisited);
-      return assertCount;
-    }
+    return PAsserts.countAsserts(pipeline);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAsserts.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAsserts.java
@@ -1,0 +1,1616 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.Pipeline.PipelineVisitor;
+import org.apache.beam.sdk.PipelineRunner;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.runners.TransformHierarchy.Node;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Never;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing;
+import org.apache.beam.sdk.transforms.windowing.Trigger;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.ValueInSingleWindow;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.joda.time.Duration;
+
+/**
+ * An assertion on the contents of a {@link PCollection} incorporated into the pipeline. Such an
+ * assertion can be checked no matter what kind of {@link PipelineRunner} is used.
+ *
+ * <p>Note that the {@code PAssert} call must precede the call to {@link Pipeline#run}.
+ *
+ * <p>Examples of use: <pre>{@code
+ * Pipeline p = TestPipeline.create();
+ * ...
+ * PCollection<String> output =
+ *      input
+ *      .apply(ParDo.of(new TestDoFn()));
+ * PAssert.that(output)
+ *     .containsInAnyOrder("out1", "out2", "out3");
+ * ...
+ * PCollection<Integer> ints = ...
+ * PCollection<Integer> sum =
+ *     ints
+ *     .apply(Combine.globally(new SumInts()));
+ * PAssert.that(sum)
+ *     .is(42);
+ * ...
+ * p.run();
+ * }</pre>
+ *
+ * <p>JUnit and Hamcrest must be linked in by any code that uses PAssert.
+ */
+public class PAsserts {
+  public static final String SUCCESS_COUNTER = "PAssertSuccess";
+  public static final String FAILURE_COUNTER = "PAssertFailure";
+  private static final Counter successCounter = Metrics.counter(
+          PAsserts.class, PAsserts.SUCCESS_COUNTER);
+  private static final Counter failureCounter = Metrics.counter(
+          PAsserts.class, PAsserts.FAILURE_COUNTER);
+
+  private static int assertCount = 0;
+
+  private static String nextAssertionName() {
+    return "PAssert$" + (assertCount++);
+  }
+
+  // Do not instantiate.
+  private PAsserts() {}
+
+  /**
+   * A {@link DoFn} that counts the number of successful {@link SuccessOrFailure} in the
+   * input {@link PCollection} and counts them. If a failed {@link SuccessOrFailure} is
+   * encountered, it is counted and immediately raised.
+   */
+  private static final class DefaultConcludeFn extends DoFn<SuccessOrFailure, Void> {
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      SuccessOrFailure e = c.element();
+      if (e.isSuccess()) {
+        PAsserts.successCounter.inc();
+      } else {
+        PAsserts.failureCounter.inc();
+        throw e.assertionError();
+      }
+    }
+  }
+
+  /**
+   * Default transform to check that a PAssert was successful. This transform
+   * relies on two {@link Counter} objects from the Metrics API to count the number of
+   * successful and failed asserts.
+   * Runners that do not support the Metrics API should replace this transform with
+   * their own implementation.
+   */
+  public static class DefaultConcludeTransform
+          extends PTransform<PCollection<SuccessOrFailure>, PCollection<Void>> {
+    public PCollection<Void> expand(PCollection<SuccessOrFailure> input) {
+      return input.apply(ParDo.of(new DefaultConcludeFn()));
+    }
+  }
+
+  /**
+   * Track the place where an assertion is defined.
+   * This is necessary because the stack trace of a Throwable is a transient attribute, and can't
+   * be serialized. {@link PAssertionSite} helps track the stack trace
+   * of the place where an assertion is issued.
+   */
+  public static class PAssertionSite implements Serializable {
+    private final String message;
+    private final StackTraceElement[] creationStackTrace;
+
+    static PAssertionSite capture(String message) {
+      return new PAssertionSite(message, new Throwable().getStackTrace());
+    }
+
+    PAssertionSite(String message, StackTraceElement[] creationStackTrace) {
+      this.message = message;
+      this.creationStackTrace = creationStackTrace;
+    }
+
+    public AssertionError wrap(Throwable t) {
+      AssertionError res =
+              new AssertionError(
+                      message.isEmpty() ? t.getMessage() : (message + ": " + t.getMessage()), t);
+      res.setStackTrace(creationStackTrace);
+      return res;
+    }
+
+    public AssertionError wrap(String message) {
+      String outputMessage = (this.message == null || this.message.isEmpty())
+              ? message : (this.message + ": " + message);
+      AssertionError res = new AssertionError(outputMessage);
+      res.setStackTrace(creationStackTrace);
+      return res;
+    }
+  }
+
+  /**
+   * abstraction to be portable accross junit 4/5
+   * and potentially testng ....
+   */
+  public interface AssertBase<X> extends Serializable {
+
+    <T> void assertThat(T actual, X matcher);
+
+    <T> void assertEquals(T actual, T expected);
+
+    <T> void assertNotEquals(T actual, T expected);
+
+    <T> X containsInAnyOrder(T[] expected);
+  }
+
+  /**
+   * Builder interface for assertions applicable to iterables and PCollection contents.
+   */
+  public interface IterableAssert<T> {
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on the provided window.
+     *
+     * <p>The assertion will concatenate all panes present in the provided window if the
+     * {@link Trigger} produces multiple panes. If the windowing strategy accumulates fired panes
+     * and triggers fire multple times, consider using instead {@link #inFinalPane(BoundedWindow)}
+     * or {@link #inOnTimePane(BoundedWindow)}.
+     *
+     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
+     * specified window.
+     */
+    IterableAssert<T> inWindow(BoundedWindow window);
+
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on the provided window, running the checker only on the final pane for each key.
+     *
+     * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
+     * may be executed over an empty input even if the trigger has fired previously. To ensure that
+     * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
+     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
+     * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
+     *
+     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
+     * specified window.
+     */
+    IterableAssert<T> inFinalPane(BoundedWindow window);
+
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on the provided window.
+     *
+     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
+     * specified window.
+     */
+    IterableAssert<T> inOnTimePane(BoundedWindow window);
+
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on the provided window across all panes that were not produced by the arrival of late
+     * data.
+     *
+     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
+     * specified window.
+     */
+    IterableAssert<T> inCombinedNonLatePanes(BoundedWindow window);
+
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on panes in the {@link GlobalWindow} that were emitted before the {@link GlobalWindow}
+     * closed. These panes have {@link Timing#EARLY}.
+     */
+    IterableAssert<T> inEarlyGlobalWindowPanes();
+
+    /**
+     * Asserts that the iterable in question contains the provided elements.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> containsInAnyOrder(T... expectedElements);
+
+    /**
+     * Asserts that the iterable in question contains the provided elements.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements);
+
+    /**
+     * Asserts that the iterable in question is empty.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> empty();
+
+    /**
+     * Applies the provided checking function (presumably containing assertions) to the
+     * iterable in question.
+     *
+     * @return the same {@link IterableAssert} builder for further assertions
+     */
+    IterableAssert<T> satisfies(SerializableFunction<Iterable<T>, Void> checkerFn);
+  }
+
+  /**
+   * Builder interface for assertions applicable to a single value.
+   */
+  public interface SingletonAssert<T> {
+    /**
+     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
+     * only run on the provided window.
+     *
+     * <p>The assertion will expect outputs to be produced to the provided window exactly once. If
+     * the upstream {@link Trigger} may produce output multiple times, consider instead using
+     * {@link #inFinalPane(BoundedWindow)} or {@link #inOnTimePane(BoundedWindow)}.
+     *
+     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
+     * the specified window.
+     */
+    SingletonAssert<T> inOnlyPane(BoundedWindow window);
+
+    /**
+     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
+     * only run on the provided window, running the checker only on the final pane for each key.
+     *
+     * <p>If the input {@link WindowingStrategy} does not always produce final panes, the assertion
+     * may be executed over an empty input even if the trigger has fired previously. To ensure that
+     * a final pane is always produced, set the {@link ClosingBehavior} of the windowing strategy
+     * (via {@link Window#withAllowedLateness(Duration, ClosingBehavior)} setting
+     * {@link ClosingBehavior} to {@link ClosingBehavior#FIRE_ALWAYS}).
+     *
+     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
+     * the specified window.
+     */
+    SingletonAssert<T> inFinalPane(BoundedWindow window);
+
+    /**
+     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
+     * only run on the provided window, running the checker only on the on-time pane for each key.
+     *
+     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
+     * the specified window.
+     */
+    SingletonAssert<T> inOnTimePane(BoundedWindow window);
+
+    /**
+     * Asserts that the value in question is equal to the provided value, according to
+     * {@link Object#equals}.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> isEqualTo(T expected);
+
+    /**
+     * Asserts that the value in question is not equal to the provided value, according
+     * to {@link Object#equals}.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> notEqualTo(T notExpected);
+
+    /**
+     * Applies the provided checking function (presumably containing assertions) to the
+     * value in question.
+     *
+     * @return the same {@link SingletonAssert} builder for further assertions
+     */
+    SingletonAssert<T> satisfies(SerializableFunction<T, Void> checkerFn);
+  }
+
+  /**
+   * Constructs an {@link IterableAssert} for the elements of the provided {@link PCollection}
+   * with the specified reason.
+   */
+  public static <T> IterableAssert<T> that(String reason,
+                                           PCollection<T> actual,
+                                           AssertBase asserts) {
+    return new PCollectionContentsAssert<>(actual, PAssertionSite.capture(reason), asserts);
+  }
+
+  /**
+   * Constructs an {@link IterableAssert} for the value of the provided {@link PCollection } with
+   * the specified reason. The provided PCollection must contain a single {@code Iterable<T>} value.
+   */
+  public static <T> IterableAssert<T> thatSingletonIterable(
+          String reason, PCollection<? extends Iterable<T>> actual, AssertBase asserts) {
+    @SuppressWarnings("unchecked") // Safe covariant cast
+            PCollection<Iterable<T>> actualIterables = (PCollection<Iterable<T>>) actual;
+
+    return new PCollectionSingletonIterableAssert<>(
+            actualIterables, PAssertionSite.capture(reason), asserts);
+  }
+
+  /**
+   * Constructs a {@link SingletonAssert} for the value of the provided
+   * {@code PCollection PCollection<T>} with the specified reason. The provided PCollection must be
+   * a singleton.
+   */
+  public static <T> SingletonAssert<T> thatSingleton(String reason, PCollection<T> actual,
+                                                     AssertBase asserts) {
+    return new PCollectionViewAssert<>(
+            actual, View.<T>asSingleton(), actual.getCoder(), PAssertionSite.capture(reason),
+            asserts);
+  }
+
+  /**
+   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}.
+   *
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
+   */
+  public static <K, V> SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+          PCollection<KV<K, V>> actual, AssertBase asserts) {
+    return thatMultimap(actual.getName(), actual, asserts);
+  }
+
+  /**
+   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection} with the
+   * specified reason.
+   *
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
+   */
+  public static <K, V> SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+          String reason, PCollection<KV<K, V>> actual, AssertBase asserts) {
+    @SuppressWarnings("unchecked")
+    KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
+    return new PCollectionViewAssert<>(
+            actual,
+            View.<K, V>asMultimap(),
+            MapCoder.of(kvCoder.getKeyCoder(), IterableCoder.of(kvCoder.getValueCoder())),
+            PAssertionSite.capture(reason),
+            asserts);
+  }
+
+  /**
+   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection}, which
+   * must have at most one value per key.
+   *
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
+   */
+  public static <K, V> SingletonAssert<Map<K, V>> thatMap(PCollection<KV<K, V>> actual,
+                                                          AssertBase asserts) {
+    return thatMap(actual.getName(), actual, asserts);
+  }
+
+  /**
+   * Constructs a {@link SingletonAssert} for the value of the provided {@link PCollection} with
+   * the specified reason. The {@link PCollection} must have at most one value per key.
+   *
+   * <p>Note that the actual value must be coded by a {@link KvCoder}, not just any
+   * {@code Coder<K, V>}.
+   */
+  public static <K, V> SingletonAssert<Map<K, V>> thatMap(
+          String reason, PCollection<KV<K, V>> actual, AssertBase asserts) {
+    @SuppressWarnings("unchecked")
+    KvCoder<K, V> kvCoder = (KvCoder<K, V>) actual.getCoder();
+    return new PCollectionViewAssert<>(
+            actual,
+            View.<K, V>asMap(),
+            MapCoder.of(kvCoder.getKeyCoder(), kvCoder.getValueCoder()),
+            PAssertionSite.capture(reason), asserts);
+  }
+
+  ////////////////////////////////////////////////////////////
+
+  /**
+   * An {@link IterableAssert} about the contents of a {@link PCollection}. This does not require
+   * the runner to support side inputs.
+   */
+  protected static class PCollectionContentsAssert<T> implements IterableAssert<T> {
+    private final PCollection<T> actual;
+    private final AssertionWindows rewindowingStrategy;
+    private final SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor;
+    private final PAssertionSite site;
+    private final AssertBase asserts;
+
+    public PCollectionContentsAssert(PCollection<T> actual,
+                                     PAssertionSite site,
+                                     AssertBase asserts) {
+      this(actual, IntoGlobalWindow.of(), PaneExtractors.<T>allPanes(), site, asserts);
+    }
+
+    public PCollectionContentsAssert(
+            PCollection<T> actual,
+            AssertionWindows rewindowingStrategy,
+            SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor,
+            PAssertionSite site,
+            AssertBase assertBase) {
+      this.actual = actual;
+      this.rewindowingStrategy = rewindowingStrategy;
+      this.paneExtractor = paneExtractor;
+      this.site = site;
+      this.asserts = assertBase;
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> inWindow(BoundedWindow window) {
+      return withPane(window, PaneExtractors.<T>allPanes());
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> inFinalPane(BoundedWindow window) {
+      return withPane(window, PaneExtractors.<T>finalPane());
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> inOnTimePane(BoundedWindow window) {
+      return withPane(window, PaneExtractors.<T>onTimePane());
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
+      return withPane(window, PaneExtractors.<T>nonLatePanes());
+    }
+
+    @Override
+    public IterableAssert<T> inEarlyGlobalWindowPanes() {
+      return withPane(GlobalWindow.INSTANCE, PaneExtractors.<T>earlyPanes());
+    }
+
+    private PCollectionContentsAssert<T> withPane(
+            BoundedWindow window,
+            SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor) {
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      Coder<BoundedWindow> windowCoder =
+              (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder();
+      return new PCollectionContentsAssert<>(
+              actual, IntoStaticWindows.of(windowCoder, window), paneExtractor, site, asserts);
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains the expected elements, in any order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @Override
+    @SafeVarargs
+    public final PCollectionContentsAssert<T> containsInAnyOrder(T... expectedElements) {
+      return containsInAnyOrder(Arrays.asList(expectedElements));
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains the expected elements, in any order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @Override
+    public PCollectionContentsAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
+      return satisfies(new AssertContainsInAnyOrderRelation<T>(asserts), expectedElements);
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> empty() {
+      containsInAnyOrder(Collections.<T>emptyList());
+      return this;
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> satisfies(
+            SerializableFunction<Iterable<T>, Void> checkerFn) {
+      actual.apply(
+              nextAssertionName(),
+              new GroupThenAssert<>(checkerFn, rewindowingStrategy, paneExtractor, site));
+      return this;
+    }
+
+    /**
+     * Checks that the {@code Iterable} contains elements that match the provided matchers, in any
+     * order.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    @SafeVarargs
+    final PCollectionContentsAssert<T> containsInAnyOrder(
+            final SerializableMatcher<T>... elementMatchers) {
+      return satisfies(new AssertMatcherContainsInAnyOrder<T>(elementMatchers));
+    }
+
+    /**
+     * Applies a {@link SerializableFunction} to check the elements of the {@code Iterable}.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    private PCollectionContentsAssert<T> satisfies(
+            AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
+      return satisfies(
+              new CheckRelationAgainstExpected<>(
+                      relation, expectedElements, IterableCoder.of(actual.getCoder())));
+    }
+
+    /**
+     * Applies a {@link SerializableMatcher} to check the elements of the {@code Iterable}.
+     *
+     * <p>Returns this {@code IterableAssert}.
+     */
+    PCollectionContentsAssert<T> satisfies(
+            final SerializableMatcher matcher) {
+      // Safe covariant cast. Could be elided by changing a lot of this file to use
+      // more flexible bounds.
+      @SuppressWarnings({"rawtypes", "unchecked"})
+      SerializableFunction<Iterable<T>, Void> checkerFn =
+              (SerializableFunction) new MatcherCheckerFn<>(matcher, asserts);
+      actual.apply(
+              "PAssert$" + (assertCount++),
+              new GroupThenAssert<>(checkerFn, rewindowingStrategy, paneExtractor, site));
+      return this;
+    }
+
+    /** Check that the passed-in matchers match the existing data. */
+    protected static class MatcherCheckerFn<T> implements SerializableFunction<T, Void> {
+      private AssertBase asserts;
+      private SerializableMatcher matcher;
+
+      public MatcherCheckerFn(SerializableMatcher matcher, AssertBase asserts) {
+        this.matcher = matcher;
+        this.asserts = asserts;
+      }
+
+      @Override
+      @Nullable
+      public Void apply(T actual) {
+        asserts.assertThat(actual, matcher);
+        return null;
+      }
+    }
+
+    /**
+     * @throws UnsupportedOperationException always
+     * @deprecated {@link Object#equals(Object)} is not supported on PAssert objects. If you meant
+     * to test object equality, use a variant of {@link #containsInAnyOrder} instead.
+     */
+    @Deprecated
+    @Override
+    public boolean equals(Object o) {
+      throw new UnsupportedOperationException(
+              "If you meant to test object equality, use .containsInAnyOrder instead.");
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     * @deprecated {@link Object#hashCode()} is not supported on PAssert objects.
+     */
+    @Deprecated
+    @Override
+    public int hashCode() {
+      throw new UnsupportedOperationException(
+          String.format("%s.hashCode() is not supported.", IterableAssert.class.getSimpleName()));
+    }
+  }
+
+  /** matcher for N matchers. */
+  private static class AssertMatcherContainsInAnyOrder<T> extends BaseMatcher<T>
+          implements SerializableMatcher<T> {
+    private final SerializableMatcher<T>[] matchers;
+
+    private AssertMatcherContainsInAnyOrder(final SerializableMatcher<T>[] elementMatchers) {
+      matchers = elementMatchers;
+    }
+
+    @Override
+    public boolean matches(Object item) {
+      for (final SerializableMatcher<T> matcher : matchers) {
+        if (!matcher.matches(item)) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendText("containsInAnyOrder matches");
+    }
+
+    @Override
+    public void describeMismatch(Object item, Description mismatchDescription) {
+      mismatchDescription.appendValue(item).appendText(" doesn't match");
+    }
+  }
+
+  /**
+   * An {@link IterableAssert} for an iterable that is the sole element of a {@link PCollection}.
+   * This does not require the runner to support side inputs.
+   */
+  private static class PCollectionSingletonIterableAssert<T> implements IterableAssert<T> {
+    private final PCollection<Iterable<T>> actual;
+    private final Coder<T> elementCoder;
+    private final AssertionWindows rewindowingStrategy;
+    private final SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
+            paneExtractor;
+    private final PAssertionSite site;
+    private final AssertBase asserts;
+
+    public PCollectionSingletonIterableAssert(
+            PCollection<Iterable<T>> actual, PAssertionSite site, AssertBase asserts) {
+      this(
+              actual,
+              IntoGlobalWindow.of(),
+              PaneExtractors.<Iterable<T>>allPanes(),
+              site,
+              asserts);
+    }
+
+    public PCollectionSingletonIterableAssert(
+            PCollection<Iterable<T>> actual,
+            AssertionWindows rewindowingStrategy,
+            SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
+                    paneExtractor,
+            PAssertionSite site,
+            AssertBase asserts) {
+      this.actual = actual;
+      this.asserts = asserts;
+
+      @SuppressWarnings("unchecked")
+      Coder<T> typedCoder = (Coder<T>) actual.getCoder().getCoderArguments().get(0);
+      this.elementCoder = typedCoder;
+
+      this.rewindowingStrategy = rewindowingStrategy;
+      this.paneExtractor = paneExtractor;
+      this.site = site;
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> inWindow(BoundedWindow window) {
+      return withPanes(window, PaneExtractors.<Iterable<T>>allPanes());
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> inFinalPane(BoundedWindow window) {
+      return withPanes(window, PaneExtractors.<Iterable<T>>finalPane());
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> inOnTimePane(BoundedWindow window) {
+      return withPanes(window, PaneExtractors.<Iterable<T>>onTimePane());
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
+      return withPanes(window, PaneExtractors.<Iterable<T>>nonLatePanes());
+    }
+
+    @Override
+    public IterableAssert<T> inEarlyGlobalWindowPanes() {
+      return withPanes(GlobalWindow.INSTANCE, PaneExtractors.<Iterable<T>>earlyPanes());
+    }
+
+    private PCollectionSingletonIterableAssert<T> withPanes(
+            BoundedWindow window,
+            SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
+                    paneExtractor) {
+      @SuppressWarnings({"unchecked", "rawtypes"})
+      Coder<BoundedWindow> windowCoder =
+              (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder();
+      return new PCollectionSingletonIterableAssert<>(
+              actual, IntoStaticWindows.of(windowCoder, window), paneExtractor, site, asserts);
+    }
+
+    @Override
+    @SafeVarargs
+    public final PCollectionSingletonIterableAssert<T> containsInAnyOrder(T... expectedElements) {
+      return containsInAnyOrder(Arrays.asList(expectedElements));
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> empty() {
+      return containsInAnyOrder(Collections.<T>emptyList());
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> containsInAnyOrder(Iterable<T> expectedElements) {
+      return satisfies(new AssertContainsInAnyOrderRelation<T>(asserts), expectedElements);
+    }
+
+    @Override
+    public PCollectionSingletonIterableAssert<T> satisfies(
+            SerializableFunction<Iterable<T>, Void> checkerFn) {
+      actual.apply(
+              "PAssert$" + (assertCount++),
+              new GroupThenAssertForSingleton<>(
+                      checkerFn, rewindowingStrategy, paneExtractor, site));
+      return this;
+    }
+
+    private PCollectionSingletonIterableAssert<T> satisfies(
+            AssertRelation<Iterable<T>, Iterable<T>> relation, Iterable<T> expectedElements) {
+      return satisfies(
+              new CheckRelationAgainstExpected<>(
+                      relation, expectedElements, IterableCoder.of(elementCoder)));
+    }
+  }
+
+  /**
+   * An assertion about the contents of a {@link PCollection} when it is viewed as a single value
+   * of type {@code ViewT}. This requires side input support from the runner.
+   */
+  private static class PCollectionViewAssert<ElemT, ViewT> implements SingletonAssert<ViewT> {
+    private final PCollection<ElemT> actual;
+    private final PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view;
+    private final AssertionWindows rewindowActuals;
+    private final SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>>
+            paneExtractor;
+    private final Coder<ViewT> coder;
+    private final PAssertionSite site;
+    private final AssertBase asserts;
+
+    protected PCollectionViewAssert(
+            PCollection<ElemT> actual,
+            PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view,
+            Coder<ViewT> coder,
+            PAssertionSite site,
+            AssertBase asserts) {
+      this(
+              actual,
+              view,
+              IntoGlobalWindow.of(),
+              PaneExtractors.<ElemT>allPanes(),
+              coder,
+              site,
+              asserts);
+    }
+
+    private PCollectionViewAssert(
+            PCollection<ElemT> actual,
+            PTransform<PCollection<ElemT>, PCollectionView<ViewT>> view,
+            AssertionWindows rewindowActuals,
+            SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>> paneExtractor,
+            Coder<ViewT> coder,
+            PAssertionSite site,
+            AssertBase asserts) {
+      this.actual = actual;
+      this.view = view;
+      this.rewindowActuals = rewindowActuals;
+      this.paneExtractor = paneExtractor;
+      this.coder = coder;
+      this.site = site;
+      this.asserts = asserts;
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> inOnlyPane(BoundedWindow window) {
+      return inPane(window, PaneExtractors.<ElemT>onlyPane(site));
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> inFinalPane(BoundedWindow window) {
+      return inPane(window, PaneExtractors.<ElemT>finalPane());
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> inOnTimePane(BoundedWindow window) {
+      return inPane(window, PaneExtractors.<ElemT>onTimePane());
+    }
+
+    private PCollectionViewAssert<ElemT, ViewT> inPane(
+            BoundedWindow window,
+            SimpleFunction<Iterable<ValueInSingleWindow<ElemT>>, Iterable<ElemT>> paneExtractor) {
+      return new PCollectionViewAssert<>(
+              actual,
+              view,
+              IntoStaticWindows.of(
+                      (Coder) actual.getWindowingStrategy().getWindowFn().windowCoder(), window),
+              paneExtractor,
+              coder,
+              site,
+              asserts);
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> isEqualTo(ViewT expectedValue) {
+      return satisfies(new AssertIsEqualToRelation<ViewT>(asserts), expectedValue);
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> notEqualTo(ViewT expectedValue) {
+      return satisfies(new AssertNotEqualToRelation<ViewT>(asserts), expectedValue);
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> satisfies(
+            SerializableFunction<ViewT, Void> checkerFn) {
+      actual
+              .getPipeline()
+              .apply(
+                      "PAssert$" + (assertCount++),
+                      new OneSideInputAssert<>(
+                              CreateActual.from(actual, rewindowActuals, paneExtractor, view),
+                              rewindowActuals.<Integer>windowDummy(),
+                              checkerFn,
+                              site));
+      return this;
+    }
+
+    /**
+     * Applies an {@link AssertRelation} to check the provided relation against the value of this
+     * assert and the provided expected value.
+     *
+     * <p>Returns this {@code SingletonAssert}.
+     */
+    private PCollectionViewAssert<ElemT, ViewT> satisfies(
+            AssertRelation<ViewT, ViewT> relation, final ViewT expectedValue) {
+      return satisfies(new CheckRelationAgainstExpected<>(relation, expectedValue, coder));
+    }
+
+    /**
+     * @throws UnsupportedOperationException always
+     * @deprecated {@link Object#equals(Object)} is not supported on PAssert objects. If you meant
+     * to test object equality, use {@link #isEqualTo} instead.
+     */
+    @Deprecated
+    @Override
+    public boolean equals(Object o) {
+      throw new UnsupportedOperationException(
+              String.format(
+                      "tests for Java equality of the %s object, not the PCollection in question. "
+                              + "Call a test method, such as isEqualTo.",
+                      getClass().getSimpleName()));
+    }
+
+    /**
+     * @throws UnsupportedOperationException always.
+     * @deprecated {@link Object#hashCode()} is not supported on {@link PAsserts} objects.
+     */
+    @Deprecated
+    @Override
+    public int hashCode() {
+      throw new UnsupportedOperationException(
+          String.format("%s.hashCode() is not supported.", SingletonAssert.class.getSimpleName()));
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////
+
+  private static class CreateActual<T, ActualT>
+          extends PTransform<PBegin, PCollectionView<ActualT>> {
+
+    private final transient PCollection<T> actual;
+    private final transient AssertionWindows rewindowActuals;
+    private final transient SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>>
+            extractPane;
+    private final transient PTransform<PCollection<T>, PCollectionView<ActualT>> actualView;
+
+    public static <T, ActualT> CreateActual<T, ActualT> from(
+            PCollection<T> actual,
+            AssertionWindows rewindowActuals,
+            SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> extractPane,
+            PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
+      return new CreateActual<>(actual, rewindowActuals, extractPane, actualView);
+    }
+
+    private CreateActual(
+            PCollection<T> actual,
+            AssertionWindows rewindowActuals,
+            SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> extractPane,
+            PTransform<PCollection<T>, PCollectionView<ActualT>> actualView) {
+      this.actual = actual;
+      this.rewindowActuals = rewindowActuals;
+      this.extractPane = extractPane;
+      this.actualView = actualView;
+    }
+
+    @Override
+    public PCollectionView<ActualT> expand(PBegin input) {
+      final Coder<T> coder = actual.getCoder();
+      return actual
+              .apply("FilterActuals", rewindowActuals.<T>prepareActuals())
+              .apply("GatherPanes", GatherAllPanes.<T>globally())
+              .apply("ExtractPane", MapElements.via(extractPane))
+              .setCoder(IterableCoder.of(actual.getCoder()))
+              .apply(Flatten.<T>iterables())
+              .apply("RewindowActuals", rewindowActuals.<T>windowActuals())
+              .apply(
+                  ParDo.of(
+                      new DoFn<T, T>() {
+                        @ProcessElement
+                        public void processElement(ProcessContext context) throws CoderException {
+                          context.output(CoderUtils.clone(coder, context.element()));
+                        }
+                      }))
+              .apply(actualView);
+    }
+  }
+
+  /**
+   * A partially applied {@link AssertRelation}, where one value is provided along with a coder to
+   * serialize/deserialize them.
+   */
+  private static class CheckRelationAgainstExpected<T> implements SerializableFunction<T, Void> {
+    private final AssertRelation<T, T> relation;
+    private final byte[] encodedExpected;
+    private final Coder<T> coder;
+
+    public CheckRelationAgainstExpected(AssertRelation<T, T> relation, T expected, Coder<T> coder) {
+      this.relation = relation;
+      this.coder = coder;
+
+      try {
+        this.encodedExpected = CoderUtils.encodeToByteArray(coder, expected);
+      } catch (IOException coderException) {
+        throw new RuntimeException(coderException);
+      }
+    }
+
+    @Override
+    public Void apply(T actual) {
+      try {
+        T expected = CoderUtils.decodeFromByteArray(coder, encodedExpected);
+        return relation.assertFor(expected).apply(actual);
+      } catch (IOException coderException) {
+        throw new RuntimeException(coderException);
+      }
+    }
+  }
+
+  /**
+   * A transform that gathers the contents of a {@link PCollection} into a single main input
+   * iterable in the global window. This requires a runner to support {@link GroupByKey} in the
+   * global window, but not side inputs or other windowing or triggers.
+   *
+   * <p>If the {@link PCollection} is empty, this transform returns a {@link PCollection} containing
+   * a single empty iterable, even though in practice most runners will not produce any element.
+   */
+  private static class GroupGlobally<T>
+          extends PTransform<PCollection<T>, PCollection<Iterable<ValueInSingleWindow<T>>>>
+          implements Serializable {
+    private final AssertionWindows rewindowingStrategy;
+
+    public GroupGlobally(AssertionWindows rewindowingStrategy) {
+      this.rewindowingStrategy = rewindowingStrategy;
+    }
+
+    @Override
+    public PCollection<Iterable<ValueInSingleWindow<T>>> expand(PCollection<T> input) {
+      final int combinedKey = 42;
+
+      // Remove the triggering on both
+      PTransform<
+              PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>,
+              PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>>>
+              removeTriggering =
+              Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
+                      .triggering(Never.ever())
+                      .discardingFiredPanes()
+                      .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness());
+      // Group the contents by key. If it is empty, this PCollection will be empty, too.
+      // Then key it again with a dummy key.
+      PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>> groupedContents =
+        // TODO: Split the filtering from the rewindowing, and apply filtering before the Gather
+        // if the grouping of extra records
+        input
+          .apply(rewindowingStrategy.<T>prepareActuals())
+          .apply("GatherAllOutputs", GatherAllPanes.<T>globally())
+          .apply(
+                  "RewindowActuals",
+                  rewindowingStrategy.<Iterable<ValueInSingleWindow<T>>>windowActuals())
+          .apply(
+                  "KeyForDummy",
+                  WithKeys.<Integer, Iterable<ValueInSingleWindow<T>>>of(combinedKey))
+          .apply("RemoveActualsTriggering", removeTriggering);
+
+      // Create another non-empty PCollection that is keyed with a distinct dummy key
+      PCollection<KV<Integer, Iterable<ValueInSingleWindow<T>>>> keyedDummy =
+        input
+          .getPipeline()
+          .apply(
+                  Create.of(
+                          KV.of(
+                                  combinedKey,
+                                  (Iterable<ValueInSingleWindow<T>>)
+                                          Collections.<ValueInSingleWindow<T>>emptyList()))
+                        .withCoder(groupedContents.getCoder()))
+          .apply(
+                  "WindowIntoDummy",
+                  rewindowingStrategy.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>windowDummy())
+          .apply("RemoveDummyTriggering", removeTriggering);
+
+      // Flatten them together and group by the combined key to get a single element
+      PCollection<KV<Integer, Iterable<Iterable<ValueInSingleWindow<T>>>>> dummyAndContents =
+        PCollectionList.of(groupedContents)
+           .and(keyedDummy)
+           .apply(
+                   "FlattenDummyAndContents",
+                   Flatten.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>pCollections())
+           .apply(
+                   "NeverTrigger",
+                   Window.<KV<Integer, Iterable<ValueInSingleWindow<T>>>>configure()
+                           .triggering(Never.ever())
+                           .withAllowedLateness(input.getWindowingStrategy().getAllowedLateness())
+                           .discardingFiredPanes())
+           .apply(
+                   "GroupDummyAndContents",
+                   GroupByKey.<Integer, Iterable<ValueInSingleWindow<T>>>create());
+
+      return dummyAndContents
+              .apply(Values.<Iterable<Iterable<ValueInSingleWindow<T>>>>create())
+              .apply(ParDo.of(new ConcatFn<ValueInSingleWindow<T>>()));
+    }
+  }
+
+  private static final class ConcatFn<T> extends DoFn<Iterable<Iterable<T>>, Iterable<T>> {
+    @ProcessElement
+    public void processElement(ProcessContext c) throws Exception {
+      c.output(Iterables.concat(c.element()));
+    }
+  }
+
+  /**
+   * A transform that applies an assertion-checking function over iterables of {@code ActualT} to
+   * the entirety of the contents of its input.
+   */
+  public static class GroupThenAssert<T> extends PTransform<PCollection<T>, PDone>
+          implements Serializable {
+    private final SerializableFunction<Iterable<T>, Void> checkerFn;
+    private final AssertionWindows rewindowingStrategy;
+    private final SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor;
+    private final PAssertionSite site;
+
+    private GroupThenAssert(
+            SerializableFunction<Iterable<T>, Void> checkerFn,
+            AssertionWindows rewindowingStrategy,
+            SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> paneExtractor,
+            PAssertionSite site) {
+      this.checkerFn = checkerFn;
+      this.rewindowingStrategy = rewindowingStrategy;
+      this.paneExtractor = paneExtractor;
+      this.site = site;
+    }
+
+    @Override
+    public PDone expand(PCollection<T> input) {
+      input
+              .apply("GroupGlobally", new GroupGlobally<T>(rewindowingStrategy))
+              .apply("GetPane", MapElements.via(paneExtractor))
+              .setCoder(IterableCoder.of(input.getCoder()))
+              .apply("RunChecks", ParDo.of(new GroupedValuesCheckerDoFn<>(checkerFn, site)))
+              .apply("VerifyAssertions", new DefaultConcludeTransform());
+
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /**
+   * A transform that applies an assertion-checking function to a single iterable contained as the
+   * sole element of a {@link PCollection}.
+   */
+  public static class GroupThenAssertForSingleton<T>
+          extends PTransform<PCollection<Iterable<T>>, PDone> implements Serializable {
+    private final SerializableFunction<Iterable<T>, Void> checkerFn;
+    private final AssertionWindows rewindowingStrategy;
+    private final SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
+            paneExtractor;
+    private final PAssertionSite site;
+
+    private GroupThenAssertForSingleton(
+            SerializableFunction<Iterable<T>, Void> checkerFn,
+            AssertionWindows rewindowingStrategy,
+            SimpleFunction<Iterable<ValueInSingleWindow<Iterable<T>>>, Iterable<Iterable<T>>>
+                    paneExtractor,
+            PAssertionSite site) {
+      this.checkerFn = checkerFn;
+      this.rewindowingStrategy = rewindowingStrategy;
+      this.paneExtractor = paneExtractor;
+      this.site = site;
+    }
+
+    @Override
+    public PDone expand(PCollection<Iterable<T>> input) {
+      input
+              .apply("GroupGlobally", new GroupGlobally<Iterable<T>>(rewindowingStrategy))
+              .apply("GetPane", MapElements.via(paneExtractor))
+              .setCoder(IterableCoder.of(input.getCoder()))
+              .apply("RunChecks", ParDo.of(new SingletonCheckerDoFn<>(checkerFn, site)))
+              .apply("VerifyAssertions", new DefaultConcludeTransform());
+
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /**
+   * An assertion checker that takes a single {@link PCollectionView
+   * PCollectionView&lt;ActualT&gt;} and an assertion over {@code ActualT},
+   * and checks it within a
+   * Beam pipeline.
+   *
+   * <p>Note that the entire assertion must be serializable.
+   *
+   * <p>This is generally useful for assertion functions that are serializable but whose underlying
+   * data may not have a coder.
+   */
+  public static class OneSideInputAssert<ActualT> extends PTransform<PBegin, PDone>
+          implements Serializable {
+    private final transient PTransform<PBegin, PCollectionView<ActualT>> createActual;
+    private final transient PTransform<PCollection<Integer>, PCollection<Integer>> windowToken;
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final PAssertionSite site;
+
+    private OneSideInputAssert(
+            PTransform<PBegin, PCollectionView<ActualT>> createActual,
+            PTransform<PCollection<Integer>, PCollection<Integer>> windowToken,
+            SerializableFunction<ActualT, Void> checkerFn,
+            PAssertionSite site) {
+      this.createActual = createActual;
+      this.windowToken = windowToken;
+      this.checkerFn = checkerFn;
+      this.site = site;
+    }
+
+    @Override
+    public PDone expand(PBegin input) {
+      final PCollectionView<ActualT> actual = input.apply("CreateActual", createActual);
+
+      input
+              .apply(Create.of(0).withCoder(VarIntCoder.of()))
+              .apply("WindowToken", windowToken)
+              .apply(
+                      "RunChecks",
+                      ParDo.of(new SideInputCheckerDoFn<>(checkerFn, actual, site))
+                           .withSideInputs(actual))
+              .apply("VerifyAssertions", new DefaultConcludeTransform());
+      return PDone.in(input.getPipeline());
+    }
+  }
+
+  /**
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of a
+   * {@link PCollectionView}, and adjusts counters and thrown exceptions for use in testing.
+   *
+   * <p>The input is ignored, but is {@link Integer} to be usable on runners that do not support
+   * null values.
+   */
+  private static class SideInputCheckerDoFn<ActualT> extends DoFn<Integer, SuccessOrFailure> {
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final PCollectionView<ActualT> actual;
+    private final PAssertionSite site;
+
+    private SideInputCheckerDoFn(
+            SerializableFunction<ActualT, Void> checkerFn,
+            PCollectionView<ActualT> actual,
+            PAssertionSite site) {
+      this.checkerFn = checkerFn;
+      this.actual = actual;
+      this.site = site;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      ActualT actualContents = c.sideInput(actual);
+      c.output(doChecks(site, actualContents, checkerFn));
+    }
+  }
+
+  /**
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
+   * the single iterable element of the input {@link PCollection} and adjusts counters and
+   * thrown exceptions for use in testing.
+   *
+   * <p>The singleton property is presumed, not enforced.
+   */
+  private static class GroupedValuesCheckerDoFn<ActualT> extends DoFn<ActualT, SuccessOrFailure> {
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final PAssertionSite site;
+
+    private GroupedValuesCheckerDoFn(
+            SerializableFunction<ActualT, Void> checkerFn, PAssertionSite site) {
+      this.checkerFn = checkerFn;
+      this.site = site;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      c.output(doChecks(site, c.element(), checkerFn));
+    }
+  }
+
+  /**
+   * A {@link DoFn} that runs a checking {@link SerializableFunction} on the contents of
+   * the single item contained within the single iterable on input and
+   * adjusts counters and thrown exceptions for use in testing.
+   *
+   * <p>The singleton property of the input {@link PCollection} is presumed, not enforced. However,
+   * each input element must be a singleton iterable, or this will fail.
+   */
+  private static class SingletonCheckerDoFn<ActualT>
+          extends DoFn<Iterable<ActualT>, SuccessOrFailure> {
+    private final SerializableFunction<ActualT, Void> checkerFn;
+    private final PAssertionSite site;
+
+    private SingletonCheckerDoFn(
+            SerializableFunction<ActualT, Void> checkerFn, PAssertionSite site) {
+      this.checkerFn = checkerFn;
+      this.site = site;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c) {
+      ActualT actualContents = Iterables.getOnlyElement(c.element());
+      c.output(doChecks(site, actualContents, checkerFn));
+    }
+  }
+
+  protected static <ActualT> SuccessOrFailure doChecks(
+          PAssertionSite site,
+          ActualT actualContents,
+          SerializableFunction<ActualT, Void> checkerFn) {
+    try {
+      checkerFn.apply(actualContents);
+      return SuccessOrFailure.success();
+    } catch (Throwable t) {
+      return SuccessOrFailure.failure(site, t);
+    }
+  }
+
+  /////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * A {@link SerializableFunction} that verifies that an actual value is equal to an expected
+   * value.
+   */
+  private static class AssertIsEqualTo<T> implements SerializableFunction<T, Void> {
+    private T expected;
+    private AssertBase asserts;
+
+    public AssertIsEqualTo(T expected, AssertBase asserts) {
+      this.expected = expected;
+      this.asserts = asserts;
+    }
+
+    @Override
+    @Nullable
+    public Void apply(T actual) {
+      asserts.assertEquals(actual, expected);
+      return null;
+    }
+  }
+
+  /**
+   * A {@link SerializableFunction} that verifies that an actual value is not equal to an expected
+   * value.
+   */
+  private static class AssertNotEqualTo<T> implements SerializableFunction<T, Void> {
+    private T expected;
+    private AssertBase asserts;
+
+    public AssertNotEqualTo(T expected, AssertBase asserts) {
+      this.expected = expected;
+      this.asserts = asserts;
+    }
+
+    @Override
+    @Nullable
+    public Void apply(T actual) {
+      asserts.assertNotEquals(actual, expected);
+      return null;
+    }
+  }
+
+  /**
+   * A {@link SerializableFunction} that verifies that an {@code Iterable} contains expected items
+   * in any order.
+   */
+  private static class AssertContainsInAnyOrder<T>
+          implements SerializableFunction<Iterable<T>, Void> {
+    private T[] expected;
+    private AssertBase asserts;
+
+    @SafeVarargs
+    public AssertContainsInAnyOrder(AssertBase asserts, T... expected) {
+      this.expected = expected;
+      this.asserts = asserts;
+    }
+
+    @SuppressWarnings("unchecked")
+    public AssertContainsInAnyOrder(Collection<T> expected, AssertBase asserts) {
+      this(asserts, (T[]) expected.toArray());
+    }
+
+    public AssertContainsInAnyOrder(Iterable<T> expected, AssertBase asserts) {
+      this(Lists.newArrayList(expected), asserts);
+    }
+
+    @Override
+    @Nullable
+    public Void apply(Iterable<T> actual) {
+      asserts.assertThat(actual, asserts.containsInAnyOrder(expected));
+      return null;
+    }
+  }
+
+  ////////////////////////////////////////////////////////////
+
+  /**
+   * A binary predicate between types {@code Actual} and {@code Expected}. Implemented as a method
+   * {@code assertFor(Expected)} which returns a {@code SerializableFunction<Actual, Void>} that
+   * should verify the assertion..
+   */
+  private interface AssertRelation<ActualT, ExpectedT> extends Serializable {
+    SerializableFunction<ActualT, Void> assertFor(ExpectedT input);
+  }
+
+  /**
+   * An {@link AssertRelation} implementing the binary predicate that two objects are equal.
+   */
+  private static class AssertIsEqualToRelation<T> implements AssertRelation<T, T> {
+    private AssertBase asserts;
+
+    private AssertIsEqualToRelation(AssertBase asserts) {
+      this.asserts = asserts;
+    }
+
+    @Override
+    public SerializableFunction<T, Void> assertFor(T expected) {
+      return new AssertIsEqualTo<>(expected, asserts);
+    }
+  }
+
+  /**
+   * An {@link AssertRelation} implementing the binary predicate that two objects are not equal.
+   */
+  private static class AssertNotEqualToRelation<T> implements AssertRelation<T, T> {
+    private AssertBase asserts;
+
+    private AssertNotEqualToRelation(AssertBase asserts) {
+      this.asserts = asserts;
+    }
+
+    @Override
+    public SerializableFunction<T, Void> assertFor(T expected) {
+      return new AssertNotEqualTo<>(expected, asserts);
+    }
+  }
+
+  /**
+   * An {@code AssertRelation} implementing the binary predicate that two collections are equal
+   * modulo reordering.
+   */
+  private static class AssertContainsInAnyOrderRelation<T>
+          implements AssertRelation<Iterable<T>, Iterable<T>> {
+    private AssertBase asserts;
+
+    private AssertContainsInAnyOrderRelation(AssertBase asserts) {
+      this.asserts = asserts;
+    }
+
+    @Override
+    public SerializableFunction<Iterable<T>, Void> assertFor(Iterable<T> expectedElements) {
+      return new AssertContainsInAnyOrder<>(expectedElements, asserts);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * A strategy for filtering and rewindowing the actual and dummy {@link PCollection PCollections}
+   * within a {@link PAsserts}.
+   *
+   * <p>This must ensure that the windowing strategies of the output of {@link #windowActuals()} and
+   * {@link #windowDummy()} are compatible (and can be {@link Flatten Flattened}).
+   *
+   * <p>The {@link PCollection} produced by {@link #prepareActuals()} will be a parent (though not
+   * a direct parent) of the transform provided to {@link #windowActuals()}.
+   */
+  private interface AssertionWindows {
+    /**
+     * Returns a transform that assigns the dummy element into the appropriate
+     * {@link BoundedWindow windows}.
+     */
+    <T> PTransform<PCollection<T>, PCollection<T>> windowDummy();
+
+    /**
+     * Returns a transform that filters and reassigns windows of the actual elements if necessary.
+     */
+    <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals();
+
+    /**
+     * Returns a transform that assigns the actual elements into the appropriate
+     * {@link BoundedWindow windows}. Will be called after {@link #prepareActuals()}.
+     */
+    <T> PTransform<PCollection<T>, PCollection<T>> windowActuals();
+  }
+
+  /**
+   * An {@link AssertionWindows} which assigns all elements to the {@link GlobalWindow}.
+   */
+  private static class IntoGlobalWindow implements AssertionWindows, Serializable {
+    public static AssertionWindows of() {
+      return new IntoGlobalWindow();
+    }
+
+    private <T> PTransform<PCollection<T>, PCollection<T>> window() {
+      return Window.into(new GlobalWindows());
+    }
+
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> windowDummy() {
+      return window();
+    }
+
+    /**
+     * Rewindows all input elements into the {@link GlobalWindow}. This ensures that the result
+     * PCollection will contain all of the elements of the PCollection when the window is not
+     * specified.
+     */
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals() {
+      return window();
+    }
+
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> windowActuals() {
+      return window();
+    }
+  }
+
+  private static class IntoStaticWindows implements AssertionWindows {
+    private final StaticWindows windowFn;
+
+    public static AssertionWindows of(Coder<BoundedWindow> windowCoder, BoundedWindow window) {
+      return new IntoStaticWindows(StaticWindows.of(windowCoder, window));
+    }
+
+    private IntoStaticWindows(StaticWindows windowFn) {
+      this.windowFn = windowFn;
+    }
+
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> windowDummy() {
+      return Window.into(windowFn);
+    }
+
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> prepareActuals() {
+      return new FilterWindows<>(windowFn);
+    }
+
+    @Override
+    public <T> PTransform<PCollection<T>, PCollection<T>> windowActuals() {
+      return Window.into(windowFn.intoOnlyExisting());
+    }
+  }
+
+  /**
+   * A DoFn that filters elements based on their presence in a static collection of windows.
+   */
+  private static final class FilterWindows<T> extends PTransform<PCollection<T>, PCollection<T>> {
+    private final StaticWindows windows;
+
+    public FilterWindows(StaticWindows windows) {
+      this.windows = windows;
+    }
+
+    @Override
+    public PCollection<T> expand(PCollection<T> input) {
+      return input.apply("FilterWindows", ParDo.of(new Fn()));
+    }
+
+    private class Fn extends DoFn<T, T> {
+      @ProcessElement
+      public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
+        if (windows.getWindows().contains(window)) {
+          c.output(c.element());
+        }
+      }
+    }
+  }
+
+  public static int countAsserts(Pipeline pipeline) {
+    AssertionCountingVisitor visitor = new AssertionCountingVisitor();
+    pipeline.traverseTopologically(visitor);
+    return visitor.getPAssertCount();
+  }
+
+  /**
+   * A {@link PipelineVisitor} that counts the number of total {@link PAsserts PAsserts} in a
+   * {@link Pipeline}.
+   */
+  private static class AssertionCountingVisitor extends PipelineVisitor.Defaults {
+    private int assertCount;
+    private boolean pipelineVisited;
+
+    private AssertionCountingVisitor() {
+      assertCount = 0;
+      pipelineVisited = false;
+    }
+
+    @Override
+    public CompositeBehavior enterCompositeTransform(Node node) {
+      if (node.isRootNode()) {
+        checkState(
+                !pipelineVisited,
+                "Tried to visit a pipeline with an already used %s",
+                AssertionCountingVisitor.class.getSimpleName());
+      }
+      if (!node.isRootNode()
+              && (node.getTransform() instanceof PAsserts.OneSideInputAssert
+              || node.getTransform() instanceof PAsserts.GroupThenAssert
+              || node.getTransform() instanceof PAsserts.GroupThenAssertForSingleton)) {
+        assertCount++;
+      }
+      return CompositeBehavior.ENTER_TRANSFORM;
+    }
+
+    public void leaveCompositeTransform(Node node) {
+      if (node.isRootNode()) {
+        pipelineVisited = true;
+      }
+    }
+
+    @Override
+    public void visitPrimitiveTransform(Node node) {
+      if
+              (node.getTransform() instanceof PAsserts.OneSideInputAssert
+              || node.getTransform() instanceof PAsserts.GroupThenAssert
+              || node.getTransform() instanceof PAsserts.GroupThenAssertForSingleton) {
+        assertCount++;
+      }
+    }
+
+    /**
+     * Gets the number of {@link PAsserts PAsserts} in the pipeline.
+     */
+    int getPAssertCount() {
+      checkState(pipelineVisited);
+      return assertCount;
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PaneExtractors.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PaneExtractors.java
@@ -41,7 +41,7 @@ final class PaneExtractors {
   }
 
   static <T> SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> onlyPane(
-      PAssert.PAssertionSite site) {
+      PAsserts.PAssertionSite site) {
     return new ExtractOnlyPane<>(site);
   }
 
@@ -67,9 +67,9 @@ final class PaneExtractors {
 
   private static class ExtractOnlyPane<T>
       extends SimpleFunction<Iterable<ValueInSingleWindow<T>>, Iterable<T>> {
-    private final PAssert.PAssertionSite site;
+    private final PAsserts.PAssertionSite site;
 
-    private ExtractOnlyPane(PAssert.PAssertionSite site) {
+    private ExtractOnlyPane(PAsserts.PAssertionSite site) {
       this.site = site;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SerializableMatchers.java
@@ -56,1125 +56,1135 @@ import org.hamcrest.Matchers;
  */
 class SerializableMatchers implements Serializable {
 
-  // Serializable only because of capture by anonymous inner classes
-  private SerializableMatchers() { } // not instantiable
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#allOf(Iterable)}.
-   */
-  public static <T> SerializableMatcher<T>
-  allOf(Iterable<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final Iterable<Matcher<? super T>> matchers = (Iterable) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.allOf(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#allOf(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T> allOf(final SerializableMatcher<T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.allOf(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anyOf(Iterable)}.
-   */
-  public static <T> SerializableMatcher<T>
-  anyOf(Iterable<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final Iterable<Matcher<? super T>> matchers = (Iterable) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.anyOf(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anyOf(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T> anyOf(final SerializableMatcher<T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.anyOf(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anything()}.
-   */
-  public static SerializableMatcher<Object> anything() {
-    return fromSupplier(new SerializableSupplier<Matcher<Object>>() {
-      @Override
-      public Matcher<Object> get() {
-        return Matchers.anything();
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContaining(Object[])}.
-   */
-  @SafeVarargs
-  public static <T extends Serializable> SerializableMatcher<T[]>
-  arrayContaining(final T... items) {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContaining(items);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContaining(Object[])}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
-   * explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T[]> arrayContaining(Coder<T> coder, T... items) {
-
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContaining(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContaining(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T[]>
-  arrayContaining(final SerializableMatcher<? super T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.<T>arrayContaining(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContaining(List)}.
-   */
-  public static <T> SerializableMatcher<T[]>
-  arrayContaining(List<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final List<Matcher<? super T>> matchers = (List) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContaining(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContainingInAnyOrder(Object[])}.
-   */
-  @SafeVarargs
-  public static <T extends Serializable> SerializableMatcher<T[]>
-  arrayContainingInAnyOrder(final T... items) {
-
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContainingInAnyOrder(items);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContainingInAnyOrder(Object[])}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
-   * explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(Coder<T> coder, T... items) {
-
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContaining(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContainingInAnyOrder(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(
-      final SerializableMatcher<? super T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.<T>arrayContainingInAnyOrder(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayContainingInAnyOrder(Collection)}.
-   */
-  public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(
-      Collection<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final Collection<Matcher<? super T>> matchers = (Collection) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayContainingInAnyOrder(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayWithSize(int)}.
-   */
-  public static <T> SerializableMatcher<T[]> arrayWithSize(final int size) {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayWithSize(size);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#arrayWithSize(Matcher)}.
-   */
-  public static <T> SerializableMatcher<T[]> arrayWithSize(
-      final SerializableMatcher<? super Integer> sizeMatcher) {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.arrayWithSize(sizeMatcher);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#closeTo(double,double)}.
-   */
-  public static SerializableMatcher<Double> closeTo(final double target, final double error) {
-    return fromSupplier(new SerializableSupplier<Matcher<Double>>() {
-      @Override
-      public Matcher<Double> get() {
-        return Matchers.closeTo(target, error);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#contains(Object[])}.
-   */
-  @SafeVarargs
-  public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>> contains(
-      final T... items) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.contains(items);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#contains(Object[])}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
-   * explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<Iterable<? extends T>>
-  contains(Coder<T> coder, T... items) {
-
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.containsInAnyOrder(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#contains(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<Iterable<? extends T>> contains(
-      final SerializableMatcher<? super T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.<T>contains(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#contains(List)}.
-   */
-  public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>> contains(
-      List<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final List<Matcher<? super T>> matchers = (List) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.contains(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#containsInAnyOrder(Object[])}.
-   */
-  @SafeVarargs
-  public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>>
-  containsInAnyOrder(final T... items) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.containsInAnyOrder(items);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#containsInAnyOrder(Object[])}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<Iterable<? extends T>>
-  containsInAnyOrder(Coder<T> coder, T... items) {
-
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.containsInAnyOrder(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#containsInAnyOrder(Matcher[])}.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<Iterable<? extends T>> containsInAnyOrder(
-      final SerializableMatcher<? super T>... matchers) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.<T>containsInAnyOrder(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#containsInAnyOrder(Collection)}.
-   */
-  public static <T> SerializableMatcher<Iterable<? extends T>> containsInAnyOrder(
-      Collection<SerializableMatcher<? super T>> serializableMatchers) {
-
-    @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
-    final Collection<Matcher<? super T>> matchers = (Collection) serializableMatchers;
-
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.containsInAnyOrder(matchers);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#containsString}.
-   */
-  public static SerializableMatcher<String> containsString(final String substring) {
-    return fromSupplier(new SerializableSupplier<Matcher<String>>() {
-      @Override
-      public Matcher<String> get() {
-        return Matchers.containsString(substring);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#empty()}.
-   */
-  public static <T> SerializableMatcher<Collection<? extends T>> empty() {
-    return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
-      @Override
-      public Matcher<Collection<? extends T>> get() {
-        return Matchers.empty();
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#emptyArray()}.
-   */
-  public static <T> SerializableMatcher<T[]> emptyArray() {
-    return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
-      @Override
-      public Matcher<T[]> get() {
-        return Matchers.emptyArray();
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#emptyIterable()}.
-   */
-  public static <T> SerializableMatcher<Iterable<? extends T>> emptyIterable() {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
-      @Override
-      public Matcher<Iterable<? extends T>> get() {
-        return Matchers.emptyIterable();
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#endsWith}.
-   */
-  public static SerializableMatcher<String> endsWith(final String substring) {
-    return fromSupplier(new SerializableSupplier<Matcher<String>>() {
-      @Override
-      public Matcher<String> get() {
-        return Matchers.endsWith(substring);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#equalTo(Object)}.
-   */
-  public static <T extends Serializable> SerializableMatcher<T> equalTo(final T expected) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.equalTo(expected);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#equalTo(Object)}.
-   *
-   * <p>The expected value of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T> SerializableMatcher<T> equalTo(Coder<T> coder, T expected) {
-
-    final SerializableSupplier<T> expectedSupplier = new SerializableViaCoder<>(coder, expected);
-
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.equalTo(expectedSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#greaterThan(Comparable)}.
-   */
-  public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
-  greaterThan(final T target) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.greaterThan(target);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#greaterThan(Comparable)}.
-   *
-   * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
-  greaterThan(final Coder<T> coder, T target) {
-    final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.greaterThan(targetSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#greaterThanOrEqualTo(Comparable)}.
-   */
-  public static <T extends Comparable<T>> SerializableMatcher<T> greaterThanOrEqualTo(
-      final T target) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.greaterThanOrEqualTo(target);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#greaterThanOrEqualTo(Comparable)}.
-   *
-   * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
-  greaterThanOrEqualTo(final Coder<T> coder, T target) {
-    final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.greaterThanOrEqualTo(targetSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Object)}.
-   */
-  public static <T extends Serializable> SerializableMatcher<Iterable<? super T>> hasItem(
-      final T target) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
-      @Override
-      public Matcher<Iterable<? super T>> get() {
-        return Matchers.hasItem(target);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Object)}.
-   *
-   * <p>The item of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T> SerializableMatcher<Iterable<? super T>> hasItem(Coder<T> coder, T target) {
-    final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
-      @Override
-      public Matcher<Iterable<? super T>> get() {
-        return Matchers.hasItem(targetSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Matcher)}.
-   */
-  public static <T> SerializableMatcher<Iterable<? super T>> hasItem(
-      final SerializableMatcher<? super T> matcher) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
-      @Override
-      public Matcher<Iterable<? super T>> get() {
-        return Matchers.hasItem(matcher);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasSize(int)}.
-   */
-  public static <T> SerializableMatcher<Collection<? extends T>> hasSize(final int size) {
-    return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
-      @Override
-      public Matcher<Collection<? extends T>> get() {
-        return Matchers.hasSize(size);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasSize(Matcher)}.
-   */
-  public static <T> SerializableMatcher<Collection<? extends T>> hasSize(
-      final SerializableMatcher<? super Integer> sizeMatcher) {
-    return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
-      @Override
-      public Matcher<Collection<? extends T>> get() {
-        return Matchers.hasSize(sizeMatcher);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#iterableWithSize(int)}.
-   */
-  public static <T> SerializableMatcher<Iterable<T>> iterableWithSize(final int size) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<T>>>() {
-      @Override
-      public Matcher<Iterable<T>> get() {
-        return Matchers.iterableWithSize(size);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#iterableWithSize(Matcher)}.
-   */
-  public static <T> SerializableMatcher<Iterable<T>> iterableWithSize(
-      final SerializableMatcher<? super Integer> sizeMatcher) {
-    return fromSupplier(new SerializableSupplier<Matcher<Iterable<T>>>() {
-      @Override
-      public Matcher<Iterable<T>> get() {
-        return Matchers.iterableWithSize(sizeMatcher);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Collection)}.
-   */
-  public static <T extends Serializable> SerializableMatcher<T>
-  isIn(final Collection<T> collection) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isIn(collection);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Collection)}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
-   * They are explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T> SerializableMatcher<T> isIn(Coder<T> coder, Collection<T> collection) {
-    @SuppressWarnings("unchecked")
-    T[] items = (T[]) collection.toArray();
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isIn(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Object[])}.
-   */
-  public static <T extends Serializable> SerializableMatcher<T> isIn(final T[] items) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isIn(items);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Object[])}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
-   * They are explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T> SerializableMatcher<T> isIn(Coder<T> coder, T[] items) {
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isIn(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isOneOf}.
-   */
-  @SafeVarargs
-  public static <T extends Serializable> SerializableMatcher<T> isOneOf(final T... elems) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isOneOf(elems);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isOneOf}.
-   *
-   * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
-   * They are explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  @SafeVarargs
-  public static <T> SerializableMatcher<T> isOneOf(Coder<T> coder, T... items) {
-    final SerializableSupplier<T[]> itemsSupplier =
-        new SerializableArrayViaCoder<>(coder, items);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.isOneOf(itemsSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with the specified key.
-   */
-  public static <K extends Serializable, V> SerializableMatcher<KV<? extends K, ? extends V>>
-  kvWithKey(K key) {
-    return new KvKeyMatcher<K, V>(equalTo(key));
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with the specified key.
-   *
-   * <p>The key of type {@code K} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>>
-  kvWithKey(Coder<K> coder, K key) {
-    return new KvKeyMatcher<K, V>(equalTo(coder, key));
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with matching key.
-   */
-  public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kvWithKey(
-      final SerializableMatcher<? super K> keyMatcher) {
-    return new KvKeyMatcher<K, V>(keyMatcher);
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with the specified value.
-   */
-  public static <K, V extends Serializable> SerializableMatcher<KV<? extends K, ? extends V>>
-  kvWithValue(V value) {
-    return new KvValueMatcher<K, V>(equalTo(value));
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with the specified value.
-   *
-   * <p>The value of type {@code V} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>>
-  kvWithValue(Coder<V> coder, V value) {
-    return new KvValueMatcher<K, V>(equalTo(coder, value));
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with matching value.
-   */
-  public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kvWithValue(
-      final SerializableMatcher<? super V> valueMatcher) {
-    return new KvValueMatcher<>(valueMatcher);
-  }
-
-  /**
-   * A {@link SerializableMatcher} that matches any {@link KV} with matching key and value.
-   */
-  public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kv(
-      final SerializableMatcher<? super K> keyMatcher,
-      final SerializableMatcher<? super V> valueMatcher) {
-
-    return SerializableMatchers.<KV<? extends K, ? extends V>>allOf(
-        SerializableMatchers.<K, V>kvWithKey(keyMatcher),
-        SerializableMatchers.<K, V>kvWithValue(valueMatcher));
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#lessThan(Comparable)}.
-   */
-  public static <T extends Comparable<T> & Serializable> SerializableMatcher<T> lessThan(
-      final T target) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.lessThan(target);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#lessThan(Comparable)}.
-   *
-   * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T extends Comparable<T>> SerializableMatcher<T>
-  lessThan(Coder<T> coder, T target) {
-    final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.lessThan(targetSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#lessThanOrEqualTo(Comparable)}.
-   */
-  public static <T extends Comparable<T> & Serializable> SerializableMatcher<T> lessThanOrEqualTo(
-      final T target) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.lessThanOrEqualTo(target);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#lessThanOrEqualTo(Comparable)}.
-   *
-   * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
-   * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
-   */
-  public static <T extends Comparable<T>> SerializableMatcher<T> lessThanOrEqualTo(
-      Coder<T> coder, T target) {
-    final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.lessThanOrEqualTo(targetSupplier.get());
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#not}.
-   */
-  public static <T> SerializableMatcher<T> not(final SerializableMatcher<T> matcher) {
-    return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-      @Override
-      public Matcher<T> get() {
-        return Matchers.not(matcher);
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to
-   * {@link Matchers#nullValue}.
-   */
-  public static SerializableMatcher<Object> nullValue() {
-    return fromSupplier(new SerializableSupplier<Matcher<Object>>() {
-      @Override
-      public Matcher<Object> get() {
-        return Matchers.nullValue();
-      }
-    });
-  }
-
-  /**
-   * A {@link SerializableMatcher} with identical criteria to {@link Matchers#startsWith}.
-   */
-  public static SerializableMatcher<String> startsWith(final String substring) {
-    return fromSupplier(new SerializableSupplier<Matcher<String>>() {
-      @Override
-      public Matcher<String> get() {
-        return Matchers.startsWith(substring);
-      }
-    });
-  }
-
-  private static class KvKeyMatcher<K, V>
-  extends BaseMatcher<KV<? extends K, ? extends V>>
-  implements SerializableMatcher<KV<? extends K, ? extends V>> {
-    private final SerializableMatcher<? super K> keyMatcher;
-
-    public KvKeyMatcher(SerializableMatcher<? super K> keyMatcher) {
-      this.keyMatcher = keyMatcher;
+    // Serializable only because of capture by anonymous inner classes
+    private SerializableMatchers() { } // not instantiable
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#allOf(Iterable)}.
+     */
+    public static <T> SerializableMatcher<T>
+    allOf(Iterable<SerializableMatcher<? super T>> serializableMatchers) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final Iterable<Matcher<? super T>> matchers = (Iterable) serializableMatchers;
+
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.allOf(matchers);
+            }
+        });
     }
 
-    @Override
-    public boolean matches(Object item) {
-      @SuppressWarnings("unchecked")
-      KV<K, ?> kvItem = (KV<K, ?>) item;
-      return keyMatcher.matches(kvItem.getKey());
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#allOf(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T> allOf(final SerializableMatcher<T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.allOf(matchers);
+            }
+        });
     }
 
-    @Override
-    public void describeMismatch(Object item, Description mismatchDescription) {
-      @SuppressWarnings("unchecked")
-      KV<K, ?> kvItem = (KV<K, ?>) item;
-      if (!keyMatcher.matches(kvItem.getKey())) {
-        mismatchDescription.appendText("key did not match: ");
-        keyMatcher.describeMismatch(kvItem.getKey(), mismatchDescription);
-      }
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anyOf(Iterable)}.
+     */
+    public static <T> SerializableMatcher<T>
+    anyOf(Iterable<SerializableMatcher<? super T>> serializableMatchers) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final Iterable<Matcher<? super T>> matchers = (Iterable) serializableMatchers;
+
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.anyOf(matchers);
+            }
+        });
     }
 
-    @Override
-    public void describeTo(Description description) {
-      description.appendText("KV with key matching ");
-      keyMatcher.describeTo(description);
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anyOf(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T> anyOf(final SerializableMatcher<T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.anyOf(matchers);
+            }
+        });
     }
 
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .addValue(keyMatcher)
-          .toString();
-    }
-  }
-
-  private static class KvValueMatcher<K, V>
-  extends BaseMatcher<KV<? extends K, ? extends V>>
-  implements SerializableMatcher<KV<? extends K, ? extends V>> {
-    private final SerializableMatcher<? super V> valueMatcher;
-
-    public KvValueMatcher(SerializableMatcher<? super V> valueMatcher) {
-      this.valueMatcher = valueMatcher;
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#anything()}.
+     */
+    public static SerializableMatcher<Object> anything() {
+        return fromSupplier(new SerializableSupplier<Matcher<Object>>() {
+            @Override
+            public Matcher<Object> get() {
+                return Matchers.anything();
+            }
+        });
     }
 
-    @Override
-    public boolean matches(Object item) {
-      @SuppressWarnings("unchecked")
-      KV<?, V> kvItem = (KV<?, V>) item;
-      return valueMatcher.matches(kvItem.getValue());
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContaining(Object[])}.
+     */
+    @SafeVarargs
+    public static <T extends Serializable> SerializableMatcher<T[]>
+    arrayContaining(final T... items) {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContaining(items);
+            }
+        });
     }
 
-    @Override
-    public void describeMismatch(Object item, Description mismatchDescription) {
-      @SuppressWarnings("unchecked")
-      KV<?, V> kvItem = (KV<?, V>) item;
-      if (!valueMatcher.matches(kvItem.getValue())) {
-        mismatchDescription.appendText("value did not match: ");
-        valueMatcher.describeMismatch(kvItem.getValue(), mismatchDescription);
-      }
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContaining(Object[])}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
+     * explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T[]> arrayContaining(Coder<T> coder, T... items) {
+
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContaining(itemsSupplier.get());
+            }
+        });
     }
 
-    @Override
-    public void describeTo(Description description) {
-      description.appendText("KV with value matching ");
-      valueMatcher.describeTo(description);
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContaining(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T[]>
+    arrayContaining(final SerializableMatcher<? super T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.<T>arrayContaining(matchers);
+            }
+        });
     }
 
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .addValue(valueMatcher)
-          .toString();
-    }
-  }
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContaining(List)}.
+     */
+    public static <T> SerializableMatcher<T[]>
+    arrayContaining(List<SerializableMatcher<? super T>> serializableMatchers) {
 
-  /**
-   * Constructs a {@link SerializableMatcher} from a non-serializable {@link Matcher} via
-   * indirection through {@link SerializableSupplier}.
-   *
-   * <p>To wrap a {@link Matcher} which is not serializable, provide a {@link SerializableSupplier}
-   * with a {@link SerializableSupplier#get()} method that returns a fresh instance of the
-   * {@link Matcher} desired. The resulting {@link SerializableMatcher} will behave according to
-   * the {@link Matcher} returned by {@link SerializableSupplier#get() get()} when it is invoked
-   * during matching (which may occur on another machine).
-   *
-   * <pre>{@code
-   * return fromSupplier(new SerializableSupplier<Matcher<T>>() {
-   *   *     @Override
-   *     public Matcher<T> get() {
-   *       return new MyMatcherForT();
-   *     }
-   * });
-   * }</pre>
-   */
-  public static <T> SerializableMatcher<T> fromSupplier(
-      SerializableSupplier<Matcher<T>> supplier) {
-    return new SerializableMatcherFromSupplier<>(supplier);
-  }
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final List<Matcher<? super T>> matchers = (List) serializableMatchers;
 
-  /**
-   * Supplies values of type {@code T}, and is serializable. Thus, even if {@code T} is not
-   * serializable, the supplier can be serialized and provide a {@code T} wherever it is
-   * deserialized.
-   *
-   * @param <T> the type of value supplied.
-   */
-  public interface SerializableSupplier<T> extends Serializable {
-    T get();
-  }
-
-  /**
-   * Since the delegate {@link Matcher} is not generally serializable, instead this takes a nullary
-   * SerializableFunction to return such a matcher.
-   */
-  private static class SerializableMatcherFromSupplier<T> extends BaseMatcher<T>
-  implements SerializableMatcher<T> {
-
-    private SerializableSupplier<Matcher<T>> supplier;
-
-    public SerializableMatcherFromSupplier(SerializableSupplier<Matcher<T>> supplier) {
-      this.supplier = supplier;
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContaining(matchers);
+            }
+        });
     }
 
-    @Override
-    public void describeTo(Description description) {
-      supplier.get().describeTo(description);
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContainingInAnyOrder(Object[])}.
+     */
+    @SafeVarargs
+    public static <T extends Serializable> SerializableMatcher<T[]>
+    arrayContainingInAnyOrder(final T... items) {
+
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContainingInAnyOrder(items);
+            }
+        });
     }
 
-    @Override
-    public boolean matches(Object item) {
-      return supplier.get().matches(item);
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContainingInAnyOrder(Object[])}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
+     * explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(Coder<T> coder,
+                                                                         T... items) {
+
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContaining(itemsSupplier.get());
+            }
+        });
     }
 
-    @Override
-    public void describeMismatch(Object item, Description mismatchDescription) {
-      supplier.get().describeMismatch(item, mismatchDescription);
-    }
-  }
-
-  /**
-   * Wraps any value that can be encoded via a {@link Coder} to make it {@link Serializable}.
-   * This is not likely to be a good encoding, so should be used only for tests, where data
-   * volume is small and minor costs are not critical.
-   */
-  private static class SerializableViaCoder<T> implements SerializableSupplier<T> {
-    /** Cached value that is not serialized. */
-    @Nullable
-    private transient T value;
-
-    /** The bytes of {@link #value} when encoded via {@link #coder}. */
-    private byte[] encodedValue;
-
-    private Coder<T> coder;
-
-    public SerializableViaCoder(Coder<T> coder, T value) {
-      this.coder = coder;
-      this.value = value;
-      try {
-        this.encodedValue = CoderUtils.encodeToByteArray(coder, value);
-      } catch (CoderException exc) {
-        throw new RuntimeException("Error serializing via Coder", exc);
-      }
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContainingInAnyOrder(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(
+            final SerializableMatcher<? super T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.<T>arrayContainingInAnyOrder(matchers);
+            }
+        });
     }
 
-    @Override
-    public T get() {
-      if (value == null) {
-        try {
-          value = CoderUtils.decodeFromByteArray(coder, encodedValue);
-        } catch (CoderException exc) {
-          throw new RuntimeException("Error deserializing via Coder", exc);
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayContainingInAnyOrder(Collection)}.
+     */
+    public static <T> SerializableMatcher<T[]> arrayContainingInAnyOrder(
+            Collection<SerializableMatcher<? super T>> serializableMatchers) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final Collection<Matcher<? super T>> matchers = (Collection) serializableMatchers;
+
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayContainingInAnyOrder(matchers);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayWithSize(int)}.
+     */
+    public static <T> SerializableMatcher<T[]> arrayWithSize(final int size) {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayWithSize(size);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#arrayWithSize(Matcher)}.
+     */
+    public static <T> SerializableMatcher<T[]> arrayWithSize(
+            final SerializableMatcher<? super Integer> sizeMatcher) {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.arrayWithSize(sizeMatcher);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#closeTo(double,double)}.
+     */
+    public static SerializableMatcher<Double> closeTo(final double target, final double error) {
+        return fromSupplier(new SerializableSupplier<Matcher<Double>>() {
+            @Override
+            public Matcher<Double> get() {
+                return Matchers.closeTo(target, error);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#contains(Object[])}.
+     */
+    @SafeVarargs
+    public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>> contains(
+            final T... items) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.contains(items);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#contains(Object[])}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}. They are
+     * explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<Iterable<? extends T>>
+    contains(Coder<T> coder, T... items) {
+
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.containsInAnyOrder(itemsSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#contains(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<Iterable<? extends T>> contains(
+            final SerializableMatcher<? super T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.<T>contains(matchers);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#contains(List)}.
+     */
+    public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>> contains(
+            List<SerializableMatcher<? super T>> serializableMatchers) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final List<Matcher<? super T>> matchers = (List) serializableMatchers;
+
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.contains(matchers);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#containsInAnyOrder(Object[])}.
+     */
+    @SafeVarargs
+    public static <T extends Serializable> SerializableMatcher<Iterable<? extends T>>
+    containsInAnyOrder(final T... items) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.containsInAnyOrder(items);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#containsInAnyOrder(Object[])}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<Iterable<? extends T>>
+    containsInAnyOrder(Coder<T> coder, T... items) {
+
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.containsInAnyOrder(itemsSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#containsInAnyOrder(Matcher[])}.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<Iterable<? extends T>> containsInAnyOrder(
+            final SerializableMatcher<? super T>... matchers) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.<T>containsInAnyOrder(matchers);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#containsInAnyOrder(Collection)}.
+     */
+    public static <T> SerializableMatcher<Iterable<? extends T>> containsInAnyOrder(
+            Collection<SerializableMatcher<? super T>> serializableMatchers) {
+
+        @SuppressWarnings({"rawtypes", "unchecked"}) // safe covariant cast
+        final Collection<Matcher<? super T>> matchers = (Collection) serializableMatchers;
+
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.containsInAnyOrder(matchers);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#containsString}.
+     */
+    public static SerializableMatcher<String> containsString(final String substring) {
+        return fromSupplier(new SerializableSupplier<Matcher<String>>() {
+            @Override
+            public Matcher<String> get() {
+                return Matchers.containsString(substring);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#empty()}.
+     */
+    public static <T> SerializableMatcher<Collection<? extends T>> empty() {
+        return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
+            @Override
+            public Matcher<Collection<? extends T>> get() {
+                return Matchers.empty();
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#emptyArray()}.
+     */
+    public static <T> SerializableMatcher<T[]> emptyArray() {
+        return fromSupplier(new SerializableSupplier<Matcher<T[]>>() {
+            @Override
+            public Matcher<T[]> get() {
+                return Matchers.emptyArray();
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#emptyIterable()}.
+     */
+    public static <T> SerializableMatcher<Iterable<? extends T>> emptyIterable() {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? extends T>>>() {
+            @Override
+            public Matcher<Iterable<? extends T>> get() {
+                return Matchers.emptyIterable();
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#endsWith}.
+     */
+    public static SerializableMatcher<String> endsWith(final String substring) {
+        return fromSupplier(new SerializableSupplier<Matcher<String>>() {
+            @Override
+            public Matcher<String> get() {
+                return Matchers.endsWith(substring);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#equalTo(Object)}.
+     */
+    public static <T extends Serializable> SerializableMatcher<T> equalTo(final T expected) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.equalTo(expected);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#equalTo(Object)}.
+     *
+     * <p>The expected value of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T> SerializableMatcher<T> equalTo(Coder<T> coder, T expected) {
+
+        final SerializableSupplier<T> expectedSupplier =
+                new SerializableViaCoder<>(coder, expected);
+
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.equalTo(expectedSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#greaterThan(Comparable)}.
+     */
+    public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
+    greaterThan(final T target) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.greaterThan(target);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#greaterThan(Comparable)}.
+     *
+     * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
+    greaterThan(final Coder<T> coder, T target) {
+        final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.greaterThan(targetSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#greaterThanOrEqualTo(Comparable)}.
+     */
+    public static <T extends Comparable<T>> SerializableMatcher<T> greaterThanOrEqualTo(
+            final T target) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.greaterThanOrEqualTo(target);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#greaterThanOrEqualTo(Comparable)}.
+     *
+     * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
+    greaterThanOrEqualTo(final Coder<T> coder, T target) {
+        final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.greaterThanOrEqualTo(targetSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Object)}.
+     */
+    public static <T extends Serializable> SerializableMatcher<Iterable<? super T>> hasItem(
+            final T target) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
+            @Override
+            public Matcher<Iterable<? super T>> get() {
+                return Matchers.hasItem(target);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Object)}.
+     *
+     * <p>The item of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T> SerializableMatcher<Iterable<? super T>> hasItem(Coder<T> coder, T target) {
+        final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
+            @Override
+            public Matcher<Iterable<? super T>> get() {
+                return Matchers.hasItem(targetSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasItem(Matcher)}.
+     */
+    public static <T> SerializableMatcher<Iterable<? super T>> hasItem(
+            final SerializableMatcher<? super T> matcher) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<? super T>>>() {
+            @Override
+            public Matcher<Iterable<? super T>> get() {
+                return Matchers.hasItem(matcher);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasSize(int)}.
+     */
+    public static <T> SerializableMatcher<Collection<? extends T>> hasSize(final int size) {
+        return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
+            @Override
+            public Matcher<Collection<? extends T>> get() {
+                return Matchers.hasSize(size);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#hasSize(Matcher)}.
+     */
+    public static <T> SerializableMatcher<Collection<? extends T>> hasSize(
+            final SerializableMatcher<? super Integer> sizeMatcher) {
+        return fromSupplier(new SerializableSupplier<Matcher<Collection<? extends T>>>() {
+            @Override
+            public Matcher<Collection<? extends T>> get() {
+                return Matchers.hasSize(sizeMatcher);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#iterableWithSize(int)}.
+     */
+    public static <T> SerializableMatcher<Iterable<T>> iterableWithSize(final int size) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<T>>>() {
+            @Override
+            public Matcher<Iterable<T>> get() {
+                return Matchers.iterableWithSize(size);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#iterableWithSize(Matcher)}.
+     */
+    public static <T> SerializableMatcher<Iterable<T>> iterableWithSize(
+            final SerializableMatcher<? super Integer> sizeMatcher) {
+        return fromSupplier(new SerializableSupplier<Matcher<Iterable<T>>>() {
+            @Override
+            public Matcher<Iterable<T>> get() {
+                return Matchers.iterableWithSize(sizeMatcher);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Collection)}.
+     */
+    public static <T extends Serializable> SerializableMatcher<T>
+    isIn(final Collection<T> collection) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isIn(collection);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Collection)}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
+     * They are explicitly <i>not</i> required or expected
+     * to be serializable via Java serialization.
+     */
+    public static <T> SerializableMatcher<T> isIn(Coder<T> coder, Collection<T> collection) {
+        @SuppressWarnings("unchecked")
+        T[] items = (T[]) collection.toArray();
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isIn(itemsSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Object[])}.
+     */
+    public static <T extends Serializable> SerializableMatcher<T> isIn(final T[] items) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isIn(items);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isIn(Object[])}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
+     * They are explicitly <i>not</i> required or expected
+     * to be serializable via Java serialization.
+     */
+    public static <T> SerializableMatcher<T> isIn(Coder<T> coder, T[] items) {
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isIn(itemsSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isOneOf}.
+     */
+    @SafeVarargs
+    public static <T extends Serializable> SerializableMatcher<T> isOneOf(final T... elems) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isOneOf(elems);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#isOneOf}.
+     *
+     * <p>The items of type {@code T} will be serialized using the provided {@link Coder}.
+     * They are explicitly <i>not</i> required or expected
+     * to be serializable via Java serialization.
+     */
+    @SafeVarargs
+    public static <T> SerializableMatcher<T> isOneOf(Coder<T> coder, T... items) {
+        final SerializableSupplier<T[]> itemsSupplier =
+                new SerializableArrayViaCoder<>(coder, items);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.isOneOf(itemsSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with the specified key.
+     */
+    public static <K extends Serializable, V> SerializableMatcher<KV<? extends K, ? extends V>>
+    kvWithKey(K key) {
+        return new KvKeyMatcher<K, V>(equalTo(key));
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with the specified key.
+     *
+     * <p>The key of type {@code K} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>>
+    kvWithKey(Coder<K> coder, K key) {
+        return new KvKeyMatcher<K, V>(equalTo(coder, key));
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with matching key.
+     */
+    public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kvWithKey(
+            final SerializableMatcher<? super K> keyMatcher) {
+        return new KvKeyMatcher<K, V>(keyMatcher);
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with the specified value.
+     */
+    public static <K, V extends Serializable> SerializableMatcher<KV<? extends K, ? extends V>>
+    kvWithValue(V value) {
+        return new KvValueMatcher<K, V>(equalTo(value));
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with the specified value.
+     *
+     * <p>The value of type {@code V} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>>
+    kvWithValue(Coder<V> coder, V value) {
+        return new KvValueMatcher<K, V>(equalTo(coder, value));
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with matching value.
+     */
+    public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kvWithValue(
+            final SerializableMatcher<? super V> valueMatcher) {
+        return new KvValueMatcher<>(valueMatcher);
+    }
+
+    /**
+     * A {@link SerializableMatcher} that matches any {@link KV} with matching key and value.
+     */
+    public static <K, V> SerializableMatcher<KV<? extends K, ? extends V>> kv(
+            final SerializableMatcher<? super K> keyMatcher,
+            final SerializableMatcher<? super V> valueMatcher) {
+
+        return SerializableMatchers.<KV<? extends K, ? extends V>>allOf(
+                SerializableMatchers.<K, V>kvWithKey(keyMatcher),
+                SerializableMatchers.<K, V>kvWithValue(valueMatcher));
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#lessThan(Comparable)}.
+     */
+    public static <T extends Comparable<T> & Serializable> SerializableMatcher<T> lessThan(
+            final T target) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.lessThan(target);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#lessThan(Comparable)}.
+     *
+     * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T extends Comparable<T>> SerializableMatcher<T>
+    lessThan(Coder<T> coder, T target) {
+        final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.lessThan(targetSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#lessThanOrEqualTo(Comparable)}.
+     */
+    public static <T extends Comparable<T> & Serializable> SerializableMatcher<T>
+    lessThanOrEqualTo(final T target) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.lessThanOrEqualTo(target);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#lessThanOrEqualTo(Comparable)}.
+     *
+     * <p>The target value of type {@code T} will be serialized using the provided {@link Coder}.
+     * It is explicitly <i>not</i> required or expected to be serializable via Java serialization.
+     */
+    public static <T extends Comparable<T>> SerializableMatcher<T> lessThanOrEqualTo(
+            Coder<T> coder, T target) {
+        final SerializableSupplier<T> targetSupplier = new SerializableViaCoder<>(coder, target);
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.lessThanOrEqualTo(targetSupplier.get());
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#not}.
+     */
+    public static <T> SerializableMatcher<T> not(final SerializableMatcher<T> matcher) {
+        return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+            @Override
+            public Matcher<T> get() {
+                return Matchers.not(matcher);
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to
+     * {@link Matchers#nullValue}.
+     */
+    public static SerializableMatcher<Object> nullValue() {
+        return fromSupplier(new SerializableSupplier<Matcher<Object>>() {
+            @Override
+            public Matcher<Object> get() {
+                return Matchers.nullValue();
+            }
+        });
+    }
+
+    /**
+     * A {@link SerializableMatcher} with identical criteria to {@link Matchers#startsWith}.
+     */
+    public static SerializableMatcher<String> startsWith(final String substring) {
+        return fromSupplier(new SerializableSupplier<Matcher<String>>() {
+            @Override
+            public Matcher<String> get() {
+                return Matchers.startsWith(substring);
+            }
+        });
+    }
+
+    private static class KvKeyMatcher<K, V>
+            extends BaseMatcher<KV<? extends K, ? extends V>>
+            implements SerializableMatcher<KV<? extends K, ? extends V>> {
+        private final SerializableMatcher<? super K> keyMatcher;
+
+        public KvKeyMatcher(SerializableMatcher<? super K> keyMatcher) {
+            this.keyMatcher = keyMatcher;
         }
-      }
-      return value;
-    }
-  }
 
-  /**
-   * Wraps any array with values that can be encoded via a {@link Coder} to make it
-   * {@link Serializable}. This is not likely to be a good encoding, so should be used only for
-   * tests, where data volume is small and minor costs are not critical.
-   */
-  private static class SerializableArrayViaCoder<T> implements SerializableSupplier<T[]> {
-    /** Cached value that is not serialized. */
-    @Nullable
-    private transient T[] value;
-
-    /** The bytes of {@link #value} when encoded via {@link #coder}. */
-    private byte[] encodedValue;
-
-    private Coder<List<T>> coder;
-
-    public SerializableArrayViaCoder(Coder<T> elementCoder, T[] value) {
-      this.coder = ListCoder.of(elementCoder);
-      this.value = value;
-      try {
-        this.encodedValue = CoderUtils.encodeToByteArray(coder, Arrays.asList(value));
-      } catch (CoderException exc) {
-        throw UserCodeException.wrap(exc);
-      }
-    }
-
-    @Override
-    public T[] get() {
-      if (value == null) {
-        try {
-          @SuppressWarnings("unchecked")
-          T[] decoded = (T[]) CoderUtils.decodeFromByteArray(coder, encodedValue).toArray();
-          value = decoded;
-        } catch (CoderException exc) {
-          throw new RuntimeException("Error deserializing via Coder", exc);
+        @Override
+        public boolean matches(Object item) {
+            @SuppressWarnings("unchecked")
+            KV<K, ?> kvItem = (KV<K, ?>) item;
+            return keyMatcher.matches(kvItem.getKey());
         }
-      }
-      return value;
+
+        @Override
+        public void describeMismatch(Object item, Description mismatchDescription) {
+            @SuppressWarnings("unchecked")
+            KV<K, ?> kvItem = (KV<K, ?>) item;
+            if (!keyMatcher.matches(kvItem.getKey())) {
+                mismatchDescription.appendText("key did not match: ");
+                keyMatcher.describeMismatch(kvItem.getKey(), mismatchDescription);
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("KV with key matching ");
+            keyMatcher.describeTo(description);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .addValue(keyMatcher)
+                              .toString();
+        }
     }
-  }
+
+    private static class KvValueMatcher<K, V>
+            extends BaseMatcher<KV<? extends K, ? extends V>>
+            implements SerializableMatcher<KV<? extends K, ? extends V>> {
+        private final SerializableMatcher<? super V> valueMatcher;
+
+        public KvValueMatcher(SerializableMatcher<? super V> valueMatcher) {
+            this.valueMatcher = valueMatcher;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            @SuppressWarnings("unchecked")
+            KV<?, V> kvItem = (KV<?, V>) item;
+            return valueMatcher.matches(kvItem.getValue());
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description mismatchDescription) {
+            @SuppressWarnings("unchecked")
+            KV<?, V> kvItem = (KV<?, V>) item;
+            if (!valueMatcher.matches(kvItem.getValue())) {
+                mismatchDescription.appendText("value did not match: ");
+                valueMatcher.describeMismatch(kvItem.getValue(), mismatchDescription);
+            }
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("KV with value matching ");
+            valueMatcher.describeTo(description);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .addValue(valueMatcher)
+                              .toString();
+        }
+    }
+
+    /**
+     * Constructs a {@link SerializableMatcher} from a non-serializable {@link Matcher} via
+     * indirection through {@link SerializableSupplier}.
+     *
+     * <p>To wrap a {@link Matcher} which is not serializable, provide a
+     * {@link SerializableSupplier}
+     * with a {@link SerializableSupplier#get()} method that returns a fresh instance of the
+     * {@link Matcher} desired. The resulting {@link SerializableMatcher} will behave according to
+     * the {@link Matcher} returned by {@link SerializableSupplier#get() get()} when it is invoked
+     * during matching (which may occur on another machine).
+     *
+     * <pre>{@code
+     * return fromSupplier(new SerializableSupplier<Matcher<T>>() {
+     *   *     @Override
+     *     public Matcher<T> get() {
+     *       return new MyMatcherForT();
+     *     }
+     * });
+     * }</pre>
+     */
+    public static <T> SerializableMatcher<T> fromSupplier(
+            SerializableSupplier<Matcher<T>> supplier) {
+        return new SerializableMatcherFromSupplier<>(supplier);
+    }
+
+    /**
+     * Supplies values of type {@code T}, and is serializable. Thus, even if {@code T} is not
+     * serializable, the supplier can be serialized and provide a {@code T} wherever it is
+     * deserialized.
+     *
+     * @param <T> the type of value supplied.
+     */
+    public interface SerializableSupplier<T> extends Serializable {
+        T get();
+    }
+
+    /**
+     * Since the delegate {@link Matcher} is not generally serializable,
+     * instead this takes a nullary
+     * SerializableFunction to return such a matcher.
+     */
+    private static class SerializableMatcherFromSupplier<T> extends BaseMatcher<T>
+            implements SerializableMatcher<T> {
+
+        private SerializableSupplier<Matcher<T>> supplier;
+
+        public SerializableMatcherFromSupplier(SerializableSupplier<Matcher<T>> supplier) {
+            this.supplier = supplier;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            supplier.get().describeTo(description);
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            return supplier.get().matches(item);
+        }
+
+        @Override
+        public void describeMismatch(Object item, Description mismatchDescription) {
+            supplier.get().describeMismatch(item, mismatchDescription);
+        }
+    }
+
+    /**
+     * Wraps any value that can be encoded via a {@link Coder} to make it {@link Serializable}.
+     * This is not likely to be a good encoding, so should be used only for tests, where data
+     * volume is small and minor costs are not critical.
+     */
+    private static class SerializableViaCoder<T> implements SerializableSupplier<T> {
+        /** Cached value that is not serialized. */
+        @Nullable
+        private transient T value;
+
+        /** The bytes of {@link #value} when encoded via {@link #coder}. */
+        private byte[] encodedValue;
+
+        private Coder<T> coder;
+
+        public SerializableViaCoder(Coder<T> coder, T value) {
+            this.coder = coder;
+            this.value = value;
+            try {
+                this.encodedValue = CoderUtils.encodeToByteArray(coder, value);
+            } catch (CoderException exc) {
+                throw new RuntimeException("Error serializing via Coder", exc);
+            }
+        }
+
+        @Override
+        public T get() {
+            if (value == null) {
+                try {
+                    value = CoderUtils.decodeFromByteArray(coder, encodedValue);
+                } catch (CoderException exc) {
+                    throw new RuntimeException("Error deserializing via Coder", exc);
+                }
+            }
+            return value;
+        }
+    }
+
+    /**
+     * Wraps any array with values that can be encoded via a {@link Coder} to make it
+     * {@link Serializable}. This is not likely to be a good encoding, so should be used only for
+     * tests, where data volume is small and minor costs are not critical.
+     */
+    private static class SerializableArrayViaCoder<T> implements SerializableSupplier<T[]> {
+        /** Cached value that is not serialized. */
+        @Nullable
+        private transient T[] value;
+
+        /** The bytes of {@link #value} when encoded via {@link #coder}. */
+        private byte[] encodedValue;
+
+        private Coder<List<T>> coder;
+
+        public SerializableArrayViaCoder(Coder<T> elementCoder, T[] value) {
+            this.coder = ListCoder.of(elementCoder);
+            this.value = value;
+            try {
+                this.encodedValue = CoderUtils.encodeToByteArray(coder, Arrays.asList(value));
+            } catch (CoderException exc) {
+                throw UserCodeException.wrap(exc);
+            }
+        }
+
+        @Override
+        public T[] get() {
+            if (value == null) {
+                try {
+                    @SuppressWarnings("unchecked")
+                    T[] decoded = (T[]) CoderUtils.decodeFromByteArray(
+                            coder, encodedValue).toArray();
+                    value = decoded;
+                } catch (CoderException exc) {
+                    throw new RuntimeException("Error deserializing via Coder", exc);
+                }
+            }
+            return value;
+        }
+    }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SuccessOrFailure.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/SuccessOrFailure.java
@@ -32,13 +32,13 @@ public final class SuccessOrFailure implements Serializable {
 
   private final boolean isSuccess;
   @Nullable
-  private final PAssert.PAssertionSite site;
+  private final PAsserts.PAssertionSite site;
   @Nullable
   private final SerializableThrowable throwable;
 
   private SuccessOrFailure(
       boolean isSuccess,
-      @Nullable PAssert.PAssertionSite site,
+      @Nullable PAsserts.PAssertionSite site,
       @Nullable Throwable throwable) {
     this.isSuccess = isSuccess;
     this.site = site;
@@ -58,7 +58,7 @@ public final class SuccessOrFailure implements Serializable {
     return new SuccessOrFailure(true, null, null);
   }
 
-  public static SuccessOrFailure failure(@Nullable PAssert.PAssertionSite site,
+  public static SuccessOrFailure failure(@Nullable PAsserts.PAssertionSite site,
       @Nullable Throwable t) {
     return new SuccessOrFailure(false, site, t);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -18,46 +18,14 @@
 package org.apache.beam.sdk.testing;
 
 import static com.google.common.base.Preconditions.checkState;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
 import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Maps;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.UUID;
-import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
-import org.apache.beam.sdk.annotations.Internal;
-import org.apache.beam.sdk.io.FileSystems;
-import org.apache.beam.sdk.metrics.MetricNameFilter;
-import org.apache.beam.sdk.metrics.MetricResult;
-import org.apache.beam.sdk.metrics.MetricsEnvironment;
-import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
-import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
-import org.apache.beam.sdk.runners.TransformHierarchy;
-import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -107,159 +75,13 @@ import org.junit.runners.model.Statement;
  * section.</p>
  */
 public class TestPipeline extends Pipeline implements TestRule {
-
-  private final PipelineOptions options;
-
-  private static class PipelineRunEnforcement {
-
-    @SuppressWarnings("WeakerAccess")
-    protected boolean enableAutoRunIfMissing;
-
-    protected final Pipeline pipeline;
-
-    protected boolean runAttempted;
-
-    private PipelineRunEnforcement(final Pipeline pipeline) {
-      this.pipeline = pipeline;
-    }
-
-    protected void enableAutoRunIfMissing(final boolean enable) {
-      enableAutoRunIfMissing = enable;
-    }
-
-    protected void beforePipelineExecution() {
-      runAttempted = true;
-    }
-
-    protected void afterPipelineExecution() {}
-
-    protected void afterUserCodeFinished() {
-      if (!runAttempted && enableAutoRunIfMissing) {
-        pipeline.run().waitUntilFinish();
-      }
-    }
-  }
-
-  private static class PipelineAbandonedNodeEnforcement extends PipelineRunEnforcement {
-
-    // Null until the pipeline has been run
-    @Nullable private List<TransformHierarchy.Node> runVisitedNodes;
-
-    private final Predicate<TransformHierarchy.Node> isPAssertNode =
-        new Predicate<TransformHierarchy.Node>() {
-
-          @Override
-          public boolean apply(final TransformHierarchy.Node node) {
-            return node.getTransform() instanceof PAssert.GroupThenAssert
-                || node.getTransform() instanceof PAssert.GroupThenAssertForSingleton
-                || node.getTransform() instanceof PAssert.OneSideInputAssert;
-          }
-        };
-
-    private static class NodeRecorder extends PipelineVisitor.Defaults {
-
-      private final List<TransformHierarchy.Node> visited = new LinkedList<>();
-
-      @Override
-      public void leaveCompositeTransform(final TransformHierarchy.Node node) {
-        visited.add(node);
-      }
-
-      @Override
-      public void visitPrimitiveTransform(final TransformHierarchy.Node node) {
-        visited.add(node);
-      }
-    }
-
-    private PipelineAbandonedNodeEnforcement(final TestPipeline pipeline) {
-      super(pipeline);
-      runVisitedNodes = null;
-    }
-
-    private List<TransformHierarchy.Node> recordPipelineNodes(final Pipeline pipeline) {
-      final NodeRecorder nodeRecorder = new NodeRecorder();
-      pipeline.traverseTopologically(nodeRecorder);
-      return nodeRecorder.visited;
-    }
-
-    private boolean isEmptyPipeline(final Pipeline pipeline) {
-      final IsEmptyVisitor isEmptyVisitor = new IsEmptyVisitor();
-      pipeline.traverseTopologically(isEmptyVisitor);
-      return isEmptyVisitor.isEmpty();
-    }
-
-    private void verifyPipelineExecution() {
-      if (!isEmptyPipeline(pipeline)) {
-        if (!runAttempted && !enableAutoRunIfMissing) {
-          throw new PipelineRunMissingException("The pipeline has not been run.");
-
-        } else {
-          final List<TransformHierarchy.Node> pipelineNodes = recordPipelineNodes(pipeline);
-          if (pipelineRunSucceeded() && !visitedAll(pipelineNodes)) {
-            final boolean hasDanglingPAssert =
-                FluentIterable.from(pipelineNodes)
-                    .filter(Predicates.not(Predicates.in(runVisitedNodes)))
-                    .anyMatch(isPAssertNode);
-            if (hasDanglingPAssert) {
-              throw new AbandonedNodeException("The pipeline contains abandoned PAssert(s).");
-            } else {
-              throw new AbandonedNodeException("The pipeline contains abandoned PTransform(s).");
-            }
-          }
-        }
-      }
-    }
-
-    private boolean visitedAll(final List<TransformHierarchy.Node> pipelineNodes) {
-      return runVisitedNodes.equals(pipelineNodes);
-    }
-
-    private boolean pipelineRunSucceeded() {
-      return runVisitedNodes != null;
-    }
-
-    @Override
-    protected void afterPipelineExecution() {
-      runVisitedNodes = recordPipelineNodes(pipeline);
-      super.afterPipelineExecution();
-    }
-
-    @Override
-    protected void afterUserCodeFinished() {
-      super.afterUserCodeFinished();
-      verifyPipelineExecution();
-    }
-  }
-
   /**
-   * An exception thrown in case an abandoned {@link org.apache.beam.sdk.transforms.PTransform} is
-   * detected, that is, a {@link org.apache.beam.sdk.transforms.PTransform} that has not been run.
+   * @deprecated use TestPipelineHandler flavor instead
    */
-  public static class AbandonedNodeException extends RuntimeException {
-
-    AbandonedNodeException(final String msg) {
-      super(msg);
-    }
-  }
-
-  /** An exception thrown in case a test finishes without invoking {@link Pipeline#run()}. */
-  public static class PipelineRunMissingException extends RuntimeException {
-
-    PipelineRunMissingException(final String msg) {
-      super(msg);
-    }
-  }
-
-  /** System property used to set {@link TestPipelineOptions}. */
+  @Deprecated
   public static final String PROPERTY_BEAM_TEST_PIPELINE_OPTIONS = "beamTestPipelineOptions";
 
-  static final String PROPERTY_USE_DEFAULT_DUMMY_RUNNER = "beamUseDummyRunner";
-
-  private static final ObjectMapper MAPPER = new ObjectMapper().registerModules(
-      ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
-
-  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-  private Optional<? extends PipelineRunEnforcement> enforcement = Optional.absent();
+  private final TestPipelineHandler<Description> execution;
 
   /**
    * Creates and returns a new test pipeline.
@@ -277,242 +99,75 @@ public class TestPipeline extends Pipeline implements TestRule {
 
   private TestPipeline(final PipelineOptions options) {
     super(options);
-    this.options = options;
+    this.execution = new TestPipelineHandler<Description>(options) {
+      @Override
+      protected boolean doesNeedRunner(final Description description) {
+        return FluentIterable.from(description.getAnnotations())
+           .filter(Annotations.Predicates.isAnnotationOfType(Category.class))
+           .anyMatch(Annotations.Predicates.isCategoryOf(NeedsRunner.class, true));
+      }
+
+      /** Returns the class + method name of the test. */
+      @Override
+      protected String getAppName(final Description description) {
+        final String methodName = description.getMethodName();
+        final Class<?> testClass = description.getTestClass();
+        return appName(testClass, methodName);
+      }
+    };
+  }
+
+  public <T> ValueProvider<T> newProvider(final T runtimeValue) {
+    return execution.newProvider(runtimeValue);
+  }
+
+  public TestPipeline enableAbandonedNodeEnforcement(final boolean enable) {
+    execution.enableAbandonedNodeEnforcement(enable);
+    return this;
+  }
+
+  public TestPipeline enableAutoRunIfMissing(final boolean enable) {
+    execution.enableAutoRunIfMissing(enable);
+    return this;
+  }
+
+  @Override
+  public PipelineResult run() {
+    checkState(
+            execution.isEnforcementPresent(),
+            "Is your TestPipeline declaration missing a @Rule annotation? Usage: "
+                  + "@Rule public final transient TestPipeline pipeline = TestPipeline.create();");
+    return super.run();
   }
 
   public PipelineOptions getOptions() {
-    return this.options;
+    return execution.getOptions();
   }
 
   @Override
   public Statement apply(final Statement statement, final Description description) {
     return new Statement() {
-
-      private void setDeducedEnforcementLevel() {
-        // if the enforcement level has not been set by the user do auto-inference
-        if (!enforcement.isPresent()) {
-
-          final boolean annotatedWithNeedsRunner =
-              FluentIterable.from(description.getAnnotations())
-                  .filter(Annotations.Predicates.isAnnotationOfType(Category.class))
-                  .anyMatch(Annotations.Predicates.isCategoryOf(NeedsRunner.class, true));
-
-          final boolean crashingRunner =
-              CrashingRunner.class.isAssignableFrom(options.getRunner());
-
-          checkState(
-              !(annotatedWithNeedsRunner && crashingRunner),
-              "The test was annotated with a [@%s] / [@%s] while the runner "
-                  + "was set to [%s]. Please re-check your configuration.",
-              NeedsRunner.class.getSimpleName(),
-              ValidatesRunner.class.getSimpleName(),
-              CrashingRunner.class.getSimpleName());
-
-          enableAbandonedNodeEnforcement(annotatedWithNeedsRunner || !crashingRunner);
-        }
-      }
-
       @Override
       public void evaluate() throws Throwable {
-        options.as(ApplicationNameOptions.class).setAppName(getAppName(description));
-
-        setDeducedEnforcementLevel();
-
-        // statement.evaluate() essentially runs the user code contained in the unit test at hand.
-        // Exceptions thrown during the execution of the user's test code will propagate here,
-        // unless the user explicitly handles them with a "catch" clause in his code. If the
-        // exception is handled by a user's "catch" clause, is does not interrupt the flow and
-        // we move on to invoking the configured enforcements.
-        // If the user does not handle a thrown exception, it will propagate here and interrupt
-        // the flow, preventing the enforcement(s) from being activated.
-        // The motivation for this is avoiding enforcements over faulty pipelines.
-        statement.evaluate();
-        enforcement.get().afterUserCodeFinished();
+        try (final AutoCloseable closeable = execution.start(description)) {
+          statement.evaluate();
+        }
       }
     };
   }
 
-  /**
-   * Runs this {@link TestPipeline}, unwrapping any {@code AssertionError} that is raised during
-   * testing.
-   */
-  public PipelineResult run() {
-    return run(getOptions());
-  }
-
-  /** Like {@link #run} but with the given potentially modified options. */
-  public PipelineResult run(PipelineOptions options) {
-    checkState(
-        enforcement.isPresent(),
-        "Is your TestPipeline declaration missing a @Rule annotation? Usage: "
-            + "@Rule public final transient TestPipeline pipeline = TestPipeline.create();");
-
-    final PipelineResult pipelineResult;
-    try {
-      enforcement.get().beforePipelineExecution();
-      PipelineOptions updatedOptions =
-          MAPPER.convertValue(MAPPER.valueToTree(options), PipelineOptions.class);
-      updatedOptions
-          .as(TestValueProviderOptions.class)
-          .setProviderRuntimeValues(StaticValueProvider.of(providerRuntimeValues));
-      pipelineResult = super.run(updatedOptions);
-      verifyPAssertsSucceeded(this, pipelineResult);
-    } catch (RuntimeException exc) {
-      Throwable cause = exc.getCause();
-      if (cause instanceof AssertionError) {
-        throw (AssertionError) cause;
-      } else {
-        throw exc;
-      }
-    }
-
-    // If we reach this point, the pipeline has been run and no exceptions have been thrown during
-    // its execution.
-    enforcement.get().afterPipelineExecution();
-    return pipelineResult;
-  }
-
-  /** Implementation detail of {@link #newProvider}, do not use. */
-  @Internal
-  public interface TestValueProviderOptions extends PipelineOptions {
-    ValueProvider<Map<String, Object>> getProviderRuntimeValues();
-    void setProviderRuntimeValues(ValueProvider<Map<String, Object>> runtimeValues);
-  }
-
-  /**
-   * Returns a new {@link ValueProvider} that is inaccessible before {@link #run}, but will be
-   * accessible while the pipeline runs.
-   */
-  public <T> ValueProvider<T> newProvider(T runtimeValue) {
-    String uuid = UUID.randomUUID().toString();
-    providerRuntimeValues.put(uuid, runtimeValue);
-    return ValueProvider.NestedValueProvider.of(
-        options.as(TestValueProviderOptions.class).getProviderRuntimeValues(),
-        new GetFromRuntimeValues<T>(uuid));
-  }
-
-  private final Map<String, Object> providerRuntimeValues = Maps.newHashMap();
-
-  private static class GetFromRuntimeValues<T>
-      implements SerializableFunction<Map<String, Object>, T> {
-    private final String key;
-
-    private GetFromRuntimeValues(String key) {
-      this.key = key;
-    }
-
-    @Override
-    public T apply(Map<String, Object> input) {
-      return (T) input.get(key);
-    }
-  }
-
-  /**
-   * Enables the abandoned node detection. Abandoned nodes are <code>PTransforms</code>, <code>
-   * PAsserts</code> included, that were not executed by the pipeline runner. Abandoned nodes are
-   * most likely to occur due to the one of the following scenarios:
-   * <ul>
-   * <li>Lack of a <code>pipeline.run()</code> statement at the end of a test.
-   * <li>Addition of PTransforms after the pipeline has already run.
-   * </ul>
-   * Abandoned node detection is automatically enabled when a real pipeline runner (i.e. not a
-   * {@link CrashingRunner}) and/or a {@link NeedsRunner} or a {@link ValidatesRunner} annotation
-   * are detected.
-   */
-  public TestPipeline enableAbandonedNodeEnforcement(final boolean enable) {
-    enforcement =
-        enable
-            ? Optional.of(new PipelineAbandonedNodeEnforcement(this))
-            : Optional.of(new PipelineRunEnforcement(this));
-
-    return this;
-  }
-
-  /**
-   * If enabled, a <code>pipeline.run()</code> statement will be added automatically in case it is
-   * missing in the test.
-   */
-  public TestPipeline enableAutoRunIfMissing(final boolean enable) {
-    enforcement.get().enableAutoRunIfMissing(enable);
-    return this;
-  }
-
   @Override
   public String toString() {
-    return "TestPipeline#" + options.as(ApplicationNameOptions.class).getAppName();
+    return "TestPipeline#" + getOptions().as(ApplicationNameOptions.class).getAppName();
   }
 
   /** Creates {@link PipelineOptions} for testing. */
   public static PipelineOptions testingPipelineOptions() {
-    try {
-      @Nullable
-      String beamTestPipelineOptions = System.getProperty(PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
-
-      PipelineOptions options =
-          Strings.isNullOrEmpty(beamTestPipelineOptions)
-              ? PipelineOptionsFactory.create()
-              : PipelineOptionsFactory.fromArgs(
-              MAPPER.readValue(beamTestPipelineOptions, String[].class))
-              .as(TestPipelineOptions.class);
-
-      // If no options were specified, set some reasonable defaults
-      if (Strings.isNullOrEmpty(beamTestPipelineOptions)) {
-        // If there are no provided options, check to see if a dummy runner should be used.
-        String useDefaultDummy = System.getProperty(PROPERTY_USE_DEFAULT_DUMMY_RUNNER);
-        if (!Strings.isNullOrEmpty(useDefaultDummy) && Boolean.valueOf(useDefaultDummy)) {
-          options.setRunner(CrashingRunner.class);
-        }
-      }
-      options.setStableUniqueNames(CheckEnabled.ERROR);
-
-      FileSystems.setDefaultPipelineOptions(options);
-      return options;
-    } catch (IOException e) {
-      throw new RuntimeException(
-          "Unable to instantiate test options from system property "
-              + PROPERTY_BEAM_TEST_PIPELINE_OPTIONS
-              + ":"
-              + System.getProperty(PROPERTY_BEAM_TEST_PIPELINE_OPTIONS),
-          e);
-    }
+    return TestPipelineHandler.testingPipelineOptions();
   }
 
   public static String[] convertToArgs(PipelineOptions options) {
-    try {
-      byte[] opts = MAPPER.writeValueAsBytes(options);
-
-      JsonParser jsonParser = MAPPER.getFactory().createParser(opts);
-      TreeNode node = jsonParser.readValueAsTree();
-      ObjectNode optsNode = (ObjectNode) node.get("options");
-      ArrayList<String> optArrayList = new ArrayList<>();
-      Iterator<Entry<String, JsonNode>> entries = optsNode.fields();
-      while (entries.hasNext()) {
-        Entry<String, JsonNode> entry = entries.next();
-        if (entry.getValue().isNull()) {
-          continue;
-        } else if (entry.getValue().isTextual()) {
-          optArrayList.add("--" + entry.getKey() + "=" + entry.getValue().asText());
-        } else {
-          optArrayList.add("--" + entry.getKey() + "=" + entry.getValue());
-        }
-      }
-      return optArrayList.toArray(new String[optArrayList.size()]);
-    } catch (IOException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  /** Returns the class + method name of the test. */
-  private String getAppName(Description description) {
-    String methodName = description.getMethodName();
-    Class<?> testClass = description.getTestClass();
-    if (testClass.isMemberClass()) {
-      return String.format(
-          "%s$%s-%s",
-          testClass.getEnclosingClass().getSimpleName(), testClass.getSimpleName(), methodName);
-    } else {
-      return String.format("%s-%s", testClass.getSimpleName(), methodName);
-    }
+    return TestPipelineHandler.convertToArgs(options);
   }
 
   /**
@@ -522,38 +177,10 @@ public class TestPipeline extends Pipeline implements TestRule {
    * this in some other way. See: https://issues.apache.org/jira/browse/BEAM-2001</p>
    */
   public static void verifyPAssertsSucceeded(Pipeline pipeline, PipelineResult pipelineResult) {
-    if (MetricsEnvironment.isMetricsSupported()) {
-      long expectedNumberOfAssertions = (long) PAssert.countAsserts(pipeline);
-
-      long successfulAssertions = 0;
-      Iterable<MetricResult<Long>> successCounterResults =
-          pipelineResult.metrics().queryMetrics(
-              MetricsFilter.builder()
-                  .addNameFilter(MetricNameFilter.named(PAssert.class, PAssert.SUCCESS_COUNTER))
-                  .build())
-              .counters();
-      for (MetricResult<Long> counter : successCounterResults) {
-        if (counter.attempted() > 0) {
-          successfulAssertions++;
-        }
-      }
-
-      assertThat(String
-          .format("Expected %d successful assertions, but found %d.", expectedNumberOfAssertions,
-              successfulAssertions), successfulAssertions, is(expectedNumberOfAssertions));
-    }
-  }
-
-  private static class IsEmptyVisitor extends PipelineVisitor.Defaults {
-    private boolean empty = true;
-
-    public boolean isEmpty() {
-      return empty;
-    }
-
-    @Override
-    public void visitPrimitiveTransform(TransformHierarchy.Node node) {
-      empty = false;
+    try {
+      TestPipelineHandler.verifyPAssertsSucceeded(pipeline, pipelineResult);
+    } catch (final IllegalStateException ise) { // backward compatibility
+      fail(ise.getMessage());
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipelineHandler.java
@@ -1,0 +1,499 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Maps;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.metrics.MetricNameFilter;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricsEnvironment;
+import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.sdk.options.ApplicationNameOptions;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.runners.TransformHierarchy;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+
+/**
+ * Handler allowing to execute pipeline in tests.
+ * This abstraction is portable accross testing frameworks.
+ *
+ * @param <T> the type used by the integration to handle specific configuration like app name.
+ */
+public abstract class TestPipelineHandler<T> extends Pipeline {
+
+  private final PipelineOptions options;
+
+  private static class PipelineRunEnforcement {
+
+    @SuppressWarnings("WeakerAccess")
+    protected boolean enableAutoRunIfMissing;
+
+    protected final Pipeline pipeline;
+
+    protected boolean runAttempted;
+
+    private PipelineRunEnforcement(final Pipeline pipeline) {
+      this.pipeline = pipeline;
+    }
+
+    protected void enableAutoRunIfMissing(final boolean enable) {
+      enableAutoRunIfMissing = enable;
+    }
+
+    protected void beforePipelineExecution() {
+      runAttempted = true;
+    }
+
+    protected void afterPipelineExecution() {}
+
+    protected void afterUserCodeFinished() {
+      if (!runAttempted && enableAutoRunIfMissing) {
+        pipeline.run().waitUntilFinish();
+      }
+    }
+  }
+
+  private static class PipelineAbandonedNodeEnforcement extends PipelineRunEnforcement {
+
+    // Null until the pipeline has been run
+    @Nullable private List<TransformHierarchy.Node> runVisitedNodes;
+
+    private final Predicate<TransformHierarchy.Node> isPAssertNode =
+        new Predicate<TransformHierarchy.Node>() {
+
+          @Override
+          public boolean apply(final TransformHierarchy.Node node) {
+            return node.getTransform() instanceof PAsserts.GroupThenAssert
+                || node.getTransform() instanceof PAsserts.GroupThenAssertForSingleton
+                || node.getTransform() instanceof PAsserts.OneSideInputAssert;
+          }
+        };
+
+    private static class NodeRecorder extends PipelineVisitor.Defaults {
+
+      private final List<TransformHierarchy.Node> visited = new LinkedList<>();
+
+      @Override
+      public void leaveCompositeTransform(final TransformHierarchy.Node node) {
+        visited.add(node);
+      }
+
+      @Override
+      public void visitPrimitiveTransform(final TransformHierarchy.Node node) {
+        visited.add(node);
+      }
+    }
+
+    private PipelineAbandonedNodeEnforcement(final TestPipelineHandler pipeline) {
+      super(pipeline);
+      runVisitedNodes = null;
+    }
+
+    private List<TransformHierarchy.Node> recordPipelineNodes(final Pipeline pipeline) {
+      final NodeRecorder nodeRecorder = new NodeRecorder();
+      pipeline.traverseTopologically(nodeRecorder);
+      return nodeRecorder.visited;
+    }
+
+    private boolean isEmptyPipeline(final Pipeline pipeline) {
+      final IsEmptyVisitor isEmptyVisitor = new IsEmptyVisitor();
+      pipeline.traverseTopologically(isEmptyVisitor);
+      return isEmptyVisitor.isEmpty();
+    }
+
+    private void verifyPipelineExecution() {
+      if (!isEmptyPipeline(pipeline)) {
+        if (!runAttempted && !enableAutoRunIfMissing) {
+          throw new PipelineRunMissingException("The pipeline has not been run.");
+
+        } else {
+          final List<TransformHierarchy.Node> pipelineNodes = recordPipelineNodes(pipeline);
+          if (pipelineRunSucceeded() && !visitedAll(pipelineNodes)) {
+            final boolean hasDanglingPAssert =
+                FluentIterable.from(pipelineNodes)
+                    .filter(Predicates.not(Predicates.in(runVisitedNodes)))
+                    .anyMatch(isPAssertNode);
+            if (hasDanglingPAssert) {
+              throw new AbandonedNodeException("The pipeline contains abandoned PAssert(s).");
+            } else {
+              throw new AbandonedNodeException("The pipeline contains abandoned PTransform(s).");
+            }
+          }
+        }
+      }
+    }
+
+    private boolean visitedAll(final List<TransformHierarchy.Node> pipelineNodes) {
+      return runVisitedNodes.equals(pipelineNodes);
+    }
+
+    private boolean pipelineRunSucceeded() {
+      return runVisitedNodes != null;
+    }
+
+    @Override
+    protected void afterPipelineExecution() {
+      runVisitedNodes = recordPipelineNodes(pipeline);
+      super.afterPipelineExecution();
+    }
+
+    @Override
+    protected void afterUserCodeFinished() {
+      super.afterUserCodeFinished();
+      verifyPipelineExecution();
+    }
+  }
+
+  /**
+   * An exception thrown in case an abandoned {@link org.apache.beam.sdk.transforms.PTransform} is
+   * detected, that is, a {@link org.apache.beam.sdk.transforms.PTransform} that has not been run.
+   */
+  public static class AbandonedNodeException extends RuntimeException {
+
+    AbandonedNodeException(final String msg) {
+      super(msg);
+    }
+  }
+
+  /** An exception thrown in case a test finishes without invoking {@link Pipeline#run()}. */
+  public static class PipelineRunMissingException extends RuntimeException {
+
+    PipelineRunMissingException(final String msg) {
+      super(msg);
+    }
+  }
+
+  /** System property used to set {@link TestPipelineOptions}. */
+  public static final String PROPERTY_BEAM_TEST_PIPELINE_OPTIONS = "beamTestPipelineOptions";
+
+  static final String PROPERTY_USE_DEFAULT_DUMMY_RUNNER = "beamUseDummyRunner";
+
+  private static final ObjectMapper MAPPER = new ObjectMapper().registerModules(
+      ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  private Optional<? extends PipelineRunEnforcement> enforcement = Optional.absent();
+
+  protected TestPipelineHandler(final PipelineOptions options) {
+    super(options);
+    this.options = options;
+  }
+
+  protected abstract boolean doesNeedRunner(final T context);
+  protected abstract String getAppName(final T context);
+
+  boolean isEnforcementPresent() {
+    return enforcement.isPresent();
+  }
+
+  protected String appName(final Class<?> testClass, final String methodName) {
+    if (testClass.isMemberClass()) {
+      return String.format(
+              "%s$%s-%s",
+              testClass.getEnclosingClass().getSimpleName(), testClass.getSimpleName(), methodName);
+    }
+    return String.format("%s-%s", testClass.getSimpleName(), methodName);
+  }
+
+  public PipelineOptions getOptions() {
+    return this.options;
+  }
+
+  public AutoCloseable start(final T context) {
+    options.as(ApplicationNameOptions.class).setAppName(getAppName(context));
+    setDeducedEnforcementLevel(context);
+
+    // statement.evaluate() essentially runs the user code contained in the unit test at hand.
+    // Exceptions thrown during the execution of the user's test code will propagate here,
+    // unless the user explicitly handles them with a "catch" clause in his code. If the
+    // exception is handled by a user's "catch" clause, is does not interrupt the flow and
+    // we move on to invoking the configured enforcements.
+    // If the user does not handle a thrown exception, it will propagate here and interrupt
+    // the flow, preventing the enforcement(s) from being activated.
+    // The motivation for this is avoiding enforcements over faulty pipelines.
+
+    // here the integration will delegate the execution and respect previous comment
+    return new AutoCloseable() {
+      @Override
+      public void close() {
+        enforcement.get().afterUserCodeFinished();
+      }
+    };
+  }
+
+  private void setDeducedEnforcementLevel(final T annotations) {
+    // if the enforcement level has not been set by the user do auto-inference
+    if (!enforcement.isPresent()) {
+
+      final boolean annotatedWithNeedsRunner =
+              doesNeedRunner(annotations);
+
+      final boolean crashingRunner =
+              CrashingRunner.class.isAssignableFrom(options.getRunner());
+
+      checkState(
+              !(annotatedWithNeedsRunner && crashingRunner),
+              "The test was annotated with a [@%s] / [@%s] while the runner "
+                      + "was set to [%s]. Please re-check your configuration.",
+              NeedsRunner.class.getSimpleName(),
+              ValidatesRunner.class.getSimpleName(),
+              CrashingRunner.class.getSimpleName());
+
+      enableAbandonedNodeEnforcement(annotatedWithNeedsRunner || !crashingRunner);
+    }
+  }
+
+  /**
+   * Runs this {@link TestPipelineHandler},
+   * unwrapping any {@code AssertionError} that is raised during
+   * testing.
+   */
+  public PipelineResult run() {
+    return run(getOptions());
+  }
+
+  /** Like {@link #run} but with the given potentially modified options. */
+  public PipelineResult run(PipelineOptions options) {
+    final PipelineResult pipelineResult;
+    try {
+      enforcement.get().beforePipelineExecution();
+      PipelineOptions updatedOptions =
+          MAPPER.convertValue(MAPPER.valueToTree(options), PipelineOptions.class);
+      updatedOptions
+          .as(TestValueProviderOptions.class)
+          .setProviderRuntimeValues(StaticValueProvider.of(providerRuntimeValues));
+      pipelineResult = super.run(updatedOptions);
+      verifyPAssertsSucceeded(this, pipelineResult);
+    } catch (RuntimeException exc) {
+      Throwable cause = exc.getCause();
+      if (cause instanceof AssertionError) {
+        throw (AssertionError) cause;
+      } else {
+        throw exc;
+      }
+    }
+
+    // If we reach this point, the pipeline has been run and no exceptions have been thrown during
+    // its execution.
+    enforcement.get().afterPipelineExecution();
+    return pipelineResult;
+  }
+
+  /** Implementation detail of {@link #newProvider}, do not use. */
+  @Internal
+  public interface TestValueProviderOptions extends PipelineOptions {
+    ValueProvider<Map<String, Object>> getProviderRuntimeValues();
+    void setProviderRuntimeValues(ValueProvider<Map<String, Object>> runtimeValues);
+  }
+
+  /**
+   * Returns a new {@link ValueProvider} that is inaccessible before {@link #run}, but will be
+   * accessible while the pipeline runs.
+   */
+  public <T> ValueProvider<T> newProvider(T runtimeValue) {
+    String uuid = UUID.randomUUID().toString();
+    providerRuntimeValues.put(uuid, runtimeValue);
+    return ValueProvider.NestedValueProvider.of(
+        options.as(TestValueProviderOptions.class).getProviderRuntimeValues(),
+        new GetFromRuntimeValues<T>(uuid));
+  }
+
+  private final Map<String, Object> providerRuntimeValues = Maps.newHashMap();
+
+  private static class GetFromRuntimeValues<T>
+      implements SerializableFunction<Map<String, Object>, T> {
+    private final String key;
+
+    private GetFromRuntimeValues(String key) {
+      this.key = key;
+    }
+
+    @Override
+    public T apply(Map<String, Object> input) {
+      return (T) input.get(key);
+    }
+  }
+
+  /**
+   * Enables the abandoned node detection. Abandoned nodes are <code>PTransforms</code>, <code>
+   * PAsserts</code> included, that were not executed by the pipeline runner. Abandoned nodes are
+   * most likely to occur due to the one of the following scenarios:
+   * <ul>
+   * <li>Lack of a <code>pipeline.run()</code> statement at the end of a test.
+   * <li>Addition of PTransforms after the pipeline has already run.
+   * </ul>
+   * Abandoned node detection is automatically enabled when a real pipeline runner (i.e. not a
+   * {@link CrashingRunner}) and/or a {@link NeedsRunner} or a {@link ValidatesRunner} annotation
+   * are detected.
+   */
+  public TestPipelineHandler enableAbandonedNodeEnforcement(final boolean enable) {
+    enforcement =
+        enable
+            ? Optional.of(new PipelineAbandonedNodeEnforcement(this))
+            : Optional.of(new PipelineRunEnforcement(this));
+
+    return this;
+  }
+
+  /**
+   * If enabled, a <code>pipeline.run()</code> statement will be added automatically in case it is
+   * missing in the test.
+   */
+  public TestPipelineHandler enableAutoRunIfMissing(final boolean enable) {
+    enforcement.get().enableAutoRunIfMissing(enable);
+    return this;
+  }
+
+  @Override
+  public String toString() {
+    return "TestPipeline#" + options.as(ApplicationNameOptions.class).getAppName();
+  }
+
+  /** Creates {@link PipelineOptions} for testing. */
+  public static PipelineOptions testingPipelineOptions() {
+    try {
+      @Nullable
+      String beamTestPipelineOptions = System.getProperty(PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
+
+      PipelineOptions options =
+          Strings.isNullOrEmpty(beamTestPipelineOptions)
+              ? PipelineOptionsFactory.create()
+              : PipelineOptionsFactory.fromArgs(
+              MAPPER.readValue(beamTestPipelineOptions, String[].class))
+              .as(TestPipelineOptions.class);
+
+      // If no options were specified, set some reasonable defaults
+      if (Strings.isNullOrEmpty(beamTestPipelineOptions)) {
+        // If there are no provided options, check to see if a dummy runner should be used.
+        String useDefaultDummy = System.getProperty(PROPERTY_USE_DEFAULT_DUMMY_RUNNER);
+        if (!Strings.isNullOrEmpty(useDefaultDummy) && Boolean.valueOf(useDefaultDummy)) {
+          options.setRunner(CrashingRunner.class);
+        }
+      }
+      options.setStableUniqueNames(CheckEnabled.ERROR);
+
+      FileSystems.setDefaultPipelineOptions(options);
+      return options;
+    } catch (IOException e) {
+      throw new RuntimeException(
+          "Unable to instantiate test options from system property "
+              + PROPERTY_BEAM_TEST_PIPELINE_OPTIONS
+              + ":"
+              + System.getProperty(PROPERTY_BEAM_TEST_PIPELINE_OPTIONS),
+          e);
+    }
+  }
+
+  public static String[] convertToArgs(PipelineOptions options) {
+    try {
+      byte[] opts = MAPPER.writeValueAsBytes(options);
+
+      JsonParser jsonParser = MAPPER.getFactory().createParser(opts);
+      TreeNode node = jsonParser.readValueAsTree();
+      ObjectNode optsNode = (ObjectNode) node.get("options");
+      ArrayList<String> optArrayList = new ArrayList<>();
+      Iterator<Entry<String, JsonNode>> entries = optsNode.fields();
+      while (entries.hasNext()) {
+        Entry<String, JsonNode> entry = entries.next();
+        if (entry.getValue().isNull()) {
+          continue;
+        } else if (entry.getValue().isTextual()) {
+          optArrayList.add("--" + entry.getKey() + "=" + entry.getValue().asText());
+        } else {
+          optArrayList.add("--" + entry.getKey() + "=" + entry.getValue());
+        }
+      }
+      return optArrayList.toArray(new String[optArrayList.size()]);
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /**
+   * Verifies all {{@link PAssert PAsserts}} in the pipeline have been executed and were successful.
+   *
+   * <p>Note this only runs for runners which support Metrics. Runners which do not should verify
+   * this in some other way. See: https://issues.apache.org/jira/browse/BEAM-2001</p>
+   */
+  public static void verifyPAssertsSucceeded(Pipeline pipeline, PipelineResult pipelineResult) {
+    if (MetricsEnvironment.isMetricsSupported()) {
+      long expectedNumberOfAssertions = (long) PAsserts.countAsserts(pipeline);
+
+      long successfulAssertions = 0;
+      Iterable<MetricResult<Long>> successCounterResults =
+          pipelineResult.metrics().queryMetrics(
+              MetricsFilter.builder()
+                  .addNameFilter(MetricNameFilter.named(PAssert.class, PAsserts.SUCCESS_COUNTER))
+                  .build())
+              .counters();
+      for (MetricResult<Long> counter : successCounterResults) {
+        if (counter.attempted() > 0) {
+          successfulAssertions++;
+        }
+      }
+
+      if (successfulAssertions != expectedNumberOfAssertions) {
+        throw new IllegalStateException(String
+                .format("Expected %d successful assertions, but found %d.",
+                        expectedNumberOfAssertions, successfulAssertions));
+      }
+    }
+  }
+
+  private static class IsEmptyVisitor extends PipelineVisitor.Defaults {
+    private boolean empty = true;
+
+    public boolean isEmpty() {
+      return empty;
+    }
+
+    @Override
+    public void visitPrimitiveTransform(TransformHierarchy.Node node) {
+      empty = false;
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/BeamInject.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/BeamInject.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a field of type TestPipelineHandler as injected by the extension.
+ */
+@Retention(RUNTIME)
+@Target(FIELD)
+public @interface BeamInject {
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/PAssert.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.beam.sdk.testing.PAsserts;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * JUnit 5 flavor of PAssert. See JUnit 4 version for more details.
+ *nop IMPORTANT: you must have hamcrest in the classpath for now.
+ */
+public final class PAssert {
+    private static final PAsserts.AssertBase ASSERTS =
+            new PAsserts.AssertBase<Function<Object, Boolean>>() {
+                @Override
+                public <T> void assertThat(T actual, Function<Object, Boolean> booleanFunction) {
+                    Assertions.assertTrue(
+                            booleanFunction.apply(actual),
+                            "condition on " + actual + " failed");
+                }
+
+                @Override
+                public <T> void assertEquals(T actual, T expected) {
+                    Assertions.assertEquals(actual, expected);
+                }
+
+                @Override
+                public <T> void assertNotEquals(T actual, T expected) {
+                    Assertions.assertNotEquals(actual, expected);
+                }
+
+                @Override
+                public <T> Function<Object, Boolean> containsInAnyOrder(final T[] expected) {
+                    return value -> Stream.of(expected)
+                            .noneMatch(i -> StreamSupport.stream(
+                                    Iterable.class.cast(value).spliterator(), false)
+                                    .anyMatch(v -> i == v || (i != null && i.equals(v))));
+                }
+            };
+
+    private PAssert() {
+        // no-op
+    }
+
+    public static <T> PAsserts.IterableAssert<T> that(PCollection<T> actual) {
+        return that(actual.getName(), actual);
+    }
+
+    public static <T> PAsserts.IterableAssert<T> that(String reason, PCollection<T> actual) {
+        return PAsserts.that(reason, actual, ASSERTS);
+    }
+
+    public static <T> PAsserts.IterableAssert<T> thatSingletonIterable(
+            PCollection<? extends Iterable<T>> actual) {
+        return thatSingletonIterable(actual.getName(), actual);
+    }
+
+    public static <T> PAsserts.IterableAssert<T> thatSingletonIterable(
+            String reason, PCollection<? extends Iterable<T>> actual) {
+        return PAsserts.thatSingletonIterable(reason, actual, ASSERTS);
+    }
+
+    public static <T> PAsserts.SingletonAssert<T> thatSingleton(PCollection<T> actual) {
+        return thatSingleton(actual.getName(), actual);
+    }
+
+    public static <T> PAsserts.SingletonAssert<T> thatSingleton(String reason,
+                                                                PCollection<T> actual) {
+        return PAsserts.thatSingleton(reason, actual, ASSERTS);
+    }
+
+    public static <K, V> PAsserts.SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+            PCollection<KV<K, V>> actual) {
+        return thatMultimap(actual.getName(), actual);
+    }
+
+    public static <K, V> PAsserts.SingletonAssert<Map<K, Iterable<V>>> thatMultimap(
+            String reason, PCollection<KV<K, V>> actual) {
+        return PAsserts.thatMultimap(reason, actual, ASSERTS);
+    }
+
+    public static <K, V> PAsserts.SingletonAssert<Map<K, V>> thatMap(PCollection<KV<K, V>> actual) {
+        return thatMap(actual.getName(), actual);
+    }
+
+    public static <K, V> PAsserts.SingletonAssert<Map<K, V>> thatMap(
+            String reason, PCollection<KV<K, V>> actual) {
+        return PAsserts.thatMap(reason, actual, ASSERTS);
+    }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/WithApacheBeam.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/WithApacheBeam.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.apache.beam.sdk.testing.junit5.internal.BeamJUnit5Extension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Marks a class or method as using beam test pipeline.
+ */
+@Inherited
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@ExtendWith(BeamJUnit5Extension.class)
+public @interface WithApacheBeam {
+    /**
+     * @return the pipeline options for the test.
+     */
+    String[] options() default {};
+
+    /**
+     * @return true if the pipeline is automatically ran.
+     */
+    boolean enableAutoRunIfMissing() default false;
+
+    /**
+     * @return true if all the PAssert should be visited to validate the result.
+     */
+    boolean enableAbandonedNodeEnforcement() default false;
+
+    /**
+     * @return by default a runner enforcement is done on the test,
+     * i.e. if no runner is available a test requiring a runner with
+     * the tag NeedsRunner will fail. Setting it to false will just
+     * disable the test.
+     */
+    boolean skipMissingRunnerTests() default false;
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/internal/BeamJUnit5Extension.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/internal/BeamJUnit5Extension.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5.internal;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.CrashingRunner;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.TestPipelineHandler;
+import org.apache.beam.sdk.testing.junit5.BeamInject;
+import org.apache.beam.sdk.testing.junit5.WithApacheBeam;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+/**
+ * JUnit 5 integration code glue.
+ */
+public class BeamJUnit5Extension implements
+        BeforeAllCallback, AfterAllCallback,
+        BeforeEachCallback, AfterEachCallback,
+        TestInstancePostProcessor, ParameterResolver,
+        ExecutionCondition {
+
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace
+            .create(BeamJUnit5Extension.class.getName());
+
+    private static final String RELEASE_PHASE = BeamJUnit5Extension.class.getName() + "#release";
+
+    @Override
+    public void beforeAll(final ExtensionContext context) {
+        final ExtensionContext.Store store = context.getStore(NAMESPACE);
+        store.put(RELEASE_PHASE, "all");
+    }
+
+    @Override
+    public void afterAll(final ExtensionContext context) throws Exception {
+        final Object closeable = context.getStore(NAMESPACE).get(AutoCloseable.class.getName());
+        if (closeable != null) {
+            AutoCloseable.class.cast(closeable).close();
+        }
+    }
+
+    @Override
+    public void beforeEach(final ExtensionContext context) {
+        final ExtensionContext.Store store = context.getStore(NAMESPACE);
+        if (store.get(AutoCloseable.class.getName()) == null) {
+            store.put(AutoCloseable.class.getName(), getOrCreateHandler(context).start(context));
+        }
+    }
+
+    @Override
+    public void afterEach(final ExtensionContext context) throws Exception {
+        if (context.getStore(NAMESPACE).get(RELEASE_PHASE) == null) {
+            afterAll(context);
+        }
+    }
+
+    @Override
+    public boolean supportsParameter(final ParameterContext parameterContext,
+                                     final ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return TestPipelineHandler.class.isAssignableFrom(
+                parameterContext.getParameter().getType());
+    }
+
+    @Override
+    public Object resolveParameter(final ParameterContext parameterContext,
+                                   final ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return getOrCreateHandler(extensionContext);
+    }
+
+    @Override
+    public void postProcessTestInstance(final Object testInstance,
+                                        final ExtensionContext context) {
+        Class<?> testClass = context.getRequiredTestClass();
+        while (testClass != Object.class) {
+            Stream.of(testClass.getDeclaredFields())
+                  .filter(c -> c.isAnnotationPresent(BeamInject.class))
+                  .forEach(f -> {
+                    if (!TestPipelineHandler.class.isAssignableFrom(f.getType())) {
+                        throw new IllegalArgumentException("@BeamInject not supported on " + f);
+                    }
+                    if (!f.isAccessible()) {
+                        f.setAccessible(true);
+                    }
+                    try {
+                        f.set(testInstance, getOrCreateHandler(context));
+                    } catch (final IllegalAccessException e) {
+                        throw new IllegalStateException(e);
+                    }
+                });
+            testClass = testClass.getSuperclass();
+        }
+    }
+
+    @Override // responsible to deactivate methods requiring a runner if it is not set
+    public ConditionEvaluationResult evaluateExecutionCondition(final ExtensionContext context) {
+        if (!context.getTestMethod().isPresent()) {
+            return ConditionEvaluationResult.enabled("Classes are always active");
+        }
+        try {
+            if (doesNeedsRunner(context) && skipOnMissingRunner(context)
+                    && CrashingRunner.class.isAssignableFrom(TestPipelineHandler.class.cast(
+                            getOrCreateHandler(context)).getOptions().getRunner())) {
+                return ConditionEvaluationResult.disabled("No available runner");
+            }
+        } catch (final IllegalArgumentException iae) {
+            return ConditionEvaluationResult.disabled("No available runner: " + iae.getMessage());
+        }
+        return ConditionEvaluationResult.enabled("Test active");
+    }
+
+    private boolean skipOnMissingRunner(final ExtensionContext context) {
+        final Optional<WithApacheBeam> config = context.getElement()
+                .map(e -> Optional.ofNullable(e.getAnnotation(WithApacheBeam.class)))
+                .filter(Optional::isPresent)
+                .orElseGet(() -> context.getTestClass()
+                        .map(e -> e.getAnnotation(WithApacheBeam.class)));
+        return config.map(WithApacheBeam::skipMissingRunnerTests).orElse(true);
+    }
+
+    // we support the tag "NeedsRunner" or fqn categories (interfaces)
+    private boolean doesNeedsRunner(final ExtensionContext context) {
+        return context.getTags().stream().anyMatch(tag -> {
+            if (NeedsRunner.class.getSimpleName().equalsIgnoreCase(tag)) {
+                return true;
+            }
+            try { // compat with junit 4 mode but weird in junit 5
+                return NeedsRunner.class.isAssignableFrom(
+                        BeamJUnit5Extension.class.getClassLoader()
+                                .loadClass(tag.trim()));
+            } catch (final Exception e) {
+                return false;
+            }
+        });
+    }
+
+    private TestPipelineHandler<ExtensionContext> getOrCreateHandler(
+            final ExtensionContext context) {
+        return Optional.ofNullable(TestPipelineHandler.class.cast(context.getStore(NAMESPACE)
+                    .get(TestPipelineHandler.class.getName())))
+                .orElseGet(() -> {
+                    final TestPipelineHandler<ExtensionContext> testPipeline =
+                            new TestPipelineHandler<ExtensionContext>(findOptions(context)) {
+
+                                @Override
+                                protected boolean doesNeedRunner(final ExtensionContext context) {
+                                    return BeamJUnit5Extension.this
+                                            .doesNeedsRunner(context);
+                                }
+
+                                @Override
+                                protected String getAppName(final ExtensionContext context) {
+                                    final String methodName = context
+                                            .getRequiredTestMethod()
+                                            .getName();
+                                    final Class<?> testClass = context
+                                            .getRequiredTestClass();
+                                    return appName(testClass, methodName);
+                                }
+                            };
+
+                    context.getElement()
+                            .flatMap(e -> Optional.ofNullable(
+                                    e.getAnnotation(WithApacheBeam.class)))
+                            .ifPresent(config -> {
+                                testPipeline.enableAbandonedNodeEnforcement(
+                                        config.enableAbandonedNodeEnforcement());
+                                testPipeline.enableAutoRunIfMissing(
+                                        config.enableAutoRunIfMissing());
+                            });
+
+                    context.getStore(NAMESPACE)
+                            .put(TestPipelineHandler.class.getName(), testPipeline);
+                    return testPipeline;
+                });
+    }
+
+    // options are deduced from the @WithApacheBeam config,
+    // if empty it uses the default logic with the system properties
+    private PipelineOptions findOptions(final ExtensionContext context) {
+        return context.getElement()
+                .flatMap(e -> Optional.ofNullable(e.getAnnotation(WithApacheBeam.class))
+                                      .map(WithApacheBeam::options))
+                .map(PipelineOptionsFactory::fromArgs).map(PipelineOptionsFactory.Builder::create)
+                .orElseGet(TestPipelineHandler::testingPipelineOptions);
+    }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/internal/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/internal/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This package contains the glue code an user shouldnt use.
+ */
+package org.apache.beam.sdk.testing.junit5.internal;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/junit5/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Junit 5 integration package.
+ */
+package org.apache.beam.sdk.testing.junit5;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
@@ -40,7 +40,6 @@ import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.io.GenerateSequence;
-import org.apache.beam.sdk.testing.PAssert.PCollectionContentsAssert.MatcherCheckerFn;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.Sum;
@@ -143,7 +142,7 @@ public class PAssertTest implements Serializable {
       error = e;
     }
     SuccessOrFailure failure =
-        SuccessOrFailure.failure(PAssert.PAssertionSite.capture("here"), error);
+        SuccessOrFailure.failure(PAsserts.PAssertionSite.capture("here"), error);
     SuccessOrFailure res = CoderUtils.clone(SerializableCoder.of(SuccessOrFailure.class), failure);
     assertEquals(
         "Encode-decode failed SuccessOrFailure",
@@ -503,10 +502,11 @@ public class PAssertTest implements Serializable {
   @Test
   public void testAssertionSiteIsCaptured() {
     // This check should return a failure.
-    SuccessOrFailure res = PAssert.doChecks(
-        PAssert.PAssertionSite.capture("Captured assertion message."),
+    SuccessOrFailure res = PAsserts.doChecks(
+        PAsserts.PAssertionSite.capture("Captured assertion message."),
         new Integer(10),
-        new MatcherCheckerFn(SerializableMatchers.contains(new Integer(11))));
+        new PAsserts.PCollectionContentsAssert.MatcherCheckerFn<Integer>(
+                SerializableMatchers.contains(new Integer(11)), PAssert.ASSERTS));
 
     String stacktrace = Throwables.getStackTraceAsString(res.assertionError());
     assertEquals(res.isSuccess(), false);
@@ -577,7 +577,7 @@ public class PAssertTest implements Serializable {
     PAssert.thatMap(pipeline.apply("CreateMap", Create.of(KV.of(1, 2))))
         .isEqualTo(Collections.singletonMap(1, 2));
 
-    assertThat(PAssert.countAsserts(pipeline), equalTo(3));
+    assertThat(PAsserts.countAsserts(pipeline), equalTo(3));
   }
 
   @Test
@@ -586,11 +586,11 @@ public class PAssertTest implements Serializable {
 
     PAssert.that(create).containsInAnyOrder(1, 2, 3);
     PAssert.thatSingleton(create.apply(Sum.integersGlobally())).isEqualTo(6);
-    assertThat(PAssert.countAsserts(pipeline), equalTo(2));
+    assertThat(PAsserts.countAsserts(pipeline), equalTo(2));
 
     PAssert.thatMap(pipeline.apply("CreateMap", Create.of(KV.of(1, 2))))
         .isEqualTo(Collections.singletonMap(1, 2));
 
-    assertThat(PAssert.countAsserts(pipeline), equalTo(3));
+    assertThat(PAsserts.countAsserts(pipeline), equalTo(3));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PaneExtractorsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PaneExtractorsTest.java
@@ -43,7 +43,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneNoFiring() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
+        PaneExtractors.onlyPane(PAsserts.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> noFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(
@@ -56,7 +56,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneOnlyOneFiring() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
+        PaneExtractors.onlyPane(PAsserts.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> onlyFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(
@@ -70,7 +70,7 @@ public class PaneExtractorsTest {
   @Test
   public void onlyPaneMultiplePanesFails() {
     SerializableFunction<Iterable<ValueInSingleWindow<Integer>>, Iterable<Integer>> extractor =
-        PaneExtractors.onlyPane(PAssert.PAssertionSite.capture(""));
+        PaneExtractors.onlyPane(PAsserts.PAssertionSite.capture(""));
     Iterable<ValueInSingleWindow<Integer>> multipleFiring =
         ImmutableList.of(
             ValueInSingleWindow.of(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SerializableMatchersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/SerializableMatchersTest.java
@@ -50,114 +50,114 @@ import org.junit.runners.JUnit4;
  */
 @RunWith(JUnit4.class)
 public class SerializableMatchersTest implements Serializable {
-  @Rule
-  public transient ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public transient ExpectedException thrown = ExpectedException.none();
 
-  @Test
-  public void testAnythingSerializable() throws Exception {
-    SerializableUtils.ensureSerializable(anything());
-  }
-
-  @Test
-  public void testAllOfSerializable() throws Exception {
-    SerializableUtils.ensureSerializable(allOf(anything()));
-  }
-
-  @Test
-  public void testContainsInAnyOrderSerializable() throws Exception {
-    assertThat(ImmutableList.of(2, 1, 3),
-        SerializableUtils.ensureSerializable(containsInAnyOrder(1, 2, 3)));
-  }
-
-  @Test
-  public void testContainsInAnyOrderNotSerializable() throws Exception {
-    assertThat(
-        ImmutableList.of(new NotSerializableClass()),
-        SerializableUtils.ensureSerializable(containsInAnyOrder(
-            new NotSerializableClassCoder(),
-            new NotSerializableClass())));
-  }
-
-  @Test
-  public void testKvKeyMatcherSerializable() throws Exception {
-    assertThat(
-        KV.of("hello", 42L),
-        SerializableUtils.ensureSerializable(kvWithKey("hello")));
-  }
-
-  @Test
-  public void testKvMatcherBasicSuccess() throws Exception {
-    assertThat(
-        KV.of(1, 2),
-        SerializableMatchers.<Integer, Integer>kv(anything(), anything()));
-  }
-
-  @Test
-  public void testKvMatcherKeyFailure() throws Exception {
-    try {
-      assertThat(
-          KV.of(1, 2),
-          SerializableMatchers.<Integer, Integer>kv(not(anything()), anything()));
-    } catch (AssertionError exc) {
-      assertThat(exc.getMessage(), Matchers.containsString("key did not match"));
-      return;
-    }
-    fail("Should have failed");
-  }
-
-  @Test
-  public void testKvMatcherValueFailure() throws Exception {
-    try {
-      assertThat(
-          KV.of(1, 2),
-          SerializableMatchers.<Integer, Integer>kv(anything(), not(anything())));
-    } catch (AssertionError exc) {
-      assertThat(exc.getMessage(), Matchers.containsString("value did not match"));
-      return;
-    }
-    fail("Should have failed");
-  }
-
-  @Test
-  public void testKvMatcherGBKLikeSuccess() throws Exception {
-    assertThat(
-        KV.of("key", ImmutableList.of(1, 2, 3)),
-        SerializableMatchers.<Object, Iterable<Integer>>kv(
-            anything(), containsInAnyOrder(3, 2, 1)));
-  }
-
-  @Test
-  public void testKvMatcherGBKLikeFailure() throws Exception {
-    try {
-      assertThat(
-          KV.of("key", ImmutableList.of(1, 2, 3)),
-          SerializableMatchers.<String, Iterable<Integer>>kv(
-              anything(), containsInAnyOrder(1, 2, 3, 4)));
-    } catch (AssertionError exc) {
-      assertThat(exc.getMessage(), Matchers.containsString("value did not match"));
-      return;
-    }
-    fail("Should have failed.");
-  }
-
-  private static class NotSerializableClass {
-    @Override public boolean equals(Object other) {
-      return other instanceof NotSerializableClass;
+    @Test
+    public void testAnythingSerializable() throws Exception {
+        SerializableUtils.ensureSerializable(anything());
     }
 
-    @Override public int hashCode() {
-      return 0;
-    }
-  }
-
-  private static class NotSerializableClassCoder extends AtomicCoder<NotSerializableClass> {
-    @Override
-    public void encode(NotSerializableClass value, OutputStream outStream) {
+    @Test
+    public void testAllOfSerializable() throws Exception {
+        SerializableUtils.ensureSerializable(allOf(anything()));
     }
 
-    @Override
-    public NotSerializableClass decode(InputStream inStream) {
-      return new NotSerializableClass();
+    @Test
+    public void testContainsInAnyOrderSerializable() throws Exception {
+        assertThat(ImmutableList.of(2, 1, 3),
+                SerializableUtils.ensureSerializable(containsInAnyOrder(1, 2, 3)));
     }
-  }
+
+    @Test
+    public void testContainsInAnyOrderNotSerializable() throws Exception {
+        assertThat(
+                ImmutableList.of(new NotSerializableClass()),
+                SerializableUtils.ensureSerializable(containsInAnyOrder(
+                        new NotSerializableClassCoder(),
+                        new NotSerializableClass())));
+    }
+
+    @Test
+    public void testKvKeyMatcherSerializable() throws Exception {
+        assertThat(
+                KV.of("hello", 42L),
+                SerializableUtils.ensureSerializable(kvWithKey("hello")));
+    }
+
+    @Test
+    public void testKvMatcherBasicSuccess() throws Exception {
+        assertThat(
+                KV.of(1, 2),
+                SerializableMatchers.<Integer, Integer>kv(anything(), anything()));
+    }
+
+    @Test
+    public void testKvMatcherKeyFailure() throws Exception {
+        try {
+            assertThat(
+                    KV.of(1, 2),
+                    SerializableMatchers.<Integer, Integer>kv(not(anything()), anything()));
+        } catch (AssertionError exc) {
+            assertThat(exc.getMessage(), Matchers.containsString("key did not match"));
+            return;
+        }
+        fail("Should have failed");
+    }
+
+    @Test
+    public void testKvMatcherValueFailure() throws Exception {
+        try {
+            assertThat(
+                    KV.of(1, 2),
+                    SerializableMatchers.<Integer, Integer>kv(anything(), not(anything())));
+        } catch (AssertionError exc) {
+            assertThat(exc.getMessage(), Matchers.containsString("value did not match"));
+            return;
+        }
+        fail("Should have failed");
+    }
+
+    @Test
+    public void testKvMatcherGBKLikeSuccess() throws Exception {
+        assertThat(
+                KV.of("key", ImmutableList.of(1, 2, 3)),
+                SerializableMatchers.<Object, Iterable<Integer>>kv(
+                        anything(), containsInAnyOrder(3, 2, 1)));
+    }
+
+    @Test
+    public void testKvMatcherGBKLikeFailure() throws Exception {
+        try {
+            assertThat(
+                    KV.of("key", ImmutableList.of(1, 2, 3)),
+                    SerializableMatchers.<String, Iterable<Integer>>kv(
+                            anything(), containsInAnyOrder(1, 2, 3, 4)));
+        } catch (AssertionError exc) {
+            assertThat(exc.getMessage(), Matchers.containsString("value did not match"));
+            return;
+        }
+        fail("Should have failed.");
+    }
+
+    private static class NotSerializableClass {
+        @Override public boolean equals(Object other) {
+            return other instanceof NotSerializableClass;
+        }
+
+        @Override public int hashCode() {
+            return 0;
+        }
+    }
+
+    private static class NotSerializableClassCoder extends AtomicCoder<NotSerializableClass> {
+        @Override
+        public void encode(NotSerializableClass value, OutputStream outStream) {
+        }
+
+        @Override
+        public NotSerializableClass decode(InputStream inStream) {
+            return new NotSerializableClass();
+        }
+    }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineHandlerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.junit.Test;
+
+/**
+ * Validates the options parsing from json or not.
+ */
+public class TestPipelineHandlerTest {
+    @Test
+    public void parseOptionsWhenNotJson() {
+        final String value = System.getProperty(
+                TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
+        try {
+            System.setProperty(TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS,
+                    "[\"--jobName=test\",\"--tempLocation=OFF\"]");
+            final PipelineOptions fromJson = TestPipelineHandler.testingPipelineOptions();
+            assertEquals("test", fromJson.getJobName());
+            assertEquals("OFF", fromJson.getTempLocation());
+
+            System.setProperty(TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS,
+                    "--jobName=test --tempLocation=OFF");
+            final PipelineOptions fromCli = TestPipelineHandler.testingPipelineOptions();
+            assertEquals("test", fromCli.getJobName());
+            assertEquals("OFF", fromCli.getTempLocation());
+
+            System.setProperty(TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS,
+                    "    \n\n\n   --jobName=test\n    --tempLocation=OFF\n");
+            final PipelineOptions fromWeirdCli = TestPipelineHandler.testingPipelineOptions();
+            assertEquals("test", fromWeirdCli.getJobName());
+            assertEquals("OFF", fromWeirdCli.getTempLocation());
+        } finally {
+            if (value == null) {
+                System.clearProperty(TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS);
+            } else {
+                System.setProperty(TestPipelineHandler.PROPERTY_BEAM_TEST_PIPELINE_OPTIONS, value);
+            }
+        }
+    }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -136,7 +136,8 @@ public class TestPipelineTest implements Serializable {
     @Test
     public void testRunWithDummyEnvironmentVariableFails() {
       System.getProperties()
-          .setProperty(TestPipeline.PROPERTY_USE_DEFAULT_DUMMY_RUNNER, Boolean.toString(true));
+        .setProperty(TestPipelineHandler.PROPERTY_USE_DEFAULT_DUMMY_RUNNER,
+            Boolean.toString(true));
       pipeline.apply(Create.of(1, 2, 3));
 
       thrown.expect(IllegalArgumentException.class);
@@ -236,7 +237,7 @@ public class TestPipelineTest implements Serializable {
       @Category(ValidatesRunner.class)
       @Test
       public void testMissingRun() throws Exception {
-        exception.expect(TestPipeline.PipelineRunMissingException.class);
+        exception.expect(TestPipelineHandler.PipelineRunMissingException.class);
         addTransform(pCollection(pipeline));
       }
 
@@ -265,7 +266,7 @@ public class TestPipelineTest implements Serializable {
         PAssert.that(pCollection).containsInAnyOrder(WHATEVER);
         pipeline.run().waitUntilFinish();
 
-        exception.expect(TestPipeline.AbandonedNodeException.class);
+        exception.expect(TestPipelineHandler.AbandonedNodeException.class);
         exception.expectMessage(P_TRANSFORM);
         // dangling PTransform
         addTransform(pCollection);
@@ -278,7 +279,7 @@ public class TestPipelineTest implements Serializable {
         PAssert.that(pCollection).containsInAnyOrder(WHATEVER);
         pipeline.run().waitUntilFinish();
 
-        exception.expect(TestPipeline.AbandonedNodeException.class);
+        exception.expect(TestPipelineHandler.AbandonedNodeException.class);
         exception.expectMessage(P_TRANSFORM);
         // dangling PTransform
         addTransform(pCollection);
@@ -291,7 +292,7 @@ public class TestPipelineTest implements Serializable {
         PAssert.that(pCollection).containsInAnyOrder(WHATEVER);
         pipeline.run().waitUntilFinish();
 
-        exception.expect(TestPipeline.AbandonedNodeException.class);
+        exception.expect(TestPipelineHandler.AbandonedNodeException.class);
         exception.expectMessage(P_ASSERT);
         // dangling PAssert
         PAssert.that(pCollection).containsInAnyOrder(WHATEVER);
@@ -318,7 +319,9 @@ public class TestPipelineTest implements Serializable {
     public static class WithCrashingPipelineRunner {
 
       static {
-        System.setProperty(TestPipeline.PROPERTY_USE_DEFAULT_DUMMY_RUNNER, Boolean.TRUE.toString());
+        System.setProperty(
+          TestPipelineHandler.PROPERTY_USE_DEFAULT_DUMMY_RUNNER,
+          Boolean.TRUE.toString());
       }
 
       private final transient ExpectedException exception = ExpectedException.none();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/junit5/WithApacheBeamCustomRunnerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/junit5/WithApacheBeamCustomRunnerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineRunner;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricResults;
+import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.testing.TestPipelineHandler;
+import org.apache.beam.sdk.transforms.Create;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@WithApacheBeam(
+    options = {
+        "--runner=org.apache.beam.sdk.testing.junit5.WithApacheBeamCustomRunnerTest$MyTestRunner"
+    }
+)
+// just until we can fix the project setup and surefire config
+@RunWith(JUnitPlatform.class)
+class WithApacheBeamCustomRunnerTest {
+    @BeamInject
+    private TestPipelineHandler<?> pipeline;
+
+    @Test
+    void injections(final TestPipelineHandler<?> pipeline) {
+        assertNotNull(pipeline);
+        assertEquals(pipeline, this.pipeline);
+    }
+
+    @Test
+    void configuration(final TestPipelineHandler<?> pipeline) {
+        pipeline.apply(Create.of("a", "b")); // runner is a mock so whatever is set it suceeds
+        assertEquals(PipelineResult.State.DONE, pipeline.run().getState());
+    }
+
+    public static class MyTestRunner extends PipelineRunner<PipelineResult> {
+        public static MyTestRunner fromOptions(final PipelineOptions options) {
+            return new MyTestRunner();
+        }
+
+        @Override
+        public PipelineResult run(final Pipeline pipeline) {
+            return new PipelineResult() {
+                @Override
+                public State getState() {
+                    return State.DONE;
+                }
+
+                @Override
+                public State cancel() throws IOException {
+                    return State.CANCELLED;
+                }
+
+                @Override
+                public State waitUntilFinish(final Duration duration) {
+                    return getState();
+                }
+
+                @Override
+                public State waitUntilFinish() {
+                    return getState();
+                }
+
+                @Override
+                public MetricResults metrics() {
+                    return new MetricResults() {
+                        @Override
+                        public MetricQueryResults queryMetrics(final MetricsFilter filter) {
+                            return new MetricQueryResults() {
+                                @Override
+                                public Iterable<MetricResult<Long>> counters() {
+                                    return emptyList();
+                                }
+
+                                @Override
+                                public Iterable<MetricResult<DistributionResult>> distributions() {
+                                    return emptyList();
+                                }
+
+                                @Override
+                                public Iterable<MetricResult<GaugeResult>> gauges() {
+                                    return emptyList();
+                                }
+                            };
+                        }
+                    };
+                }
+            };
+        }
+    }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/junit5/WithApacheBeamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/junit5/WithApacheBeamTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing.junit5;
+
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipelineHandler;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@WithApacheBeam(skipMissingRunnerTests = true)
+// just until we can fix the project setup and surefire config
+@RunWith(JUnitPlatform.class)
+class WithApacheBeamTest {
+    @BeamInject
+    private TestPipelineHandler<?> pipeline;
+
+    @Test
+    @Tag("NeedsRunner")
+    @Category(NeedsRunner.class) // for now we go through surefire and therefore junit4 API
+    void simplePipeline() { // this test is trivial and just validates the extension setup/filter
+        final PCollection<String> apply = pipeline.apply(Create.of("a", "b"));
+        PAssert.that(apply).containsInAnyOrder("a", "b");
+        pipeline.run();
+    }
+}


### PR DESCRIPTION
Basic JUnit 5 extension. It still uses hamcrest for the PAssert impl since refactoring it will break the API deeply due to the way it has been done but hamcrest can be used with JUnit 5 so not a huge deal for now.


Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

  