### PR TITLE
BEAM-3505: Allow grpcx.Dial to support overrides.

### DIFF
--- a/sdks/go/pkg/beam/util/grpcx/dial.go
+++ b/sdks/go/pkg/beam/util/grpcx/dial.go
@@ -23,9 +23,12 @@ import (
 	"google.golang.org/grpc"
 )
 
-// Dial is a convenience wrapper over grpc.Dial that specifies an insecure,
-// blocking connection with a timeout.
-func Dial(ctx context.Context, endpoint string, timeout time.Duration) (*grpc.ClientConn, error) {
+// Dial is a convenience wrapper over grpc.Dial. It can be overridden
+// to provide a customized dialing behavior.
+var Dial = DefaultDial
+
+// DefaultDial is a dialer that specifies an insecure blocking connection with a timeout.
+func DefaultDial(ctx context.Context, endpoint string, timeout time.Duration) (*grpc.ClientConn, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 


### PR DESCRIPTION
A user environment might want a different gRPC connection method.
This hook allows for that. An example usecase would be having TLS
connections, customized transport setting, or registering client-side
interceptors.


