### PR TITLE
Spotless gradle: only check current module source

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -263,9 +263,8 @@ ext.applyJavaNature = {
   apply plugin: "com.diffplug.gradle.spotless"
   spotless {
     java {
-      target rootProject.fileTree(rootProject.rootDir) {
-        include 'sdks/java/**/*.java'
-      }
+      target "src/**/*.java"
+
       // Code formatting disabled because style rules are out of date.
       // eclipse().configFile(rootProject.file('sdks/java/build-tools/src/main/resources/beam/beam-codestyle.xml'))
     }


### PR DESCRIPTION
Today, every single module's `spotlessJavaCheck` is configured to glob the entire source tree for Java files. This is my naive attempt to just glob the current project. Probably the very best solution would be to refactor `applyJavaNature` to be `applyJavaNature(Project project)` and explicitly pass the full path "${project.projectDir}/src" or whatever standard field that is stored in.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

