### PR TITLE
[BEAM-3537] Allow more general eager in-process pipeline execution

### DIFF
--- a/sdks/python/apache_beam/runners/__init__.py
+++ b/sdks/python/apache_beam/runners/__init__.py
@@ -21,7 +21,6 @@ This package defines runners, which are used to execute a pipeline.
 """
 
 from apache_beam.runners.direct.direct_runner import DirectRunner
-from apache_beam.runners.direct.direct_runner import EagerRunner
 from apache_beam.runners.runner import PipelineRunner
 from apache_beam.runners.runner import PipelineState
 from apache_beam.runners.runner import create_runner

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -155,7 +155,6 @@ class EvaluationContext(object):
     self._side_inputs_container = _SideInputsContainer(views)
     self._pending_unblocked_tasks = []
     self._counter_factory = counters.CounterFactory()
-    self._cache = None
     self._metrics = DirectMetrics()
 
     self._lock = threading.Lock()
@@ -169,22 +168,9 @@ class EvaluationContext(object):
         transform_keyed_states[consumer] = {}
     return transform_keyed_states
 
-  def use_pvalue_cache(self, cache):
-    assert not self._cache
-    self._cache = cache
-
   def metrics(self):
     # TODO. Should this be made a @property?
     return self._metrics
-
-  @property
-  def has_cache(self):
-    return self._cache is not None
-
-  def append_to_cache(self, applied_ptransform, tag, elements):
-    with self._lock:
-      assert self._cache
-      self._cache.append(applied_ptransform, tag, elements)
 
   def is_root_transform(self, applied_ptransform):
     return applied_ptransform in self._root_transforms

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -341,17 +341,6 @@ class TransformExecutor(_ExecutorService.CallableTask):
       result = evaluator.finish_bundle()
       result.logical_metric_updates = metrics_container.get_cumulative()
 
-    if self._evaluation_context.has_cache:
-      for uncommitted_bundle in result.uncommitted_output_bundles:
-        self._evaluation_context.append_to_cache(
-            self._applied_ptransform, uncommitted_bundle.tag,
-            uncommitted_bundle.get_elements_iterable())
-      undeclared_tag_values = result.undeclared_tag_values
-      if undeclared_tag_values:
-        for tag, value in undeclared_tag_values.iteritems():
-          self._evaluation_context.append_to_cache(
-              self._applied_ptransform, tag, value)
-
     self._completion_callback.handle_result(self, self._input_bundle, result)
     return result
 

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -45,7 +45,7 @@ _PYTHON_RPC_DIRECT_RUNNER = (
     'python_rpc_direct_runner.')
 
 _KNOWN_PYTHON_RPC_DIRECT_RUNNER = ('PythonRPCDirectRunner',)
-_KNOWN_DIRECT_RUNNERS = ('DirectRunner', 'EagerRunner')
+_KNOWN_DIRECT_RUNNERS = ('DirectRunner',)
 _KNOWN_DATAFLOW_RUNNERS = ('DataflowRunner',)
 _KNOWN_TEST_RUNNERS = ('TestDataflowRunner',)
 

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1407,7 +1407,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Valid object instance must be of type 'tuple'. Instead, "
         "an instance of 'float' was received.")
 
-  def test_pipline_runtime_checking_violation_with_side_inputs_decorator(self):
+  def test_pipeline_runtime_checking_violation_with_side_inputs_decorator(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
     self.p._options.view_as(TypeOptions).runtime_type_check = True
 
@@ -1427,7 +1427,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Expected an instance of <type 'int'>, "
         "instead found 1.0, an instance of <type 'float'>.")
 
-  def test_pipline_runtime_checking_violation_with_side_inputs_via_method(self):
+  def test_pipeline_runtime_checking_violation_with_side_inputs_via_method(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
 
@@ -2061,6 +2061,28 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.p._options.view_as(TypeOptions).pipeline_type_check = True
     x = self.p | 'C2' >> beam.Create([1, 2, 3, 4])
     self.assertEqual(int, x.element_type)
+
+  def test_eager_execution(self):
+
+    class DoubleDoFn(beam.DoFn):
+
+      def process(self, element):
+        return [2 * element]
+
+    doubled = [1, 2, 3, 4] | beam.ParDo(DoubleDoFn())
+    self.assertEqual([2, 4, 6, 8], doubled)
+
+  def test_eager_execution_tagged_outputs(self):
+
+    class DoubleDoFn(beam.DoFn):
+
+      def process(self, element):
+        yield pvalue.TaggedOutput('bar', 2 * element)
+
+    result = [1, 2, 3, 4] | beam.ParDo(DoubleDoFn()).with_outputs('bar')
+    self.assertEqual([2, 4, 6, 8], result.bar)
+    with self.assertRaises(KeyError, msg='Tag \'foo\' is not a defined output tag'):
+      result.foo
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1427,7 +1427,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Expected an instance of <type 'int'>, "
         "instead found 1.0, an instance of <type 'float'>.")
 
-  def test_pipeline_runtime_checking_violation_with_side_inputs_via_method(self):
+  def test_pipeline_runtime_checking_violation_with_side_inputs_via_method(self):  # pylint: disable=line-too-long
     self.p._options.view_as(TypeOptions).runtime_type_check = True
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
 
@@ -2063,25 +2063,15 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual(int, x.element_type)
 
   def test_eager_execution(self):
-
-    class DoubleDoFn(beam.DoFn):
-
-      def process(self, element):
-        return [2 * element]
-
-    doubled = [1, 2, 3, 4] | beam.ParDo(DoubleDoFn())
+    doubled = [1, 2, 3, 4] | beam.Map(lambda x: 2 * x)
     self.assertEqual([2, 4, 6, 8], doubled)
 
   def test_eager_execution_tagged_outputs(self):
-
-    class DoubleDoFn(beam.DoFn):
-
-      def process(self, element):
-        yield pvalue.TaggedOutput('bar', 2 * element)
-
-    result = [1, 2, 3, 4] | beam.ParDo(DoubleDoFn()).with_outputs('bar')
+    result = [1, 2, 3, 4] | beam.Map(
+        lambda x: pvalue.TaggedOutput('bar', 2 * x)).with_outputs('bar')
     self.assertEqual([2, 4, 6, 8], result.bar)
-    with self.assertRaises(KeyError, msg='Tag \'foo\' is not a defined output tag'):
+    with self.assertRaises(KeyError,
+                           msg='Tag \'foo\' is not a defined output tag'):
       result.foo
 
 


### PR DESCRIPTION
This change also removes the Python DirectRunner-specific PValue cache.