### PR TITLE
[BEAM-3525] Fix KafkaIO metric

### DIFF
--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -127,5 +127,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.kafka;
 
 import static org.apache.beam.sdk.metrics.MetricResultsMatchers.attemptedMetricsResult;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -714,6 +715,19 @@ public class KafkaIOTest {
 
     // since gauge values may be inconsistent in some environments assert only on their existence.
     assertThat(backlogBytesMetrics.gauges(), IsIterableWithSize.iterableWithSize(1));
+
+    // Check checkpointMarkCommitsEnqueued metric.
+    MetricQueryResults commitsEnqueuedMetrics =
+        result.metrics().queryMetrics(
+            MetricsFilter.builder()
+                .addNameFilter(
+                    MetricNameFilter.named(
+                        KafkaIO.UnboundedKafkaReader.METRIC_NAMESPACE,
+                        KafkaIO.UnboundedKafkaReader.CHECKPOINT_MARK_COMMITS_ENQUEUED_METRIC))
+                .build());
+
+    assertThat(commitsEnqueuedMetrics.counters(), IsIterableWithSize.iterableWithSize(1));
+    assertThat(commitsEnqueuedMetrics.counters().iterator().next().attempted(), greaterThan(0L));
   }
 
   @Test


### PR DESCRIPTION
This is a follow up to recent PR #4481.  Couple of fixes:  

1) 'checkpointMarkCommits' was incremented outside a Beam API context (inside consumerPollLoop), it is not supported. Instead, increment new metric 'enqueued'. 'enqueued' - 'skipped' gives total number of actual commits. Improved the unit test to verify the metric.
    
2) Reverted an earlier PR #4505 that removed a test dependency. It is required for tests for output.
