### PR TITLE
global INT64_MAX, INT64_MIN to placate linters

### DIFF
--- a/sdks/python/apache_beam/transforms/cy_combiners.py
+++ b/sdks/python/apache_beam/transforms/cy_combiners.py
@@ -77,6 +77,7 @@ class SumInt64Accumulator(object):
     self.value = 0
 
   def add_input(self, element):
+    global INT64_MAX, INT64_MIN  # pylint: disable=global-variable-not-assigned
     element = int(element)
     if not INT64_MIN <= element <= INT64_MAX:
       raise OverflowError(element)


### PR DESCRIPTION
Lines 56 and 57 use a very unique way of defining global variables that makes linters panic (see below).  A single __global__ statement makes the intention clear and silences all 16 linter issues.

flake8 testing of https://github.com/apache/beam

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sdks/python/apache_beam/transforms/cy_combiners.py:81:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= element <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:81:36: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= element <= INT64_MAX:
                                   ^
./sdks/python/apache_beam/transforms/cy_combiners.py:90:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= self.value <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:90:39: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= self.value <= INT64_MAX:
                                      ^
./sdks/python/apache_beam/transforms/cy_combiners.py:92:24: F821 undefined name 'INT64_MAX'
      if self.value >= INT64_MAX:
                       ^
./sdks/python/apache_beam/transforms/cy_combiners.py:99:18: F821 undefined name 'INT64_MAX'
    self.value = INT64_MAX
                 ^
./sdks/python/apache_beam/transforms/cy_combiners.py:103:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= element <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:103:36: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= element <= INT64_MAX:
                                   ^
./sdks/python/apache_beam/transforms/cy_combiners.py:119:18: F821 undefined name 'INT64_MIN'
    self.value = INT64_MIN
                 ^
./sdks/python/apache_beam/transforms/cy_combiners.py:123:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= element <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:123:36: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= element <= INT64_MAX:
                                   ^
./sdks/python/apache_beam/transforms/cy_combiners.py:144:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= element <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:144:36: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= element <= INT64_MAX:
                                   ^
./sdks/python/apache_beam/transforms/cy_combiners.py:155:12: F821 undefined name 'INT64_MIN'
    if not INT64_MIN <= self.sum <= INT64_MAX:
           ^
./sdks/python/apache_beam/transforms/cy_combiners.py:155:37: F821 undefined name 'INT64_MAX'
    if not INT64_MIN <= self.sum <= INT64_MAX:
                                    ^
./sdks/python/apache_beam/transforms/cy_combiners.py:157:22: F821 undefined name 'INT64_MAX'
      if self.sum >= INT64_MAX:
                     ^
```