### PR TITLE
[BEAM-3456] Re-enable JDBC performance test

### DIFF
--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -19,45 +19,66 @@
 import common_job_properties
 
 // This job runs the Beam performance tests on PerfKit Benchmarker.
-job('beam_PerformanceTests_JDBC'){
+job('beam_PerformanceTests_JDBC') {
     // Set default Beam job properties.
     common_job_properties.setTopLevelMainJobProperties(delegate)
 
     // Run job in postcommit every 6 hours, don't trigger every push, and
     // don't email individual committers.
     common_job_properties.setPostCommit(
-        delegate,
-        '0 */6 * * *',
-        false,
-        'commits@beam.apache.org',
-        false)
+            delegate,
+            '0 */6 * * *',
+            false,
+            'commits@beam.apache.org',
+            false)
+
+    common_job_properties.enablePhraseTriggeringFromPullRequest(
+            delegate,
+            'Java JdbcIO Performance Test',
+            'Run Java JdbcIO Performance Test')
 
     def pipelineArgs = [
-        tempRoot: 'gs://temp-storage-for-end-to-end-tests',
-        project: 'apache-beam-testing',
-        postgresServerName: '10.36.0.11',
-        postgresUsername: 'postgres',
-        postgresDatabaseName: 'postgres',
-        postgresPassword: 'uuinkks',
-        postgresSsl: 'false'
+            tempRoot            : 'gs://temp-storage-for-perf-tests',
+            project             : 'apache-beam-testing',
+            numberOfRecords     : '5000000',
+            postgresUsername    : 'postgres',
+            postgresDatabaseName: 'postgres',
+            postgresPassword    : 'uuinkks',
+            postgresSsl         : 'false'
     ]
-    def pipelineArgList = []
+
+    def testArgs = [
+            kubeconfig              : '"$HOME/.kube/config"',
+            beam_it_timeout         : '1800',
+            benchmarks              : 'beam_integration_benchmark',
+            beam_it_profile         : 'io-it',
+            beam_prebuilt           : 'true',
+            beam_sdk                : 'java',
+            beam_it_module          : 'sdks/java/io/jdbc',
+            beam_it_class           : 'org.apache.beam.sdk.io.jdbc.JdbcIOIT',
+            beam_it_options         : joinPipelineOptions(pipelineArgs),
+            beam_kubernetes_scripts : makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres.yml')
+                    + ',' + makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
+            beam_options_config_file: makePathAbsolute('src/.test-infra/kubernetes/postgres/pkb-config-local.yml'),
+            bigquery_table          : 'beam_performance.jdbcioit_pkb_results'
+    ]
+
+    steps {
+        // create .kube/config file for perfkit (if not exists)
+        shell('gcloud container clusters get-credentials io-datastores --zone=us-central1-a --verbosity=debug')
+    }
+
+    common_job_properties.buildPerformanceTest(delegate, testArgs)
+}
+
+static String joinPipelineOptions(Map pipelineArgs) {
+    List<String> pipelineArgList = []
     pipelineArgs.each({
-        key, value -> pipelineArgList.add("--$key=$value")
+        key, value -> pipelineArgList.add("\"--$key=$value\"")
     })
-    def pipelineArgsJoined = pipelineArgList.join(',')
+    return "[" + pipelineArgList.join(',') + "]"
+}
 
-    def argMap = [
-      benchmarks: 'beam_integration_benchmark',
-      beam_it_module: 'sdks/java/io/jdbc',
-      beam_it_args: pipelineArgsJoined,
-      beam_it_class: 'org.apache.beam.sdk.io.jdbc.JdbcIOIT',
-      // Profile is located in $BEAM_ROOT/sdks/java/io/pom.xml.
-      beam_it_profile: 'io-it'
-    ]
-
-    common_job_properties.buildPerformanceTest(delegate, argMap)
-
-    // [BEAM-2141] Perf tests do not pass.
-    disabled()
+static String makePathAbsolute(String path) {
+    return '"$WORKSPACE/' + path + '"'
 }

--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -40,11 +40,7 @@ job('beam_PerformanceTests_JDBC') {
     def pipelineArgs = [
             tempRoot            : 'gs://temp-storage-for-perf-tests',
             project             : 'apache-beam-testing',
-            numberOfRecords     : '5000000',
-            postgresUsername    : 'postgres',
-            postgresDatabaseName: 'postgres',
-            postgresPassword    : 'uuinkks',
-            postgresSsl         : 'false'
+            numberOfRecords     : '5000000'
     ]
 
     def testArgs = [

--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -38,9 +38,10 @@ job('beam_PerformanceTests_JDBC') {
             'Run Java JdbcIO Performance Test')
 
     def pipelineArgs = [
-            tempRoot            : 'gs://temp-storage-for-perf-tests',
-            project             : 'apache-beam-testing',
-            numberOfRecords     : '5000000'
+            tempRoot       : 'gs://temp-storage-for-perf-tests',
+            project        : 'apache-beam-testing',
+            postgresPort   : '5432',
+            numberOfRecords: '5000000'
     ]
 
     def testArgs = [


### PR DESCRIPTION
This PR re-enables the JDBC IO IT running on jenkins and kubernetes cluster. It's best to think of it as a follow up PR to https://github.com/apache/beam/pull/4392. back then it was impossible to run kubectl on all Jenkins executors. 

The jenkins job:
- Changes number of processed records to 5 000 000 
- Connects to postgres database hosted in kubernetes cluster
- Obtains necessary kubernetes credentials if needed
- Stores the results in bigquery table
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

