### PR TITLE
[BEAM-3601] Switch to Java 8 futures

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
@@ -32,9 +32,6 @@ import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.io.Files;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.Closeable;
 import java.io.File;
@@ -47,7 +44,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -61,6 +60,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.util.BackOffAdapter;
 import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.MimeTypes;
+import org.apache.beam.sdk.util.MoreFutures;
 import org.apache.beam.sdk.util.ZipFiles;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
@@ -95,9 +95,9 @@ class PackageUtil implements Closeable {
    */
   private static final ApiErrorExtractor ERROR_EXTRACTOR = new ApiErrorExtractor();
 
-  private final ListeningExecutorService executorService;
+  private final ExecutorService executorService;
 
-  private PackageUtil(ListeningExecutorService executorService) {
+  private PackageUtil(ExecutorService executorService) {
     this.executorService = executorService;
   }
 
@@ -107,7 +107,7 @@ class PackageUtil implements Closeable {
             MoreExecutors.platformThreadFactory())));
   }
 
-  public static PackageUtil withExecutorService(ListeningExecutorService executorService) {
+  public static PackageUtil withExecutorService(ExecutorService executorService) {
     return new PackageUtil(executorService);
   }
 
@@ -134,10 +134,10 @@ class PackageUtil implements Closeable {
   }
 
   /** Asynchronously computes {@link PackageAttributes} for a single staged file. */
-  private ListenableFuture<PackageAttributes> computePackageAttributes(
+  private CompletionStage<PackageAttributes> computePackageAttributes(
       final DataflowPackage source, final String stagingPath) {
 
-    return executorService.submit(
+    return MoreFutures.supplyAsync(
         () -> {
           final File file = new File(source.getLocation());
           if (!file.exists()) {
@@ -150,7 +150,8 @@ class PackageUtil implements Closeable {
             attributes = attributes.withPackageName(source.getName());
           }
           return attributes;
-        });
+        },
+        executorService);
   }
 
   private boolean alreadyStaged(PackageAttributes attributes) throws IOException {
@@ -165,12 +166,12 @@ class PackageUtil implements Closeable {
   }
 
   /** Stages one file ("package") if necessary. */
-  public ListenableFuture<StagingResult> stagePackage(
+  public CompletionStage<StagingResult> stagePackage(
       final PackageAttributes attributes,
       final Sleeper retrySleeper,
       final CreateOptions createOptions) {
-    return executorService.submit(
-        () -> stagePackageSynchronously(attributes, retrySleeper, createOptions));
+    return MoreFutures.supplyAsync(
+        () -> stagePackageSynchronously(attributes, retrySleeper, createOptions), executorService);
   }
 
   /** Synchronously stages a package, with retry and backoff for resiliency. */
@@ -286,11 +287,11 @@ class PackageUtil implements Closeable {
   public DataflowPackage stageToFile(
       byte[] bytes, String target, String stagingPath, CreateOptions createOptions) {
     try {
-      return stagePackage(
-              PackageAttributes.forBytesToStage(bytes, target, stagingPath),
-              DEFAULT_SLEEPER,
-              createOptions)
-          .get()
+      return MoreFutures.get(
+              stagePackage(
+                  PackageAttributes.forBytesToStage(bytes, target, stagingPath),
+                  DEFAULT_SLEEPER,
+                  createOptions))
           .getPackageAttributes()
           .getDestination();
     } catch (InterruptedException e) {
@@ -331,7 +332,7 @@ class PackageUtil implements Closeable {
 
     final AtomicInteger numUploaded = new AtomicInteger(0);
     final AtomicInteger numCached = new AtomicInteger(0);
-    List<ListenableFuture<DataflowPackage>> destinationPackages = new ArrayList<>();
+    List<CompletionStage<DataflowPackage>> destinationPackages = new ArrayList<>();
 
     for (String classpathElement : classpathElements) {
       DataflowPackage sourcePackage = new DataflowPackage();
@@ -350,15 +351,14 @@ class PackageUtil implements Closeable {
         continue;
       }
 
-      // TODO: Java 8 / Guava 23.0: FluentFuture
-      ListenableFuture<StagingResult> stagingResult =
-          Futures.transformAsync(
-              computePackageAttributes(sourcePackage, stagingPath),
-              packageAttributes -> stagePackage(packageAttributes, retrySleeper, createOptions));
+      CompletionStage<StagingResult> stagingResult =
+          computePackageAttributes(sourcePackage, stagingPath)
+              .thenComposeAsync(
+                  packageAttributes ->
+                      stagePackage(packageAttributes, retrySleeper, createOptions));
 
-      ListenableFuture<DataflowPackage> stagedPackage =
-          Futures.transform(
-              stagingResult,
+      CompletionStage<DataflowPackage> stagedPackage =
+          stagingResult.thenApply(
               stagingResult1 -> {
                 if (stagingResult1.alreadyStaged()) {
                   numCached.incrementAndGet();
@@ -372,19 +372,19 @@ class PackageUtil implements Closeable {
     }
 
     try {
-      ListenableFuture<List<DataflowPackage>> stagingFutures =
-          Futures.allAsList(destinationPackages);
+      CompletionStage<List<DataflowPackage>> stagingFutures =
+          MoreFutures.allAsList(destinationPackages);
       boolean finished = false;
       do {
         try {
-          stagingFutures.get(3L, TimeUnit.MINUTES);
+          MoreFutures.get(stagingFutures, 3L, TimeUnit.MINUTES);
           finished = true;
         } catch (TimeoutException e) {
           // finished will still be false
           LOG.info("Still staging {} files", classpathElements.size());
         }
       } while (!finished);
-      List<DataflowPackage> stagedPackages = stagingFutures.get();
+      List<DataflowPackage> stagedPackages = MoreFutures.get(stagingFutures);
       LOG.info(
           "Staging files complete: {} files cached, {} files newly uploaded",
           numCached.get(), numUploaded.get());

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
@@ -23,11 +23,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.stub.StreamObserver;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.sdk.util.MoreFutures;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -52,14 +53,14 @@ public class FnApiControlClientPoolServiceTest {
 
     // Check that the client is wired up to the request channel
     String id = "fakeInstruction";
-    ListenableFuture<BeamFnApi.InstructionResponse> responseFuture =
+    CompletionStage<BeamFnApi.InstructionResponse> responseFuture =
         client.handle(BeamFnApi.InstructionRequest.newBuilder().setInstructionId(id).build());
     verify(requestObserver).onNext(any(BeamFnApi.InstructionRequest.class));
-    assertThat(responseFuture.isDone(), is(false));
+    assertThat(MoreFutures.isDone(responseFuture), is(false));
 
     // Check that the response channel really came from the client
     responseObserver.onNext(
         BeamFnApi.InstructionResponse.newBuilder().setInstructionId(id).build());
-    responseFuture.get();
+    MoreFutures.get(responseFuture);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MoreFutures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MoreFutures.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import com.google.auto.value.AutoValue;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
+/**
+ * Utilities to do future programming with Java 8.
+ *
+ * <p>Standards for these utilities:
+ *
+ * <ul> <li>Always allow thrown exceptions, and they should cause futures to complete exceptionally.
+ * <li>Always return {@link CompletionStage} as a future value. <li>Return {@link CompletableFuture}
+ * only to the <i>producer</i> of a future value. </ul>
+ */
+public class MoreFutures {
+
+  /**
+   * Gets the result of the given future.
+   *
+   * <p>This utility is provided so consumers of futures need not even convert to {@link
+   * CompletableFuture}, an interface that is only suitable for producers of futures.
+   */
+  public static <T> T get(CompletionStage<T> future)
+      throws InterruptedException, ExecutionException {
+    return future.toCompletableFuture().get();
+  }
+
+  /**
+   * Gets the result of the given future.
+   *
+   * <p>This utility is provided so consumers of futures need not even convert to {@link
+   * CompletableFuture}, an interface that is only suitable for producers of futures.
+   */
+  public static <T> T get(CompletionStage<T> future, long duration, TimeUnit unit)
+      throws InterruptedException, ExecutionException, TimeoutException {
+    return future.toCompletableFuture().get(duration, unit);
+  }
+
+  /**
+   * Indicates whether the future is done.
+   *
+   * <p>This utility is provided so consumers of futures need not even convert to {@link
+   * CompletableFuture}, an interface that is only suitable for producers of futures.
+   */
+  public static boolean isDone(CompletionStage<?> future) {
+    return future.toCompletableFuture().isDone();
+  }
+
+  /**
+   * Indicates whether the future is cancelled.
+   *
+   * <p>This utility is provided so consumers of futures need not even convert to {@link
+   * CompletableFuture}, an interface that is only suitable for producers of futures.
+   */
+  public static boolean isCancelled(CompletionStage<?> future) {
+    return future.toCompletableFuture().isCancelled();
+  }
+
+  /**
+   * Like {@link CompletableFuture#supplyAsync(Supplier)} but for {@link ThrowingSupplier}.
+   *
+   * <p>If the {@link ThrowingSupplier} throws an exception, the future completes exceptionally.
+   */
+  public static <T> CompletionStage<T> supplyAsync(
+      ThrowingSupplier<T> supplier, ExecutorService executorService) {
+    CompletableFuture<T> result = new CompletableFuture<>();
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            result.complete(supplier.get());
+          } catch (InterruptedException e) {
+            result.completeExceptionally(e);
+            Thread.currentThread().interrupt();
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        },
+        executorService);
+    return result;
+  }
+
+  /**
+   * Shorthand for {@link #supplyAsync(ThrowingSupplier, ExecutorService)} using {@link
+   * ForkJoinPool#commonPool()}.
+   */
+  public static <T> CompletionStage<T> supplyAsync(ThrowingSupplier<T> supplier) {
+    return supplyAsync(supplier, ForkJoinPool.commonPool());
+  }
+
+  /**
+   * Like {@link CompletableFuture#runAsync} but for {@link ThrowingRunnable}.
+   *
+   * <p>If the {@link ThrowingRunnable} throws an exception, the future completes exceptionally.
+   */
+  public static CompletionStage<Void> runAsync(
+      ThrowingRunnable runnable, ExecutorService executorService) {
+    CompletableFuture<Void> result = new CompletableFuture<>();
+    CompletableFuture.runAsync(
+        () -> {
+          try {
+            runnable.run();
+            result.complete(null);
+          } catch (InterruptedException e) {
+            result.completeExceptionally(e);
+            Thread.currentThread().interrupt();
+          } catch (Throwable t) {
+            result.completeExceptionally(t);
+          }
+        },
+        executorService);
+    return result;
+  }
+
+  /**
+   * Shorthand for {@link #runAsync(ThrowingRunnable, ExecutorService)} using {@link
+   * ForkJoinPool#commonPool()}.
+   */
+  public static CompletionStage<Void> runAsync(ThrowingRunnable runnable) {
+    return runAsync(runnable, ForkJoinPool.commonPool());
+  }
+
+  /**
+   * Like {@link CompletableFuture#allOf} but returning the result of constituent futures.
+   */
+  public static <T> CompletionStage<List<T>> allAsList(
+      Collection<? extends CompletionStage<? extends T>> futures) {
+
+    // CompletableFuture.allOf completes exceptionally if any of the futures do.
+    // We have to gather the results separately.
+    CompletionStage<Void> blockAndDiscard =
+        CompletableFuture.allOf(futuresToCompletableFutures(futures));
+
+    return blockAndDiscard.thenApply(
+        nothing ->
+            futures
+                .stream()
+                .map(future -> future.toCompletableFuture().join())
+                .collect(Collectors.toList()));
+  }
+
+  /**
+   * An object that represents either a result or an exceptional termination.
+   *
+   * <p>This is used, for example, in aggregating the results of many future values in {@link
+   * #allAsList(Collection)}.
+   */
+  @SuppressWarnings(value = "NM_CLASS_NOT_EXCEPTION",
+      justification = "The class does hold an exception; its name is accurate.")
+  @AutoValue
+  public abstract static class ExceptionOrResult<T> {
+
+    /**
+     * Describes whether the result was an exception.
+     */
+    public enum IsException {
+      EXCEPTION,
+      RESULT
+    }
+
+    public abstract IsException isException();
+
+    public abstract @Nullable
+    T getResult();
+
+    public abstract @Nullable
+    Throwable getException();
+
+    public static <T> ExceptionOrResult<T> exception(Throwable throwable) {
+      return new AutoValue_MoreFutures_ExceptionOrResult(IsException.EXCEPTION, null, throwable);
+    }
+
+    public static <T> ExceptionOrResult<T> result(T result) {
+      return new AutoValue_MoreFutures_ExceptionOrResult(IsException.EXCEPTION, result, null);
+    }
+  }
+
+  /**
+   * Like {@link #allAsList} but return a list .
+   */
+  public static <T> CompletionStage<List<ExceptionOrResult<T>>> allAsListWithExceptions(
+      Collection<? extends CompletionStage<? extends T>> futures) {
+
+    // CompletableFuture.allOf completes exceptionally if any of the futures do.
+    // We have to gather the results separately.
+    CompletionStage<Void> blockAndDiscard =
+        CompletableFuture.allOf(futuresToCompletableFutures(futures))
+            .whenComplete((ignoredValues, arbitraryException) -> {
+            });
+
+    return blockAndDiscard.thenApply(
+        nothing ->
+            futures
+                .stream()
+                .map(
+                    future -> {
+                      // The limited scope of the exceptions wrapped allows CancellationException
+                      // to still be thrown.
+                      try {
+                        return ExceptionOrResult.<T>result(future.toCompletableFuture().join());
+                      } catch (CompletionException exc) {
+                        return ExceptionOrResult.<T>exception(exc);
+                      }
+                    })
+                .collect(Collectors.toList()));
+  }
+
+  /**
+   * Helper to convert a list of futures into an array for use in {@link CompletableFuture} vararg
+   * combinators.
+   */
+  private static <T> CompletableFuture<? extends T>[] futuresToCompletableFutures(
+      Collection<? extends CompletionStage<? extends T>> futures) {
+    CompletableFuture<? extends T>[] completableFutures = new CompletableFuture[futures.size()];
+    int i = 0;
+    for (CompletionStage<? extends T> future : futures) {
+      completableFutures[i] = future.toCompletableFuture();
+      ++i;
+    }
+    return completableFutures;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ThrowingRunnable.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ThrowingRunnable.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+/** Like {@link Runnable} but allowed to throw any exception. */
+@FunctionalInterface
+public interface ThrowingRunnable {
+  void run() throws Exception;
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ThrowingSupplier.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ThrowingSupplier.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import java.util.function.Supplier;
+
+/** Like {@link Supplier} but allowed to throw any exception. */
+@FunctionalInterface
+public interface ThrowingSupplier<T> {
+  T get() throws Exception;
+}

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
@@ -44,9 +44,6 @@ import com.google.cloud.hadoop.util.RetryDeterminer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -59,6 +56,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -578,7 +576,7 @@ public class GcsUtil {
   }
 
   private static void executeBatches(List<BatchRequest> batches) throws IOException {
-    ListeningExecutorService executor =
+    ExecutorService executor =
         MoreExecutors.listeningDecorator(
             MoreExecutors.getExitingExecutorService(
                 new ThreadPoolExecutor(
@@ -588,18 +586,17 @@ public class GcsUtil {
                     TimeUnit.MILLISECONDS,
                     new LinkedBlockingQueue<>())));
 
-    List<ListenableFuture<Void>> futures = new LinkedList<>();
+    List<CompletionStage<Void>> futures = new LinkedList<>();
     for (final BatchRequest batch : batches) {
-      futures.add(
-          executor.submit(
-              () -> {
-                batch.execute();
-                return null;
-              }));
+      futures.add(MoreFutures.runAsync(
+          () -> {
+            batch.execute();
+          },
+          executor));
     }
 
     try {
-      Futures.allAsList(futures).get();
+      MoreFutures.get(MoreFutures.allAsList(futures));
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while executing batch GCS request", e);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.auto.value.AutoValue;
-import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.RowFilter;
@@ -33,9 +32,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.MoreExecutors;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Arrays;
@@ -705,10 +701,14 @@ public class BigtableIO {
       @ProcessElement
       public void processElement(ProcessContext c) throws Exception {
         checkForFailures();
-        Futures.addCallback(
-            bigtableWriter.writeRecord(c.element()),
-            new WriteExceptionCallback(c.element()),
-            MoreExecutors.directExecutor());
+        bigtableWriter
+            .writeRecord(c.element())
+            .whenComplete(
+                (mutationResult, exception) -> {
+                  if (exception != null) {
+                    failures.add(new BigtableWriteException(c.element(), exception));
+                  }
+                });
         ++recordsWritten;
       }
 
@@ -771,22 +771,6 @@ public class BigtableIO {
           exception.addSuppressed(e);
         }
         throw exception;
-      }
-
-      private class WriteExceptionCallback implements FutureCallback<MutateRowResponse> {
-        private final KV<ByteString, Iterable<Mutation>> value;
-
-        public WriteExceptionCallback(KV<ByteString, Iterable<Mutation>> value) {
-          this.value = value;
-        }
-
-        @Override
-        public void onFailure(Throwable cause) {
-          failures.add(new BigtableWriteException(value, cause));
-        }
-
-        @Override
-        public void onSuccess(MutateRowResponse produced) {}
       }
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
@@ -22,12 +22,12 @@ import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.Row;
 import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletionStage;
 import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.BigtableSource;
 import org.apache.beam.sdk.values.KV;
 
@@ -47,7 +47,7 @@ interface BigtableService extends Serializable {
      *
      * @throws IOException if there is an error submitting the write.
      */
-    ListenableFuture<MutateRowResponse> writeRecord(KV<ByteString, Iterable<Mutation>> record)
+    CompletionStage<MutateRowResponse> writeRecord(KV<ByteString, Iterable<Mutation>> record)
         throws IOException;
 
     /**

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -56,8 +56,6 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.io.Serializable;
@@ -72,6 +70,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
@@ -1180,7 +1180,7 @@ public class BigtableIOTest {
    * entries. The column family in the {@link SetCell} is ignored; only the value is used.
    *
    * <p>When no {@link SetCell} is provided, the write will fail and this will be exposed via an
-   * exception on the returned {@link ListenableFuture}.
+   * exception on the returned {@link CompletionStage}.
    */
   private static class FakeBigtableWriter implements BigtableService.Writer {
     private final String tableId;
@@ -1190,7 +1190,7 @@ public class BigtableIOTest {
     }
 
     @Override
-    public ListenableFuture<MutateRowResponse> writeRecord(
+    public CompletionStage<MutateRowResponse> writeRecord(
         KV<ByteString, Iterable<Mutation>> record) {
       service.verifyTableExists(tableId);
       Map<ByteString, ByteString> table = service.getTable(tableId);
@@ -1198,11 +1198,13 @@ public class BigtableIOTest {
       for (Mutation m : record.getValue()) {
         SetCell cell = m.getSetCell();
         if (cell.getValue().isEmpty()) {
-          return Futures.immediateFailedCheckedFuture(new IOException("cell value missing"));
+          CompletableFuture<MutateRowResponse> result = new CompletableFuture<>();
+          result.completeExceptionally(new IOException("cell value missing"));
+          return result;
         }
         table.put(key, cell.getValue());
       }
-      return Futures.immediateFuture(MutateRowResponse.getDefaultInstance());
+      return CompletableFuture.completedFuture(MutateRowResponse.getDefaultInstance());
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.bigtable.v2.MutateRowsRequest.Entry;
 import com.google.bigtable.v2.Mutation;
@@ -36,6 +37,8 @@ import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Arrays;
@@ -132,7 +135,11 @@ public class BigtableServiceImplTest {
     Mutation mutation = Mutation.newBuilder()
         .setSetCell(SetCell.newBuilder().setFamilyName("Family").build()).build();
     ByteString key = ByteString.copyFromUtf8("key");
-    underTest.writeRecord(KV.of(key, (Iterable<Mutation>) Arrays.asList(mutation)));
+
+    SettableFuture<MutateRowResponse> fakeResponse = SettableFuture.create();
+    when(mockBulkMutation.add(any(MutateRowsRequest.Entry.class))).thenReturn(fakeResponse);
+
+    underTest.writeRecord(KV.of(key, ImmutableList.of(mutation)));
     Entry expected = MutateRowsRequest.Entry.newBuilder()
         .setRowKey(key)
         .addMutations(mutation)


### PR DESCRIPTION
This ports the Beam codebase from Guava futures to Java 8 futures. This has been discussed at length on the Beam dev list.

The standards that I have held:

 - Consumers of futures use `CompletionStage`. They can do async chaining and can use `MoreFutures.get(...)` to get the result without passing through types they shouldn't be touching.
 - Producers of futures use `CompletableFuture` and return it as a `CompletionStage`.
 - When you need to handle exceptions in a reasonable way, use `MoreFutures` helpers that will complete things exceptionally based on the underlying function throwing.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

