### PR TITLE
[BEAM-3754]: Fix readBytes() initialization in KafkaIO

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -216,21 +216,13 @@ import org.slf4j.LoggerFactory;
 public class KafkaIO {
 
   /**
-   * Creates an uninitialized {@link Read} {@link PTransform}. Before use, basic Kafka
-   * configuration should set with {@link Read#withBootstrapServers(String)} and
-   * {@link Read#withTopics(List)}. Other optional settings include key and value
-   * {@link Deserializer}s, custom timestamp and watermark functions.
+   * A specific instance of uninitialized {@link #read()} where key and values are bytes.
+   * See #read().
    */
   public static Read<byte[], byte[]> readBytes() {
-    return new AutoValue_KafkaIO_Read.Builder<byte[], byte[]>()
-        .setTopics(new ArrayList<>())
-        .setTopicPartitions(new ArrayList<>())
-        .setKeyDeserializer(ByteArrayDeserializer.class)
-        .setValueDeserializer(ByteArrayDeserializer.class)
-        .setConsumerFactoryFn(Read.KAFKA_CONSUMER_FACTORY_FN)
-        .setConsumerConfig(Read.DEFAULT_CONSUMER_PROPERTIES)
-        .setMaxNumRecords(Long.MAX_VALUE)
-        .build();
+    return KafkaIO.<byte[], byte[]>read()
+      .withKeyDeserializer(ByteArrayDeserializer.class)
+      .withValueDeserializer(ByteArrayDeserializer.class);
   }
 
   /**

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -1044,14 +1044,12 @@ public class KafkaIOTest {
 
   @Test
   public void testSourceWithExplicitPartitionsDisplayData() {
-    KafkaIO.Read<byte[], Long> read = KafkaIO.<byte[], Long>read()
+    KafkaIO.Read<byte[], byte[]> read = KafkaIO.readBytes()
         .withBootstrapServers("myServer1:9092,myServer2:9092")
         .withTopicPartitions(ImmutableList.of(new TopicPartition("test", 5),
             new TopicPartition("test", 6)))
         .withConsumerFactoryFn(new ConsumerFactoryFn(
-            Lists.newArrayList("test"), 10, 10, OffsetResetStrategy.EARLIEST)) // 10 partitions
-        .withKeyDeserializer(ByteArrayDeserializer.class)
-        .withValueDeserializer(LongDeserializer.class);
+            Lists.newArrayList("test"), 10, 10, OffsetResetStrategy.EARLIEST)); // 10 partitions
 
     DisplayData displayData = DisplayData.from(read);
 


### PR DESCRIPTION
`readBytes()` should invoke `read()` rather than duplicating code (as suggested by the reporter in BEAM-3754). Only `read()` was updated with recent changes and caused a check failure.

Also made sure that this constructor is invoked in one of the tests. 

+R: @XuMingmin