### PR TITLE
[BEAM-3760] Run NeedsRunner tests from direct runner gradle build

### DIFF
--- a/runners/core-construction-java/build.gradle
+++ b/runners/core-construction-java/build.gradle
@@ -45,7 +45,29 @@ dependencies {
   shadow library.java.slf4j_api
   shadow library.java.grpc_core
   shadow library.java.grpc_stub
-  testCompile library.java.hamcrest_core
-  testCompile library.java.junit
-  testCompile library.java.mockito_core
+  shadowTest library.java.hamcrest_core
+  shadowTest library.java.junit
+  shadowTest library.java.mockito_core
+}
+
+// Create a shaded test jar.
+task shadowTestJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  classifier = "shaded-tests"
+  from sourceSets.test.output
+  configurations = [project.configurations.testRuntime]
+  dependencies {
+    exclude(".*")
+    include(dependency(library.java.guava))
+  }
+  relocate("com.google.common", getJavaRelocatedPath("com.google.common")) {
+    // com.google.common is too generic, need to exclude guava-testlib
+    exclude "com.google.common.collect.testing.**"
+    exclude "com.google.common.escape.testing.**"
+    exclude "com.google.common.testing.**"
+    exclude "com.google.common.util.concurrent.testing.**"
+  }
+}
+
+artifacts {
+  shadowTest shadowTestJar
 }

--- a/runners/core-java/build.gradle
+++ b/runners/core-java/build.gradle
@@ -41,10 +41,32 @@ dependencies {
   shadow library.java.grpc_stub
   shadow library.java.joda_time
   shadow library.java.slf4j_api
-  testCompile project(path: ":sdks:java:core", configuration: "shadowTest")
-  testCompile library.java.hamcrest_core
-  testCompile library.java.mockito_core
-  testCompile library.java.junit
-  testCompile library.java.slf4j_jdk14
-  testCompile library.java.jackson_dataformat_yaml
+  shadowTest project(path: ":sdks:java:core", configuration: "shadowTest")
+  shadowTest library.java.hamcrest_core
+  shadowTest library.java.mockito_core
+  shadowTest library.java.junit
+  shadowTest library.java.slf4j_jdk14
+  shadowTest library.java.jackson_dataformat_yaml
+}
+
+// Create a shaded test jar.
+task shadowTestJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  classifier = "shaded-tests"
+  from sourceSets.test.output
+  configurations = [project.configurations.testRuntime]
+  dependencies {
+    exclude(".*")
+    include(dependency(library.java.guava))
+  }
+  relocate("com.google.common", getJavaRelocatedPath("com.google.common")) {
+    // com.google.common is too generic, need to exclude guava-testlib
+    exclude "com.google.common.collect.testing.**"
+    exclude "com.google.common.escape.testing.**"
+    exclude "com.google.common.testing.**"
+    exclude "com.google.common.util.concurrent.testing.**"
+  }
+}
+
+artifacts {
+  shadowTest shadowTestJar
 }

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -27,8 +27,6 @@ description = "Apache Beam :: Runners :: Direct Java"
  * We need to rely on manually specifying these evaluationDependsOn to ensure that
  * the following projects are evaluated before we evaluate this project. This is because
  * we are attempting to reference the "sourceSets.test.output" directly.
- * TODO: Swap to generating test artifacts which we can then rely on instead of
- * the test outputs directly.
  */
 evaluationDependsOn(":model:fn-execution")
 evaluationDependsOn(":runners:core-construction-java")
@@ -52,7 +50,7 @@ dependencies {
   shadow library.java.hamcrest_core
   shadow library.java.junit
   shadowTest project(path: ":sdks:java:core", configuration: "shadowTest")
-  shadowTest project(":runners:core-java").sourceSets.test.output
+  shadowTest project(path: ":runners:core-java", configuration: "shadowTest")
   shadowTest project(":model:fn-execution").sourceSets.test.output
   shadowTest library.java.guava_testlib
   shadowTest library.java.slf4j_jdk14

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import groovy.json.JsonOutput
+
 apply from: project(":").file("build_rules.gradle")
 applyJavaNature(artifactId: "beam-runners-direct-java")
 
@@ -28,8 +30,14 @@ description = "Apache Beam :: Runners :: Direct Java"
  * TODO: Swap to generating test artifacts which we can then rely on instead of
  * the test outputs directly.
  */
-evaluationDependsOn(":runners:core-java")
 evaluationDependsOn(":model:fn-execution")
+evaluationDependsOn(":runners:core-construction-java")
+evaluationDependsOn(":runners:core-java")
+evaluationDependsOn(":sdks:java:core")
+
+configurations {
+  needsRunner
+}
 
 dependencies {
   compile library.java.guava
@@ -43,16 +51,40 @@ dependencies {
   shadow library.java.slf4j_api
   shadow library.java.hamcrest_core
   shadow library.java.junit
-  testCompile project(path: ":sdks:java:core", configuration: "shadowTest")
-  testCompile project(":runners:core-java").sourceSets.test.output
-  testCompile project(":model:fn-execution").sourceSets.test.output
-  testCompile library.java.guava_testlib
-  testCompile library.java.slf4j_jdk14
-  testCompile library.java.mockito_core
-  testCompile library.java.stax2_api
-  testCompile library.java.woodstox_core_asl
-  testCompile library.java.google_cloud_dataflow_java_proto_library_all
-  testCompile library.java.jackson_dataformat_yaml
+  shadowTest project(path: ":sdks:java:core", configuration: "shadowTest")
+  shadowTest project(":runners:core-java").sourceSets.test.output
+  shadowTest project(":model:fn-execution").sourceSets.test.output
+  shadowTest library.java.guava_testlib
+  shadowTest library.java.slf4j_jdk14
+  shadowTest library.java.mockito_core
+  shadowTest library.java.stax2_api
+  shadowTest library.java.woodstox_core_asl
+  shadowTest library.java.google_cloud_dataflow_java_proto_library_all
+  shadowTest library.java.jackson_dataformat_yaml
+  needsRunner project(path: ":runners:core-construction-java", configuration: "shadowTest")
+  needsRunner project(path: ":runners:core-java", configuration: "shadowTest")
+  needsRunner project(path: ":sdks:java:core", configuration: "shadowTest")
+  needsRunner project(path: project.path, configuration: "shadow")
+  needsRunner project(path: project.path, configuration: "shadowTest")
+}
+
+task needsRunnerTests(type: Test) {
+  group = "Verification"
+  description = "Runs tests that require a runner"
+
+  def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false"])
+  systemProperty "beamTestPipelineOptions", pipelineOptions
+
+  classpath = configurations.needsRunner
+  // NOTE: We only add to the test class dirs to ensure that the direct runner
+  // tests (i.e., those from this subproject) get scanned.
+  testClassesDirs += files(project(":runners:core-construction-java").sourceSets.test.output.classesDirs)
+  testClassesDirs += files(project(":runners:core-java").sourceSets.test.output.classesDirs)
+  testClassesDirs += files(project(":sdks:java:core").sourceSets.test.output.classesDirs)
+  useJUnit {
+    includeCategories "org.apache.beam.sdk.testing.NeedsRunner"
+    excludeCategories "org.apache.beam.sdk.testing.LargeKeys\$Above100MB"
+  }
 }
 
 shadowJar {
@@ -68,6 +100,38 @@ shadowJar {
   relocate "org.apache.beam.model", getJavaRelocatedPath("model")
   relocate "com.google.protobuf", getJavaRelocatedPath("com.google.protobuf")
   relocate "javax.annotation", getJavaRelocatedPath("javax.annotation")
+}
+
+// Create a shaded test jar.
+task shadowTestJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  classifier = "shaded-tests"
+  from sourceSets.test.output
+  configurations = [project.configurations.testRuntime]
+  dependencies {
+    exclude(".*")
+    include(dependency(library.java.guava))
+    include(dependency(library.java.protobuf_java))
+    include(dependency(library.java.protobuf_java_util))
+    include(project(path: ":model:pipeline", configuration: "shadow"))
+    include(project(path: ":runners:core-construction-java", configuration: "shadow"))
+    include(project(path: ":runners:core-java", configuration: "shadow"))
+    include(project(path: ":runners:local-java", configuration: "shadow"))
+  }
+  relocate("com.google.common", getJavaRelocatedPath("com.google.common")) {
+    // com.google.common is too generic, need to exclude guava-testlib
+    exclude "com.google.common.collect.testing.**"
+    exclude "com.google.common.escape.testing.**"
+    exclude "com.google.common.testing.**"
+    exclude "com.google.common.util.concurrent.testing.**"
+  }
+  relocate "org.apache.beam.runners.core", getJavaRelocatedPath("runners.core")
+  relocate "org.apache.beam.model", getJavaRelocatedPath("model")
+  relocate "com.google.protobuf", getJavaRelocatedPath("com.google.protobuf")
+  relocate "javax.annotation", getJavaRelocatedPath("javax.annotation")
+}
+
+artifacts {
+  shadowTest shadowTestJar
 }
 
 // Generates :runners:direct-java:runQuickstartJavaDirect

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
 task needsRunnerTests(type: Test) {
   group = "Verification"
-  description = "Runs tests that require a runner"
+  description = "Runs tests that require a runner to validate that piplines/transforms work correctly"
 
   def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false"])
   systemProperty "beamTestPipelineOptions", pipelineOptions

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -152,7 +152,7 @@
               <failIfNoTests>true</failIfNoTests>
               <dependenciesToScan>
                 <dependency>org.apache.beam:beam-sdks-java-core</dependency>
-                <dependency>org.apache.beam:beam-runners-java-core-construction</dependency>
+                <dependency>org.apache.beam:beam-runners-core-construction-java</dependency>
                 <dependency>org.apache.beam:beam-runners-java-core</dependency>
               </dependenciesToScan>
               <systemPropertyVariables>


### PR DESCRIPTION
The approach used here is similar to that used in the ValidatesRunner tests: depend on scanned dependencies for build evaluation, add a new configuration that captures these test dependencies, and manually depend on the test class directories from a new test task.

In addition to this, each dependency to scan now exports a `shadowTestJar` artifact. This allows the test classes to be added to the classpath of the new test task.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

