### PR TITLE
[BEAM-3565] Add a single-stage fusion implementation

### DIFF
--- a/model/pipeline/src/main/resources/org/apache/beam/model/common_urns.md
+++ b/model/pipeline/src/main/resources/org/apache/beam/model/common_urns.md
@@ -47,6 +47,7 @@ Payload: A windowing strategy id.
 
 ### beam:transform:read:v1
 
+### beam:transform:impulse:v1
 
 ## Combining
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ImpulseTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ImpulseTranslation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction;
+
+import com.google.auto.service.AutoService;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.runners.core.construction.PTransformTranslation.TransformPayloadTranslator;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.transforms.Impulse;
+import org.apache.beam.sdk.transforms.PTransform;
+
+ /**
+ * Utility methods for translating a {@link Impulse} to and from {@link RunnerApi}
+ * representations.
+ */
+public class ImpulseTranslation {
+  private static class ImpulseTranslator
+      extends TransformPayloadTranslator.WithDefaultRehydration<Impulse> {
+    @Override
+    public String getUrn(Impulse transform) {
+      return PTransformTranslation.IMPULSE_TRANSFORM_URN;
+    }
+
+    @Override
+    public FunctionSpec translate(
+        AppliedPTransform<?, ?, Impulse> application, SdkComponents components) throws IOException {
+      return FunctionSpec.newBuilder().setUrn(getUrn(application.getTransform())).build();
+    }
+  }
+
+  /** Registers {@link ImpulseTranslator}. */
+  @AutoService(TransformPayloadTranslatorRegistrar.class)
+  public static class Registrar implements TransformPayloadTranslatorRegistrar {
+    @Override
+    public Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
+    getTransformPayloadTranslators() {
+      return Collections.singletonMap(Impulse.class, new ImpulseTranslator());
+    }
+
+    @Override
+    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
+      return Collections.emptyMap();
+    }
+  }
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -58,6 +58,7 @@ public class PTransformTranslation {
       validateCommonUrn("beam:transform:flatten:v1");
   public static final String GROUP_BY_KEY_TRANSFORM_URN =
       validateCommonUrn("beam:transform:group_by_key:v1");
+  public static final String IMPULSE_TRANSFORM_URN = validateCommonUrn("beam:transform:impulse:v1");
   public static final String READ_TRANSFORM_URN =
       validateCommonUrn("beam:transform:read:v1");
   public static final String ASSIGN_WINDOWS_TRANSFORM_URN =

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ExecutableStage.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ExecutableStage.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import java.util.Collection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+
+/**
+ * A combination of PTransforms that can be executed within a single SDK harness.
+ *
+ * <p>Contains only the nodes that specify the processing to perform within the SDK harness, and
+ * does not contain any runner-executed nodes.
+ *
+ * <p>Within a single {@link Pipeline}, {@link PTransform PTransforms} and {@link PCollection
+ * PCollections} are permitted to appear in multiple executable stages. However, paths from a root
+ * {@link PTransform} to any other {@link PTransform} within that set of stages must be unique.
+ */
+public interface ExecutableStage {
+  /**
+   * The URN identifying an {@link ExecutableStage} that has been converted to a {@link PTransform}.
+   */
+  String URN = "beam:runner:executable_stage:v1";
+
+  /**
+   * Returns the {@link Environment} this stage executes in.
+   *
+   * <p>An {@link ExecutableStage} consists of {@link PTransform PTransforms} which can all be
+   * executed within a single {@link Environment}. The assumption made here is that
+   * runner-implemented transforms will be associated with these subgraphs by the overall graph
+   * topology, which will be handled by runners by performing already-required element routing and
+   * runner-side processing.
+   */
+  Environment getEnvironment();
+
+  /**
+   * Returns the root {@link PCollectionNode} of this {@link ExecutableStage}. This
+   * {@link ExecutableStage} executes by reading elements from a Remote gRPC Read Node.
+   */
+  PCollectionNode getInputPCollection();
+
+  /**
+   * Returns the leaf {@link PCollectionNode PCollections} of this {@link ExecutableStage}.
+   *
+   * <p>All of these {@link PCollectionNode PCollections} are consumed by a {@link PTransformNode
+   * PTransform} which is not contained within this executable stage, and must be materialized at
+   * execution time by a Remote gRPC Write Transform.
+   */
+  Collection<PCollectionNode> getOutputPCollections();
+
+  Collection<PTransformNode> getTransforms();
+
+  /**
+   * Returns a composite {@link PTransform} which contains all of the {@link PTransform PTransforms}
+   * fused into this {@link ExecutableStage} as {@link PTransform#getSubtransformsList()
+   * subtransforms} .
+   *
+   * <p>The input {@link PCollection} for the returned {@link PTransform} will be the consumed
+   * {@link PCollectionNode} returned by {@link #getInputPCollection()} and the output {@link
+   * PCollection PCollections} will be the {@link PCollectionNode PCollections} returned by {@link
+   * #getOutputPCollections()}.
+   */
+  PTransform toPTransform();
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedilyFusedExecutableStage.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedilyFusedExecutableStage.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Queue;
+import java.util.Set;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link ExecutableStage} that will greedily fuse all available {@link PCollectionNode
+ * PCollections} when it is constructed.
+ *
+ * <p>A {@link PCollectionNode} is fused into a stage if all of its consumers can be fused into the
+ * stage. A consumer can be fused into a stage if it is executed within the environment of that
+ * {@link ExecutableStage}, and receives only per-element inputs. PTransforms which consume side
+ * inputs are always at the root of a stage.
+ *
+ * <p>A {@link PCollectionNode} with consumers that execute in an environment other than a stage is
+ * materialized, and its consumers execute in independent stages.
+ */
+public class GreedilyFusedExecutableStage implements ExecutableStage {
+  // TODO: Provide a way to merge in a compatible subgraph (e.g. one where all of the siblings
+  // consume a PCollection materialized by this subgraph and can be fused into it).
+  private static final Logger LOG = LoggerFactory.getLogger(GreedilyFusedExecutableStage.class);
+
+  /**
+   * Returns an {@link ExecutableStage} where the initial {@link PTransformNode PTransform} is a
+   * Remote gRPC Port Read, reading elements from the materialized {@link PCollectionNode
+   * PCollection}.
+   *
+   * @param initialNodes the initial set of sibling transforms to fuse into this node. All of the
+   *     transforms must consume the {@code inputPCollection} on a per-element basis, and must all
+   *     be mutually compatible.
+   */
+  public static ExecutableStage forGrpcPortRead(
+      QueryablePipeline pipeline,
+      PCollectionNode inputPCollection,
+      Set<PTransformNode> initialNodes) {
+    return new GreedilyFusedExecutableStage(pipeline, inputPCollection, initialNodes);
+  }
+
+  private final QueryablePipeline pipeline;
+  private final Environment environment;
+
+  private final PCollectionNode inputPCollection;
+
+  private final Set<PCollectionNode> fusedCollections;
+  private final Set<PTransformNode> fusedTransforms;
+  private final Set<PCollectionNode> materializedPCollections;
+
+  private final Queue<PCollectionNode> fusionCandidates;
+
+  private GreedilyFusedExecutableStage(
+      QueryablePipeline pipeline,
+      PCollectionNode inputPCollection,
+      Set<PTransformNode> initialNodes) {
+    checkArgument(
+        !initialNodes.isEmpty(),
+        "%s must contain at least one %s.",
+        GreedilyFusedExecutableStage.class.getSimpleName(),
+        PTransformNode.class.getSimpleName());
+    // Choose the environment from an arbitrary node. The initial nodes may not be empty for this
+    // subgraph to make any sense, there has to be at least one processor node
+    // (otherwise the stage is gRPC Read -> gRPC Write, which doesn't do anything).
+    this.environment =
+        pipeline
+            .getEnvironment(initialNodes.iterator().next())
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        String.format(
+                            "%s must be populated on all %s in a %s",
+                            Environment.class.getSimpleName(),
+                            PTransformNode.class.getSimpleName(),
+                            GreedilyFusedExecutableStage.class.getSimpleName())));
+    initialNodes.forEach(
+        transformNode ->
+            checkArgument(
+                environment.equals(pipeline.getEnvironment(transformNode).orElse(null)),
+                "All %s in a %s must be the same. Got %s and %s",
+                Environment.class.getSimpleName(),
+                GreedilyFusedExecutableStage.class.getSimpleName(),
+                environment,
+                pipeline.getEnvironment(transformNode).orElse(null)));
+    this.pipeline = pipeline;
+    this.inputPCollection = inputPCollection;
+    this.fusedCollections = new HashSet<>();
+    this.fusedTransforms = new LinkedHashSet<>(initialNodes);
+    this.materializedPCollections = new HashSet<>();
+
+    this.fusionCandidates = new ArrayDeque<>();
+    for (PTransformNode initialConsumer : initialNodes) {
+      fusionCandidates.addAll(pipeline.getOutputPCollections(initialConsumer));
+    }
+    while (!fusionCandidates.isEmpty()) {
+      tryFuseCandiate(fusionCandidates.poll());
+    }
+  }
+
+  private void tryFuseCandiate(PCollectionNode candidate) {
+    if (materializedPCollections.contains(candidate) || fusedCollections.contains(candidate)) {
+      // This should generally mean we get to a Flatten via multiple paths through the graph and
+      // we've already determined what to do with the output.
+      LOG.debug(
+          "Skipping fusion candidate {} because it is {} already in this {}",
+          candidate,
+          materializedPCollections.contains(candidate) ? "materialized" : "fused",
+          GreedilyFusedExecutableStage.class.getSimpleName());
+      return;
+    }
+    for (PTransformNode node : pipeline.getPerElementConsumers(candidate)) {
+      if (!(GreedyPCollectionFusers.canFuse(node, this, pipeline))) {
+        // Some of the consumers can't be fused into this subgraph, so the PCollection has to be
+        // materialized.
+        // TODO: Potentially, some of the consumers can be fused back into this stage later
+        // complicate the process, but at a high level, if a downstream stage can be fused into all
+        // of the stages that produce a PCollection it can be fused into all of those stages.
+        materializedPCollections.add(candidate);
+        return;
+      }
+    }
+    // All of the consumers of the candidate PCollection can be fused into this stage, so do so.
+    fusedCollections.add(candidate);
+    fusedTransforms.addAll(pipeline.getPerElementConsumers(candidate));
+    for (PTransformNode consumer : pipeline.getPerElementConsumers(candidate)) {
+      // The outputs of every transform fused into this stage must be either materialized or
+      // themselves fused away, so add them to the set of candidates.
+      fusionCandidates.addAll(pipeline.getOutputPCollections(consumer));
+    }
+  }
+
+  @Override
+  public Environment getEnvironment() {
+    return environment;
+  }
+
+  @Override
+  public PCollectionNode getInputPCollection() {
+    return inputPCollection;
+  }
+
+  @Override
+  public Collection<PCollectionNode> getOutputPCollections() {
+    return Collections.unmodifiableSet(materializedPCollections);
+  }
+
+  public Collection<PTransformNode> getTransforms() {
+    return Collections.unmodifiableSet(fusedTransforms);
+  }
+
+  @Override
+  public PTransform toPTransform() {
+    PTransform.Builder pt = PTransform.newBuilder();
+    pt.putInputs("input", inputPCollection.getId());
+    int i = 0;
+    for (PCollectionNode materializedPCollection : materializedPCollections) {
+      pt.putOutputs(String.format("materialized_%s", i), materializedPCollection.getId());
+      i++;
+    }
+    for (PTransformNode fusedTransform : fusedTransforms) {
+      pt.addSubtransforms(fusedTransform.getId());
+    }
+    pt.setSpec(FunctionSpec.newBuilder().setUrn(ExecutableStage.URN));
+    return pt.build();
+  }
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.apache.beam.sdk.transforms.Flatten;
+
+/**
+ * A Fuser that constructs a fused pipeline by fusing as many PCollections into a stage as possible.
+ */
+class GreedyPCollectionFusers {
+  private static final Map<String, FusibilityChecker> URN_FUSIBILITY_CHECKERS =
+      ImmutableMap.<String, FusibilityChecker>builder()
+          .put(PTransformTranslation.PAR_DO_TRANSFORM_URN, GreedyPCollectionFusers::canFuseParDo)
+          .put(
+              PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN,
+              GreedyPCollectionFusers::canFuseAssignWindows)
+          .put(PTransformTranslation.FLATTEN_TRANSFORM_URN, GreedyPCollectionFusers::canFuseFlatten)
+          .put(
+              PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN,
+              GreedyPCollectionFusers::canFuseGroupByKey)
+          .build();
+  private static final FusibilityChecker DEFAULT_FUSIBILITY_CHECKER =
+      GreedyPCollectionFusers::unknownTransformFusion;
+
+  // TODO: Migrate
+  private static final Map<String, CompatibilityChecker> URN_COMPATIBILITY_CHECKERS =
+      ImmutableMap.<String, CompatibilityChecker>builder()
+          .put(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              GreedyPCollectionFusers::parDoCompatibility)
+          .put(
+              PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN,
+              GreedyPCollectionFusers::compatibleEnvironments)
+          .put(
+              PTransformTranslation.FLATTEN_TRANSFORM_URN, GreedyPCollectionFusers::noCompatibility)
+          .put(
+              PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN,
+              GreedyPCollectionFusers::noCompatibility)
+          .build();
+  private static final CompatibilityChecker DEFAULT_COMPATIBILITY_CHECKER =
+      GreedyPCollectionFusers::unknownTransformCompatibility;
+
+  public static boolean canFuse(
+      PTransformNode transformNode, ExecutableStage subgraph, QueryablePipeline pipeline) {
+    return URN_FUSIBILITY_CHECKERS
+        .getOrDefault(transformNode.getTransform().getSpec().getUrn(), DEFAULT_FUSIBILITY_CHECKER)
+        .canFuse(transformNode, subgraph, pipeline);
+  }
+
+  public static boolean isCompatible(
+      PTransformNode left, PTransformNode right, QueryablePipeline pipeline) {
+    CompatibilityChecker leftChecker =
+        URN_COMPATIBILITY_CHECKERS.getOrDefault(
+            left.getTransform().getSpec().getUrn(), DEFAULT_COMPATIBILITY_CHECKER);
+    CompatibilityChecker rightChecker =
+        URN_COMPATIBILITY_CHECKERS.getOrDefault(
+            right.getTransform().getSpec().getUrn(), DEFAULT_COMPATIBILITY_CHECKER);
+    // The nodes are mutually compatible
+    return leftChecker.isCompatible(left, right, pipeline)
+        && rightChecker.isCompatible(right, left, pipeline);
+  }
+
+  // For the following methods, these should be called if the ptransform is consumed by a
+  // PCollection output by the ExecutableStage, to determine if it can be fused into that
+  // Subgraph
+
+  private interface FusibilityChecker {
+    /**
+     * Determine if a {@link PTransformNode} can be fused into an existing {@link ExecutableStage}.
+     */
+    boolean canFuse(PTransformNode consumer, ExecutableStage subgraph, QueryablePipeline pipeline);
+  }
+
+  private interface CompatibilityChecker {
+    /**
+     * Determine if two {@link PTransformNode PTransforms} can be fused into a new stage. This
+     * determines sibling fusion for new {@link ExecutableStage stages}.
+     */
+    boolean isCompatible(
+        PTransformNode newNode, PTransformNode otherNode, QueryablePipeline pipeline);
+  }
+
+  /**
+   * A ParDo can be fused into a stage if it executes in the same Environment as that stage, and no
+   * transform that are upstream of any of its side input are present in that stage.
+   *
+   * <p>A ParDo that consumes a side input cannot process an element until all of the side inputs
+   * contain data for the side input window that contains the element.
+   */
+  private static boolean canFuseParDo(
+      PTransformNode parDo, ExecutableStage stage, QueryablePipeline pipeline) {
+    Optional<Environment> env = pipeline.getEnvironment(parDo);
+    checkArgument(
+        env.isPresent(),
+        "A %s must have an %s associated with it",
+        ParDoPayload.class.getSimpleName(),
+        Environment.class.getSimpleName());
+    if (!env.get().equals(stage.getEnvironment())) {
+      // The PCollection's producer and this ParDo execute in different environments, so fusion
+      // is never possible.
+      return false;
+    } else if (!pipeline.getSideInputs(parDo).isEmpty()) {
+      // At execution time, a Runner is required to only provide inputs to a PTransform that, at the
+      // time the PTransform processes them, the associated window is ready in all side inputs that
+      // the PTransform consumes. For an arbitrary stage, it is significantly complex for the runner
+      // to determine this for each input. As a result, we break fusion to simplify this inspection.
+      // In general, a ParDo which consumes side inputs cannot be fused into an executable subgraph
+      // alongside any transforms which are upstream of any of its side inputs.
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean parDoCompatibility(
+      PTransformNode parDo, PTransformNode other, QueryablePipeline pipeline) {
+    if (!pipeline.getSideInputs(parDo).isEmpty()) {
+      // This is a convenience rather than a strict requirement. In general, a ParDo that consumes
+      // side inputs can be fused with other transforms in the same environment which are not
+      // upstream of any of the side inputs.
+      return false;
+    }
+    return compatibleEnvironments(parDo, other, pipeline);
+  }
+
+  /**
+   * A WindowInto can be fused into a stage if it executes in the same Environment as that stage.
+   */
+  private static boolean canFuseAssignWindows(
+      PTransformNode window, ExecutableStage stage, QueryablePipeline pipeline) {
+    // WindowInto transforms may not have an environment
+    Optional<Environment> windowEnvironment = pipeline.getEnvironment(window);
+    return stage.getEnvironment().equals(windowEnvironment.orElse(null));
+  }
+
+  private static boolean compatibleEnvironments(
+      PTransformNode left, PTransformNode right, QueryablePipeline pipeline) {
+    return pipeline.getEnvironment(left).equals(pipeline.getEnvironment(right));
+  }
+
+  /**
+   * Flatten can be fused into any stage.
+   *
+   * <p>If the assumption that for each {@link PCollection}, an element is produced in that {@link
+   * PCollection} via a single path through the {@link Pipeline} DAG, a Flatten can appear in each
+   * stage that produces any of its input {@link PCollection PCollections}, as all of its inputs
+   * will reach it via only one of those paths.
+   *
+   * <p>As flatten consumes multiple inputs and produces a single output, there are two cases that
+   * must be considered for the inputs.
+   *
+   * <ul>
+   *   <li>All of the producers of all inputs are within a single stage
+   *   <li>The producers of the inputs are in two or more stages
+   * </ul>
+   *
+   * <p>If all of the producers exist within a single stage, this is identical to any other
+   * transform that consumes a single input - the output PCollection is materialized based only on
+   * its consumers.
+   *
+   * <p>If the producers exist within separate stages, there are two other considerations:
+   *
+   * <ul>
+   *   <li>The output PCollection must be materialized in all cases (has consumers which cannot be
+   *       fused into at least one of the upstream stages).
+   *   <li>All of the consumers of the output PCollection can be fused into at least one of the
+   *       producing stages.
+   * </ul>
+   *
+   * <p>For the former case, this again is identical to a transform that produces a materialized
+   * {@link PCollection}; each path to the {@link Flatten} produces elements for the input {@link
+   * PCollection}, and the output is materialized and consumed by downstream transforms identically
+   * to any other materialized {@link PCollection}.
+   *
+   * <p>For the latter, where fusion is possible into at least one of the producer stages, Flatten
+   * unzipping is performed. This consists of the following steps:
+   *
+   * <ol>
+   *   <li>The flatten is fused into each upstream stage
+   *   <li>Each stage which contains a producer that can be fused with the output {@link
+   *       PCollection} fuses that {@link PCollection}. Elements produced by that stage for the
+   *       output of the flatten are never materialized.
+   *   <li>Each stage which cannot be fused with the output {@link PCollection} materializes the
+   *       output of the {@link Flatten}. All of the downstream consumers exist in a stage which
+   *       reads from the output of that {@link Flatten}, which contains all of the elements from
+   *       the stages that could not fuse with those consumers.
+   * </ol>
+   */
+  private static boolean canFuseFlatten(
+      @SuppressWarnings("unused") PTransformNode flatten,
+      @SuppressWarnings("unused") ExecutableStage stage,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    return true;
+  }
+
+  private static boolean canFuseGroupByKey(
+      @SuppressWarnings("unused") PTransformNode gbk,
+      @SuppressWarnings("unused") ExecutableStage stage,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    // GroupByKeys are runner-implemented only. PCollections consumed by a GroupByKey must be
+    // materialized.
+    return false;
+  }
+
+  private static boolean noCompatibility(
+      @SuppressWarnings("unused") PTransformNode self,
+      @SuppressWarnings("unused") PTransformNode other,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    // TODO: There is performance to be gained if the output of a flatten is fused into a stage
+    // where its output is wholly consumed after a fusion break. This requires slightly more
+    // lookahead.
+    return false;
+  }
+
+  private static boolean unknownTransformFusion(
+      PTransformNode transform,
+      @SuppressWarnings("unused") ExecutableStage stage,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    throw new IllegalArgumentException(
+        String.format("Unknown URN %s", transform.getTransform().getSpec().getUrn()));
+  }
+
+  private static boolean unknownTransformCompatibility(
+      PTransformNode transform,
+      @SuppressWarnings("unused") PTransformNode other,
+      @SuppressWarnings("unused") QueryablePipeline pipeline) {
+    throw new IllegalArgumentException(
+        String.format(
+            "Unknown or unsupported URN %s", transform.getTransform().getSpec().getUrn()));
+  }
+}

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedilyFusedExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedilyFusedExecutableStageTest.java
@@ -1,0 +1,826 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.SideInput;
+import org.apache.beam.model.pipeline.v1.RunnerApi.WindowIntoPayload;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link GreedilyFusedExecutableStage}. */
+@RunWith(JUnit4.class)
+public class GreedilyFusedExecutableStageTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private final PCollection impulseDotOut =
+      PCollection.newBuilder().setUniqueName("impulse.out").build();
+  private final PCollectionNode impulseOutputNode =
+      PipelineNode.pCollection("impulse.out", impulseDotOut);
+
+  private Components partialComponents;
+
+  @Before
+  public void setup() {
+    partialComponents =
+        Components.newBuilder()
+            .putTransforms(
+                "impulse",
+                PTransform.newBuilder()
+                    .putOutputs("output", "impulse.out")
+                    .setSpec(
+                        FunctionSpec.newBuilder()
+                            .setUrn(PTransformTranslation.IMPULSE_TRANSFORM_URN))
+                    .build())
+            .putPcollections("impulse.out", impulseDotOut)
+            .build();
+  }
+
+  @Test
+  public void noInitialConsumersThrows() {
+    // (impulse.out) -> () is not a meaningful stage, so it should never be called
+    QueryablePipeline p = QueryablePipeline.fromComponents(partialComponents);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("at least one PTransform");
+    GreedilyFusedExecutableStage.forGrpcPortRead(p, impulseOutputNode, Collections.emptySet());
+  }
+
+  @Test
+  public void differentEnvironmentsThrows() {
+    // (impulse.out) -> read -> read.out --> go -> go.out
+    //                                   \
+    //                                    -> py -> py.out
+    // read.out can't be fused with both 'go' and 'py', so we should refuse to create this stage
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms(
+                    "read",
+                    PTransform.newBuilder()
+                        .putInputs("input", "impulse.out")
+                        .putOutputs("output", "read.out")
+                        .build())
+                .putPcollections(
+                    "read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+                .putTransforms(
+                    "goTransform",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "go.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                                .setPayload(
+                                    ParDoPayload.newBuilder()
+                                        .setDoFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("go"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections("go.out", PCollection.newBuilder().setUniqueName("go.out").build())
+                .putTransforms(
+                    "pyTransform",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "py.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                                .setPayload(
+                                    WindowIntoPayload.newBuilder()
+                                        .setWindowFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("py"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections("py.out", PCollection.newBuilder().setUniqueName("py.out").build())
+                .putEnvironments("go", Environment.newBuilder().setUrl("go").build())
+                .putEnvironments("py", Environment.newBuilder().setUrl("py").build())
+                .build());
+    Set<PTransformNode> differentEnvironments =
+        p.getPerElementConsumers(
+            PipelineNode.pCollection(
+                "read.out", PCollection.newBuilder().setUniqueName("read.out").build()));
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("go");
+    thrown.expectMessage("py");
+    thrown.expectMessage("same");
+    GreedilyFusedExecutableStage.forGrpcPortRead(
+        p,
+        PipelineNode.pCollection(
+            "read.out", PCollection.newBuilder().setUniqueName("read.out").build()),
+        differentEnvironments);
+  }
+
+  @Test
+  public void noEnvironmentThrows() {
+    // (impulse.out) -> runnerTransform -> gbk.out
+    // runnerTransform can't be executed in an environment, so trying to construct it should fail
+    PTransform gbkTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .setSpec(
+                FunctionSpec.newBuilder().setUrn(PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN))
+            .putOutputs("output", "gbk.out")
+            .build();
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("runnerTransform", gbkTransform)
+                .putPcollections(
+                    "gbk.out", PCollection.newBuilder().setUniqueName("gbk.out").build())
+                .build());
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Environment must be populated");
+    GreedilyFusedExecutableStage.forGrpcPortRead(
+        p,
+        impulseOutputNode,
+        ImmutableSet.of(PipelineNode.pTransform("runnerTransform", gbkTransform)));
+  }
+
+  @Test
+  public void fusesCompatibleEnvironments() {
+    // (impulse.out) -> parDo -> parDo.out -> window -> window.out
+    // parDo and window both have the environment "common" and can be fused together
+    PTransform parDoTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "parDo.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+    PTransform windowTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "window.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                    .setPayload(
+                        WindowIntoPayload.newBuilder()
+                            .setWindowFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("parDo", parDoTransform)
+                .putPcollections(
+                    "parDo.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putTransforms("window", windowTransform)
+                .putPcollections(
+                    "window.out", PCollection.newBuilder().setUniqueName("window.out").build())
+                .putEnvironments("common", Environment.newBuilder().setUrl("common").build())
+                .build());
+
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p,
+            impulseOutputNode,
+            ImmutableSet.of(
+                PipelineNode.pTransform("parDo", parDoTransform),
+                PipelineNode.pTransform("window", windowTransform)));
+    // Nothing consumes the outputs of ParDo or Window, so they don't have to be materialized
+    assertThat(subgraph.getOutputPCollections(), emptyIterable());
+    assertThat(
+        subgraph.toPTransform().getSubtransformsList(), containsInAnyOrder("parDo", "window"));
+  }
+
+  @Test
+  public void fusesFlatten() {
+    // (impulse.out) -> parDo -> parDo.out --> flatten -> flatten.out -> window -> window.out
+    //               \                     /
+    //                -> read -> read.out -
+    // The flatten can be executed within the same environment as any transform; the window can
+    // execute in the same environment as the rest of the transforms, and can fuse with the stage
+    PTransform readTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "read.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+    PTransform parDoTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "parDo.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+    PTransform flattenTransform =
+        PTransform.newBuilder()
+            .putInputs("readInput", "read.out")
+            .putInputs("parDoInput", "parDo.out")
+            .putOutputs("output", "flatten.out")
+            .setSpec(FunctionSpec.newBuilder().setUrn(PTransformTranslation.FLATTEN_TRANSFORM_URN))
+            .build();
+    PTransform windowTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "flatten.out")
+            .putOutputs("output", "window.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                    .setPayload(
+                        WindowIntoPayload.newBuilder()
+                            .setWindowFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("read", readTransform)
+                .putPcollections(
+                    "read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+                .putTransforms("parDo", parDoTransform)
+                .putPcollections(
+                    "parDo.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putTransforms("flatten", flattenTransform)
+                .putPcollections(
+                    "flatten.out", PCollection.newBuilder().setUniqueName("flatten.out").build())
+                .putTransforms("window", windowTransform)
+                .putPcollections(
+                    "window.out", PCollection.newBuilder().setUniqueName("window.out").build())
+                .putEnvironments("common", Environment.newBuilder().setUrl("common").build())
+                .build());
+
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, p.getPerElementConsumers(impulseOutputNode));
+    assertThat(subgraph.getOutputPCollections(), emptyIterable());
+    assertThat(
+        subgraph.toPTransform().getSubtransformsList(),
+        containsInAnyOrder("read", "parDo", "flatten", "window"));
+  }
+
+  @Test
+  public void fusesFlattenWithDifferentEnvironmentInputs() {
+    // (impulse.out) -> read -> read.out \                                 -> window -> window.out
+    //                                    -------> flatten -> flatten.out /
+    // (impulse.out) -> envRead -> envRead.out /
+    // fuses into
+    // read -> read.out -> flatten -> flatten.out -> window -> window.out
+    // envRead -> envRead.out -> flatten -> (flatten.out)
+    // (flatten.out) -> window -> window.out
+    PTransform readTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "read.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+    PTransform otherEnvRead =
+        PTransform.newBuilder()
+            .putInputs("impulse", "impulse.out")
+            .putOutputs("output", "envRead.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("rare"))
+                            .build()
+                            .toByteString()))
+            .build();
+    PTransform flattenTransform =
+        PTransform.newBuilder()
+            .putInputs("readInput", "read.out")
+            .putInputs("otherEnvInput", "envRead.out")
+            .putOutputs("output", "flatten.out")
+            .setSpec(FunctionSpec.newBuilder().setUrn(PTransformTranslation.FLATTEN_TRANSFORM_URN))
+            .build();
+    PTransform windowTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "flatten.out")
+            .putOutputs("output", "window.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                    .setPayload(
+                        WindowIntoPayload.newBuilder()
+                            .setWindowFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+
+    Components components =
+        partialComponents
+            .toBuilder()
+            .putTransforms("read", readTransform)
+            .putPcollections("read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+            .putTransforms("envRead", otherEnvRead)
+            .putPcollections(
+                "envRead.out", PCollection.newBuilder().setUniqueName("envRead.out").build())
+            .putTransforms("flatten", flattenTransform)
+            .putPcollections(
+                "flatten.out", PCollection.newBuilder().setUniqueName("flatten.out").build())
+            .putTransforms("window", windowTransform)
+            .putPcollections(
+                "window.out", PCollection.newBuilder().setUniqueName("window.out").build())
+            .putEnvironments("common", Environment.newBuilder().setUrl("common").build())
+            .putEnvironments("rare", Environment.newBuilder().setUrl("rare").build())
+            .build();
+    QueryablePipeline p = QueryablePipeline.fromComponents(components);
+
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(PipelineNode.pTransform("read", readTransform)));
+    assertThat(subgraph.getOutputPCollections(), emptyIterable());
+    assertThat(
+        subgraph.toPTransform().getSubtransformsList(),
+        containsInAnyOrder("read", "flatten", "window"));
+
+    // Flatten shows up in both of these subgraphs, but elements only go through a path to the
+    // flatten once.
+    ExecutableStage readFromOtherEnv =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p,
+            impulseOutputNode,
+            ImmutableSet.of(PipelineNode.pTransform("envRead", otherEnvRead)));
+    assertThat(
+        readFromOtherEnv.getOutputPCollections(),
+        contains(
+            PipelineNode.pCollection(
+                "flatten.out", components.getPcollectionsOrThrow("flatten.out"))));
+    assertThat(
+        readFromOtherEnv.toPTransform().getSubtransformsList(),
+        containsInAnyOrder("envRead", "flatten"));
+  }
+
+  @Test
+  public void flattenWithHeterogeneousInputsAndOutputs() {
+    // (impulse.out) -> pyRead -> pyRead.out \                           -> pyParDo -> pyParDo.out
+    // (impulse.out) ->                       -> flatten -> flatten.out |
+    // (impulse.out) -> goRead -> goRead.out /                           -> goWindow -> goWindow.out
+    // fuses into
+    // (impulse.out) -> pyRead -> pyRead.out -> flatten -> (flatten.out)
+    // (impulse.out) -> goRead -> goRead.out -> flatten -> (flatten.out)
+    // (flatten.out) -> pyParDo -> pyParDo.out
+    // (flatten.out) -> goWindow -> goWindow.out
+    PTransform pyRead =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "pyRead.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("py"))
+                            .build()
+                            .toByteString())
+                    .build())
+            .build();
+    PTransform goRead =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "goRead.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("go"))
+                            .build()
+                            .toByteString())
+                    .build())
+            .build();
+
+    PTransform pyParDo =
+        PTransform.newBuilder()
+            .putInputs("input", "flatten.out")
+            .putOutputs("output", "pyParDo.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("py"))
+                            .build()
+                            .toByteString())
+                    .build())
+            .build();
+    PTransform goWindow =
+        PTransform.newBuilder()
+            .putInputs("input", "flatten.out")
+            .putOutputs("output", "goWindow.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                    .setPayload(
+                        WindowIntoPayload.newBuilder()
+                            .setWindowFn(SdkFunctionSpec.newBuilder().setEnvironmentId("go"))
+                            .build()
+                            .toByteString())
+                    .build())
+            .build();
+
+    PCollection flattenPc = PCollection.newBuilder().setUniqueName("flatten.out").build();
+    Components components =
+        partialComponents
+            .toBuilder()
+            .putTransforms("pyRead", pyRead)
+            .putPcollections(
+                "pyRead.out", PCollection.newBuilder().setUniqueName("pyRead.out").build())
+            .putTransforms("goRead", goRead)
+            .putPcollections(
+                "goRead.out", PCollection.newBuilder().setUniqueName("goRead.out").build())
+            .putTransforms(
+                "flatten",
+                PTransform.newBuilder()
+                    .putInputs("py_input", "pyRead.out")
+                    .putInputs("go_input", "goRead.out")
+                    .putOutputs("output", "flatten.out")
+                    .setSpec(
+                        FunctionSpec.newBuilder()
+                            .setUrn(PTransformTranslation.FLATTEN_TRANSFORM_URN)
+                            .build())
+                    .build())
+            .putPcollections("flatten.out", flattenPc)
+            .putTransforms("pyParDo", pyParDo)
+            .putPcollections(
+                "pyParDo.out", PCollection.newBuilder().setUniqueName("pyParDo.out").build())
+            .putTransforms("goWindow", goWindow)
+            .putPcollections(
+                "goWindow.out", PCollection.newBuilder().setUniqueName("goWindow.out").build())
+            .putEnvironments("go", Environment.newBuilder().setUrl("go").build())
+            .putEnvironments("py", Environment.newBuilder().setUrl("py").build())
+            .build();
+    QueryablePipeline p = QueryablePipeline.fromComponents(components);
+
+    ExecutableStage readFromPy =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(PipelineNode.pTransform("pyRead", pyRead)));
+    ExecutableStage readFromGo =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(PipelineNode.pTransform("goRead", goRead)));
+
+    assertThat(
+        readFromPy.getOutputPCollections(),
+        contains(PipelineNode.pCollection("flatten.out", flattenPc)));
+    // The stage must materialize the flatten, so the `go` stage can read it; this means that this
+    // parDo can't be in the stage, as it'll be a reader of that materialized PCollection. The same
+    // is true for the go window.
+    assertThat(
+        readFromPy.getTransforms(), not(hasItem(PipelineNode.pTransform("pyParDo", pyParDo))));
+
+    assertThat(
+        readFromGo.getOutputPCollections(),
+        contains(PipelineNode.pCollection("flatten.out", flattenPc)));
+    assertThat(
+        readFromGo.getTransforms(), not(hasItem(PipelineNode.pTransform("goWindow", goWindow))));
+  }
+
+  @Test
+  public void materializesWithDifferentEnvConsumer() {
+    // (impulse.out) -> parDo -> parDo.out -> window -> window.out
+    // Fuses into
+    // (impulse.out) -> parDo -> (parDo.out)
+    // (parDo.out) -> window -> window.out
+    Environment env = Environment.newBuilder().setUrl("common").build();
+    PTransform parDoTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .putOutputs("out", "parDo.out")
+            .build();
+
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("parDo", parDoTransform)
+                .putPcollections(
+                    "parDo.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putTransforms(
+                    "window",
+                    PTransform.newBuilder()
+                        .putInputs("input", "parDo.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                                .setPayload(
+                                    WindowIntoPayload.newBuilder()
+                                        .setWindowFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("rare"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putEnvironments("rare", Environment.newBuilder().setUrl("rare").build())
+                .putEnvironments("common", env)
+                .build());
+
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, p.getPerElementConsumers(impulseOutputNode));
+    assertThat(subgraph.getOutputPCollections(), emptyIterable());
+    assertThat(subgraph.getInputPCollection(), equalTo(impulseOutputNode));
+    assertThat(subgraph.getEnvironment(), equalTo(env));
+    assertThat(
+        subgraph.getTransforms(), contains(PipelineNode.pTransform("parDo", parDoTransform)));
+  }
+
+  @Test
+  public void materializesWithDifferentEnvSibling() {
+    // (impulse.out) -> read -> read.out -> parDo -> parDo.out
+    //                                   \
+    //                                    -> window -> window.out
+    // Fuses into
+    // (impulse.out) -> read -> (read.out)
+    // (read.out) -> parDo -> parDo.out
+    // (read.out) -> window -> window.out
+    // The window can't be fused into the stage, which forces the PCollection to be materialized.
+    // ParDo in this case _could_ be fused into the stage, but is not for simplicity of
+    // implementation
+    Environment env = Environment.newBuilder().setUrl("common").build();
+    PTransform readTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "read.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("read", readTransform)
+                .putPcollections(
+                    "read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+                .putTransforms(
+                    "parDo",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "parDo.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                                .setPayload(
+                                    ParDoPayload.newBuilder()
+                                        .setDoFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections(
+                    "parDo.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putTransforms(
+                    "window",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "window.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                                .setPayload(
+                                    WindowIntoPayload.newBuilder()
+                                        .setWindowFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("rare"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections(
+                    "window.out", PCollection.newBuilder().setUniqueName("window.out").build())
+                .putEnvironments("rare", Environment.newBuilder().setUrl("rare").build())
+                .putEnvironments("common", env)
+                .build());
+
+    PTransformNode readNode = PipelineNode.pTransform("read", readTransform);
+    PCollectionNode readOutput = getOnlyElement(p.getOutputPCollections(readNode));
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(PipelineNode.pTransform("read", readTransform)));
+    assertThat(subgraph.getOutputPCollections(), contains(readOutput));
+    assertThat(subgraph.getTransforms(), contains(readNode));
+  }
+
+  @Test
+  public void materializesWithSideInputConsumer() {
+    // (impulse.out) -> read -> read.out -----------> parDo -> parDo.out -> window -> window.out
+    // (impulse.out) -> side_read -> side_read.out /
+    // Where parDo takes side_read as a side input, fuses into
+    // (impulse.out) -> read -> (read.out)
+    // (impulse.out) -> side_read -> (side_read.out)
+    // (read.out) -> parDo -> parDo.out -> window -> window.out
+    // parDo doesn't have a per-element consumer from side_read.out, so it can't root a stage
+    // which consumes from that materialized collection. Nodes with side inputs must root a stage,
+    // but do not restrict fusion of consumers.
+    Environment env = Environment.newBuilder().setUrl("common").build();
+    PTransform readTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "read.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("read", readTransform)
+                .putPcollections(
+                    "read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+                .putTransforms(
+                    "side_read",
+                    PTransform.newBuilder()
+                        .putInputs("input", "impulse.out")
+                        .putOutputs("output", "side_read.out")
+                        .build())
+                .putPcollections(
+                    "side_read.out",
+                    PCollection.newBuilder().setUniqueName("side_read.out").build())
+                .putTransforms(
+                    "parDo",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putInputs("side_input", "side_read.out")
+                        .putOutputs("output", "parDo.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                                .setPayload(
+                                    ParDoPayload.newBuilder()
+                                        .setDoFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                                        .putSideInputs("side_input", SideInput.getDefaultInstance())
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections(
+                    "parDo.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putTransforms(
+                    "window",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "window.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN)
+                                .setPayload(
+                                    WindowIntoPayload.newBuilder()
+                                        .setWindowFn(
+                                            SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                                        .build()
+                                        .toByteString()))
+                        .build())
+                .putPcollections(
+                    "window.out", PCollection.newBuilder().setUniqueName("window.out").build())
+                .putEnvironments("common", env)
+                .build());
+
+    PTransformNode readNode = PipelineNode.pTransform("read", readTransform);
+    PCollectionNode readOutput = getOnlyElement(p.getOutputPCollections(readNode));
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(readNode));
+    assertThat(subgraph.getOutputPCollections(), contains(readOutput));
+    assertThat(subgraph.toPTransform().getSubtransformsList(), contains(readNode.getId()));
+  }
+
+  @Test
+  public void materializesWithGroupByKeyConsumer() {
+    // (impulse.out) -> read -> read.out -> gbk -> gbk.out
+    // Fuses to
+    // (impulse.out) -> read -> (read.out)
+    // GBK is the responsibility of the runner, so it is not included in a stage.
+    Environment env = Environment.newBuilder().setUrl("common").build();
+    PTransform readTransform =
+        PTransform.newBuilder()
+            .putInputs("input", "impulse.out")
+            .putOutputs("output", "read.out")
+            .setSpec(
+                FunctionSpec.newBuilder()
+                    .setUrn(PTransformTranslation.PAR_DO_TRANSFORM_URN)
+                    .setPayload(
+                        ParDoPayload.newBuilder()
+                            .setDoFn(SdkFunctionSpec.newBuilder().setEnvironmentId("common"))
+                            .build()
+                            .toByteString()))
+            .build();
+
+    QueryablePipeline p =
+        QueryablePipeline.fromComponents(
+            partialComponents
+                .toBuilder()
+                .putTransforms("read", readTransform)
+                .putPcollections(
+                    "read.out", PCollection.newBuilder().setUniqueName("read.out").build())
+                .putTransforms(
+                    "gbk",
+                    PTransform.newBuilder()
+                        .putInputs("input", "read.out")
+                        .putOutputs("output", "gbk.out")
+                        .setSpec(
+                            FunctionSpec.newBuilder()
+                                .setUrn(PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN))
+                        .build())
+                .putPcollections(
+                    "gbk.out", PCollection.newBuilder().setUniqueName("parDo.out").build())
+                .putEnvironments("common", env)
+                .build());
+
+    PTransformNode readNode = PipelineNode.pTransform("read", readTransform);
+    PCollectionNode readOutput = getOnlyElement(p.getOutputPCollections(readNode));
+    ExecutableStage subgraph =
+        GreedilyFusedExecutableStage.forGrpcPortRead(
+            p, impulseOutputNode, ImmutableSet.of(readNode));
+    assertThat(subgraph.getOutputPCollections(), contains(readOutput));
+    assertThat(subgraph.toPTransform().getSubtransformsList(), contains(readNode.getId()));
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Impulse.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Impulse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.transforms;
+
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollection.IsBounded;
+import org.apache.beam.sdk.values.WindowingStrategy;
+
+/**
+ * <b><i>For internal use only; no backwards-compatibility guarantees.</i></b>
+ *
+ * <p>A {@link PTransform} which produces a single empty byte array at the minimum timestamp in the
+ * {@link GlobalWindow}.
+ *
+ * <p>Users should instead use {@link Create} or another {@link Read} transform to begin consuming
+ * elements.
+ */
+@Internal
+public class Impulse extends PTransform<PBegin, PCollection<byte[]>> {
+  /**
+   * Create a new {@link Impulse} {@link PTransform}.
+   */
+  // TODO: Make public and implement the default expansion of Read with Impulse -> ParDo
+  static Impulse create() {
+    return new Impulse();
+  }
+
+  private Impulse() {}
+
+  @Override
+  public PCollection<byte[]> expand(PBegin input) {
+    return PCollection.createPrimitiveOutputInternal(
+        input.getPipeline(),
+        WindowingStrategy.globalDefault(),
+        IsBounded.BOUNDED,
+        ByteArrayCoder.of());
+  }
+}


### PR DESCRIPTION
This takes in either a root PCollection (at execution time, a
RemoteGrpcRead), and a collection of consuming transforms (siblings)
or an in-environment Read node, and fuses as many PCollections
as possible into the stage, materializing PCollections which have
consumers that cannot be fused into the stage.

Future work can be performed to merge multiple subgraphs.

The current 'GreedyPCollectionFusers' implementation uses a slightly
simpler model for ParDo Fusion than the maximally permissive model.
For example, the fuser never fuses a `ParDo` which contains a side
input into an upstream stage, though it can if that stage contains no
upstream PCollections of any of its side inputs. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

