### PR TITLE
[BEAM-3250] Migrate Flink and Spark ValidatesRunner to Gradle

### DIFF
--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -186,49 +186,55 @@ def flinkExcludedCategories = [
   'org.apache.beam.sdk.testing.UsesTestStream',
 ]
 
-def flinkPipelineOptions(streaming) {
+def validatesRunnerConfigs = [
   [
-    runner: "TestFlinkRunner",
-    streaming: streaming as String,
-  ]
-}
-
-createValidatesRunner(
     runner: "flinkBatch",
-    configuration: configurations.flinkValidatesRunner,
     excludes: flinkExcludedCategories,
-    pipelineOptions: flinkPipelineOptions(false))
-
-createValidatesRunner(
+    pipelineOptions: [
+      runner: "TestFlinkRunner",
+      streaming: false,
+    ],
+    configuration: configurations.flinkValidatesRunner,
+  ],
+  [
     runner: "flinkStreaming",
-    configuration: configurations.flinkValidatesRunner,
     excludes: flinkExcludedCategories,
-    pipelineOptions: flinkPipelineOptions(true))
-
-def sparkBatchExcludedCategories = [
-  'org.apache.beam.sdk.testing.UsesSplittableParDo',
-  'org.apache.beam.sdk.testing.UsesCommittedMetrics',
-  'org.apache.beam.sdk.testing.UsesTestStream',
-  'org.apache.beam.sdk.testing.UsesCustomWindowMerging',
+    pipelineOptions: [
+      runner: "TestFlinkRunner",
+      streaming: true,
+    ],
+    configuration: configurations.flinkValidatesRunner,
+  ],
+  [
+    runner: "sparkBatch",
+    excludes: [
+      'org.apache.beam.sdk.testing.UsesSplittableParDo',
+      'org.apache.beam.sdk.testing.UsesCommittedMetrics',
+      'org.apache.beam.sdk.testing.UsesTestStream',
+      'org.apache.beam.sdk.testing.UsesCustomWindowMerging',
+    ],
+    pipelineOptions: [
+      runner: "TestSparkRunner",
+      streaming: "false",
+      enableSparkMetricSinks: "false",
+    ],
+    configuration: configurations.sparkValidatesRunner,
+    systemProperties: [
+      "beam.spark.test.reuseSparkContext": "true",
+      "spark.ui.enabled": "false",
+      "spark.ui.showConsoleProgress": "false",
+    ],
+  ],
 ]
 
-def sparkBatchPipelineOptions = [
-  runner: "TestSparkRunner",
-  streaming: "false",
-  enableSparkMetricSinks: "false",
-]
-
-def sparkBatchSystemProperties = [
-  "beam.spark.test.reuseSparkContext": "true",
-  "spark.ui.enabled": "false",
-  "spark.ui.showConsoleProgress": "false",
-]
-
-createValidatesRunner(
-  runner: "sparkBatch",
-  configuration: configurations.sparkValidatesRunner,
-  excludes: sparkBatchExcludedCategories,
-  pipelineOptions: sparkBatchPipelineOptions)
+task(validatesRunners) {
+  group = "Verification"
+  description = "Validates all runners"
+}
+for (Map config : validatesRunnerConfigs as List<Map>) {
+  def t = createValidatesRunner(config)
+  validatesRunners.dependsOn t
+}
 
 artifacts.archives packageTests
 artifacts {

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -82,10 +82,10 @@ dependencies {
   shadowTest library.java.mockito_core
   shadowTest "com.esotericsoftware.kryo:kryo:2.21"
   flinkValidatesRunner project(path: project.path, configuration: "shadowTest")
-  flinkValidatesRunner project(path: ":beam-runners-parent:beam-runners-flink_2.11", configuration: "shadow")
+  flinkValidatesRunner project(path: ":runners:flink", configuration: "shadow")
   sparkValidatesRunner project(path: project.path, configuration: "shadowTest")
-  sparkValidatesRunner project(path: ":beam-runners-parent:beam-runners-spark", configuration: "shadow")
-  sparkValidatesRunner project(path: ":beam-runners-parent:beam-runners-spark", configuration: "provided")
+  sparkValidatesRunner project(path: ":runners:spark", configuration: "shadow")
+  sparkValidatesRunner project(path: ":runners:spark", configuration: "provided")
 }
 
 // Shade dependencies.

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -38,6 +38,14 @@ processResources {
   ]
 }
 
+configurations {
+    flinkValidatesRunner
+    sparkValidatesRunner {
+      // Testing the Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
+      exclude group: "org.slf4j", module: "slf4j-jdk14"
+    }
+}
+
 // Exclude tests that need a runner
 test {
   systemProperty "beamUseDummyRunner", "true"
@@ -71,6 +79,13 @@ dependencies {
   shadowTest library.java.slf4j_jdk14
   shadowTest library.java.mockito_core
   shadowTest "com.esotericsoftware.kryo:kryo:2.21"
+  flinkValidatesRunner project(path: project.path, configuration: "shadowTest")
+  flinkValidatesRunner project(path: ":beam-runners-parent:beam-runners-flink_2.11", configuration: "shadow")
+  sparkValidatesRunner project(path: project.path, configuration: "shadowTest")
+  sparkValidatesRunner project(path: ":beam-runners-parent:beam-runners-spark", configuration: "shadow")
+  // TODO: Is there a way to refer to the `provided` configuration from the Spark build?
+  sparkValidatesRunner library.java.spark_core
+  sparkValidatesRunner library.java.spark_streaming
 }
 
 // Shade dependencies.
@@ -116,6 +131,113 @@ task packageTests(type: Jar) {
   from sourceSets.test.output
   classifier = "tests"
 }
+
+class ValidatesRunnerConfig {
+  // Task name prefix
+  String testPrefix
+  // Runner name in documentation string
+  String runnerName
+  // List of test categories to exclude from this task. Optional.
+  List<String> excludes
+  // Pipeline options command line arguments.
+  // TODO: Can option keys be specified multiple times?
+  Map<String, String> pipelineOptions
+  // Configuration to use for test runtime classpath.
+  FileCollection configuration
+  // Additional system properties to be set for tests. Optional.
+  Map<String, String> systemProperties
+}
+
+def createValidatesRunner(Map m) {
+  def config = m as ValidatesRunnerConfig
+  assert config.testPrefix != null
+  assert config.runnerName != null
+  assert config.pipelineOptions != null
+  assert config.configuration != null
+  tasks.create(name: "${config.testPrefix}ValidatesRunner", type: Test) {
+    group = "Verification"
+    description = "Validate ${config.runnerName} runner"
+    def optionsList = config.pipelineOptions.collect {
+      // Escape strings with embedded '\' and '"' characters.
+      // TODO: Verify that this happens correctly between JSON and command line parsing.
+      def key = it.getKey().replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"")
+      def value = it.getValue().replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"")
+      "\"--${key}=${value}\""
+    }
+    def pipelineOptions = "[${optionsList.join(",")}]"
+
+    systemProperty "beamTestPipelineOptions", pipelineOptions
+    if (config.systemProperties != null) {
+      for (Map.Entry<String, String> property : config.systemProperties) {
+        systemProperty property.getKey(), property.getValue()
+      }
+    }
+    // TODO: Does Spark require a different forking strategy?
+    maxParallelForks 4
+    classpath = config.configuration
+    useJUnit {
+      includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+      if (config.excludes != null) {
+        excludeCategories(*config.excludes)
+      }
+    }
+  }
+}
+
+def flinkExcludedCategories = [
+  'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders',
+  'org.apache.beam.sdk.testing.LargeKeys$Above100MB',
+  'org.apache.beam.sdk.testing.UsesSplittableParDo',
+  'org.apache.beam.sdk.testing.UsesCommittedMetrics',
+  'org.apache.beam.sdk.testing.UsesTestStream',
+]
+
+def flinkPipelineOptions(streaming) {
+  [
+    runner: "TestFlinkRunner",
+    streaming: streaming as String,
+  ]
+}
+
+createValidatesRunner(
+    testPrefix: "flinkBatch",
+    runnerName: "Flink batch",
+    configuration: configurations.flinkValidatesRunner,
+    excludes: flinkExcludedCategories,
+    pipelineOptions: flinkPipelineOptions(false))
+
+createValidatesRunner(
+    testPrefix: "flinkStreaming",
+    runnerName: "Flink streaming",
+    configuration: configurations.flinkValidatesRunner,
+    excludes: flinkExcludedCategories,
+    pipelineOptions: flinkPipelineOptions(true))
+
+def sparkBatchExcludedCategories = [
+  'org.apache.beam.sdk.testing.UsesSplittableParDo',
+  'org.apache.beam.sdk.testing.UsesCommittedMetrics',
+  'org.apache.beam.sdk.testing.UsesTestStream',
+  'org.apache.beam.sdk.testing.UsesCustomWindowMerging',
+]
+
+def sparkBatchPipelineOptions = [
+  runner: "TestSparkRunner",
+  streaming: "false",
+  enableSparkMetricSinks: "false",
+]
+
+def sparkBatchSystemProperties = [
+  "beam.spark.test.reuseSparkContext": "true",
+  "spark.ui.enabled": "false",
+  "spark.ui.showConsoleProgress": "false",
+]
+
+createValidatesRunner(
+  testPrefix: "sparkBatch",
+  runnerName: "Spark batch",
+  configuration: configurations.sparkValidatesRunner,
+  excludes: sparkBatchExcludedCategories,
+  pipelineOptions: sparkBatchPipelineOptions)
 
 artifacts.archives packageTests
 artifacts {

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import groovy.json.JsonOutput
+
 apply from: project(":").file("build_rules.gradle")
 applyJavaNature()
 applyAvroNature()
@@ -136,7 +138,6 @@ class ValidatesRunnerConfig {
   // List of test categories to exclude from this task. Optional.
   List<String> excludes
   // Pipeline options command line arguments.
-  // TODO: Can option keys be specified multiple times?
   Map<String, String> pipelineOptions
   // Configuration to use for test runtime classpath.
   FileCollection configuration
@@ -153,16 +154,14 @@ def createValidatesRunner(Map m) {
     group = "Verification"
     description = "Validate ${config.runner} runner"
     def optionsList = config.pipelineOptions.collect {
-      // Escape strings with embedded '\' and '"' characters.
-      // TODO: Verify that this happens correctly between JSON and command line parsing.
-      def key = it.getKey().replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"")
-      def value = it.getValue().replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"")
-      "\"--${key}=${value}\""
+      def key = it.getKey()
+      def value = it.getValue()
+      "--${key}=${value}"
     }
-    def pipelineOptions = "[${optionsList.join(",")}]"
+    def pipelineOptions = JsonOutput.toJson(optionsList)
 
     systemProperty "beamTestPipelineOptions", pipelineOptions
-    if (config.systemProperties != null) {
+    if (config.systemProperties) {
       for (Map.Entry<String, String> property : config.systemProperties) {
         systemProperty property.getKey(), property.getValue()
       }
@@ -172,7 +171,7 @@ def createValidatesRunner(Map m) {
     classpath = config.configuration
     useJUnit {
       includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-      if (config.excludes != null) {
+      if (config.excludes) {
         excludeCategories(*config.excludes)
       }
     }

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -83,9 +83,7 @@ dependencies {
   flinkValidatesRunner project(path: ":beam-runners-parent:beam-runners-flink_2.11", configuration: "shadow")
   sparkValidatesRunner project(path: project.path, configuration: "shadowTest")
   sparkValidatesRunner project(path: ":beam-runners-parent:beam-runners-spark", configuration: "shadow")
-  // TODO: Is there a way to refer to the `provided` configuration from the Spark build?
-  sparkValidatesRunner library.java.spark_core
-  sparkValidatesRunner library.java.spark_streaming
+  sparkValidatesRunner project(path: ":beam-runners-parent:beam-runners-spark", configuration: "provided")
 }
 
 // Shade dependencies.

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -131,10 +131,8 @@ task packageTests(type: Jar) {
 }
 
 class ValidatesRunnerConfig {
-  // Task name prefix
-  String testPrefix
-  // Runner name in documentation string
-  String runnerName
+  // Runner name prefix
+  String runner
   // List of test categories to exclude from this task. Optional.
   List<String> excludes
   // Pipeline options command line arguments.
@@ -148,13 +146,12 @@ class ValidatesRunnerConfig {
 
 def createValidatesRunner(Map m) {
   def config = m as ValidatesRunnerConfig
-  assert config.testPrefix != null
-  assert config.runnerName != null
+  assert config.runner != null
   assert config.pipelineOptions != null
   assert config.configuration != null
-  tasks.create(name: "${config.testPrefix}ValidatesRunner", type: Test) {
+  tasks.create(name: "${config.runner}ValidatesRunner", type: Test) {
     group = "Verification"
-    description = "Validate ${config.runnerName} runner"
+    description = "Validate ${config.runner} runner"
     def optionsList = config.pipelineOptions.collect {
       // Escape strings with embedded '\' and '"' characters.
       // TODO: Verify that this happens correctly between JSON and command line parsing.
@@ -198,15 +195,13 @@ def flinkPipelineOptions(streaming) {
 }
 
 createValidatesRunner(
-    testPrefix: "flinkBatch",
-    runnerName: "Flink batch",
+    runner: "flinkBatch",
     configuration: configurations.flinkValidatesRunner,
     excludes: flinkExcludedCategories,
     pipelineOptions: flinkPipelineOptions(false))
 
 createValidatesRunner(
-    testPrefix: "flinkStreaming",
-    runnerName: "Flink streaming",
+    runner: "flinkStreaming",
     configuration: configurations.flinkValidatesRunner,
     excludes: flinkExcludedCategories,
     pipelineOptions: flinkPipelineOptions(true))
@@ -231,8 +226,7 @@ def sparkBatchSystemProperties = [
 ]
 
 createValidatesRunner(
-  testPrefix: "sparkBatch",
-  runnerName: "Spark batch",
+  runner: "sparkBatch",
   configuration: configurations.sparkValidatesRunner,
   excludes: sparkBatchExcludedCategories,
   pipelineOptions: sparkBatchPipelineOptions)


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

Note that Gradle does not support scanning arbitrary jars/dependencies for test classes. For this reason, this change inverts structure of the validates-runner tests, moving them into `sdks/java/core` rather than the runner modules themselves. This does not create a cyclic dependency because dependencies are analyzed by module/configuration rather than by module.

On my machine, the Flink validates-runner tests take about 20 minutes to run on maven and about 5 minutes to run with Gradle.