### PR TITLE
[BEAM-3613] Correct typo in SpannerIO.Write.withHost

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -293,7 +293,7 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public ReadAll witHost(String host) {
+    public ReadAll withHost(String host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
     }
@@ -399,7 +399,7 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public Read witHost(String host) {
+    public Read withHost(String host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
     }
@@ -559,7 +559,7 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public CreateTransaction witHost(String host) {
+    public CreateTransaction withHost(String host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
     }
@@ -663,7 +663,7 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public Write witHost(String host) {
+    public Write withHost(String host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
     }


### PR DESCRIPTION
Request for cherry picking f06ba98db8de25f972502e640f01e84f42f17705 to the next RC of 2.3.0.
@lukecwik PTAL. Thanks!