### PR TITLE
[BEAM-3456] enable JdbcIOIT on Jenkins

### DIFF
--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -32,32 +32,55 @@ job('beam_PerformanceTests_JDBC'){
         'commits@beam.apache.org',
         false)
 
+    common_job_properties.enablePhraseTriggeringFromPullRequest(
+            delegate,
+            'Java JdbcIO Performance Test',
+            'Run Java JdbcIO Performance Test'
+    )
+
+    // Allow the test to only run on nodes with kubernetes installed.
+    // TODO(INFRA-14819): remove when kubernetes is installed on all Jenkins workers
+    parameters {
+        nodeParam('TEST_HOST') {
+            description('select beam2 test host')
+            defaultNodes(['beam2'])
+            allowedNodes(['beam2'])
+            trigger('multiSelectionDisallowed')
+            eligibility('IgnoreOfflineNodeEligibility')
+        }
+    }
+
     def pipelineArgs = [
-        tempRoot: 'gs://temp-storage-for-end-to-end-tests',
+        tempRoot: 'gs://temp-storage-for-perf-tests',
         project: 'apache-beam-testing',
-        postgresServerName: '10.36.0.11',
-        postgresUsername: 'postgres',
-        postgresDatabaseName: 'postgres',
-        postgresPassword: 'uuinkks',
-        postgresSsl: 'false'
+        postgresPort: '5432',
+        numberOfRecords: '5000000'
     ]
+
     def pipelineArgList = []
     pipelineArgs.each({
-        key, value -> pipelineArgList.add("--$key=$value")
+        key, value -> pipelineArgList.add("\"--$key=$value\"")
     })
-    def pipelineArgsJoined = pipelineArgList.join(',')
+    def pipelineArgsJoined = "[" + pipelineArgList.join(',') + "]"
 
     def argMap = [
-      benchmarks: 'beam_integration_benchmark',
-      beam_it_module: 'sdks/java/io/jdbc',
-      beam_it_args: pipelineArgsJoined,
-      beam_it_class: 'org.apache.beam.sdk.io.jdbc.JdbcIOIT',
-      // Profile is located in $BEAM_ROOT/sdks/java/io/pom.xml.
-      beam_it_profile: 'io-it'
+        beam_it_timeout: '1200',
+        benchmarks: 'beam_integration_benchmark',
+        beam_it_profile: 'io-it',
+        beam_prebuilt: 'true',
+        beam_sdk: 'java',
+        beam_it_module: 'sdks/java/io/jdbc',
+        beam_it_class: 'org.apache.beam.sdk.io.jdbc.JdbcIOIT',
+        beam_it_options: pipelineArgsJoined,
+        beam_kubernetes_scripts: makePathAbsolute('.test-infra/kubernetes/postgres/postgres.yml')
+                + ',' + makePathAbsolute('.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
+        beam_options_config_file: makePathAbsolute('.test-infra/kubernetes/postgres/pkb-config-local.yml'),
+        bigquery_table: 'beam_performance.JdbcIOIT_pkb_results'
     ]
 
     common_job_properties.buildPerformanceTest(delegate, argMap)
+}
 
-    // [BEAM-2141] Perf tests do not pass.
-    disabled()
+static def makePathAbsolute(String path) {
+    return '"$WORKSPACE/' + path + '"'
 }


### PR DESCRIPTION
Add jenkins job for doing so. 

First a wall I want to ensure that jenkins can run kubernetes now (see: [INFRA-14819](https://issues.apache.org/jira/browse/INFRA-14819)). I Used 'beam2' executor to avoid other problem that we have ([BEAM-3480](https://issues.apache.org/jira/browse/BEAM-3480))

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
