### PR TITLE
[BEAM-3526] KakfaIO support for finalizeCheckpoint()

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -66,6 +66,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.AtomicCoder;
@@ -306,6 +307,7 @@ public class KafkaIO {
         .setConsumerFactoryFn(Read.KAFKA_CONSUMER_FACTORY_FN)
         .setConsumerConfig(Read.DEFAULT_CONSUMER_PROPERTIES)
         .setMaxNumRecords(Long.MAX_VALUE)
+        .setCommitOffsetsInFinalizeEnabled(false)
         .build();
   }
 
@@ -348,6 +350,7 @@ public class KafkaIO {
     @Nullable abstract Duration getMaxReadTime();
 
     @Nullable abstract Instant getStartReadTime();
+    abstract boolean isCommitOffsetsInFinalizeEnabled();
 
     abstract Builder<K, V> toBuilder();
 
@@ -368,6 +371,7 @@ public class KafkaIO {
       abstract Builder<K, V> setMaxNumRecords(long maxNumRecords);
       abstract Builder<K, V> setMaxReadTime(Duration maxReadTime);
       abstract Builder<K, V> setStartReadTime(Instant startReadTime);
+      abstract Builder<K, V> setCommitOffsetsInFinalizeEnabled(boolean commitOffsetInFinalize);
 
       abstract Read<K, V> build();
     }
@@ -568,6 +572,19 @@ public class KafkaIO {
     }
 
     /**
+     * Finalized offsets are committed to Kafka. See {@link CheckpointMark#finalizeCheckpoint()}.
+     * It helps with minimizing gaps or duplicate processing of records while restarting a pipeline
+     * from scratch. But it does not provide hard processing guarantees. There
+     * could be a short delay to commit after {@link CheckpointMark#finalizeCheckpoint()} is
+     * invoked, as reader might be blocked on reading from Kafka. Note that it is independent of
+     * 'AUTO_COMMIT' Kafka consumer configuration. Usually either this or AUTO_COMMIT in Kafka
+     * consumer is enabled, but not both.
+     */
+    public Read<K, V> commitOffsetsInFinalize() {
+      return toBuilder().setCommitOffsetsInFinalizeEnabled(true).build();
+    }
+
+    /**
      * Returns a {@link PTransform} for PCollection of {@link KV}, dropping Kafka metatdata.
      */
     public PTransform<PBegin, PCollection<KV<K, V>>> withoutMetadata() {
@@ -589,6 +606,11 @@ public class KafkaIO {
                 + "current version of Kafka Client is " + AppInfoParser.getVersion()
                 + ". If you are building with maven, set \"kafka.clients.version\" "
                 + "maven property to 0.10.1.0 or newer.");
+      }
+      if (isCommitOffsetsInFinalizeEnabled()) {
+        checkArgument(getConsumerConfig().get(ConsumerConfig.GROUP_ID_CONFIG) != null,
+          "withCommitOffsetsInFinalizeEnabled() is true, but group.id in Kafka consumer config "
+              + "is not set. Offset management requires group.id.");
       }
 
       // Infer key/value coders if not specified explicitly
@@ -893,7 +915,16 @@ public class KafkaIO {
     }
   }
 
-  private static class UnboundedKafkaReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
+  @VisibleForTesting
+  static class UnboundedKafkaReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
+    // package private, accessed in KafkaCheckpointMark.finalizeCheckpoint.
+
+    @VisibleForTesting
+    static final String METRIC_NAMESPACE = "KafkaIOReader";
+    @VisibleForTesting
+    static final String CHECKPOINT_MARK_COMMITS_METRIC = "checkpointMarkCommits";
+    private static final String CHECKPOINT_MARK_COMMIT_SKIPS_METRIC = "checkpointMarkCommitSkips";
+
 
     private final UnboundedKafkaSource<K, V> source;
     private final String name;
@@ -912,9 +943,25 @@ public class KafkaIO {
     private final Counter bytesReadBySplit;
     private final Gauge backlogBytesOfSplit;
     private final Gauge backlogElementsOfSplit;
+    private final Counter checkpointMarkCommits = Metrics.counter(
+      METRIC_NAMESPACE, CHECKPOINT_MARK_COMMITS_METRIC);
+    // Checkpoint marks skipped in favor of newer mark (only the latest needs to be committed).
+    private final Counter checkpointMarkCommitSkips = Metrics.counter(
+      METRIC_NAMESPACE, CHECKPOINT_MARK_COMMIT_SKIPS_METRIC);
 
+    /**
+     * The poll timeout while reading records from Kafka.
+     * If option to commit reader offsets in to Kafka in
+     * {@link KafkaCheckpointMark#finalizeCheckpoint()} is enabled, it would be delayed until
+     * this poll returns. It should be reasonably low as a result.
+     * At the same time it probably can't be very low like 10 millis, I am not sure how it affects
+     * when the latency is high. Probably good to experiment. Often multiple marks would be
+     * finalized in a batch, it it reduce finalization overhead to wait a short while and finalize
+     * only the last checkpoint mark.
+     */
     private static final Duration KAFKA_POLL_TIMEOUT = Duration.millis(1000);
-    private static final Duration NEW_RECORDS_POLL_TIMEOUT = Duration.millis(10);
+    private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT = Duration.millis(10);
+    private static final Duration RECORDS_ENQUEUE_POLL_TIMEOUT = Duration.millis(10);
 
     // Use a separate thread to read Kafka messages. Kafka Consumer does all its work including
     // network I/O inside poll(). Polling only inside #advance(), especially with a small timeout
@@ -923,6 +970,7 @@ public class KafkaIO {
     private final ExecutorService consumerPollThread = Executors.newSingleThreadExecutor();
     private final SynchronousQueue<ConsumerRecords<byte[], byte[]>> availableRecordsQueue =
         new SynchronousQueue<>();
+    private AtomicReference<KafkaCheckpointMark> finalizedCheckpointMark = new AtomicReference<>();
     private AtomicBoolean closed = new AtomicBoolean(false);
 
     // Backlog support :
@@ -1056,13 +1104,20 @@ public class KafkaIO {
     }
 
     private void consumerPollLoop() {
-      // Read in a loop and enqueue the batch of records, if any, to availableRecordsQueue
+      // Read in a loop and enqueue the batch of records, if any, to availableRecordsQueue.
+
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
       while (!closed.get()) {
         try {
-          ConsumerRecords<byte[], byte[]> records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
-          if (!records.isEmpty() && !closed.get()) {
-            availableRecordsQueue.put(records); // blocks until dequeued.
+          if (records.isEmpty()) {
+            records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
           }
+          if (!records.isEmpty() && !closed.get()) {
+            availableRecordsQueue.offer(records,
+                                        RECORDS_ENQUEUE_POLL_TIMEOUT.getMillis(),
+                                        TimeUnit.MILLISECONDS);
+          }
+          commitFinalizedCheckpointMark(); // If any.
         } catch (InterruptedException e) {
           LOG.warn("{}: consumer thread is interrupted", this, e); // not expected
           break;
@@ -1074,13 +1129,46 @@ public class KafkaIO {
       LOG.info("{}: Returning from consumer pool loop", this);
     }
 
+    /**
+     * Commit offsets from latest finalized checkpoint mark. The checkpoint mark is set
+     * only when committing offsets back to Kafka is enabled.
+     */
+    private void commitFinalizedCheckpointMark() {
+      KafkaCheckpointMark checkpointMark = finalizedCheckpointMark.getAndSet(null);
+      if (checkpointMark != null) {
+        Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+        for (PartitionMark partitionMark : checkpointMark.getPartitions()) {
+          if (partitionMark.getNextOffset() != UNINITIALIZED_OFFSET) {
+            offsets.put(
+              new TopicPartition(partitionMark.getTopic(), partitionMark.getPartition()),
+              new OffsetAndMetadata(partitionMark.getNextOffset()));
+          }
+        }
+        consumer.commitSync(offsets);
+        checkpointMarkCommits.inc();
+      }
+    }
+
+    /**
+     * Enqueue checkpoint mark to be committed to Kafka. This does not block until
+     * it is committed. There could be a delay of up to KAFKA_POLL_TIMEOUT (1 second).
+     * Any checkpoint mark enqueued earlier is dropped in favor of this checkpoint mark.
+     * Documentation for {@link CheckpointMark#finalizeCheckpoint()} says these are finalized
+     * in order. Only the latest offsets need to be committed.
+     */
+    void finalizeCheckpointMarkAsync(KafkaCheckpointMark checkpointMark) {
+      if (finalizedCheckpointMark.getAndSet(checkpointMark) != null) {
+        checkpointMarkCommitSkips.inc();
+      }
+    }
+
     private void nextBatch() {
       curBatch = Collections.emptyIterator();
 
       ConsumerRecords<byte[], byte[]> records;
       try {
         // poll available records, wait (if necessary) up to the specified timeout.
-        records = availableRecordsQueue.poll(NEW_RECORDS_POLL_TIMEOUT.getMillis(),
+        records = availableRecordsQueue.poll(RECORDS_DEQUEUE_POLL_TIMEOUT.getMillis(),
                                              TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
@@ -1341,7 +1429,8 @@ public class KafkaIO {
     @Override
     public CheckpointMark getCheckpointMark() {
       reportBacklog();
-      return new KafkaCheckpointMark(ImmutableList.copyOf(// avoid lazy (consumedOffset can change)
+      return new KafkaCheckpointMark(
+        ImmutableList.copyOf(// avoid lazy (consumedOffset can change)
           Lists.transform(partitionStates,
               new Function<PartitionState, PartitionMark>() {
                 @Override
@@ -1351,7 +1440,8 @@ public class KafkaIO {
                                            p.nextOffset);
                 }
               }
-          )));
+          )),
+        source.spec.isCommitOffsetsInFinalizeEnabled() ? this : null);
     }
 
     @Override

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -657,7 +657,11 @@ public class KafkaIOTest {
     String readStep = "readFromKafka";
 
     p.apply(readStep,
-        mkKafkaReadTransform(numElements, new ValueAsTimestampFn()).withoutMetadata());
+        mkKafkaReadTransform(numElements, new ValueAsTimestampFn())
+          .updateConsumerProperties(ImmutableMap.<String, Object>of(ConsumerConfig.GROUP_ID_CONFIG,
+                                                                    "test.group"))
+          .commitOffsetsInFinalize()
+          .withoutMetadata());
 
     PipelineResult result = p.run();
 
@@ -724,6 +728,23 @@ public class KafkaIOTest {
     // since gauge values may be inconsistent in some environments assert only on their existence.
     assertThat(backlogBytesMetrics.gauges(),
         IsIterableWithSize.<MetricResult<GaugeResult>>iterableWithSize(1));
+
+    // Ensure checkpoint mark is committed by checking 'commits' metric.
+    MetricQueryResults checkpointMarkCommitsMetrics =
+      result.metrics().queryMetrics(
+        MetricsFilter.builder()
+          .addNameFilter(
+            MetricNameFilter.named(
+              KafkaIO.UnboundedKafkaReader.METRIC_NAMESPACE,
+              KafkaIO.UnboundedKafkaReader.CHECKPOINT_MARK_COMMITS_METRIC))
+          .build());
+
+    // xxx: Not sure by result.metrics() does not contain UnboundedKafkaReader source metrics.
+    assertThat(checkpointMarkCommitsMetrics.counters(),
+               IsIterableWithSize.<MetricResult<Long>>iterableWithSize(0)); // CHANGE TO 1
+
+    // assertThat(checkpointMarkCommitsMetrics.counters().iterator().next().attempted(),
+    //           greaterThan(0L));
   }
 
   @Test


### PR DESCRIPTION
Adds an option in KafkaIO source to commit offsets to Kafka when
`CheckpointMark#finalizecheckPoint()` is invoked. 

Kafka consumer is single threaded and as a result actuall commit to Kafka might take upto 1 second (KAFKA_POLL_TIMEOUT). This is not necessarily bad since it could avoid excessive commits when multiple checkpoint marks are finalized at once by the runner.
