### PR TITLE
[BEAM-3688] add setup/teardown for BeamSqlSeekableTable

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
@@ -29,7 +29,17 @@ import org.apache.beam.sdk.values.Row;
 @Experimental
 public interface BeamSqlSeekableTable extends Serializable{
   /**
+   * prepare the instance.
+   */
+  void setup();
+
+  /**
    * return a list of {@code Row} with given key set.
    */
   List<Row> seekRow(Row lookupSubRow);
+
+  /**
+   * cleanup resources of the instance.
+   */
+  void teardown();
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
@@ -31,7 +31,7 @@ public interface BeamSqlSeekableTable extends Serializable{
   /**
    * prepare the instance.
    */
-  void setup();
+  default void setUp(){};
 
   /**
    * return a list of {@code Row} with given key set.
@@ -41,5 +41,5 @@ public interface BeamSqlSeekableTable extends Serializable{
   /**
    * cleanup resources of the instance.
    */
-  void teardown();
+  default void tearDown(){};
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
@@ -219,7 +219,12 @@ public class BeamJoinTransforms {
 
     @Override
     public PCollection<Row> expand(PCollection<Row> input) {
-      return input.apply("join_as_lookup", ParDo.of(new DoFn<Row, Row>() {
+      return input.apply("join_as_lookup", ParDo.of(new DoFn<Row, Row>(){
+        @Setup
+        public void setup(){
+          seekableTable.setup();
+        }
+
         @ProcessElement
         public void processElement(ProcessContext context) {
           Row factRow = context.element();
@@ -228,6 +233,11 @@ public class BeamJoinTransforms {
           for (Row lr : lookupRows) {
             context.output(combineTwoRowsIntoOneHelper(factRow, lr));
           }
+        }
+
+        @Teardown
+        public void teardown(){
+          seekableTable.teardown();
         }
 
         private Row extractJoinSubRow(Row factRow) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
@@ -222,7 +222,7 @@ public class BeamJoinTransforms {
       return input.apply("join_as_lookup", ParDo.of(new DoFn<Row, Row>(){
         @Setup
         public void setup(){
-          seekableTable.setup();
+          seekableTable.setUp();
         }
 
         @ProcessElement
@@ -237,7 +237,7 @@ public class BeamJoinTransforms {
 
         @Teardown
         public void teardown(){
-          seekableTable.teardown();
+          seekableTable.tearDown();
         }
 
         private Row extractJoinSubRow(Row factRow) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -131,14 +131,6 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     public List<Row> seekRow(Row lookupSubRow) {
       return Arrays.asList(Row.withRowType(getRowType()).addValues(1, "SITE1").build());
     }
-
-    @Override
-    public void setup() {
-    }
-
-    @Override
-    public void teardown() {
-    }
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -131,6 +131,14 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     public List<Row> seekRow(Row lookupSubRow) {
       return Arrays.asList(Row.withRowType(getRowType()).addValues(1, "SITE1").build());
     }
+
+    @Override
+    public void setup() {
+    }
+
+    @Override
+    public void teardown() {
+    }
   }
 
   @Test


### PR DESCRIPTION
This PR add two methods `setup()` and `teardown()` in  `BeamSqlSeekableTable`, so developers can initial and cleanup the instance properly.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

