### PR TITLE
[BEAM-3388] Use a typeswitch instead of reflect.Convert

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -134,9 +134,15 @@ type bytesEncoder struct{}
 
 func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
 	// Encoding: size (varint) + raw data
-
-	data := reflect.ValueOf(val.Elm).Convert(reflectx.ByteSlice).Interface().([]byte)
-	size := len(data)
+	var data []byte
+	switch v := val.Elm.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return fmt.Errorf("received unknown value type: want []byte or string, got %T", v)
+	}
 
 	if err := coder.EncodeVarInt((int32)(size), w); err != nil {
 		return err

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -143,6 +143,7 @@ func (*bytesEncoder) Encode(val FullValue, w io.Writer) error {
 	default:
 		return fmt.Errorf("received unknown value type: want []byte or string, got %T", v)
 	}
+	size := len(data)
 
 	if err := coder.EncodeVarInt((int32)(size), w); err != nil {
 		return err


### PR DESCRIPTION
Use a typeswitch instead of reflect.Convert when converting strings or bytes.