### PR TITLE
[BEAM-3423] Fix Distinct null pointer error with speculative triggers

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Distinct.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Distinct.java
@@ -29,50 +29,45 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * {@code Distinct<T>} takes a {@code PCollection<T>} and
- * returns a {@code PCollection<T>} that has all distinct elements of the
- * input. Thus, each element is unique within each window.
+ * {@code Distinct<T>} takes a {@code PCollection<T>} and returns a {@code PCollection<T>} that has
+ * all distinct elements of the input. Thus, each element is unique within each window.
  *
- * <p>Two values of type {@code T} are compared for equality <b>not</b> by
- * regular Java {@link Object#equals}, but instead by first encoding
- * each of the elements using the {@code PCollection}'s {@code Coder}, and then
- * comparing the encoded bytes.  This admits efficient parallel
- * evaluation.
+ * <p>Two values of type {@code T} are compared for equality <b>not</b> by regular Java {@link
+ * Object#equals}, but instead by first encoding each of the elements using the {@code
+ * PCollection}'s {@code Coder}, and then comparing the encoded bytes. This admits efficient
+ * parallel evaluation.
  *
- * <p>Optionally, a function may be provided that maps each element to a representative
- * value.  In this case, two elements will be considered duplicates if they have equal
- * representative values, with equality being determined as above.
+ * <p>Optionally, a function may be provided that maps each element to a representative value. In
+ * this case, two elements will be considered duplicates if they have equal representative values,
+ * with equality being determined as above.
  *
- * <p>By default, the {@code Coder} of the output {@code PCollection}
- * is the same as the {@code Coder} of the input {@code PCollection}.
+ * <p>By default, the {@code Coder} of the output {@code PCollection} is the same as the {@code
+ * Coder} of the input {@code PCollection}.
  *
- * <p>Each output element is in the same window as its corresponding input
- * element, and has the timestamp of the end of that window.  The output
- * {@code PCollection} has the same
- * {@link org.apache.beam.sdk.transforms.windowing.WindowFn}
- * as the input.
+ * <p>Each output element is in the same window as its corresponding input element, and has the
+ * timestamp of the end of that window. The output {@code PCollection} has the same {@link
+ * org.apache.beam.sdk.transforms.windowing.WindowFn} as the input.
  *
  * <p>Does not preserve any order the input PCollection might have had.
  *
  * <p>Example of use:
- * <pre> {@code
+ *
+ * <pre>{@code
  * PCollection<String> words = ...;
  * PCollection<String> uniqueWords =
  *     words.apply(Distinct.<String>create());
- * } </pre>
+ * }
+ * </pre>
  *
- * @param <T> the type of the elements of the input and output
- * {@code PCollection}s
+ * @param <T> the type of the elements of the input and output {@code PCollection}s
  */
-public class Distinct<T> extends PTransform<PCollection<T>,
-                                                    PCollection<T>> {
+public class Distinct<T> extends PTransform<PCollection<T>, PCollection<T>> {
   private static final Logger LOG = LoggerFactory.getLogger(Distinct.class);
 
   /**
    * Returns a {@code Distinct<T>} {@code PTransform}.
    *
-   * @param <T> the type of the elements of the input and output
-   * {@code PCollection}s
+   * @param <T> the type of the elements of the input and output {@code PCollection}s
    */
   public static <T> Distinct<T> create() {
     return new Distinct<>();
@@ -81,8 +76,7 @@ public class Distinct<T> extends PTransform<PCollection<T>,
   /**
    * Returns a {@code Distinct<T, IdT>} {@code PTransform}.
    *
-   * @param <T> the type of the elements of the input and output
-   * {@code PCollection}s
+   * @param <T> the type of the elements of the input and output {@code PCollection}s
    * @param <IdT> the type of the representative value used to dedup
    */
   public static <T, IdT> WithRepresentativeValues<T, IdT> withRepresentativeValueFn(
@@ -94,10 +88,12 @@ public class Distinct<T> extends PTransform<PCollection<T>,
       WindowingStrategy<T, W> strategy) {
     if (!strategy.getWindowFn().isNonMerging()
         && (!strategy.getTrigger().getClass().equals(DefaultTrigger.class)
-        || strategy.getAllowedLateness().isLongerThan(Duration.ZERO))) {
-        throw new UnsupportedOperationException(String.format(
-            "%s does not support non-merging windowing strategies, except when using the default "
-                + "trigger and zero allowed lateness.", Distinct.class.getSimpleName()));
+            || strategy.getAllowedLateness().isLongerThan(Duration.ZERO))) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "%s does not support non-merging windowing strategies, except when using the default "
+                  + "trigger and zero allowed lateness.",
+              Distinct.class.getSimpleName()));
     }
   }
 
@@ -124,20 +120,23 @@ public class Distinct<T> extends PTransform<PCollection<T>,
                         return null; // ignore input
                       }
                     }));
-    return combined.apply("ExtractFirstKey", ParDo.of(new DoFn<KV<T, Void>, T>() {
-      @ProcessElement
-      public void processElement(ProcessContext c) {
-        if (c.pane().isFirst()) {
-          // Only output the key if it's the first time it's been seen.
-          c.output(c.element().getKey());
-        }
-      }
-    }));
+    return combined.apply(
+        "ExtractFirstKey",
+        ParDo.of(
+            new DoFn<KV<T, Void>, T>() {
+              @ProcessElement
+              public void processElement(ProcessContext c) {
+                if (c.pane().isFirst()) {
+                  // Only output the key if it's the first time it's been seen.
+                  c.output(c.element().getKey());
+                }
+              }
+            }));
   }
 
   /**
-   * A {@link Distinct} {@link PTransform} that uses a {@link SerializableFunction} to
-   * obtain a representative value for each input element.
+   * A {@link Distinct} {@link PTransform} that uses a {@link SerializableFunction} to obtain a
+   * representative value for each input element.
    *
    * <p>Construct via {@link Distinct#withRepresentativeValueFn(SerializableFunction)}.
    *
@@ -154,7 +153,6 @@ public class Distinct<T> extends PTransform<PCollection<T>,
       this.fn = fn;
       this.representativeType = representativeType;
     }
-
 
     @Override
     public PCollection<T> expand(PCollection<T> in) {
@@ -174,29 +172,31 @@ public class Distinct<T> extends PTransform<PCollection<T>,
                           return left;
                         }
                       }));
-        return combined.apply("KeepFirstPane", ParDo.of(new DoFn<KV<IdT, T>, T>() {
-          @ProcessElement
-          public void processElement(ProcessContext c) {
-            // Only output the value if it's the first time it's been seen.
-            if (c.pane().isFirst()) {
-              c.output(c.element().getValue());
-            }
-          }
-        }));
+      return combined.apply(
+          "KeepFirstPane",
+          ParDo.of(
+              new DoFn<KV<IdT, T>, T>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  // Only output the value if it's the first time it's been seen.
+                  if (c.pane().isFirst()) {
+                    c.output(c.element().getValue());
+                  }
+                }
+              }));
     }
 
     /**
      * Return a {@code WithRepresentativeValues} {@link PTransform} that is like this one, but with
      * the specified output type descriptor.
      *
-     * <p>Required for use of
-     * {@link Distinct#withRepresentativeValueFn(SerializableFunction)}
-     * in Java 8 with a lambda as the fn.
+     * <p>Required for use of {@link Distinct#withRepresentativeValueFn(SerializableFunction)} in
+     * Java 8 with a lambda as the fn.
      *
-     * @param type a {@link TypeDescriptor} describing the representative type of this
-     *             {@code WithRepresentativeValues}
+     * @param type a {@link TypeDescriptor} describing the representative type of this {@code
+     *     WithRepresentativeValues}
      * @return A {@code WithRepresentativeValues} {@link PTransform} that is like this one, but with
-     *         the specified output type descriptor.
+     *     the specified output type descriptor.
      */
     public WithRepresentativeValues<T, IdT> withRepresentativeType(TypeDescriptor<IdT> type) {
       return new WithRepresentativeValues<>(fn, type);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
@@ -27,12 +27,14 @@ import java.util.Map;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.testing.UsesTestStream;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
@@ -234,6 +236,41 @@ public class DistinctTest {
                     .withRepresentativeType(TypeDescriptor.of(Integer.class)));
 
     PAssert.that(distinctValues).containsInAnyOrder(KV.of(1, "k1"), KV.of(2, "k2"), KV.of(3, "k3"));
+    triggeredDistinctRepresentativePipeline.run();
+  }
+
+  /**
+   * Regression test: when all values are emitted by a speculative trigger, caused a null KV when
+   * the on-time firing occurred.
+   */
+  @Test
+  @Category({NeedsRunner.class, UsesTestStream.class})
+  public void testTriggeredDistinctRepresentativeValuesEmpty() {
+    Instant base = new Instant(0);
+    TestStream<KV<Integer, String>> values =
+        TestStream.create(KvCoder.of(VarIntCoder.of(), StringUtf8Coder.of()))
+            .advanceWatermarkTo(base)
+            .addElements(TimestampedValue.of(KV.of(1, "k1"), base))
+            .advanceProcessingTime(Duration.standardMinutes(1))
+            .advanceWatermarkToInfinity();
+
+    PCollection<KV<Integer, String>> distinctValues =
+        triggeredDistinctRepresentativePipeline
+            .apply(values)
+            .apply(
+                Window.<KV<Integer, String>>into(FixedWindows.of(Duration.standardMinutes(1)))
+                    .triggering(
+                        AfterWatermark.pastEndOfWindow()
+                            .withEarlyFirings(
+                                AfterProcessingTime.pastFirstElementInPane()
+                                    .plusDelayOf(Duration.standardSeconds(30))))
+                    .withAllowedLateness(Duration.ZERO)
+                    .discardingFiredPanes())
+            .apply(
+                Distinct.withRepresentativeValueFn(new Keys<Integer>())
+                    .withRepresentativeType(TypeDescriptor.of(Integer.class)));
+
+    PAssert.that(distinctValues).containsInAnyOrder(KV.of(1, "k1"));
     triggeredDistinctRepresentativePipeline.run();
   }
 }


### PR DESCRIPTION
Previously, Distinct with representative values could crash when a speculative trigger consumes all the input, because the output of a combine of no elements (the watermark-driven firing) is null.

----

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
