### PR TITLE
Use platformThreadFactory for default thread pool in PackageUtil

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
@@ -106,7 +106,8 @@ class PackageUtil implements Closeable {
 
   public static PackageUtil withDefaultThreadPool() {
     return PackageUtil.withExecutorService(
-        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE)));
+        MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(DEFAULT_THREAD_POOL_SIZE,
+            MoreExecutors.platformThreadFactory())));
   }
 
   public static PackageUtil withExecutorService(ListeningExecutorService executorService) {


### PR DESCRIPTION
Currently, there is an issue with org/apache/beam/runners/dataflow/util/PackageUtil (beam-runners-google-cloud-dataflow-java) when running on Google App Engine (GAE), which restricts the way threads can be created. On GAE threads should be created via com.google.appengine.api.ThreadManager.  

Beam's source code already handles this by using MoreExecutors.platformThreadFactory() in [various places](https://github.com/apache/beam/search?utf8=%E2%9C%93&q=platformThreadFactory&type=).

However, there was one place in PackageUtil that simply used JDK's thread pool. This pull request addresses the issue.
