### PR TITLE
[BEAM-3450] Add wire_coder_id to RemoteGrpcPort

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -76,6 +76,9 @@ message RemoteGrpcPort {
   // (Required) An API descriptor which describes where to
   // connect to including any authentication that is required.
   org.apache.beam.model.pipeline.v1.ApiServiceDescriptor api_service_descriptor = 1;
+
+  // (Required) The ID of the Coder that will be used to encode and decode data sent over this port.
+  string coder_id = 2;
 }
 
 /*

--- a/sdks/java/fn-execution/pom.xml
+++ b/sdks/java/fn-execution/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataReadRunner.java
@@ -34,8 +34,10 @@ import org.apache.beam.fn.harness.data.MultiplexingFnDataReceiver;
 import org.apache.beam.fn.harness.fn.ThrowingRunnable;
 import org.apache.beam.fn.harness.state.BeamFnStateClient;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.runners.core.construction.CoderTranslation;
@@ -121,7 +123,7 @@ public class BeamFnDataReadRunner<OutputT> {
   private final Endpoints.ApiServiceDescriptor apiServiceDescriptor;
   private final FnDataReceiver<WindowedValue<OutputT>> receiver;
   private final Supplier<String> processBundleInstructionIdSupplier;
-  private final BeamFnDataClient beamFnDataClientFactory;
+  private final BeamFnDataClient beamFnDataClient;
   private final Coder<WindowedValue<OutputT>> coder;
   private final BeamFnApi.Target inputTarget;
 
@@ -133,28 +135,37 @@ public class BeamFnDataReadRunner<OutputT> {
       BeamFnApi.Target inputTarget,
       RunnerApi.Coder coderSpec,
       Map<String, RunnerApi.Coder> coders,
-      BeamFnDataClient beamFnDataClientFactory,
+      BeamFnDataClient beamFnDataClient,
       Collection<FnDataReceiver<WindowedValue<OutputT>>> consumers)
-          throws IOException {
-    this.apiServiceDescriptor =
-        RemoteGrpcPortRead.fromPTransform(grpcReadNode).getPort().getApiServiceDescriptor();
+      throws IOException {
+    RemoteGrpcPort port = RemoteGrpcPortRead.fromPTransform(grpcReadNode).getPort();
+    this.apiServiceDescriptor = port.getApiServiceDescriptor();
     this.inputTarget = inputTarget;
     this.processBundleInstructionIdSupplier = processBundleInstructionIdSupplier;
-    this.beamFnDataClientFactory = beamFnDataClientFactory;
+    this.beamFnDataClient = beamFnDataClient;
     this.receiver = MultiplexingFnDataReceiver.forConsumers(consumers);
 
+    RehydratedComponents components =
+        RehydratedComponents.forComponents(Components.newBuilder().putAllCoders(coders).build());
     @SuppressWarnings("unchecked")
-    Coder<WindowedValue<OutputT>> coder =
-        (Coder<WindowedValue<OutputT>>)
-            CoderTranslation.fromProto(
-                coderSpec,
-                RehydratedComponents.forComponents(
-                    RunnerApi.Components.newBuilder().putAllCoders(coders).build()));
+    Coder<WindowedValue<OutputT>> coder;
+    if (!port.getCoderId().isEmpty()) {
+      coder =
+          (Coder<WindowedValue<OutputT>>)
+              CoderTranslation.fromProto(coders.get(port.getCoderId()), components);
+    } else {
+      // TODO: Remove this path once it is no longer used
+      coder =
+          (Coder<WindowedValue<OutputT>>)
+              CoderTranslation.fromProto(
+                  coderSpec,
+                  components);
+    }
     this.coder = coder;
   }
 
   public void registerInputLocation() {
-    this.readFuture = beamFnDataClientFactory.receive(
+    this.readFuture = beamFnDataClient.receive(
         apiServiceDescriptor,
         LogicalEndpoint.of(processBundleInstructionIdSupplier.get(), inputTarget),
         coder,


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
This is the first step to decouple the wire-format coders from intermediate PCollection coders

Fallback to the coder of the output PCollection if this field is not populated.