### PR TITLE
[BEAM-3715] Explicitly exclude some troublesome optional deps

### DIFF
--- a/sdks/java/io/hadoop-input-format/build.gradle
+++ b/sdks/java/io/hadoop-input-format/build.gradle
@@ -61,6 +61,10 @@ dependencies {
   testCompile "io.netty:netty-transport-native-epoll:4.1.0.CR3"
   testCompile "org.elasticsearch:elasticsearch:$elastic_search_version"
   testCompile ("org.elasticsearch:elasticsearch-hadoop:$elastic_search_version") {
+    // TODO(https://issues.apache.org/jira/browse/BEAM-3715)
+    // These are all optional deps of elasticsearch-hadoop. Why do they have to be excluded?
+    exclude group: "cascading", module: "cascading-local"
+    exclude group: "org.apache.hive", module: "hive-service"
     exclude group: "org.apache.spark", module: "spark-core_2.10"
     exclude group: "org.apache.spark", module: "spark-streaming_2.10"
     exclude group: "org.apache.spark", module: "spark-sql_2.10"


### PR DESCRIPTION
The optional dependencies of elasticsearch-hadoop, pulled in by hadoop-input-format, appear to be getting fetched by Gradle. For some reason we have explicitly excluded three of them (also in the Maven config) even though they should already be left out. To fix the build, this explicitly excludes those that I have seen flake.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [n/a] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [n/a] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).