### PR TITLE
Changing FileIO.Write.FileNaming Interface to public

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -755,7 +755,7 @@ public class FileIO {
   public abstract static class Write<DestinationT, UserT>
       extends PTransform<PCollection<UserT>, WriteFilesResult<DestinationT>> {
     /** A policy for generating names for shard files. */
-    interface FileNaming extends Serializable {
+    public interface FileNaming extends Serializable {
       /**
        * Generates the filename. MUST use each argument and return different values for
        * each combination of the arguments.


### PR DESCRIPTION
Currently, FileNaming is package local, which means that users can't actually implement it for custom naming strategies. This doesn't seem to be intended.

No JIRA ticket since it's a one word change. @jkff could you do a quick look for approval? Would be useful to get this in before 2.3.0.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [N/A] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [N/A] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

