### PR TITLE
[SQL] Inherit windowing strategy from the input in Aggregate operation

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -17,26 +17,31 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
+import static org.apache.beam.sdk.values.PCollection.IsBounded.BOUNDED;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.apache.beam.sdk.coders.BeamRecordCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.extensions.sql.BeamRecordSqlType;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.rule.AggregateWindowField;
 import org.apache.beam.sdk.extensions.sql.impl.transform.BeamAggregationTransforms;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.WithTimestamps;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-import org.apache.beam.sdk.transforms.windowing.Trigger;
+import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
-import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.values.BeamRecord;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -51,52 +56,55 @@ import org.joda.time.Duration;
 
 /**
  * {@link BeamRelNode} to replace a {@link Aggregate} node.
- *
  */
 public class BeamAggregationRel extends Aggregate implements BeamRelNode {
-  private int windowFieldIdx = -1;
-  private WindowFn<BeamRecord, BoundedWindow> windowFn;
-  private Trigger trigger;
-  private Duration allowedLatence = Duration.ZERO;
+  private final int windowFieldIndex;
+  private Optional<AggregateWindowField> windowField;
 
-  public BeamAggregationRel(RelOptCluster cluster, RelTraitSet traits
-      , RelNode child, boolean indicator,
-      ImmutableBitSet groupSet, List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls
-      , WindowFn windowFn, Trigger trigger, int windowFieldIdx, Duration allowedLatence) {
+  public BeamAggregationRel(
+      RelOptCluster cluster,
+      RelTraitSet traits,
+      RelNode child,
+      boolean indicator,
+      ImmutableBitSet groupSet,
+      List<ImmutableBitSet> groupSets,
+      List<AggregateCall> aggCalls,
+      Optional<AggregateWindowField> windowField) {
+
     super(cluster, traits, child, indicator, groupSet, groupSets, aggCalls);
-    this.windowFn = windowFn;
-    this.trigger = trigger;
-    this.windowFieldIdx = windowFieldIdx;
-    this.allowedLatence = allowedLatence;
+    this.windowField = windowField;
+    this.windowFieldIndex = windowField.map(AggregateWindowField::fieldIndex).orElse(-1);
   }
 
   @Override
-  public PCollection<BeamRecord> buildBeamPipeline(PCollectionTuple inputPCollections
-      , BeamSqlEnv sqlEnv) throws Exception {
+  public PCollection<BeamRecord> buildBeamPipeline(
+      PCollectionTuple inputPCollections,
+      BeamSqlEnv sqlEnv) throws Exception {
+
     RelNode input = getInput();
     String stageName = BeamSqlRelUtils.getStageName(this) + "_";
 
     PCollection<BeamRecord> upstream =
         BeamSqlRelUtils.getBeamRelInput(input).buildBeamPipeline(inputPCollections, sqlEnv);
-    if (windowFieldIdx != -1) {
+    if (windowField.isPresent()) {
       upstream = upstream.apply(stageName + "assignEventTimestamp", WithTimestamps
-          .of(new BeamAggregationTransforms.WindowTimestampFn(windowFieldIdx))
+          .of(new BeamAggregationTransforms.WindowTimestampFn(windowFieldIndex))
           .withAllowedTimestampSkew(new Duration(Long.MAX_VALUE)))
           .setCoder(upstream.getCoder());
     }
 
-    PCollection<BeamRecord> windowStream = upstream.apply(stageName + "window",
-        Window.into(windowFn)
-        .triggering(trigger)
-        .withAllowedLateness(allowedLatence)
-        .accumulatingFiredPanes());
+    PCollection<BeamRecord> windowedStream =
+        windowField.isPresent()
+            ? upstream.apply(stageName + "window", Window.into(windowField.get().windowFn()))
+            : upstream;
+
+    validateWindowIsSupported(windowedStream);
 
     BeamRecordCoder keyCoder = exKeyFieldsSchema(input.getRowType()).getRecordCoder();
-    PCollection<KV<BeamRecord, BeamRecord>> exCombineByStream = windowStream.apply(
+    PCollection<KV<BeamRecord, BeamRecord>> exCombineByStream = windowedStream.apply(
         stageName + "exCombineBy",
         WithKeys
-            .of(new BeamAggregationTransforms.AggregationGroupByKeyFn(
-                windowFieldIdx, groupSet)))
+            .of(new BeamAggregationTransforms.AggregationGroupByKeyFn(windowFieldIndex, groupSet)))
         .setCoder(KvCoder.of(keyCoder, upstream.getCoder()));
 
 
@@ -111,12 +119,40 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
                         getAggCallList(), CalciteUtils.toBeamRowType(input.getRowType()))))
             .setCoder(KvCoder.of(keyCoder, aggCoder));
 
-    PCollection<BeamRecord> mergedStream = aggregatedStream.apply(stageName + "mergeRecord",
-        ParDo.of(new BeamAggregationTransforms.MergeAggregationRecord(
-            CalciteUtils.toBeamRowType(getRowType()), getAggCallList(), windowFieldIdx)));
+    PCollection<BeamRecord> mergedStream = aggregatedStream.apply(
+        stageName + "mergeRecord",
+        ParDo.of(
+            new BeamAggregationTransforms.MergeAggregationRecord(
+                CalciteUtils.toBeamRowType(getRowType()),
+                getAggCallList(),
+                windowFieldIndex)));
     mergedStream.setCoder(CalciteUtils.toBeamRowType(getRowType()).getRecordCoder());
 
     return mergedStream;
+  }
+
+
+  /**
+   * Performs the same check as {@link GroupByKey}, provides more context in exception.
+   *
+   * <p>Verifies that the input PCollection is bounded, or that there is windowing/triggering being
+   * used. Without this, the watermark (at end of global window) will never be reached.
+   *
+   * <p>Throws {@link UnsupportedOperationException} if validation fails.
+   */
+  private void validateWindowIsSupported(PCollection<BeamRecord> upstream) {
+    WindowingStrategy<?, ?> windowingStrategy = upstream.getWindowingStrategy();
+    if (windowingStrategy.getWindowFn() instanceof GlobalWindows
+        && windowingStrategy.getTrigger() instanceof DefaultTrigger
+        && upstream.isBounded() != BOUNDED) {
+
+      throw new UnsupportedOperationException(
+          "Please explicitly specify windowing in SQL query using HOP/TUMBLE/SESSION functions "
+              + "(default trigger will be used in this case). "
+              + "Unbounded input with global windowing and default trigger is not supported "
+              + "in Beam SQL aggregations. "
+              + "See GroupByKey section in Beam Programming Guide");
+    }
   }
 
   /**
@@ -126,8 +162,9 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
     BeamRecordSqlType inputRowType = CalciteUtils.toBeamRowType(relDataType);
     List<String> fieldNames = new ArrayList<>();
     List<Integer> fieldTypes = new ArrayList<>();
+    int windowFieldIndex = windowField.map(AggregateWindowField::fieldIndex).orElse(-1);
     for (int i : groupSet.asList()) {
-      if (i != windowFieldIdx) {
+      if (i != windowFieldIndex) {
         fieldNames.add(inputRowType.getFieldNameByIndex(i));
         fieldTypes.add(inputRowType.getFieldTypeByIndex(i));
       }
@@ -150,27 +187,18 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
   }
 
   @Override
-  public Aggregate copy(RelTraitSet traitSet, RelNode input, boolean indicator
+  public Aggregate copy(
+      RelTraitSet traitSet, RelNode input, boolean indicator
       , ImmutableBitSet groupSet,
       List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
     return new BeamAggregationRel(getCluster(), traitSet, input, indicator
-        , groupSet, groupSets, aggCalls, windowFn, trigger, windowFieldIdx, allowedLatence);
-  }
-
-  public void setWindowFn(WindowFn windowFn) {
-    this.windowFn = windowFn;
-  }
-
-  public void setTrigger(Trigger trigger) {
-    this.trigger = trigger;
+        , groupSet, groupSets, aggCalls, windowField);
   }
 
   public RelWriter explainTerms(RelWriter pw) {
     // We skip the "groups" element if it is a singleton of "group".
     pw.item("group", groupSet)
-        .itemIf("window", windowFn, windowFn != null)
-        .itemIf("trigger", trigger, trigger != null)
-        .itemIf("event_time", windowFieldIdx, windowFieldIdx != -1)
+        .itemIf("window", windowField.orElse(null), windowField.isPresent())
         .itemIf("groups", groupSets, getGroupType() != Group.SIMPLE)
         .itemIf("indicator", indicator, indicator)
         .itemIf("aggs", aggCalls, pw.nest());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
@@ -26,7 +26,6 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
-import org.apache.calcite.rel.RelInput;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.SetOp;
 import org.apache.calcite.rel.core.Union;
@@ -71,10 +70,6 @@ public class BeamUnionRel extends Union implements BeamRelNode {
     this.delegate = new BeamSetOperatorRelBase(this,
         BeamSetOperatorRelBase.OpType.UNION,
         inputs, all);
-  }
-
-  public BeamUnionRel(RelInput input) {
-    super(input);
   }
 
   @Override public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/package-info.java
@@ -20,4 +20,8 @@
  * BeamSQL specified nodes, to replace {@link org.apache.calcite.rel.RelNode}.
  *
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.rel;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowFactory.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowFactory.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.sql.impl.rule;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.joda.time.Duration;
+
+/**
+ * Creates {@link WindowFn} wrapper based on HOP/TUMBLE/SESSION call in a query.
+ */
+class AggregateWindowFactory {
+
+  /**
+   * Returns optional of {@link AggregateWindowField} which represents a
+   * windowing function specified by HOP/TUMBLE/SESSION in the SQL query.
+   *
+   * <p>If no known windowing function is specified in the query, then {@link Optional#empty()}
+   * is returned.
+   *
+   * <p>Throws {@link UnsupportedOperationException} if it cannot convert SQL windowing function
+   * call to Beam model, see {@link #getWindowFieldAt(RexCall, int)} for details.
+   */
+  static Optional<AggregateWindowField> getWindowFieldAt(RexCall call, int groupField) {
+
+    Optional<WindowFn> windowFnOptional = createWindowFn(call.operands, call.op.kind);
+
+    return
+        windowFnOptional
+            .map(windowFn ->
+                     AggregateWindowField
+                         .builder()
+                         .setFieldIndex(groupField)
+                         .setWindowFn(windowFn)
+                         .build());
+  }
+
+  /**
+   * Returns a {@link WindowFn} based on the SQL windowing function defined by {#code operatorKind}.
+   * Supported {@link SqlKind}s:
+   * <ul>
+   *   <li>{@link SqlKind#TUMBLE}, mapped to {@link FixedWindows};</li>
+   *   <li>{@link SqlKind#HOP}, mapped to {@link SlidingWindows};</li>
+   *   <li>{@link SqlKind#SESSION}, mapped to {@link Sessions};</li>
+   * </ul>
+   *
+   * <p>For example:
+   * <pre>{@code
+   *   SELECT event_timestamp, COUNT(*)
+   *   FROM PCOLLECTION
+   *   GROUP BY TUMBLE(event_timestamp, INTERVAL '1' HOUR)
+   * }</pre>
+   *
+   * <p>SQL window functions support optional window_offset parameter which indicates a
+   * how window definition is offset from the event time. Offset is zero if not specified.
+   *
+   * <p>Beam model does not support offset for session windows, so this method will throw
+   * {@link UnsupportedOperationException} if offset is specified
+   * in SQL query for {@link SqlKind#SESSION}.
+   */
+  private static Optional<WindowFn> createWindowFn(List<RexNode> parameters, SqlKind operatorKind) {
+    switch (operatorKind) {
+      case TUMBLE:
+
+        // Fixed-size, non-intersecting time-based windows, for example:
+        //   every hour aggregate elements from the previous hour;
+        //
+        // SQL Syntax:
+        //   TUMBLE(monotonic_field, window_size [, window_offset])
+        //
+        // Example:
+        //   TUMBLE(event_timestamp_field, INTERVAL '1' HOUR)
+
+        FixedWindows fixedWindows = FixedWindows.of(durationParameter(parameters, 1));
+        if (parameters.size() == 3) {
+          fixedWindows = fixedWindows.withOffset(durationParameter(parameters, 2));
+        }
+
+        return Optional.of(fixedWindows);
+      case HOP:
+
+        // Sliding, fixed-size, intersecting time-based windows, for example:
+        //   every minute aggregate elements from the previous hour;
+        //
+        // SQL Syntax:
+        //   HOP(monotonic_field, emit_frequency, window_size [, window_offset])
+        //
+        // Example:
+        //   HOP(event_timestamp_field, INTERVAL '1' MINUTE, INTERVAL '1' HOUR)
+
+        SlidingWindows slidingWindows = SlidingWindows
+            .of(durationParameter(parameters, 2))
+            .every(durationParameter(parameters, 1));
+
+        if (parameters.size() == 4) {
+          slidingWindows = slidingWindows.withOffset(durationParameter(parameters, 3));
+        }
+
+        return Optional.of(slidingWindows);
+      case SESSION:
+
+        // Session windows, for example:
+        //   aggregate events after a gap of 1 minute of no events;
+        //
+        // SQL Syntax:
+        //   SESSION(monotonic_field, session_gap)
+        //
+        // Example:
+        //   SESSION(event_timestamp_field, INTERVAL '1' MINUTE)
+
+        Sessions sessions = Sessions.withGapDuration(durationParameter(parameters, 1));
+        if (parameters.size() == 3) {
+          throw new UnsupportedOperationException(
+              "Specifying alignment (offset) is not supported for session windows");
+        }
+
+        return Optional.of(sessions);
+      default:
+        return Optional.empty();
+    }
+  }
+
+  private static Duration durationParameter(List<RexNode> parameters, int parameterIndex) {
+    return Duration.millis(intValue(parameters.get(parameterIndex)));
+  }
+
+  private static long intValue(RexNode operand) {
+    if (operand instanceof RexLiteral) {
+      return RexLiteral.intValue(operand);
+    } else {
+      throw new IllegalArgumentException(String.format("[%s] is not valid.", operand));
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowField.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowField.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.sql.impl.rule;
+
+import com.google.auto.value.AutoValue;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.values.BeamRecord;
+
+/**
+ * <b>For internal use only; no backwards compatibility guarantees.</b>
+ *
+ * <p>Represents a field with a window function call in a SQL expression.
+ */
+@Internal
+@AutoValue
+public abstract class AggregateWindowField {
+  public abstract int fieldIndex();
+  public abstract WindowFn<BeamRecord, ? extends BoundedWindow> windowFn();
+
+  static Builder builder() {
+    return new AutoValue_AggregateWindowField.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setFieldIndex(int fieldIndex);
+    abstract Builder setWindowFn(WindowFn<BeamRecord, ? extends BoundedWindow> window);
+    abstract AggregateWindowField build();
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
@@ -17,20 +17,10 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.rule;
 
-import com.google.common.collect.ImmutableList;
-import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.Optional;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamAggregationRel;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamLogicalConvention;
-import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
-import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
-import org.apache.beam.sdk.transforms.windowing.FixedWindows;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
-import org.apache.beam.sdk.transforms.windowing.Repeatedly;
-import org.apache.beam.sdk.transforms.windowing.Sessions;
-import org.apache.beam.sdk.transforms.windowing.SlidingWindows;
-import org.apache.beam.sdk.transforms.windowing.Trigger;
-import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
@@ -38,12 +28,9 @@ import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
-import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.joda.time.Duration;
 
 /**
  * Rule to detect the window/trigger settings.
@@ -71,64 +58,23 @@ public class BeamAggregationRule extends RelOptRule {
   public void onMatch(RelOptRuleCall call) {
     final Aggregate aggregate = call.rel(0);
     final Project project = call.rel(1);
-    updateWindowTrigger(call, aggregate, project);
+    updateWindow(call, aggregate, project);
   }
 
-  private void updateWindowTrigger(RelOptRuleCall call, Aggregate aggregate,
-      Project project) {
+  private void updateWindow(RelOptRuleCall call, Aggregate aggregate,
+                            Project project) {
     ImmutableBitSet groupByFields = aggregate.getGroupSet();
     List<RexNode> projectMapping = project.getProjects();
 
-    WindowFn windowFn = new GlobalWindows();
-    Trigger triggerFn = Repeatedly.forever(AfterWatermark.pastEndOfWindow());
-    int windowFieldIdx = -1;
-    Duration allowedLatence = Duration.ZERO;
+    Optional<AggregateWindowField> windowField = Optional.empty();
 
-    for (int groupField : groupByFields.asList()) {
-      RexNode projNode = projectMapping.get(groupField);
-      if (projNode instanceof RexCall) {
-        SqlOperator op = ((RexCall) projNode).op;
-        ImmutableList<RexNode> parameters = ((RexCall) projNode).operands;
-        String functionName = op.getName();
-        switch (functionName) {
-        case "TUMBLE":
-          windowFieldIdx = groupField;
-          windowFn = FixedWindows
-              .of(Duration.millis(getWindowParameterAsMillis(parameters.get(1))));
-          if (parameters.size() == 3) {
-            GregorianCalendar delayTime = (GregorianCalendar) ((RexLiteral) parameters.get(2))
-                .getValue();
-            triggerFn = createTriggerWithDelay(delayTime);
-            allowedLatence = (Duration.millis(delayTime.getTimeInMillis()));
-          }
-          break;
-        case "HOP":
-          windowFieldIdx = groupField;
-          windowFn = SlidingWindows
-              .of(Duration.millis(getWindowParameterAsMillis(parameters.get(1))))
-              .every(Duration.millis(getWindowParameterAsMillis(parameters.get(2))));
-          if (parameters.size() == 4) {
-            GregorianCalendar delayTime = (GregorianCalendar) ((RexLiteral) parameters.get(3))
-                .getValue();
-            triggerFn = createTriggerWithDelay(delayTime);
-            allowedLatence = (Duration.millis(delayTime.getTimeInMillis()));
-          }
-          break;
-        case "SESSION":
-          windowFieldIdx = groupField;
-          windowFn = Sessions
-              .withGapDuration(Duration.millis(getWindowParameterAsMillis(parameters.get(1))));
-          if (parameters.size() == 3) {
-            GregorianCalendar delayTime = (GregorianCalendar) ((RexLiteral) parameters.get(2))
-                .getValue();
-            triggerFn = createTriggerWithDelay(delayTime);
-            allowedLatence = (Duration.millis(delayTime.getTimeInMillis()));
-          }
-          break;
-        default:
-          break;
-        }
+    for (int groupFieldIndex : groupByFields.asList()) {
+      RexNode projNode = projectMapping.get(groupFieldIndex);
+      if (!(projNode instanceof RexCall)) {
+        continue;
       }
+
+      windowField = AggregateWindowFactory.getWindowFieldAt((RexCall) projNode, groupFieldIndex);
     }
 
     BeamAggregationRel newAggregator = new BeamAggregationRel(aggregate.getCluster(),
@@ -139,24 +85,8 @@ public class BeamAggregationRule extends RelOptRule {
         aggregate.getGroupSet(),
         aggregate.getGroupSets(),
         aggregate.getAggCallList(),
-        windowFn,
-        triggerFn,
-        windowFieldIdx,
-        allowedLatence);
+        windowField);
     call.transformTo(newAggregator);
-  }
-
-  private Trigger createTriggerWithDelay(GregorianCalendar delayTime) {
-    return Repeatedly.forever(AfterWatermark.pastEndOfWindow().withLateFirings(AfterProcessingTime
-        .pastFirstElementInPane().plusDelayOf(Duration.millis(delayTime.getTimeInMillis()))));
-  }
-
-  private long getWindowParameterAsMillis(RexNode parameterNode) {
-    if (parameterNode instanceof RexLiteral) {
-      return RexLiteral.intValue(parameterNode);
-    } else {
-      throw new IllegalArgumentException(String.format("[%s] is not valid.", parameterNode));
-    }
   }
 
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/package-info.java
@@ -20,4 +20,8 @@
  * {@link org.apache.calcite.plan.RelOptRule} to generate
  * {@link org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode}.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.rule;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslBase.java
@@ -28,9 +28,12 @@ import java.util.List;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.BeamRecord;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -94,7 +97,11 @@ public class BeamSqlDslBase {
       values = values.addElements(row);
     }
 
-    return PBegin.in(pipeline).apply("unboundedInput1", values.advanceWatermarkToInfinity());
+    return PBegin
+        .in(pipeline)
+        .apply("unboundedInput1", values.advanceWatermarkToInfinity())
+        .apply("unboundedInput1.fixedWindow1year",
+               Window.into(FixedWindows.of(Duration.standardDays(365))));
   }
 
   private PCollection<BeamRecord> prepareUnboundedPCollection2() {
@@ -105,7 +112,11 @@ public class BeamSqlDslBase {
     values = values.advanceWatermarkTo(new Instant(row.getDate("f_timestamp")));
     values = values.addElements(row);
 
-    return PBegin.in(pipeline).apply("unboundedInput2", values.advanceWatermarkToInfinity());
+    return PBegin
+        .in(pipeline)
+        .apply("unboundedInput2", values.advanceWatermarkToInfinity())
+        .apply("unboundedInput2.fixedWindow1year",
+               Window.into(FixedWindows.of(Duration.standardDays(365))));
   }
 
   private static List<BeamRecord> prepareInputRowsInTableA() throws ParseException{


### PR DESCRIPTION
Aggregate operation (GROUP BY + aggregate functions) was overriding input's windowing strategy even when it was not explicitly specified in SQL. This change makes it inherit input's configuration (window and trigger) unless windowing is explicitly specified using 'HOP/TUMBLE/SESSION' windowing functions.

Details in the doc: https://docs.google.com/document/d/1RmyV9e1Qab-axsLI1WWpw5oGAJDv0X7y9OSnPnrZWJk/edit#heading=h.q943qvxj4tt6

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
