### PR TITLE
Handle a populated Error field in FnApiControlClient

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
@@ -128,7 +128,11 @@ class FnApiControlClient implements Closeable {
       SettableFuture<BeamFnApi.InstructionResponse> completableFuture =
           outstandingRequests.remove(response.getInstructionId());
       if (completableFuture != null) {
-        completableFuture.set(response);
+        if (response.getError().isEmpty()) {
+          completableFuture.set(response);
+        } else {
+          completableFuture.setException(new RuntimeException(response.getError()));
+        }
       }
     }
 


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
If the error field is set, the instruction has failed and the
instruction response should be completed exceptionally.

This seems to me like a reasonable behavior instead of setting the response
and then checking to see if the error field is set everywhere that tries to extract
a specific response. It does slightly expand the definition of 'only for correlating requests with responses'.