### PR TITLE
[BEAM-3601] Switch runner portability support code to Java 8 futures

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This low-level client is responsible only for correlating requests with responses.
  */
-class FnApiControlClient implements Closeable {
+public class FnApiControlClient implements Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(FnApiControlClient.class);
 
   // All writes to this StreamObserver need to be synchronized.
@@ -75,7 +75,7 @@ class FnApiControlClient implements Closeable {
     return resultFuture;
   }
 
-  StreamObserver<BeamFnApi.InstructionResponse> asResponseObserver() {
+  public StreamObserver<BeamFnApi.InstructionResponse> asResponseObserver() {
     return responseObserver;
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
@@ -17,13 +17,13 @@
  */
 package org.apache.beam.runners.fnexecution.control;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.io.Closeable;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.slf4j.Logger;
@@ -46,7 +46,7 @@ public class FnApiControlClient implements Closeable {
   // All writes to this StreamObserver need to be synchronized.
   private final StreamObserver<BeamFnApi.InstructionRequest> requestReceiver;
   private final ResponseStreamObserver responseObserver = new ResponseStreamObserver();
-  private final Map<String, SettableFuture<BeamFnApi.InstructionResponse>> outstandingRequests;
+  private final Map<String, CompletableFuture<BeamFnApi.InstructionResponse>> outstandingRequests;
   private volatile boolean isClosed;
 
   private FnApiControlClient(StreamObserver<BeamFnApi.InstructionRequest> requestReceiver) {
@@ -66,10 +66,10 @@ public class FnApiControlClient implements Closeable {
     return new FnApiControlClient(requestObserver);
   }
 
-  public synchronized ListenableFuture<BeamFnApi.InstructionResponse> handle(
+  public synchronized CompletionStage<BeamFnApi.InstructionResponse> handle(
       BeamFnApi.InstructionRequest request) {
     LOG.debug("Sending InstructionRequest {}", request);
-    SettableFuture<BeamFnApi.InstructionResponse> resultFuture = SettableFuture.create();
+    CompletableFuture<BeamFnApi.InstructionResponse> resultFuture = new CompletableFuture<>();
     outstandingRequests.put(request.getInstructionId(), resultFuture);
     requestReceiver.onNext(request);
     return resultFuture;
@@ -91,7 +91,7 @@ public class FnApiControlClient implements Closeable {
     }
 
     // Make a copy of the map to make the view of the outstanding requests consistent.
-    Map<String, SettableFuture<BeamFnApi.InstructionResponse>> outstandingRequestsCopy =
+    Map<String, CompletableFuture<BeamFnApi.InstructionResponse>> outstandingRequestsCopy =
         new ConcurrentHashMap<>(outstandingRequests);
     outstandingRequests.clear();
     isClosed = true;
@@ -107,9 +107,9 @@ public class FnApiControlClient implements Closeable {
         "{} closed, clearing outstanding requests {}",
         FnApiControlClient.class.getSimpleName(),
         outstandingRequestsCopy);
-    for (SettableFuture<BeamFnApi.InstructionResponse> outstandingRequest :
+    for (CompletableFuture<BeamFnApi.InstructionResponse> outstandingRequest :
         outstandingRequestsCopy.values()) {
-      outstandingRequest.setException(cause);
+      outstandingRequest.completeExceptionally(cause);
     }
   }
 
@@ -125,13 +125,13 @@ public class FnApiControlClient implements Closeable {
     @Override
     public void onNext(BeamFnApi.InstructionResponse response) {
       LOG.debug("Received InstructionResponse {}", response);
-      SettableFuture<BeamFnApi.InstructionResponse> completableFuture =
+      CompletableFuture<BeamFnApi.InstructionResponse> responseFuture =
           outstandingRequests.remove(response.getInstructionId());
-      if (completableFuture != null) {
+      if (responseFuture != null) {
         if (response.getError().isEmpty()) {
-          completableFuture.set(response);
+          responseFuture.complete(response);
         } else {
-          completableFuture.setException(
+          responseFuture.completeExceptionally(
               new RuntimeException(String.format(
                   "Error received from SDK harness for instruction %s: %s",
                   response.getInstructionId(),

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -20,12 +20,11 @@ package org.apache.beam.runners.fnexecution.control;
 import com.google.auto.value.AutoValue;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
@@ -76,20 +75,20 @@ public class SdkHarnessClient {
    */
   public class BundleProcessor<T> {
     private final String processBundleDescriptorId;
-    private final Future<RegisterResponse> registrationFuture;
+    private final CompletionStage<RegisterResponse> registrationFuture;
 
     private final RemoteInputDestination<WindowedValue<T>> remoteInput;
 
     private BundleProcessor(
         String processBundleDescriptorId,
-        Future<RegisterResponse> registrationFuture,
+        CompletionStage<RegisterResponse> registrationFuture,
         RemoteInputDestination<WindowedValue<T>> remoteInput) {
       this.processBundleDescriptorId = processBundleDescriptorId;
       this.registrationFuture = registrationFuture;
       this.remoteInput = remoteInput;
     }
 
-    public Future<RegisterResponse> getRegistrationFuture() {
+    public CompletionStage<RegisterResponse> getRegistrationFuture() {
       return registrationFuture;
     }
 
@@ -103,7 +102,7 @@ public class SdkHarnessClient {
         Map<BeamFnApi.Target, RemoteOutputReceiver<?>> outputReceivers) {
       String bundleId = idGenerator.getId();
 
-      final ListenableFuture<BeamFnApi.InstructionResponse> genericResponse =
+      final CompletionStage<BeamFnApi.InstructionResponse> genericResponse =
           fnApiControlClient.handle(
               BeamFnApi.InstructionRequest.newBuilder()
                   .setInstructionId(bundleId)
@@ -118,8 +117,8 @@ public class SdkHarnessClient {
           ProcessBundleDescriptor.class.getSimpleName(),
           processBundleDescriptorId);
 
-      ListenableFuture<BeamFnApi.ProcessBundleResponse> specificResponse =
-          Futures.transform(genericResponse, InstructionResponse::getProcessBundle);
+      CompletionStage<BeamFnApi.ProcessBundleResponse> specificResponse =
+          genericResponse.thenApply(InstructionResponse::getProcessBundle);
       Map<BeamFnApi.Target, InboundDataClient> outputClients = new HashMap<>();
       for (Map.Entry<BeamFnApi.Target, RemoteOutputReceiver<?>> targetReceiver :
           outputReceivers.entrySet()) {
@@ -152,14 +151,14 @@ public class SdkHarnessClient {
   public abstract static class ActiveBundle<InputT> {
     public abstract String getBundleId();
 
-    public abstract Future<BeamFnApi.ProcessBundleResponse> getBundleResponse();
+    public abstract CompletionStage<BeamFnApi.ProcessBundleResponse> getBundleResponse();
 
     public abstract CloseableFnDataReceiver<WindowedValue<InputT>> getInputReceiver();
     public abstract Map<BeamFnApi.Target, InboundDataClient> getOutputClients();
 
     public static <InputT> ActiveBundle<InputT> create(
         String bundleId,
-        Future<BeamFnApi.ProcessBundleResponse> response,
+        CompletionStage<BeamFnApi.ProcessBundleResponse> response,
         CloseableFnDataReceiver<WindowedValue<InputT>> dataReceiver,
         Map<BeamFnApi.Target, InboundDataClient> outputClients) {
       return new AutoValue_SdkHarnessClient_ActiveBundle<>(
@@ -225,7 +224,7 @@ public class SdkHarnessClient {
 
     LOG.debug("Registering {}", processBundleDescriptors.keySet());
     // TODO: validate that all the necessary data endpoints are known
-    ListenableFuture<BeamFnApi.InstructionResponse> genericResponse =
+    CompletionStage<BeamFnApi.InstructionResponse> genericResponse =
         fnApiControlClient.handle(
             BeamFnApi.InstructionRequest.newBuilder()
                 .setInstructionId(idGenerator.getId())
@@ -235,10 +234,9 @@ public class SdkHarnessClient {
                         .build())
                 .build());
 
-    ListenableFuture<RegisterResponse> registerResponseFuture =
-        Futures.transform(
-            genericResponse, InstructionResponse::getRegister,
-            MoreExecutors.directExecutor());
+    CompletionStage<RegisterResponse> registerResponseFuture =
+        genericResponse.thenApply(InstructionResponse::getRegister);
+
     for (Map.Entry<ProcessBundleDescriptor, RemoteInputDestination<WindowedValue<?>>>
         descriptorInputEntry : processBundleDescriptors.entrySet()) {
       clientProcessors.put(

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.junit.Test;
@@ -52,7 +52,7 @@ public class FnApiControlClientPoolServiceTest {
 
     // Check that the client is wired up to the request channel
     String id = "fakeInstruction";
-    ListenableFuture<BeamFnApi.InstructionResponse> responseFuture =
+    CompletionStage<BeamFnApi.InstructionResponse> responseFuture =
         client.handle(BeamFnApi.InstructionRequest.newBuilder().setInstructionId(id).build());
     verify(requestObserver).onNext(any(BeamFnApi.InstructionRequest.class));
     assertThat(responseFuture.isDone(), is(false));

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientTest.java
@@ -24,8 +24,8 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.stub.StreamObserver;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
@@ -81,7 +81,7 @@ public class FnApiControlClientTest {
   @Test
   public void testRequestError() throws Exception {
     String id = "instructionId";
-    ListenableFuture<InstructionResponse> responseFuture =
+    CompletionStage<InstructionResponse> responseFuture =
         client.handle(InstructionRequest.newBuilder().setInstructionId(id).build());
     String error = "Oh no an error!";
     client
@@ -102,7 +102,7 @@ public class FnApiControlClientTest {
     String id = "actualInstruction";
     String unknownId = "unknownInstruction";
 
-    ListenableFuture<BeamFnApi.InstructionResponse> responseFuture =
+    CompletionStage<BeamFnApi.InstructionResponse> responseFuture =
         client.handle(BeamFnApi.InstructionRequest.newBuilder().setInstructionId(id).build());
 
     client


### PR DESCRIPTION
Java 8 now has `CompletionStage` which is adequate for using those futures. This solves the issue of shading problems for code where we put Guava's `ListenableFuture` on the API surface.

Discussed on the dev list.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

