### PR TITLE
[BEAM-3566] Replace apply_* hooks in DirectRunner with PTransformOverrides

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -22,10 +22,13 @@ import unittest
 
 import hamcrest as hc
 
+from apache_beam import Map
 from apache_beam.io.gcp.pubsub import ReadStringsFromPubSub
 from apache_beam.io.gcp.pubsub import WriteStringsToPubSub
 from apache_beam.io.gcp.pubsub import _PubSubPayloadSink
 from apache_beam.io.gcp.pubsub import _PubSubPayloadSource
+from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.runners.direct.direct_runner import _get_transform_overrides
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
@@ -43,25 +46,48 @@ except ImportError:
 class TestReadStringsFromPubSub(unittest.TestCase):
   def test_expand_with_topic(self):
     p = TestPipeline()
-    pcoll = p | ReadStringsFromPubSub('projects/fakeprj/topics/a_topic',
-                                      None, 'a_label')
-    # Ensure that the output type is str
+    p.options.view_as(StandardOptions).streaming = True
+    pcoll = (p
+             | ReadStringsFromPubSub('projects/fakeprj/topics/a_topic',
+                                     None, 'a_label')
+             | Map(lambda x: x))
+    # Ensure that the output type is str.
     self.assertEqual(unicode, pcoll.element_type)
 
+    # Apply the necessary PTransformOverrides.
+    overrides = _get_transform_overrides(p.options)
+    p.replace_all(overrides)
+
+    # Note that the direct output of ReadStringsFromPubSub will be replaced
+    # by a PTransformOverride, so we use a no-op Map.
+    read_transform = pcoll.producer.inputs[0].producer.transform
+
     # Ensure that the properties passed through correctly
-    source = pcoll.producer.transform._source
+    source = read_transform._source
     self.assertEqual('a_topic', source.topic_name)
     self.assertEqual('a_label', source.id_label)
 
   def test_expand_with_subscription(self):
     p = TestPipeline()
-    pcoll = p | ReadStringsFromPubSub(
-        None, 'projects/fakeprj/subscriptions/a_subscription', 'a_label')
+    p.options.view_as(StandardOptions).streaming = True
+    pcoll = (p
+             | ReadStringsFromPubSub(
+                 None, 'projects/fakeprj/subscriptions/a_subscription',
+                 'a_label')
+             | Map(lambda x: x))
     # Ensure that the output type is str
     self.assertEqual(unicode, pcoll.element_type)
 
+    # Apply the necessary PTransformOverrides.
+    overrides = _get_transform_overrides(p.options)
+    p.replace_all(overrides)
+
+    # Note that the direct output of ReadStringsFromPubSub will be replaced
+    # by a PTransformOverride, so we use a no-op Map.
+    read_transform = pcoll.producer.inputs[0].producer.transform
+
     # Ensure that the properties passed through correctly
-    source = pcoll.producer.transform._source
+    source = read_transform._source
     self.assertEqual('a_subscription', source.subscription_name)
     self.assertEqual('a_label', source.id_label)
 
@@ -80,12 +106,22 @@ class TestReadStringsFromPubSub(unittest.TestCase):
 class TestWriteStringsToPubSub(unittest.TestCase):
   def test_expand(self):
     p = TestPipeline()
-    pdone = (p
+    p.options.view_as(StandardOptions).streaming = True
+    pcoll = (p
              | ReadStringsFromPubSub('projects/fakeprj/topics/baz')
-             | WriteStringsToPubSub('projects/fakeprj/topics/a_topic'))
+             | WriteStringsToPubSub('projects/fakeprj/topics/a_topic')
+             | Map(lambda x: x))
+
+    # Apply the necessary PTransformOverrides.
+    overrides = _get_transform_overrides(p.options)
+    p.replace_all(overrides)
+
+    # Note that the direct output of ReadStringsFromPubSub will be replaced
+    # by a PTransformOverride, so we use a no-op Map.
+    write_transform = pcoll.producer.inputs[0].producer.transform
 
     # Ensure that the properties passed through correctly
-    self.assertEqual('a_topic', pdone.producer.transform.dofn.topic_name)
+    self.assertEqual('a_topic', write_transform.dofn.topic_name)
 
 
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -22,7 +22,7 @@ import unittest
 
 import hamcrest as hc
 
-from apache_beam import Map
+import apache_beam as beam
 from apache_beam.io.gcp.pubsub import ReadStringsFromPubSub
 from apache_beam.io.gcp.pubsub import WriteStringsToPubSub
 from apache_beam.io.gcp.pubsub import _PubSubPayloadSink
@@ -43,14 +43,14 @@ except ImportError:
 
 
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
-class TestReadStringsFromPubSub(unittest.TestCase):
+class TestReadStringsFromPubSubOverride(unittest.TestCase):
   def test_expand_with_topic(self):
     p = TestPipeline()
     p.options.view_as(StandardOptions).streaming = True
     pcoll = (p
              | ReadStringsFromPubSub('projects/fakeprj/topics/a_topic',
                                      None, 'a_label')
-             | Map(lambda x: x))
+             | beam.Map(lambda x: x))
     # Ensure that the output type is str.
     self.assertEqual(unicode, pcoll.element_type)
 
@@ -74,7 +74,7 @@ class TestReadStringsFromPubSub(unittest.TestCase):
              | ReadStringsFromPubSub(
                  None, 'projects/fakeprj/subscriptions/a_subscription',
                  'a_label')
-             | Map(lambda x: x))
+             | beam.Map(lambda x: x))
     # Ensure that the output type is str
     self.assertEqual(unicode, pcoll.element_type)
 
@@ -110,7 +110,7 @@ class TestWriteStringsToPubSub(unittest.TestCase):
     pcoll = (p
              | ReadStringsFromPubSub('projects/fakeprj/topics/baz')
              | WriteStringsToPubSub('projects/fakeprj/topics/a_topic')
-             | Map(lambda x: x))
+             | beam.Map(lambda x: x))
 
     # Apply the necessary PTransformOverrides.
     overrides = _get_transform_overrides(p.options)

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -62,6 +62,7 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TypeOptions
 from apache_beam.options.pipeline_options_validator import PipelineOptionsValidator
 from apache_beam.pvalue import PCollection
+from apache_beam.pvalue import PDone
 from apache_beam.runners import PipelineRunner
 from apache_beam.runners import create_runner
 from apache_beam.transforms import ptransform
@@ -197,6 +198,8 @@ class Pipeline(object):
           assert isinstance(original_transform_node, AppliedPTransform)
           replacement_transform = override.get_replacement_transform(
               original_transform_node.transform)
+          if replacement_transform is original_transform_node.transform:
+            return
 
           replacement_transform_node = AppliedPTransform(
               original_transform_node.parent, replacement_transform,
@@ -227,6 +230,10 @@ class Pipeline(object):
                 'have a single input. Tried to replace input of '
                 'AppliedPTransform %r that has %d inputs',
                 original_transform_node, len(inputs))
+          elif len(inputs) == 1:
+            input_node = inputs[0]
+          elif len(inputs) == 0:
+            input_node = pvalue.PBegin(self)
 
           # We have to add the new AppliedTransform to the stack before expand()
           # and pop it out later to make sure that parts get added correctly.
@@ -239,16 +246,18 @@ class Pipeline(object):
           # with labels of the children of the original.
           self.pipeline._remove_labels_recursively(original_transform_node)
 
-          new_output = replacement_transform.expand(inputs[0])
+          new_output = replacement_transform.expand(input_node)
           replacement_transform_node.add_output(new_output)
+          if not new_output.producer:
+            new_output.producer = replacement_transform_node
 
           # We only support replacing transforms with a single output with
           # another transform that produces a single output.
           # TODO: Support replacing PTransforms with multiple outputs.
           if (len(original_transform_node.outputs) > 1 or
-              not isinstance(
-                  original_transform_node.outputs[None], PCollection) or
-              not isinstance(new_output, PCollection)):
+              not isinstance(original_transform_node.outputs[None],
+                             (PCollection, PDone)) or
+              not isinstance(new_output, (PCollection, PDone))):
             raise NotImplementedError(
                 'PTransform overriding is only supported for PTransforms that '
                 'have a single output. Tried to replace output of '

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -323,7 +323,7 @@ class PipelineTest(unittest.TestCase):
           return TripleParDo()
         raise ValueError('Unsupported type of transform: %r', ptransform)
 
-    def get_overrides():
+    def get_overrides(unused_pipeline_options):
       return [MyParDoOverride()]
 
     file_system_override_mock.side_effect = get_overrides

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -310,13 +310,10 @@ class PipelineTest(unittest.TestCase):
       'apache_beam.runners.direct.direct_runner._get_transform_overrides')
   def test_ptransform_overrides(self, file_system_override_mock):
 
-    def my_par_do_matcher(applied_ptransform):
-      return isinstance(applied_ptransform.transform, DoubleParDo)
-
     class MyParDoOverride(PTransformOverride):
 
-      def get_matcher(self):
-        return my_par_do_matcher
+      def matches(self, applied_ptransform):
+        return isinstance(applied_ptransform.transform, DoubleParDo)
 
       def get_replacement_transform(self, ptransform):
         if isinstance(ptransform, DoubleParDo):

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -273,8 +273,10 @@ class DataflowRunnerTest(unittest.TestCase):
       pcoll2.element_type = typehints.Any
       pcoll3.element_type = typehints.KV[typehints.Any, typehints.Any]
       for pcoll in [pcoll1, pcoll2, pcoll3]:
+        applied = AppliedPTransform(None, transform, "label", [pcoll])
+        applied.outputs[None] = PCollection(None)
         DataflowRunner.group_by_key_input_visitor().visit_transform(
-            AppliedPTransform(None, transform, "label", [pcoll]))
+            applied)
         self.assertEqual(pcoll.element_type,
                          typehints.KV[typehints.Any, typehints.Any])
 

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -24,11 +24,7 @@ from apache_beam.pipeline import PTransformOverride
 class CreatePTransformOverride(PTransformOverride):
   """A ``PTransformOverride`` for ``Create`` in streaming mode."""
 
-  def get_matcher(self):
-    return self.is_streaming_create
-
-  @staticmethod
-  def is_streaming_create(applied_ptransform):
+  def matches(self, applied_ptransform):
     # Imported here to avoid circular dependencies.
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam import Create

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -44,12 +44,9 @@ from apache_beam.utils.windowed_value import WindowedValue
 class ProcessKeyedElementsViaKeyedWorkItemsOverride(PTransformOverride):
   """A transform override for ProcessElements transform."""
 
-  def get_matcher(self):
-    def _matcher(applied_ptransform):
-      return isinstance(
-          applied_ptransform.transform, ProcessKeyedElements)
-
-    return _matcher
+  def matches(self, applied_ptransform):
+    return isinstance(
+        applied_ptransform.transform, ProcessKeyedElements)
 
   def get_replacement_transform(self, ptransform):
     return ProcessKeyedElementsViaKeyedWorkItems(ptransform)

--- a/sdks/python/apache_beam/runners/sdf_common.py
+++ b/sdks/python/apache_beam/runners/sdf_common.py
@@ -37,15 +37,12 @@ class SplittableParDoOverride(PTransformOverride):
   SDF specific logic.
   """
 
-  def get_matcher(self):
-    def _matcher(applied_ptransform):
-      assert isinstance(applied_ptransform, AppliedPTransform)
-      transform = applied_ptransform.transform
-      if isinstance(transform, ParDo):
-        signature = DoFnSignature(transform.fn)
-        return signature.is_splittable_dofn()
-
-    return _matcher
+  def matches(self, applied_ptransform):
+    assert isinstance(applied_ptransform, AppliedPTransform)
+    transform = applied_ptransform.transform
+    if isinstance(transform, ParDo):
+      signature = DoFnSignature(transform.fn)
+      return signature.is_splittable_dofn()
 
   def get_replacement_transform(self, ptransform):
     assert isinstance(ptransform, ParDo)

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -563,8 +563,8 @@ class _CurriedFn(core.CombineFn):
 def curry_combine_fn(fn, args, kwargs):
   if not args and not kwargs:
     return fn
-
-  return _CurriedFn(fn, args, kwargs)
+  else:
+    return _CurriedFn(fn, args, kwargs)
 
 
 class PhasedCombineFnExecutor(object):

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -536,30 +536,35 @@ class ToDictCombineFn(core.CombineFn):
     return accumulator
 
 
+class _CurriedFn(core.CombineFn):
+  """Wrapped CombineFn with extra arguments."""
+
+  def __init__(self, fn, args, kwargs):
+    self.fn = fn
+    self.args = args
+    self.kwargs = kwargs
+
+  def create_accumulator(self):
+    return self.fn.create_accumulator(*self.args, **self.kwargs)
+
+  def add_input(self, accumulator, element):
+    return self.fn.add_input(accumulator, element, *self.args, **self.kwargs)
+
+  def merge_accumulators(self, accumulators):
+    return self.fn.merge_accumulators(accumulators, *self.args, **self.kwargs)
+
+  def extract_output(self, accumulator):
+    return self.fn.extract_output(accumulator, *self.args, **self.kwargs)
+
+  def apply(self, elements):
+    return self.fn.apply(elements, *self.args, **self.kwargs)
+
+
 def curry_combine_fn(fn, args, kwargs):
   if not args and not kwargs:
     return fn
 
-  # Create CurriedFn class for the combiner
-  class CurriedFn(core.CombineFn):
-    """CombineFn that applies extra arguments."""
-
-    def create_accumulator(self):
-      return fn.create_accumulator(*args, **kwargs)
-
-    def add_input(self, accumulator, element):
-      return fn.add_input(accumulator, element, *args, **kwargs)
-
-    def merge_accumulators(self, accumulators):
-      return fn.merge_accumulators(accumulators, *args, **kwargs)
-
-    def extract_output(self, accumulator):
-      return fn.extract_output(accumulator, *args, **kwargs)
-
-    def apply(self, elements):
-      return fn.apply(elements, *args, **kwargs)
-
-  return CurriedFn()
+  return _CurriedFn(fn, args, kwargs)
 
 
 class PhasedCombineFnExecutor(object):


### PR DESCRIPTION
In the Python DirectRunner, we currently use apply_* overrides to override the operation of the default .expand() operation for certain transforms.  For example, GroupByKey has a special implementation in the DirectRunner, so we use an apply_* override hook to replace the implementation of GroupByKey.expand().

However, this strategy has drawbacks.  Because this override operation happens eagerly during graph construction, the pipeline graph is specialized and modified before a specific runner is bound to the pipeline's execution.  This makes the pipeline graph non-portable and blocks full migration to using the Runner API pipeline representation in the DirectRunner.

By contrast, the SDK's PTransformOverride mechanism allows the expression of matchers that operate on the unspecialized graph, replacing PTransforms as necessary to produce a DirectRunner-specialized pipeline graph for execution.

We therefore want to replace these eager apply_* overrides with PTransformOverrides that operate on the completely constructed graph.

https://issues.apache.org/jira/browse/BEAM-3566