### PR TITLE
[BEAM-3326] Add `SdkHarnessClientControlService`

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A Fn API control service which adds incoming SDK harness connections to a pool. */
-public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnControlImplBase
+class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnControlImplBase
     implements FnService {
   private static final Logger LOGGER = LoggerFactory.getLogger(FnApiControlClientPoolService.class);
 
@@ -39,6 +39,9 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
   /**
    * Creates a new {@link FnApiControlClientPoolService} which will enqueue and vend new SDK harness
    * connections.
+   *
+   * <p>Clients placed into the {@code clientPool} are owned by whichever consumer owns the pool.
+   * That consumer is responsible for closing the clients when they are no longer needed.
    */
   public static FnApiControlClientPoolService offeringClientsToPool(
       BlockingQueue<FnApiControlClient> clientPool) {
@@ -68,6 +71,6 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
 
   @Override
   public void close() throws Exception {
-    // TODO: terminate existing clients.
+    // The clients in the pool are owned by the consumer, which is responsible for closing them
   }
 }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** A Fn API control service which adds incoming SDK harness connections to a pool. */
-class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnControlImplBase
+public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnControlImplBase
     implements FnService {
   private static final Logger LOGGER = LoggerFactory.getLogger(FnApiControlClientPoolService.class);
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * <p>This provides a Java-friendly wrapper around {@link FnApiControlClient} and {@link
  * CloseableFnDataReceiver}, which handle lower-level gRPC message wrangling.
  */
-public class SdkHarnessClient {
+public class SdkHarnessClient implements AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(SdkHarnessClient.class);
 
   /**
@@ -250,6 +250,11 @@ public class SdkHarnessClient {
     }
 
     return clientProcessors.asMap();
+  }
+
+  @Override
+  public void close() throws Exception {
+    this.fnApiControlClient.close();
   }
 
   /**

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientControlService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientControlService.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.control;
+
+import io.grpc.ServerServiceDefinition;
+import java.util.Collection;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.function.Supplier;
+import org.apache.beam.runners.fnexecution.FnService;
+import org.apache.beam.runners.fnexecution.data.FnDataService;
+
+/**
+ * A service providing {@link SdkHarnessClient} based on an internally managed {@link
+ * FnApiControlClientPoolService}.
+ */
+public class SdkHarnessClientControlService implements FnService {
+  private final FnApiControlClientPoolService clientPoolService;
+  private final BlockingQueue<FnApiControlClient> pendingClients;
+
+  private final Supplier<FnDataService> dataService;
+
+  private final Collection<SdkHarnessClient> activeClients;
+
+  public static SdkHarnessClientControlService create(Supplier<FnDataService> dataService) {
+    return new SdkHarnessClientControlService(dataService);
+  }
+
+  private SdkHarnessClientControlService(Supplier<FnDataService> dataService) {
+    this.dataService = dataService;
+    activeClients = new ConcurrentLinkedQueue<>();
+    pendingClients = new SynchronousQueue<>();
+    clientPoolService = FnApiControlClientPoolService.offeringClientsToPool(pendingClients);
+  }
+
+  public SdkHarnessClient getClient() {
+    try {
+      // Block until a client is available.
+      FnApiControlClient getClient = pendingClients.take();
+      return SdkHarnessClient.usingFnApiClient(getClient, dataService.get());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting for client", e);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    for (SdkHarnessClient client : activeClients) {
+      client.close();
+    }
+  }
+
+  @Override
+  public ServerServiceDefinition bindService() {
+    return clientPoolService.bindService();
+  }
+}

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/SynchronizedStreamObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/SynchronizedStreamObserver.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.fn.stream;
+
+import io.grpc.stub.StreamObserver;
+
+/**
+ * A {@link StreamObserver} which provides synchronous access access to an underlying {@link
+ * StreamObserver}.
+ *
+ * <p>The underlying {@link StreamObserver} must not be used by any other clients.
+ */
+public class SynchronizedStreamObserver<V> implements StreamObserver<V> {
+  private final StreamObserver<V> underlying;
+
+  private SynchronizedStreamObserver(StreamObserver<V> underlying) {
+    this.underlying = underlying;
+  }
+
+  /**
+   * Create a new {@link SynchronizedStreamObserver} which will delegate all calls to the underlying
+   * {@link StreamObserver}, synchronizing access to that observer.
+   */
+  public static <V> StreamObserver<V> wrapping(StreamObserver<V> underlying) {
+    return new SynchronizedStreamObserver<>(underlying);
+  }
+
+  @Override
+  public void onNext(V value) {
+    synchronized (underlying) {
+      underlying.onNext(value);
+    }
+  }
+
+  @Override
+  public synchronized void onError(Throwable t) {
+    synchronized (underlying) {
+      underlying.onError(t);
+    }
+  }
+
+  @Override
+  public synchronized void onCompleted() {
+    synchronized (underlying) {
+      underlying.onCompleted();
+    }
+  }
+}


### PR DESCRIPTION
This is the higher-level Control Service implementation which vends
SdkHarnessClient instances.

Implement AutoCloseable on SdkHarnessClient to close the underlying
control client when the high-level service is shut down.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

