### PR TITLE
[BEAM-1866] Make Metrics protos use best practices & match original design

### DIFF
--- a/model/fn-execution/src/main/proto/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/beam_fn_api.proto
@@ -281,46 +281,49 @@ message Metrics {
     // TODO: Define other transform level system metrics.
   }
 
-  // User defined metrics
-  message User {
-
-    // A key for identifying a metric at the most granular level.
-    message MetricKey {
-      // The step, if any, this metric is associated with.
-      string step = 1;
-
-      // (Required): The namespace of this metric.
-      string namespace = 2;
-
-      // (Required): The name of this metric.
-      string name = 3;
-    }
-
-    // Data associated with a counter metric.
-    message CounterData {
-      int64 value = 1;
-    }
-
-    // Data associated with a distribution metric.
-    message DistributionData {
-      int64 count = 1;
-      int64 sum = 2;
-      int64 min = 3;
-      int64 max = 4;
-    }
-
-    // (Required) The identifier for this metric.
-    MetricKey key = 1;
-
-    // (Required) The data for this metric.
-    oneof data {
-      CounterData counter_data = 1001;
-      DistributionData distribution_data = 1002;
-    }
-  }
-
   map<string, PTransform> ptransforms = 1;
-  repeated User user = 2;
+
+  repeated MetricUpdate updates = 2;
+}
+
+// User defined metrics
+message MetricUpdate {
+
+  // (Required) The identifier for this metric.
+  MetricKey key = 1;
+
+  // (Required) The data for this metric.
+  oneof data {
+    CounterData counter_data = 1001;
+    DistributionData distribution_data = 1002;
+  }
+}
+
+// A key for identifying a metric at the most granular level.
+message MetricKey {
+  // The step, if any, this metric is associated with.
+  string step = 1;
+}
+
+message MetricName {
+  // (Required): The namespace of this metric.
+  string namespace = 1;
+
+  // (Required): The name of this metric.
+  string name = 2;
+}
+
+// Data associated with a counter metric.
+message CounterData {
+  int64 value = 1;
+}
+
+// Data associated with a distribution metric.
+message DistributionData {
+  int64 count = 1;
+  int64 sum = 2;
+  int64 min = 3;
+  int64 max = 4;
 }
 
 message ProcessBundleProgressResponse {


### PR DESCRIPTION
Tried to improve the current draft protos after trying to use them in translation from existing metrics support. For discussion. I think they can be further simplified but I stopped here.

Two guiding principles:

 - the Metrics API prior to portability had a lot of work go into it, both design and implementation, so unless there's Fn API specific considerations we should keep it as-is
 - proto best practice "Group related fields into a new message. Rarely make that a nested message."

The changes:

 - `MetricName` already exists and is meaningful on its own. It is a namespace plus a name and identifies some common conceptual metric that might be measured in many places.
 - `MetricKey` already exists and is self-explanatory and useful as a top-level message. I know we've chatted about dropping the step name but I don't think we should. `MetricName` already exists for that purpose.
 - `MetricUpdate` already exists and is a simpler name for `Metrics.User`. We've chatted a little about changing this to contain only a `MetricsName` rather than a full `MetricsKey`. The current implementation keeps the full `MetricsKey`. It may be for some concurrency performance reason, which doesn't apply to the proto, but I don't know.
 - `CounterUpdate` already exists and is self-explanatory at the top level.
 - `DistributionUpdate` already exists and is self-explanatory at the top level.

I did not try to adapt the Python until after we could discuss.