### PR TITLE
[BEAM-3420] Uses timer ID for comparing TimerData

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
@@ -175,6 +175,8 @@ public interface TimerInternals {
 
     public abstract TimeDomain getDomain();
 
+    // When adding a new field, make sure to add it to the compareTo() method.
+
     /**
      * Construct a {@link TimerData} for the given parameters, where the timer ID is automatically
      * generated.
@@ -201,8 +203,9 @@ public interface TimerInternals {
     /**
      * {@inheritDoc}.
      *
-     * <p>The ordering of {@link TimerData} that are not in the same namespace or domain is
-     * arbitrary.
+     * <p>Used for sorting {@link TimerData} by timestamp. Furthermore, we compare timers by all the
+     * other fields so that {@code compareTo()} only returns 0 when {@code equals()} returns 0.
+     * This ensures consistent sort order.
      */
     @Override
     public int compareTo(TimerData that) {
@@ -212,7 +215,8 @@ public interface TimerInternals {
       ComparisonChain chain =
           ComparisonChain.start()
               .compare(this.getTimestamp(), that.getTimestamp())
-              .compare(this.getDomain(), that.getDomain());
+              .compare(this.getDomain(), that.getDomain())
+              .compare(this.getTimerId(), that.getTimerId());
       if (chain.result() == 0 && !this.getNamespace().equals(that.getNamespace())) {
         // Obtaining the stringKey may be expensive; only do so if required
         chain = chain.compare(getNamespace().stringKey(), that.getNamespace().stringKey());


### PR DESCRIPTION
Previously, if two timers have same timestamp, domain, and namespace, BUT different ID, TimerData's compareTo method considered them equal. Fixed it by adding timerID comparison to the compareTo method.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

