### PR TITLE
[BEAM-2535] Added control to set output timestamp independent of firing time for event time timers. (Direct Runner implementation)

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
@@ -42,7 +42,9 @@ public interface DoFnRunner<InputT, OutputT> {
    * Calls a {@link DoFn DoFn's} {@link DoFn.OnTimer @OnTimer} method for the given timer
    * in the given window.
    */
-  void onTimer(String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain);
+  void onTimer(
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain);
 
   /**
    * Calls a {@link DoFn DoFn's} {@link DoFn.FinishBundle @FinishBundle} method and performs

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
@@ -103,12 +103,12 @@ public class InMemoryTimerInternals implements TimerInternals {
 
   @Override
   public void setTimer(StateNamespace namespace, String timerId, Instant target,
-      TimeDomain timeDomain) {
-    setTimer(TimerData.of(timerId, namespace, target, timeDomain));
+      Instant outputTimestamp, TimeDomain timeDomain) {
+    setTimer(TimerData.of(timerId, namespace, target, outputTimestamp, timeDomain));
   }
 
   /**
-   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, TimeDomain)}.
+   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, Instant, TimeDomain)}.
    */
   @Deprecated
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
@@ -75,9 +75,10 @@ public class LateDataDroppingDoFnRunner<K, InputT, OutputT, W extends BoundedWin
   }
 
   @Override
-  public void onTimer(String timerId, BoundedWindow window, Instant timestamp,
+  public void onTimer(
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
       TimeDomain timeDomain) {
-    doFnRunner.onTimer(timerId, window, timestamp, timeDomain);
+    doFnRunner.onTimer(timerId, window, timestamp, outputTimestamp, timeDomain);
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
@@ -77,7 +77,8 @@ public class ProcessFnRunner<InputT, OutputT, RestrictionT>
 
   @Override
   public void onTimer(
-      String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain) {
     throw new UnsupportedOperationException("User timers unsupported in ProcessFn");
   }
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
@@ -43,8 +43,9 @@ public interface PushbackSideInputDoFnRunner<InputT, OutputT> {
   Iterable<WindowedValue<InputT>> processElementInReadyWindows(WindowedValue<InputT> elem);
 
   /** Calls the underlying {@link DoFn.OnTimer} method. */
-  void onTimer(String timerId, BoundedWindow window, Instant timestamp,
-               TimeDomain timeDomain);
+  void onTimer(
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain);
 
   /** Calls the underlying {@link DoFn.FinishBundle} method. */
   void finishBundle();

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -144,16 +144,17 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
   @Override
   public void onTimer(
-      String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain) {
 
     // The effective timestamp is when derived elements will have their timestamp set, if not
-    // otherwise specified. If this is an event time timer, then they have the timestamp of the
-    // timer itself. Otherwise, they are set to the input timestamp, which is by definition
+    // otherwise specified. If this is an event time timer, then they have the timer's output
+    // timestamp. Otherwise, they are set to the input timestamp, which is by definition
     // non-late.
     Instant effectiveTimestamp;
     switch (timeDomain) {
       case EVENT_TIME:
-        effectiveTimestamp = timestamp;
+        effectiveTimestamp = outputTimestamp;
         break;
 
       case PROCESSING_TIME:

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -681,6 +681,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     private final StateNamespace namespace;
     private final String timerId;
     private final TimerSpec spec;
+    private Instant target;
+    private Instant outputTimestamp;
     private Duration period = Duration.ZERO;
     private Duration offset = Duration.ZERO;
 
@@ -699,14 +701,14 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
 
     @Override
     public void set(Instant target) {
+      this.target = target;
       verifyAbsoluteTimeDomain();
-      verifyTargetTime(target);
-      setUnderlyingTimer(target);
+      setAndVerifyOutputTimestamp();
+      setUnderlyingTimer();
     }
 
     @Override
     public void setRelative() {
-      Instant target;
       Instant now = getCurrentTime();
       if (period.equals(Duration.ZERO)) {
         target = now.plus(offset);
@@ -714,8 +716,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
         long millisSinceStart = now.plus(offset).getMillis() % period.getMillis();
         target = millisSinceStart == 0 ? now : now.plus(period).minus(millisSinceStart);
       }
-      target = minTargetAndGcTime(target);
-      setUnderlyingTimer(target);
+      setAndVerifyOutputTimestamp();
+      setUnderlyingTimer();
     }
 
     @Override
@@ -730,31 +732,10 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
       return this;
     }
 
-    /**
-     * For event time timers the target time should be prior to window GC time. So it return
-     * min(time to set, GC Time of window).
-     */
-    private Instant minTargetAndGcTime(Instant target) {
-      if (TimeDomain.EVENT_TIME.equals(spec.getTimeDomain())) {
-        Instant windowExpiry = LateDataUtils.garbageCollectionTime(window, allowedLateness);
-        if (target.isAfter(windowExpiry)) {
-          return windowExpiry;
-        }
-      }
-      return target;
-    }
-
-    /**
-     * Ensures that the target time is reasonable. For event time timers this means that the
-     * time should be prior to window GC time.
-     */
-    private void verifyTargetTime(Instant target) {
-      if (TimeDomain.EVENT_TIME.equals(spec.getTimeDomain())) {
-        Instant windowExpiry = window.maxTimestamp().plus(allowedLateness);
-        checkArgument(!target.isAfter(windowExpiry),
-            "Attempted to set event time timer for %s but that is after"
-            + " the expiration of window %s", target, windowExpiry);
-      }
+    @Override
+    public Timer withOutputTimestamp(Instant outputTimestamp) {
+      this.outputTimestamp = outputTimestamp;
+      return this;
     }
 
     /** Verifies that the time domain of this timer is acceptable for absolute timers. */
@@ -767,12 +748,36 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
     }
 
     /**
+     * <ul>Ensures that:
+     *   <li>Users can't set {@code outputTimestamp} for processing time timers.</li>
+     *   <li>Event time timers' {@code outputTimestamp} is set before window expiration.</li></ul>
+     */
+    private void setAndVerifyOutputTimestamp() {
+      // Output timestamp is currently not supported in processing time timers.
+      if (outputTimestamp != null && !TimeDomain.EVENT_TIME.equals(spec.getTimeDomain())) {
+        throw new IllegalStateException("Cannot set outputTimestamp in processing time domain.");
+      }
+      // Output timestamp is set to the delivery time if not initialized by an user.
+      if (outputTimestamp == null) {
+        outputTimestamp = target;
+      }
+
+      System.out.println(outputTimestamp);
+      if (TimeDomain.EVENT_TIME.equals(spec.getTimeDomain())) {
+        Instant windowExpiry = window.maxTimestamp().plus(allowedLateness);
+        checkArgument(!outputTimestamp.isAfter(windowExpiry),
+            "Attempted to set event time timer that outputs for %s but that is"
+                + " after the expiration of window %s", outputTimestamp, windowExpiry);
+      }
+    }
+
+    /**
      * Sets the timer for the target time without checking anything about whether it is
      * a reasonable thing to do. For example, absolute processing time timers are not
      * really sensible since the user has no way to compute a good choice of time.
      */
-    private void setUnderlyingTimer(Instant target) {
-      timerInternals.setTimer(namespace, timerId, target, spec.getTimeDomain());
+    private void setUnderlyingTimer() {
+      timerInternals.setTimer(namespace, timerId, target, outputTimestamp, spec.getTimeDomain());
     }
 
     private Instant getCurrentTime() {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunner.java
@@ -102,9 +102,10 @@ public class SimplePushbackSideInputDoFnRunner<InputT, OutputT>
   }
 
   @Override
-  public void onTimer(String timerId, BoundedWindow window, Instant timestamp,
-                      TimeDomain timeDomain) {
-    underlying.onTimer(timerId, window, timestamp, timeDomain);
+  public void onTimer(
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain) {
+    underlying.onTimer(timerId, window, timestamp, outputTimestamp, timeDomain);
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
@@ -213,7 +213,7 @@ public class StatefulDoFnRunner<InputT, OutputT, W extends BoundedWindow>
       // make sure this fires after any window.maxTimestamp() timers
       gcTime = gcTime.plus(GC_DELAY_MS);
       timerInternals.setTimer(StateNamespaces.window(windowCoder, window),
-          GC_TIMER_ID, gcTime, TimeDomain.EVENT_TIME);
+          GC_TIMER_ID, gcTime, gcTime, TimeDomain.EVENT_TIME);
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
@@ -111,7 +111,8 @@ public class StatefulDoFnRunner<InputT, OutputT, W extends BoundedWindow>
 
   @Override
   public void onTimer(
-      String timerId, BoundedWindow window, Instant timestamp, TimeDomain timeDomain) {
+      String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
+      TimeDomain timeDomain) {
     if (cleanupTimer.isForWindow(timerId, window, timestamp, timeDomain)) {
       stateCleaner.clearForWindow(window);
       // There should invoke the onWindowExpiration of DoFn
@@ -126,7 +127,7 @@ public class StatefulDoFnRunner<InputT, OutputT, W extends BoundedWindow>
                 + "since window is too far behind inputWatermark:{}",
             timestamp, window, cleanupTimer.currentInputWatermarkTime());
       } else {
-        doFnRunner.onTimer(timerId, window, timestamp, timeDomain);
+        doFnRunner.onTimer(timerId, window, timestamp, outputTimestamp, timeDomain);
       }
     }
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
@@ -55,10 +55,11 @@ public interface TimerInternals {
    *
    * <p>It is an error to set a timer for two different time domains.
    */
-  void setTimer(StateNamespace namespace, String timerId, Instant target, TimeDomain timeDomain);
+  void setTimer(StateNamespace namespace, String timerId, Instant target, Instant outputTimestamp,
+      TimeDomain timeDomain);
 
   /**
-   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, TimeDomain)}.
+   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, Instant, TimeDomain)}.
    */
   @Deprecated
   void setTimer(TimerData timerData);
@@ -193,7 +194,7 @@ public interface TimerInternals {
         String timerId, StateNamespace namespace, Instant timestamp, Instant outputTimestamp,
         TimeDomain domain) {
       return new AutoValue_TimerInternals_TimerData(
-          timerId, namespace, timestamp, outputTimestamp,domain);
+          timerId, namespace, timestamp, outputTimestamp, domain);
     }
 
     /**
@@ -260,7 +261,7 @@ public interface TimerInternals {
   /**
    * Used for sorting {@link TimerData} by output timestamp of the timer.
    */
-  public class TimerOutputTimestampComparator implements Comparator<TimerData> {
+  class TimerOutputTimestampComparator implements Comparator<TimerData> {
 
     @Override
     public int compare(TimerData timer1, TimerData timer2) {
@@ -303,6 +304,7 @@ public interface TimerInternals {
       STRING_CODER.encode(timer.getTimerId(), outStream);
       STRING_CODER.encode(timer.getNamespace().stringKey(), outStream);
       INSTANT_CODER.encode(timer.getTimestamp(), outStream);
+      INSTANT_CODER.encode(timer.getOutputTimestamp(), outStream);
       STRING_CODER.encode(timer.getDomain().name(), outStream);
     }
 
@@ -313,8 +315,9 @@ public interface TimerInternals {
       StateNamespace namespace =
           StateNamespaces.fromString(STRING_CODER.decode(inStream), windowCoder);
       Instant timestamp = INSTANT_CODER.decode(inStream);
+      Instant outputTimestamp = INSTANT_CODER.decode(inStream);
       TimeDomain domain = TimeDomain.valueOf(STRING_CODER.decode(inStream));
-      return TimerData.of(timerId, namespace, timestamp, domain);
+      return TimerData.of(timerId, namespace, timestamp, outputTimestamp, domain);
     }
 
     @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
@@ -163,14 +163,14 @@ public interface TimerInternals {
   @Nullable
   Instant currentOutputWatermarkTime();
 
-  /**
-   * Data about a timer as represented within {@link TimerInternals}.
-   */
+  /** Data about a timer as represented within {@link TimerInternals}. */
+  // TODO: Expose the window that this timer is in, if appropriate
   @AutoValue
   abstract class TimerData implements Comparable<TimerData> {
 
     public abstract String getTimerId();
 
+    // TODO: Document what kinds of namespaces are permitted
     public abstract StateNamespace getNamespace();
 
     /** Timestamp, at which the timer fires. */

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/TimerInternals.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.Coder;
@@ -171,33 +172,63 @@ public interface TimerInternals {
 
     public abstract StateNamespace getNamespace();
 
+    /** Timestamp, at which the timer fires. */
     public abstract Instant getTimestamp();
+
+    /**
+     * Timestamp the timer assigns to outputted elements from
+     * {@link org.apache.beam.sdk.transforms.DoFn.OnTimer} method. For event time timers, output
+     * watermark is held at this timestamp until the timer fires.
+     * */
+    public abstract Instant getOutputTimestamp();
 
     public abstract TimeDomain getDomain();
 
     // When adding a new field, make sure to add it to the compareTo() method.
 
     /**
-     * Construct a {@link TimerData} for the given parameters, where the timer ID is automatically
-     * generated.
+     * Construct a {@link TimerData} for the given parameters.
      */
     public static TimerData of(
-        String timerId, StateNamespace namespace, Instant timestamp, TimeDomain domain) {
-      return new AutoValue_TimerInternals_TimerData(timerId, namespace, timestamp, domain);
+        String timerId, StateNamespace namespace, Instant timestamp, Instant outputTimestamp,
+        TimeDomain domain) {
+      return new AutoValue_TimerInternals_TimerData(
+          timerId, namespace, timestamp, outputTimestamp,domain);
     }
 
     /**
-     * Construct a {@link TimerData} for the given parameters, where the timer ID is
+     * Construct a {@link TimerData} for the given parameters except for {@code outputTimestamp}.
+     * {@code outputTimestamp} is set to timer {@code timestamp}.
+     */
+    public static TimerData of(
+        String timerId, StateNamespace namespace, Instant timestamp, TimeDomain domain) {
+      return new AutoValue_TimerInternals_TimerData(
+          timerId, namespace, timestamp, timestamp, domain);
+    }
+
+    /**
+     * Construct a {@link TimerData} for the given parameters except for timer ID. Timer ID is
      * deterministically generated from the {@code timestamp} and {@code domain}.
      */
-    public static TimerData of(StateNamespace namespace, Instant timestamp, TimeDomain domain) {
+    public static TimerData of(StateNamespace namespace, Instant timestamp, Instant outputTimestamp,
+        TimeDomain domain) {
       String timerId =
           new StringBuilder()
               .append(domain.ordinal())
               .append(':')
               .append(timestamp.getMillis())
               .toString();
-      return of(timerId, namespace, timestamp, domain);
+      return of(timerId, namespace, timestamp, outputTimestamp, domain);
+    }
+
+
+    /**
+     * Construct a {@link TimerData} for the given parameters, where the timer ID is
+     * deterministically generated from the {@code timestamp} and {@code domain}. Also, output
+     * timestamp is set to the timer timestamp by default.
+     */
+    public static TimerData of(StateNamespace namespace, Instant timestamp, TimeDomain domain) {
+      return of(namespace, timestamp, timestamp, domain);
     }
 
     /**
@@ -215,11 +246,36 @@ public interface TimerInternals {
       ComparisonChain chain =
           ComparisonChain.start()
               .compare(this.getTimestamp(), that.getTimestamp())
+              .compare(this.getOutputTimestamp(), that.getOutputTimestamp())
               .compare(this.getDomain(), that.getDomain())
               .compare(this.getTimerId(), that.getTimerId());
       if (chain.result() == 0 && !this.getNamespace().equals(that.getNamespace())) {
         // Obtaining the stringKey may be expensive; only do so if required
         chain = chain.compare(getNamespace().stringKey(), that.getNamespace().stringKey());
+      }
+      return chain.result();
+    }
+  }
+
+  /**
+   * Used for sorting {@link TimerData} by output timestamp of the timer.
+   */
+  public class TimerOutputTimestampComparator implements Comparator<TimerData> {
+
+    @Override
+    public int compare(TimerData timer1, TimerData timer2) {
+      if (timer1.equals(timer2)) {
+        return 0;
+      }
+      ComparisonChain chain =
+          ComparisonChain.start()
+              .compare(timer1.getOutputTimestamp(), timer2.getOutputTimestamp())
+              .compare(timer1.getTimestamp(), timer2.getTimestamp())
+              .compare(timer1.getDomain(), timer2.getDomain())
+              .compare(timer1.getTimerId(), timer2.getTimerId());
+      if (chain.result() == 0 && !timer1.getNamespace().equals(timer2.getNamespace())) {
+        // Obtaining the stringKey may be expensive; only do so if required
+        chain = chain.compare(timer1.getNamespace().stringKey(), timer2.getNamespace().stringKey());
       }
       return chain.result();
     }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/InMemoryTimerInternalsTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/InMemoryTimerInternalsTest.java
@@ -73,8 +73,8 @@ public class InMemoryTimerInternalsTest {
     Instant laterTimestamp = new Instant(42);
 
     underTest.advanceInputWatermark(new Instant(0));
-    underTest.setTimer(NS1, ID1, earlyTimestamp, TimeDomain.EVENT_TIME);
-    underTest.setTimer(NS1, ID1, laterTimestamp, TimeDomain.EVENT_TIME);
+    underTest.setTimer(NS1, ID1, earlyTimestamp, earlyTimestamp, TimeDomain.EVENT_TIME);
+    underTest.setTimer(NS1, ID1, laterTimestamp, laterTimestamp, TimeDomain.EVENT_TIME);
     underTest.advanceInputWatermark(earlyTimestamp.plus(1L));
     assertThat(underTest.removeNextEventTimer(), nullValue());
 
@@ -88,7 +88,7 @@ public class InMemoryTimerInternalsTest {
   public void testDeletionIdempotent() throws Exception {
     InMemoryTimerInternals underTest = new InMemoryTimerInternals();
     Instant timestamp = new Instant(42);
-    underTest.setTimer(NS1, ID1, timestamp, TimeDomain.EVENT_TIME);
+    underTest.setTimer(NS1, ID1, timestamp, timestamp, TimeDomain.EVENT_TIME);
     underTest.deleteTimer(NS1, ID1);
     underTest.deleteTimer(NS1, ID1);
   }
@@ -99,7 +99,7 @@ public class InMemoryTimerInternalsTest {
     Instant timestamp = new Instant(42);
 
     underTest.advanceInputWatermark(new Instant(0));
-    underTest.setTimer(NS1, ID1, timestamp, TimeDomain.EVENT_TIME);
+    underTest.setTimer(NS1, ID1, timestamp, timestamp, TimeDomain.EVENT_TIME);
     underTest.deleteTimer(NS1, ID1);
     underTest.advanceInputWatermark(new Instant(43));
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -114,6 +114,7 @@ public class SimpleDoFnRunnerTest {
         ThrowingDoFn.TIMER_ID,
         GlobalWindow.INSTANCE,
         new Instant(0),
+        new Instant(0),
         TimeDomain.EVENT_TIME);
   }
 
@@ -219,6 +220,7 @@ public class SimpleDoFnRunnerTest {
     runner.onTimer(
         DoFnWithTimers.TIMER_ID,
         GlobalWindow.INSTANCE,
+        currentTime.plus(offset),
         currentTime.plus(offset),
         TimeDomain.EVENT_TIME);
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -149,6 +149,7 @@ public class SimpleDoFnRunnerTest {
             StateNamespaces.window(new GlobalWindows().windowCoder(), GlobalWindow.INSTANCE),
             DoFnWithTimers.TIMER_ID,
             currentTime.plus(DoFnWithTimers.TIMER_OFFSET),
+            currentTime.plus(DoFnWithTimers.TIMER_OFFSET),
             TimeDomain.EVENT_TIME);
   }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -229,7 +229,8 @@ public class SimplePushbackSideInputDoFnRunnerTest {
 
     // Mocking is not easily compatible with annotation analysis, so we manually record
     // the method call.
-    runner.onTimer(timerId, window, new Instant(timestamp), TimeDomain.EVENT_TIME);
+    runner.onTimer(
+        timerId, window, new Instant(timestamp), new Instant(timestamp), TimeDomain.EVENT_TIME);
 
     assertThat(
         underlying.firedTimers,
@@ -260,13 +261,15 @@ public class SimplePushbackSideInputDoFnRunnerTest {
     }
 
     @Override
-    public void onTimer(String timerId, BoundedWindow window, Instant timestamp,
+    public void onTimer(
+        String timerId, BoundedWindow window, Instant timestamp, Instant outputTimestamp,
         TimeDomain timeDomain) {
       firedTimers.add(
           TimerData.of(
               timerId,
               StateNamespaces.window(IntervalWindow.getCoder(), (IntervalWindow) window),
               timestamp,
+              outputTimestamp,
               timeDomain));
     }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/StatefulDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/StatefulDoFnRunnerTest.java
@@ -217,7 +217,9 @@ public class StatefulDoFnRunnerTest {
       StateNamespace namespace = timer.getNamespace();
       checkArgument(namespace instanceof StateNamespaces.WindowNamespace);
       BoundedWindow window = ((StateNamespaces.WindowNamespace) namespace).getWindow();
-      toTrigger.onTimer(timer.getTimerId(), window, timer.getTimestamp(), timer.getDomain());
+      toTrigger.onTimer(
+          timer.getTimerId(), window, timer.getTimestamp(), timer.getOutputTimestamp(),
+          timer.getDomain());
     }
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTimerInternals.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTimerInternals.java
@@ -48,12 +48,13 @@ class DirectTimerInternals implements TimerInternals {
 
   @Override
   public void setTimer(StateNamespace namespace, String timerId, Instant target,
-      TimeDomain timeDomain) {
-    timerUpdateBuilder.setTimer(TimerData.of(timerId, namespace, target, timeDomain));
+      Instant outputTimestamp, TimeDomain timeDomain) {
+    timerUpdateBuilder.setTimer(
+        TimerData.of(timerId, namespace, target, outputTimestamp, timeDomain));
   }
 
   /**
-   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, TimeDomain)}.
+   * @deprecated use {@link #setTimer(StateNamespace, String, Instant, Instant, TimeDomain)}.
    */
   @Deprecated
   @Override

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -185,7 +185,9 @@ class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
 
   public void onTimer(TimerData timer, BoundedWindow window) {
     try {
-      fnRunner.onTimer(timer.getTimerId(), window, timer.getTimestamp(), timer.getDomain());
+      fnRunner.onTimer(
+          timer.getTimerId(), window, timer.getTimestamp(), timer.getOutputTimestamp(),
+          timer.getDomain());
     } catch (Exception e) {
       throw UserCodeException.wrap(e);
     }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -427,11 +427,14 @@ class WatermarkManager {
     @Override
     public synchronized WatermarkUpdate refresh() {
       Instant oldWatermark = currentWatermark.get();
-      Instant newWatermark = INSTANT_ORDERING.min(
-          inputWatermark.get(),
-          holds.getMinHold(),
-          inputWatermark.getEarliestTimerTimestamp(),
-          inputWatermark.getEarliestTimerOutputTimestamp());
+      Instant newWatermark =
+          INSTANT_ORDERING.min(
+              inputWatermark.get(), holds.getMinHold(), inputWatermark.getEarliestTimerTimestamp()
+              // inputWatermark.getEarliestTimerOutputTimestamp()
+              );
+      // if (holds.getMinHold().equals(new Instant(5)))
+      //   System.out.println("WM hold: " + holds.getMinHold());
+      System.out.println("WM hold: " + holds.getMinHold() + " " + holds.keyedHolds.keySet());
       newWatermark = INSTANT_ORDERING.max(oldWatermark, newWatermark);
       currentWatermark.set(newWatermark);
       return WatermarkUpdate.fromTimestamps(oldWatermark, newWatermark);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ParDoTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.direct;
+
+import java.io.Serializable;
+import org.apache.beam.runners.core.ReadyCheckingSideInputReader;
+import org.apache.beam.runners.core.StateInternals;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.testing.UsesStatefulParDo;
+import org.apache.beam.sdk.testing.UsesTestStream;
+import org.apache.beam.sdk.testing.UsesTimersInParDo;
+import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+/** Tests for {@link StatefulParDoEvaluatorFactory}. */
+@RunWith(JUnit4.class)
+public class ParDoTest implements Serializable {
+  @Mock private transient EvaluationContext mockEvaluationContext;
+  @Mock private transient DirectExecutionContext mockExecutionContext;
+  @Mock private transient DirectExecutionContext.DirectStepContext mockStepContext;
+  @Mock private transient ReadyCheckingSideInputReader mockSideInputReader;
+  @Mock private transient UncommittedBundle<Integer> mockUncommittedBundle;
+
+  private static final String KEY = "any-key";
+  private transient StateInternals stateInternals =
+      CopyOnAccessInMemoryStateInternals.<Object>withUnderlying(KEY, null);
+
+  private static final BundleFactory BUNDLE_FACTORY = ImmutableListBundleFactory.create();
+
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class,
+    UsesTimersInParDo.class,
+    UsesTestStream.class
+  })
+  public void testValueStateSimple() {
+    final String stateId = "foo";
+    final String timerId = "bar";
+    DoFn<KV<String, Integer>, Integer> fn =
+        new DoFn<KV<String, Integer>, Integer>() {
+
+          @TimerId(timerId)
+          private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+          @ProcessElement
+          public void processElement(ProcessContext c, @TimerId(timerId) Timer timer) {
+            System.out.println("\n\nSTARTED: " + c.timestamp() + "\n\n");
+            // c.output(c.element().getValue());
+
+            timer.withOutputTimestamp(new Instant(5)).set(new Instant(8));
+          }
+
+          @OnTimer(timerId)
+          public void onTimer(OnTimerContext c, BoundedWindow w) {
+
+            System.out.println("timer");
+            c.output(100);
+          }
+        };
+
+    DoFn<Integer, Instant> fn1 =
+        new DoFn<Integer, Instant>() {
+
+          @ProcessElement
+          public void processElement(ProcessContext c) {
+            System.out.println("fn1: " + c.timestamp() + "\n\n\n");
+            c.output(c.timestamp());
+          }
+        };
+
+    Instant base = new Instant(0);
+
+    TestStream<KV<String, Integer>> stream =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()))
+            .advanceWatermarkTo(new Instant(0))
+            .addElements(KV.of("key", 1))
+            .advanceWatermarkTo(new Instant(100))
+            .advanceWatermarkToInfinity();
+
+    PCollection<Integer> output =
+        pipeline
+            .apply(stream)
+            .apply(
+                Window.<KV<String, Integer>>into(FixedWindows.of(Duration.millis(10))) // window
+                    .withAllowedLateness(Duration.millis(10)) // lateness
+                    .discardingFiredPanes())
+            .apply("first", ParDo.of(fn));
+    // .apply("second", ParDo.of(fn1));
+
+    PAssert.that(output)
+        .inWindow(new IntervalWindow(base, base.plus(Duration.millis(10)))) // interval window
+        .containsInAnyOrder(100); // result outpit
+    pipeline.run();
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timer.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/Timer.java
@@ -67,4 +67,10 @@ public interface Timer {
    * period}.
    */
   Timer align(Duration period);
+
+  /**
+   * Sets event time timer's output timestamp. Output watermark will be held at this timestamp until
+   * the timer fires.
+   * */
+  Timer withOutputTimestamp(Instant outputTime);
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -419,6 +419,7 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
       String timerId,
       BoundedWindow window,
       Instant timestamp,
+      Instant outputTimestamp,
       TimeDomain timeDomain) {
     throw new UnsupportedOperationException("TODO: Add support for timers");
   }


### PR DESCRIPTION
This PR adds ability to control the output timestamp of event timers. This feature only works for the direct runner at the moment. Before this PR, the output timestamp of event timers are set to timer's delivery timestamp. 

Example:
When an user sets timer with output timestamp 3 and delivery timestamp 5:

@ProcessElement()
public void processElement(ProcessContext c, @TimerId("foo") Timer timer) {
  timer.withOutputTimestamp(new Instant(3)).set(new Instant(5));
}

@OnTimer("foo")
public void myTimerCallback(OnTimerContext c, BoundedWindow w) {
   c.output("some_value"); // outputs with timestamp 3.
}

The timer will deliver at 5 as usual. However, output() method of the OnTimerContext in myTimerCallback function uses 3 as the output timestamp. To make sure the element is not late for further transforms down the pipeline, output watermark will be held at the output timestamp of the timer (3 in the example) until myTimerCallback executes.

This WM hold feature is also useful for outputting values saved in state cells right before garbage collection. (BEAM-1589) GC timer fires after the window expiration, therefore, outputting elements with output timestamp past the window expiration results them to be dropped further down the pipeline. By setting onWindowExpiration timer as:
timer.withOutputTimestamp(windowExpiration).set(GCtime), we could output these elements inside the window.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

