### PR TITLE
[BEAM-3705] ApproximateUnique resets its accumulator with each firing.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CombineFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CombineFnTester.java
@@ -102,7 +102,7 @@ public class CombineFnTester {
       } else {
         accumulator = fn.mergeAccumulators(Arrays.asList(accumulator, inputAccum));
       }
-      fn.extractOutput(accumulator); // Extract output to simulate multiple firings.
+      fn.extractOutput(accumulator); // Extract output to simulate multiple firings
     }
     assertThat(fn.extractOutput(accumulator), matcher);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CombineFnTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/CombineFnTester.java
@@ -102,6 +102,7 @@ public class CombineFnTester {
       } else {
         accumulator = fn.mergeAccumulators(Arrays.asList(accumulator, inputAccum));
       }
+      fn.extractOutput(accumulator); // Extract output to simulate multiple firings.
     }
     assertThat(fn.extractOutput(accumulator), matcher);
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
@@ -394,11 +394,11 @@ public class ApproximateUnique {
     @Override
     public LargestUnique mergeAccumulators(Iterable<LargestUnique> heaps) {
       Iterator<LargestUnique> iterator = heaps.iterator();
-      LargestUnique heap = iterator.next();
+      LargestUnique accumulator = iterator.next();
       while (iterator.hasNext()) {
-        iterator.next().heap.forEach(h -> heap.add(h));
+        iterator.next().heap.forEach(h -> accumulator.add(h));
       }
-      return heap;
+      return accumulator;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ApproximateUnique.java
@@ -23,7 +23,7 @@ import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Iterator;
-import java.util.PriorityQueue;
+import java.util.TreeSet;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.Coder.Context;
@@ -319,7 +319,8 @@ public class ApproximateUnique {
      * A heap utility class to efficiently track the largest added elements.
      */
     public static class LargestUnique implements Serializable {
-      private PriorityQueue<Long> heap = new PriorityQueue<>();
+      private TreeSet<Long> heap = new TreeSet<>();
+      private long minHash = Long.MAX_VALUE;
       private final long sampleSize;
 
       /**
@@ -336,14 +337,16 @@ public class ApproximateUnique {
        * to be) in the heap.
        */
       public boolean add(long value) {
-        if (heap.size() >= sampleSize && value < heap.element()) {
+        if (heap.size() >= sampleSize && value < minHash) {
           return false; // Common case as input size increases.
         }
-        if (!heap.contains(value)) {
-          if (heap.size() >= sampleSize) {
-            heap.remove();
+        if (heap.add(value)) {
+          if (heap.size() > sampleSize) {
+            heap.remove(minHash);
+            minHash = heap.first();
+          } else if (value < minHash) {
+            minHash = value;
           }
-          heap.add(value);
         }
         return true;
       }
@@ -352,8 +355,7 @@ public class ApproximateUnique {
         if (heap.size() < sampleSize) {
           return (long) heap.size();
         } else {
-          long smallestSampleHash = heap.element();
-          double sampleSpaceSize = Long.MAX_VALUE - (double) smallestSampleHash;
+          double sampleSpaceSize = Long.MAX_VALUE - (double) minHash;
           // This formula takes into account the possibility of hash collisions,
           // which become more likely than not for 2^32 distinct elements.
           // Note that log(1+x) ~ x for small x, so for sampleSize << maxHash

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ApproximateUniqueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ApproximateUniqueTest.java
@@ -302,20 +302,12 @@ public class ApproximateUniqueTest implements Serializable {
   }
 
   /**
-   * Test ApproximateUniqueCombineFn. TestPipeline does not use combiners.
+   * Test ApproximateUniqueCombineFn. TestPipeline does seem to test merging partial results.
    */
-  @RunWith(Parameterized.class)
+  @RunWith(JUnit4.class)
   public static class ApproximateUniqueCombineFnTest {
 
-    @Parameterized.Parameter
-    public long elementCount;
-    @Parameterized.Parameter(1)
-    public long uniqueCount;
-    @Parameterized.Parameter(2)
-    public int sampleSize;
-
-    @Test
-    public void testCombineFn() {
+    private void runCombineFnTest(long elementCount, long uniqueCount, int sampleSize) {
       List<Double> input = LongStream
         .range(0, elementCount)
         .mapToObj(i -> 1.0 / (i % uniqueCount  + 1))
@@ -328,20 +320,19 @@ public class ApproximateUniqueTest implements Serializable {
       );
     }
 
-    @Parameterized.Parameters(name = "elements_{0}_unique_{1}_sample_{2}")
-    public static Iterable<Object[]> data() {
-      return ImmutableList.<Object[]>builder()
-        .add(
-          new Object[] {
-            1000, 100, 16
-          },
-          new Object[] {
-            1000, 800, 100
-          },
-          new Object[] {
-            200, 100, 150 // Exact match expected.
-          })
-        .build();
+    @Test
+    public void testFnWithSmallerFractionOfUniques() {
+      runCombineFnTest(1000, 100, 16);
+    }
+
+    @Test
+    public void testWithLargerFractionOfUniques() {
+      runCombineFnTest(1000, 800, 100);
+    }
+
+    @Test
+    public void testWithLargeSampleSize() {
+      runCombineFnTest(200, 100, 150);
     }
   }
 


### PR DESCRIPTION
`extractOutput()` ended up resetting underlying aggregation. This is due to use of `extractOrderedList()` which removes all the elements from the heap. `extractOrderedList()` is costly and is not required either. `extractOutput()` does not mutate now and is cheaper too.  

Merging was not tested as direct-runner does not seem to use combiner. Added test to merge and extract as happens in a window with multiple firings.
