### PR TITLE
[BEAM-3644] Use the switching DirectRunner implementation

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -380,8 +380,8 @@ class BundleBasedDirectRunner(PipelineRunner):
     return result
 
 
-# Use the BundleBasedDirectRunner as the default.
-DirectRunner = BundleBasedDirectRunner
+# Use the SwitchingDirectRunner as the default.
+DirectRunner = SwitchingDirectRunner
 
 
 class DirectPipelineResult(PipelineResult):


### PR DESCRIPTION
This change improves DirectRunner execution speed by resolving https://issues.apache.org/jira/browse/BEAM-3644.