### PR TITLE
[BEAM-3153] Add processing-time timers for the DirectRunner.

### DIFF
--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -342,8 +342,8 @@ class _TestStreamEvaluator(_TransformEvaluator):
       assert event.new_watermark >= self.watermark
       self.watermark = event.new_watermark
     elif isinstance(event, ProcessingTimeEvent):
-      # TODO(ccy): advance processing time in the context's mock clock.
-      pass
+      self._evaluation_context._watermark_manager._clock.advance_time(
+          event.advance_by)
     else:
       raise ValueError('Invalid TestStream event: %s.' % event)
 
@@ -736,7 +736,8 @@ class _StreamingGroupAlsoByWindowEvaluator(_TransformEvaluator):
     self.output_pcollection = list(self._outputs)[0]
     self.step_context = self._execution_context.get_step_context()
     self.driver = create_trigger_driver(
-        self._applied_ptransform.transform.windowing)
+        self._applied_ptransform.transform.windowing,
+        clock=self._evaluation_context._watermark_manager._clock)
     self.gabw_items = []
     self.keyed_holds = {}
 

--- a/sdks/python/apache_beam/runners/direct/util.py
+++ b/sdks/python/apache_beam/runners/direct/util.py
@@ -61,6 +61,11 @@ class TimerFiring(object):
     self.time_domain = time_domain
     self.timestamp = timestamp
 
+  def __repr__(self):
+    return 'TimerFiring(%r, %r, %s, %s)' % (self.encoded_key,
+                                            self.name, self.time_domain,
+                                            self.timestamp)
+
 
 class KeyedWorkItem(object):
   """A keyed item that can either be a timer firing or a list of elements."""

--- a/sdks/python/apache_beam/transforms/trigger_test.py
+++ b/sdks/python/apache_beam/transforms/trigger_test.py
@@ -26,6 +26,7 @@ import yaml
 
 import apache_beam as beam
 from apache_beam.runners import pipeline_context
+from apache_beam.runners.direct.clock import TestClock
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -100,7 +101,7 @@ class TriggerTest(unittest.TestCase):
                   expected_panes):
     actual_panes = collections.defaultdict(list)
     driver = GeneralTriggerDriver(
-        Windowing(window_fn, trigger_fn, accumulation_mode))
+        Windowing(window_fn, trigger_fn, accumulation_mode), TestClock())
     state = InMemoryUnmergedState()
 
     for bundle in bundles:


### PR DESCRIPTION
- [x] Add test for fired processing-time (realtime) timers 
- [ ] Add test for not-yet-fired realtime timers
- [x] Add `class AfterProcessingTime`
- [x] Advance processing time for `_TestStreamEvaluator`
- [x] Re-engineer _should_shutdown (a realtime timer set no longer makes _is_executing() return True, instead it makes _should_shutdown return False)
- [x] Add test for watermark timers