### PR TITLE
[BEAM-3217] Jenkins job for HadoopInputFormatIOIT

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -381,4 +381,27 @@ class common_job_properties {
       }
     }
   }
+
+  /**
+   * Transforms pipeline options to a string of format like below:
+   * ["--pipelineOption=123", "--pipelineOption2=abc", ...]
+   *
+   * @param pipelineOptions A map of pipeline options.
+   */
+  static String joinPipelineOptions(Map pipelineOptions) {
+    List<String> pipelineArgList = []
+    pipelineOptions.each({
+      key, value -> pipelineArgList.add("\"--$key=$value\"")
+    })
+    return "[" + pipelineArgList.join(',') + "]"
+  }
+
+
+  /**
+   * Returns absolute path to beam project's files.
+   * @param path A relative path to project resource.
+   */
+  static String makePathAbsolute(String path) {
+    return '"$WORKSPACE/' + path + '"'
+  }
 }

--- a/.test-infra/jenkins/job_beam_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_FileBasedIO_IT.groovy
@@ -86,21 +86,15 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
                 'commits@beam.apache.org',
                 false)
 
-        def pipelineArgs = [
+        def pipelineOptions = [
                 project        : 'apache-beam-testing',
                 tempRoot       : 'gs://temp-storage-for-perf-tests',
                 numberOfRecords: '1000000',
                 filenamePrefix : "gs://temp-storage-for-perf-tests/${testConfiguration.jobName}/\${BUILD_ID}/",
         ]
         if (testConfiguration.containsKey('extraPipelineArgs')) {
-            pipelineArgs << testConfiguration.extraPipelineArgs
+            pipelineOptions << testConfiguration.extraPipelineArgs
         }
-
-        def pipelineArgList = []
-        pipelineArgs.each({
-            key, value -> pipelineArgList.add("\"--$key=$value\"")
-        })
-        def pipelineArgsJoined = "[" + pipelineArgList.join(',') + "]"
 
         def argMap = [
                 benchmarks               : 'beam_integration_benchmark',
@@ -110,7 +104,7 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
                 beam_sdk                 : 'java',
                 beam_it_module           : 'sdks/java/io/file-based-io-tests',
                 beam_it_class            : testConfiguration.itClass,
-                beam_it_options          : pipelineArgsJoined,
+                beam_it_options          : common_job_properties.joinPipelineOptions(pipelineOptions),
                 beam_extra_mvn_properties: '["filesystem=gcs"]',
                 bigquery_table           : testConfiguration.bqTable,
         ]

--- a/.test-infra/jenkins/job_beam_PerformanceTests_HadoopInputFormat.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_HadoopInputFormat.groovy
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common_job_properties
+
+// This job runs the Beam performance tests on PerfKit Benchmarker.
+job('beam_PerformanceTests_HadoopInputFormat') {
+    // Set default Beam job properties.
+    common_job_properties.setTopLevelMainJobProperties(delegate)
+
+    // Run job in postcommit every 6 hours, don't trigger every push, and
+    // don't email individual committers.
+    common_job_properties.setPostCommit(
+            delegate,
+            '0 */6 * * *',
+            false,
+            'commits@beam.apache.org',
+            false)
+
+    common_job_properties.enablePhraseTriggeringFromPullRequest(
+            delegate,
+            'Java HadoopInputFormatIO Performance Test',
+            'Run Java HadoopInputFormatIO Performance Test')
+
+    def pipelineOptions = [
+            tempRoot       : 'gs://temp-storage-for-perf-tests',
+            project        : 'apache-beam-testing',
+            postgresPort   : '5432',
+            numberOfRecords: '600000'
+    ]
+
+    def testArgs = [
+            kubeconfig              : '"$HOME/.kube/config"',
+            beam_it_timeout         : '1200',
+            benchmarks              : 'beam_integration_benchmark',
+            beam_it_profile         : 'io-it',
+            beam_prebuilt           : 'true',
+            beam_sdk                : 'java',
+            beam_it_module          : 'sdks/java/io/hadoop-input-format',
+            beam_it_class           : 'org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIOIT',
+            beam_it_options         : common_job_properties.joinPipelineOptions(pipelineOptions),
+            beam_kubernetes_scripts : common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres.yml')
+                    + ',' + common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
+            beam_options_config_file: common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/pkb-config-local.yml'),
+            bigquery_table          : 'beam_performance.hadoopinputformatioit_pkb_results'
+    ]
+
+    steps {
+        // create .kube/config file for perfkit (if not exists)
+        shell('gcloud container clusters get-credentials io-datastores --zone=us-central1-a --verbosity=debug')
+    }
+
+    common_job_properties.buildPerformanceTest(delegate, testArgs)
+}
+

--- a/.test-infra/jenkins/job_beam_PerformanceTests_HadoopInputFormat.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_HadoopInputFormat.groovy
@@ -18,7 +18,6 @@
 
 import common_job_properties
 
-// This job runs the Beam performance tests on PerfKit Benchmarker.
 job('beam_PerformanceTests_HadoopInputFormat') {
     // Set default Beam job properties.
     common_job_properties.setTopLevelMainJobProperties(delegate)
@@ -44,8 +43,11 @@ job('beam_PerformanceTests_HadoopInputFormat') {
             numberOfRecords: '600000'
     ]
 
+    String namespace = common_job_properties.getKubernetesNamespace('hadoopinputformatioit')
+    String kubeconfig = common_job_properties.getKubeconfigLocationForNamespace(namespace)
+
     def testArgs = [
-            kubeconfig              : '"$HOME/.kube/config"',
+            kubeconfig              : kubeconfig,
             beam_it_timeout         : '1200',
             benchmarks              : 'beam_integration_benchmark',
             beam_it_profile         : 'io-it',
@@ -54,17 +56,13 @@ job('beam_PerformanceTests_HadoopInputFormat') {
             beam_it_module          : 'sdks/java/io/hadoop-input-format',
             beam_it_class           : 'org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIOIT',
             beam_it_options         : common_job_properties.joinPipelineOptions(pipelineOptions),
-            beam_kubernetes_scripts : common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres.yml')
-                    + ',' + common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
+            beam_kubernetes_scripts : common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
             beam_options_config_file: common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/pkb-config-local.yml'),
             bigquery_table          : 'beam_performance.hadoopinputformatioit_pkb_results'
     ]
 
-    steps {
-        // create .kube/config file for perfkit (if not exists)
-        shell('gcloud container clusters get-credentials io-datastores --zone=us-central1-a --verbosity=debug')
-    }
-
+    common_job_properties.setupKubernetes(delegate, namespace, kubeconfig)
     common_job_properties.buildPerformanceTest(delegate, testArgs)
+    common_job_properties.cleanupKubernetes(delegate, namespace, kubeconfig)
 }
 

--- a/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_JDBC.groovy
@@ -37,7 +37,7 @@ job('beam_PerformanceTests_JDBC') {
             'Java JdbcIO Performance Test',
             'Run Java JdbcIO Performance Test')
 
-    def pipelineArgs = [
+    def pipelineOptions = [
             tempRoot       : 'gs://temp-storage-for-perf-tests',
             project        : 'apache-beam-testing',
             postgresPort   : '5432',
@@ -53,10 +53,10 @@ job('beam_PerformanceTests_JDBC') {
             beam_sdk                : 'java',
             beam_it_module          : 'sdks/java/io/jdbc',
             beam_it_class           : 'org.apache.beam.sdk.io.jdbc.JdbcIOIT',
-            beam_it_options         : joinPipelineOptions(pipelineArgs),
-            beam_kubernetes_scripts : makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres.yml')
-                    + ',' + makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
-            beam_options_config_file: makePathAbsolute('src/.test-infra/kubernetes/postgres/pkb-config-local.yml'),
+            beam_it_options         : common_job_properties.joinPipelineOptions(pipelineOptions),
+            beam_kubernetes_scripts : common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres.yml')
+                    + ',' + common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml'),
+            beam_options_config_file: common_job_properties.makePathAbsolute('src/.test-infra/kubernetes/postgres/pkb-config-local.yml'),
             bigquery_table          : 'beam_performance.jdbcioit_pkb_results'
     ]
 
@@ -68,14 +68,3 @@ job('beam_PerformanceTests_JDBC') {
     common_job_properties.buildPerformanceTest(delegate, testArgs)
 }
 
-static String joinPipelineOptions(Map pipelineArgs) {
-    List<String> pipelineArgList = []
-    pipelineArgs.each({
-        key, value -> pipelineArgList.add("\"--$key=$value\"")
-    })
-    return "[" + pipelineArgList.join(',') + "]"
-}
-
-static String makePathAbsolute(String path) {
-    return '"$WORKSPACE/' + path + '"'
-}

--- a/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml
+++ b/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml
@@ -26,3 +26,30 @@ spec:
   selector:
     name: postgres
   type: LoadBalancer
+
+---
+
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    name: postgres
+  template:
+    metadata:
+      name: postgres
+      labels:
+        name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres
+          env:
+            - name: POSTGRES_PASSWORD
+              value: uuinkks
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - containerPort: 5432

--- a/sdks/java/io/hadoop-input-format/pom.xml
+++ b/sdks/java/io/hadoop-input-format/pom.xml
@@ -253,7 +253,7 @@
                 <argument>-beam_it_module=sdks/java/io/hadoop-input-format</argument>
                 <argument>-beam_it_class=org.apache.beam.sdk.io.hadoop.inputformat.HadoopInputFormatIOIT</argument>
                 <argument>-beam_options_config_file=${beamRootProjectDir}/.test-infra/kubernetes/postgres/pkb-config-local.yml</argument>
-                <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres.yml,${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml</argument>
+                <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml</argument>
                 <!-- arguments typically defined by user -->
                 <argument>-beam_it_options=${integrationTestPipelineOptions}</argument>
               </arguments>

--- a/sdks/java/io/jdbc/pom.xml
+++ b/sdks/java/io/jdbc/pom.xml
@@ -220,7 +220,7 @@
                 <argument>${pkbBeamRunnerOption}</argument>
                 <!-- specific to this IO -->
                 <argument>-beam_options_config_file=${beamRootProjectDir}/.test-infra/kubernetes/postgres/pkb-config-local.yml</argument>
-                <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres.yml,${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml</argument>
+                <argument>-beam_kubernetes_scripts=${beamRootProjectDir}/.test-infra/kubernetes/postgres/postgres-service-for-local-dev.yml</argument>
                 <argument>-beam_it_module=sdks/java/io/jdbc</argument>
                 <argument>-beam_it_class=org.apache.beam.sdk.io.jdbc.JdbcIOIT</argument>
                 <!-- arguments typically defined by user -->


### PR DESCRIPTION
This PR adds jenkins jobs for HadoopInputFormatIOIT. 

Before this PR there was only one test that used postgres kubernetes scripts (JDBC IOIT). Right now, while having more than one test using those, there is a strong possiblility that two tests will try to create kubernetes resources (eg. service or replication controller) of the same name (say, "postgres"). This will result in one test being unable to run successfully (due to names collision). 

This PR proposes a solution to above problem. Every kubernetes test resource is being created in it's own namespace. This avoids the name collisions and allows running them "in isolation". 

This solution has some other (minor) advantages: 
 - if a Jenkins job gets killed and doesn't clean up it's Kubernetes resources on the cluster we don't have to manually delete them to be able to run other test (now the test fails due to name collisions with the "dangling" resources that are left there)
 - we can easily clean up the cluster with one command. To delete every resource (service, rc, pods etc) it's sufficient to delete the namespace only (`kubectl delete namespace foo`) it deletes it's "inner resources" too. 

Remarks: 
 - Port collisions are still possible even when using namespaces. If two services from different namespaces want bind to the same port we get an error from Kubernetes ("port is already allocated"). This doesn't happen while using load balancer service so it's not a problem for our IOIT tests now.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

