### PR TITLE
[BEAM-2728] Add TDigest implementation for finding Quantiles to sketching extension

### DIFF
--- a/sdks/java/extensions/sketching/build.gradle
+++ b/sdks/java/extensions/sketching/build.gradle
@@ -22,11 +22,13 @@ applyJavaNature()
 description = "Apache Beam :: SDKs :: Java :: Extensions :: Sketching"
 
 def streamlib_version = "2.9.5"
+def tdigest_version = "3.2"
 
 dependencies {
   compile library.java.guava
   shadow project(path: ":sdks:java:core", configuration: "shadow")
   shadow "com.clearspring.analytics:stream:$streamlib_version"
+  shadow "com.tdunning:t-digest:$tdigest_version"
   shadow library.java.slf4j_api
   shadowTest library.java.avro
   shadowTest library.java.commons_lang3

--- a/sdks/java/extensions/sketching/pom.xml
+++ b/sdks/java/extensions/sketching/pom.xml
@@ -31,6 +31,7 @@
 
   <properties>
     <streamlib.version>2.9.5</streamlib.version>
+    <t-digest.version>3.2</t-digest.version>
   </properties>
 
   <dependencies>
@@ -50,7 +51,7 @@
     <dependency>
       <groupId>com.tdunning</groupId>
       <artifactId>t-digest</artifactId>
-      <version>3.2</version>
+      <version>${t-digest.version}</version>
     </dependency>
 
     <dependency>

--- a/sdks/java/extensions/sketching/pom.xml
+++ b/sdks/java/extensions/sketching/pom.xml
@@ -39,11 +39,18 @@
       <artifactId>beam-sdks-java-core</artifactId>
     </dependency>
 
-    <!-- Library containing sketches' implementation -->
+    <!-- Library containing sketches' implementations -->
     <dependency>
       <groupId>com.clearspring.analytics</groupId>
       <artifactId>stream</artifactId>
       <version>${streamlib.version}</version>
+    </dependency>
+
+    <!-- Ted Dunning's library for t-digest implementation -->
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+      <version>3.2</version>
     </dependency>
 
     <dependency>

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
@@ -259,7 +259,7 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new precision {@code p}.
+     * Sets the precision {@code p}.
      *
      * <p>Keep in mind that {@code p} cannot be lower than 4, because the estimation would be too
      * inaccurate.
@@ -275,7 +275,7 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link PTransform} with a sparse representation of precision {@code sp}.
+     * Sets the sparse representation's precision {@code sp}.
      *
      * <p>Values above 32 are not yet supported by the AddThis version of HyperLogLog+.
      *
@@ -333,7 +333,7 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new precision {@code p}.
+     * Sets the precision {@code p}.
      *
      * <p>Keep in mind that {@code p} cannot be lower than 4, because the estimation would be too
      * inaccurate.
@@ -349,7 +349,7 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link PTransform} with a sparse representation of precision {@code sp}.
+     * Sets the sparse representation's precision {@code sp}.
      *
      * <p>Values above 32 are not yet supported by the AddThis version of HyperLogLog+.
      *
@@ -411,7 +411,7 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link ApproximateDistinctFn} combiner with a new precision {@code p}.
+     * Returns an {@link ApproximateDistinctFn} combiner with a new precision {@code p}.
      *
      * <p>Keep in mind that {@code p} cannot be lower than 4, because the estimation would be too
      * inaccurate.
@@ -428,8 +428,8 @@ public final class ApproximateDistinct {
     }
 
     /**
-     * Returns a new {@link ApproximateDistinctFn} combiner with a sparse representation of
-     * precision {@code sp}.
+     * Returns an {@link ApproximateDistinctFn} combiner with a new
+     * sparse representation's precision {@code sp}.
      *
      * <p>Values above 32 are not yet supported by the AddThis version of HyperLogLog+.
      *

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/ApproximateDistinct.java
@@ -258,10 +258,32 @@ public final class ApproximateDistinct {
       abstract GloballyDistinct<InputT> build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new precision {@code p}.
+     *
+     * <p>Keep in mind that {@code p} cannot be lower than 4, because the estimation would be too
+     * inaccurate.
+     *
+     * <p>See {@link ApproximateDistinct#precisionForRelativeError(double)} and {@link
+     * ApproximateDistinct#relativeErrorForPrecision(int)} to have more information about the
+     * relationship between precision and relative error.
+     *
+     * @param p the precision value for the normal representation
+     */
     public GloballyDistinct<InputT> withPrecision(int p) {
       return toBuilder().setPrecision(p).build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a sparse representation of precision {@code sp}.
+     *
+     * <p>Values above 32 are not yet supported by the AddThis version of HyperLogLog+.
+     *
+     * <p>Fore more information about the sparse representation, read Google's paper available <a
+     * href="https://research.google.com/pubs/pub40671.html">here</a>.
+     *
+     * @param sp the precision of HyperLogLog+' sparse representation
+     */
     public GloballyDistinct<InputT> withSparsePrecision(int sp) {
       return toBuilder().setSparsePrecision(sp).build();
     }
@@ -310,10 +332,32 @@ public final class ApproximateDistinct {
       abstract PerKeyDistinct<K, V> build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new precision {@code p}.
+     *
+     * <p>Keep in mind that {@code p} cannot be lower than 4, because the estimation would be too
+     * inaccurate.
+     *
+     * <p>See {@link ApproximateDistinct#precisionForRelativeError(double)} and {@link
+     * ApproximateDistinct#relativeErrorForPrecision(int)} to have more information about the
+     * relationship between precision and relative error.
+     *
+     * @param p the precision value for the normal representation
+     */
     public PerKeyDistinct<K, V> withPrecision(int p) {
       return toBuilder().setPrecision(p).build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a sparse representation of precision {@code sp}.
+     *
+     * <p>Values above 32 are not yet supported by the AddThis version of HyperLogLog+.
+     *
+     * <p>Fore more information about the sparse representation, read Google's paper available <a
+     * href="https://research.google.com/pubs/pub40671.html">here</a>.
+     *
+     * @param sp the precision of HyperLogLog+' sparse representation
+     */
     public PerKeyDistinct<K, V> withSparsePrecision(int sp) {
       return toBuilder().setSparsePrecision(sp).build();
     }

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
@@ -236,7 +236,7 @@ public final class SketchFrequencies {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new relative error {@code epsilon}.
+     * Sets the relative error {@code epsilon}.
      *
      * <p>Keep in mind that the lower the {@code epsilon} value, the greater the width.
      *
@@ -247,7 +247,7 @@ public final class SketchFrequencies {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new {@code confidence} value, i.e.
+     * Sets the {@code confidence} value, i.e.
      * the probability that the relative error is lower or equal to {@code epsilon}.
      *
      * <p>Keep in mind that the greater the confidence, the greater the depth.
@@ -299,7 +299,7 @@ public final class SketchFrequencies {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new relative error {@code epsilon}.
+     * Sets the relative error {@code epsilon}.
      *
      * <p>Keep in mind that the lower the {@code epsilon} value, the greater the width.
      *
@@ -310,7 +310,7 @@ public final class SketchFrequencies {
     }
 
     /**
-     * Returns a new {@link PTransform} with a new {@code confidence} value, i.e.
+     * Sets the {@code confidence} value, i.e.
      * the probability that the relative error is lower or equal to {@code epsilon}.
      *
      * <p>Keep in mind that the greater the confidence, the greater the depth.

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
@@ -98,16 +98,15 @@ import org.apache.beam.sdk.values.PCollection;
  *       advanced processing involving the Count-Min sketch.
  * </ul>
  *
- * <h3>Example 1: simple default use</h3>
+ * <h3>Example 1: default use</h3>
  *
- * <p>The simplest use is simply to call the {@link #globally()} or {@link #perKey()} method in
+ * <p>The simplest use is to call the {@link #globally()} or {@link #perKey()} method in
  * order to retrieve the sketch with an estimate number of hits for each element in the stream.
  *
  * <pre><code>
  * {@literal PCollection<MyObject>} pc = ...;
  * {@literal PCollection<CountMinSketch>} countMinSketch = pc.apply(SketchFrequencies
  * {@literal        .<MyObject>}globally()); //{@literal .<MyObject>}perKey();
- * }
  * </code></pre>
  *
  * <h3>Example 2: tune accuracy parameters</h3>
@@ -124,7 +123,6 @@ import org.apache.beam.sdk.values.PCollection;
  * {@literal  .<MyObject>}globally() //{@literal .<MyObject>}perKey()
  *            .withRelativeError(eps)
  *            .withConfidence(conf));
- * }
  * </code></pre>
  *
  * <h3>Example 3: query the resulting sketch</h3>
@@ -153,9 +151,8 @@ import org.apache.beam.sdk.values.PCollection;
  *           public void procesElement(ProcessContext c) {
  *             Long elem = c.element();
  *             CountMinSketch sketch = c.sideInput(sketchView);
- *             sketch.estimateCount(elem, coder);
+ *             c.output(sketch.estimateCount(elem, coder));
  *            }}).withSideInputs(sketchView));
- * }
  * </code></pre>
  *
  * <h3>Example 4: Using the CombineFn</h3>
@@ -175,7 +172,6 @@ import org.apache.beam.sdk.values.PCollection;
  * {@literal PCollection<CountMinSketch>} output = input.apply(Combine.globally(CountMinSketchFn
  * {@literal    .<MyObject>}create(new MyObjectCoder())
  *              .withAccuracy(eps, conf)));
- * }
  * </code></pre>
  *
  * <p><b>Warning: this class is experimental.</b> <br>
@@ -328,7 +324,7 @@ public final class SketchFrequencies {
     }
 
     /**
-     * Returns an {@link CountMinSketchFn} combiner with the given input coder. <br>
+     * Returns a {@link CountMinSketchFn} combiner with the given input coder. <br>
      * <b>Warning :</b> the coder must be deterministic.
      *
      * @param coder the coder that encodes the elements' type

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/SketchFrequencies.java
@@ -235,10 +235,25 @@ public final class SketchFrequencies {
       abstract GlobalSketch<InputT> build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new relative error {@code epsilon}.
+     *
+     * <p>Keep in mind that the lower the {@code epsilon} value, the greater the width.
+     *
+     * @param eps the error relative to the total number of distinct elements
+     */
     public GlobalSketch<InputT> withRelativeError(double eps) {
       return toBuilder().setRelativeError(eps).build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new {@code confidence} value, i.e.
+     * the probability that the relative error is lower or equal to {@code epsilon}.
+     *
+     * <p>Keep in mind that the greater the confidence, the greater the depth.
+     *
+     * @param conf the confidence in the result to not exceed the relative error
+     */
     public GlobalSketch<InputT> withConfidence(double conf) {
       return toBuilder().setConfidence(conf).build();
     }
@@ -283,10 +298,25 @@ public final class SketchFrequencies {
       abstract PerKeySketch<K, V> build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new relative error {@code epsilon}.
+     *
+     * <p>Keep in mind that the lower the {@code epsilon} value, the greater the width.
+     *
+     * @param eps the error relative to the total number of distinct elements
+     */
     public PerKeySketch<K, V> withRelativeError(double eps) {
       return toBuilder().setRelativeError(eps).build();
     }
 
+    /**
+     * Returns a new {@link PTransform} with a new {@code confidence} value, i.e.
+     * the probability that the relative error is lower or equal to {@code epsilon}.
+     *
+     * <p>Keep in mind that the greater the confidence, the greater the depth.
+     *
+     * @param conf the confidence in the result to not exceed the relative error
+     */
     public PerKeySketch<K, V> withConfidence(double conf) {
       return toBuilder().setConfidence(conf).build();
     }

--- a/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/TDigestQuantiles.java
+++ b/sdks/java/extensions/sketching/src/main/java/org/apache/beam/sdk/extensions/sketching/TDigestQuantiles.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sketching;
+
+import com.google.auto.value.AutoValue;
+import com.tdunning.math.stats.MergingDigest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Iterator;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.CustomCoder;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+
+/**
+ * {@code PTransform}s for getting information about quantiles in a stream.
+ *
+ * <p>This class uses the T-Digest structure introduced by Ted Dunning, and more precisely
+ * the {@link MergingDigest} implementation.
+ *
+ * <h2>References</h2>
+ *
+ * <p>The paper and implementation are available on Ted Dunning's
+ * <a href="https://github.com/tdunning/t-digest">Github profile</a>
+ *
+ * <h2>Parameters</h2>
+ *
+ * <p>Only one parameter can be tuned in order ton control the estimation accuracy and memory use,
+ * called the compression factor {@code cf}.
+ *
+ * <p>Stream elements are compressed into a linked list of centroids.
+ * The compression factor is used to limit the number of elements represented by each centroid
+ * as well as the total number of centroids. <br>
+ * The accuracy is really high (in parts per million) for extreme quantiles and
+ * in general {@code <1000 ppm} for middle quantiles. <br>
+ * By default the compression factor is set to 100. A value of 1000 is extremely large.
+ *
+ * <h2>Examples</h2>
+ *
+ * <p>There are 2 ways of using this class:
+ *
+ * <ul>
+ *   <li>Use the {@link PTransform}s that return a {@link PCollection} which contains
+ *       a {@link MergingDigest} for querying the value at a given quantile or
+ *       the approximate quantile position of an element.
+ *   <li>Use the {@link TDigestQuantilesFn} {@code CombineFn} that is exposed in order
+ *   to make advanced processing involving the {@link MergingDigest}.
+ * </ul>
+ *
+ * <h3>Example 1: Default use</h3>
+ *
+ * <p>The simplest use is to call the {@link #globally()} or {@link #perKey()} method in
+ * order to retrieve the digest, and then to query the structure.
+ *
+ * <pre><code>
+ * {@literal PCollection<Double>} pc = ...;
+ * {@literal PCollection<MergingDigest>} countMinSketch = pc.apply(TDigestQuantiles
+ *         .globally()); // .perKey()
+ * </code></pre>
+ *
+ * <h3>Example 2: tune accuracy parameters</h3>
+ *
+ * <p>One can tune the compression factor {@code cf} in order to control accuracy and memory. <br>
+ * This tuning works exactly the same for {@link #globally()} and {@link #perKey()}.
+ *
+ * <pre><code>
+ *  double cf = 500;
+ * {@literal PCollection<Double>} pc = ...;
+ * {@literal PCollection<MergingDigest>} countMinSketch = pc.apply(TDigestQuantiles
+ *         .globally() // .perKey()
+ *         .withCompression(cf);
+ * </code></pre>
+ *
+ * <h3>Example 3 : Query the resulting structure</h3>
+ *
+ * <p>This example shows how to query the resulting structure, for example to
+ * build  {@code PCollection} of {@link KV}s with each pair corresponding to
+ * a couple (quantile, value).
+ *
+ * <pre><code>
+ * {@literal PCollection<MergingDigest>} pc = ...;
+ * {@literal PCollection<KV<Double, Double>>} quantiles = pc.apply(ParDo.of(
+ *        {@literal new DoFn<MergingDigest, KV<Double, Double>>()} {
+ *          {@literal @ProcessElement}
+ *           public void procesElement(ProcessContext c) {
+ *             Double[] quantiles = {0.01, 0.25, 0.5, 0.75, 0.99}
+ *             for (Double q : quantiles) {
+ *                c.output(KV.of(q, c.element().quantile(q));
+ *             }
+ *           }}));
+ * </code></pre>
+ *
+ * <p>One can also retrieve the approximate quantile position of a given element in the stream
+ * using {@code cdf(double)} method instead of {@code quantile(double)}.
+ *
+ * <h3>Example 4: Using the CombineFn</h3>
+ *
+ * <p>The {@code CombineFn} does the same thing as the {@code PTransform}s but
+ * it can be used for doing stateful processing or in
+ * {@link org.apache.beam.sdk.transforms.CombineFns.ComposedCombineFn}.
+ *
+ * <p>This example is not really interesting but it shows how one can properly
+ * create a {@link TDigestQuantilesFn}.
+ *
+ * <pre><code>
+ *  double cf = 250;
+ * {@literal PCollection<Double>} input = ...;
+ * {@literal PCollection<MergingDigest>} output = input.apply(Combine
+ *         .globally(TDigestQuantilesFn.create(cf)));
+ * </code></pre>
+ *
+ * <p><b>Warning: this class is experimental.</b> <br>
+ * Its API is subject to change in future versions of Beam.
+ * */
+@Experimental
+public final class TDigestQuantiles {
+
+  /**
+   * Compute the stream in order to build a T-Digest structure (MergingDigest)
+   * for keeping track of the stream distribution and returns a {@code PCollection<MergingDigest>}.
+   * <br> The resulting structure can be queried in order to retrieve the approximate value
+   * at a given quantile or the approximate quantile position of a given element.
+   */
+  public static GlobalDigest globally() {
+    return GlobalDigest.builder().build();
+  }
+
+  /**
+   * Like {@link #globally()}, but builds a digest for each key in the stream.
+   *
+   * @param <K>             the type of the keys
+   */
+  public static <K> PerKeyDigest<K> perKey() {
+    return PerKeyDigest.<K>builder().build();
+  }
+
+  /** Implementation of {@link #globally()}. */
+  @AutoValue
+  public abstract static class GlobalDigest
+          extends PTransform<PCollection<Double>, PCollection<MergingDigest>> {
+
+    abstract double compression();
+
+    abstract Builder toBuilder();
+
+    static Builder builder() {
+      return new AutoValue_TDigestQuantiles_GlobalDigest.Builder()
+              .setCompression(100);
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setCompression(double cf);
+
+      abstract GlobalDigest build();
+    }
+
+    public GlobalDigest withCompression(double cf) {
+      return toBuilder().setCompression(cf).build();
+    }
+
+    @Override
+    public PCollection<MergingDigest> expand(PCollection<Double> input) {
+      return input.apply(
+                      "Compute HyperLogLog Structure",
+                      Combine.globally(TDigestQuantilesFn.create(this.compression())));
+    }
+  }
+
+  /** Implementation of {@link #perKey()}. */
+  @AutoValue
+  public abstract static class PerKeyDigest<K>
+          extends PTransform<PCollection<KV<K, Double>>, PCollection<KV<K, MergingDigest>>> {
+
+    abstract double compression();
+    abstract Builder<K> toBuilder();
+
+    static <K> Builder<K> builder() {
+      return new AutoValue_TDigestQuantiles_PerKeyDigest.Builder<K>()
+              .setCompression(100);
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<K> {
+      abstract Builder<K> setCompression(double c);
+
+      abstract PerKeyDigest<K> build();
+    }
+
+    public PerKeyDigest<K> withCompression(double c) {
+      return toBuilder().setCompression(c).build();
+    }
+
+    @Override
+    public PCollection<KV<K, MergingDigest>> expand(PCollection<KV<K, Double>> input) {
+      return input.apply(
+              "Compute HyperLogLog Structure",
+              Combine.perKey(TDigestQuantilesFn.create(this.compression())));
+    }
+  }
+
+  /** Implements the {@link Combine.CombineFn} of {@link TDigestQuantiles} transforms. */
+  public static class TDigestQuantilesFn
+      extends Combine.CombineFn<Double, MergingDigest, MergingDigest> {
+
+    private final double compression;
+
+    private TDigestQuantilesFn(double compression) {
+      this.compression = compression;
+    }
+
+    /**
+     * Returns {@link TDigestQuantilesFn} combiner with the given compression factor.
+     *
+     * @param compression   the compression factor guarantees a relative error of at most
+     *                      {@code 3 / compression} on quantiles.
+     */
+    public static TDigestQuantilesFn create(double compression) {
+        if (compression > 0) {
+            return new TDigestQuantilesFn(compression);
+        }
+        throw new IllegalArgumentException("Compression factor should be greater than 0.");
+    }
+
+    @Override public MergingDigest createAccumulator() {
+      return new MergingDigest(compression);
+    }
+
+    @Override public MergingDigest addInput(MergingDigest accum, Double value) {
+      accum.add(value);
+      return accum;
+    }
+
+    /** Output the whole structure so it can be queried, reused or stored easily. */
+    @Override public MergingDigest extractOutput(MergingDigest accum) {
+      return accum;
+    }
+
+    @Override public MergingDigest mergeAccumulators(
+        Iterable<MergingDigest> accumulators) {
+      Iterator<MergingDigest> it = accumulators.iterator();
+      MergingDigest merged = it.next();
+      while (it.hasNext()) {
+        merged.add(it.next());
+      }
+      return merged;
+    }
+
+    @Override public Coder<MergingDigest> getAccumulatorCoder(CoderRegistry registry,
+        Coder inputCoder) {
+      return new MergingDigestCoder();
+    }
+
+    @Override public Coder<MergingDigest> getDefaultOutputCoder(CoderRegistry registry,
+        Coder inputCoder) {
+      return new MergingDigestCoder();
+    }
+
+    @Override public MergingDigest defaultValue() {
+      return new MergingDigest(10);
+    }
+  }
+
+  /** Coder for {@link MergingDigest} class. */
+  static class MergingDigestCoder extends CustomCoder<MergingDigest> {
+
+    private static final ByteArrayCoder BYTE_ARRAY_CODER = ByteArrayCoder.of();
+
+    @Override public void encode(MergingDigest value, OutputStream outStream)
+          throws IOException {
+      if (value == null) {
+        throw new CoderException("cannot encode a null T-Digest sketch");
+      }
+      ByteBuffer buf = ByteBuffer.allocate(value.smallByteSize());
+      value.asSmallBytes(buf);
+      BYTE_ARRAY_CODER.encode(buf.array(), outStream);
+    }
+
+    @Override public MergingDigest decode(InputStream inStream) throws IOException {
+      byte[] bytes = BYTE_ARRAY_CODER.decode(inStream);
+      ByteBuffer buf = ByteBuffer.wrap(bytes);
+      return MergingDigest.fromBytes(buf);
+    }
+
+    @Override public boolean isRegisterByteSizeObserverCheap(MergingDigest value) {
+      return true;
+    }
+
+    @Override protected long getEncodedElementByteSize(MergingDigest value)
+          throws IOException {
+      if (value == null) {
+        throw new CoderException("cannot encode a null T-Digest sketch");
+      }
+      return value.smallByteSize();
+    }
+  }
+}

--- a/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/TDigestQuantilesTest.java
+++ b/sdks/java/extensions/sketching/src/test/java/org/apache/beam/sdk/extensions/sketching/TDigestQuantilesTest.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sketching;
+
+import com.tdunning.math.stats.Centroid;
+import com.tdunning.math.stats.MergingDigest;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import org.apache.beam.sdk.extensions.sketching.TDigestQuantiles.MergingDigestCoder;
+import org.apache.beam.sdk.extensions.sketching.TDigestQuantiles.TDigestQuantilesFn;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.Values;
+import org.apache.beam.sdk.transforms.WithKeys;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests for {@link TDigestQuantiles}. */
+public class TDigestQuantilesTest {
+
+  @Rule public final transient TestPipeline tp = TestPipeline.create();
+
+  private static final List<Double> stream = generateStream();
+
+  private static final int size = 999;
+
+  private static final int compression = 100;
+
+  private static List<Double> generateStream() {
+    List<Double> li = new ArrayList<>();
+    for (double i = 1D; i <= size; i++) {
+      li.add(i);
+    }
+    Collections.shuffle(li);
+    return li;
+  }
+
+  @Test
+  public void globally() {
+    PCollection<KV<Double, Double>> col = tp.apply(Create.of(stream))
+            .apply(TDigestQuantiles.globally().withCompression(compression))
+            .apply(ParDo.of(new RetrieveQuantiles(0.25, 0.5, 0.75, 0.99)));
+
+    PAssert.that("Verify Accuracy", col).satisfies(new VerifyAccuracy());
+    tp.run();
+  }
+
+  @Test
+  public void perKey() {
+    PCollection<KV<Double, Double>> col = tp.apply(Create.of(stream))
+            .apply(WithKeys.<Integer, Double>of(1))
+            .apply(TDigestQuantiles.<Integer>perKey().withCompression(compression))
+            .apply(Values.<MergingDigest>create())
+            .apply(ParDo.of(new RetrieveQuantiles(0.25,  0.5, 0.75, 0.99)));
+
+    PAssert.that("Verify Accuracy", col).satisfies(new VerifyAccuracy());
+
+    tp.run();
+  }
+
+  @Test
+  public void testCoder() throws Exception {
+    MergingDigest tDigest = new MergingDigest(1000);
+    for (int i = 0; i < 10; i++) {
+      tDigest.add(2.4 + i);
+    }
+
+    Assert.assertTrue("Encode and Decode", encodeDecodeEquals(tDigest));
+  }
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testMergeAccum() {
+      Random rd = new Random(1234);
+      List<MergingDigest> accums = new ArrayList<>();
+      for (int i = 0; i < 3; i++) {
+          MergingDigest std = new MergingDigest(100);
+          for (int j = 0; j < 1000; j++) {
+              std.add(rd.nextDouble());
+          }
+          accums.add(std);
+      }
+      TDigestQuantilesFn fn = TDigestQuantilesFn.create(100);
+      MergingDigest res = fn.mergeAccumulators(accums);
+  }
+
+  private <T> boolean encodeDecodeEquals(MergingDigest tDigest) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    MergingDigestCoder tDigestCoder = new MergingDigestCoder();
+
+    tDigestCoder.encode(tDigest, baos);
+    byte[] bytes = baos.toByteArray();
+
+    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+    MergingDigest decoded = tDigestCoder.decode(bais);
+
+    boolean equal = true;
+    // the only way to compare the two sketches is to compare them centroid by centroid.
+    // Indeed, the means are doubles but are encoded as float and cast during decoding.
+    // This entails a small approximation that makes the centroids different after decoding.
+    Iterator<Centroid> it1 = decoded.centroids().iterator();
+    Iterator<Centroid> it2 = tDigest.centroids().iterator();
+
+    for (int i = 0; i < decoded.centroids().size(); i++) {
+      Centroid c1 = it1.next();
+      Centroid c2 = it2.next();
+      if ((float) c1.mean() != (float) c2.mean() || c1.count() != c2.count()) {
+        equal = false;
+        break;
+      }
+    }
+    return equal;
+  }
+
+  static class RetrieveQuantiles extends DoFn<MergingDigest, KV<Double, Double>> {
+    private final double quantile;
+    private final double[] otherQ;
+
+    public RetrieveQuantiles(double q, double... otherQ) {
+      this.quantile = q;
+      this.otherQ = otherQ;
+    }
+
+    @ProcessElement public void processElement(ProcessContext c) {
+      c.output(KV.of(quantile, c.element().quantile(quantile)));
+      for (Double q : otherQ) {
+        c.output(KV.of(q, c.element().quantile(q)));
+      }
+    }
+  }
+
+  static class VerifyAccuracy implements SerializableFunction<Iterable<KV<Double, Double>>, Void> {
+
+    double expectedError = 3D / compression;
+
+    public Void apply(Iterable<KV<Double, Double>> input) {
+      for (KV<Double, Double> pair : input) {
+        double expectedValue = pair.getKey() * size;
+        boolean isAccurate = Math.abs(pair.getValue() - expectedValue)
+                / size <= expectedError;
+        Assert.assertTrue("not accurate enough : \nQuantile " + pair.getKey()
+                        + " is " + pair.getValue() + " and not " + expectedValue,
+                isAccurate);
+      }
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new functionality : finding quantiles in a stream of Double-typed elements thanks to Ted Dunning's T-Digest implementation. More precisely, MergingDigest is used.

As for previous structures, AutoValue is used to build transforms in a firendly manner.

The PR also comes with minor Javadoc corrections in SketchFrequencies (first commit)

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

