### PR TITLE
[BEAM-3600] Improve FileBasedSink rename safety.

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -811,7 +811,10 @@ class SimpleKVSink(iobase.Sink):
     table_name = 'table' + uid
     return SimpleKVWriter(self._simplekv, access_token, table_name)
 
-  def finalize_write(self, access_token, table_names):
+  def pre_finalize(self, init_result, writer_results):
+    pass
+
+  def finalize_write(self, access_token, table_names, pre_finalize_result):
     for i, table_name in enumerate(table_names):
       self._simplekv.rename_table(
           access_token, table_name, self._final_table_name + str(i))

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -178,85 +178,118 @@ class FileBasedSink(iobase.Sink):
     return FileBasedSinkWriter(self, os.path.join(init_result, uid) + suffix)
 
   @check_accessible(['file_path_prefix', 'file_name_suffix'])
-  def finalize_write(self, init_result, writer_results):
-    file_path_prefix = self.file_path_prefix.get()
-    file_name_suffix = self.file_name_suffix.get()
+  def _get_final_name(self, shard_num, num_shards):
+    return ''.join([
+        self.file_path_prefix.get(),
+        self.shard_name_format % dict(shard_num=shard_num,
+                                      num_shards=num_shards),
+        self.file_name_suffix.get()
+    ])
+
+  def pre_finalize(self, init_result, writer_results):
     writer_results = sorted(writer_results)
     num_shards = len(writer_results)
-    min_threads = min(num_shards, FileBasedSink._MAX_RENAME_THREADS)
+    existing_files = []
+    for shard_num in range(len(writer_results)):
+      final_name = self._get_final_name(shard_num, num_shards)
+      if FileSystems.exists(final_name):
+        existing_files.append(final_name)
+    if existing_files:
+      logging.info('Deleting existing files in target path: %d',
+                   len(existing_files))
+      FileSystems.delete(existing_files)
+
+  @check_accessible(['file_path_prefix'])
+  def finalize_write(self, init_result, writer_results,
+                     unused_pre_finalize_results):
+    writer_results = sorted(writer_results)
+    num_shards = len(writer_results)
+
+    src_files = []
+    dst_files = []
+    delete_files = []
+    chunk_size = FileSystems.get_chunk_size(self.file_path_prefix.get())
+    num_skipped = 0
+    for shard_num, shard in enumerate(writer_results):
+      final_name = self._get_final_name(shard_num, num_shards)
+      src = shard
+      dst = final_name
+      src_exists = FileSystems.exists(src)
+      dst_exists = FileSystems.exists(dst)
+      if not src_exists and not dst_exists:
+        raise BeamIOError('src and dst files do not exist. src: %s, dst: %s' % (
+            src, dst))
+      if not src_exists and dst_exists:
+        logging.debug('src: %s -> dst: %s already renamed, skipping', src, dst)
+        num_skipped += 1
+        continue
+      if (src_exists and dst_exists and
+          FileSystems.checksum(src) == FileSystems.checksum(dst)):
+        logging.debug('src: %s == dst: %s, deleting src', src, dst)
+        delete_files.append(src)
+        continue
+
+      src_files.append(src)
+      dst_files.append(dst)
+
+    num_skipped = len(delete_files)
+    FileSystems.delete(delete_files)
+    num_shards_to_finalize = len(src_files)
+    min_threads = min(num_shards_to_finalize, FileBasedSink._MAX_RENAME_THREADS)
     num_threads = max(1, min_threads)
 
-    source_files = []
-    destination_files = []
-    chunk_size = FileSystems.get_chunk_size(file_path_prefix)
-    for shard_num, shard in enumerate(writer_results):
-      final_name = ''.join([
-          file_path_prefix, self.shard_name_format % dict(
-              shard_num=shard_num, num_shards=num_shards), file_name_suffix
-      ])
-      source_files.append(shard)
-      destination_files.append(final_name)
+    source_file_batch = [src_files[i:i + chunk_size]
+                         for i in range(0, len(src_files), chunk_size)]
+    destination_file_batch = [dst_files[i:i + chunk_size]
+                              for i in range(0, len(dst_files), chunk_size)]
 
-    source_file_batch = [source_files[i:i + chunk_size]
-                         for i in range(0, len(source_files),
-                                        chunk_size)]
-    destination_file_batch = [destination_files[i:i + chunk_size]
-                              for i in range(0, len(destination_files),
-                                             chunk_size)]
+    if num_shards_to_finalize:
+      logging.info(
+          'Starting finalize_write threads with num_shards: %d (skipped: %d), '
+          'batches: %d, num_threads: %d',
+          num_shards_to_finalize, num_skipped, len(source_file_batch),
+          num_threads)
+      start_time = time.time()
 
-    logging.info(
-        'Starting finalize_write threads with num_shards: %d, '
-        'batches: %d, num_threads: %d',
-        num_shards, len(source_file_batch), num_threads)
-    start_time = time.time()
-
-    # Use a thread pool for renaming operations.
-    def _rename_batch(batch):
-      """_rename_batch executes batch rename operations."""
-      source_files, destination_files = batch
-      exceptions = []
-      try:
-        FileSystems.rename(source_files, destination_files)
-        return exceptions
-      except BeamIOError as exp:
-        if exp.exception_details is None:
-          raise
-        for (src, dest), exception in exp.exception_details.iteritems():
-          if exception:
-            logging.warning('Rename not successful: %s -> %s, %s', src, dest,
-                            exception)
-            should_report = True
-            if isinstance(exception, IOError):
-              # May have already been copied.
-              try:
-                if FileSystems.exists(dest):
-                  should_report = False
-              except Exception as exists_e:  # pylint: disable=broad-except
-                logging.warning('Exception when checking if file %s exists: '
-                                '%s', dest, exists_e)
-            if should_report:
-              logging.warning(('Exception in _rename_batch. src: %s, '
-                               'dest: %s, err: %s'), src, dest, exception)
+      # Use a thread pool for renaming operations.
+      def _rename_batch(batch):
+        """_rename_batch executes batch rename operations."""
+        source_files, destination_files = batch
+        exceptions = []
+        try:
+          FileSystems.rename(source_files, destination_files)
+          return exceptions
+        except BeamIOError as exp:
+          if exp.exception_details is None:
+            raise
+          for (src, dst), exception in exp.exception_details.iteritems():
+            if exception:
+              logging.error(('Exception in _rename_batch. src: %s, '
+                             'dst: %s, err: %s'), src, dst, exception)
               exceptions.append(exception)
-          else:
-            logging.debug('Rename successful: %s -> %s', src, dest)
-        return exceptions
+            else:
+              logging.debug('Rename successful: %s -> %s', src, dst)
+          return exceptions
 
-    exception_batches = util.run_using_threadpool(
-        _rename_batch, zip(source_file_batch, destination_file_batch),
-        num_threads)
+      exception_batches = util.run_using_threadpool(
+          _rename_batch, zip(source_file_batch, destination_file_batch),
+          num_threads)
 
-    all_exceptions = [e for exception_batch in exception_batches
-                      for e in exception_batch]
-    if all_exceptions:
-      raise Exception(
-          'Encountered exceptions in finalize_write: %s' % all_exceptions)
+      all_exceptions = [e for exception_batch in exception_batches
+                        for e in exception_batch]
+      if all_exceptions:
+        raise Exception(
+            'Encountered exceptions in finalize_write: %s' % all_exceptions)
 
-    for final_name in destination_files:
-      yield final_name
+      for final_name in dst_files:
+        yield final_name
 
-    logging.info('Renamed %d shards in %.2f seconds.', num_shards,
-                 time.time() - start_time)
+      logging.info('Renamed %d shards in %.2f seconds.', num_shards_to_finalize,
+                   time.time() - start_time)
+    else:
+      logging.warning(
+          'No shards found to finalize. num_shards: %d, skipped: %d',
+          num_shards, num_skipped)
 
     try:
       FileSystems.delete([init_result])

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -577,6 +577,28 @@ class FileSystem(BeamPlugin):
     raise NotImplementedError
 
   @abc.abstractmethod
+  def checksum(self, path):
+    """Fetch checksum metadata of a file on the
+    :class:`~apache_beam.io.filesystem.FileSystem`.
+
+    This operation returns checksum metadata as stored in the underlying
+    FileSystem. It should not need to read file data to obtain this value.
+    Checksum type and format are FileSystem dependent and are not compatible
+    between FileSystems.
+    FileSystem implementations may return file size if a checksum isn't
+    available.
+
+    Args:
+      path: string path of a file.
+
+    Returns: string containing checksum
+
+    Raises:
+      ``BeamIOError`` if path isn't a file or doesn't exist.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
   def delete(self, paths):
     """Deletes files or directories at the provided paths.
     Directories will be deleted recursively.

--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -231,6 +231,26 @@ class FileSystems(object):
     return filesystem.exists(path)
 
   @staticmethod
+  def checksum(path):
+    """Fetch checksum metadata of a file on the
+    :class:`~apache_beam.io.filesystem.FileSystem`.
+
+    This operation returns checksum metadata as stored in the underlying
+    FileSystem. It should not read any file data. Checksum type and format are
+    FileSystem dependent and are not compatible between FileSystems.
+
+    Args:
+      path: string path of a file.
+
+    Returns: string containing checksum
+
+    Raises:
+      ``BeamIOError`` if path isn't a file or doesn't exist.
+    """
+    filesystem = FileSystems.get_filesystem(path)
+    return filesystem.checksum(path)
+
+  @staticmethod
   def delete(paths):
     """Deletes files or directories at the provided paths.
     Directories will be deleted recursively.
@@ -241,6 +261,9 @@ class FileSystems(object):
     Raises:
       ``BeamIOError`` if any of the delete operations fail
     """
+    if isinstance(paths, basestring):
+      raise BeamIOError('Delete passed string argument instead of list: %s' %
+                        paths)
     if len(paths) == 0:
       return
     filesystem = FileSystems.get_filesystem(paths[0])

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -265,6 +265,23 @@ class GCSFileSystem(FileSystem):
     """
     return gcsio.GcsIO().exists(path)
 
+  def checksum(self, path):
+    """Fetch checksum metadata of a file on the
+    :class:`~apache_beam.io.filesystem.FileSystem`.
+
+    Args:
+      path: string path of a file.
+
+    Returns: string containing checksum
+
+    Raises:
+      ``BeamIOError`` if path isn't a file or doesn't exist.
+    """
+    try:
+      return gcsio.GcsIO().checksum(path)
+    except Exception as e:  # pylint: disable=broad-except
+      raise BeamIOError("Checksum operation failed", {path: e})
+
   def delete(self, paths):
     """Deletes files or directories at the provided paths.
     Directories will be deleted recursively.

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -614,10 +614,13 @@ class Sink(HasDisplayData):
 
   **Execution of the Write transform**
 
-  ``initialize_write()`` and ``finalize_write()`` are conceptually called once:
-  at the beginning and end of a ``Write`` transform. However, implementors must
+  ``initialize_write()``, ``pre_finalize()``, and ``finalize_write()`` are
+  conceptually called once. However, implementors must
   ensure that these methods are *idempotent*, as they may be called multiple
-  times on different machines in the case of failure/retry or for redundancy.
+  times on different machines in the case of failure/retry. A method may be
+  called more than once concurrently, in which case it's okay to have a
+  transient failure (such as due to a race condition). This failure should not
+  prevent subsequent retries from succeeding.
 
   ``initialize_write()`` should perform any initialization that needs to be done
   prior to writing to the sink. ``initialize_write()`` may return a result
@@ -641,9 +644,8 @@ class Sink(HasDisplayData):
   encoding of the unique bundle id. For example, if each bundle is written to a
   unique temporary file, ``close()`` method may return an object that contains
   the temporary file name. After writing of all bundles is complete, execution
-  engine will invoke ``finalize_write()`` implementation. As parameters to this
-  invocation execution engine will provide ``init_result`` as well as an
-  iterable of ``write_result``.
+  engine will invoke ``pre_finalize()`` and then ``finalize_write()``
+  implementation.
 
   The execution of a write transform can be illustrated using following pseudo
   code (assume that the outer for loop happens in parallel across many
@@ -656,7 +658,8 @@ class Sink(HasDisplayData):
       for elem in bundle:
         writer.write(elem)
       write_results.append(writer.close())
-    sink.finalize_write(init_result, write_results)
+    pre_finalize_result = sink.pre_finalize(init_result, write_results)
+    sink.finalize_write(init_result, write_results, pre_finalize_result)
 
 
   **init_result**
@@ -737,7 +740,27 @@ class Sink(HasDisplayData):
     """
     raise NotImplementedError
 
-  def finalize_write(self, init_result, writer_results):
+  def pre_finalize(self, init_result, writer_results):
+    """Pre-finalization stage for sink.
+
+    Called after all bundle writes are complete and before finalize_write.
+    Used to setup and verify filesystem and sink states.
+
+    Args:
+      init_result: the result of ``initialize_write()`` invocation.
+      writer_results: an iterable containing results of ``Writer.close()``
+        invocations. This will only contain results of successful writes, and
+        will only contain the result of a single successful write for a given
+        bundle.
+
+    Returns:
+      An object that contains any sink specific state generated.
+      This object will be passed to finalize_write().
+    """
+    raise NotImplementedError
+
+  def finalize_write(self, init_result, writer_results,
+                     pre_finalize_result):
     """Finalizes the sink after all data is written to it.
 
     Given the result of initialization and an iterable of results from bundle
@@ -769,6 +792,7 @@ class Sink(HasDisplayData):
         invocations. This will only contain results of successful writes, and
         will only contain the result of a single successful write for a given
         bundle.
+      pre_finalize_result: the result of ``pre_finalize()`` invocation.
     """
     raise NotImplementedError
 
@@ -942,12 +966,20 @@ class WriteImpl(ptransform.PTransform):
                            | core.WindowInto(window.GlobalWindows())
                            | core.GroupByKey()
                            | 'Extract' >> core.FlatMap(lambda x: x[1]))
+    # PreFinalize should run before FinalizeWrite, and the two should not be
+    # fused.
+    pre_finalize_coll = do_once | 'PreFinalize' >> core.FlatMap(
+        _pre_finalize,
+        self.sink,
+        AsSingleton(init_result_coll),
+        AsIter(write_result_coll))
     return do_once | 'FinalizeWrite' >> core.FlatMap(
         _finalize_write,
         self.sink,
         AsSingleton(init_result_coll),
         AsIter(write_result_coll),
-        min_shards)
+        min_shards,
+        AsSingleton(pre_finalize_coll))
 
 
 class _WriteBundleDoFn(core.DoFn):
@@ -990,7 +1022,12 @@ class _WriteKeyedBundleDoFn(core.DoFn):
     return [window.TimestampedValue(writer.close(), window.MAX_TIMESTAMP)]
 
 
-def _finalize_write(_, sink, init_result, write_results, min_shards):
+def _pre_finalize(unused_element, sink, init_result, write_results):
+  return sink.pre_finalize(init_result, write_results)
+
+
+def _finalize_write(unused_element, sink, init_result, write_results,
+                    min_shards, pre_finalize_results):
   write_results = list(write_results)
   extra_shards = []
   if len(write_results) < min_shards:
@@ -999,7 +1036,8 @@ def _finalize_write(_, sink, init_result, write_results, min_shards):
     for _ in range(min_shards - len(write_results)):
       writer = sink.open_writer(init_result, str(uuid.uuid4()))
       extra_shards.append(writer.close())
-  outputs = sink.finalize_write(init_result, write_results + extra_shards)
+  outputs = sink.finalize_write(init_result, write_results + extra_shards,
+                                pre_finalize_results)
   if outputs:
     return (window.TimestampedValue(v, window.MAX_TIMESTAMP) for v in outputs)
 

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -235,6 +235,22 @@ class LocalFileSystem(FileSystem):
     """
     return os.path.exists(path)
 
+  def checksum(self, path):
+    """Fetch checksum metadata of a file on the
+    :class:`~apache_beam.io.filesystem.FileSystem`.
+
+    Args:
+      path: string path of a file.
+
+    Returns: string containing file size.
+
+    Raises:
+      ``BeamIOError`` if path isn't a file or doesn't exist.
+    """
+    if not self.exists(path):
+      raise BeamIOError('Path does not exist: %s' % path)
+    return str(os.path.getsize(path))
+
   def delete(self, paths):
     """Deletes files or directories at the provided paths.
     Directories will be deleted recursively.

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -237,6 +237,16 @@ class LocalFileSystemTest(unittest.TestCase):
     self.assertTrue(self.fs.exists(path1))
     self.assertFalse(self.fs.exists(path2))
 
+  def test_checksum(self):
+    path1 = os.path.join(self.tmpdir, 'f1')
+    path2 = os.path.join(self.tmpdir, 'f2')
+    with open(path1, 'a') as f:
+      f.write('Hello')
+    with open(path2, 'a') as f:
+      f.write('foo')
+    self.assertEquals(self.fs.checksum(path1), str(5))
+    self.assertEquals(self.fs.checksum(path2), str(3))
+
   def test_delete(self):
     path1 = os.path.join(self.tmpdir, 'f1')
 

--- a/sdks/python/apache_beam/transforms/write_ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/write_ptransform_test.py
@@ -38,7 +38,11 @@ class _TestSink(iobase.Sink):
     if self.return_init_result:
       return _TestSink.TEST_INIT_RESULT
 
-  def finalize_write(self, init_result, writer_results):
+  def pre_finalize(self, init_result, writer_results):
+    pass
+
+  def finalize_write(self, init_result, writer_results,
+                     unused_pre_finalize_result):
     self.init_result_at_finalize = init_result
     self.write_results_at_finalize = writer_results
 


### PR DESCRIPTION
This changes FileBasedSink's finalize_write in two major ways:
A. Splitting it into 2 (unfused) phases:
1. pre_finalize - deletes existing target files (dst files for rename(src, dst) in finalize_writes)
2. finalize_writes - same as before

B. Changing finalize_writes' rename(src, dst) handling:
Previously it'd assume that if rename failed and dst exists then everything is okay.
It now checks for existence of src and dst and determines whether to rename(src, dst), delete(dst), delete(src), and/or do nothing (see code for details). Any errors returned from rename() will cause finalize_writes to fail.

The scenario where 2 or more finalize_writes running concurrently is partially supported. Success is not guaranteed as long as there are 2 or more running, since there might be race conditions if rename() is not atomic (such as GCS's copy and delete). It is however guaranteed that these failures are transient and should clear up once there is only 1 finalize_write running concurrently.

See also: discussion linked to from BEAM-3600.
