### PR TITLE
[BEAM-2937] Disable combiner lifting optimization in python DataflowRunner for fnapi

### DIFF
--- a/sdks/python/apache_beam/examples/wordcount_fnapi.py
+++ b/sdks/python/apache_beam/examples/wordcount_fnapi.py
@@ -100,17 +100,11 @@ def run(argv=None):
   # Read the text file[pattern] into a PCollection.
   lines = p | 'read' >> ReadFromText(known_args.input)
 
-  # Count the occurrences of each word.
-  def count_ones(word_ones):
-    (word, ones) = word_ones
-    return (word, sum(ones))
-
   counts = (lines
             | 'split' >> (beam.ParDo(WordExtractingDoFn())
                           .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
-            | 'group' >> beam.GroupByKey()
-            | 'count' >> beam.Map(count_ones))
+            | 'group_and_sum' >> beam.CombinePerKey(sum))
 
   # Format the counts into a PCollection of strings.
   def format_result(word_count):

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -34,7 +34,6 @@ from apache_beam import error
 from apache_beam import pvalue
 from apache_beam.internal import pickler
 from apache_beam.internal.gcp import json_value
-from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TestOptions
@@ -616,12 +615,12 @@ class DataflowRunner(PipelineRunner):
 
   def apply_CombineValues(self, transform, pcoll):
     # TODO(BEAM-2937): Disable combiner lifting for fnapi. Remove this
-    # restrictions once this feature is supported in the portability framework.
-    debug_options = pcoll.pipeline._options.view_as(DebugOptions)
-    use_fn_api = (
-        debug_options.experiments and 'beam_fn_api' in debug_options.experiments
-    )
-    if use_fn_api:
+    # restrictions once this feature is supported in the dataflow runner
+    # harness.
+    # Import here to avoid adding the dependency for local running scenarios.
+    # pylint: disable=wrong-import-order, wrong-import-position
+    from apache_beam.runners.dataflow.internal import apiclient
+    if apiclient._use_fnapi(pcoll.pipeline._options):
       return self.apply_PTransform(transform, pcoll)
 
     return pvalue.PCollection(pcoll.pipeline)


### PR DESCRIPTION
Tried out a fnapi and non-fnapi job to see that it works and optimizations is preserved respectively. Switched the fnapi wordcount to use the combiner api for testing purposes.

R: @robertwb 