### PR TITLE
[BEAM-3632] Table partioning in DynamicDestination is lost with project is not set in Table Destination

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -139,7 +139,7 @@ class WriteTables<DestinationT>
         tableReference.setProjectId(
             c.getPipelineOptions().as(BigQueryOptions.class).getProject());
         tableDestination = new TableDestination(
-            tableReference, tableDestination.getTableDescription(),tableDestination.getTimePartitioning());
+            tableReference, tableDestination.getTableDescription(), tableDestination.getTimePartitioning());
       }
 
       Integer partition = c.element().getKey().getShardNumber();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -139,7 +139,7 @@ class WriteTables<DestinationT>
         tableReference.setProjectId(
             c.getPipelineOptions().as(BigQueryOptions.class).getProject());
         tableDestination = new TableDestination(
-            tableReference, tableDestination.getTableDescription());
+            tableReference, tableDestination.getTableDescription(),tableDestination.getTimePartitioning());
       }
 
       Integer partition = c.element().getKey().getShardNumber();


### PR DESCRIPTION
TablePartitionning value were lost if project was not set in TableSpec

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

