### PR TITLE
[BEAM-2732] Metrics rely on statesampler state

### DIFF
--- a/sdks/python/apache_beam/metrics/execution_test.py
+++ b/sdks/python/apache_beam/metrics/execution_test.py
@@ -18,11 +18,7 @@
 import unittest
 
 from apache_beam.metrics.cells import CellCommitState
-from apache_beam.metrics.execution import MetricKey
 from apache_beam.metrics.execution import MetricsContainer
-from apache_beam.metrics.execution import MetricsEnvironment
-from apache_beam.metrics.execution import ScopedMetricsContainer
-from apache_beam.metrics.metric import Metrics
 from apache_beam.metrics.metricbase import MetricName
 
 
@@ -32,29 +28,6 @@ class TestMetricsContainer(unittest.TestCase):
     self.assertFalse(MetricName('namespace', 'name') in mc.counters)
     mc.get_counter(MetricName('namespace', 'name'))
     self.assertTrue(MetricName('namespace', 'name') in mc.counters)
-
-  def test_scoped_container(self):
-    c1 = MetricsContainer('mystep')
-    c2 = MetricsContainer('myinternalstep')
-    with ScopedMetricsContainer(c1):
-      self.assertEqual(c1, MetricsEnvironment.current_container())
-      counter = Metrics.counter('ns', 'name')
-      counter.inc(2)
-
-      with ScopedMetricsContainer(c2):
-        self.assertEqual(c2, MetricsEnvironment.current_container())
-        counter = Metrics.counter('ns', 'name')
-        counter.inc(3)
-        self.assertEqual(
-            list(c2.get_cumulative().counters.items()),
-            [(MetricKey('myinternalstep', MetricName('ns', 'name')), 3)])
-
-      self.assertEqual(c1, MetricsEnvironment.current_container())
-      counter = Metrics.counter('ns', 'name')
-      counter.inc(4)
-      self.assertEqual(
-          list(c1.get_cumulative().counters.items()),
-          [(MetricKey('mystep', MetricName('ns', 'name')), 6)])
 
   def test_add_to_counter(self):
     mc = MetricsContainer('astep')
@@ -116,30 +89,6 @@ class TestMetricsContainer(unittest.TestCase):
                      set([v for _, v in cumulative.counters.items()]))
     self.assertEqual(set(dirty_values + clean_values),
                      set([v.value for _, v in cumulative.gauges.items()]))
-
-
-class TestMetricsEnvironment(unittest.TestCase):
-  def test_uses_right_container(self):
-    c1 = MetricsContainer('step1')
-    c2 = MetricsContainer('step2')
-    counter = Metrics.counter('ns', 'name')
-    MetricsEnvironment.set_current_container(c1)
-    counter.inc()
-    MetricsEnvironment.set_current_container(c2)
-    counter.inc(3)
-    MetricsEnvironment.unset_current_container()
-
-    self.assertEqual(
-        list(c1.get_cumulative().counters.items()),
-        [(MetricKey('step1', MetricName('ns', 'name')), 1)])
-
-    self.assertEqual(
-        list(c2.get_cumulative().counters.items()),
-        [(MetricKey('step2', MetricName('ns', 'name')), 3)])
-
-  def test_no_container(self):
-    self.assertEqual(MetricsEnvironment.current_container(),
-                     None)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -28,7 +28,6 @@ import traceback
 import six
 
 from apache_beam.internal import util
-from apache_beam.metrics.execution import ScopedMetricsContainer
 from apache_beam.pvalue import TaggedOutput
 from apache_beam.transforms import DoFn
 from apache_beam.transforms import core
@@ -536,6 +535,8 @@ class DoFnRunner(Receiver):
     """
     # Need to support multiple iterations.
     side_inputs = list(side_inputs)
+
+    from apache_beam.metrics.execution import ScopedMetricsContainer
 
     self.scoped_metrics_container = (
         scoped_metrics_container or ScopedMetricsContainer())

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -31,8 +31,9 @@ from weakref import WeakValueDictionary
 import six
 
 from apache_beam.metrics.execution import MetricsContainer
-from apache_beam.metrics.execution import ScopedMetricsContainer
+from apache_beam.runners.worker import statesampler
 from apache_beam.transforms import sideinputs
+from apache_beam.utils import counters
 
 
 class _ExecutorService(object):
@@ -40,7 +41,7 @@ class _ExecutorService(object):
 
   class CallableTask(object):
 
-    def call(self):
+    def call(self, state_sampler):
       pass
 
     @property
@@ -83,13 +84,15 @@ class _ExecutorService(object):
         return None
 
     def run(self):
+      state_sampler = statesampler.StateSampler('', counters.CounterFactory())
+      statesampler.set_current_tracker(state_sampler)
       while not self.shutdown_requested:
         task = self._get_task_or_none()
         if task:
           try:
             if not self.shutdown_requested:
               self._update_name(task)
-              task.call()
+              task.call(state_sampler)
               self._update_name()
           finally:
             self.queue.task_done()
@@ -290,35 +293,52 @@ class TransformExecutor(_ExecutorService.CallableTask):
     self._retry_count = 0
     self._max_retries_per_bundle = TransformExecutor._MAX_RETRY_PER_BUNDLE
 
-  def call(self):
+  def call(self, state_sampler):
     self._call_count += 1
     assert self._call_count <= (1 + len(self._applied_ptransform.side_inputs))
     metrics_container = MetricsContainer(self._applied_ptransform.full_label)
-    scoped_metrics_container = ScopedMetricsContainer(metrics_container)
+    start_state = state_sampler.scoped_state(
+        self._applied_ptransform.full_label,
+        'start',
+        metrics_container=metrics_container)
+    process_state = state_sampler.scoped_state(
+        self._applied_ptransform.full_label,
+        'process',
+        metrics_container=metrics_container)
+    finish_state = state_sampler.scoped_state(
+        self._applied_ptransform.full_label,
+        'finish',
+        metrics_container=metrics_container)
 
-    for side_input in self._applied_ptransform.side_inputs:
-      # Find the projection of main's window onto the side input's window.
-      window_mapping_fn = side_input._view_options().get(
-          'window_mapping_fn', sideinputs._global_window_mapping_fn)
-      main_onto_side_window = window_mapping_fn(self._latest_main_input_window)
-      block_until = main_onto_side_window.end
+    with start_state:
+      # Side input initialization should be accounted for in start_state.
+      for side_input in self._applied_ptransform.side_inputs:
+        # Find the projection of main's window onto the side input's window.
+        window_mapping_fn = side_input._view_options().get(
+            'window_mapping_fn', sideinputs._global_window_mapping_fn)
+        main_onto_side_window = window_mapping_fn(
+            self._latest_main_input_window)
+        block_until = main_onto_side_window.end
 
-      if side_input not in self._side_input_values:
-        value = self._evaluation_context.get_value_or_block_until_ready(
-            side_input, self, block_until)
-        if not value:
-          # Monitor task will reschedule this executor once the side input is
-          # available.
-          return
-        self._side_input_values[side_input] = value
-    side_input_values = [self._side_input_values[side_input]
-                         for side_input in self._applied_ptransform.side_inputs]
+        if side_input not in self._side_input_values:
+          value = self._evaluation_context.get_value_or_block_until_ready(
+              side_input, self, block_until)
+          if not value:
+            # Monitor task will reschedule this executor once the side input is
+            # available.
+            return
+          self._side_input_values[side_input] = value
+      side_input_values = [
+          self._side_input_values[side_input]
+          for side_input in self._applied_ptransform.side_inputs]
 
     while self._retry_count < self._max_retries_per_bundle:
       try:
         self.attempt_call(metrics_container,
-                          scoped_metrics_container,
-                          side_input_values)
+                          side_input_values,
+                          start_state,
+                          process_state,
+                          finish_state)
         break
       except Exception as e:
         self._retry_count += 1
@@ -336,24 +356,28 @@ class TransformExecutor(_ExecutorService.CallableTask):
     self._transform_evaluation_state.complete(self)
 
   def attempt_call(self, metrics_container,
-                   scoped_metrics_container,
-                   side_input_values):
+                   side_input_values,
+                   start_state,
+                   process_state,
+                   finish_state):
+    """Attempts to run a bundle."""
     evaluator = self._transform_evaluator_registry.get_evaluator(
         self._applied_ptransform, self._input_bundle,
-        side_input_values, scoped_metrics_container)
+        side_input_values)
 
-    with scoped_metrics_container:
+    with start_state:
       evaluator.start_bundle()
 
-    if self._fired_timers:
-      for timer_firing in self._fired_timers:
-        evaluator.process_timer_wrapper(timer_firing)
+    with process_state:
+      if self._fired_timers:
+        for timer_firing in self._fired_timers:
+          evaluator.process_timer_wrapper(timer_firing)
 
-    if self._input_bundle:
-      for value in self._input_bundle.get_elements_iterable():
-        evaluator.process_element(value)
+      if self._input_bundle:
+        for value in self._input_bundle.get_elements_iterable():
+          evaluator.process_element(value)
 
-    with scoped_metrics_container:
+    with finish_state:
       result = evaluator.finish_bundle()
       result.logical_metric_updates = metrics_container.get_cumulative()
 
@@ -525,7 +549,7 @@ class _ExecutorServiceParallelExecutor(object):
     def name(self):
       return 'monitor'
 
-    def call(self):
+    def call(self, state_sampler):
       try:
         update = self._executor.all_updates.poll()
         while update:

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -211,8 +211,7 @@ def only_element(iterable):
 
 
 class BundleProcessor(object):
-  """A class for processing bundles of elements.
-  """
+  """A class for processing bundles of elements."""
   def __init__(
       self, process_bundle_descriptor, state_handler, data_channel_factory):
     self.process_bundle_descriptor = process_bundle_descriptor

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -133,24 +133,27 @@ class Operation(object):
 
     # These are overwritten in the legacy harness.
     self.metrics_container = MetricsContainer(self.name_context.metrics_name())
-    self.scoped_metrics_container = ScopedMetricsContainer(
-        self.metrics_container)
+    # TODO(BEAM-4094): Remove ScopedMetricsContainer after Dataflow no longer
+    # depends on it.
+    self.scoped_metrics_container = ScopedMetricsContainer()
 
     self.state_sampler = state_sampler
     self.scoped_start_state = self.state_sampler.scoped_state(
-        self.name_context.metrics_name(), 'start')
+        self.name_context.metrics_name(), 'start',
+        metrics_container=self.metrics_container)
     self.scoped_process_state = self.state_sampler.scoped_state(
-        self.name_context.metrics_name(), 'process')
+        self.name_context.metrics_name(), 'process',
+        metrics_container=self.metrics_container)
     self.scoped_finish_state = self.state_sampler.scoped_state(
-        self.name_context.metrics_name(), 'finish')
+        self.name_context.metrics_name(), 'finish',
+        metrics_container=self.metrics_container)
     # TODO(ccy): the '-abort' state can be added when the abort is supported in
     # Operations.
     self.receivers = []
 
   def start(self):
     """Start operation."""
-    self.debug_logging_enabled = logging.getLogger().isEnabledFor(
-        logging.DEBUG)
+    self.debug_logging_enabled = logging.getLogger().isEnabledFor(logging.DEBUG)
     # Everything except WorkerSideInputSource, which is not a
     # top-level operation, should have output_coders
     #TODO(pabloem): Define better what step name is used here.
@@ -240,16 +243,15 @@ class ReadOperation(Operation):
 
   def start(self):
     with self.scoped_start_state:
-      with self.scoped_metrics_container:
-        super(ReadOperation, self).start()
-        range_tracker = self.spec.source.source.get_range_tracker(
-            self.spec.source.start_position, self.spec.source.stop_position)
-        for value in self.spec.source.source.read(range_tracker):
-          if isinstance(value, WindowedValue):
-            windowed_value = value
-          else:
-            windowed_value = _globally_windowed_value.with_value(value)
-          self.output(windowed_value)
+      super(ReadOperation, self).start()
+      range_tracker = self.spec.source.source.get_range_tracker(
+          self.spec.source.start_position, self.spec.source.stop_position)
+      for value in self.spec.source.source.read(range_tracker):
+        if isinstance(value, WindowedValue):
+          windowed_value = value
+        else:
+          windowed_value = _globally_windowed_value.with_value(value)
+        self.output(windowed_value)
 
 
 class InMemoryWriteOperation(Operation):
@@ -390,7 +392,7 @@ class DoOperation(Operation):
           logging_context=logger.PerThreadLoggingContext(
               step_name=self.name_context.logging_name()),
           state=state,
-          scoped_metrics_container=self.scoped_metrics_container)
+          scoped_metrics_container=None)
       self.dofn_receiver = (self.dofn_runner
                             if isinstance(self.dofn_runner, Receiver)
                             else DoFnRunnerReceiver(self.dofn_runner))
@@ -444,9 +446,8 @@ class CombineOperation(Operation):
     if self.debug_logging_enabled:
       logging.debug('Processing [%s] in %s', o, self)
     key, values = o.value
-    with self.scoped_metrics_container:
-      self.output(
-          o.with_value((key, self.phased_combine_fn.apply(values))))
+    self.output(
+        o.with_value((key, self.phased_combine_fn.apply(values))))
 
 
 def create_pgbk_op(step_name, spec, counter_factory, state_sampler):
@@ -725,8 +726,6 @@ class SimpleMapTaskExecutor(object):
 
     for ix, op in reversed(list(enumerate(self._ops))):
       logging.debug('Starting op %d %s', ix, op)
-      with op.scoped_metrics_container:
-        op.start()
+      op.start()
     for op in self._ops:
-      with op.scoped_metrics_container:
-        op.finish()
+      op.finish()

--- a/sdks/python/apache_beam/runners/worker/statesampler_slow.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_slow.py
@@ -28,11 +28,17 @@ class StateSampler(object):
     self.finished = False
 
   def current_state(self):
-    """Returns the current execution state."""
+    """Returns the current execution state.
+
+    This operation is not thread safe, and should only be called from the
+    execution thread."""
     return self._state_stack[-1]
 
-  def _scoped_state(self, counter_name, output_counter):
-    return ScopedState(self, counter_name, output_counter)
+  def _scoped_state(self,
+                    counter_name,
+                    output_counter,
+                    metrics_container=None):
+    return ScopedState(self, counter_name, output_counter, metrics_container)
 
   def _enter_state(self, state):
     self.state_transition_count += 1
@@ -44,24 +50,20 @@ class StateSampler(object):
 
   def start(self):
     # Sampling not yet supported. Only state tracking at the moment.
-    self.started = True
+    pass
 
   def stop(self):
     self.finished = True
 
-  def get_info(self):
-    """Returns StateSamplerInfo with transition statistics."""
-    return StateSamplerInfo(
-        self.current_state().name, self.transition_count, 0)
-
 
 class ScopedState(object):
 
-  def __init__(self, sampler, name, counter=None):
+  def __init__(self, sampler, name, counter=None, metrics_container=None):
     self.state_sampler = sampler
     self.name = name
     self.counter = counter
     self.nsecs = 0
+    self.metrics_container = metrics_container
 
   def sampled_seconds(self):
     return 1e-9 * self.nsecs

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -221,6 +221,7 @@ class _BatchSizeEstimator(object):
     self._clock = clock
     self._data = []
     self._ignore_next_timing = False
+
     self._size_distribution = Metrics.distribution(
         'BatchElements', 'batch_size')
     self._time_distribution = Metrics.distribution(


### PR DESCRIPTION
This PR depends on PR #4375.

This PR is a backward-compatible change that allows metrics to rely on statesampler state to provide the current container.

This change should enable all clients to stop tracking metrics with its own context, and start using statesampler for that.

Benchmarks showed no impact on performance. Benchmark done using an ML Criteo pipeline that processes 10gb.

Results Before Change (5 runs):
Mean: 1809.2s, Stdev: 227.1622768

Results With Change (5 runs):
Mean: 1758.4s, Stdev: 93.46282684