### PR TITLE
[BEAM-3499, BEAM-2607] Gives the runner access to positions of SDF claimed blocks

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/ParDoTranslator.java
@@ -117,7 +117,7 @@ class ParDoTranslator<InputT, OutputT>
   }
 
   static class SplittableProcessElementsTranslator<
-          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
       implements TransformTranslator<ProcessElements<InputT, OutputT, RestrictionT, TrackerT>> {
 
     @Override

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexParDoOperator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexParDoOperator.java
@@ -474,7 +474,7 @@ public class ApexParDoOperator<InputT, OutputT> extends BaseOperator implements 
           (StateInternalsFactory<String>) this.currentKeyStateInternals.getFactory();
 
       @SuppressWarnings({ "rawtypes", "unchecked" })
-      ProcessFn<InputT, OutputT, Object, RestrictionTracker<Object>>
+      ProcessFn<InputT, OutputT, Object, RestrictionTracker<Object, ?>>
         splittableDoFn = (ProcessFn) doFn;
       splittableDoFn.setStateInternalsFactory(stateInternalsFactory);
       TimerInternalsFactory<String> timerInternalsFactory = key -> currentKeyTimerInternals;

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexParDoOperator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexParDoOperator.java
@@ -474,7 +474,7 @@ public class ApexParDoOperator<InputT, OutputT> extends BaseOperator implements 
           (StateInternalsFactory<String>) this.currentKeyStateInternals.getFactory();
 
       @SuppressWarnings({ "rawtypes", "unchecked" })
-      ProcessFn<InputT, OutputT, Object, RestrictionTracker<Object, ?>>
+      ProcessFn<InputT, OutputT, Object, RestrictionTracker<Object, Object>>
         splittableDoFn = (ProcessFn) doFn;
       splittableDoFn.setStateInternalsFactory(stateInternalsFactory);
       TimerInternalsFactory<String> timerInternalsFactory = key -> currentKeyTimerInternals;

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -160,7 +160,7 @@ public class PTransformMatchersTest implements Serializable {
           ctxt.output(ctxt.element().getValue() + 1);
         }
       };
-  private abstract static class SomeTracker implements RestrictionTracker<Void> {}
+  private abstract static class SomeTracker extends RestrictionTracker<Void, Void> {}
   private DoFn<KV<String, Integer>, Integer> splittableDoFn =
       new DoFn<KV<String, Integer>, Integer>() {
         @ProcessElement

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
@@ -231,7 +231,7 @@ public class ParDoTranslationTest {
 
   private static class SplittableDropElementsFn extends DoFn<KV<Long, String>, Void> {
     @ProcessElement
-    public void proc(ProcessContext context, RestrictionTracker<Integer> restriction) {
+    public void proc(ProcessContext context, RestrictionTracker<Integer, ?> restriction) {
       context.output(null);
     }
 
@@ -241,7 +241,7 @@ public class ParDoTranslationTest {
     }
 
     @NewTracker
-    public RestrictionTracker<Integer> newTracker(Integer restriction) {
+    public RestrictionTracker<Integer, ?> newTracker(Integer restriction) {
       throw new UnsupportedOperationException("Should never be called; only to test translation");
     }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -50,11 +50,16 @@ public class SplittableParDoTest {
     }
   }
 
-  private static class SomeRestrictionTracker implements RestrictionTracker<SomeRestriction> {
+  private static class SomeRestrictionTracker extends RestrictionTracker<SomeRestriction, Void> {
     private final SomeRestriction someRestriction;
 
     public SomeRestrictionTracker(SomeRestriction someRestriction) {
       this.someRestriction = someRestriction;
+    }
+
+    @Override
+    protected boolean tryClaimImpl(Void position) {
+      return false;
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
@@ -34,6 +34,7 @@ import org.apache.beam.runners.core.StateTag.StateBinder;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
@@ -49,6 +50,7 @@ import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.CombineWithContext.CombineFnWithContext;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
+import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.CombineFnUtil;
 import org.joda.time.Instant;
 
@@ -126,25 +128,25 @@ public class InMemoryStateInternals<K> implements StateInternals {
     @Override
     public <T> ValueState<T> bindValue(
         StateTag<ValueState<T>> address, Coder<T> coder) {
-      return new InMemoryValue<>();
+      return new InMemoryValue<>(coder);
     }
 
     @Override
     public <T> BagState<T> bindBag(
         final StateTag<BagState<T>> address, Coder<T> elemCoder) {
-      return new InMemoryBag<>();
+      return new InMemoryBag<>(elemCoder);
     }
 
     @Override
     public <T> SetState<T> bindSet(StateTag<SetState<T>> spec, Coder<T> elemCoder) {
-      return new InMemorySet<>();
+      return new InMemorySet<>(elemCoder);
     }
 
     @Override
     public <KeyT, ValueT> MapState<KeyT, ValueT> bindMap(
         StateTag<MapState<KeyT, ValueT>> spec,
         Coder<KeyT> mapKeyCoder, Coder<ValueT> mapValueCoder) {
-      return new InMemoryMap<>();
+      return new InMemoryMap<>(mapKeyCoder, mapValueCoder);
     }
 
     @Override
@@ -153,7 +155,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
             StateTag<CombiningState<InputT, AccumT, OutputT>> address,
             Coder<AccumT> accumCoder,
             final CombineFn<InputT, AccumT, OutputT> combineFn) {
-      return new InMemoryCombiningState<>(combineFn);
+      return new InMemoryCombiningState<>(combineFn, accumCoder);
     }
 
     @Override
@@ -178,8 +180,14 @@ public class InMemoryStateInternals<K> implements StateInternals {
    */
   public static final class InMemoryValue<T>
       implements ValueState<T>, InMemoryState<InMemoryValue<T>> {
+    private final Coder<T> coder;
+
     private boolean isCleared = true;
     private @Nullable T value = null;
+
+    public InMemoryValue(Coder<T> coder) {
+      this.coder = coder;
+    }
 
     @Override
     public void clear() {
@@ -207,10 +215,10 @@ public class InMemoryStateInternals<K> implements StateInternals {
 
     @Override
     public InMemoryValue<T> copy() {
-      InMemoryValue<T> that = new InMemoryValue<>();
+      InMemoryValue<T> that = new InMemoryValue<>(coder);
       if (!this.isCleared) {
         that.isCleared = this.isCleared;
-        that.value = this.value;
+        that.value = unsafeClone(coder, this.value);
       }
       return that;
     }
@@ -305,14 +313,16 @@ public class InMemoryStateInternals<K> implements StateInternals {
   public static final class InMemoryCombiningState<InputT, AccumT, OutputT>
       implements CombiningState<InputT, AccumT, OutputT>,
           InMemoryState<InMemoryCombiningState<InputT, AccumT, OutputT>> {
-    private boolean isCleared = true;
     private final CombineFn<InputT, AccumT, OutputT> combineFn;
+    private final Coder<AccumT> accumCoder;
+    private boolean isCleared = true;
     private AccumT accum;
 
     public InMemoryCombiningState(
-        CombineFn<InputT, AccumT, OutputT> combineFn) {
+        CombineFn<InputT, AccumT, OutputT> combineFn, Coder<AccumT> accumCoder) {
       this.combineFn = combineFn;
       accum = combineFn.createAccumulator();
+      this.accumCoder = accumCoder;
     }
 
     @Override
@@ -378,7 +388,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
     @Override
     public InMemoryCombiningState<InputT, AccumT, OutputT> copy() {
       InMemoryCombiningState<InputT, AccumT, OutputT> that =
-          new InMemoryCombiningState<>(combineFn);
+          new InMemoryCombiningState<>(combineFn, accumCoder);
       if (!this.isCleared) {
         that.isCleared = this.isCleared;
         that.addAccum(accum);
@@ -391,7 +401,12 @@ public class InMemoryStateInternals<K> implements StateInternals {
    * An {@link InMemoryState} implementation of {@link BagState}.
    */
   public static final class InMemoryBag<T> implements BagState<T>, InMemoryState<InMemoryBag<T>> {
+    private final Coder<T> elemCoder;
     private List<T> contents = new ArrayList<>();
+
+    public InMemoryBag(Coder<T> elemCoder) {
+      this.elemCoder = elemCoder;
+    }
 
     @Override
     public void clear() {
@@ -442,8 +457,10 @@ public class InMemoryStateInternals<K> implements StateInternals {
 
     @Override
     public InMemoryBag<T> copy() {
-      InMemoryBag<T> that = new InMemoryBag<>();
-      that.contents.addAll(this.contents);
+      InMemoryBag<T> that = new InMemoryBag<>(elemCoder);
+      for (T elem : this.contents) {
+        that.contents.add(unsafeClone(elemCoder, elem));
+      }
       return that;
     }
   }
@@ -452,7 +469,12 @@ public class InMemoryStateInternals<K> implements StateInternals {
    * An {@link InMemoryState} implementation of {@link SetState}.
    */
   public static final class InMemorySet<T> implements SetState<T>, InMemoryState<InMemorySet<T>> {
+    private final Coder<T> elemCoder;
     private Set<T> contents = new HashSet<>();
+
+    public InMemorySet(Coder<T> elemCoder) {
+      this.elemCoder = elemCoder;
+    }
 
     @Override
     public void clear() {
@@ -513,8 +535,10 @@ public class InMemoryStateInternals<K> implements StateInternals {
 
     @Override
     public InMemorySet<T> copy() {
-      InMemorySet<T> that = new InMemorySet<>();
-      that.contents.addAll(this.contents);
+      InMemorySet<T> that = new InMemorySet<>(elemCoder);
+      for (T elem : this.contents) {
+        that.contents.add(unsafeClone(elemCoder, elem));
+      }
       return that;
     }
   }
@@ -524,7 +548,15 @@ public class InMemoryStateInternals<K> implements StateInternals {
    */
   public static final class InMemoryMap<K, V> implements
       MapState<K, V>, InMemoryState<InMemoryMap<K, V>> {
+    private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
+
     private Map<K, V> contents = new HashMap<>();
+
+    public InMemoryMap(Coder<K> keyCoder, Coder<V> valueCoder) {
+      this.keyCoder = keyCoder;
+      this.valueCoder = valueCoder;
+    }
 
     @Override
     public void clear() {
@@ -600,9 +632,21 @@ public class InMemoryStateInternals<K> implements StateInternals {
 
     @Override
     public InMemoryMap<K, V> copy() {
-      InMemoryMap<K, V> that = new InMemoryMap<>();
+      InMemoryMap<K, V> that = new InMemoryMap<>(keyCoder, valueCoder);
+      for (Map.Entry<K, V> entry : this.contents.entrySet()) {
+        that.contents.put(
+            unsafeClone(keyCoder, entry.getKey()), unsafeClone(valueCoder, entry.getValue()));
+      }
       that.contents.putAll(this.contents);
       return that;
+    }
+  }
+
+  private static <T> T unsafeClone(Coder<T> coder, T value) {
+    try {
+      return CoderUtils.clone(coder, value);
+    } catch (CoderException e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
@@ -218,7 +218,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
       InMemoryValue<T> that = new InMemoryValue<>(coder);
       if (!this.isCleared) {
         that.isCleared = this.isCleared;
-        that.value = unsafeClone(coder, this.value);
+        that.value = uncheckedClone(coder, this.value);
       }
       return that;
     }
@@ -391,7 +391,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
           new InMemoryCombiningState<>(combineFn, accumCoder);
       if (!this.isCleared) {
         that.isCleared = this.isCleared;
-        that.addAccum(accum);
+        that.addAccum(uncheckedClone(accumCoder, accum));
       }
       return that;
     }
@@ -459,7 +459,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
     public InMemoryBag<T> copy() {
       InMemoryBag<T> that = new InMemoryBag<>(elemCoder);
       for (T elem : this.contents) {
-        that.contents.add(unsafeClone(elemCoder, elem));
+        that.contents.add(uncheckedClone(elemCoder, elem));
       }
       return that;
     }
@@ -537,7 +537,7 @@ public class InMemoryStateInternals<K> implements StateInternals {
     public InMemorySet<T> copy() {
       InMemorySet<T> that = new InMemorySet<>(elemCoder);
       for (T elem : this.contents) {
-        that.contents.add(unsafeClone(elemCoder, elem));
+        that.contents.add(uncheckedClone(elemCoder, elem));
       }
       return that;
     }
@@ -635,14 +635,15 @@ public class InMemoryStateInternals<K> implements StateInternals {
       InMemoryMap<K, V> that = new InMemoryMap<>(keyCoder, valueCoder);
       for (Map.Entry<K, V> entry : this.contents.entrySet()) {
         that.contents.put(
-            unsafeClone(keyCoder, entry.getKey()), unsafeClone(valueCoder, entry.getValue()));
+            uncheckedClone(keyCoder, entry.getKey()), uncheckedClone(valueCoder, entry.getValue()));
       }
       that.contents.putAll(this.contents);
       return that;
     }
   }
 
-  private static <T> T unsafeClone(Coder<T> coder, T value) {
+  /** Like {@link CoderUtils#clone} but without a checked exception. */
+  private static <T> T uncheckedClone(Coder<T> coder, T value) {
     try {
       return CoderUtils.clone(coder, value);
     } catch (CoderException e) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -50,7 +50,11 @@ import org.joda.time.Instant;
  * outputs), or runs for the given duration.
  */
 public class OutputAndTimeBoundedSplittableProcessElementInvoker<
-        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
+        InputT,
+        OutputT,
+        RestrictionT,
+        PositionT,
+        TrackerT extends RestrictionTracker<RestrictionT, PositionT>>
     extends SplittableProcessElementInvoker<InputT, OutputT, RestrictionT, TrackerT> {
   private final DoFn<InputT, OutputT> fn;
   private final PipelineOptions pipelineOptions;
@@ -71,9 +75,10 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
    * @param maxNumOutputs Maximum number of outputs, in total over all output tags, after which a
    *     checkpoint will be requested. This is a best-effort request - the {@link DoFn} may output
    *     more after receiving the request.
-   * @param maxDuration Maximum duration of the {@link DoFn.ProcessElement} call after which a
-   *     checkpoint will be requested. This is a best-effort request - the {@link DoFn} may run for
-   *     longer after receiving the request.
+   * @param maxDuration Maximum duration of the {@link DoFn.ProcessElement} call (counted from the
+   *     first successful {@link RestrictionTracker#tryClaim} call) after which a checkpoint will be
+   *     requested. This is a best-effort request - the {@link DoFn} may run for longer after
+   *     receiving the request.
    */
   public OutputAndTimeBoundedSplittableProcessElementInvoker(
       DoFn<InputT, OutputT> fn,
@@ -98,6 +103,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
       final WindowedValue<InputT> element,
       final TrackerT tracker) {
     final ProcessContext processContext = new ProcessContext(element, tracker);
+    tracker.setClaimObserver(processContext);
     DoFn.ProcessContinuation cont = invoker.invokeProcessElement(
         new DoFnInvoker.ArgumentProvider<InputT, OutputT>() {
           @Override
@@ -157,19 +163,30 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
                 "Access to timers not supported in Splittable DoFn");
           }
         });
-    // TODO: verify that if there was a failed tryClaim() call, then cont.shouldResume() is false.
-    // Currently we can't verify this because there are no hooks into tryClaim().
-    // See https://issues.apache.org/jira/browse/BEAM-2607
     processContext.cancelScheduledCheckpoint();
     @Nullable KV<RestrictionT, Instant> residual = processContext.getTakenCheckpoint();
     if (cont.shouldResume()) {
+      checkState(
+          !processContext.hasClaimFailed,
+          "After tryClaim() returned false, @ProcessElement must return stop(), "
+              + "but returned resume()");
       if (residual == null) {
         // No checkpoint had been taken by the runner while the ProcessElement call ran, however
         // the call says that not the whole restriction has been processed. So we need to take
         // a checkpoint now: checkpoint() guarantees that the primary restriction describes exactly
         // the work that was done in the current ProcessElement call, and returns a residual
         // restriction that describes exactly the work that wasn't done in the current call.
-        residual = checkNotNull(processContext.takeCheckpointNow());
+        if (processContext.numClaimedBlocks > 0) {
+          residual = checkNotNull(processContext.takeCheckpointNow());
+          tracker.checkDone();
+        } else {
+          // The call returned resume() without trying to claim any blocks, i.e. it is unaware
+          // of any work to be done at the moment, but more might emerge later. In this case,
+          // we must simply reschedule the original restriction - checkpointing a tracker that
+          // hasn't claimed any work is not allowed.
+          residual = KV.of(tracker.currentRestriction(), processContext.lastReportedWatermark);
+          // Don't call tracker.checkDone() - it's not done.
+        }
       } else {
         // A checkpoint was taken by the runner, and then the ProcessElement call returned resume()
         // without making more tryClaim() calls (since no tryClaim() calls can succeed after
@@ -180,14 +197,15 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
         // ProcessElement call.
         // In other words, if we took a checkpoint *after* ProcessElement completed (like in the
         // branch above), it would have been equivalent to this one.
+        tracker.checkDone();
       }
     } else {
       // The ProcessElement call returned stop() - that means the tracker's current restriction
       // has been fully processed by the call. A checkpoint may or may not have been taken in
       // "residual"; if it was, then we'll need to process it; if no, then we don't - nothing
       // special needs to be done.
+      tracker.checkDone();
     }
-    tracker.checkDone();
     if (residual == null) {
       // Can only be true if cont.shouldResume() is false and no checkpoint was taken.
       // This means the restriction has been fully processed.
@@ -197,9 +215,12 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
     return new Result(residual.getKey(), cont, residual.getValue());
   }
 
-  private class ProcessContext extends DoFn<InputT, OutputT>.ProcessContext {
+  private class ProcessContext extends DoFn<InputT, OutputT>.ProcessContext
+      implements RestrictionTracker.ClaimObserver<PositionT> {
     private final WindowedValue<InputT> element;
     private final TrackerT tracker;
+    private int numClaimedBlocks;
+    private boolean hasClaimFailed;
 
     private int numOutputs;
     // Checkpoint may be initiated either when the given number of outputs is reached,
@@ -212,20 +233,46 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
     // on the output from "checkpoint".
     private @Nullable Instant residualWatermark;
     // A handle on the scheduled action to take a checkpoint.
-    private Future<?> scheduledCheckpoint;
+    private @Nullable Future<?> scheduledCheckpoint;
     private @Nullable Instant lastReportedWatermark;
 
     public ProcessContext(WindowedValue<InputT> element, TrackerT tracker) {
       fn.super();
       this.element = element;
       this.tracker = tracker;
+    }
 
-      this.scheduledCheckpoint =
-          executor.schedule(
-              (Runnable) this::takeCheckpointNow, maxDuration.getMillis(), TimeUnit.MILLISECONDS);
+    void checkClaimHasNotFailed() {
+      checkState(
+          !hasClaimFailed,
+          "Must not call tryClaim() after it has previously returned false");
+    }
+
+    @Override
+    public void onClaimed(PositionT position) {
+      checkClaimHasNotFailed();
+      if (numClaimedBlocks == 0) {
+        // Claiming first block: can schedule the checkpoint now.
+        // We don't schedule it right away to prevent checkpointing before any blocks are claimed,
+        // in a state where no work has been done yet - because such a checkpoint is equivalent to
+        // the original restriction, i.e. pointless.
+        this.scheduledCheckpoint =
+            executor.schedule(
+                (Runnable) this::takeCheckpointNow, maxDuration.getMillis(), TimeUnit.MILLISECONDS);
+      }
+      ++numClaimedBlocks;
+    }
+
+    @Override
+    public void onClaimFailed(PositionT position) {
+      checkClaimHasNotFailed();
+      hasClaimFailed = true;
     }
 
     void cancelScheduledCheckpoint() {
+      if (scheduledCheckpoint == null) {
+        return;
+      }
       scheduledCheckpoint.cancel(true);
       try {
         Futures.getUnchecked(scheduledCheckpoint);
@@ -275,6 +322,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public synchronized void updateWatermark(Instant watermark) {
+      // Updating the watermark without any claimed blocks is allowed.
       lastReportedWatermark = watermark;
     }
 
@@ -290,8 +338,8 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public void outputWithTimestamp(OutputT value, Instant timestamp) {
-      output.outputWindowedValue(value, timestamp, element.getWindows(), element.getPane());
       noteOutput();
+      output.outputWindowedValue(value, timestamp, element.getWindows(), element.getPane());
     }
 
     @Override
@@ -301,12 +349,14 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public <T> void outputWithTimestamp(TupleTag<T> tag, T value, Instant timestamp) {
+      noteOutput();
       output.outputWindowedValue(
           tag, value, timestamp, element.getWindows(), element.getPane());
-      noteOutput();
     }
 
     private void noteOutput() {
+      checkState(!hasClaimFailed, "Output is not allowed after a failed tryClaim()");
+      checkState(numClaimedBlocks > 0, "Output is not allowed before tryClaim()");
       ++numOutputs;
       if (numOutputs >= maxNumOutputs) {
         takeCheckpointNow();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -50,7 +50,7 @@ import org.joda.time.Instant;
  * outputs), or runs for the given duration.
  */
 public class OutputAndTimeBoundedSplittableProcessElementInvoker<
-        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
     extends SplittableProcessElementInvoker<InputT, OutputT, RestrictionT, TrackerT> {
   private final DoFn<InputT, OutputT> fn;
   private final PipelineOptions pipelineOptions;
@@ -107,7 +107,7 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
           }
 
           @Override
-          public RestrictionTracker<?> restrictionTracker() {
+          public RestrictionTracker<?, ?> restrictionTracker() {
             return tracker;
           }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java
@@ -181,10 +181,19 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
           tracker.checkDone();
         } else {
           // The call returned resume() without trying to claim any blocks, i.e. it is unaware
-          // of any work to be done at the moment, but more might emerge later. In this case,
-          // we must simply reschedule the original restriction - checkpointing a tracker that
-          // hasn't claimed any work is not allowed.
-          residual = KV.of(tracker.currentRestriction(), processContext.lastReportedWatermark);
+          // of any work to be done at the moment, but more might emerge later. This is a valid
+          // use case: e.g. a DoFn reading from a streaming source might see that there are
+          // currently no new elements (hence not claim anything) and return resume() with a delay
+          // to check again later.
+          // In this case, we must simply reschedule the original restriction - checkpointing a
+          // tracker that hasn't claimed any work is not allowed.
+          //
+          // Note that the situation "a DoFn repeatedly says that it doesn't have any work to claim
+          // and asks to try again later with the same restriction" is different from the situation
+          // "a runner repeatedly checkpoints the DoFn before it has a chance to even attempt
+          // claiming work": the former is valid, and the latter would be a bug, and is addressed
+          // by not checkpointing the tracker until it attempts to claim some work.
+          residual = KV.of(tracker.currentRestriction(), processContext.getLastReportedWatermark());
           // Don't call tracker.checkDone() - it's not done.
         }
       } else {
@@ -242,15 +251,11 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
       this.tracker = tracker;
     }
 
-    void checkClaimHasNotFailed() {
+    @Override
+    public void onClaimed(PositionT position) {
       checkState(
           !hasClaimFailed,
           "Must not call tryClaim() after it has previously returned false");
-    }
-
-    @Override
-    public void onClaimed(PositionT position) {
-      checkClaimHasNotFailed();
       if (numClaimedBlocks == 0) {
         // Claiming first block: can schedule the checkpoint now.
         // We don't schedule it right away to prevent checkpointing before any blocks are claimed,
@@ -265,7 +270,9 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
 
     @Override
     public void onClaimFailed(PositionT position) {
-      checkClaimHasNotFailed();
+      checkState(
+          !hasClaimFailed,
+          "Must not call tryClaim() after it has previously returned false");
       hasClaimFailed = true;
     }
 
@@ -323,7 +330,16 @@ public class OutputAndTimeBoundedSplittableProcessElementInvoker<
     @Override
     public synchronized void updateWatermark(Instant watermark) {
       // Updating the watermark without any claimed blocks is allowed.
+      // The watermark is a promise about the timestamps of output from future claimed blocks.
+      // Such a promise can be made even if there are no claimed blocks. E.g. imagine reading
+      // from a streaming source that currently has no new data: there are no blocks to claim, but
+      // we may still want to advance the watermark if we have information about what timestamps
+      // of future elements in the source will be like.
       lastReportedWatermark = watermark;
+    }
+
+    synchronized Instant getLastReportedWatermark() {
+      return lastReportedWatermark;
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -262,7 +262,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException(
           "Cannot access RestrictionTracker outside of @ProcessElement method.");
     }
@@ -332,7 +332,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException(
           "Cannot access RestrictionTracker outside of @ProcessElement method.");
     }
@@ -504,7 +504,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException("RestrictionTracker parameters are not supported.");
     }
 
@@ -615,7 +615,7 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException("RestrictionTracker parameters are not supported.");
     }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableParDoViaKeyedWorkItems.java
@@ -150,7 +150,7 @@ public class SplittableParDoViaKeyedWorkItems {
 
   /** A primitive transform wrapping around {@link ProcessFn}. */
   public static class ProcessElements<
-          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
       extends PTransform<
           PCollection<KeyedWorkItem<String, KV<InputT, RestrictionT>>>, PCollectionTuple> {
     private final ProcessKeyedElements<InputT, OutputT, RestrictionT> original;
@@ -211,7 +211,7 @@ public class SplittableParDoViaKeyedWorkItems {
    */
   @VisibleForTesting
   public static class ProcessFn<
-          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
       extends DoFn<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> {
     /**
      * The state cell containing a watermark hold for the output of this {@link DoFn}. The hold is

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableProcessElementInvoker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SplittableProcessElementInvoker.java
@@ -31,7 +31,7 @@ import org.joda.time.Instant;
  * DoFn}, in particular, allowing the runner to access the {@link RestrictionTracker}.
  */
 public abstract class SplittableProcessElementInvoker<
-    InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>> {
+    InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>> {
   /** Specifies how to resume a splittable {@link DoFn.ProcessElement} call. */
   public class Result {
     @Nullable

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvokerTest.java
@@ -27,8 +27,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.Collection;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -41,26 +43,38 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /** Tests for {@link OutputAndTimeBoundedSplittableProcessElementInvoker}. */
 public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
-  private static class SomeFn extends DoFn<Integer, String> {
+  @Rule
+  public transient ExpectedException e = ExpectedException.none();
+
+  private static class SomeFn extends DoFn<Void, String> {
+    private final Duration sleepBeforeFirstClaim;
     private final int numOutputsPerProcessCall;
     private final Duration sleepBeforeEachOutput;
 
-    private SomeFn(int numOutputsPerProcessCall, Duration sleepBeforeEachOutput) {
+    private SomeFn(
+        Duration sleepBeforeFirstClaim,
+        int numOutputsPerProcessCall,
+        Duration sleepBeforeEachOutput) {
+      this.sleepBeforeFirstClaim = sleepBeforeFirstClaim;
       this.numOutputsPerProcessCall = numOutputsPerProcessCall;
       this.sleepBeforeEachOutput = sleepBeforeEachOutput;
     }
 
     @ProcessElement
-    public ProcessContinuation process(ProcessContext context, OffsetRangeTracker tracker)
-        throws Exception {
+    public ProcessContinuation process(ProcessContext context, OffsetRangeTracker tracker) {
+      Uninterruptibles.sleepUninterruptibly(
+          sleepBeforeFirstClaim.getMillis(), TimeUnit.MILLISECONDS);
       for (long i = tracker.currentRestriction().getFrom(), numIterations = 1;
           tracker.tryClaim(i);
           ++i, ++numIterations) {
-        Thread.sleep(sleepBeforeEachOutput.getMillis());
+        Uninterruptibles.sleepUninterruptibly(
+            sleepBeforeEachOutput.getMillis(), TimeUnit.MILLISECONDS);
         context.output("" + i);
         if (numIterations == numOutputsPerProcessCall) {
           return resume();
@@ -70,15 +84,25 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
     }
 
     @GetInitialRestriction
-    public OffsetRange getInitialRestriction(Integer element) {
+    public OffsetRange getInitialRestriction(Void element) {
       throw new UnsupportedOperationException("Should not be called in this test");
     }
   }
 
-  private SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result
-      runTest(int totalNumOutputs, int numOutputsPerProcessCall, Duration sleepPerElement) {
-    SomeFn fn = new SomeFn(numOutputsPerProcessCall, sleepPerElement);
-    SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker> invoker =
+  private SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result
+      runTest(
+          int totalNumOutputs,
+          Duration sleepBeforeFirstClaim,
+          int numOutputsPerProcessCall,
+          Duration sleepBeforeEachOutput) {
+    SomeFn fn = new SomeFn(sleepBeforeFirstClaim, numOutputsPerProcessCall, sleepBeforeEachOutput);
+    OffsetRange initialRestriction = new OffsetRange(0, totalNumOutputs);
+    return runTest(fn, initialRestriction);
+  }
+
+  private SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result
+      runTest(DoFn<Void, String> fn, OffsetRange initialRestriction) {
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker> invoker =
         new OutputAndTimeBoundedSplittableProcessElementInvoker<>(
             fn,
             PipelineOptionsFactory.create(),
@@ -105,14 +129,14 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
 
     return invoker.invokeProcessElement(
         DoFnInvokers.invokerFor(fn),
-        WindowedValue.of(totalNumOutputs, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING),
-        new OffsetRangeTracker(new OffsetRange(0, totalNumOutputs)));
+        WindowedValue.of(null, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING),
+        new OffsetRangeTracker(initialRestriction));
   }
 
   @Test
   public void testInvokeProcessElementOutputBounded() throws Exception {
-    SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
-        runTest(10000, Integer.MAX_VALUE, Duration.ZERO);
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result res =
+        runTest(10000, Duration.ZERO, Integer.MAX_VALUE, Duration.ZERO);
     assertFalse(res.getContinuation().shouldResume());
     OffsetRange residualRange = res.getResidualRestriction();
     // Should process the first 100 elements.
@@ -122,8 +146,8 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
 
   @Test
   public void testInvokeProcessElementTimeBounded() throws Exception {
-    SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
-        runTest(10000, Integer.MAX_VALUE, Duration.millis(100));
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result res =
+        runTest(10000, Duration.ZERO, Integer.MAX_VALUE, Duration.millis(100));
     assertFalse(res.getContinuation().shouldResume());
     OffsetRange residualRange = res.getResidualRestriction();
     // Should process ideally around 30 elements - but due to timing flakiness, we can't enforce
@@ -134,18 +158,65 @@ public class OutputAndTimeBoundedSplittableProcessElementInvokerTest {
   }
 
   @Test
+  public void testInvokeProcessElementTimeBoundedWithStartupDelay() throws Exception {
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result res =
+        runTest(10000, Duration.standardSeconds(3), Integer.MAX_VALUE, Duration.millis(100));
+    assertFalse(res.getContinuation().shouldResume());
+    OffsetRange residualRange = res.getResidualRestriction();
+    // Same as above, but this time it counts from the time of the first tryClaim() call
+    assertThat(residualRange.getFrom(), greaterThan(10L));
+    assertThat(residualRange.getFrom(), lessThan(100L));
+    assertEquals(10000, residualRange.getTo());
+  }
+
+  @Test
   public void testInvokeProcessElementVoluntaryReturnStop() throws Exception {
-    SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
-        runTest(5, Integer.MAX_VALUE, Duration.millis(100));
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result res =
+        runTest(5, Duration.ZERO, Integer.MAX_VALUE, Duration.millis(100));
     assertFalse(res.getContinuation().shouldResume());
     assertNull(res.getResidualRestriction());
   }
 
   @Test
   public void testInvokeProcessElementVoluntaryReturnResume() throws Exception {
-    SplittableProcessElementInvoker<Integer, String, OffsetRange, OffsetRangeTracker>.Result res =
-        runTest(10, 5, Duration.millis(100));
+    SplittableProcessElementInvoker<Void, String, OffsetRange, OffsetRangeTracker>.Result res =
+        runTest(10, Duration.ZERO, 5, Duration.millis(100));
     assertTrue(res.getContinuation().shouldResume());
     assertEquals(new OffsetRange(5, 10), res.getResidualRestriction());
+  }
+
+  @Test
+  public void testInvokeProcessElementOutputDisallowedBeforeTryClaim() throws Exception {
+    DoFn<Void, String> brokenFn = new DoFn<Void, String>() {
+      @ProcessElement
+      public void process(ProcessContext c, OffsetRangeTracker tracker) {
+        c.output("foo");
+      }
+
+      @GetInitialRestriction
+      public OffsetRange getInitialRestriction(Void element) {
+        throw new UnsupportedOperationException("Should not be called in this test");
+      }
+    };
+    e.expectMessage("Output is not allowed before tryClaim()");
+    runTest(brokenFn, new OffsetRange(0, 5));
+  }
+
+  @Test
+  public void testInvokeProcessElementOutputDisallowedAfterFailedTryClaim() throws Exception {
+    DoFn<Void, String> brokenFn = new DoFn<Void, String>() {
+      @ProcessElement
+      public void process(ProcessContext c, OffsetRangeTracker tracker) {
+        assertFalse(tracker.tryClaim(6L));
+        c.output("foo");
+      }
+
+      @GetInitialRestriction
+      public OffsetRange getInitialRestriction(Void element) {
+        throw new UnsupportedOperationException("Should not be called in this test");
+      }
+    };
+    e.expectMessage("Output is not allowed after a failed tryClaim()");
+    runTest(brokenFn, new OffsetRange(0, 5));
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -83,11 +83,16 @@ public class SplittableParDoProcessFnTest {
     }
   }
 
-  private static class SomeRestrictionTracker implements RestrictionTracker<SomeRestriction> {
+  private static class SomeRestrictionTracker extends RestrictionTracker<SomeRestriction, Void> {
     private final SomeRestriction someRestriction;
 
     public SomeRestrictionTracker(SomeRestriction someRestriction) {
       this.someRestriction = someRestriction;
+    }
+
+    @Override
+    protected boolean tryClaimImpl(Void position) {
+      return false;
     }
 
     @Override
@@ -112,7 +117,7 @@ public class SplittableParDoProcessFnTest {
    * possibly over multiple {@link DoFn.ProcessElement} calls).
    */
   private static class ProcessFnTester<
-          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+          InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
       implements AutoCloseable {
     private final DoFnTester<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> tester;
     private Instant currentProcessingTime;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CopyOnAccessInMemoryStateInternals.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CopyOnAccessInMemoryStateInternals.java
@@ -300,7 +300,7 @@ class CopyOnAccessInMemoryStateInternals<K> implements StateInternals {
                       underlying.get().get(namespace, address, c);
               return existingState.copy();
             } else {
-              return new InMemoryValue<>();
+              return new InMemoryValue<>(coder);
             }
           }
 
@@ -317,7 +317,7 @@ class CopyOnAccessInMemoryStateInternals<K> implements StateInternals {
                       underlying.get().get(namespace, address, c);
               return existingState.copy();
             } else {
-              return new InMemoryCombiningState<>(combineFn);
+              return new InMemoryCombiningState<>(combineFn, accumCoder);
             }
           }
 
@@ -331,7 +331,7 @@ class CopyOnAccessInMemoryStateInternals<K> implements StateInternals {
                       underlying.get().get(namespace, address, c);
               return existingState.copy();
             } else {
-              return new InMemoryBag<>();
+              return new InMemoryBag<>(elemCoder);
             }
           }
 
@@ -345,7 +345,7 @@ class CopyOnAccessInMemoryStateInternals<K> implements StateInternals {
                       underlying.get().get(namespace, address, c);
               return existingState.copy();
             } else {
-              return new InMemorySet<>();
+              return new InMemorySet<>(elemCoder);
             }
           }
 
@@ -361,7 +361,7 @@ class CopyOnAccessInMemoryStateInternals<K> implements StateInternals {
                       underlying.get().get(namespace, address, c);
               return existingState.copy();
             } else {
-              return new InMemoryMap<>();
+              return new InMemoryMap<>(mapKeyCoder, mapValueCoder);
             }
           }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
@@ -42,7 +42,7 @@ import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 class SplittableProcessElementsEvaluatorFactory<
-        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
     implements TransformEvaluatorFactory {
   private final ParDoEvaluatorFactory<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT>
       delegateFactory;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
@@ -42,7 +42,11 @@ import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 class SplittableProcessElementsEvaluatorFactory<
-        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
+        InputT,
+        OutputT,
+        RestrictionT,
+        PositionT,
+        TrackerT extends RestrictionTracker<RestrictionT, PositionT>>
     implements TransformEvaluatorFactory {
   private final ParDoEvaluatorFactory<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT>
       delegateFactory;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -624,7 +624,7 @@ class FlinkStreamingTransformTranslators {
   }
 
   private static class SplittableProcessElementsStreamingTranslator<
-      InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+      InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
       SplittableParDoViaKeyedWorkItems.ProcessElements<InputT, OutputT, RestrictionT, TrackerT>> {
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -55,7 +55,7 @@ import org.joda.time.Instant;
  * the {@code @ProcessElement} method of a splittable {@link DoFn}.
  */
 public class SplittableDoFnOperator<
-        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>>
+        InputT, OutputT, RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>>
     extends DoFnOperator<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> {
 
   private transient ScheduledExecutorService executorService;

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -33,7 +33,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.container_version>beam-master-20180122</dataflow.container_version>
+    <dataflow.container_version>beam-master-20180205</dataflow.container_version>
     <dataflow.fnapi_environment_major_version>1</dataflow.fnapi_environment_major_version>
     <dataflow.legacy_environment_major_version>7</dataflow.legacy_environment_major_version>
   </properties>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SnappyCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SnappyCoder.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.coders;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.xerial.snappy.Snappy;
+
+/**
+ * Wraps an existing coder with Snappy compression. It makes sense to use this coder only when it's
+ * likely that the encoded value is quite large and compressible.
+ */
+public class SnappyCoder<T> extends StructuredCoder<T> {
+  private final Coder<T> innerCoder;
+
+  /** Wraps the given coder into a {@link SnappyCoder}. */
+  public static <T> SnappyCoder<T> of(Coder<T> innerCoder) {
+    return new SnappyCoder<>(innerCoder);
+  }
+
+  private SnappyCoder(Coder<T> innerCoder) {
+    this.innerCoder = innerCoder;
+  }
+
+  @Override
+  public void encode(T value, OutputStream os) throws IOException {
+    ByteArrayCoder.of()
+        .encode(Snappy.compress(CoderUtils.encodeToByteArray(innerCoder, value)), os);
+  }
+
+  @Override
+  public T decode(InputStream is) throws IOException {
+    return CoderUtils.decodeFromByteArray(
+        innerCoder, Snappy.uncompress(ByteArrayCoder.of().decode(is)));
+  }
+
+  @Override
+  public List<? extends Coder<?>> getCoderArguments() {
+    return ImmutableList.of(innerCoder);
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    innerCoder.verifyDeterministic();
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnTester.java
@@ -319,7 +319,7 @@ public class DoFnTester<InputT, OutputT> implements AutoCloseable {
             }
 
             @Override
-            public RestrictionTracker<?> restrictionTracker() {
+            public RestrictionTracker<?, ?> restrictionTracker() {
               throw new UnsupportedOperationException(
                   "Not expected to access RestrictionTracker from a regular DoFn in DoFnTester");
             }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -78,7 +78,7 @@ public interface DoFnInvoker<InputT, OutputT> {
       DoFn.OutputReceiver<RestrictionT> restrictionReceiver);
 
   /** Invoke the {@link DoFn.NewTracker} method on the bound {@link DoFn}. */
-  <RestrictionT, TrackerT extends RestrictionTracker<RestrictionT>> TrackerT invokeNewTracker(
+  <RestrictionT, TrackerT extends RestrictionTracker<RestrictionT, ?>> TrackerT invokeNewTracker(
       RestrictionT restriction);
 
   /** Get the bound {@link DoFn}. */
@@ -124,7 +124,7 @@ public interface DoFnInvoker<InputT, OutputT> {
      * If this is a splittable {@link DoFn}, returns the {@link RestrictionTracker} associated with
      * the current {@link ProcessElement} call.
      */
-    RestrictionTracker<?> restrictionTracker();
+    RestrictionTracker<?, ?> restrictionTracker();
 
     /** Returns the state cell for the given {@link StateId}. */
     State state(String stateId);
@@ -203,7 +203,7 @@ public interface DoFnInvoker<InputT, OutputT> {
               FakeArgumentProvider.class.getSimpleName()));
     }
 
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException(
           String.format(
               "Should never call non-overridden methods of %s",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -908,7 +908,7 @@ public class DoFnSignatures {
       List<String> allowedParamTypes =
           Arrays.asList(
               formatType(new TypeDescriptor<BoundedWindow>() {}),
-              formatType(new TypeDescriptor<RestrictionTracker<?>>() {}));
+              formatType(new TypeDescriptor<RestrictionTracker<?, ?>>() {}));
       paramErrors.throwIllegalArgument(
           "%s is not a valid context parameter. Should be one of %s",
           formatType(paramT), allowedParamTypes);
@@ -1131,9 +1131,9 @@ public class DoFnSignatures {
    * RestrictionT}.
    */
   private static <RestrictionT>
-      TypeDescriptor<RestrictionTracker<RestrictionT>> restrictionTrackerTypeOf(
+      TypeDescriptor<RestrictionTracker<RestrictionT, ?>> restrictionTrackerTypeOf(
           TypeDescriptor<RestrictionT> restrictionT) {
-    return new TypeDescriptor<RestrictionTracker<RestrictionT>>() {}.where(
+    return new TypeDescriptor<RestrictionTracker<RestrictionT, ?>>() {}.where(
         new TypeParameter<RestrictionT>() {}, restrictionT);
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/HasDefaultTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/HasDefaultTracker.java
@@ -24,7 +24,7 @@ package org.apache.beam.sdk.transforms.splittabledofn;
  */
 public interface HasDefaultTracker<
     RestrictionT extends HasDefaultTracker<RestrictionT, TrackerT>,
-    TrackerT extends RestrictionTracker<RestrictionT>> {
+    TrackerT extends RestrictionTracker<RestrictionT, ?>> {
   /** Creates a new tracker for {@code this}. */
   TrackerT newTracker();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -46,11 +46,8 @@ public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long> {
 
   @Override
   public synchronized OffsetRange checkpoint() {
-    if (lastClaimedOffset == null) {
-      OffsetRange res = range;
-      range = new OffsetRange(range.getFrom(), range.getFrom());
-      return res;
-    }
+    checkState(
+        lastClaimedOffset != null, "Can't checkpoint before any offset was successfully claimed");
     OffsetRange res = new OffsetRange(lastClaimedOffset + 1, range.getTo());
     this.range = new OffsetRange(range.getFrom(), lastClaimedOffset + 1);
     return res;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.transforms.DoFn;
  * A {@link RestrictionTracker} for claiming offsets in an {@link OffsetRange} in a monotonically
  * increasing fashion.
  */
-public class OffsetRangeTracker implements RestrictionTracker<OffsetRange> {
+public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long> {
   private OffsetRange range;
   @Nullable private Long lastClaimedOffset = null;
   @Nullable private Long lastAttemptedOffset = null;
@@ -64,7 +64,8 @@ public class OffsetRangeTracker implements RestrictionTracker<OffsetRange> {
    * @return {@code true} if the offset was successfully claimed, {@code false} if it is outside the
    *     current {@link OffsetRange} of this tracker (in that case this operation is a no-op).
    */
-  public synchronized boolean tryClaim(long i) {
+  @Override
+  protected synchronized boolean tryClaimImpl(Long i) {
     checkArgument(
         lastAttemptedOffset == null || i > lastAttemptedOffset,
         "Trying to claim offset %s while last attempted was %s",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -17,6 +17,11 @@
  */
 package org.apache.beam.sdk.transforms.splittabledofn;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /**
@@ -24,14 +29,19 @@ import org.apache.beam.sdk.transforms.DoFn;
  * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn}.
  */
 public abstract class RestrictionTracker<RestrictionT, PositionT> {
-  interface ClaimObserver<PositionT> {
+  @Internal
+  public interface ClaimObserver<PositionT> {
     void onClaimed(PositionT position);
     void onClaimFailed(PositionT position);
   }
 
+  @Nullable
   private ClaimObserver<PositionT> claimObserver;
 
-  void setClaimObserver(ClaimObserver<PositionT> claimObserver) {
+  @Internal
+  public void setClaimObserver(ClaimObserver<PositionT> claimObserver) {
+    checkNotNull(claimObserver, "claimObserver");
+    checkState(this.claimObserver == null, "A claim observer has already been set");
     this.claimObserver = claimObserver;
   }
 
@@ -49,6 +59,7 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
     }
   }
 
+  @Internal
   protected abstract boolean tryClaimImpl(PositionT position);
 
   /**
@@ -64,7 +75,10 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    *
    * <p>Modifies {@link #currentRestriction}. Returns a restriction representing the rest of the
    * work: the old value of {@link #currentRestriction} is equivalent to the new value and the
-   * return value of this method combined. Must be called at most once on a given object.
+   * return value of this method combined.
+   *
+   * <p>Must be called at most once on a given object. Must not be called before the first
+   * successful {@link #tryClaim} call.
    */
   public abstract RestrictionT checkpoint();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SplittableDoFnTest.java
@@ -223,7 +223,7 @@ public class SplittableDoFnTest implements Serializable {
       int[] blockStarts = {-1, 0, 12, 123, 1234, 12345, 34567, MAX_INDEX};
       int trueStart = snapToNextBlock((int) tracker.currentRestriction().getFrom(), blockStarts);
       for (int i = trueStart, numIterations = 1;
-          tracker.tryClaim(blockStarts[i]);
+          tracker.tryClaim((long) blockStarts[i]);
           ++i, ++numIterations) {
         for (int index = blockStarts[i]; index < blockStarts[i + 1]; ++index) {
           c.output(index);
@@ -351,7 +351,7 @@ public class SplittableDoFnTest implements Serializable {
       int[] blockStarts = {-1, 0, 12, 123, 1234, 12345, 34567, MAX_INDEX};
       int trueStart = snapToNextBlock((int) tracker.currentRestriction().getFrom(), blockStarts);
       for (int i = trueStart, numIterations = 1;
-          tracker.tryClaim(blockStarts[i]);
+          tracker.tryClaim((long) blockStarts[i]);
           ++i, ++numIterations) {
         for (int index = blockStarts[i]; index < blockStarts[i + 1]; ++index) {
           c.output(KV.of(c.sideInput(sideInput) + ":" + c.element(), index));
@@ -516,7 +516,7 @@ public class SplittableDoFnTest implements Serializable {
     @ProcessElement
     public void processElement(ProcessContext c, OffsetRangeTracker tracker) {
       assertEquals(State.INSIDE_BUNDLE, state);
-      assertTrue(tracker.tryClaim(0));
+      assertTrue(tracker.tryClaim(0L));
       c.output(c.element());
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
@@ -27,19 +27,21 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.joda.time.Duration.standardSeconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
+import com.google.common.hash.HashCode;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -506,8 +508,8 @@ public class WatchTest implements Serializable {
     assertEquals(
         primary.toString(condition),
         new GrowthState<>(
-                Collections.emptyMap() /* completed */,
-                Collections.<TimestampedValue<String>>emptyList() /* pending */,
+                ImmutableMap.of() /* completed */,
+                ImmutableMap.of() /* pending */,
                 true /* isOutputFinal */,
                 (Integer) null /* terminationState */,
                 BoundedWindow.TIMESTAMP_MAX_VALUE /* pollWatermark */)
@@ -515,12 +517,19 @@ public class WatchTest implements Serializable {
     assertEquals(
         residual.toString(condition),
         new GrowthState<>(
-                Collections.emptyMap() /* completed */,
-                Collections.<TimestampedValue<String>>emptyList() /* pending */,
+                ImmutableMap.of() /* completed */,
+                ImmutableMap.of() /* pending */,
                 false /* isOutputFinal */,
                 0 /* terminationState */,
                 BoundedWindow.TIMESTAMP_MIN_VALUE /* pollWatermark */)
             .toString(condition));
+  }
+
+  private String tryClaimNextPending(GrowthTracker<String, ?, ?> tracker) {
+    assertTrue(tracker.hasPending());
+    Map.Entry<HashCode, TimestampedValue<String>> entry = tracker.getNextPending();
+    tracker.tryClaim(entry.getKey());
+    return entry.getValue().getValue();
   }
 
   @Test
@@ -537,10 +546,8 @@ public class WatchTest implements Serializable {
             .withWatermark(now.plus(standardSeconds(7))));
 
     assertEquals(now.plus(standardSeconds(1)), tracker.getWatermark());
-    assertTrue(tracker.hasPending());
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertTrue(tracker.hasPending());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
     assertTrue(tracker.hasPending());
     assertEquals(now.plus(standardSeconds(3)), tracker.getWatermark());
 
@@ -550,10 +557,8 @@ public class WatchTest implements Serializable {
 
     // Verify primary: should contain what the current tracker claimed, and nothing else.
     assertEquals(now.plus(standardSeconds(1)), primaryTracker.getWatermark());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("a", primaryTracker.tryClaimNextPending().getValue());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("b", primaryTracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(primaryTracker));
+    assertEquals("b", tryClaimNextPending(primaryTracker));
     assertFalse(primaryTracker.hasPending());
     assertFalse(primaryTracker.shouldPollMore());
     // No more pending elements in primary restriction, and no polling.
@@ -562,19 +567,16 @@ public class WatchTest implements Serializable {
 
     // Verify residual: should contain what the current tracker didn't claim.
     assertEquals(now.plus(standardSeconds(3)), residualTracker.getWatermark());
-    assertTrue(residualTracker.hasPending());
-    assertEquals("c", residualTracker.tryClaimNextPending().getValue());
-    assertTrue(residualTracker.hasPending());
-    assertEquals("d", residualTracker.tryClaimNextPending().getValue());
+    assertEquals("c", tryClaimNextPending(residualTracker));
+    assertEquals("d", tryClaimNextPending(residualTracker));
     assertFalse(residualTracker.hasPending());
     assertTrue(residualTracker.shouldPollMore());
     // No more pending elements in residual restriction, but poll watermark still holds.
     assertEquals(now.plus(standardSeconds(7)), residualTracker.getWatermark());
 
     // Verify current tracker: it was checkpointed, so should contain nothing else.
-    assertNull(tracker.tryClaimNextPending());
-    tracker.checkDone();
     assertFalse(tracker.hasPending());
+    tracker.checkDone();
     assertFalse(tracker.shouldPollMore());
     assertEquals(BoundedWindow.TIMESTAMP_MAX_VALUE, tracker.getWatermark());
   }
@@ -592,10 +594,10 @@ public class WatchTest implements Serializable {
                     TimestampedValue.of("b", now.plus(standardSeconds(2)))))
             .withWatermark(now.plus(standardSeconds(7))));
 
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
-    assertEquals("c", tracker.tryClaimNextPending().getValue());
-    assertEquals("d", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
+    assertEquals("c", tryClaimNextPending(tracker));
+    assertEquals("d", tryClaimNextPending(tracker));
     assertFalse(tracker.hasPending());
     assertEquals(now.plus(standardSeconds(7)), tracker.getWatermark());
 
@@ -605,14 +607,10 @@ public class WatchTest implements Serializable {
 
     // Verify primary: should contain what the current tracker claimed, and nothing else.
     assertEquals(now.plus(standardSeconds(1)), primaryTracker.getWatermark());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("a", primaryTracker.tryClaimNextPending().getValue());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("b", primaryTracker.tryClaimNextPending().getValue());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("c", primaryTracker.tryClaimNextPending().getValue());
-    assertTrue(primaryTracker.hasPending());
-    assertEquals("d", primaryTracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(primaryTracker));
+    assertEquals("b", tryClaimNextPending(primaryTracker));
+    assertEquals("c", tryClaimNextPending(primaryTracker));
+    assertEquals("d", tryClaimNextPending(primaryTracker));
     assertFalse(primaryTracker.hasPending());
     assertFalse(primaryTracker.shouldPollMore());
     // No more pending elements in primary restriction, and no polling.
@@ -645,10 +643,10 @@ public class WatchTest implements Serializable {
                     TimestampedValue.of("b", now.plus(standardSeconds(2)))))
             .withWatermark(now.plus(standardSeconds(7))));
 
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
-    assertEquals("c", tracker.tryClaimNextPending().getValue());
-    assertEquals("d", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
+    assertEquals("c", tryClaimNextPending(tracker));
+    assertEquals("d", tryClaimNextPending(tracker));
 
     GrowthState<String, String, Integer> checkpoint = tracker.checkpoint();
     // Simulate resuming from the checkpoint and adding more elements.
@@ -666,9 +664,9 @@ public class WatchTest implements Serializable {
               .withWatermark(now.plus(standardSeconds(12))));
 
       assertEquals(now.plus(standardSeconds(5)), residualTracker.getWatermark());
-      assertEquals("e", residualTracker.tryClaimNextPending().getValue());
+      assertEquals("e", tryClaimNextPending(residualTracker));
       assertEquals(now.plus(standardSeconds(8)), residualTracker.getWatermark());
-      assertEquals("f", residualTracker.tryClaimNextPending().getValue());
+      assertEquals("f", tryClaimNextPending(residualTracker));
 
       assertFalse(residualTracker.hasPending());
       assertTrue(residualTracker.shouldPollMore());
@@ -688,9 +686,9 @@ public class WatchTest implements Serializable {
                   TimestampedValue.of("f", now.plus(standardSeconds(8))))));
 
       assertEquals(now.plus(standardSeconds(5)), residualTracker.getWatermark());
-      assertEquals("e", residualTracker.tryClaimNextPending().getValue());
+      assertEquals("e", tryClaimNextPending(residualTracker));
       assertEquals(now.plus(standardSeconds(5)), residualTracker.getWatermark());
-      assertEquals("f", residualTracker.tryClaimNextPending().getValue());
+      assertEquals("f", tryClaimNextPending(residualTracker));
 
       assertFalse(residualTracker.hasPending());
       assertTrue(residualTracker.shouldPollMore());
@@ -711,10 +709,10 @@ public class WatchTest implements Serializable {
                     TimestampedValue.of("b", now.plus(standardSeconds(2)))))
             .withWatermark(now.plus(standardSeconds(7))));
 
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
-    assertEquals("c", tracker.tryClaimNextPending().getValue());
-    assertEquals("d", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
+    assertEquals("c", tryClaimNextPending(tracker));
+    assertEquals("d", tryClaimNextPending(tracker));
 
     // Simulate resuming from the checkpoint but there are no new elements.
     GrowthState<String, String, Integer> checkpoint = tracker.checkpoint();
@@ -759,10 +757,10 @@ public class WatchTest implements Serializable {
                 TimestampedValue.of("c", now.plus(standardSeconds(3))),
                 TimestampedValue.of("a", now.plus(standardSeconds(1))),
                 TimestampedValue.of("b", now.plus(standardSeconds(2))))));
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
-    assertEquals("c", tracker.tryClaimNextPending().getValue());
-    assertEquals("d", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
+    assertEquals("c", tryClaimNextPending(tracker));
+    assertEquals("d", tryClaimNextPending(tracker));
     assertEquals(now.plus(standardSeconds(1)), tracker.getWatermark());
 
     // Simulate resuming from the checkpoint but there are no new elements.
@@ -822,10 +820,10 @@ public class WatchTest implements Serializable {
                 TimestampedValue.of("a", now.plus(standardSeconds(1))),
                 TimestampedValue.of("b", now.plus(standardSeconds(2))))));
 
-    assertEquals("a", tracker.tryClaimNextPending().getValue());
-    assertEquals("b", tracker.tryClaimNextPending().getValue());
-    assertEquals("c", tracker.tryClaimNextPending().getValue());
-    assertEquals("d", tracker.tryClaimNextPending().getValue());
+    assertEquals("a", tryClaimNextPending(tracker));
+    assertEquals("b", tryClaimNextPending(tracker));
+    assertEquals("c", tryClaimNextPending(tracker));
+    assertEquals("d", tryClaimNextPending(tracker));
     assertFalse(tracker.hasPending());
     assertEquals(BoundedWindow.TIMESTAMP_MAX_VALUE, tracker.getWatermark());
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -295,7 +295,7 @@ public class DoFnInvokersTest {
   private static class SomeRestriction {}
 
   private abstract static class SomeRestrictionTracker
-      implements RestrictionTracker<SomeRestriction> {}
+      extends RestrictionTracker<SomeRestriction, Void> {}
 
   private static class SomeRestrictionCoder extends AtomicCoder<SomeRestriction> {
     public static SomeRestrictionCoder of() {
@@ -385,7 +385,7 @@ public class DoFnInvokersTest {
               }
 
               @Override
-              public RestrictionTracker<?> restrictionTracker() {
+              public RestrictionTracker<?, ?> restrictionTracker() {
                 return tracker;
               }
             }));
@@ -399,7 +399,13 @@ public class DoFnInvokersTest {
     }
   }
 
-  private static class DefaultTracker implements RestrictionTracker<RestrictionWithDefaultTracker> {
+  private static class DefaultTracker
+      extends RestrictionTracker<RestrictionWithDefaultTracker, Void> {
+    @Override
+    protected boolean tryClaimImpl(Void position) {
+      throw new UnsupportedOperationException();
+    }
+
     @Override
     public RestrictionWithDefaultTracker currentRestriction() {
       throw new UnsupportedOperationException();
@@ -653,7 +659,7 @@ public class DoFnInvokersTest {
           }
 
           @Override
-          public RestrictionTracker<?> restrictionTracker() {
+          public RestrictionTracker<?, ?> restrictionTracker() {
             return null; // will not be touched
           }
         });

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesProcessElementTest.java
@@ -39,7 +39,7 @@ public class DoFnSignaturesProcessElementTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage(
         "Integer is not a valid context parameter. "
-            + "Should be one of [BoundedWindow, RestrictionTracker<?>]");
+            + "Should be one of [BoundedWindow, RestrictionTracker<?, ?>]");
 
     analyzeProcessElementMethod(
         new AnonymousMethod() {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -55,7 +55,7 @@ public class DoFnSignaturesSplittableDoFnTest {
       implements HasDefaultTracker<SomeRestriction, SomeRestrictionTracker> {}
 
   private abstract static class SomeRestrictionTracker
-      implements RestrictionTracker<SomeRestriction> {}
+      extends RestrictionTracker<SomeRestriction, Void> {}
 
   private abstract static class SomeRestrictionCoder extends StructuredCoder<SomeRestriction> {}
 
@@ -332,7 +332,9 @@ public class DoFnSignaturesSplittableDoFnTest {
     DoFnSignatures.getSignature(BadFn.class);
   }
 
-  abstract class SomeDefaultTracker implements RestrictionTracker<RestrictionWithDefaultTracker> {}
+  abstract class SomeDefaultTracker
+      extends RestrictionTracker<RestrictionWithDefaultTracker, Void> {}
+
   abstract class RestrictionWithDefaultTracker
       implements HasDefaultTracker<RestrictionWithDefaultTracker, SomeDefaultTracker> {}
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -392,7 +392,7 @@ public class DoFnSignaturesSplittableDoFnTest {
     }
 
     thrown.expectMessage(
-        "Returns void, but must return a subtype of RestrictionTracker<SomeRestriction>");
+        "Returns void, but must return a subtype of RestrictionTracker<SomeRestriction, ?>");
     DoFnSignatures.getSignature(BadFn.class);
   }
 
@@ -580,7 +580,8 @@ public class DoFnSignaturesSplittableDoFnTest {
   @Test
   public void testNewTrackerInconsistent() throws Exception {
     thrown.expectMessage(
-        "Returns SomeRestrictionTracker, but must return a subtype of RestrictionTracker<String>");
+        "Returns SomeRestrictionTracker, "
+            + "but must return a subtype of RestrictionTracker<String, ?>");
     DoFnSignatures.analyzeNewTrackerMethod(
         errors(),
         TypeDescriptor.of(FakeDoFn.class),

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
@@ -38,10 +38,10 @@ public class OffsetRangeTrackerTest {
     OffsetRange range = new OffsetRange(100, 200);
     OffsetRangeTracker tracker = new OffsetRangeTracker(range);
     assertEquals(range, tracker.currentRestriction());
-    assertTrue(tracker.tryClaim(100));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(199));
-    assertFalse(tracker.tryClaim(200));
+    assertTrue(tracker.tryClaim(100L));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(199L));
+    assertFalse(tracker.tryClaim(200L));
   }
 
   @Test
@@ -55,7 +55,7 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckpointJustStarted() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(100));
+    assertTrue(tracker.tryClaim(100L));
     OffsetRange checkpoint = tracker.checkpoint();
     assertEquals(new OffsetRange(100, 101), tracker.currentRestriction());
     assertEquals(new OffsetRange(101, 200), checkpoint);
@@ -64,8 +64,8 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckpointRegular() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(105));
-    assertTrue(tracker.tryClaim(110));
+    assertTrue(tracker.tryClaim(105L));
+    assertTrue(tracker.tryClaim(110L));
     OffsetRange checkpoint = tracker.checkpoint();
     assertEquals(new OffsetRange(100, 111), tracker.currentRestriction());
     assertEquals(new OffsetRange(111, 200), checkpoint);
@@ -74,9 +74,9 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckpointClaimedLast() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(105));
-    assertTrue(tracker.tryClaim(110));
-    assertTrue(tracker.tryClaim(199));
+    assertTrue(tracker.tryClaim(105L));
+    assertTrue(tracker.tryClaim(110L));
+    assertTrue(tracker.tryClaim(199L));
     OffsetRange checkpoint = tracker.checkpoint();
     assertEquals(new OffsetRange(100, 200), tracker.currentRestriction());
     assertEquals(new OffsetRange(200, 200), checkpoint);
@@ -85,10 +85,10 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckpointAfterFailedClaim() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(105));
-    assertTrue(tracker.tryClaim(110));
-    assertTrue(tracker.tryClaim(160));
-    assertFalse(tracker.tryClaim(240));
+    assertTrue(tracker.tryClaim(105L));
+    assertTrue(tracker.tryClaim(110L));
+    assertTrue(tracker.tryClaim(160L));
+    assertFalse(tracker.tryClaim(240L));
     OffsetRange checkpoint = tracker.checkpoint();
     assertEquals(new OffsetRange(100, 161), tracker.currentRestriction());
     assertEquals(new OffsetRange(161, 200), checkpoint);
@@ -98,50 +98,50 @@ public class OffsetRangeTrackerTest {
   public void testNonMonotonicClaim() throws Exception {
     expected.expectMessage("Trying to claim offset 103 while last attempted was 110");
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(105));
-    assertTrue(tracker.tryClaim(110));
-    tracker.tryClaim(103);
+    assertTrue(tracker.tryClaim(105L));
+    assertTrue(tracker.tryClaim(110L));
+    tracker.tryClaim(103L);
   }
 
   @Test
   public void testClaimBeforeStartOfRange() throws Exception {
     expected.expectMessage("Trying to claim offset 90 before start of the range [100, 200)");
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    tracker.tryClaim(90);
+    tracker.tryClaim(90L);
   }
 
   @Test
   public void testCheckDoneAfterTryClaimPastEndOfRange() {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(175));
-    assertFalse(tracker.tryClaim(220));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(175L));
+    assertFalse(tracker.tryClaim(220L));
     tracker.checkDone();
   }
 
   @Test
   public void testCheckDoneAfterTryClaimAtEndOfRange() {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(175));
-    assertFalse(tracker.tryClaim(200));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(175L));
+    assertFalse(tracker.tryClaim(200L));
     tracker.checkDone();
   }
 
   @Test
   public void testCheckDoneAfterTryClaimRightBeforeEndOfRange() {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(175));
-    assertTrue(tracker.tryClaim(199));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(175L));
+    assertTrue(tracker.tryClaim(199L));
     tracker.checkDone();
   }
 
   @Test
   public void testCheckDoneWhenNotDone() {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(175));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(175L));
     expected.expectMessage(
         "Last attempted offset was 175 in range [100, 200), "
             + "claiming work in [176, 200) was not attempted");
@@ -151,8 +151,8 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckDoneWhenExplicitlyMarkedDone() {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
-    assertTrue(tracker.tryClaim(150));
-    assertTrue(tracker.tryClaim(175));
+    assertTrue(tracker.tryClaim(150L));
+    assertTrue(tracker.tryClaim(175L));
     tracker.markDone();
     tracker.checkDone();
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTrackerTest.java
@@ -47,9 +47,16 @@ public class OffsetRangeTrackerTest {
   @Test
   public void testCheckpointUnstarted() throws Exception {
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
+    expected.expect(IllegalStateException.class);
+    tracker.checkpoint();
+  }
+
+  @Test
+  public void testCheckpointOnlyFailedClaim() throws Exception {
+    OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(100, 200));
+    assertFalse(tracker.tryClaim(250L));
+    expected.expect(IllegalStateException.class);
     OffsetRange checkpoint = tracker.checkpoint();
-    assertEquals(new OffsetRange(100, 100), tracker.currentRestriction());
-    assertEquals(new OffsetRange(100, 200), checkpoint);
   }
 
   @Test

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -512,7 +512,7 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException(
           "Cannot access RestrictionTracker outside of @ProcessElement method.");
     }
@@ -569,7 +569,7 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException("TODO: Add support for SplittableDoFn");
     }
 
@@ -728,7 +728,7 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
     }
 
     @Override
-    public RestrictionTracker<?> restrictionTracker() {
+    public RestrictionTracker<?, ?> restrictionTracker() {
       throw new UnsupportedOperationException(
           "Cannot access RestrictionTracker outside of @ProcessElement method.");
     }


### PR DESCRIPTION
This addresses the following issues:

* https://issues.apache.org/jira/browse/BEAM-3499 Watch can make no progress if a single poll takes more than checkpoint interval
* https://issues.apache.org/jira/browse/BEAM-2607 Enforce that SDF must return stop() after a failed tryClaim() call

The former is the primary motivation for this PR. This PR changes SDF checkpointing timer countdown to start from the first claimed block, rather than from the beginning of `@ProcessElement`. This requires giving the runner visibility into claimed blocks. Such visibility enables fixing BEAM-2607 as well. It also is a required part of implementing SDF splitting over Fn API (tracked separately).

This PR also, of course, changes the Watch transform to the new API; and, while we're at it, does some related improvements:

* Compresses Watch.GrowthState using Snappy. E.g. with 100k files, the encoded state is about 3MB instead of 8MB. Compressing it much more is difficult because the state includes uncompressible hashes. To address this, one must shard the filepattern, or implement the improvements suggested in https://issues.apache.org/jira/browse/BEAM-2680 .
* Makes direct runner create a clone of state cells - I did this mainly because I noticed that GrowthStateCoder was never called on the Watch state, which risks missing coder bugs when testing with direct runner.

This PR is update-incompatible for users of the Watch transform, e.g. FileIO.match().continuously(). This is an experimental and very recent transform, so I'm going to ignore the incompatibility. It also requires a traditional Dataflow worker dance to get the worker container in sync with these runners-core changes - I'll perform that when the rest of the PR is approved.

R: @tgroh @chamikaramj 
CC: @kennknowles @reuvenlax