### PR TITLE
[BEAM-3506] - Add a feature in JdbcIO that allows writing PCollection<Iterable<T>>

### DIFF
--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOIT.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOIT.java
@@ -112,7 +112,7 @@ public class JdbcIOIT {
   @Test
   public void testWriteIterableThenRead() {
     runWriteIterable();
-    runRead(writeTableName);
+    runRead(writeIterableTableName);
   }
 
   /**


### PR DESCRIPTION
This PR adds a feature to JdbcIO that allows PCollection<Iterable<T>> to be the input of a write in addition to the current PCollection<T>. Each Iterable<T> is written to the database as one batch. This allows the user to determine the size of the batches, and also to have different sizes of batches based on the actual data.
Writing data in (large) batches has a significantly positive effect on the performance when writing to cloud databases such as Google Cloud Spanner. This example project illustrates how to use this feature in combination with Google Cloud Spanner: [https://github.com/olavloite/spanner-beam-example](https://github.com/olavloite/spanner-beam-example)

