### PR TITLE
Dot rendering improvement

### DIFF
--- a/sdks/go/pkg/beam/core/util/dot/dot.go
+++ b/sdks/go/pkg/beam/core/util/dot/dot.go
@@ -37,7 +37,7 @@ digraph execution_plan {
 	concentrate="true";
 
 	// Node definition used for multiedge
-  node [shape="square" style="filled" fillcolor="honeydew" fontname="Ubuntu" penwidth="1.0" margin="0.05,0.0.05"];
+  node [shape="rectangle" style="filled" fillcolor="honeydew" fontname="Ubuntu" penwidth="1.0" margin="0.05,0.0.05"];
 
 	bgcolor="#e6ecfa";
 `


### PR DESCRIPTION
Use rectangles instead of squares so graphs lay out more nicely.
