### PR TITLE
[BEAM-2530] Make classloader handling more compatible with JDK 9

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.core.construction;
 
+import com.google.common.base.Splitter;
+import com.google.common.base.StandardSystemProperty;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -37,6 +39,11 @@ public class PipelineResources {
    * @return A list of absolute paths to the resources the class loader uses.
    */
   public static List<String> detectClassPathResourcesToStage(ClassLoader classLoader) {
+    if (classLoader == ClassLoader.getSystemClassLoader()) {
+      return Splitter.on(File.pathSeparatorChar)
+        .splitToList(StandardSystemProperty.JAVA_CLASS_PATH.value());
+    }
+
     if (!(classLoader instanceof URLClassLoader)) {
       String message = String.format("Unable to use ClassLoader to detect classpath elements. "
           + "Current ClassLoader is %s, only URLClassLoaders are supported.", classLoader);


### PR DESCRIPTION
From
http://www.oracle.com/technetwork/java/javase/9-relnote-issues-3704069.html:

> The application class loader is no longer an instance of
> java.net.URLClassLoader (an implementation detail that was never
> specified in previous releases). Code that assumes that
> ClassLoader::getSytemClassLoader returns a URLClassLoader object will
> need to be updated. Note that Java SE and the JDK do not provide an
> API for applications or libraries to dynamically augment the class
> path at run-time.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
