### PR TITLE
Clarify error message is received from SDK harness

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
@@ -131,7 +131,11 @@ class FnApiControlClient implements Closeable {
         if (response.getError().isEmpty()) {
           completableFuture.set(response);
         } else {
-          completableFuture.setException(new RuntimeException(response.getError()));
+          completableFuture.setException(
+              new RuntimeException(String.format(
+                  "Error received from SDK harness for instruction %s: %s",
+                  response.getInstructionId(),
+                  response.getError())));
         }
       }
     }


### PR DESCRIPTION
Error messages surfaced by the Runner harness should indicate if the SDK harness is their source. Otherwise it spuriously appears that the error came from the Runner harness rather than the SDK harness.