### PR TITLE
Use maven-publish plugin to publish java artifacts

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -126,6 +126,7 @@ class JavaNatureConfiguration {
   double javaVersion = 1.8        // Controls the JDK source language and target compatibility
   boolean enableFindbugs = true   // Controls whether the findbugs plugin is enabled and configured
   boolean enableShadow = true     // Controls whether the shadow plugin is enabled and configured
+  String artifactId = null        // Sets the maven publication artifact id
 }
 
 // Configures a project with a default set of plugins that should apply to all Java projects.
@@ -177,7 +178,7 @@ ext.applyJavaNature = {
   println "applyJavaNature with " + (it ? "$it" : "default configuration") + " for project $project.name"
   // Use the implicit it parameter of the closure to handle zero argument or one argument map calls.
   JavaNatureConfiguration configuration = it ? it as JavaNatureConfiguration : new JavaNatureConfiguration()
-  apply plugin: "maven"
+  apply plugin: "maven-publish"
   apply plugin: "java"
 
   // Configure the Java compiler source language and target compatibility levels. Also ensure that
@@ -328,6 +329,26 @@ ext.applyJavaNature = {
 
     // Ensure that shaded classes are part of the artifact set.
     artifacts.archives shadowJar
+
+    if (configuration.artifactId) {
+      // If a publication artifact id is supplied, publish the shadow jar.
+      publishing {
+        publications {
+          mavenJava(MavenPublication) {
+            artifact(shadowJar) {
+              groupId "org.apache.beam"
+              artifactId configuration.artifactId
+              // Strip the "shaded" classifier.
+              classifier null
+              // Set readable name to project description.
+              pom.withXml {
+                asNode().appendNode('name', description)
+              }
+            }
+          }
+        }
+      }
+    }
 
     // TODO: Figure out how to create ShadowJar task for ShadowTestJar here
     // that is extendable within each sub-project with any additional includes.

--- a/runners/apex/build.gradle
+++ b/runners/apex/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "beam-runners-apex")
 
 description = "Apache Beam :: Runners :: Apex"
 

--- a/runners/core-construction-java/build.gradle
+++ b/runners/core-construction-java/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "beam-runners-core-construction-java")
 
 description = "Apache Beam :: Runners :: Core Construction Java"
 

--- a/runners/core-java/build.gradle
+++ b/runners/core-java/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "runners-core-java")
 
 description = "Apache Beam :: Runners :: Core Java"
 

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "beam-runners-direct-java")
 
 description = "Apache Beam :: Runners :: Direct Java"
 

--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -19,7 +19,7 @@
 import groovy.json.JsonOutput
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "beam-runners-flink_2.11")
 
 description = "Apache Beam :: Runners :: Flink"
 

--- a/runners/gearpump/build.gradle
+++ b/runners/gearpump/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(artifactId: "beam-runners-gearpump")
 
 description = "Apache Beam :: Runners :: Gearpump"
 

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -17,7 +17,8 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false /* BEAM-925 */)
+applyJavaNature(enableFindbugs: false /* BEAM-925 */,
+    artifactId: "beam-runners-google-cloud-dataflow-java")
 
 description = "Apache Beam :: Runners :: Google Cloud Dataflow"
 


### PR DESCRIPTION
Use the `maven-publish` plugin to publish java artifacts. The old `maven` plugin does not allow classifiers to be stripped from published artifacts. Since we want to export shaded jars but do not want the `shaded` classifier appended, we need to manually strip this.

This change additionally sets project groups and allows subprojects to register artifact ids. Artifacts can be published to the local maven repository for testing via `publishToMavenLocal`. This is equivalent to `mvn install`.

I was unable to find mappings between all gradle project names and maven artifacts, so I've only included a few here.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

