### PR TITLE
[BEAM-3620] Update Readme and JavaDoc for KafkaIO.

### DIFF
--- a/sdks/java/io/kafka/README.md
+++ b/sdks/java/io/kafka/README.md
@@ -21,7 +21,11 @@ KafkaIO contains I/O transforms which allow you to read/write messages from/to [
 
 ## Dependencies
 
-To use KafkaIO you must first add a dependency on `beam-sdks-java-io-kafka`
+To use KafkaIO you must first add a dependency on `beam-sdks-java-io-kafka`. KafkaIO supports
+multiple versions of Kafka clients at run time. It does not pull a specific version `kafka-clients`
+transitively. You need to include a compatible version of `kafka-clients` as runtime dependency.
+Usually current and recent versions of Kafka are supported, please see JavaDoc for KafkaIO for
+complete list.
 
 ```maven
 <dependency>
@@ -29,8 +33,17 @@ To use KafkaIO you must first add a dependency on `beam-sdks-java-io-kafka`
     <artifactId>beam-sdks-java-io-kafka</artifactId>
     <version>...</version>
 </dependency>
+
+<dependency>
+  <groupId>org.apache.kafka</groupId>
+  <artifactId>kafka-clients</artifactId>
+  <version>a_recent_version</version>
+  <scope>runtime</scope>
+</dependency>
 ```
 
 ## Documentation
 
-- [KafkaIO.java](https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java)
+The documentation is maintained in JavaDoc for KafkaIO class. It includes
+ usage examples and primary concepts.
+- [KafkaIO.java](src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java)

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -80,9 +80,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * An unbounded source and a sink for <a href="http://kafka.apache.org/">Kafka</a> topics.
- * Kafka version 0.9 and 0.10 are supported. If you need a specific version of Kafka
- * client(e.g. 0.9 for 0.9 servers, or 0.10 for security features), specify explicit
- * kafka-client dependency.
  *
  * <h3>Reading from Kafka topics</h3>
  *
@@ -205,12 +202,18 @@ import org.slf4j.LoggerFactory;
  * <em>auto commit</em> (for external monitoring or other purposes), you can set
  * <tt>"group.id"</tt>, <tt>"enable.auto.commit"</tt>, etc.
  *
- * <h3>Event Timestamp and Watermark</h3>
+ * <h3>Event Timestamps and Watermark</h3>
  * By default, record timestamp (event time) is set to processing time in KafkaIO reader and
  * source watermark is current wall time. If a topic has Kafka server-side ingestion timestamp
  * enabled ('LogAppendTime'), it can enabled with {@link Read#withLogAppendTime()}.
  * A custom timestamp policy can be provided by implementing {@link TimestampPolicyFactory}. See
  * {@link Read#withTimestampPolicyFactory(TimestampPolicyFactory)} for more information.
+ *
+ * <h3>Supported Kakfa Client Versions</h3>
+ * KafkaIO relies <i>kafka-clients</i> for all its interactions with the Kafka cluster.
+ * <i>kafka-clients</i> versions 0.10.1 and newer are supported at runtime. Please ensure that
+ * the version included with the application is compatible with the version of your Kafka cluster.
+ * Kafka client usually fails to initialize with a clear error message in case of incompatibility.
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class KafkaIO {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -209,11 +209,13 @@ import org.slf4j.LoggerFactory;
  * A custom timestamp policy can be provided by implementing {@link TimestampPolicyFactory}. See
  * {@link Read#withTimestampPolicyFactory(TimestampPolicyFactory)} for more information.
  *
- * <h3>Supported Kakfa Client Versions</h3>
- * KafkaIO relies <i>kafka-clients</i> for all its interactions with the Kafka cluster.
- * <i>kafka-clients</i> versions 0.10.1 and newer are supported at runtime. Please ensure that
- * the version included with the application is compatible with the version of your Kafka cluster.
- * Kafka client usually fails to initialize with a clear error message in case of incompatibility.
+ * <h3>Supported Kafka Client Versions</h3>
+ * KafkaIO relies on <i>kafka-clients</i> for all its interactions with the Kafka cluster.
+ * <i>kafka-clients</i> versions 0.10.1 and newer are supported at runtime. The older versions
+ * 0.9.x - 0.10.0.0 are also supported, but are deprecated and likely be removed in near future.
+ * Please ensure that the version included with the application is compatible with the version of
+ * your Kafka cluster. Kafka client usually fails to initialize with a clear error message in
+ * case of incompatibility.
  */
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class KafkaIO {


### PR DESCRIPTION
Update dependencies in Readme. Include 'supported versions' section in JavaDoc.
`kafka-clients` dependency was moved to `provided` scope in #4603.

+R: @iemejia +CC: @XuMingmin 