### PR TITLE
[BEAM-3644] Add switchable DirectRunner which uses the fast FnApiRunner when possible

### DIFF
--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -170,8 +170,7 @@ class PipelineTest(unittest.TestCase):
   # TODO(BEAM-1555): Test is failing on the service, with FakeSource.
   # @attr('ValidatesRunner')
   def test_metrics_in_fake_source(self):
-    # FakeSource mock requires DirectRunner.
-    pipeline = TestPipeline(runner='DirectRunner')
+    pipeline = TestPipeline()
     pcoll = pipeline | Read(FakeSource([1, 2, 3, 4, 5, 6]))
     assert_that(pcoll, equal_to([1, 2, 3, 4, 5, 6]))
     res = pipeline.run()
@@ -182,8 +181,7 @@ class PipelineTest(unittest.TestCase):
     self.assertEqual(outputs_counter.committed, 6)
 
   def test_fake_read(self):
-    # FakeSource mock requires DirectRunner.
-    pipeline = TestPipeline(runner='DirectRunner')
+    pipeline = TestPipeline()
     pcoll = pipeline | 'read' >> Read(FakeSource([1, 2, 3]))
     assert_that(pcoll, equal_to([1, 2, 3]))
     pipeline.run()
@@ -279,7 +277,9 @@ class PipelineTest(unittest.TestCase):
     num_elements = 10
     num_maps = 100
 
-    pipeline = TestPipeline()
+    # TODO(robertwb): reduce memory usage of FnApiRunner so that this test
+    # passes.
+    pipeline = TestPipeline(runner='BundleBasedDirectRunner')
 
     # Consumed memory should not be proportional to the number of maps.
     memory_threshold = (
@@ -335,7 +335,7 @@ class PipelineTest(unittest.TestCase):
     file_system_override_mock.side_effect = get_overrides
 
     # Specify DirectRunner as it's the one patched above.
-    with Pipeline(runner='DirectRunner') as p:
+    with Pipeline(runner='BundleBasedDirectRunner') as p:
       pcoll = p | beam.Create([1, 2, 3]) | 'Multiply' >> DoubleParDo()
       assert_that(pcoll, equal_to([3, 6, 9]))
 
@@ -566,7 +566,9 @@ class RunnerApiTest(unittest.TestCase):
 class DirectRunnerRetryTests(unittest.TestCase):
 
   def test_retry_fork_graph(self):
-    p = beam.Pipeline(runner='DirectRunner')
+    # TODO(BEAM-3642): The FnApiRunner currently does not currently support
+    # retries.
+    p = beam.Pipeline(runner='BundleBasedDirectRunner')
 
     # TODO(mariagh): Remove the use of globals from the test.
     global count_b, count_c # pylint: disable=global-variable-undefined

--- a/sdks/python/apache_beam/runners/dataflow/native_io/iobase_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/native_io/iobase_test.py
@@ -182,8 +182,7 @@ class TestNativeSink(unittest.TestCase):
       def Write(self, value):
         self.written_values.append(value)
 
-    # Records in-memory writes, only works on Direct runner.
-    p = TestPipeline(runner='DirectRunner')
+    p = TestPipeline()
     sink = FakeSink()
     p | Create(['a', 'b', 'c']) | _NativeWrite(sink)  # pylint: disable=expression-not-assigned
     p.run()

--- a/sdks/python/apache_beam/runners/direct/direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner_test.py
@@ -27,14 +27,16 @@ class DirectPipelineResultTest(unittest.TestCase):
   def test_waiting_on_result_stops_executor_threads(self):
     pre_test_threads = set(t.ident for t in threading.enumerate())
 
-    pipeline = test_pipeline.TestPipeline(runner='DirectRunner')
-    _ = (pipeline | beam.Create([{'foo': 'bar'}]))
-    result = pipeline.run()
-    result.wait_until_finish()
+    for runner in ['DirectRunner', 'BundleBasedDirectRunner',
+                   'SwitchingDirectRunner']:
+      pipeline = test_pipeline.TestPipeline(runner=runner)
+      _ = (pipeline | beam.Create([{'foo': 'bar'}]))
+      result = pipeline.run()
+      result.wait_until_finish()
 
-    post_test_threads = set(t.ident for t in threading.enumerate())
-    new_threads = post_test_threads - pre_test_threads
-    self.assertEqual(len(new_threads), 0)
+      post_test_threads = set(t.ident for t in threading.enumerate())
+      new_threads = post_test_threads - pre_test_threads
+      self.assertEqual(len(new_threads), 0)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner_test.py
@@ -145,7 +145,7 @@ class SDFDirectRunnerTest(unittest.TestCase):
 
     assert len(expected_data) > 0
 
-    with TestPipeline(runner='DirectRunner') as p:
+    with TestPipeline() as p:
       pc1 = (p
              | 'Create1' >> beam.Create(file_names)
              | 'SDF' >> beam.ParDo(ReadFiles(resume_count)))
@@ -205,7 +205,7 @@ class SDFDirectRunnerTest(unittest.TestCase):
         resume_count)
 
   def test_sdf_with_windowed_timestamped_input(self):
-    with TestPipeline(runner='DirectRunner') as p:
+    with TestPipeline() as p:
       result = (p
                 | beam.Create([1, 3, 5, 10])
                 | beam.FlatMap(lambda t: [TimestampedValue(('A', t), t),
@@ -221,7 +221,7 @@ class SDFDirectRunnerTest(unittest.TestCase):
       assert_that(result, equal_to(expected_result))
 
   def test_sdf_with_side_inputs(self):
-    with TestPipeline(runner='DirectRunner') as p:
+    with TestPipeline() as p:
       result = (p
                 | 'create_main' >> beam.Create(['1', '3', '5'])
                 | beam.ParDo(ExpandStrings(), side=['1', '3']))

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -45,7 +45,8 @@ _PYTHON_RPC_DIRECT_RUNNER = (
     'python_rpc_direct_runner.')
 
 _KNOWN_PYTHON_RPC_DIRECT_RUNNER = ('PythonRPCDirectRunner',)
-_KNOWN_DIRECT_RUNNERS = ('DirectRunner',)
+_KNOWN_DIRECT_RUNNERS = ('DirectRunner', 'BundleBasedDirectRunner',
+                         'SwitchingDirectRunner')
 _KNOWN_DATAFLOW_RUNNERS = ('DataflowRunner',)
 _KNOWN_TEST_RUNNERS = ('TestDataflowRunner',)
 


### PR DESCRIPTION
This change lets users leverage the fast FnApiRunner in local execution of batch pipelines, which gives a 15x performance improvement that users can get for free, with no pipeline changes.

For example, WordCount on the Shakespeare dataset with a single CPU core now takes 50 seconds to run, compared to 12 minutes before.