### PR TITLE
Revert invalid use of io.StringIO in utils/profiler.py

### DIFF
--- a/sdks/python/apache_beam/utils/profiler.py
+++ b/sdks/python/apache_beam/utils/profiler.py
@@ -21,14 +21,19 @@ For internal use only; no backwards-compatibility guarantees.
 """
 
 import cProfile
-import io
 import logging
 import os
 import pstats
+import sys
 import tempfile
 import time
 import warnings
 from threading import Timer
+
+if sys.version_info[0] < 3:
+  import StringIO
+else:
+  from io import StringIO
 
 
 class Profile(object):
@@ -66,7 +71,7 @@ class Profile(object):
       os.remove(filename)
 
     if self.log_results:
-      s = io.StringIO()
+      s = StringIO()
       self.stats = pstats.Stats(
           self.profile, stream=s).sort_stats(Profile.SORTBY)
       self.stats.print_stats()


### PR DESCRIPTION
DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

My previous Python 3 compatibility PR converted cStringIO.StringIO to io.StringIO. This doesn't work  in Python 2 because io.StringIO operates only unicode input.