### PR TITLE
[BEAM-3564] Return no environment more often

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.core.construction;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.InvalidProtocolBufferException;
 import java.io.IOException;
@@ -62,7 +63,10 @@ public class Environments {
           KNOWN_URN_SPEC_EXTRACTORS
               .getOrDefault(ptransform.getSpec().getUrn(), DEFAULT_SPEC_EXTRACTOR)
               .getEnvironmentId(ptransform);
-      if (envId != null) {
+      if (!Strings.isNullOrEmpty(envId)) {
+        // Some PTransform payloads may have an empty (default) Environment ID, for example a
+        // WindowIntoPayload with a known WindowFn. Others will never have an Environment ID, such
+        // as a GroupByKeyPayload, and the Default extractor returns null in this case.
         return Optional.of(components.getEnvironment(envId));
       } else {
         return Optional.empty();


### PR DESCRIPTION
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
Some PTransforms have an environment only sometimes. In this
case, the EnvironmentID will be the empty string instead of
null, but this should still return 'no environment'

