### PR TITLE
[BEAM-3728][BEAM-3729] fixing the classloader lookup for pipeline options factory creation

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1754,10 +1754,10 @@ public class PipelineOptionsFactory {
               FluentIterable.from(validatedPipelineOptionsInterfaces).append(iface).toSet();
       // Validate that the view of all currently passed in options classes is well formed.
       if (!combinedCache.containsKey(combinedPipelineOptionsInterfaces)) {
+        final Class<?>[] interfaces = combinedPipelineOptionsInterfaces.toArray(EMPTY_CLASS_ARRAY);
         @SuppressWarnings("unchecked")
-        Class<T> allProxyClass =
-                (Class<T>) Proxy.getProxyClass(ReflectHelpers.findClassLoader(),
-                        combinedPipelineOptionsInterfaces.toArray(EMPTY_CLASS_ARRAY));
+        Class<T> allProxyClass = (Class<T>) Proxy.getProxyClass(
+          ReflectHelpers.findClassLoader(interfaces), interfaces);
         try {
           List<PropertyDescriptor> propertyDescriptors =
                   validateClass(iface, validatedPipelineOptionsInterfaces, allProxyClass);
@@ -1772,7 +1772,7 @@ public class PipelineOptionsFactory {
       if (!interfaceCache.containsKey(iface)) {
         @SuppressWarnings({"rawtypes", "unchecked"})
         Class<T> proxyClass = (Class<T>) Proxy.getProxyClass(
-                ReflectHelpers.findClassLoader(), new Class[] {iface});
+                ReflectHelpers.findClassLoader(iface), new Class[] {iface});
         try {
           List<PropertyDescriptor> propertyDescriptors =
                   validateClass(iface, validatedPipelineOptionsInterfaces, proxyClass);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
@@ -33,7 +33,9 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Queue;
 import java.util.ServiceLoader;
@@ -217,6 +219,30 @@ public class ReflectHelpers {
   }
 
   /**
+   * Find the common classloader of all these classes.
+   */
+  public static ClassLoader findClassLoader(final Class<?>... classes) {
+    if (classes == null || classes.length == 0) {
+      throw new IllegalArgumentException("set of classes can't be null");
+    }
+    ClassLoader current = null;
+    for (final Class<?> clazz : classes) {
+      final ClassLoader proposed = clazz.getClassLoader();
+      if (proposed == null) {
+        continue;
+      }
+      if (current == null) {
+        current = proposed;
+      } else if (proposed != current) {
+        if (isParent(current, proposed)) {
+          current = proposed;
+        }
+      }
+    }
+    return current == null ? ClassLoader.getSystemClassLoader() : current;
+  }
+
+  /**
    * Finds the appropriate {@code ClassLoader} to be used by the
    * {@link ServiceLoader#load} call, which by default would use the context
    * {@code ClassLoader}, which can be null. The fallback is as follows: context
@@ -224,5 +250,27 @@ public class ReflectHelpers {
    */
   public static ClassLoader findClassLoader() {
     return findClassLoader(Thread.currentThread().getContextClassLoader());
+  }
+
+  /**
+   * Checks if current is a parent of proposed.
+   * @param current the potential parent.
+   * @param proposed the potential child.
+   * @return true if current is in proposed hierarchy.
+   */
+  private static boolean isParent(final ClassLoader current, final ClassLoader proposed) {
+    final Collection<ClassLoader> visited = new ArrayList<>();
+    ClassLoader it = proposed.getParent();
+    while (it != null) {
+      if (it == current) {
+        return true;
+      }
+      if (visited.contains(it)) { // avoid loops
+        return false;
+      }
+      visited.add(it);
+      it = it.getParent();
+    }
+    return false;
   }
 }


### PR DESCRIPTION
DESCRIPTION HERE

For local runners the classloading hierarchy needs to handle parent correctly.
This PR ensures the proxy lookup is able to handle the parent for that case.
A better but way more impacting fix can be to serialize the PO each time even for local runners - kind of pass by value pattern.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

