### PR TITLE
[BEAM-3640] part 2 - add STATIC_INIT,INSTANCE_INIT,ENUM_DEF,INTERFACE…

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/AutoComplete.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/AutoComplete.java
@@ -254,13 +254,16 @@ public class AutoComplete {
       extends DoFn<CompletionCandidate, KV<String, CompletionCandidate>> {
     private final int minPrefix;
     private final int maxPrefix;
+
     public AllPrefixes(int minPrefix) {
       this(minPrefix, Integer.MAX_VALUE);
     }
+
     public AllPrefixes(int minPrefix, int maxPrefix) {
       this.minPrefix = minPrefix;
       this.maxPrefix = maxPrefix;
     }
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       String word = c.element().value;

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/TriggerExample.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/TriggerExample.java
@@ -367,6 +367,7 @@ public class TriggerExample {
     public FormatTotalFlow(String triggerType) {
       this.triggerType = triggerType;
     }
+
     @ProcessElement
     public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
       String[] values = c.element().getValue().split(",");

--- a/examples/java/src/main/java/org/apache/beam/examples/snippets/Snippets.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/snippets/Snippets.java
@@ -65,6 +65,7 @@ public class Snippets {
       this.source = "";
       this.quote = "";
     }
+
     public Quote(String source, String quote) {
       this.source = source;
       this.quote = quote;
@@ -84,6 +85,7 @@ public class Snippets {
       this.day = 0;
       this.maxTemp = 0.0f;
     }
+
     public WeatherData(long year, long month, long day, double maxTemp) {
       this.year = year;
       this.month = month;

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexProcessFnOperator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexProcessFnOperator.java
@@ -78,7 +78,7 @@ public class ApexProcessFnOperator<InputT> extends BaseOperator {
    */
   public interface OutputEmitter<T> {
     void emit(T tuple);
-  };
+  }
 
   /**
    * The processing logic for this operator.

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowingStrategyTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowingStrategyTranslation.java
@@ -207,6 +207,7 @@ public class WindowingStrategyTranslation implements Serializable {
     UrnUtils.validateCommonUrn(SLIDING_WINDOWS_FN);
     UrnUtils.validateCommonUrn(SESSION_WINDOWS_FN);
   }
+
   // This URN says that the WindowFn is just a UDF blob the Java SDK understands
   // TODO: standardize such things
   public static final String SERIALIZED_JAVA_WINDOWFN_URN = "beam:windowfn:javasdk:v0.1";

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRegistrar.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRegistrar.java
@@ -30,6 +30,7 @@ import org.apache.beam.sdk.runners.PipelineRunnerRegistrar;
  */
 public class DirectRegistrar {
   private DirectRegistrar() {}
+
   /**
    * Registers the {@link DirectRunner}.
    */

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/EmptyCheckpointMark.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/EmptyCheckpointMark.java
@@ -31,7 +31,7 @@ public class EmptyCheckpointMark implements UnboundedSource.CheckpointMark, Seri
   private static final EmptyCheckpointMark INSTANCE = new EmptyCheckpointMark();
   private static final int ID = 2654265; // some constant to serve as identifier.
 
-  private EmptyCheckpointMark() {};
+  private EmptyCheckpointMark() {}
 
   public static EmptyCheckpointMark get() {
     return INSTANCE;

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -383,9 +383,10 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="allowNoEmptyLineBetweenFields" value="false"/>
       <property name="allowMultipleEmptyLines" value="true"/>
       <property name="allowMultipleEmptyLinesInsideClassMembers" value="true"/>
-      <property name="tokens" value="IMPORT,CLASS_DEF" />
-      <!-- eventually start adding: ,INTERFACE_DEF,ENUM_DEF,
-           STATIC_INIT,INSTANCE_INIT,METHOD_DEF,CTOR_DEF, VARIABLE_DEF -->
+      <property name="tokens" value="IMPORT,CLASS_DEF,INTERFACE_DEF,STATIC_INIT,
+                                     INSTANCE_INIT,ENUM_DEF,CTOR_DEF" />
+           <!-- we don't want blank lines between member variables, so don't use VARIABLE_DEF -->
+           <!-- eventually add: METHOD_DEF -->
     </module>
 
     <module name="WhitespaceAround">

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -511,7 +511,9 @@ public class Combine {
   public static class Holder<V> {
     @Nullable private V value;
     private boolean present;
+
     private Holder() { }
+
     private Holder(V value) {
       set(value);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -375,6 +375,7 @@ public abstract class DoFnSignature {
     @AutoValue
     public abstract static class WindowParameter extends Parameter {
       WindowParameter() {}
+
       public abstract TypeDescriptor<? extends BoundedWindow> windowT();
     }
 
@@ -387,6 +388,7 @@ public abstract class DoFnSignature {
     public abstract static class RestrictionTrackerParameter extends Parameter {
       // Package visible for AutoValue
       RestrictionTrackerParameter() {}
+
       public abstract TypeDescriptor<?> trackerT();
     }
 
@@ -400,6 +402,7 @@ public abstract class DoFnSignature {
     public abstract static class StateParameter extends Parameter {
       // Package visible for AutoValue
       StateParameter() {}
+
       public abstract StateDeclaration referent();
     }
 
@@ -411,6 +414,7 @@ public abstract class DoFnSignature {
     public abstract static class TimerParameter extends Parameter {
       // Package visible for AutoValue
       TimerParameter() {}
+
       public abstract TimerDeclaration referent();
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/MergeOverlappingIntervalWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/MergeOverlappingIntervalWindows.java
@@ -64,14 +64,17 @@ public class MergeOverlappingIntervalWindows {
   private static class MergeCandidate {
     @Nullable private IntervalWindow union;
     private final List<IntervalWindow> parts;
+
     public MergeCandidate() {
       union = null;
       parts = new ArrayList<>();
     }
+
     public MergeCandidate(IntervalWindow window) {
       union = window;
       parts = new ArrayList<>(Arrays.asList(window));
     }
+
     public boolean intersects(IntervalWindow window) {
       return union == null || union.intersects(window);
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StructuredCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/StructuredCoderTest.java
@@ -96,6 +96,7 @@ public class StructuredCoderTest {
     public ObjectIdentityBoolean(boolean value) {
       this.value = value;
     }
+
     public boolean getValue() {
       return value;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PAssertTest.java
@@ -90,6 +90,7 @@ public class PAssertTest implements Serializable {
 
   private static class NotSerializableObjectCoder extends AtomicCoder<NotSerializableObject> {
     private NotSerializableObjectCoder() { }
+
     private static final NotSerializableObjectCoder INSTANCE = new NotSerializableObjectCoder();
 
     @JsonCreator

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DoFnTesterTest.java
@@ -416,6 +416,7 @@ public class DoFnTesterTest {
       INSIDE_BUNDLE,
       TORN_DOWN
     }
+
     private LifecycleState state = LifecycleState.UNINITIALIZED;
 
     @Setup

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -965,6 +965,7 @@ public class ParDoTest implements Serializable {
 
   private static class TestDummyCoder extends AtomicCoder<TestDummy> {
     private TestDummyCoder() { }
+
     private static final TestDummyCoder INSTANCE = new TestDummyCoder();
 
     @JsonCreator
@@ -1017,6 +1018,7 @@ public class ParDoTest implements Serializable {
     public MainOutputDummyFn(TupleTag<Integer> intOutputTag) {
       this.intOutputTag = intOutputTag;
     }
+
     @ProcessElement
     public void processElement(ProcessContext c) {
       c.output(new TestDummy());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
@@ -73,6 +73,7 @@ public class WindowingTest implements Serializable {
     public WindowedCount(WindowFn<? super String, ?> windowFn) {
       this.windowFn = windowFn;
     }
+
     @Override
     public PCollection<String> expand(PCollection<String> in) {
       return in.apply(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -163,9 +163,11 @@ public class BeamSqlEnv implements Serializable {
 
   private static class BeamCalciteTable implements ScannableTable, Serializable {
     private RowType beamRowType;
+
     public BeamCalciteTable(RowType beamRowType) {
       this.beamRowType = beamRowType;
     }
+
     @Override
     public RelDataType getRowType(RelDataTypeFactory typeFactory) {
       return CalciteUtils.toCalciteRowType(this.beamRowType)

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
@@ -35,6 +35,7 @@ public class BeamSqlCurrentDateExpression extends BeamSqlExpression {
   public BeamSqlCurrentDateExpression() {
     super(Collections.emptyList(), SqlTypeName.DATE);
   }
+
   @Override public boolean accept() {
     return getOperands().size() == 0;
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
@@ -40,6 +40,7 @@ public class BeamSqlCurrentTimeExpression extends BeamSqlExpression {
   public BeamSqlCurrentTimeExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.TIME);
   }
+
   @Override public boolean accept() {
     int opCount = getOperands().size();
     return opCount <= 1;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
@@ -38,6 +38,7 @@ public class BeamSqlCurrentTimestampExpression extends BeamSqlExpression {
   public BeamSqlCurrentTimestampExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.TIMESTAMP);
   }
+
   @Override public boolean accept() {
     int opCount = getOperands().size();
     return opCount <= 1;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
@@ -37,6 +37,7 @@ public class BeamSqlDateCeilExpression extends BeamSqlExpression {
   public BeamSqlDateCeilExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.TIMESTAMP);
   }
+
   @Override public boolean accept() {
     return operands.size() == 2
         && opType(1) == SqlTypeName.SYMBOL;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
@@ -37,6 +37,7 @@ public class BeamSqlDateFloorExpression extends BeamSqlExpression {
   public BeamSqlDateFloorExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DATE);
   }
+
   @Override public boolean accept() {
     return operands.size() == 2
         && opType(1) == SqlTypeName.SYMBOL;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
@@ -50,6 +50,7 @@ public class BeamSqlExtractExpression extends BeamSqlExpression {
   public BeamSqlExtractExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.BIGINT);
   }
+
   @Override public boolean accept() {
     return operands.size() == 2
         && opType(1) == SqlTypeName.TIMESTAMP;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlLogicalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlLogicalExpression.java
@@ -29,6 +29,7 @@ public abstract class BeamSqlLogicalExpression extends BeamSqlExpression {
   private BeamSqlLogicalExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
+
   public BeamSqlLogicalExpression(List<BeamSqlExpression> operands) {
     this(operands, SqlTypeName.BOOLEAN);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/CheckSize.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/CheckSize.java
@@ -30,6 +30,7 @@ public class CheckSize implements SerializableFunction<Iterable<Row>, Void> {
   public CheckSize(int size) {
     this.size = size;
   }
+
   @Override public Void apply(Iterable<Row> input) {
     int count = 0;
     for (Row row : input) {

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/DataStreams.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/stream/DataStreams.java
@@ -126,7 +126,8 @@ public class DataStreams {
    * first access to {@link #next()} or {@link #hasNext()}.
    */
   public static class DataStreamDecoder<T> implements Iterator<T> {
-    private enum State { READ_REQUIRED, HAS_NEXT, EOF };
+
+    private enum State { READ_REQUIRED, HAS_NEXT, EOF }
 
     private final CountingInputStream countingInputStream;
     private final PushbackInputStream pushbackInputStream;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
@@ -59,7 +59,9 @@ public class StateFetchingIterators {
    * pre-fetch any future chunks and blocks whenever required to fetch the next block.
    */
   static class LazyBlockingStateFetchingIterator implements Iterator<ByteString> {
-    private enum State { READ_REQUIRED, HAS_NEXT, EOF };
+
+    private enum State { READ_REQUIRED, HAS_NEXT, EOF }
+
     private final BeamFnStateClient beamFnStateClient;
     private final StateRequest stateRequestForFirstChunk;
     private State currentState;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -107,6 +107,7 @@ public class BeamFnDataReadRunnerTest {
       throw new ExceptionInInitializerError(e);
     }
   }
+
   private static final BeamFnApi.Target INPUT_TARGET = BeamFnApi.Target.newBuilder()
       .setPrimitiveTransformReference("1")
       .setName("out")

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataWriteRunnerTest.java
@@ -102,6 +102,7 @@ public class BeamFnDataWriteRunnerTest {
       throw new ExceptionInInitializerError(e);
     }
   }
+
   private static final BeamFnApi.Target OUTPUT_TARGET = BeamFnApi.Target.newBuilder()
       .setPrimitiveTransformReference("1")
       .setName("out")

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -472,6 +472,7 @@ public class ElasticsearchIO {
       this.numSlices = numSlices;
       this.sliceId = sliceId;
     }
+
     @Override
     public List<? extends BoundedSource<String>> split(
         long desiredBundleSizeBytes, PipelineOptions options) throws Exception {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -135,6 +135,7 @@ class DynamicDestinationsHelpers {
     DelegatingDynamicDestinations(DynamicDestinations<T, DestinationT> inner) {
       this.inner = inner;
     }
+
     @Override
     public DestinationT getDestination(ValueInSingleWindow<T> element) {
       return inner.getDestination(element);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowJsonCoderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowJsonCoderTest.java
@@ -41,6 +41,7 @@ public class TableRowJsonCoderTest {
     public TableRowBuilder() {
       row = new TableRow();
     }
+
     public TableRowBuilder set(String fieldName, Object value) {
       row.set(fieldName, value);
       return this;

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.coders.VarIntCoder;
  * {@link Bid}.
  */
 public class Event implements KnownSize, Serializable {
+
   private enum Tag {
     PERSON(0),
     AUCTION(1),
@@ -42,6 +43,7 @@ public class Event implements KnownSize, Serializable {
       this.value = value;
     }
   }
+
   private static final Coder<Integer> INT_CODER = VarIntCoder.of();
 
   public static final Coder<Event> CODER =


### PR DESCRIPTION
Part 2 of BEAM-3640

Add STATIC_INIT,INSTANCE_INIT,ENUM_DEF,INTERFACE_DEF,CTOR_DEF to the list of tokens for the EmptyLineSeparator rule.   Code changes are all white space additions to fix rule violations and removal of irrelevant semi-colons that cause rule violations.
