### PR TITLE
[BEAM-3409] waitUntilFinish() doesn't wait for the teardown execution on Direct runner - fixing compilation issue on flink

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/DoFnRunner.java
@@ -49,4 +49,10 @@ public interface DoFnRunner<InputT, OutputT> {
    * additional tasks, such as flushing in-memory states.
    */
   void finishBundle();
+
+  /**
+   * @since 2.5.0
+   * @return the underlying fn instance.
+   */
+  DoFn<InputT, OutputT> getFn();
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/LateDataDroppingDoFnRunner.java
@@ -61,6 +61,11 @@ public class LateDataDroppingDoFnRunner<K, InputT, OutputT, W extends BoundedWin
   }
 
   @Override
+  public DoFn<KeyedWorkItem<K, InputT>, KV<K, OutputT>> getFn() {
+    return doFnRunner.getFn();
+  }
+
+  @Override
   public void startBundle() {
     doFnRunner.startBundle();
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ProcessFnRunner.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import org.apache.beam.runners.core.StateNamespaces.WindowNamespace;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -50,6 +51,11 @@ public class ProcessFnRunner<InputT, OutputT, RestrictionT>
     this.underlying = underlying;
     this.views = views;
     this.sideInputReader = sideInputReader;
+  }
+
+  @Override
+  public DoFn<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT> getFn() {
+    return underlying.getFn();
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/PushbackSideInputDoFnRunner.java
@@ -48,4 +48,10 @@ public interface PushbackSideInputDoFnRunner<InputT, OutputT> {
 
   /** Calls the underlying {@link DoFn.FinishBundle} method. */
   void finishBundle();
+
+  /**
+   * @since 2.5.0
+   * @return the underlying fn instance.
+   */
+  DoFn<InputT, OutputT> getFn();
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -121,6 +121,11 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
   }
 
   @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return fn;
+  }
+
+  @Override
   public void startBundle() {
     // This can contain user code. Wrap it in case it throws an exception.
     try {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunner.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionView;
@@ -51,12 +52,17 @@ public class SimplePushbackSideInputDoFnRunner<InputT, OutputT>
   }
 
   private SimplePushbackSideInputDoFnRunner(
-      DoFnRunner<InputT, OutputT> underlying,
+          DoFnRunner<InputT, OutputT> underlying,
       Collection<PCollectionView<?>> views,
       ReadyCheckingSideInputReader sideInputReader) {
     this.underlying = underlying;
     this.views = views;
     this.sideInputReader = sideInputReader;
+  }
+
+  @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return underlying.getFn();
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StatefulDoFnRunner.java
@@ -77,6 +77,11 @@ public class StatefulDoFnRunner<InputT, OutputT, W extends BoundedWindow>
   }
 
   @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return doFnRunner.getFn();
+  }
+
+  @Override
   public void startBundle() {
     doFnRunner.startBundle();
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimplePushbackSideInputDoFnRunnerTest.java
@@ -32,6 +32,7 @@ import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -246,6 +247,11 @@ public class SimplePushbackSideInputDoFnRunnerTest {
     List<TimerData> firedTimers;
     private boolean started = false;
     private boolean finished = false;
+
+    @Override
+    public DoFn<InputT, OutputT> getFn() {
+      return null;
+    }
 
     @Override
     public void startBundle() {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DoFnLifecycleManagerRemovingTransformEvaluator.java
@@ -45,6 +45,10 @@ class DoFnLifecycleManagerRemovingTransformEvaluator<InputT> implements Transfor
     this.lifecycleManager = lifecycleManager;
   }
 
+  public ParDoEvaluator<InputT> getParDoEvaluator() {
+    return underlying;
+  }
+
   @Override
   public void processElement(WindowedValue<InputT> element) throws Exception {
     try {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -25,6 +25,7 @@ import com.google.common.cache.RemovalListener;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -34,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.local.ExecutionDriver;
 import org.apache.beam.runners.local.ExecutionDriver.DriverState;
@@ -272,17 +274,43 @@ final class ExecutorServiceParallelExecutor
       return;
     }
     LOG.debug("Pipeline has terminated. Shutting down.");
-    pipelineState.compareAndSet(State.RUNNING, newState);
+
+    final Collection<Exception> errors = new ArrayList<>();
     // Stop accepting new work before shutting down the executor. This ensures that thread don't try
     // to add work to the shutdown executor.
-    serialExecutorServices.invalidateAll();
-    serialExecutorServices.cleanUp();
-    parallelExecutorService.shutdown();
-    executorService.shutdown();
+    try {
+      serialExecutorServices.invalidateAll();
+    } catch (final RuntimeException re) {
+      errors.add(re);
+    }
+    try {
+      serialExecutorServices.cleanUp();
+    } catch (final RuntimeException re) {
+      errors.add(re);
+    }
+    try {
+      parallelExecutorService.shutdown();
+    } catch (final RuntimeException re) {
+      errors.add(re);
+    }
+    try {
+      executorService.shutdown();
+    } catch (final RuntimeException re) {
+      errors.add(re);
+    }
     try {
       registry.cleanup();
-    } catch (Exception e) {
-      visibleUpdates.failed(e);
+    } catch (final Exception e) {
+      errors.add(e);
+    }
+    pipelineState.compareAndSet(State.RUNNING, newState); // ensure we hit a terminal node
+    if (!errors.isEmpty()) {
+      final IllegalStateException exception = new IllegalStateException(
+        "Error" + (errors.size() == 1 ? "" : "s") + " during executor shutdown:\n"
+        + errors.stream().map(Exception::getMessage)
+          .collect(Collectors.joining("\n- ", "- ", "")));
+      visibleUpdates.failed(exception);
+      throw exception;
     }
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -169,6 +169,14 @@ class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
     }
   }
 
+  public PushbackSideInputDoFnRunner<InputT, ?> getFnRunner() {
+    return fnRunner;
+  }
+
+  public DirectStepContext getStepContext() {
+    return stepContext;
+  }
+
   public BundleOutputManager getOutputManager() {
     return outputManager;
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/SplittableProcessElementsEvaluatorFactory.java
@@ -17,18 +17,22 @@
  */
 package org.apache.beam.runners.direct;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.cache.CacheLoader;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.Collection;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.apache.beam.runners.core.DoFnRunners;
 import org.apache.beam.runners.core.DoFnRunners.OutputManager;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.OutputAndTimeBoundedSplittableProcessElementInvoker;
 import org.apache.beam.runners.core.OutputWindowedValue;
+import org.apache.beam.runners.core.ProcessFnRunner;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems.ProcessElements;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems.ProcessFn;
-import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -50,16 +54,33 @@ class SplittableProcessElementsEvaluatorFactory<
     implements TransformEvaluatorFactory {
   private final ParDoEvaluatorFactory<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT>
       delegateFactory;
+  private final ScheduledExecutorService ses;
   private final EvaluationContext evaluationContext;
 
   SplittableProcessElementsEvaluatorFactory(EvaluationContext evaluationContext) {
     this.evaluationContext = evaluationContext;
     this.delegateFactory =
-        new ParDoEvaluatorFactory<>(
-            evaluationContext,
-            SplittableProcessElementsEvaluatorFactory
-                .<InputT, OutputT, RestrictionT>processFnRunnerFactory(),
-            ParDoEvaluatorFactory.basicDoFnCacheLoader());
+      new ParDoEvaluatorFactory<>(
+        evaluationContext,
+        SplittableProcessElementsEvaluatorFactory.
+          <InputT, OutputT, RestrictionT>processFnRunnerFactory(),
+          new CacheLoader<AppliedPTransform<?, ?, ?>, DoFnLifecycleManager>() {
+            @Override
+            public DoFnLifecycleManager load(final AppliedPTransform<?, ?, ?> application) {
+              checkArgument(
+                ProcessElements.class.isInstance(application.getTransform()),
+                "No know extraction of the fn from " + application);
+              final ProcessElements<InputT, OutputT, RestrictionT, TrackerT> transform =
+                (ProcessElements<InputT, OutputT, RestrictionT, TrackerT>)
+                  application.getTransform();
+              return DoFnLifecycleManager.of(transform.newProcessFn(transform.getFn()));
+            }
+          });
+    this.ses = Executors.newSingleThreadScheduledExecutor(
+      new ThreadFactoryBuilder()
+        .setThreadFactory(MoreExecutors.platformThreadFactory())
+        .setNameFormat("direct-splittable-process-element-checkpoint-executor_" + hashCode())
+        .build());
   }
 
   @Override
@@ -74,6 +95,7 @@ class SplittableProcessElementsEvaluatorFactory<
 
   @Override
   public void cleanup() throws Exception {
+    ses.shutdownNow(); // stop before cleaning
     delegateFactory.cleanup();
   }
 
@@ -88,41 +110,28 @@ class SplittableProcessElementsEvaluatorFactory<
     final ProcessElements<InputT, OutputT, RestrictionT, TrackerT> transform =
         application.getTransform();
 
-    ProcessFn<InputT, OutputT, RestrictionT, TrackerT> processFn =
-        transform.newProcessFn(transform.getFn());
+    final DoFnLifecycleManagerRemovingTransformEvaluator
+      <KeyedWorkItem<String, KV<InputT, RestrictionT>>> evaluator =
+      delegateFactory.createEvaluator(
+        (AppliedPTransform) application,
+        (PCollection<KeyedWorkItem<String, KV<InputT, RestrictionT>>>) inputBundle.getPCollection(),
+        inputBundle.getKey(),
+        application.getTransform().getSideInputs(),
+        application.getTransform().getMainOutputTag(),
+        application.getTransform().getAdditionalOutputTags().getAll());
+    final ParDoEvaluator<KeyedWorkItem<String, KV<InputT, RestrictionT>>> pde =
+      evaluator.getParDoEvaluator();
+    final ProcessFn<InputT, OutputT, RestrictionT, TrackerT> processFn =
+      (ProcessFn<InputT, OutputT, RestrictionT, TrackerT>)
+        ProcessFnRunner.class.cast(pde.getFnRunner()).getFn();
 
-    DoFnLifecycleManager fnManager = DoFnLifecycleManager.of(processFn);
-    processFn =
-        ((ProcessFn<InputT, OutputT, RestrictionT, TrackerT>)
-            fnManager.<KeyedWorkItem<String, KV<InputT, RestrictionT>>, OutputT>get());
-
-    String stepName = evaluationContext.getStepName(application);
-    final DirectExecutionContext.DirectStepContext stepContext =
-        evaluationContext
-            .getExecutionContext(application, inputBundle.getKey())
-            .getStepContext(stepName);
-
-    final ParDoEvaluator<KeyedWorkItem<String, KV<InputT, RestrictionT>>>
-        parDoEvaluator =
-            delegateFactory.createParDoEvaluator(
-                application,
-                inputBundle.getKey(),
-                (PCollection<KeyedWorkItem<String, KV<InputT, RestrictionT>>>)
-                    inputBundle.getPCollection(),
-                transform.getSideInputs(),
-                transform.getMainOutputTag(),
-                transform.getAdditionalOutputTags().getAll(),
-                stepContext,
-                processFn,
-                fnManager);
-
-    processFn.setStateInternalsFactory(key -> (StateInternals) stepContext.stateInternals());
-
+    final DirectExecutionContext.DirectStepContext stepContext = pde.getStepContext();
+    processFn.setStateInternalsFactory(key -> stepContext.stateInternals());
     processFn.setTimerInternalsFactory(key -> stepContext.timerInternals());
 
     OutputWindowedValue<OutputT> outputWindowedValue =
         new OutputWindowedValue<OutputT>() {
-          private final OutputManager outputManager = parDoEvaluator.getOutputManager();
+          private final OutputManager outputManager = pde.getOutputManager();
 
           @Override
           public void outputWindowedValue(
@@ -150,21 +159,13 @@ class SplittableProcessElementsEvaluatorFactory<
             evaluationContext.getPipelineOptions(),
             outputWindowedValue,
             evaluationContext.createSideInputReader(transform.getSideInputs()),
-            // TODO: For better performance, use a higher-level executor?
-            // TODO: (BEAM-723) Create a shared ExecutorService for maintenance tasks in the
-            // DirectRunner.
-            Executors.newSingleThreadScheduledExecutor(
-                new ThreadFactoryBuilder()
-                    .setThreadFactory(MoreExecutors.platformThreadFactory())
-                    .setDaemon(true)
-                    .setNameFormat("direct-splittable-process-element-checkpoint-executor")
-                    .build()),
+            ses,
             // Setting small values here to stimulate frequent checkpointing and better exercise
             // splittable DoFn's in that respect.
             100,
             Duration.standardSeconds(1)));
 
-    return DoFnLifecycleManagerRemovingTransformEvaluator.wrapping(parDoEvaluator, fnManager);
+    return evaluator;
   }
 
   private static <InputT, OutputT, RestrictionT>

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/DoFnRunnerWithMetricsUpdate.java
@@ -23,6 +23,7 @@ import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.flink.api.common.functions.RuntimeContext;
@@ -90,5 +91,10 @@ public class DoFnRunnerWithMetricsUpdate<InputT, OutputT> implements DoFnRunner<
 
     // update metrics
     container.updateMetrics();
+  }
+
+  @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return delegate.getFn();
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/DoFnRunnerWithMetrics.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/DoFnRunnerWithMetrics.java
@@ -26,6 +26,7 @@ import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.spark.Accumulator;
@@ -47,6 +48,11 @@ class DoFnRunnerWithMetrics<InputT, OutputT> implements DoFnRunner<InputT, Outpu
     this.delegate = delegate;
     this.stepName = stepName;
     this.metricsAccum = metricsAccum;
+  }
+
+  @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return delegate.getFn();
   }
 
   @Override

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -443,6 +443,11 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
     stateKeyObjectCache.clear();
   }
 
+  @Override
+  public DoFn<InputT, OutputT> getFn() {
+    return doFnInvoker.getFn();
+  }
+
   /**
    * Outputs the given element to the specified set of consumers wrapping any exceptions.
    */


### PR DESCRIPTION
@Teardown is called after the pipeline result goes in state DONE with direct runner. This makes tests impossible to write in a lot of cases, this PR ensures it happens only after + rework SDF caching in direct runner as requested in previous PR on that topic.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

