### PR TITLE
[BEAM-3550] Add --awsServiceEndpoint option and use with S3 filesystem.

### DIFF
--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
@@ -40,6 +40,13 @@ public interface AwsOptions extends PipelineOptions {
   void setAwsRegion(String value);
 
   /**
+   * The AWS service endpoint used by the AWS client.
+   */
+  @Description("AWS service endpoint used by the AWS client")
+  String getAwsServiceEndpoint();
+  void setAwsServiceEndpoint(String value);
+
+  /**
    * The credential instance that should be used to authenticate against AWS services. Refer to
    * {@link DefaultAWSCredentialsProviderChain} Javadoc for usage help.
    */

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.amazonaws.AmazonClientException;
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -106,11 +107,15 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
               + "was not specified. If you don't plan to use S3, then ignore this message.");
     }
 
-    amazonS3 =
-        AmazonS3ClientBuilder.standard()
-            .withCredentials(options.getAwsCredentialsProvider())
-            .withRegion(options.getAwsRegion())
-            .build();
+    AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
+        .withCredentials(options.getAwsCredentialsProvider());
+    if (Strings.isNullOrEmpty(options.getAwsServiceEndpoint())) {
+      builder = builder.withRegion(options.getAwsRegion());
+    } else {
+      builder = builder.withEndpointConfiguration(new EndpointConfiguration(
+          options.getAwsServiceEndpoint(), options.getAwsRegion()));
+    }
+    amazonS3 = builder.build();
 
     this.storageClass = checkNotNull(options.getS3StorageClass(), "storageClass");
 


### PR DESCRIPTION
When constructing an `S3FileSystem`, if `--awsServiceEndpoint` is set, it will be used, but if the option is `null` or empty, the default endpoint will be used.

This allows the S3 filesystem to be used with alternate providers including emulators like localstack.
