### PR TITLE
[BEAM-3527] Fix construction order of DistributionResult.ZERO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DistributionResult.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/DistributionResult.java
@@ -37,7 +37,7 @@ public abstract class DistributionResult {
     return (1.0 * sum()) / count();
   }
 
-  public static final DistributionResult ZERO = create(0, 0, Long.MAX_VALUE, Long.MIN_VALUE);
+  public static final DistributionResult ZERO = create(0, 0, Long.MIN_VALUE, Long.MAX_VALUE);
 
   public static DistributionResult create(long sum, long count, long min, long max) {
     return new AutoValue_DistributionResult(sum, count, min, max);


### PR DESCRIPTION
`Long.MIN_VALUE` and `Long.MAX_VALUE` are provided in the wrong order to the DistributionResult constructor, causing confusion in our default metrics reporting.

---

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
