### PR TITLE
Fix issue from incomplete removal of has_cache

### DIFF
--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -477,14 +477,7 @@ class _TaggedReceivers(dict):
   def __init__(self, evaluation_context):
     self._evaluation_context = evaluation_context
     self._null_receiver = None
-    self._undeclared_in_memory_tag_values = None
     super(_TaggedReceivers, self).__init__()
-
-  @property
-  def undeclared_in_memory_tag_values(self):
-    assert (not self._undeclared_in_memory_tag_values
-            or self._evaluation_context.has_cache)
-    return self._undeclared_in_memory_tag_values
 
   class NullReceiver(common.Receiver):
     """Ignores undeclared outputs, default execution mode."""
@@ -503,16 +496,9 @@ class _TaggedReceivers(dict):
       self._target[self._tag].append(element)
 
   def __missing__(self, key):
-    if self._evaluation_context.has_cache:
-      if not self._undeclared_in_memory_tag_values:
-        self._undeclared_in_memory_tag_values = collections.defaultdict(list)
-      receiver = _TaggedReceivers._InMemoryReceiver(
-          self._undeclared_in_memory_tag_values, key)
-    else:
-      if not self._null_receiver:
-        self._null_receiver = _TaggedReceivers.NullReceiver()
-      receiver = self._null_receiver
-    return receiver
+    if not self._null_receiver:
+      self._null_receiver = _TaggedReceivers.NullReceiver()
+    return self._null_receiver
 
 
 class _ParDoEvaluator(_TransformEvaluator):
@@ -566,8 +552,7 @@ class _ParDoEvaluator(_TransformEvaluator):
     bundles = self._tagged_receivers.values()
     result_counters = self._counter_factory.get_counters()
     return TransformResult(
-        self, bundles, [], result_counters, None,
-        self._tagged_receivers.undeclared_in_memory_tag_values)
+        self, bundles, [], result_counters, None)
 
 
 class _GroupByKeyOnlyEvaluator(_TransformEvaluator):

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -249,7 +249,8 @@ class PTransformTest(unittest.TestCase):
     nums = pipeline | 'Some Numbers' >> beam.Create([1, 2, 3, 4])
     results = nums | 'ClassifyNumbers' >> beam.FlatMap(
         lambda x: [x,
-                   pvalue.TaggedOutput('even' if x % 2 == 0 else 'odd', x)]
+                   pvalue.TaggedOutput('even' if x % 2 == 0 else 'odd', x),
+                   pvalue.TaggedOutput('extra', x)]
     ).with_outputs()
     assert_that(results[None], equal_to([1, 2, 3, 4]))
     assert_that(results.odd, equal_to([1, 3]), label='assert:odd')


### PR DESCRIPTION
This change fixes an issue where a reference remained to the removed `has_cache`.