### PR TITLE
[BEAM-3775] Increase timeout in beam_PostCommit_Java_ValidatesRunner_…

### DIFF
--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -25,8 +25,8 @@ mavenJob('beam_PostCommit_Java_ValidatesRunner_Dataflow') {
   previousNames('beam_PostCommit_Java_RunnableOnService_Dataflow')
 
 
-  // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(delegate, 'master', 120)
+  // Set common parameters. Sets a long (3 hour) timeout due to timeouts in [BEAM-3775].
+  common_job_properties.setTopLevelMainJobProperties(delegate, 'master', 180)
 
   // Set maven parameters.
   common_job_properties.setMavenConfig(delegate)


### PR DESCRIPTION
Increase timeout in beam_PostCommit_Java_ValidatesRunner_Dataflow, from 2 hours to 3 hours. All the recent runs of beam_PostCommit_Java_ValidatesRunner_Dataflow have timed out.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

