### PR TITLE
[BEAM-3761]Fix Python 3 cmp usage

### DIFF
--- a/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
@@ -31,6 +31,7 @@ import six
 # pylint: disable=ungrouped-imports
 from apache_beam.internal.gcp import auth
 from apache_beam.utils import retry
+from apache_beam.utils.annotations import deprecated
 
 # Protect against environments where datastore library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
@@ -50,6 +51,7 @@ except ImportError:
 # pylint: enable=ungrouped-imports
 
 
+@deprecated(since="v2.4")
 def key_comparator(k1, k2):
   """A comparator for Datastore keys.
 
@@ -78,6 +80,7 @@ def key_comparator(k1, k2):
   return 0
 
 
+@deprecated(since="v2.4")
 def compare_path(p1, p2):
   """A comparator for key path.
 
@@ -90,7 +93,7 @@ def compare_path(p1, p2):
   3. If no `id` is defined for both paths, then their `names` are compared.
   """
 
-  result = cmp(p1.kind, p2.kind)
+  result = (p1.kind > p2.kind) - (p1.kind < p2.kind)
   if result != 0:
     return result
 
@@ -98,12 +101,12 @@ def compare_path(p1, p2):
     if not p2.HasField('id'):
       return -1
 
-    return cmp(p1.id, p2.id)
+    return (p1.id > p2.id) - (p1.id < p2.id)
 
   if p2.HasField('id'):
     return 1
 
-  return cmp(p1.name, p2.name)
+  return (p1.name > p2.name) - (p1.name < p2.name)
 
 
 def get_datastore(project):

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
@@ -31,7 +31,6 @@ import six
 # pylint: disable=ungrouped-imports
 from apache_beam.internal.gcp import auth
 from apache_beam.utils import retry
-from apache_beam.utils.annotations import deprecated
 
 # Protect against environments where datastore library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
@@ -51,7 +50,6 @@ except ImportError:
 # pylint: enable=ungrouped-imports
 
 
-@deprecated(since="v2.4")
 def key_comparator(k1, k2):
   """A comparator for Datastore keys.
 
@@ -80,7 +78,6 @@ def key_comparator(k1, k2):
   return 0
 
 
-@deprecated(since="v2.4")
 def compare_path(p1, p2):
   """A comparator for key path.
 

--- a/sdks/python/apache_beam/io/vcfio_test.py
+++ b/sdks/python/apache_beam/io/vcfio_test.py
@@ -70,15 +70,6 @@ def get_full_dir():
   return os.path.join(os.path.dirname(__file__), '..', 'testing', 'data', 'vcf')
 
 
-# Helper method for comparing variants.
-def _variant_comparator(v1, v2):
-  if v1.reference_name == v2.reference_name:
-    if v1.start == v2.start:
-      return cmp(v1.end, v2.end)
-    return cmp(v1.start, v2.start)
-  return cmp(v1.reference_name, v2.reference_name)
-
-
 # Helper method for verifying equal count on PCollection.
 def _count_equals_to(expected_count):
   def _count_equal(actual_list):

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -256,9 +256,6 @@ class TimestampedValue(object):
   def __eq__(self, other):
     return self.value == other.value and self.timestamp == other.timestamp
 
-  def __hash_(self):
-    return hash(self.value) ^ hash(self.timestamp) << 1
-
   def __lt__(self, other):
     if type(self) is not type(other):
       raise TypeError("Can not compare type %s and %s" %

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -200,12 +200,9 @@ class BoundedWindow(object):
 
   def __lt__(self, other):
     if type(self) is not type(other):
-      return type(self) < type(other)
+      raise TypeError("Can not compare type %s and %s" % (type(self), type(other)))
     # Order first by endpoint, then arbitrarily.
     return (self.end, hash(self)) < (other.end, hash(other))
-
-  def __hash__(self):
-    return hash(self.end)
 
   def __repr__(self):
     return '[?, %s)' % float(self.end)
@@ -263,7 +260,7 @@ class TimestampedValue(object):
 
   def __lt__(self, other):
     if type(self) is not type(other):
-      return type(self) < type(other)
+      raise TypeError("Can not compare type %s and %s" % (type(self), type(other)))
     return (self.value, self.timestamp) < (other.value, other.timestamp)
 
 

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -200,7 +200,8 @@ class BoundedWindow(object):
 
   def __lt__(self, other):
     if type(self) is not type(other):
-      raise TypeError("Can not compare type %s and %s" % (type(self), type(other)))
+      raise TypeError("Can not compare type %s and %s" %
+                      (type(self), type(other)))
     # Order first by endpoint, then arbitrarily.
     return (self.end, hash(self)) < (other.end, hash(other))
 
@@ -260,7 +261,8 @@ class TimestampedValue(object):
 
   def __lt__(self, other):
     if type(self) is not type(other):
-      raise TypeError("Can not compare type %s and %s" % (type(self), type(other)))
+      raise TypeError("Can not compare type %s and %s" %
+                      (type(self), type(other)))
     return (self.value, self.timestamp) < (other.value, other.timestamp)
 
 

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -225,9 +225,9 @@ class IntervalWindow(BoundedWindow):
     return hash((self.start, self.end))
 
   def __eq__(self, other):
-    return type(self) == type(other) and \
-      self.start == other.start and \
-      self.end == other.end
+    return (type(self) == type(other) and
+            self.start == other.start and
+            self.end == other.end)
 
   def __repr__(self):
     return '[%s, %s)' % (float(self.start), float(self.end))

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -20,15 +20,16 @@
 For internal use only; no backwards-compatibility guarantees.
 """
 
-from __future__ import absolute_import
-from __future__ import division
+from __future__ import absolute_import, division
 
 import datetime
 import re
+from functools import total_ordering
 
 import pytz
 
 
+@total_ordering
 class Timestamp(object):
   """Represents a Unix second timestamp with microsecond granularity.
 
@@ -142,11 +143,23 @@ class Timestamp(object):
     # Note that the returned value may have lost precision.
     return self.micros // 1000000
 
-  def __cmp__(self, other):
+  def __eq__(self, other):
     # Allow comparisons between Duration and Timestamp values.
-    if not isinstance(other, Duration):
+    if not isinstance(other, (Timestamp, Duration)):
       other = Timestamp.of(other)
-    return cmp(self.micros, other.micros)
+    return self.micros == other.micros
+
+  def __ne__(self, other):
+    # Allow comparisons between Duration and Timestamp values.
+    if not isinstance(other, (Timestamp, Duration)):
+      other = Timestamp.of(other)
+    return self.micros != other.micros
+
+  def __lt__(self, other):
+    # Allow comparisons between Duration and Timestamp values.
+    if not isinstance(other, (Timestamp, Duration)):
+      other = Timestamp.of(other)
+    return self.micros < other.micros
 
   def __hash__(self):
     return hash(self.micros)
@@ -171,6 +184,7 @@ MIN_TIMESTAMP = Timestamp(micros=-0x7fffffffffffffff - 1)
 MAX_TIMESTAMP = Timestamp(micros=0x7fffffffffffffff)
 
 
+@total_ordering
 class Duration(object):
   """Represents a second duration with microsecond granularity.
 
@@ -220,11 +234,23 @@ class Duration(object):
     # Note that the returned value may have lost precision.
     return self.micros / 1000000
 
-  def __cmp__(self, other):
+  def __eq__(self, other):
     # Allow comparisons between Duration and Timestamp values.
-    if not isinstance(other, Timestamp):
+    if not isinstance(other, (Timestamp, Duration)):
       other = Duration.of(other)
-    return cmp(self.micros, other.micros)
+    return self.micros == other.micros
+
+  def __ne__(self, other):
+    # Allow comparisons between Duration and Timestamp values.
+    if not isinstance(other, (Timestamp, Duration)):
+      other = Duration.of(other)
+    return self.micros != other.micros
+
+  def __lt__(self, other):
+    # Allow comparisons between Duration and Timestamp values.
+    if not isinstance(other, (Timestamp, Duration)):
+      other = Duration.of(other)
+    return self.micros < other.micros
 
   def __hash__(self):
     return hash(self.micros)

--- a/sdks/python/apache_beam/utils/windowed_value.py
+++ b/sdks/python/apache_beam/utils/windowed_value.py
@@ -193,7 +193,7 @@ class WindowedValue(object):
     on unequal values (always returning 1).
     """
     if type(left) is not type(right):
-      return cmp(type(left), type(right))
+      return 1
 
     # TODO(robertwb): Avoid the type checks?
     # Returns False (0) if equal, and True (1) if not.


### PR DESCRIPTION
Fixes our usage of cmp as part of Python 3 port. In some places where cmp was not being used remove the function entirely, in others rewrite to use total_ordering annotation.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X ] Write a pull request description that is detailed enough to understand:
   - [ X] What the pull request does
   - [ X ] Why it does it
   - [ X ] How it does it
   - [ X ] Why this approach
 - [ X ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically. (ran python tests instead)
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

