### PR TITLE
Update QueryablePipeline Factory Method Name

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
@@ -60,7 +60,7 @@ public class GreedyPipelineFuser {
   private final Set<ExecutableStage> stages = new LinkedHashSet<>();
 
   private GreedyPipelineFuser(Pipeline p) {
-    this.pipeline = QueryablePipeline.fromComponents(p.getComponents());
+    this.pipeline = QueryablePipeline.forPrimitivesIn(p.getComponents());
     NavigableSet<CollectionConsumer> rootConsumers = new TreeSet<>();
     for (PTransformNode pTransformNode : pipeline.getRootTransforms()) {
       // This will usually be a single node, the downstream of an Impulse, but may be of any size

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
@@ -133,7 +133,7 @@ public class ExecutableStageTest {
         .putPcollections("window.out", PCollection.newBuilder().setUniqueName("window.out").build())
         .putEnvironments("common", Environment.newBuilder().setUrl("common").build())
         .build();
-    QueryablePipeline p = QueryablePipeline.fromComponents(components);
+    QueryablePipeline p = QueryablePipeline.forPrimitivesIn(components);
 
     ExecutableStage subgraph =
         GreedyStageFuser.forGrpcPortRead(

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuserTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedyStageFuserTest.java
@@ -82,7 +82,7 @@ public class GreedyStageFuserTest {
   @Test
   public void noInitialConsumersThrows() {
     // (impulse.out) -> () is not a meaningful stage, so it should never be called
-    QueryablePipeline p = QueryablePipeline.fromComponents(partialComponents);
+    QueryablePipeline p = QueryablePipeline.forPrimitivesIn(partialComponents);
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("at least one PTransform");
@@ -96,7 +96,7 @@ public class GreedyStageFuserTest {
     //                                    -> py -> py.out
     // read.out can't be fused with both 'go' and 'py', so we should refuse to create this stage
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms(
@@ -170,7 +170,7 @@ public class GreedyStageFuserTest {
             .putOutputs("output", "gbk.out")
             .build();
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("runnerTransform", gbkTransform)
@@ -218,7 +218,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("parDo", parDoTransform)
@@ -277,7 +277,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("parDo", parDoTransform)
@@ -337,7 +337,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("parDo", parDoTransform)
@@ -418,7 +418,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("read", readTransform)
@@ -518,7 +518,7 @@ public class GreedyStageFuserTest {
             .putEnvironments("common", Environment.newBuilder().setUrl("common").build())
             .putEnvironments("rare", Environment.newBuilder().setUrl("rare").build())
             .build();
-    QueryablePipeline p = QueryablePipeline.fromComponents(components);
+    QueryablePipeline p = QueryablePipeline.forPrimitivesIn(components);
 
     ExecutableStage subgraph =
         GreedyStageFuser.forGrpcPortRead(
@@ -644,7 +644,7 @@ public class GreedyStageFuserTest {
             .putEnvironments("go", Environment.newBuilder().setUrl("go").build())
             .putEnvironments("py", Environment.newBuilder().setUrl("py").build())
             .build();
-    QueryablePipeline p = QueryablePipeline.fromComponents(components);
+    QueryablePipeline p = QueryablePipeline.forPrimitivesIn(components);
 
     ExecutableStage readFromPy =
         GreedyStageFuser.forGrpcPortRead(
@@ -691,7 +691,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("parDo", parDoTransform)
@@ -752,7 +752,7 @@ public class GreedyStageFuserTest {
                             .toByteString()))
             .build();
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("read", readTransform)
@@ -832,7 +832,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("read", readTransform)
@@ -917,7 +917,7 @@ public class GreedyStageFuserTest {
             .build();
 
     QueryablePipeline p =
-        QueryablePipeline.fromComponents(
+        QueryablePipeline.forPrimitivesIn(
             partialComponents
                 .toBuilder()
                 .putTransforms("read", readTransform)

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/QueryablePipelineTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/QueryablePipelineTest.java
@@ -81,7 +81,7 @@ public class QueryablePipelineTest {
   @Test
   public void fromEmptyComponents() {
     // Not that it's hugely useful, but it shouldn't throw.
-    QueryablePipeline p = QueryablePipeline.fromComponents(Components.getDefaultInstance());
+    QueryablePipeline p = QueryablePipeline.forPrimitivesIn(Components.getDefaultInstance());
     assertThat(p.getRootTransforms(), emptyIterable());
   }
 
@@ -94,7 +94,7 @@ public class QueryablePipelineTest {
             .build();
 
     thrown.expect(IllegalArgumentException.class);
-    QueryablePipeline.fromComponents(components);
+    QueryablePipeline.forPrimitivesIn(components);
   }
 
   @Test
@@ -106,7 +106,7 @@ public class QueryablePipelineTest {
     p.apply("BoundedRead", Read.from(CountingSource.upTo(100L)));
 
     Components components = PipelineTranslation.toProto(p).getComponents();
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
 
     assertThat(qp.getRootTransforms(), hasSize(2));
     for (PTransformNode rootTransform : qp.getRootTransforms()) {
@@ -139,7 +139,7 @@ public class QueryablePipelineTest {
             .withOutputTags(new TupleTag<>(), TupleTagList.empty()));
 
     Components components = PipelineTranslation.toProto(p).getComponents();
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
 
     String mainInputName =
         getOnlyElement(
@@ -198,7 +198,7 @@ public class QueryablePipelineTest {
                     .build())
             .build();
 
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
     PCollectionNode multiInputPc =
         PipelineNode.pCollection("read_pc", components.getPcollectionsOrThrow("read_pc"));
     PTransformNode multiConsumerPT =
@@ -221,7 +221,7 @@ public class QueryablePipelineTest {
     // This breaks if the way that IDs are assigned to PTransforms changes in PipelineTranslation
     String readOutput =
         getOnlyElement(components.getTransformsOrThrow("BoundedRead").getOutputsMap().values());
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
     Set<PTransformNode> consumers =
         qp.getPerElementConsumers(
             PipelineNode.pCollection(readOutput, components.getPcollectionsOrThrow(readOutput)));
@@ -239,7 +239,7 @@ public class QueryablePipelineTest {
     PCollectionList.of(longs).and(longs).and(longs).apply("flatten", Flatten.pCollections());
 
     Components components = PipelineTranslation.toProto(p).getComponents();
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
 
     String longsOutputName =
         getOnlyElement(
@@ -275,7 +275,7 @@ public class QueryablePipelineTest {
     PCollectionList.of(longs).and(longs).and(longs).apply("flatten", Flatten.pCollections());
 
     Components components = PipelineTranslation.toProto(p).getComponents();
-    QueryablePipeline qp = QueryablePipeline.fromComponents(components);
+    QueryablePipeline qp = QueryablePipeline.forPrimitivesIn(components);
 
     PTransformNode environmentalRead =
         PipelineNode.pTransform("BoundedRead", components.getTransformsOrThrow("BoundedRead"));


### PR DESCRIPTION
Signal via method name that that method constructs the pipeline which
uses only the primitives within the provided Components.

This enables future changes to construct a QueryablePipeline based on
some other set of components.

Remove unused QueryablePipeline fields and methods.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

