### PR TITLE
[BEAM-3502] Remove usage of proto.Builder.clone() in DatastoreIO

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -890,7 +890,7 @@ public class DatastoreV1 {
         QueryResultBatch currentBatch = null;
 
         while (moreResults) {
-          Query.Builder queryBuilder = Query.newBuilder().mergeFrom(query);
+          Query.Builder queryBuilder = query.toBuilder();
           queryBuilder.setLimit(Int32Value.newBuilder().setValue(
               Math.min(userLimit, QUERY_BATCH_LIMIT)));
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -890,7 +890,7 @@ public class DatastoreV1 {
         QueryResultBatch currentBatch = null;
 
         while (moreResults) {
-          Query.Builder queryBuilder = query.toBuilder().clone();
+          Query.Builder queryBuilder = Query.newBuilder().mergeFrom(query);
           queryBuilder.setLimit(Int32Value.newBuilder().setValue(
               Math.min(userLimit, QUERY_BATCH_LIMIT)));
 


### PR DESCRIPTION
This trivially removes a usage of query.Builder.clone(), which is incompatible with Google-internal Java generated proto code.