### PR TITLE
[BEAM-3519][BEAM-3668] Shaded netty related dependencies of google-cloud-platform module

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -76,3 +76,15 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.slf4j_jdk14
 }
+
+// Shade dependencies.
+shadowJar {
+  dependencies {
+    include(dependency(library.java.grpc_netty))
+    include(dependency(library.java.netty_handler))
+    include(dependency(library.java.netty_tcnative_boringssl_static))
+  }
+  relocate "io.netty", getJavaRelocatedPath("io.netty")
+  relocate "io.grpc", getJavaRelocatedPath("io.grpc")
+  relocate "org.apache.tomcat", getJavaRelocatedPath("org.apache.tomcat")
+}

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -40,7 +40,42 @@
           <executions>
             <execution>
               <id>bundle-and-repackage</id>
-              <phase>none</phase>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <artifactSet>
+                  <includes>
+                    <include>io.netty:netty-handler:jar:</include>
+                    <include>io.netty:netty-tcnative-boringssl-static:jar:</include>
+                    <include>io.grpc:grpc-netty:jar:</include>
+                  </includes>
+                </artifactSet>
+                <relocations>
+                  <relocation>
+                    <pattern>io.grpc</pattern>
+                    <!--suppress MavenModelInspection -->
+                    <shadedPattern>
+                      org.apache.beam.sdk.repackaged.io.grpc
+                    </shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.netty</pattern>
+                    <!--suppress MavenModelInspection -->
+                    <shadedPattern>
+                      org.apache.beam.sdk.repackaged.io.netty
+                    </shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>org.apache.tomcat</pattern>
+                    <!--suppress MavenModelInspection -->
+                    <shadedPattern>
+                      org.apache.beam.sdk.repackaged.org.apache.tomcat
+                    </shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
This was done to to avoid conflicts with other modules, for example, beam-runners-spark.

Shaded following dependencies.

Maven
* io.netty:netty-handler:jar:
* io.netty:netty-tcnative-boringssl-static:jar:
* io.grpc:grpc-netty:jar:

Gradle
* library.java.grpc_netty
* library.java.netty_handler
* library.java.netty_tcnative_boringssl_static


