### PR TITLE
Test: Py3.6 flake8 --select=E901,E999,F821,F822,F823

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,7 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py27,py27gcp,py27cython,lint,docs
+envlist = py27,py27gcp,py27cython,py36,lint,docs
 toxworkdir = {toxinidir}/target/.tox
 
 [pycodestyle]
@@ -88,6 +88,16 @@ commands =
   - find apache_beam -type f -name '*.pyc' -delete
   python apache_beam/examples/complete/autocomplete_test.py
   python setup.py test
+passenv = TRAVIS*
+
+[testenv:py36]
+# autocomplete_test depends on nose when invoked directly.
+deps =
+  flake8==3.5.0
+commands =
+  python --version
+  pip --version
+  flake8 . --count --exit-zero --select=E901,E999,F821,F822,F823 --show-source --statistics
 passenv = TRAVIS*
 
 [testenv:lint]

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -91,7 +91,6 @@ commands =
 passenv = TRAVIS*
 
 [testenv:py36]
-# autocomplete_test depends on nose when invoked directly.
 deps =
   flake8==3.5.0
 commands =


### PR DESCRIPTION
Run flake8 on Python 3 to find syntax errors and undefined names.   __--exit-zero__ treats _all_ errors as warnings.