### PR TITLE
Two fixes to common URN handling

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UrnUtils.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/UrnUtils.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
 /** Utilities for dealing with URNs. */
 public class UrnUtils {
 
-  private static final String STANDARD_URNS_PATH = "/org/apache/beam/model/common_urns.md";
+  private static final String STANDARD_URNS_PATH = "org/apache/beam/model/common_urns.md";
   private static final Pattern URN_REGEX = Pattern.compile("\\b(urn:)?beam:\\S+:v[0-9.]+");
   private static final Set<String> COMMON_URNS = extractUrnsFromPath(STANDARD_URNS_PATH);
 
@@ -37,7 +37,7 @@ public class UrnUtils {
     String contents;
     try {
       contents = CharStreams.toString(new InputStreamReader(
-          UrnUtils.class.getResourceAsStream(path)));
+          UrnUtils.class.getClassLoader().getResourceAsStream(path)));
     } catch (IOException exn) {
       throw new RuntimeException(exn);
     }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/graph/LengthPrefixUnknownCoders.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/graph/LengthPrefixUnknownCoders.java
@@ -41,7 +41,7 @@ public class LengthPrefixUnknownCoders {
           "beam:coder:kv:v1",
           "beam:coder:varint:v1",
           "beam:coder:interval_window:v1",
-          "beam:coder:stream:v1",
+          "beam:coder:iterable:v1",
           LENGTH_PREFIX_CODER_TYPE,
           "beam:coder:global_window:v1",
           "beam:coder:windowed_value:v1");


### PR DESCRIPTION
- Fixes a typo in LengthPrefixUnknownCoders: stream wasn't updated to iterable
- Fixes UrnUtils to not use a slash when referring to the resource, because it confuses the Maven shade plugin (https://issues.apache.org/jira/browse/MSHADE-273)

This is to stop the bleeding, I have a PR in progress to remove hard-coding of URNs by instead specifying them as enum value options in .proto.