### PR TITLE
[BEAM-3508] Eclipse oxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ sdks/python/apache_beam/portability/api/*pb2*.*
 **/.fbExcludeFilterFile
 **/.apt_generated/**/*
 **/.settings/**/*
+**/.gitignore
 
 # Ignore Visual Studio Code files.
 **/.vscode/**/*

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ buildscript {
     maven { url "http://repo.spring.io/plugins-release" }
   }
   dependencies {
-    classpath "net.ltgt.gradle:gradle-apt-plugin:0.12"                                                  // Enable a Java annotation processor
+    classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"                                                  // Enable a Java annotation processor
     classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"                                        // Enable proto code generation
     classpath "io.spring.gradle:propdeps-plugin:0.0.9.RELEASE"                                          // Enable provided and optional configurations
     classpath "gradle.plugin.org.nosphere.apache:creadur-rat-gradle:0.3.1"                              // Enable Apache license enforcement

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -222,6 +222,7 @@ ext.applyJavaNature = {
     testApt auto_service
   }
 
+
   // Add the optional and provided configurations for dependencies
   // TODO: Either remove these plugins and find another way to generate the Maven poms
   // with the correct dependency scopes configured.
@@ -433,3 +434,9 @@ ext.applyAvroNature = {
   println "applyAvroNature with " + (it ? "$it" : "default configuration") + " for project $project.name"
   apply plugin: "com.commercehub.gradle.plugin.avro"
 }
+
+// Apply the apt-eclipse plugin so the eclipse import can work
+apply plugin: 'eclipse'
+apply plugin: "net.ltgt.apt-eclipse"
+
+

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -222,7 +222,6 @@ ext.applyJavaNature = {
     testApt auto_service
   }
 
-
   // Add the optional and provided configurations for dependencies
   // TODO: Either remove these plugins and find another way to generate the Maven poms
   // with the correct dependency scopes configured.
@@ -238,6 +237,13 @@ ext.applyJavaNature = {
     showViolations = true
     maxErrors = 0
   }
+
+  // Apply the eclipse and apt-eclipse plugins.  This adds the "eclipse" task and
+  // connects the apt-eclipse plugin to update the eclipse project files
+  // with the instructions needed to run apt within eclipse to handle the AutoValue
+  // and additional annotations
+  apply plugin: 'eclipse'
+  apply plugin: "net.ltgt.apt-eclipse"
 
   // Enables a plugin which can apply code formatting to source.
   // TODO: Should this plugin be enabled for all projects?
@@ -434,9 +440,5 @@ ext.applyAvroNature = {
   println "applyAvroNature with " + (it ? "$it" : "default configuration") + " for project $project.name"
   apply plugin: "com.commercehub.gradle.plugin.avro"
 }
-
-// Apply the apt-eclipse plugin so the eclipse import can work
-apply plugin: 'eclipse'
-apply plugin: "net.ltgt.apt-eclipse"
 
 

--- a/examples/java/src/main/java/org/apache/beam/examples/snippets/Snippets.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/snippets/Snippets.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.examples;
+package org.apache.beam.examples.snippets;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/examples/java/src/test/java/org/apache/beam/examples/snippets/SnippetsTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/snippets/SnippetsTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.examples;
+package org.apache.beam.examples.snippets;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/model/job-management/pom.xml
+++ b/model/job-management/pom.xml
@@ -77,6 +77,24 @@
           </execution>
         </executions>
       </plugin>
+      
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-grpc-source</id>
+            <goals>
+               <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/protobuf/java/grpc-java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,6 @@
 
     <!-- Default skipping -->
     <rat.skip>true</rat.skip>
-
   </properties>
 
   <packaging>pom</packaging>
@@ -1772,17 +1771,17 @@
                   </action>
                 </pluginExecution>
                 <pluginExecution>
-                    <pluginExecutionFilter>
-                        <groupId>net.revelc.code.formatter</groupId>
-                        <artifactId>formatter-maven-plugin</artifactId>
-                        <versionRange>[2.0.0,)</versionRange>
-                        <goals>
-                            <goal>format</goal>
-                        </goals>
-                    </pluginExecutionFilter>
-                    <action>
-                        <ignore />
-                    </action>
+                  <pluginExecutionFilter>
+                    <groupId>net.revelc.code.formatter</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <versionRange>[2.0.0,)</versionRange>
+                    <goals>
+                      <goal>format</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore />
+                  </action>
                 </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,7 @@
 
     <!-- Default skipping -->
     <rat.skip>true</rat.skip>
+
   </properties>
 
   <packaging>pom</packaging>
@@ -343,7 +344,7 @@
                 <dependency>
                   <groupId>org.eclipse.tycho</groupId>
                   <artifactId>tycho-compiler-jdt</artifactId>
-                  <version>0.26.0</version>
+                  <version>1.0.0</version>
                 </dependency>
               </dependencies>
             </plugin>
@@ -1714,6 +1715,36 @@
                 </pluginExecution>
                 <pluginExecution>
                   <pluginExecutionFilter>
+                    <groupId>com.googlecode.fmpp-maven-plugin</groupId>
+                    <artifactId>fmpp-maven-plugin</artifactId>
+                    <versionRange>[1.0,)</versionRange>
+                    <goals>
+                      <goal>generate</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>javacc-maven-plugin</artifactId>
+                    <versionRange>[2.4,)</versionRange>
+                    <goals>
+                      <goal>javacc</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                  </action>
+                </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <versionRange>[2.5,)</versionRange>
@@ -1739,6 +1770,19 @@
                   <action>
                     <ignore />
                   </action>
+                </pluginExecution>
+                <pluginExecution>
+                    <pluginExecutionFilter>
+                        <groupId>net.revelc.code.formatter</groupId>
+                        <artifactId>formatter-maven-plugin</artifactId>
+                        <versionRange>[2.0.0,)</versionRange>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                        <ignore />
+                    </action>
                 </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnTester.java
@@ -547,7 +547,7 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
                     Instant timestamp = input.getTimestamp();
                     Collection<W> windows =
                         windowFn.assignWindows(
-                            new TestAssignContext<>(
+                            new TestAssignContext<W>(
                                 windowFn, value, timestamp, GlobalWindow.INSTANCE));
                     return WindowedValue.of(value, timestamp, windows, PaneInfo.NO_FIRING);
                   } catch (Exception e) {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
@@ -266,7 +266,7 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
         Instant timestamp = input.getTimestamp();
         Collection<W> assignedWindows =
             windowFn.assignWindows(
-                new TestAssignContext<>(windowFn, value, timestamp, GlobalWindow.INSTANCE));
+                new TestAssignContext<W>(windowFn, value, timestamp, GlobalWindow.INSTANCE));
 
         for (W window : assignedWindows) {
           activeWindows.addActiveForTesting(window);

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WindowEvaluatorFactory.java
@@ -99,7 +99,7 @@ class WindowEvaluatorFactory implements TransformEvaluatorFactory {
     private <W extends BoundedWindow> Collection<? extends BoundedWindow> assignWindows(
         WindowFn<InputT, W> windowFn, WindowedValue<InputT> element) throws Exception {
       WindowFn<InputT, W>.AssignContext assignContext =
-          new DirectAssignContext<>(windowFn, element);
+          new DirectAssignContext<InputT, W>(windowFn, element);
       Collection<? extends BoundedWindow> windows = windowFn.assignWindows(assignContext);
       return windows;
     }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectGraphVisitorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectGraphVisitorTest.java
@@ -95,8 +95,8 @@ public class DirectGraphVisitorTest implements Serializable {
     assertThat(graph.getRootTransforms(), hasSize(3));
     assertThat(
         graph.getRootTransforms(),
-        Matchers.containsInAnyOrder(
-            graph.getProducer(created), graph.getProducer(counted), graph.getProducer(unCounted)));
+        Matchers.containsInAnyOrder(new Object[] {
+            graph.getProducer(created), graph.getProducer(counted), graph.getProducer(unCounted)}));
     for (AppliedPTransform<?, ?, ?> root : graph.getRootTransforms())  {
       // Root transforms will have no inputs
       assertThat(root.getInputs().entrySet(), emptyIterable());
@@ -114,9 +114,10 @@ public class DirectGraphVisitorTest implements Serializable {
     empty.setCoder(StringUtf8Coder.of());
     p.traverseTopologically(visitor);
     DirectGraph graph = visitor.getGraph();
-    assertThat(graph.getRootTransforms(), Matchers.containsInAnyOrder(graph.getProducer(empty)));
+    assertThat(graph.getRootTransforms(),
+               Matchers.containsInAnyOrder(new Object[] {graph.getProducer(empty)}));
     AppliedPTransform<?, ?, ?> onlyRoot = Iterables.getOnlyElement(graph.getRootTransforms());
-    assertThat(onlyRoot.getTransform(), Matchers.equalTo(flatten));
+    assertThat((Object) onlyRoot.getTransform(), Matchers.equalTo(flatten));
     assertThat(onlyRoot.getInputs().entrySet(), emptyIterable());
     assertThat(onlyRoot.getOutputs(), equalTo(empty.expand()));
   }
@@ -148,9 +149,10 @@ public class DirectGraphVisitorTest implements Serializable {
 
     assertThat(
         graph.getPerElementConsumers(created),
-        Matchers.containsInAnyOrder(transformedProducer, flattenedProducer));
+        Matchers.containsInAnyOrder(new Object[] {transformedProducer, flattenedProducer}));
     assertThat(
-        graph.getPerElementConsumers(transformed), Matchers.containsInAnyOrder(flattenedProducer));
+        graph.getPerElementConsumers(transformed),
+        Matchers.containsInAnyOrder(new Object[] {flattenedProducer}));
     assertThat(graph.getPerElementConsumers(flattened), emptyIterable());
   }
 
@@ -168,7 +170,7 @@ public class DirectGraphVisitorTest implements Serializable {
 
     assertThat(
         graph.getPerElementConsumers(created),
-        Matchers.containsInAnyOrder(flattenedProducer, flattenedProducer));
+        Matchers.containsInAnyOrder(new Object[] {flattenedProducer, flattenedProducer}));
     assertThat(graph.getPerElementConsumers(flattened), emptyIterable());
   }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
@@ -74,6 +74,7 @@ import org.slf4j.LoggerFactory;
 import scala.Option;
 import scala.Tuple2;
 import scala.Tuple3;
+import scala.collection.GenTraversable;
 import scala.collection.Iterator;
 import scala.collection.Seq;
 import scala.runtime.AbstractFunction1;
@@ -272,12 +273,12 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
           if (!encodedKeyedElements.isEmpty()) {
             // new input for key.
             try {
-              //cast to GenTraversable to avoid a ambiguous call to head() which can come from
-              //mulitple super interfacesof Seq<byte[]>
-              byte[] b = ((scala.collection.GenTraversable<byte[]>) encodedKeyedElements).head();
+              // cast to GenTraversable to avoid a ambiguous call to head() which can come from
+              // multiple super interfacesof Seq<byte[]>
+              byte[] headBytes = ((GenTraversable<byte[]>) encodedKeyedElements).head();
               final KV<Long, Iterable<WindowedValue<InputT>>> keyedElements =
                   CoderHelpers.fromByteArray(
-                      b, KvCoder.of(VarLongCoder.of(), itrWvCoder));
+                      headBytes, KvCoder.of(VarLongCoder.of(), itrWvCoder));
 
               final Long rddTimestamp = keyedElements.getKey();
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
@@ -272,9 +272,12 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
           if (!encodedKeyedElements.isEmpty()) {
             // new input for key.
             try {
+              //cast to GenTraversable to avoid a ambiguous call to head() which can come from
+              //mulitple super interfacesof Seq<byte[]>
+              byte[] b = ((scala.collection.GenTraversable<byte[]>) encodedKeyedElements).head();
               final KV<Long, Iterable<WindowedValue<InputT>>> keyedElements =
                   CoderHelpers.fromByteArray(
-                      encodedKeyedElements.head(), KvCoder.of(VarLongCoder.of(), itrWvCoder));
+                      b, KvCoder.of(VarLongCoder.of(), itrWvCoder));
 
               final Long rddTimestamp = keyedElements.getKey();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -302,7 +302,7 @@ public class Pipeline {
    * by the options.
    */
   public PipelineResult run(PipelineOptions options) {
-    PipelineRunner runner = PipelineRunner.fromOptions(options);
+    PipelineRunner<? extends PipelineResult> runner = PipelineRunner.fromOptions(options);
     // Ensure all of the nodes are fully specified before a PipelineRunner gets access to the
     // pipeline.
     LOG.debug("Running {} via {}", this, runner);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -564,9 +564,9 @@ public class CoderRegistry {
       }
       for (int i = 0; i < typeArgumentCoders.size(); i++) {
         try {
-          Coder<?> c2 = typeArgumentCoders.get(i);
+          Coder<?> typeArgumentCoder = typeArgumentCoders.get(i);
           verifyCompatible(
-              c2,
+              typeArgumentCoder,
               candidateDescriptor.resolveType(typeArguments[i]).getType());
         } catch (IncompatibleCoderException exn) {
           throw new IncompatibleCoderException(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -564,8 +564,9 @@ public class CoderRegistry {
       }
       for (int i = 0; i < typeArgumentCoders.size(); i++) {
         try {
+          Coder<?> c2 = typeArgumentCoders.get(i);
           verifyCompatible(
-              typeArgumentCoders.get(i),
+              c2,
               candidateDescriptor.resolveType(typeArguments[i]).getType());
         } catch (IncompatibleCoderException exn) {
           throw new IncompatibleCoderException(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -88,7 +88,8 @@ public class WindowFnTestUtils {
       for (W window : assignedWindowsWithValue(windowFn, element)) {
         windowSet.put(window, timestampValue(element.getTimestamp().getMillis()));
       }
-      windowFn.mergeWindows(new TestMergeContext<>(windowSet, windowFn));
+      TestMergeContext<T, W> tmc = new TestMergeContext<>(windowSet, windowFn);
+      windowFn.mergeWindows(tmc);
     }
     Map<W, Set<String>> actual = new HashMap<>();
     for (W window : windowSet.windows()) {
@@ -112,8 +113,8 @@ public class WindowFnTestUtils {
    */
   public static <T, W extends BoundedWindow> Collection<W> assignedWindowsWithValue(
       WindowFn<T, W> windowFn, TimestampedValue<T> timestampedValue) throws Exception {
-    return windowFn.assignWindows(
-        new TestAssignContext<>(timestampedValue, windowFn));
+    TestAssignContext<T, W> tac = new TestAssignContext<>(timestampedValue, windowFn);
+    return windowFn.assignWindows(tac);
   }
 
   private static String timestampValue(long timestamp) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -88,8 +88,8 @@ public class WindowFnTestUtils {
       for (W window : assignedWindowsWithValue(windowFn, element)) {
         windowSet.put(window, timestampValue(element.getTimestamp().getMillis()));
       }
-      TestMergeContext<T, W> tmc = new TestMergeContext<>(windowSet, windowFn);
-      windowFn.mergeWindows(tmc);
+      TestMergeContext<T, W> mergeContext = new TestMergeContext<>(windowSet, windowFn);
+      windowFn.mergeWindows(mergeContext);
     }
     Map<W, Set<String>> actual = new HashMap<>();
     for (W window : windowSet.windows()) {
@@ -113,8 +113,8 @@ public class WindowFnTestUtils {
    */
   public static <T, W extends BoundedWindow> Collection<W> assignedWindowsWithValue(
       WindowFn<T, W> windowFn, TimestampedValue<T> timestampedValue) throws Exception {
-    TestAssignContext<T, W> tac = new TestAssignContext<>(timestampedValue, windowFn);
-    return windowFn.assignWindows(tac);
+    TestAssignContext<T, W> assignContext = new TestAssignContext<>(timestampedValue, windowFn);
+    return windowFn.assignWindows(assignContext);
   }
 
   private static String timestampValue(long timestamp) {

--- a/sdks/java/extensions/sql/pom.xml
+++ b/sdks/java/extensions/sql/pom.xml
@@ -166,7 +166,7 @@
             </goals>
             <configuration>
               <cfgFile>${project.build.directory}/codegen/config.fmpp</cfgFile>
-              <outputDirectory>target/generated-sources</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/fmpp</outputDirectory>
               <templateDirectory>${project.build.directory}/codegen/templates</templateDirectory>
             </configuration>
           </execution>
@@ -176,7 +176,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>1.9</version>
         <executions>
           <execution>
             <id>add-generated-sources</id>
@@ -186,7 +185,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>${project.build.directory}/generated-sources</source>
+                <source>${project.build.directory}/generated-sources/java</source>
               </sources>
             </configuration>
           </execution>
@@ -211,7 +210,7 @@
               </includes>
               <lookAhead>2</lookAhead>
               <isStatic>false</isStatic>
-              <outputDirectory>${project.build.directory}/generated-sources/</outputDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
             </configuration>
           </execution>
         </executions>

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
@@ -51,8 +51,8 @@ public class BeamSqlCaseExpression extends BeamSqlExpression {
 
   @Override public BeamSqlPrimitive evaluate(BeamRecord inputRow, BoundedWindow window) {
     for (int i = 0; i < operands.size() - 1; i += 2) {
-      Boolean b = opValueEvaluated(i, inputRow, window);
-      if (b != null && b) {
+      Boolean wasOpEvaluated = opValueEvaluated(i, inputRow, window);
+      if (wasOpEvaluated != null && wasOpEvaluated) {
         return BeamSqlPrimitive.of(
             outputType,
             opValueEvaluated(i + 1, inputRow, window)

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
@@ -51,7 +51,8 @@ public class BeamSqlCaseExpression extends BeamSqlExpression {
 
   @Override public BeamSqlPrimitive evaluate(BeamRecord inputRow, BoundedWindow window) {
     for (int i = 0; i < operands.size() - 1; i += 2) {
-      if (opValueEvaluated(i, inputRow, window)) {
+      Boolean b = opValueEvaluated(i, inputRow, window);
+      if (b != null && b) {
         return BeamSqlPrimitive.of(
             outputType,
             opValueEvaluated(i + 1, inputRow, window)

--- a/sdks/java/maven-archetypes/examples/pom.xml
+++ b/sdks/java/maven-archetypes/examples/pom.xml
@@ -71,6 +71,33 @@
             </execution>
           </executions>
         </plugin>
+        <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+        <plugin>
+        	  <groupId>org.eclipse.m2e</groupId>
+        	  <artifactId>lifecycle-mapping</artifactId>
+        	  <version>1.0.0</version>
+        	  <configuration>
+        		<lifecycleMappingMetadata>
+        		  <pluginExecutions>
+        			<pluginExecution>
+        		      <pluginExecutionFilter>
+        			    <groupId>org.codehaus.mojo</groupId>
+        				<artifactId>exec-maven-plugin</artifactId>
+        			    <versionRange>[1.5.0,)</versionRange>
+        				<goals>
+        				  <goal>exec</goal>
+        				</goals>
+        			  </pluginExecutionFilter>
+        			  <action>
+                    <execute>
+                      <runOnIncremental>false</runOnIncremental>
+                    </execute>
+                   </action>
+        			</pluginExecution>
+        		  </pluginExecutions>
+        		</lifecycleMappingMetadata>
+        	</configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
 

--- a/sdks/java/maven-archetypes/examples/pom.xml
+++ b/sdks/java/maven-archetypes/examples/pom.xml
@@ -73,30 +73,30 @@
         </plugin>
         <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
         <plugin>
-        	  <groupId>org.eclipse.m2e</groupId>
-        	  <artifactId>lifecycle-mapping</artifactId>
-        	  <version>1.0.0</version>
-        	  <configuration>
-        		<lifecycleMappingMetadata>
-        		  <pluginExecutions>
-        			<pluginExecution>
-        		      <pluginExecutionFilter>
-        			    <groupId>org.codehaus.mojo</groupId>
-        				<artifactId>exec-maven-plugin</artifactId>
-        			    <versionRange>[1.5.0,)</versionRange>
-        				<goals>
-        				  <goal>exec</goal>
-        				</goals>
-        			  </pluginExecutionFilter>
-        			  <action>
-                    <execute>
-                      <runOnIncremental>false</runOnIncremental>
-                    </execute>
-                   </action>
-        			</pluginExecution>
-        		  </pluginExecutions>
-        		</lifecycleMappingMetadata>
-        	</configuration>
+          <groupId>org.eclipse.m2e</groupId>
+          <artifactId>lifecycle-mapping</artifactId>
+            <version>1.0.0</version>
+            <configuration>
+              <lifecycleMappingMetadata>
+                <pluginExecutions>
+                  <pluginExecution>
+                    <pluginExecutionFilter>
+                      <groupId>org.codehaus.mojo</groupId>
+                      <artifactId>exec-maven-plugin</artifactId>
+                      <versionRange>[1.5.0,)</versionRange>
+                      <goals>
+                        <goal>exec</goal>
+                      </goals>
+                    </pluginExecutionFilter>
+                    <action>
+                      <execute>
+                        <runOnIncremental>false</runOnIncremental>
+                      </execute>
+                    </action>
+                  </pluginExecution>
+                </pluginExecutions>
+              </lifecycleMappingMetadata>
+            </configuration>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This incorporates SOME changes to get Beam building in Eclipse Oxygen.  It's not 100% there yet, but this gets the major underlying setup issues fixed so the rest can be looked at.

Basically, there are a few issues this tackles:

1) m2e lifecycle things - several of the plugins that have been added to beam in the last year or so needed lifecycle updates to get them to run within eclipse.   

2) Update a few simple casts and generics - the eclipse compile struggles in some cases to resolve the "empty bracket" generics (<>), adding the types allows it to continue.  In some cases, creating a temporary variable and assigning to that is needed. 

3) website_snippets/Snippets package name is wrong in the example.  Eclipse doesn't like that.

4) Passing a collection or iterable into a var-arg method seems to confuse eclipse.   Just wrapper it with a "new Object[] { .... }" which is what the compiler would/should do anyway resolves that.



There are still some problems:
1) Checkstyle - the beam checkstyle rules are NOT compatible with the new Checkstyle eclipse plugin which uses Checkstyle 8.x (we use 6.x) .  This will require some discussion around checkstyle rules and probably a lot of reformatting of code. (based on experience with updating checkstyle rules in CXF)

2) There are still 20 compile errors that I'm struggling to fix, all in org.apache.beam.runners.core.construction or subclasses of those.  All with errors like:
Bound mismatch: The type Combine.PerKey<?,?,?> is not a valid substitute for the bounded parameter <TransformT extends PTransform<? super InputT,OutputT>> of the type
AppliedPTransform<InputT,OutputT,TransformT>


Documentation:
The setup eclipse docs on the website needs to mention to do something like:
cp ~/.m2/repository/kr/motd/maven/os-maven-plugin/1.5.0.Final/os-maven-plugin-1.5.0.Final.jar /Applications/Eclipse.app/Contents/Eclipse/plugins
Otherwise the ${os.detected.classifier} property won't resolve and the protobuf generation fails.
