### PR TITLE
[BEAM-3228] Fix flaky KinesisMockReadTest

### DIFF
--- a/sdks/java/io/kinesis/pom.xml
+++ b/sdks/java/io/kinesis/pom.xml
@@ -31,15 +31,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <!-- BEAM-3228 Temp fix to prevent crashing forked VM during tests. -->
-          <forkCount>1</forkCount>
-          <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
       <!-- Don't shade kinesis (AWS-KPL library has a a hard dependency on guava) -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardReadersPoolTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardReadersPoolTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -79,6 +80,11 @@ public class ShardReadersPoolTest {
     shardReadersPool = Mockito.spy(new ShardReadersPool(kinesis, checkpoint));
     doReturn(firstIterator).when(shardReadersPool).createShardIterator(kinesis, firstCheckpoint);
     doReturn(secondIterator).when(shardReadersPool).createShardIterator(kinesis, secondCheckpoint);
+  }
+
+  @After
+  public void clean() {
+    shardReadersPool.stop();
   }
 
   @Test


### PR DESCRIPTION
The actual cause of flaky test is related to `ShardReadersPoolTest` (not to `KinesisMockReadTest` directly) which creates new instance of `ShardReadersPool`  in every test and then starts new thread pool and runs shard readers threads.  
Seems like when we run Kinesis tests in parallel through `maven-surefire-plugin`  and `KinesisMockReadTest` or `KinesisMockWriteTest` (they also use `ShardReadersPoolTest`) runs after `ShardReadersPoolTest`  then we can have a deadlock. It's easy to reproduce running two tests in this order.
To avoid it, we have to stop all running threads and release all resources by stopping shard reader pool after using.
After that, we don't need to set `forkCount=1` in `maven-surefire-plugin` anymore.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

