### PR TITLE
Consistantly show Python and pip versions in tests

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -33,6 +33,7 @@ deps =
 whitelist_externals=find
 commands =
   python --version
+  pip --version
   # Clean up all previous python generated files.
   - find apache_beam -type f -name '*.pyc' -delete
   pip install -e .[test]
@@ -56,6 +57,7 @@ whitelist_externals=
   time
 commands =
   python --version
+  pip --version
   # Clean up all previous python generated files.
   - find apache_beam -type f -name '*.pyc' -delete
   # Clean up all previous cython generated files.
@@ -79,8 +81,9 @@ deps =
   nose==1.3.7
 whitelist_externals=find
 commands =
-  pip install -e .[test,gcp]
   python --version
+  pip --version
+  pip install -e .[test,gcp]
   # Clean up all previous python generated files.
   - find apache_beam -type f -name '*.pyc' -delete
   python apache_beam/examples/complete/autocomplete_test.py
@@ -96,6 +99,8 @@ deps=
   isort==4.2.15
 whitelist_externals=time
 commands =
+  python --version
+  pip --version
   time pip install -e .[test]
   time {toxinidir}/run_pylint.sh
 passenv = TRAVIS*
@@ -108,6 +113,8 @@ deps=
   sphinx_rtd_theme==0.2.4
 whitelist_externals=time
 commands =
+  python --version
+  pip --version
   time pip install -e .[test,gcp,docs]
   time {toxinidir}/generate_pydoc.sh
 passenv = TRAVIS*
@@ -120,6 +127,7 @@ deps =
 whitelist_externals=find
 commands =
   python --version
+  pip --version
   pip install -e .[test,gcp]
   # Clean up all previous python generated files.
   - find apache_beam -type f -name '*.pyc' -delete


### PR DESCRIPTION
Testing with Python versions < 2.7.9 is causing Requests to raise InsecurePlatformWarnings and SNIMissingWarnings.

https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings

http://docs.python-requests.org/en/master/community/faq/#what-are-hostname-doesn-t-match-errors

py27 runtests: commands[0] | python --version
__Python 2.7.6__  <-- _How do we upgrade this?  (v2.7.14 is current)_
py27 runtests: commands[1] | pip --version
pip 9.0.1 from /home/jenkins/jenkins-slave/workspace/beam_PreCommit_Python_MavenInstall/src/sdks/python/target/.tox/py27/local/lib/python2.7/site-packages (python 2.7)
