### PR TITLE
Adjust gradle build dirs and hints to help IntelliJ

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -67,7 +67,7 @@ repositories {
   maven { url "https://repository.apache.org/content/repositories/releases" }
 }
 
-// Help IntelliJ - specific hints are in their natures
+// Apply a plugin which enables configuring projects imported into Intellij.
 apply plugin: "idea"
 
 // Provide code coverage
@@ -374,7 +374,7 @@ ext.applyJavaNature = {
       sourceDirs += file(aptGeneratedMain)
       generatedSourceDirs += file(aptGeneratedMain)
 
-      sourceDirs += file(aptGeneratedTest)
+      testSourceDirs += file(aptGeneratedTest)
       generatedSourceDirs += file(aptGeneratedTest)
     }
   }
@@ -422,7 +422,7 @@ ext.applyGoNature = {
       // which is a path baked into golang
       excludeDirs += file("${project.path}/vendor")
 
-      // Don't know what is in here, but it isn't our source
+      // gogradle's private working directory
       excludeDirs += file("${project.path}/.gogradle")
     }
   }
@@ -479,13 +479,13 @@ ext.applyGrpcNature = {
       sourceDirs += file(generatedProtoMainJavaDir)
       generatedSourceDirs += file(generatedProtoMainJavaDir)
 
-      sourceDirs += file(generatedProtoTestJavaDir)
+      testSourceDirs += file(generatedProtoTestJavaDir)
       generatedSourceDirs += file(generatedProtoTestJavaDir)
 
       sourceDirs += file(generatedProtoMainJavaDir)
       generatedSourceDirs += file(generatedGrpcMainJavaDir)
 
-      sourceDirs += file(generatedGrpcTestJavaDir)
+      testSourceDirs += file(generatedGrpcTestJavaDir)
       generatedSourceDirs += file(generatedGrpcTestJavaDir)
     }
   }

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -67,6 +67,9 @@ repositories {
   maven { url "https://repository.apache.org/content/repositories/releases" }
 }
 
+// Help IntelliJ - specific hints are in their natures
+apply plugin: "idea"
+
 // Provide code coverage
 // TODO: Should this only apply to Java projects?
 apply plugin: "jacoco"
@@ -363,6 +366,18 @@ ext.applyJavaNature = {
       force library.java.values()
     }
   }
+
+  def aptGeneratedMain = "${project.buildDir}/generated/source/apt/main"
+  def aptGeneratedTest = "${project.buildDir}/generated/source/apt/test"
+  idea {
+    module {
+      sourceDirs += file(aptGeneratedMain)
+      generatedSourceDirs += file(aptGeneratedMain)
+
+      sourceDirs += file(aptGeneratedTest)
+      generatedSourceDirs += file(aptGeneratedTest)
+    }
+  }
 }
 
 /*************************************************************************************************/
@@ -398,6 +413,17 @@ ext.applyGoNature = {
       tasks.getByPath(project.path + ":resolveBuildDependencies").mustRunAfter tasks.getByPath(previous + ":installDependencies")
       println "Forcing: '" + project.path + ":resolveTestDependencies' must run after '" + previous + ":installDependencies'"
       tasks.getByPath(project.path + ":resolveTestDependencies").mustRunAfter tasks.getByPath(previous + ":installDependencies")
+    }
+  }
+
+  idea {
+    module {
+      // The gogradle plugin downloads all dependencies into the source tree here,
+      // which is a path baked into golang
+      excludeDirs += file("${project.path}/vendor")
+
+      // Don't know what is in here, but it isn't our source
+      excludeDirs += file("${project.path}/.gogradle")
     }
   }
 }
@@ -443,6 +469,26 @@ ext.applyGrpcNature = {
       }
     }
   }
+
+  def generatedProtoMainJavaDir = "${project.buildDir}/generated/source/proto/main/java"
+  def generatedProtoTestJavaDir = "${project.buildDir}/generated/source/proto/test/java"
+  def generatedGrpcMainJavaDir = "${project.buildDir}/generated/source/proto/main/grpc"
+  def generatedGrpcTestJavaDir = "${project.buildDir}/generated/source/proto/test/grpc"
+  idea {
+    module {
+      sourceDirs += file(generatedProtoMainJavaDir)
+      generatedSourceDirs += file(generatedProtoMainJavaDir)
+
+      sourceDirs += file(generatedProtoTestJavaDir)
+      generatedSourceDirs += file(generatedProtoTestJavaDir)
+
+      sourceDirs += file(generatedProtoMainJavaDir)
+      generatedSourceDirs += file(generatedGrpcMainJavaDir)
+
+      sourceDirs += file(generatedGrpcTestJavaDir)
+      generatedSourceDirs += file(generatedGrpcTestJavaDir)
+    }
+  }
 }
 
 /*************************************************************************************************/
@@ -453,5 +499,3 @@ ext.applyAvroNature = {
   println "applyAvroNature with " + (it ? "$it" : "default configuration") + " for project $project.name"
   apply plugin: "com.commercehub.gradle.plugin.avro"
 }
-
-

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -91,7 +91,7 @@ task generateFmppSources {
   }
 }
 
-// IntelliJ is happier when the directories are in the path, so we manually set this up
+// Match the output directory for generated code with the package, to be more tool-friendly
 def generateFmppJavaccRoot = "${generateFmppOutputDir}/javacc"
 def generatedJavaccSourceDir = "${project.buildDir}/generated/javacc"
 def generatedJavaccPackageDir = "${generatedJavaccSourceDir}/org/apache/beam/sdk/extensions/sql/impl/parser/impl"

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -80,7 +80,7 @@ task copyFmppTemplatesFromCalciteCore(type: Copy) {
 }
 
 // Generate the FMPP sources from the FMPP templates.
-def generateFmppOutputDir = "${project.buildDir}/generated-fmpp"
+def generateFmppOutputDir = "${project.buildDir}/generated/fmpp"
 task generateFmppSources {
   dependsOn configurations.fmppTask
   dependsOn copyFmppTemplatesFromSrc
@@ -91,9 +91,14 @@ task generateFmppSources {
   }
 }
 
+// IntelliJ is happier when the directories are in the path, so we manually set this up
+def generateFmppJavaccRoot = "${generateFmppOutputDir}/javacc"
+def generatedJavaccSourceDir = "${project.buildDir}/generated/javacc"
+def generatedJavaccPackageDir = "${generatedJavaccSourceDir}/org/apache/beam/sdk/extensions/sql/impl/parser/impl"
 compileJavacc {
   dependsOn generateFmppSources
-  inputDirectory = file(generateFmppOutputDir)
+  inputDirectory = file(generateFmppJavaccRoot)
+  outputDirectory = file(generatedJavaccPackageDir)
   arguments = [grammar_encoding: "UTF-8", static: "false", lookahead: "2"]
 }
 
@@ -115,4 +120,15 @@ shadowJar {
   // getJavaRelocatedPath once the Maven build is no longer also shading this
   // module.
   relocate "org.codehaus", "org.apache.beam.sdks.java.extensions.sql.repackaged.org.codehaus"
+}
+
+// Help IntelliJ find the fmpp bits
+idea {
+  module {
+    sourceDirs += file(generateFmppOutputDir)
+    generatedSourceDirs += file(generateFmppOutputDir)
+
+    sourceDirs += file(generatedJavaccSourceDir)
+    generatedSourceDirs += file(generatedJavaccSourceDir)
+  }
 }


### PR DESCRIPTION
Adds a hint to Gradle config so IntelliJ finds the generated sources.

After `git clean -d -f -x`, I created an empty project that successfully builds in IntelliJ the first time.

This hint could live in a few places. It could go in proto/grpc nature but during development I had some issues that I haven't revisited. It seems benign to put in `build.gradle` in an `allprojects` block, too. That has the same affect as how we use `build_rules.gradle` I think.

The full IntelliJ sequence (very simple)

 - Create empty project first (so you can put it outside the source root)
 - Configure project JDK to be 8
 - Create new module from existing sources
   - import module from external model: Gradle
      - use auto-import (could be expensive, but our modules can be churny)
      - create separate module per source set (necessary for sanity of build times)
      - store generated project files externally (again, nothing in the source root!!!)
      - use default gradle wrapper

Build!

I have one or two other IntelliJ environments to try this on tomorrow.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [N/A] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [N/A] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [N/A] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

