### PR TITLE
Exception.message was removed in Python 3

### DIFF
--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -221,7 +221,7 @@ class PipelineTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       pipeline.apply(transform, pcoll2)
     self.assertEqual(
-        cm.exception.message,
+        cm.exception.args[0],
         'Transform "CustomTransform" does not have a stable unique label. '
         'This will prevent updating of pipelines. '
         'To apply a transform with a specified label write '

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
@@ -75,7 +75,7 @@ class SetupTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       dependency.stage_job_resources(PipelineOptions())
     self.assertEqual('The --staging_location option must be specified.',
-                     cm.exception.message)
+                     cm.exception.args[0])
 
   def test_no_temp_location(self):
     staging_dir = self.make_temp_dir()
@@ -87,7 +87,7 @@ class SetupTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       dependency.stage_job_resources(options)
     self.assertEqual('The --temp_location option must be specified.',
-                     cm.exception.message)
+                     cm.exception.args[0])
 
   def test_no_main_session(self):
     staging_dir = self.make_temp_dir()
@@ -161,7 +161,7 @@ class SetupTest(unittest.TestCase):
       dependency.stage_job_resources(
           options, populate_requirements_cache=self.populate_requirements_cache)
     self.assertEqual(
-        cm.exception.message,
+        cm.exception.args[0],
         'The file %s cannot be found. It was specified in the '
         '--requirements_file command line option.' % 'nosuchfile')
 
@@ -229,7 +229,7 @@ class SetupTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       dependency.stage_job_resources(options)
     self.assertEqual(
-        cm.exception.message,
+        cm.exception.args[0],
         'The file %s cannot be found. It was specified in the '
         '--setup_file command line option.' % 'nosuchfile')
 
@@ -248,7 +248,7 @@ class SetupTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as cm:
       dependency.stage_job_resources(options)
     self.assertTrue(
-        cm.exception.message.startswith(
+        cm.exception.args[0].startswith(
             'The --setup_file option expects the full path to a file named '
             'setup.py instead of '))
 
@@ -338,7 +338,7 @@ class SetupTest(unittest.TestCase):
         'The file "%s" cannot be found. Its '
         'location was specified by the --sdk_location command-line option.' %
         sdk_location,
-        cm.exception.message)
+        cm.exception.args[0])
 
   def test_sdk_location_gcs(self):
     staging_dir = self.make_temp_dir()
@@ -415,7 +415,7 @@ class SetupTest(unittest.TestCase):
 
       dependency.stage_job_resources(options)
     self.assertEqual(
-        cm.exception.message,
+        cm.exception.args[0],
         'The file %s cannot be found. It was specified in the '
         '--extra_packages command line option.' % 'nosuchfile.tar.gz')
 
@@ -432,7 +432,7 @@ class SetupTest(unittest.TestCase):
           os.path.join(source_dir, 'abc.tgz')]
       dependency.stage_job_resources(options)
     self.assertEqual(
-        cm.exception.message,
+        cm.exception.args[0],
         'The --extra_package option expects a full path ending with '
         '".tar", ".tar.gz", ".whl" or ".zip" '
         'instead of %s' % os.path.join(source_dir, 'abc.tgz'))

--- a/sdks/python/apache_beam/testing/pipeline_verifiers_test.py
+++ b/sdks/python/apache_beam/testing/pipeline_verifiers_test.py
@@ -127,7 +127,7 @@ class PipelineVerifiersTest(unittest.TestCase):
       verifiers.FileChecksumMatcher('file_path',
                                     'expected_checksum',
                                     'invalid_sleep_time')
-    self.assertEqual(cm.exception.message,
+    self.assertEqual(cm.exception.args[0],
                      'Sleep seconds, if received, must be int. '
                      'But received: \'invalid_sleep_time\', '
                      '<type \'str\'>')

--- a/sdks/python/apache_beam/testing/test_utils_test.py
+++ b/sdks/python/apache_beam/testing/test_utils_test.py
@@ -49,7 +49,7 @@ class TestUtilsTest(unittest.TestCase):
     with self.assertRaises(BeamIOError) as error:
       utils.delete_files([path])
     self.assertTrue(
-        error.exception.message.startswith('Delete operation failed'))
+        error.exception.args[0].startswith('Delete operation failed'))
     self.assertEqual(error.exception.exception_details.keys(), [path])
 
   def test_delete_files_fails_with_invalid_arg(self):

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -154,7 +154,7 @@ class PTransformTest(unittest.TestCase):
 
     expected_error_prefix = ('Returning a str from a ParDo or FlatMap '
                              'is discouraged.')
-    self.assertStartswith(cm.exception.message, expected_error_prefix)
+    self.assertStartswith(cm.exception.args[0], expected_error_prefix)
 
   def test_do_with_do_fn_returning_dict_raises_warning(self):
     pipeline = TestPipeline()
@@ -169,7 +169,7 @@ class PTransformTest(unittest.TestCase):
 
     expected_error_prefix = ('Returning a dict from a ParDo or FlatMap '
                              'is discouraged.')
-    self.assertStartswith(cm.exception.message, expected_error_prefix)
+    self.assertStartswith(cm.exception.args[0], expected_error_prefix)
 
   def test_do_with_multiple_outputs_maintains_unique_name(self):
     pipeline = TestPipeline()
@@ -284,7 +284,7 @@ class PTransformTest(unittest.TestCase):
       pipeline.run()
 
     expected_error_prefix = 'FlatMap and ParDo must return an iterable.'
-    self.assertStartswith(cm.exception.message, expected_error_prefix)
+    self.assertStartswith(cm.exception.args[0], expected_error_prefix)
 
   def test_do_fn_with_finish(self):
     class MyDoFn(beam.DoFn):
@@ -601,7 +601,7 @@ class PTransformTest(unittest.TestCase):
       pipeline.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         'Input type hint violation at D: expected '
         'Tuple[TypeVariable[K], TypeVariable[V]]')
 
@@ -614,7 +614,7 @@ class PTransformTest(unittest.TestCase):
 
     expected_error_prefix = ('Input type hint violation at D: expected '
                              'Tuple[TypeVariable[K], TypeVariable[V]]')
-    self.assertStartswith(cm.exception.message, expected_error_prefix)
+    self.assertStartswith(cm.exception.args[0], expected_error_prefix)
 
   def test_keys_and_values(self):
     pipeline = TestPipeline()
@@ -934,7 +934,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Upper': "
                      "requires <type 'str'> but got <type 'int'> for element",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_do_fn_pipeline_runtime_type_check_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -969,7 +969,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Add': "
                      "requires <type 'int'> but got <type 'str'> for element",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_pardo_does_not_type_check_using_type_hint_decorators(self):
     @with_input_types(a=int)
@@ -986,7 +986,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'ToStr': "
                      "requires <type 'int'> but got <type 'str'> for a",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_pardo_properly_type_checks_using_type_hint_decorators(self):
     @with_input_types(a=str)
@@ -1018,7 +1018,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Upper': "
                      "requires <type 'str'> but got <type 'int'> for x",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_pardo_properly_type_checks_using_type_hint_methods(self):
     # Pipeline should be created successfully without an error
@@ -1043,7 +1043,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Upper': "
                      "requires <type 'str'> but got <type 'int'> for x",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_map_properly_type_checks_using_type_hints_methods(self):
     # No error should be raised if this type-checks properly.
@@ -1069,7 +1069,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Upper': "
                      "requires <type 'str'> but got <type 'int'> for s",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_map_properly_type_checks_using_type_hints_decorator(self):
     @with_input_types(a=bool)
@@ -1096,7 +1096,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Below 3': "
                      "requires <type 'int'> but got <type 'str'> for x",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_filter_type_checks_using_type_hints_method(self):
     # No error should be raised if this type-checks properly.
@@ -1121,7 +1121,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Type hint violation for 'Half': "
                      "requires <type 'float'> but got <type 'int'> for a",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_filter_type_checks_using_type_hints_decorator(self):
     @with_input_types(b=int)
@@ -1170,7 +1170,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual("Input type hint violation at F: "
                      "expected Tuple[TypeVariable[K], TypeVariable[V]], "
                      "got <type 'int'>",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_group_by_does_not_type_check(self):
     # Create is returning a List[int, str], rather than a KV[int, str] that is
@@ -1184,7 +1184,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual("Input type hint violation at T: "
                      "expected Tuple[TypeVariable[K], TypeVariable[V]], "
                      "got Iterable[int]",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_pipeline_checking_pardo_insufficient_type_information(self):
     self.p._options.view_as(TypeOptions).type_check_strictness = 'ALL_REQUIRED'
@@ -1198,7 +1198,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual('Pipeline type checking is enabled, however no output '
                      'type-hint was found for the PTransform Create(Nums)',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_pipeline_checking_gbk_insufficient_type_information(self):
     self.p._options.view_as(TypeOptions).type_check_strictness = 'ALL_REQUIRED'
@@ -1213,7 +1213,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual('Pipeline type checking is enabled, however no output '
                      'type-hint was found for the PTransform '
                      'ParDo(ModDup)',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_disable_pipeline_type_check(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
@@ -1243,7 +1243,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(ToStr): "
         "Type-hint for argument: 'x' violated. "
         "Expected an instance of <type 'int'>, "
@@ -1294,7 +1294,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(IsEven): "
         "Tuple[bool, int] hint type-constraint violated. "
         "The type of element #0 in the passed tuple is incorrect. "
@@ -1334,7 +1334,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(ToInt): "
         "Type-hint for argument: 'x' violated. "
         "Expected an instance of <type 'str'>, "
@@ -1353,7 +1353,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(Add): "
         "Type-hint for argument: 'x_y' violated: "
         "Tuple[int, int] hint type-constraint violated. "
@@ -1380,7 +1380,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within "
         "ParDo(ToInt): "
         "According to type-hint expected output should be "
@@ -1404,7 +1404,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within "
         "ParDo(Swap): Tuple type constraint violated. "
         "Valid object instance must be of type 'tuple'. Instead, "
@@ -1424,7 +1424,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(Add 1): "
         "Type-hint for argument: 'b' violated. "
         "Expected an instance of <type 'int'>, "
@@ -1443,7 +1443,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within ParDo(Add 1): "
         "Type-hint for argument: 'one' violated. "
         "Expected an instance of <type 'int'>, "
@@ -1478,7 +1478,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "All functions for a Combine PTransform must accept a "
         "single argument compatible with: Iterable[Any]. "
         "Instead a function with input type: <type 'int'> was received.",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_combine_pipeline_type_propagation_using_decorators(self):
     @with_output_types(int)
@@ -1532,7 +1532,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within "
         "Mul/CombinePerKey: "
         "Type-hint for return type violated. "
@@ -1572,7 +1572,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
 
     self.assertEqual("Input type hint violation at SortJoin: "
                      "expected <type 'str'>, got <type 'int'>",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_combine_runtime_type_check_violation_using_methods(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False
@@ -1586,7 +1586,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within "
         "ParDo(SortJoin/KeyWithVoid): "
         "Type-hint for argument: 'v' violated. "
@@ -1603,7 +1603,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
        | 'F' >> beam.Map(lambda x: x + 1))
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         'Pipeline type checking is enabled, '
         'however no output type-hint was found for the PTransform '
         'ParDo('
@@ -1628,7 +1628,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Type hint violation for 'CombinePerKey': "
         "requires Tuple[TypeVariable[K], Union[float, int, long]] "
         "but got Tuple[None, str] for element",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_mean_globally_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1659,7 +1659,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
                        "the passed Iterable is incorrect: Union[int, float] "
                        "type-constraint violated. Expected an instance of one "
                        "of: ('int', 'float'), received str instead.",
-                       e.exception.message)
+                       e.exception.args[0])
 
   def test_mean_per_key_pipeline_checking_satisfied(self):
     d = (self.p
@@ -1685,7 +1685,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Type hint violation for 'CombinePerKey(MeanCombineFn)': "
         "requires Tuple[TypeVariable[K], Union[float, int, long]] "
         "but got Tuple[str, str] for element",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_mean_per_key_runtime_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1713,7 +1713,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
       self.p.run()
 
     self.assertStartswith(
-        e.exception.message,
+        e.exception.args[0],
         "Runtime type violation detected within "
         "OddMean/CombinePerKey(MeanCombineFn): "
         "Type-hint for argument: 'element' violated: "
@@ -1762,7 +1762,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Type hint violation for 'CombinePerKey(CountCombineFn)': "
         "requires Tuple[TypeVariable[K], Any] "
         "but got <type 'int'> for element",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_count_perkey_runtime_type_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1797,7 +1797,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual('Pipeline type checking is enabled, however no output '
                      'type-hint was found for the PTransform '
                      'Create(f)',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_count_perelement_runtime_type_checking_satisfied(self):
     self.p._options.view_as(TypeOptions).runtime_type_check = True
@@ -1843,7 +1843,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "Type hint violation for 'CombinePerKey(TopCombineFn)': "
         "requires Tuple[TypeVariable[K], TypeVariable[T]] "
         "but got <type 'int'> for element",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_per_key_pipeline_checking_satisfied(self):
     d = (self.p
@@ -1978,7 +1978,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
         "requires "
         "Tuple[TypeVariable[K], Tuple[TypeVariable[K], TypeVariable[V]]] "
         "but got Tuple[None, int] for element",
-        e.exception.message)
+        e.exception.args[0])
 
   def test_to_dict_pipeline_check_satisfied(self):
     d = (self.p
@@ -2015,7 +2015,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     # Instead the above pipeline should have triggered a regular Python runtime
     # TypeError.
     self.assertEqual("object of type 'int' has no len() [while running 'Len']",
-                     e.exception.message)
+                     e.exception.args[0])
     self.assertFalse(isinstance(e, typehints.TypeCheckError))
 
   def test_pardo_type_inference(self):
@@ -2048,7 +2048,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
     self.assertEqual('Input type hint violation at GroupByKey: '
                      'expected Tuple[TypeVariable[K], TypeVariable[V]], '
                      'got Tuple[str, int, float]',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_inference_command_line_flag_toggle(self):
     self.p._options.view_as(TypeOptions).pipeline_type_check = False

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -173,7 +173,7 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
     try:
       check_constraint(type_constraint, datum)
     except CompositeTypeHintError as e:
-      raise TypeCheckError, e.message, sys.exc_info()[2]
+      raise TypeCheckError, e.args[0], sys.exc_info()[2]
     except SimpleTypeHintError:
       error_msg = ("According to type-hint expected %s should be of type %s. "
                    "Instead, received '%s', an instance of type %s."

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -134,7 +134,7 @@ class UnionHintTestCase(TypeHintTestCase):
     with self.assertRaises(TypeError) as e:
       typehints.Union[5]
     self.assertEqual('Cannot create Union without a sequence of types.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_getitem_must_be_valid_type_param(self):
     t = [2, 3]
@@ -142,7 +142,7 @@ class UnionHintTestCase(TypeHintTestCase):
       typehints.Union[t]
     self.assertEqual('All parameters to a Union hint must be a non-sequence, '
                      'a type, or a TypeConstraint. 2 is an instance of int.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_getitem_duplicates_ignored(self):
     # Types should be de-duplicated.
@@ -219,7 +219,7 @@ class UnionHintTestCase(TypeHintTestCase):
     self.assertEqual("Union[float, int] type-constraint violated. Expected an "
                      "instance of one of: ('float', 'int'), received str "
                      "instead.",
-                     e.exception.message)
+                     e.exception.args[0])
 
 
 class OptionalHintTestCase(TypeHintTestCase):
@@ -227,7 +227,7 @@ class OptionalHintTestCase(TypeHintTestCase):
   def test_getitem_sequence_not_allowed(self):
     with self.assertRaises(TypeError) as e:
       typehints.Optional[int, str]
-    self.assertTrue(e.exception.message.startswith(
+    self.assertTrue(e.exception.args[0].startswith(
         'An Option type-hint only accepts a single type parameter.'))
 
   def test_getitem_proxy_to_union(self):
@@ -243,21 +243,21 @@ class TupleHintTestCase(TypeHintTestCase):
 
     with self.assertRaises(TypeError) as e:
       typehints.Tuple[int, int, ...]
-    self.assertEqual(error_msg, e.exception.message)
+    self.assertEqual(error_msg, e.exception.args[0])
 
     with self.assertRaises(TypeError) as e:
       typehints.Tuple[...]
-    self.assertEqual(error_msg, e.exception.message)
+    self.assertEqual(error_msg, e.exception.args[0])
 
   def test_getitem_params_must_be_type_or_constraint(self):
     expected_error_prefix = 'All parameters to a Tuple hint must be'
     with self.assertRaises(TypeError) as e:
       typehints.Tuple[5, [1, 3]]
-    self.assertTrue(e.exception.message.startswith(expected_error_prefix))
+    self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
 
     with self.assertRaises(TypeError) as e:
       typehints.Tuple[list, dict]
-    self.assertTrue(e.exception.message.startswith(expected_error_prefix))
+    self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
 
   def test_compatibility_arbitrary_length(self):
     self.assertNotCompatible(
@@ -310,7 +310,7 @@ class TupleHintTestCase(TypeHintTestCase):
     for t in invalid_instances:
       with self.assertRaises(TypeError) as e:
         hint.type_check(t)
-      self.assertTrue(e.exception.message.startswith(expected_error_prefix))
+      self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
 
   def test_type_check_must_have_same_arity(self):
     # A 2-tuple of ints.
@@ -322,7 +322,7 @@ class TupleHintTestCase(TypeHintTestCase):
     self.assertEqual('Passed object instance is of the proper type, but '
                      'differs in length from the hinted type. Expected a '
                      'tuple of length 2, received a tuple of length 3.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_simple_types(self):
     hint = typehints.Tuple[str, bool]
@@ -332,7 +332,7 @@ class TupleHintTestCase(TypeHintTestCase):
                      'type of element #0 in the passed tuple is incorrect.'
                      ' Expected an instance of type str, instead received '
                      'an instance of type int.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_composite_type(self):
     hint = typehints.Tuple[DummyTestClass1, DummyTestClass2]
@@ -345,7 +345,7 @@ class TupleHintTestCase(TypeHintTestCase):
                      'passed tuple is incorrect. Expected an instance of type '
                      'DummyTestClass1, instead received an instance of type '
                      'DummyTestClass2.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_valid_simple_types(self):
     hint = typehints.Tuple[float, bool]
@@ -382,7 +382,7 @@ class TupleHintTestCase(TypeHintTestCase):
                      'of element #2 in the passed tuple is incorrect. Expected '
                      'an instance of type str, instead received an instance of '
                      'type int.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_composite_type_arbitrary_length(self):
     hint = typehints.Tuple[typehints.List[int], ...]
@@ -396,7 +396,7 @@ class TupleHintTestCase(TypeHintTestCase):
                      "List type-constraint violated. Valid object instance "
                      "must be of type 'list'. Instead, an instance of 'str' "
                      "was received.",
-                     e.exception.message)
+                     e.exception.args[0])
 
 
 class ListHintTestCase(TypeHintTestCase):
@@ -439,7 +439,7 @@ class ListHintTestCase(TypeHintTestCase):
                      'element #0 in the passed list is incorrect. Expected an '
                      'instance of type int, instead received an instance of '
                      'type str.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_enforce_list_type_constraint_invalid_composite_type(self):
     hint = typehints.List[typehints.Tuple[int, int]]
@@ -453,7 +453,7 @@ class ListHintTestCase(TypeHintTestCase):
                      'violated. The type of element #0 in the passed tuple'
                      ' is incorrect. Expected an instance of type int, '
                      'instead received an instance of type str.',
-                     e.exception.message)
+                     e.exception.args[0])
 
 
 class KVHintTestCase(TypeHintTestCase):
@@ -464,7 +464,7 @@ class KVHintTestCase(TypeHintTestCase):
 
     self.assertEqual('Parameter to KV type-hint must be a tuple of types: '
                      'KV[.., ..].',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_getitem_param_must_have_length_2(self):
     with self.assertRaises(TypeError) as e:
@@ -473,7 +473,7 @@ class KVHintTestCase(TypeHintTestCase):
     self.assertEqual("Length of parameters to a KV type-hint must be "
                      "exactly 2. Passed parameters: (<type 'int'>, <type "
                      "'str'>, <type 'bool'>), have a length of 3.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_getitem_proxy_to_tuple(self):
     hint = typehints.KV[int, str]
@@ -493,7 +493,7 @@ class DictHintTestCase(TypeHintTestCase):
 
     self.assertEqual('Parameter to Dict type-hint must be a tuple of '
                      'types: Dict[.., ..].',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_getitem_param_must_have_length_2(self):
     with self.assertRaises(TypeError) as e:
@@ -502,7 +502,7 @@ class DictHintTestCase(TypeHintTestCase):
     self.assertEqual("Length of parameters to a Dict type-hint must be "
                      "exactly 2. Passed parameters: (<type 'float'>, <type "
                      "'int'>, <type 'bool'>), have a length of 3.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_key_type_must_be_valid_composite_param(self):
     with self.assertRaises(TypeError):
@@ -533,7 +533,7 @@ class DictHintTestCase(TypeHintTestCase):
       hint.type_check(l)
     self.assertEqual('Dict type-constraint violated. All passed instances '
                      'must be of type dict. [1, 2] is of type list.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_key_type(self):
     hint = typehints.Dict[typehints.Tuple[int, int, int],
@@ -548,7 +548,7 @@ class DictHintTestCase(TypeHintTestCase):
                      'instance is of the proper type, but differs in '
                      'length from the hinted type. Expected a tuple of '
                      'length 3, received a tuple of length 2.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_value_type(self):
     hint = typehints.Dict[str, typehints.Dict[int, str]]
@@ -560,7 +560,7 @@ class DictHintTestCase(TypeHintTestCase):
                      'Dict[int, str]. Instead: Dict type-constraint '
                      'violated. All passed instances must be of type dict.'
                      ' [1, 2, 3] is of type list.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_valid_simple_type(self):
     hint = typehints.Dict[int, str]
@@ -588,7 +588,7 @@ class SetHintTestCase(TypeHintTestCase):
     self.assertEqual("Parameter to a Set hint must be a non-sequence, a "
                      "type, or a TypeConstraint. <type 'list'> is an "
                      "instance of type.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_compatibility(self):
     hint1 = typehints.Set[typehints.List[str]]
@@ -609,7 +609,7 @@ class SetHintTestCase(TypeHintTestCase):
     self.assertEqual("Set type-constraint violated. Valid object instance "
                      "must be of type 'set'. Instead, an instance of 'int'"
                      " was received.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_invalid_elem_type(self):
     hint = typehints.Set[float]
@@ -635,7 +635,7 @@ class IterableHintTestCase(TypeHintTestCase):
     self.assertEqual('Parameter to an Iterable hint must be a '
                      'non-sequence, a type, or a TypeConstraint. 5 is '
                      'an instance of int.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_compatibility(self):
     self.assertCompatible(typehints.Iterable[int], typehints.List[int])
@@ -678,7 +678,7 @@ class IterableHintTestCase(TypeHintTestCase):
     self.assertEqual("Iterable type-constraint violated. Valid object "
                      "instance must be of type 'iterable'. Instead, an "
                      "instance of 'int' was received.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_violation_invalid_simple_type(self):
     hint = typehints.Iterable[float]
@@ -746,7 +746,7 @@ class GeneratorHintTestCase(TypeHintTestCase):
                      'hint type-constraint violated. Expected a iterator '
                      'of type int. Instead received a iterator of type '
                      'str.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_generator_argument_hint_invalid_yield_type(self):
     def wrong_yield_gen():
@@ -765,7 +765,7 @@ class GeneratorHintTestCase(TypeHintTestCase):
                      "hint type-constraint violated. Expected a iterator "
                      "of type int. Instead received a iterator of type "
                      "str.",
-                     e.exception.message)
+                     e.exception.args[0])
 
 
 class TakesDecoratorTestCase(TypeHintTestCase):
@@ -781,7 +781,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
     self.assertEqual('All type hint arguments must be a non-sequence, a '
                      'type, or a TypeConstraint. [1, 2] is an instance of '
                      'list.',
-                     e.exception.message)
+                     e.exception.args[0])
 
     with self.assertRaises(TypeError) as e:
       t = 5
@@ -793,7 +793,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
 
     self.assertEqual('All type hint arguments must be a non-sequence, a type, '
                      'or a TypeConstraint. 5 is an instance of int.',
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_basic_type_assertion(self):
     @check_type_hints
@@ -807,7 +807,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
     self.assertEqual("Type-hint for argument: 'a' violated. Expected an "
                      "instance of <type 'int'>, instead found an "
                      "instance of <type 'str'>.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_composite_type_assertion(self):
     @check_type_hints
@@ -823,7 +823,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
                        "type-constraint violated. The type of element #0 in "
                        "the passed list is incorrect. Expected an instance of "
                        "type int, instead received an instance of type str.",
-                       e.exception.message)
+                       e.exception.args[0])
 
   def test_valid_simple_type_arguments(self):
     @with_input_types(a=str)
@@ -861,7 +861,7 @@ class TakesDecoratorTestCase(TypeHintTestCase):
     self.assertEqual("Type-hint for argument: 'b' violated. Expected an "
                      "instance of <type 'int'>, instead found an instance "
                      "of <type 'str'>.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_valid_only_positional_arguments(self):
     @with_input_types(int, int)
@@ -907,7 +907,7 @@ class ReturnsDecoratorTestCase(TypeHintTestCase):
     self.assertEqual("Type-hint for return type violated. Expected an "
                      "instance of <type 'int'>, instead found an instance "
                      "of <type 'str'>.",
-                     e.exception.message)
+                     e.exception.args[0])
 
   def test_type_check_simple_type(self):
     @with_output_types(str)


### PR DESCRIPTION
The current Jenkins log has numerous entries that include the warning:
* DeprecationWarning: BaseException.message has been deprecated as of Python 2.6

__Exception.message__ was removed in Python 3 in favor of __Exception.args[0]__ which works in both Python 2 and Python 3.