### PR TITLE
Increase gradle logging to --info

### DIFF
--- a/.test-infra/jenkins/job_beam_PreCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_beam_PreCommit_Go_GradleBuild.groovy
@@ -33,6 +33,8 @@ job('beam_PreCommit_Go_GradleBuild') {
     240)
 
   def gradle_switches = [
+    // Gradle log verbosity enough to diagnose basic build issues
+    "--info",
     // Continue the build even if there is a failure to show as many potential failures as possible.
     '--continue',
     // Until we verify the build cache is working appropriately, force rerunning all tasks

--- a/.test-infra/jenkins/job_beam_PreCommit_Java_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_beam_PreCommit_Java_GradleBuild.groovy
@@ -38,6 +38,8 @@ job('beam_PreCommit_Java_GradleBuild') {
   }
 
   def gradle_switches = [
+    // Gradle log verbosity enough to diagnose basic build issues
+    "--info",
     // Continue the build even if there is a failure to show as many potential failures as possible.
     '--continue',
     // Until we verify the build cache is working appropriately, force rerunning all tasks


### PR DESCRIPTION
Currently gradle is logging at the default level of `lifecycle`. Increasing to `info` will show more about what work gradle is doing, such as re-downloading dependencies vs checksumming them, etc.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [N/A] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [N/A] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

