### PR TITLE
[BEAM-3626] Add a handler capable of executing a window mapping fn on a stream of windows.

### DIFF
--- a/model/pipeline/src/main/resources/org/apache/beam/model/common_urns.md
+++ b/model/pipeline/src/main/resources/org/apache/beam/model/common_urns.md
@@ -71,6 +71,7 @@ the SDK understands the last three combine helper operations.
 
 ### beam:transform:reshuffle:v1
 
+### beam:transform:map_windows:v1
 
 ## WindowFns
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunner.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.fn.harness;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.beam.fn.harness.data.BeamFnDataClient;
+import org.apache.beam.fn.harness.data.MultiplexingFnDataReceiver;
+import org.apache.beam.fn.harness.fn.ThrowingFunction;
+import org.apache.beam.fn.harness.fn.ThrowingRunnable;
+import org.apache.beam.fn.harness.state.BeamFnStateClient;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.WindowedValue;
+
+/**
+ * A {@code PTransformRunner} which executes simple map functions.
+ *
+ * <p>Simple map functions are used in a large number of transforms, especially runner-managed
+ * transforms, such as map_windows.
+ *
+ * <p>TODO: Add support for DoFns which are actually user supplied map/lambda functions instead
+ * of using the {@link FnApiDoFnRunner} instance.
+ */
+public class MapFnRunner<InputT, OutputT> {
+
+  public static <InputT, OutputT> PTransformRunnerFactory<?>
+      createMapFnRunnerFactoryWith(
+          CreateMapFunctionForPTransform<InputT, OutputT> fnFactory) {
+    return new Factory<>(fnFactory);
+  }
+
+  /** A function factory which given a PTransform returns a map function. */
+  public interface CreateMapFunctionForPTransform<InputT, OutputT> {
+    ThrowingFunction<InputT, OutputT> createMapFunctionForPTransform(
+        String ptransformId,
+        PTransform pTransform) throws IOException;
+  }
+
+  /** A factory for {@link MapFnRunner}s. */
+  static class Factory<InputT, OutputT>
+      implements PTransformRunnerFactory<MapFnRunner<InputT, OutputT>> {
+
+    private final CreateMapFunctionForPTransform<InputT, OutputT> fnFactory;
+
+    Factory(CreateMapFunctionForPTransform<InputT, OutputT> fnFactory) {
+      this.fnFactory = fnFactory;
+    }
+
+    @Override
+    public MapFnRunner<InputT, OutputT> createRunnerForPTransform(
+        PipelineOptions pipelineOptions,
+        BeamFnDataClient beamFnDataClient,
+        BeamFnStateClient beamFnStateClient,
+        String pTransformId,
+        PTransform pTransform,
+        Supplier<String> processBundleInstructionId,
+        Map<String, PCollection> pCollections,
+        Map<String, RunnerApi.Coder> coders,
+        Map<String, RunnerApi.WindowingStrategy> windowingStrategies,
+        Multimap<String, FnDataReceiver<WindowedValue<?>>> pCollectionIdsToConsumers,
+        Consumer<ThrowingRunnable> addStartFunction,
+        Consumer<ThrowingRunnable> addFinishFunction) throws IOException {
+
+      Collection<FnDataReceiver<WindowedValue<OutputT>>> consumers =
+          (Collection) pCollectionIdsToConsumers.get(
+              getOnlyElement(pTransform.getOutputsMap().values()));
+
+      MapFnRunner<InputT, OutputT> runner = new MapFnRunner<>(
+          fnFactory.createMapFunctionForPTransform(pTransformId, pTransform),
+          MultiplexingFnDataReceiver.forConsumers(consumers));
+
+      pCollectionIdsToConsumers.put(
+          Iterables.getOnlyElement(pTransform.getInputsMap().values()),
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<InputT>>) runner::map);
+      return runner;
+    }
+  }
+
+  private final ThrowingFunction<InputT, OutputT> mapFunction;
+  private final FnDataReceiver<WindowedValue<OutputT>> consumer;
+
+  MapFnRunner(
+      ThrowingFunction<InputT, OutputT> mapFunction,
+      FnDataReceiver<WindowedValue<OutputT>> consumer) {
+    this.mapFunction = mapFunction;
+    this.consumer = consumer;
+  }
+
+  public void map(WindowedValue<InputT> element) throws Exception {
+    WindowedValue<OutputT> output = element.withValue(mapFunction.apply(element.getValue()));
+    consumer.accept(output);
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/WindowMappingFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/WindowMappingFnRunner.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.runners.core.construction.UrnUtils.validateCommonUrn;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.beam.fn.harness.fn.ThrowingFunction;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
+import org.apache.beam.runners.core.construction.PCollectionViewTranslation;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
+import org.apache.beam.sdk.values.KV;
+
+/**
+ * Maps windows using a window mapping fn. The input is {@link KV} with the key being a nonce
+ * and the value being a window, the output must be a {@link KV} with the key being the same nonce
+ * as the input and the value being the mapped window.
+ */
+public class WindowMappingFnRunner {
+  static final String URN = validateCommonUrn("beam:transform:map_windows:v1");
+
+  /**
+   * A registrar which provides a factory to handle mapping main input windows onto side input
+   * windows.
+   */
+  @AutoService(PTransformRunnerFactory.Registrar.class)
+  public static class Registrar implements PTransformRunnerFactory.Registrar {
+
+    @Override
+    public Map<String, PTransformRunnerFactory> getPTransformRunnerFactories() {
+      return ImmutableMap.of(URN, MapFnRunner.createMapFnRunnerFactoryWith(
+          WindowMappingFnRunner::createMapFunctionForPTransform));
+    }
+  }
+
+  static <T, W1 extends BoundedWindow, W2 extends BoundedWindow>
+  ThrowingFunction<KV<T, W1>, KV<T, W2>> createMapFunctionForPTransform(
+      String ptransformId, PTransform pTransform) throws IOException {
+    SdkFunctionSpec windowMappingFnPayload =
+        SdkFunctionSpec.parseFrom(pTransform.getSpec().getPayload());
+    WindowMappingFn<W2> windowMappingFn =
+        (WindowMappingFn<W2>) PCollectionViewTranslation.windowMappingFnFromProto(
+            windowMappingFnPayload);
+    return (KV<T, W1> input) ->
+        KV.of(input.getKey(), windowMappingFn.getSideInputWindow(input.getValue()));
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.base.Suppliers;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.fn.harness.fn.ThrowingFunction;
+import org.apache.beam.fn.harness.fn.ThrowingRunnable;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link MapFnRunner}. */
+@RunWith(JUnit4.class)
+public class MapFnRunnerTest {
+  private static final String EXPECTED_ID = "pTransformId";
+  private static final RunnerApi.PTransform EXPECTED_PTRANSFORM = RunnerApi.PTransform.newBuilder()
+      .putInputs("input", "inputPC")
+      .putOutputs("output", "outputPC")
+      .build();
+
+  @Test
+  public void testWindowMapping() throws Exception {
+
+    List<WindowedValue<?>> outputConsumer = new ArrayList<>();
+    Multimap<String, FnDataReceiver<WindowedValue<?>>> consumers = HashMultimap.create();
+    consumers.put("outputPC", outputConsumer::add);
+
+    List<ThrowingRunnable> startFunctions = new ArrayList<>();
+    List<ThrowingRunnable> finishFunctions = new ArrayList<>();
+
+    new MapFnRunner.Factory<>(this::createMapFunctionForPTransform)
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            null /* beamFnStateClient */,
+            EXPECTED_ID,
+            EXPECTED_PTRANSFORM,
+            Suppliers.ofInstance("57L")::get,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            consumers,
+            startFunctions::add,
+            finishFunctions::add);
+
+    assertThat(startFunctions, empty());
+    assertThat(finishFunctions, empty());
+
+    assertThat(consumers.keySet(), containsInAnyOrder("inputPC", "outputPC"));
+
+    Iterables.getOnlyElement(
+        consumers.get("inputPC")).accept(valueInGlobalWindow("abc"));
+
+    assertThat(outputConsumer, contains(valueInGlobalWindow("ABC")));
+  }
+
+  public ThrowingFunction<String, String> createMapFunctionForPTransform(String ptransformId,
+      PTransform pTransform) throws IOException {
+    assertEquals(EXPECTED_ID, ptransformId);
+    assertEquals(EXPECTED_PTRANSFORM, pTransform);
+    return (String str) -> str.toUpperCase();
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/WindowMappingFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/WindowMappingFnRunnerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.beam.fn.harness.fn.ThrowingFunction;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.construction.ParDoTranslation;
+import org.apache.beam.runners.core.construction.SdkComponents;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.values.KV;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link WindowMappingFnRunner}. */
+@RunWith(JUnit4.class)
+public class WindowMappingFnRunnerTest {
+  @Test
+  public void testWindowMapping() throws Exception {
+    String pTransformId = "pTransformId";
+
+    RunnerApi.FunctionSpec functionSpec =
+        RunnerApi.FunctionSpec.newBuilder()
+            .setUrn(WindowMappingFnRunner.URN)
+            .setPayload(
+                ParDoTranslation.translateWindowMappingFn(
+                    new GlobalWindows().getDefaultWindowMappingFn(),
+                    SdkComponents.create()
+                ).toByteString())
+            .build();
+    RunnerApi.PTransform pTransform = RunnerApi.PTransform.newBuilder()
+        .setSpec(functionSpec)
+        .build();
+
+
+    ThrowingFunction<KV<Object, BoundedWindow>, KV<Object, BoundedWindow>> mapFunction =
+        WindowMappingFnRunner.createMapFunctionForPTransform(pTransformId, pTransform);
+
+    KV<Object, BoundedWindow> input =
+        KV.of("abc", new IntervalWindow(Instant.now(), Duration.standardMinutes(1)));
+
+    assertEquals(
+        KV.of(input.getKey(), GlobalWindow.INSTANCE),
+        mapFunction.apply(input));
+  }
+}


### PR DESCRIPTION
The primary use case for this is mapping main input windows onto side input windows when filtering input elements before they are sent to a ParDo containing a side input.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

