### PR TITLE
[BEAM-3701][BEAM-3700] ensure pipeline options setup is using contextual classloader and not defaulting to beam-sdk classloader

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.options.ProxyInvocationHandler.Serializer;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.util.ReleaseInfo;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
@@ -285,7 +286,9 @@ public interface PipelineOptions extends HasDisplayData {
         @SuppressWarnings({"unchecked", "rawtypes"})
         Class<? extends PipelineRunner<?>> direct =
             (Class<? extends PipelineRunner<?>>)
-                Class.forName("org.apache.beam.runners.direct.DirectRunner");
+                Class.forName(
+                  "org.apache.beam.runners.direct.DirectRunner", true,
+                  ReflectHelpers.findClassLoader());
         return direct;
       } catch (ClassNotFoundException e) {
         throw new IllegalArgumentException(String.format(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -74,7 +74,7 @@ public class ProxyInvocationHandlerTest {
   @Rule public TestRule resetPipelineOptionsRegistry = new ExternalResource() {
     @Override
     protected void before() {
-      PipelineOptionsFactory.resetRegistry();
+      PipelineOptionsFactory.resetCache();
     }
   };
 
@@ -468,7 +468,7 @@ public class ProxyInvocationHandlerTest {
     PipelineOptionsFactory.register(FooOptions.class);
     assertThat(PipelineOptionsFactory.getRegisteredOptions(), hasItem(FooOptions.class));
 
-    PipelineOptionsFactory.resetRegistry();
+    PipelineOptionsFactory.resetCache();
     assertEquals(defaultRegistry, PipelineOptionsFactory.getRegisteredOptions());
   }
 


### PR DESCRIPTION
PipelineOptions* assume the classloader is the one they got loaded with instead of relying on the TCCL.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

