### PR TITLE
[BEAM-410] Sort PriorityQueue<QuantileBuffer> with explicit comparator

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/findbugs-filter.xml
@@ -337,12 +337,6 @@
     <!--[BEAM-407] Inconsistent synchronization -->
   </Match>
   <Match>
-    <Class name="org.apache.beam.sdk.transforms.ApproximateQuantiles$QuantileBuffer"/>
-    <Method name="compareTo"/>
-    <Bug pattern="EQ_COMPARETO_USE_OBJECT_EQUALS"/>
-    <!--[BEAM-410] Class defines compareTo(...) and uses Object.equals()-->
-  </Match>
-  <Match>
     <Class name="org.apache.beam.sdk.util.CombineFnUtil$NonSerializableBoundedCombineFn"/>
     <Field name="context"/>
     <Bug pattern="SE_BAD_FIELD"/>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateQuantiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateQuantiles.java
@@ -420,7 +420,8 @@ public class ApproximateQuantiles {
       this.numQuantiles = numQuantiles;
       this.numBuffers = numBuffers;
       this.bufferSize = bufferSize;
-      this.buffers = new PriorityQueue<>(numBuffers + 1);
+      this.buffers = new PriorityQueue<>(numBuffers + 1,
+          (q1, q2) -> Integer.compare(q1.level, q2.level));
       this.min = min;
       this.max = max;
       this.unbufferedElements.addAll(unbufferedElements);
@@ -620,7 +621,7 @@ public class ApproximateQuantiles {
   /**
    * A single buffer in the sense of the referenced algorithm.
    */
-  private static class QuantileBuffer<T> implements Comparable<QuantileBuffer<T>> {
+  private static class QuantileBuffer<T> {
     private int level;
     private long weight;
     private List<T> elements;
@@ -633,11 +634,6 @@ public class ApproximateQuantiles {
       this.level = level;
       this.weight = weight;
       this.elements = elements;
-    }
-
-    @Override
-    public int compareTo(QuantileBuffer<T> other) {
-      return this.level - other.level;
     }
 
     @Override


### PR DESCRIPTION
This changes the `PriorityQueue<QuantileBuffer>` to sort with explicit comparator rather then overloading `QuantileBuffer.compareTo()`. This avoids potential issues around `compareTo()` returning 0 for values that aren't equal. It also fixes FindBugs warnings about `compareTo()` being overloaded without also overloading `equals()` and removes the FindBugs filter.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
