### PR TITLE
BEAM 3299: Source progress reporting

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -32,17 +32,23 @@ type Plan struct {
 	units []Unit
 
 	status Status
+	source *DataSource
 }
 
 // NewPlan returns a new bundle execution plan from the given units.
 func NewPlan(id string, units []Unit) (*Plan, error) {
 	var roots []Root
+	var source *DataSource
+
 	for _, u := range units {
 		if u == nil {
 			return nil, fmt.Errorf("no <nil> units")
 		}
 		if r, ok := u.(Root); ok {
 			roots = append(roots, r)
+		}
+		if s, ok := u.(*DataSource); ok {
+			source = s
 		}
 	}
 	if len(roots) == 0 {
@@ -54,6 +60,7 @@ func NewPlan(id string, units []Unit) (*Plan, error) {
 		status: Initializing,
 		roots:  roots,
 		units:  units,
+		source: source,
 	}, nil
 }
 
@@ -136,4 +143,9 @@ func (p *Plan) String() string {
 		units = append(units, fmt.Sprintf("%v: %v", u.ID(), u))
 	}
 	return fmt.Sprintf("Plan[%v]:\n%v", p.ID(), strings.Join(units, "\n"))
+}
+
+// ProgressReport returns a snapshot of input progress of the plan.
+func (p *Plan) ProgressReport() ProgressReportSnapshot {
+	return p.source.Progress()
 }

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -85,8 +85,9 @@ func Main(ctx context.Context, loggingEndpoint, controlEndpoint string) error {
 	}()
 
 	ctrl := &control{
-		plans: make(map[string]*exec.Plan),
-		data:  &DataManager{},
+		plans:  make(map[string]*exec.Plan),
+		active: make(map[string]*exec.Plan),
+		data:   &DataManager{},
 	}
 
 	var cpuProfBuf bytes.Buffer

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -176,10 +176,12 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 			if err != nil {
 				return fail(id, "translation failed: %v", err)
 			}
-			log.Debugf(ctx, "Plan %v: %v", desc.GetId(), plan)
+
+			pid := desc.GetId()
+			log.Debugf(ctx, "Plan %v: %v", pid, plan)
 
 			c.mu.Lock()
-			c.plans[desc.GetId()] = plan
+			c.plans[pid] = plan
 			c.mu.Unlock()
 		}
 


### PR DESCRIPTION
Makes the harness sufficiently multithreaded so we can handle progress
reports while we are performing work. The plans maintain their ability
to be reused, but still can't be used concurrently.

Also adds some logging functionality to the source to measure throughput and latency.
