### PR TITLE
Correct BigQuery.write JavaDoc example

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -184,7 +184,8 @@ import org.slf4j.LoggerFactory;
  *
  * PCollection<Quote> quotes = ...
  *
- * quotes.apply(BigQueryIO.write()
+ * quotes.apply(BigQueryIO
+ *     .<Quote>write()
  *     .to("my-project:my_dataset.my_table")
  *     .withSchema(new TableSchema().setFields(
  *         ImmutableList.of(


### PR DESCRIPTION
Add the type in the BigQuery.write example because without the
example will not compile (cannot infer type).
