### PR TITLE
[BEAM-3451] Update google-cloud-bigquery version.

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -62,7 +62,7 @@ RUN \
     pip install "proto-google-cloud-datastore-v1 == 0.90.4" && \
     pip install "googledatastore == 7.0.1" && \
     pip install "google-cloud-pubsub == 0.26.0" && \
-    pip install "google-cloud-bigquery == 0.25.0" && \
+    pip install "google-cloud-bigquery == 0.29.0" && \
     # Optional packages
     pip install "cython == 0.27.2" && \
     pip install "guppy == 0.1.10" && \

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -126,8 +126,7 @@ GCP_REQUIREMENTS = [
   'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4',
   'googledatastore==7.0.1',
   'google-cloud-pubsub==0.26.0',
-  # GCP packages required by tests
-  'google-cloud-bigquery==0.25.0',
+  'google-cloud-bigquery==0.29.0',
 ]
 
 


### PR DESCRIPTION
This version has load_table_from_uri(), while the previous one does not.