### PR TITLE
[BEAM-3559] Support argparse-style choices for ValueProvider

### DIFF
--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -57,6 +57,15 @@ class StaticValueProvider(ValueProvider):
   def __str__(self):
     return str(self.value)
 
+  def __eq__(self, other):
+    if self.value == other:
+      return True
+    if isinstance(other, StaticValueProvider):
+      if (self.value_type == other.value_type and
+          self.value == other.value):
+        return True
+    return False
+
 
 class RuntimeValueProvider(ValueProvider):
   runtime_options = None

--- a/sdks/python/apache_beam/options/value_provider_test.py
+++ b/sdks/python/apache_beam/options/value_provider_test.py
@@ -148,3 +148,37 @@ class ValueProviderTests(unittest.TestCase):
     self.assertIsNone(options.vpt_vp_arg9.get())
     self.assertTrue(options.vpt_vp_arg10.is_accessible())
     self.assertEqual(options.vpt_vp_arg10.get(), 1.2)
+
+  def test_choices(self):
+    class UserDefinedOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_argument(
+            '--vpt_vp_arg11',
+            choices=['a', 'b'],
+            help='This flag is a value provider with concrete choices')
+        parser.add_argument(
+            '--vpt_vp_arg12',
+            choices=[1, 2],
+            type=int,
+            help='This flag is a value provider with concrete choices')
+    options = UserDefinedOptions(['--vpt_vp_arg11', 'a', '--vpt_vp_arg12', '2'])
+    self.assertEqual(options.vpt_vp_arg11, 'a')
+    self.assertEqual(options.vpt_vp_arg12, 2)
+
+  def test_static_value_provider_choices(self):
+    class UserDefinedOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_value_provider_argument(
+            '--vpt_vp_arg13',
+            choices=['a', 'b'],
+            help='This flag is a value provider with concrete choices')
+        parser.add_value_provider_argument(
+            '--vpt_vp_arg14',
+            choices=[1, 2],
+            type=int,
+            help='This flag is a value provider with concrete choices')
+    options = UserDefinedOptions(['--vpt_vp_arg13', 'a', '--vpt_vp_arg14', '2'])
+    self.assertEqual(options.vpt_vp_arg13.get(), 'a')
+    self.assertEqual(options.vpt_vp_arg14.get(), 2)


### PR DESCRIPTION
Will allow the usage of 
```
        parser.add_value_provider_argument(
            '--a_value_provider',
            choices=['a', 'b'])
```