### PR TITLE
Fix typo in gradle idea hints

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -490,7 +490,7 @@ ext.applyGrpcNature = {
       testSourceDirs += file(generatedProtoTestJavaDir)
       generatedSourceDirs += file(generatedProtoTestJavaDir)
 
-      sourceDirs += file(generatedProtoMainJavaDir)
+      sourceDirs += file(generatedGrpcMainJavaDir)
       generatedSourceDirs += file(generatedGrpcMainJavaDir)
 
       testSourceDirs += file(generatedGrpcTestJavaDir)


### PR DESCRIPTION
In the prior change to help IntelliJ understand out gradle configuration, this typo snuck in, so generated gRPC code was not recognized as a source root.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

