### PR TITLE
[BEAM-3605] Use CountDownLatch instead of Thread.sleep()

### DIFF
--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardReadersPool.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardReadersPool.java
@@ -129,6 +129,7 @@ class ShardReadersPool {
           // immediately.
           waitUntilAllShardRecordsRead(shardRecordsIterator);
           readFromSuccessiveShards(shardRecordsIterator);
+          shardRecordsIterator.close();
           break;
         }
         for (KinesisRecord kinesisRecord : kinesisRecords) {

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardRecordsIterator.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardRecordsIterator.java
@@ -118,4 +118,10 @@ class ShardRecordsIterator {
     }
     return successiveShardRecordIterators;
   }
+
+  /**
+   * This dummy method is used for testing purposes to detect that current iterator has been
+   * finished.
+   */
+  void close() {}
 }


### PR DESCRIPTION
It fixes flaky multithreaded tests that rely on `Thread.sleep()`  to wait once all running threads will be finished. 
Sometimes, under some conditions of environment where tests are running, the amount of time for `sleep()` can't be enough and test will fail because not the whole work was done before (flaky). It doesn't make sense to set large sleep time since it directly affects the total time of test suite run and there is still no 100% guarantee that it will be enough. 
Instead, we can use `CountDownLatch` to make sure that all needed threads have finished their job. This approach guarantees that assert(s) will be performed in proper moment and the tests run faster since there is no `sleep()` call with constant amount of time to wait.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

