### PR TITLE
Fixing formatting bug in filebasedsink.py.

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -250,7 +250,7 @@ class FileBasedSink(iobase.Sink):
                       for e in exception_batch]
     if all_exceptions:
       raise Exception(
-        'Encountered exceptions in finalize_write: %s' % all_exceptions)
+          'Encountered exceptions in finalize_write: %s' % all_exceptions)
 
     for final_name in destination_files:
       yield final_name

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -249,8 +249,8 @@ class FileBasedSink(iobase.Sink):
     all_exceptions = [e for exception_batch in exception_batches
                       for e in exception_batch]
     if all_exceptions:
-      raise Exception('Encountered exceptions in finalize_write: %s',
-                      all_exceptions)
+      raise Exception(
+        'Encountered exceptions in finalize_write: %s' % all_exceptions)
 
     for final_name in destination_files:
       yield final_name


### PR DESCRIPTION
A typo added a formatting bug in filebasedsink that was not showing up.

