### PR TITLE
Fixing minor bugs in python sdk

### DIFF
--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -80,6 +80,9 @@ class RuntimeValueProvider(ValueProvider):
 
   @classmethod
   def get_value(cls, option_name, value_type, default_value):
+    if not RuntimeValueProvider.runtime_options:
+      return default_value
+
     candidate = RuntimeValueProvider.runtime_options.get(option_name)
     if candidate:
       return value_type(candidate)

--- a/sdks/python/apache_beam/utils/retry.py
+++ b/sdks/python/apache_beam/utils/retry.py
@@ -73,10 +73,12 @@ class FuzzedExponentialIntervals(object):
   def __init__(self, initial_delay_secs, num_retries, factor=2, fuzz=0.5,
                max_delay_secs=60 * 60 * 1):
     self._initial_delay_secs = initial_delay_secs
+    if num_retries > 10000:
+      raise ValueError('num_retries parameter cannot exceed 10000.')
     self._num_retries = num_retries
     self._factor = factor
     if not 0 <= fuzz <= 1:
-      raise ValueError('Fuzz parameter expected to be in [0, 1] range.')
+      raise ValueError('fuzz parameter expected to be in [0, 1] range.')
     self._fuzz = fuzz
     self._max_delay_secs = max_delay_secs
 


### PR DESCRIPTION
- Add a maximum for retry. Since a previous changed from xrange to
range, the whole retry list is materialized ahed of time resulting in
MemoryError with large retry values.
- Check that runtime_options is not None before trying to access it.
