### PR TITLE
Replace boolean ternary operator + simplify some Boolean expressions

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -1067,7 +1067,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             namespace.stringKey(),
             StringSerializer.INSTANCE,
             flinkStateDescriptor).get(t);
-        return ReadableStates.immediate(result != null ? result : false);
+        return ReadableStates.immediate(result != null && result);
       } catch (Exception e) {
         throw new RuntimeException("Error contains value from state.", e);
       }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/display/DisplayDataTest.java
@@ -366,8 +366,8 @@ public class DisplayDataTest implements Serializable {
             .addIfNotDefault(DisplayData.item("Double", Double.valueOf(1.23)), Double.valueOf(1.23))
             .addIfNotDefault(DisplayData.item("boolean", true), true)
             .addIfNotDefault(
-                DisplayData.item("Boolean", Boolean.valueOf(true)),
-                Boolean.valueOf(true));
+                DisplayData.item("Boolean", Boolean.TRUE),
+                Boolean.TRUE);
       }
     });
 


### PR DESCRIPTION
This patch replaces a boolean ternary operator with a simpler expression using "&&". Also it replaced two Boolean.valueOf(true) expressions with just Boolean.TRUE.