### PR TITLE
[BEAM-3317] Use fixed system time for testing

### DIFF
--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisReaderTest.java
@@ -29,10 +29,10 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -131,42 +131,51 @@ public class KinesisReaderTest {
   @Test
   public void watermarkDoesNotChangeWhenToFewSampleRecords()
       throws IOException, TransientKinesisException {
-    Instant now = Instant.now();
-    Instant recordsStartTimestamp = now.minus(Duration.standardHours(1));
-    final long timestampMs = recordsStartTimestamp.getMillis();
-    Duration safetyPeriod = Duration.standardMinutes(1);
-    Instant kinesisWatermarkMinValue = now.minus(KinesisReader.MAX_KINESIS_STREAM_RETENTION_PERIOD);
+    try {
+      Instant now = Instant.now();
+      DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+      Instant recordsStartTimestamp = now.minus(Duration.standardHours(1));
+      final long timestampMs = recordsStartTimestamp.getMillis();
+      Duration safetyPeriod = Duration.standardMinutes(1);
+      Instant kinesisWatermarkMinValue = now.minus(KinesisReader.MAX_KINESIS_STREAM_RETENTION_PERIOD);
 
-    prepareRecordsWithArrivalTimestamps(timestampMs, 1, KinesisReader.MIN_WATERMARK_MESSAGES / 2);
+      prepareRecordsWithArrivalTimestamps(timestampMs, 1, KinesisReader.MIN_WATERMARK_MESSAGES / 2);
 
-    for (boolean more = reader.start(); more; more = reader.advance()) {
-      assertThat(reader.getWatermark()).isBetween(
-          kinesisWatermarkMinValue.minus(safetyPeriod),
-          kinesisWatermarkMinValue.plus(safetyPeriod));
+      for (boolean more = reader.start(); more; more = reader.advance()) {
+        assertThat(reader.getWatermark()).isBetween(
+            kinesisWatermarkMinValue.minus(safetyPeriod),
+            kinesisWatermarkMinValue.plus(safetyPeriod));
+      }
+    } finally {
+      DateTimeUtils.setCurrentMillisSystem();
     }
   }
 
   @Test
-  @Ignore("https://issues.apache.org/jira/browse/BEAM-3317")
   public void watermarkAdvancesWhenEnoughRecordsReadRecently()
       throws IOException, TransientKinesisException {
-    Instant now = Instant.now();
-    Instant recordsStartTimestamp = now.minus(Duration.standardHours(1));
-    long timestampMs = recordsStartTimestamp.getMillis();
-    Duration safetyPeriod = Duration.standardMinutes(1);
-    Instant kinesisWatermarkMinValue = now.minus(KinesisReader.MAX_KINESIS_STREAM_RETENTION_PERIOD);
+    try {
+      Instant now = Instant.now();
+      DateTimeUtils.setCurrentMillisFixed(now.getMillis());
+      Instant recordsStartTimestamp = now.minus(Duration.standardHours(1));
+      long timestampMs = recordsStartTimestamp.getMillis();
+      Duration safetyPeriod = Duration.standardMinutes(1);
+      Instant kinesisWatermarkMinValue = now.minus(KinesisReader.MAX_KINESIS_STREAM_RETENTION_PERIOD);
 
-    prepareRecordsWithArrivalTimestamps(timestampMs, 1, KinesisReader.MIN_WATERMARK_MESSAGES);
+      prepareRecordsWithArrivalTimestamps(timestampMs, 1, KinesisReader.MIN_WATERMARK_MESSAGES);
 
-    int recordsNeededForWatermarkAdvancing = KinesisReader.MIN_WATERMARK_MESSAGES;
-    for (boolean more = reader.start(); more; more = reader.advance()) {
-      if (--recordsNeededForWatermarkAdvancing > 0) {
-        assertThat(reader.getWatermark()).isBetween(
-            kinesisWatermarkMinValue.minus(safetyPeriod),
-            kinesisWatermarkMinValue.plus(safetyPeriod));
-      } else {
-        assertThat(reader.getWatermark()).isEqualTo(new Instant(timestampMs));
+      int recordsNeededForWatermarkAdvancing = KinesisReader.MIN_WATERMARK_MESSAGES;
+      for (boolean more = reader.start(); more; more = reader.advance()) {
+        if (--recordsNeededForWatermarkAdvancing > 0) {
+          assertThat(reader.getWatermark()).isBetween(
+              kinesisWatermarkMinValue.minus(safetyPeriod),
+              kinesisWatermarkMinValue.plus(safetyPeriod));
+        } else {
+          assertThat(reader.getWatermark()).isEqualTo(new Instant(timestampMs));
+        }
       }
+    } finally {
+      DateTimeUtils.setCurrentMillisSystem();
     }
   }
 


### PR DESCRIPTION
The problem here was caused by unfortunate timing during watermark retrieval. KinesisReader uses [MovingFunction](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MovingFunction.java) to decide if watermark should be advanced or not, parametrized with `numSignificantBuckets=2` and `numSignificantSamples=10`. The test relied only on `numSignificantSamples` and did not take into consideration the time buckets. Now it sets the system time to a fixed value before execution so there will be no unfortunate time interatctions. I've also applied the same changes to other test that was likely to fail as it followed the same scheme. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

