### PR TITLE
[BEAM-3702] adding fromJvm to create pipelineoptions from the system properties

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -273,7 +273,7 @@ public class PipelineOptionsFactory {
      * <p>A key/value set of options. This reuses the same logic than
      * {@link PipelineOptionsFactory#fromArgs(String...)} but using
      * the configuration parameter as input. Keys don't have <pre>--</pre>
-     * as a prefix in this case.</p>
+     * as a prefix in this case.
      *
      * <p>Simple list style properties are able to be bound to {@code boolean[]}, {@code char[]},
      * {@code short[]}, {@code int[]}, {@code long[]}, {@code float[]}, {@code double[]},
@@ -1921,7 +1921,7 @@ public class PipelineOptionsFactory {
    *
    * <p>This method will filter system properties based on the conventional prefix
    * <pre>beam.</pre> to create a {@link PipelineOptions} instance from the filtered
-   * key/values.</p>
+   * key/values.
    *
    * @return a pipeline options instance based on system properties
    * filtered based on <code>beam.</code> prefix.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -273,7 +273,7 @@ public class PipelineOptionsFactory {
      * <p>A key/value set of options. This reuses the same logic than
      * {@link PipelineOptionsFactory#fromArgs(String...)} but using
      * the configuration parameter as input. Keys don't have <pre>--</pre>
-     * as a prefix in this case.
+     * as a prefix in this case.</p>
      *
      * <p>Simple list style properties are able to be bound to {@code boolean[]}, {@code char[]},
      * {@code short[]}, {@code int[]}, {@code long[]}, {@code float[]}, {@code double[]},


### PR DESCRIPTION
Adds a factory method in `PipelineOptionsFactory` to instantiate the `PipelineOptions` from the "JVM" which means using the environment and system properties (in this order to support overriding).

It also adds a factory from plain properties to let users read it the way they want.
To be flexible enough, and as discussed on the list, the factory can take a prefix to filter the properties
and if not is provided the default is "beam.".

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

