### PR TITLE
[BEAM-3409] waitUntilFinish() doesn't wait for the teardown execution on Direct runner

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunners.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunners.java
@@ -52,7 +52,7 @@ public class DoFnRunners {
    * compressed {@link WindowedValue}. It is the responsibility of the runner to perform any key
    * partitioning needed, etc.
    */
-  public static <InputT, OutputT> DoFnRunner<InputT, OutputT> simpleRunner(
+  public static <InputT, OutputT> SimpleDoFnRunner<InputT, OutputT> simpleRunner(
       PipelineOptions options,
       DoFn<InputT, OutputT> fn,
       SideInputReader sideInputReader,

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import org.apache.beam.runners.core.StateNamespaces.WindowNamespace;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -39,17 +40,22 @@ import org.joda.time.Instant;
 public class ProcessFnRunner<InputT, OutputT, RestrictionT>
     implements PushbackSideInputDoFnRunner<
         KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> {
-  private final DoFnRunner<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> underlying;
+  private final SimpleDoFnRunner<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT>
+    underlying;
   private final Collection<PCollectionView<?>> views;
   private final ReadyCheckingSideInputReader sideInputReader;
 
   public ProcessFnRunner(
-      DoFnRunner<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> underlying,
+      SimpleDoFnRunner<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> underlying,
       Collection<PCollectionView<?>> views,
       ReadyCheckingSideInputReader sideInputReader) {
     this.underlying = underlying;
     this.views = views;
     this.sideInputReader = sideInputReader;
+  }
+
+  public DoFn<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> getFn() {
+    return underlying.getFn();
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -120,6 +120,10 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     this.allowedLateness = windowingStrategy.getAllowedLateness();
   }
 
+  public DoFn<InputT, OutputT> getFn() {
+    return fn;
+  }
+
   @Override
   public void startBundle() {
     // This can contain user code. Wrap it in case it throws an exception.

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
@@ -45,6 +45,10 @@ class DoFnLifecycleManagerRemovingTransformEvaluator<InputT> implements Transfor
     this.lifecycleManager = lifecycleManager;
   }
 
+  public ParDoEvaluator<InputT> getParDoEvaluator() {
+    return underlying;
+  }
+
   @Override
   public void processElement(WindowedValue<InputT> element) throws Exception {
     try {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -169,6 +169,14 @@ class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
     }
   }
 
+  public PushbackSideInputDoFnRunner<InputT, ?> getFnRunner() {
+    return fnRunner;
+  }
+
+  public DirectStepContext getStepContext() {
+    return stepContext;
+  }
+
   public BundleOutputManager getOutputManager() {
     return outputManager;
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
@@ -42,7 +42,7 @@ final class ParDoEvaluatorFactory<InputT, OutputT> implements TransformEvaluator
 
   private static final Logger LOG = LoggerFactory.getLogger(ParDoEvaluatorFactory.class);
   private final LoadingCache<AppliedPTransform<?, ?, ?>, DoFnLifecycleManager> fnClones;
-  private final EvaluationContext evaluationContext;
+  final EvaluationContext evaluationContext;
   private final ParDoEvaluator.DoFnRunnerFactory<InputT, OutputT> runnerFactory;
 
   ParDoEvaluatorFactory(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.direct;
 
 import static com.google.common.base.Preconditions.checkState;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
@@ -39,6 +40,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.beam.runners.direct.DirectRunner.DirectPipelineResult;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -297,6 +299,39 @@ public class DirectRunnerTest implements Serializable {
     // Must time out, otherwise this test will never complete
     result.waitUntilFinish(Duration.millis(1L));
     assertThat(result.getState(), is(State.RUNNING));
+  }
+
+  private static final AtomicLong TEARDOWN_CALL = new AtomicLong(-1);
+
+  @Test
+  public void tearsDownFnsBeforeFinishing() {
+    TEARDOWN_CALL.set(-1);
+    final Pipeline pipeline = getPipeline();
+    pipeline.apply(Create.of("a"))
+      .apply(ParDo.of(new DoFn<String, String>() {
+        @ProcessElement
+        public void onElement(final ProcessContext ctx) {
+          // no-op
+        }
+
+        @Teardown
+        public void teardown() {
+          // just to not have a fast execution hiding an issue until we have a shutdown callback
+          try {
+              Thread.sleep(1000);
+          } catch (final InterruptedException e) {
+              fail();
+          }
+          TEARDOWN_CALL.set(System.nanoTime());
+        }
+      }));
+    final PipelineResult pipelineResult = pipeline.run();
+    pipelineResult.waitUntilFinish();
+
+    final long doneTs = System.nanoTime();
+    final long tearDownTs = TEARDOWN_CALL.get();
+    assertThat(tearDownTs, greaterThan(0L));
+    assertThat(doneTs, greaterThan(tearDownTs));
   }
 
   @Test


### PR DESCRIPTION
Using the direct runner, p.run().waitUntilFinish() doesn't wait for the teardown execution

This PR contains these fixes:

1. for each dofn registered it will create a latch the execution will wait on for waitUntilFinish and guarantee
the teardown methods are included into this "wait"
2. For SDF it ensure the dofnmanager are released and therefore than teardown is called (propagating previous logic as well)