### PR TITLE
[BEAM-3442] Cleanup DeprecationWarning for BaseException.message.

### DIFF
--- a/sdks/python/apache_beam/io/filesystems_test.py
+++ b/sdks/python/apache_beam/io/filesystems_test.py
@@ -120,10 +120,9 @@ class FileSystemsTest(unittest.TestCase):
 
   def test_match_file_exception(self):
     # Match files with None so that it throws an exception
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Unable to get the Filesystem') as error:
       FileSystems.match([None])
-    self.assertTrue(
-        error.exception.message.startswith('Unable to get the Filesystem'))
     self.assertEqual(error.exception.exception_details.keys(), [None])
 
   def test_match_directory(self):
@@ -155,10 +154,9 @@ class FileSystemsTest(unittest.TestCase):
   def test_copy_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Copy operation failed') as error:
       FileSystems.copy([path1], [path2])
-    self.assertTrue(
-        error.exception.message.startswith('Copy operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [(path1, path2)])
 
   def test_copy_directory(self):
@@ -188,10 +186,9 @@ class FileSystemsTest(unittest.TestCase):
   def test_rename_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Rename operation failed') as error:
       FileSystems.rename([path1], [path2])
-    self.assertTrue(
-        error.exception.message.startswith('Rename operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [(path1, path2)])
 
   def test_rename_directory(self):
@@ -230,8 +227,7 @@ class FileSystemsTest(unittest.TestCase):
 
   def test_delete_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Delete operation failed') as error:
       FileSystems.delete([path1])
-    self.assertTrue(
-        error.exception.message.startswith('Delete operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [path1])

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
@@ -125,10 +125,9 @@ class GCSFileSystemTest(unittest.TestCase):
     expected_results = {'gs://bucket/': exception}
 
     file_system = gcsfilesystem.GCSFileSystem()
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Match operation failed') as error:
       file_system.match(['gs://bucket/'])
-    self.assertTrue(
-        error.exception.message.startswith('Match operation failed'))
     self.assertEqual(error.exception.exception_details, expected_results)
     gcsio_mock.size_of_files_in_glob.assert_called_once_with(
         'gs://bucket/*', None)
@@ -207,10 +206,9 @@ class GCSFileSystemTest(unittest.TestCase):
 
     # Issue batch copy.
     file_system = gcsfilesystem.GCSFileSystem()
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Copy operation failed') as error:
       file_system.copy(sources, destinations)
-    self.assertTrue(
-        error.exception.message.startswith('Copy operation failed'))
     self.assertEqual(error.exception.exception_details, expected_results)
 
     gcsio_mock.copy.assert_called_once_with(
@@ -300,10 +298,9 @@ class GCSFileSystemTest(unittest.TestCase):
 
     # Issue batch rename.
     file_system = gcsfilesystem.GCSFileSystem()
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Rename operation failed') as error:
       file_system.rename(sources, destinations)
-    self.assertTrue(
-        error.exception.message.startswith('Rename operation failed'))
     self.assertEqual(error.exception.exception_details, expected_results)
 
     gcsio_mock.copy_batch.assert_called_once_with([
@@ -349,9 +346,8 @@ class GCSFileSystemTest(unittest.TestCase):
 
     # Issue batch delete.
     file_system = gcsfilesystem.GCSFileSystem()
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Delete operation failed') as error:
       file_system.delete(files)
-    self.assertTrue(
-        error.exception.message.startswith('Delete operation failed'))
     self.assertEqual(error.exception.exception_details, expected_results)
     gcsio_mock.delete_batch.assert_called()

--- a/sdks/python/apache_beam/io/gcp/tests/utils_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/utils_test.py
@@ -60,13 +60,12 @@ class UtilsTest(unittest.TestCase):
     mock_client.return_value.dataset = mock_dataset
     mock_dataset.return_value.exists.return_value = False
 
-    with self.assertRaises(Exception) as e:
+    with self.assertRaisesRegexp(
+        Exception, r'^Failed to cleanup. Bigquery dataset unused_dataset '
+                   r'doesn\'t exist'):
       utils.delete_bq_table('unused_project',
                             'unused_dataset',
                             'unused_table')
-    self.assertTrue(
-        e.exception.message.startswith('Failed to cleanup. Bigquery dataset '
-                                       'unused_dataset doesn\'t exist'))
 
   @patch.object(bigquery, 'Client')
   def test_delete_table_fails_table_not_exist(self, mock_client):
@@ -78,13 +77,12 @@ class UtilsTest(unittest.TestCase):
     mock_dataset.return_value.table = mock_table
     mock_table.return_value.exists.return_value = False
 
-    with self.assertRaises(Exception) as e:
+    with self.assertRaisesRegexp(Exception,
+                                 r'^Failed to cleanup. Bigquery table '
+                                 'unused_table doesn\'t exist'):
       utils.delete_bq_table('unused_project',
                             'unused_dataset',
                             'unused_table')
-    self.assertTrue(
-        e.exception.message.startswith('Failed to cleanup. Bigquery table '
-                                       'unused_table doesn\'t exist'))
 
   @patch.object(bigquery, 'Client')
   def test_delete_table_fails_service_error(self, mock_client):
@@ -96,13 +94,12 @@ class UtilsTest(unittest.TestCase):
     mock_dataset.return_value.table = mock_table
     mock_table.return_value.exists.return_value = True
 
-    with self.assertRaises(Exception) as e:
+    with self.assertRaisesRegexp(Exception,
+                                 r'^Failed to cleanup. Bigquery table '
+                                 'unused_table still exists'):
       utils.delete_bq_table('unused_project',
                             'unused_dataset',
                             'unused_table')
-    self.assertTrue(
-        e.exception.message.startswith('Failed to cleanup. Bigquery table '
-                                       'unused_table still exists'))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -140,10 +140,9 @@ class LocalFileSystemTest(unittest.TestCase):
 
   def test_match_file_exception(self):
     # Match files with None so that it throws an exception
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Match operation failed') as error:
       self.fs.match([None])
-    self.assertTrue(
-        error.exception.message.startswith('Match operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [None])
 
   def test_match_glob(self):
@@ -175,10 +174,9 @@ class LocalFileSystemTest(unittest.TestCase):
   def test_copy_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Copy operation failed') as error:
       self.fs.copy([path1], [path2])
-    self.assertTrue(
-        error.exception.message.startswith('Copy operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [(path1, path2)])
 
   def test_copy_directory(self):
@@ -208,10 +206,9 @@ class LocalFileSystemTest(unittest.TestCase):
   def test_rename_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Rename operation failed') as error:
       self.fs.rename([path1], [path2])
-    self.assertTrue(
-        error.exception.message.startswith('Rename operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [(path1, path2)])
 
   def test_rename_directory(self):
@@ -250,8 +247,7 @@ class LocalFileSystemTest(unittest.TestCase):
 
   def test_delete_error(self):
     path1 = os.path.join(self.tmpdir, 'f1')
-    with self.assertRaises(BeamIOError) as error:
+    with self.assertRaisesRegexp(BeamIOError,
+                                 r'^Delete operation failed') as error:
       self.fs.delete([path1])
-    self.assertTrue(
-        error.exception.message.startswith('Delete operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [path1])

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -23,6 +23,7 @@ import logging
 import os
 import pickle
 import random
+import re
 import shutil
 import tempfile
 import unittest
@@ -79,9 +80,8 @@ class TestTFRecordUtil(unittest.TestCase):
     return ''.join(l)
 
   def _test_error(self, record, error_text):
-    with self.assertRaises(ValueError) as context:
+    with self.assertRaisesRegexp(ValueError, re.escape(error_text)):
       _TFRecordUtil.read_record(self._as_file_handle(record))
-    self.assertIn(error_text, context.exception.message)
 
   def test_masked_crc32c(self):
     self.assertEqual(0xfd7fffa, _TFRecordUtil._masked_crc32c('\x00' * 32))


### PR DESCRIPTION
Some bugs fixed along the way, where assertions about exception contents were put after the exception was raised, such that they were never reached.