### PR TITLE
[BEAM-3732] Fix broken maven profiles

### DIFF
--- a/sdks/java/io/file-based-io-tests/pom.xml
+++ b/sdks/java/io/file-based-io-tests/pom.xml
@@ -136,7 +136,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${surefire-plugin.version}</version>
                         <configuration>
                             <skipTests>true</skipTests>
                         </configuration>

--- a/sdks/java/io/hadoop-input-format/pom.xml
+++ b/sdks/java/io/hadoop-input-format/pom.xml
@@ -109,7 +109,7 @@
 
         To invoke this, run:
 
-        mvn verify -Dio-it-suite -pl sdks/java/io/hadoop/input-format
+        mvn verify -Dio-it-suite -pl sdks/java/io/hadoop-input-format
             -DpkbLocation="path-to-pkb.py" \
             -DintegrationTestPipelineOptions='["-tempRoot=gs://bucket/staging"]'
     -->
@@ -121,7 +121,7 @@
       <properties>
         <!-- This is based on the location of the current pom relative to the root
              See discussion in BEAM-2460 -->
-        <beamRootProjectDir>${project.parent.parent.parent.parent.parent.basedir}</beamRootProjectDir>
+        <beamRootProjectDir>${project.parent.parent.parent.parent.basedir}</beamRootProjectDir>
       </properties>
       <build>
         <plugins>
@@ -170,7 +170,7 @@
                 <argument>${pkbBeamRunnerProfile}</argument>
                 <argument>${pkbBeamRunnerOption}</argument>
                 <!-- specific to this IO -->
-                <argument>-beam_it_module=sdks/java/io/hadoop/input-format</argument>
+                <argument>-beam_it_module=sdks/java/io/hadoop-input-format</argument>
                 <argument>-beam_it_class=org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIOIT</argument>
                 <argument>-beam_options_config_file=${beamRootProjectDir}/.test-infra/kubernetes/postgres/pkb-config.yml</argument>
                 <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres.yml</argument>
@@ -182,7 +182,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
             <configuration>
               <skipTests>true</skipTests>
             </configuration>
@@ -202,7 +201,7 @@
       <properties>
         <!-- This is based on the location of the current pom relative to the root
              See discussion in BEAM-2460 -->
-        <beamRootProjectDir>${project.parent.parent.parent.parent.parent.basedir}</beamRootProjectDir>
+        <beamRootProjectDir>${project.parent.parent.parent.parent.basedir}</beamRootProjectDir>
       </properties>
       <build>
         <plugins>
@@ -251,7 +250,7 @@
                 <argument>${pkbBeamRunnerProfile}</argument>
                 <argument>${pkbBeamRunnerOption}</argument>
                 <!-- specific to this IO -->
-                <argument>-beam_it_module=sdks/java/io/hadoop/input-format</argument>
+                <argument>-beam_it_module=sdks/java/io/hadoop-input-format</argument>
                 <argument>-beam_it_class=org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIOIT</argument>
                 <argument>-beam_options_config_file=${beamRootProjectDir}/.test-infra/kubernetes/postgres/pkb-config-local.yml</argument>
                 <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres.yml,${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml</argument>
@@ -264,7 +263,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
             <configuration>
               <skipTests>true</skipTests>
             </configuration>

--- a/sdks/java/io/jdbc/pom.xml
+++ b/sdks/java/io/jdbc/pom.xml
@@ -150,7 +150,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin.version}</version>
             <configuration>
               <skipTests>true</skipTests>
             </configuration>
@@ -233,7 +232,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin.version}</version>
             <configuration>
               <skipTests>true</skipTests>
             </configuration>


### PR DESCRIPTION
This fixes build break caused by changed surefire version property name and hadoop-input-format location change (paths changed). Without the fix it is impossible to use the profiles mentioned in jira issue. I fixed the paths and removed version property from places where it's not needed (child poms will derive the parent's dependency version).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

