### PR TITLE
Match Maven Java SDK harness jar name format

### DIFF
--- a/sdks/java/container/build.gradle
+++ b/sdks/java/container/build.gradle
@@ -46,7 +46,7 @@ task copyDockerfileDependencies(type: Copy) {
   from configurations.dockerDependency
   rename "slf4j-api.*", "slf4j-api.jar"
   rename "slf4j-jdk14.*", "slf4j-jdk14.jar"
-  rename "beam-sdks-java-harness.*", "beam-sdks-java-harness.jar"
+  rename "harness.*\\.jar", "beam-sdks-java-harness.jar"
   into "build/target"
 }
 


### PR DESCRIPTION
Without this change, the Java SDK image Docker build fails because the `beam-sdks-java-harness.jar` does not exist. This jar is copied over and renamed from the harness build directory in the `copyDockerfileDependencies` task. The source file pattern needs to match the output jar artifact here.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

