### PR TITLE
Add errorprone Maven config and fix a couple warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
     <maven-shade-plugin.version>3.1.0</maven-shade-plugin.version>
     <reproducible-build-maven-plugin.version>0.4</reproducible-build-maven-plugin.version>
     <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+    <plexus-compiler-java-errorprone.version>2.8.2</plexus-compiler-java-errorprone.version>
+    <error_prone_core.version>2.2.0</error_prone_core.version>
 
     <compiler.error.flag>-Werror</compiler.error.flag>
     <compiler.default.pkginfo.flag>-Xpkginfo:always</compiler.default.pkginfo.flag>
@@ -356,39 +358,32 @@
     <profile>
       <id>errorprone</id>
       <build>
-        <pluginManagement>
-          <plugins>
-            <!-- Turn on Error Prone -->
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <version>3.3</version>
-              <configuration>
-                <compilerId>javac-with-errorprone</compilerId>
-                <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                <!-- maven-compiler-plugin defaults to targeting Java 5, but our
-                     javac only supports >=6 -->
-                <source>8</source>
-                <target>8</target>
-                <showWarnings>true</showWarnings>
-              </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>org.codehaus.plexus</groupId>
-                  <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                  <version>2.8</version>
-                </dependency>
-                <!-- override plexus-compiler-javac-errorprone's dependency on
-                     Error Prone with the latest version -->
-                <dependency>
-                  <groupId>com.google.errorprone</groupId>
-                  <artifactId>error_prone_core</artifactId>
-                  <version>2.2.0</version>
-                </dependency>
-              </dependencies>
-            </plugin>
-          </plugins>
-        </pluginManagement>
+        <plugins>
+          <!-- Turn on Error Prone -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerId>javac-with-errorprone</compilerId>
+              <forceJavacCompilerUse>true</forceJavacCompilerUse>
+              <showWarnings>true</showWarnings>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-compiler-javac-errorprone</artifactId>
+		<version>${plexus-compiler-java-errorprone.version}</version>
+              </dependency>
+              <!-- override plexus-compiler-javac-errorprone's dependency on
+                   Error Prone with the latest version -->
+              <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+		<version>${error_prone_core.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
       </build>
     </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -354,6 +354,45 @@
     </profile>
 
     <profile>
+      <id>errorprone</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <!-- Turn on Error Prone -->
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-compiler-plugin</artifactId>
+              <version>3.3</version>
+              <configuration>
+                <compilerId>javac-with-errorprone</compilerId>
+                <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                <!-- maven-compiler-plugin defaults to targeting Java 5, but our
+                     javac only supports >=6 -->
+                <source>8</source>
+                <target>8</target>
+                <showWarnings>true</showWarnings>
+              </configuration>
+              <dependencies>
+                <dependency>
+                  <groupId>org.codehaus.plexus</groupId>
+                  <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                  <version>2.8</version>
+                </dependency>
+                <!-- override plexus-compiler-javac-errorprone's dependency on
+                     Error Prone with the latest version -->
+                <dependency>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.2.0</version>
+                </dependency>
+              </dependencies>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
       <id>build-containers</id>
       <build>
         <!-- TODO(BEAM-2878): enable container build for releases -->

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MoreFuturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MoreFuturesTest.java
@@ -37,6 +37,25 @@ public class MoreFuturesTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
+  public void supplyAsyncSuccess() throws Exception {
+    CompletionStage<Integer> future = MoreFutures.supplyAsync(() -> 42);
+    assertThat(MoreFutures.get(future), equalTo(42));
+  }
+
+  @Test
+  public void supplyAsyncFailure() throws Exception {
+    final String testMessage = "this is just a test";
+    CompletionStage<Long> future = MoreFutures.supplyAsync(() -> {
+      throw new IllegalStateException(testMessage);
+    });
+
+    thrown.expect(ExecutionException.class);
+    thrown.expectCause(isA(IllegalStateException.class));
+    thrown.expectMessage(testMessage);
+    MoreFutures.get(future);
+  }
+
+  @Test
   public void runAsyncSuccess() throws Exception {
     AtomicInteger result = new AtomicInteger(0);
     CompletionStage<Void> sideEffectFuture = MoreFutures.runAsync(() -> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MoreFuturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MoreFuturesTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MoreFutures}. */
+@RunWith(JUnit4.class)
+public class MoreFuturesTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void runAsyncSuccess() throws Exception {
+    AtomicInteger result = new AtomicInteger(0);
+    CompletionStage<Void> sideEffectFuture = MoreFutures.runAsync(() -> {
+      result.set(42);
+    });
+
+    MoreFutures.get(sideEffectFuture);
+    assertThat(result.get(), equalTo(42));
+  }
+
+  @Test
+  public void runAsyncFailure() throws Exception {
+    final String testMessage = "this is just a test";
+    CompletionStage<Void> sideEffectFuture = MoreFutures.runAsync(() -> {
+      throw new IllegalStateException(testMessage);
+    });
+
+    thrown.expect(ExecutionException.class);
+    thrown.expectCause(isA(IllegalStateException.class));
+    thrown.expectMessage(testMessage);
+    MoreFutures.get(sideEffectFuture);
+  }
+}


### PR DESCRIPTION
[Error-prone](http://errorprone.info/) is a good Java static analyzer. I actually think it could replace findbugs for us as it is actively maintained and operates on the sources instead of bytecode. Running it found 98 warnings; I think we should probably address them all and then turn it on as a commit blocker. For now, I fixed a couple that it found in the new `MoreFutures`.

I will do the gradle config in a separate PR.

I'm also looking into the Checker framework, which has proven correct protections that for certain things are better than findbugs or errorprone, for example no more NPEs ever.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

