### PR TITLE
[BEAM-2732] Logging deviation from sampling expectation. 

### DIFF
--- a/sdks/python/apache_beam/runners/worker/statesampler_test.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_test.py
@@ -74,6 +74,8 @@ class StateSamplerTest(unittest.TestCase):
       self.assertIn(counter.name, expected_counter_values)
       expected_value = expected_counter_values[counter.name]
       actual_value = counter.value()
+      deviation = float(abs(actual_value - expected_value)) / expected_value
+      logging.info('Sampling deviation from expectation: %f', deviation)
       self.assertGreater(actual_value, expected_value * 0.75)
       self.assertLess(actual_value, expected_value * 1.25)
 


### PR DESCRIPTION
With this change, analyzing test logs will allow to track variation in statesampler performance over time; so we'll be able to find out if deviation increases, or remains consistently high over a period of time.

r: @charlesccychen 