### PR TITLE
[BEAM-3776] Fix issue with merging late windows where a watermark hold could be added behind the input watermark.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1451,6 +1451,13 @@
       </dependency>
 
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>

--- a/runners/core-java/build.gradle
+++ b/runners/core-java/build.gradle
@@ -46,6 +46,6 @@ dependencies {
   shadowTest library.java.hamcrest_core
   shadowTest library.java.mockito_core
   shadowTest library.java.junit
-  shadowTest library.java.slf4j_jdk14
+  shadowTest library.java.slf4j_simple
   shadowTest library.java.jackson_dataformat_yaml
 }

--- a/runners/core-java/pom.xml
+++ b/runners/core-java/pom.xml
@@ -101,6 +101,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
@@ -141,7 +146,7 @@
 
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-jdk14</artifactId>
+      <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -38,7 +39,11 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import com.google.common.collect.Iterables;
+import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.triggers.DefaultTriggerStateMachine;
 import org.apache.beam.runners.core.triggers.TriggerStateMachine;
@@ -88,6 +93,8 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests for {@link ReduceFnRunner}. These tests instantiate a full "stack" of
@@ -97,6 +104,8 @@ import org.mockito.MockitoAnnotations;
  */
 @RunWith(JUnit4.class)
 public class ReduceFnRunnerTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ReduceFnRunnerTest.class);
+
   @Mock private SideInputReader mockSideInputReader;
   private TriggerStateMachine mockTriggerStateMachine;
   private PCollectionView<Integer> mockView;
@@ -127,6 +136,23 @@ public class ReduceFnRunnerTest {
       throws Exception {
     doNothing().when(mockTriggerStateMachine).onElement(anyElementContext());
     tester.injectElements(TimestampedValue.of(element, new Instant(element)));
+  }
+
+  private void injectElements(
+      ReduceFnTester<Integer, ?, IntervalWindow> tester, Iterable<Integer> values)
+      throws Exception {
+    doNothing().when(mockTriggerStateMachine).onElement(anyElementContext());
+    List<TimestampedValue<Integer>> timestampedValues = new LinkedList<>();
+    for (int value : values) {
+      timestampedValues.add(TimestampedValue.of(value, new Instant(value)));
+    }
+    tester.injectElements(timestampedValues);
+  }
+
+  private void injectElements(
+      ReduceFnTester<Integer, ?, IntervalWindow> tester, Integer... values)
+      throws Exception {
+    injectElements(tester, Arrays.asList(values));
   }
 
   private void triggerShouldFinish(TriggerStateMachine mockTrigger) throws Exception {
@@ -871,6 +897,198 @@ public class ReduceFnRunnerTest {
     // And because we're past the end of window + allowed lateness, everything should be cleaned up.
     assertFalse(tester.isMarkedFinished(firstWindow));
     tester.assertHasOnlyGlobalAndFinishedSetsFor();
+  }
+
+  @Test
+  public void testWatermarkHoldForLateNewWindow() throws Exception {
+    Duration allowedLateness = Duration.standardMinutes(1);
+    Duration gapDuration = Duration.millis(10);
+    ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(Sessions.withGapDuration(gapDuration))
+                .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+                .withTrigger(
+                    Repeatedly.forever(
+                        AfterWatermark.pastEndOfWindow()
+                            .withLateFirings(AfterPane.elementCountAtLeast(1))))
+                .withAllowedLateness(allowedLateness));
+    tester.setAutoAdvanceOutputWatermark(false);
+
+    assertEquals(null, tester.getWatermarkHold());
+    assertEquals(null, tester.getOutputWatermark());
+    tester.advanceInputWatermark(new Instant(40));
+    injectElements(tester, 1);
+    assertThat(tester.getWatermarkHold(), nullValue());
+    injectElements(tester, 10);
+    assertThat(tester.getWatermarkHold(), nullValue());
+  }
+
+  @Test
+  public void testMergingWatermarkHoldLateNewWindowMerged() throws Exception {
+    Duration allowedLateness = Duration.standardMinutes(1);
+    Duration gapDuration = Duration.millis(10);
+    ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(Sessions.withGapDuration(gapDuration))
+                .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+                .withTrigger(
+                    Repeatedly.forever(
+                        AfterWatermark.pastEndOfWindow()
+                            .withLateFirings(AfterPane.elementCountAtLeast(1))))
+                .withAllowedLateness(allowedLateness));
+    tester.setAutoAdvanceOutputWatermark(false);
+
+    assertEquals(null, tester.getWatermarkHold());
+    assertEquals(null, tester.getOutputWatermark());
+    tester.advanceInputWatermark(new Instant(24));
+    injectElements(tester, 1);
+    assertThat(tester.getWatermarkHold(), nullValue());
+    injectElements(tester, 14);
+    assertThat(tester.getWatermarkHold(), nullValue());
+    injectElements(tester, 6, 16);
+    // There should now be a watermark hold since the window has extended past the input watermark.
+    // The hold should be for the end of the window (last element + gapDuration - 1).
+    assertEquals(tester.getWatermarkHold(), new Instant(25));
+    injectElements(tester, 6, 21);
+    // The hold should be extended with the window.
+    assertEquals(tester.getWatermarkHold(), new Instant(30));
+    // Advancing the watermark should remove the hold.
+    tester.advanceInputWatermark(new Instant(31));
+    assertThat(tester.getWatermarkHold(), nullValue());
+    // Late elements added to the window should not generate a hold.
+    injectElements(tester, 0);
+    assertThat(tester.getWatermarkHold(), nullValue());
+    // Generate a new window that is ontime.
+    injectElements(tester, 32, 40);
+    assertEquals(tester.getWatermarkHold(), new Instant(49));
+    // Join the closed window with the new window.
+    injectElements(tester, 24);
+    assertEquals(tester.getWatermarkHold(), new Instant(49));
+    tester.advanceInputWatermark(new Instant(50));
+    assertThat(tester.getWatermarkHold(), nullValue());
+  }
+
+  @Test
+  public void testMergingLateWatermarkHolds() throws Exception {
+    MetricsContainerImpl container = new MetricsContainerImpl("any");
+    MetricsEnvironment.setCurrentContainer(container);
+    Duration gapDuration = Duration.millis(10);
+    Duration allowedLateness = Duration.standardMinutes(100);
+    ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(Sessions.withGapDuration(gapDuration))
+                .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+                .withTrigger(
+                    Repeatedly.forever(
+                        AfterWatermark.pastEndOfWindow()
+                            .withLateFirings(AfterPane.elementCountAtLeast(10))))
+                .withAllowedLateness(allowedLateness));
+    tester.setAutoAdvanceOutputWatermark(false);
+
+    // Input watermark -> null
+    assertEquals(null, tester.getWatermarkHold());
+    assertEquals(null, tester.getOutputWatermark());
+
+    tester.advanceInputWatermark(new Instant(20));
+    // Add two late elements that cause a window to merge.
+    injectElements(tester, Arrays.asList(3));
+    assertThat(tester.getWatermarkHold(), nullValue());
+    injectElements(tester, Arrays.asList(4));
+    Instant endOfWindow = new Instant(4).plus(gapDuration);
+    // We expect a GC hold to be one less than the end of window plus the allowed lateness.
+    Instant expectedGcHold = endOfWindow.plus(allowedLateness).minus(1);
+    assertEquals(
+        expectedGcHold,
+        tester.getWatermarkHold());
+    tester.advanceInputWatermark(new Instant(1000));
+    assertEquals(
+        expectedGcHold,
+        tester.getWatermarkHold());
+  }
+
+  @Test
+  public void testMergingWatermarkHoldAndLateDataFuzz() throws Exception {
+    MetricsContainerImpl container = new MetricsContainerImpl("any");
+    MetricsEnvironment.setCurrentContainer(container);
+    // Test handling of late data. Specifically, ensure the watermark hold is correct.
+    Duration allowedLateness = Duration.standardMinutes(100);
+    long seed = ThreadLocalRandom.current().nextLong();
+    LOG.info("Random seed: {}", seed);
+    Random r = new Random(seed);
+
+    Duration gapDuration = Duration.millis(10 + r.nextInt(40));
+    LOG.info("Gap duration {}", gapDuration);
+
+    ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
+        ReduceFnTester.nonCombining(
+            WindowingStrategy.of(Sessions.withGapDuration(gapDuration))
+                .withMode(AccumulationMode.DISCARDING_FIRED_PANES)
+                .withTrigger(
+                    Repeatedly.forever(
+                        AfterWatermark.pastEndOfWindow()
+                            .withLateFirings(AfterPane.elementCountAtLeast(1))))
+                .withAllowedLateness(allowedLateness));
+    tester.setAutoAdvanceOutputWatermark(true);
+
+    // Input watermark -> null
+    assertEquals(null, tester.getWatermarkHold());
+    assertEquals(null, tester.getOutputWatermark());
+
+    // All on time data, verify watermark hold.
+    List<Integer> times = new LinkedList<>();
+
+    int numTs = 3 + r.nextInt(100);
+    int maxTs = 1 + r.nextInt(400);
+    LOG.info("Num ts {}", numTs);
+    LOG.info("Max ts {}", maxTs);
+    for (int i = numTs; i >= 0; --i) {
+      times.add(r.nextInt(maxTs));
+    }
+    LOG.info("Times: {}", times);
+
+    int split = 0;
+    long watermark = 0;
+    while (split < times.size()) {
+      int nextSplit = split + r.nextInt(times.size());
+      if (nextSplit > times.size()) {
+        nextSplit = times.size();
+      }
+      LOG.info("nextSplit {}", nextSplit);
+      injectElements(tester, times.subList(split, nextSplit));
+      if (r.nextInt(3) == 0) {
+        int nextWatermark = r.nextInt((int) (maxTs + gapDuration.getMillis()));
+        if (nextWatermark > watermark) {
+          Boolean enabled = r.nextBoolean();
+          LOG.info("nextWatermark {} {}", nextWatermark, enabled);
+          watermark = nextWatermark;
+          tester.setAutoAdvanceOutputWatermark(enabled);
+          tester.advanceInputWatermark(new Instant(watermark));
+        }
+      }
+      split = nextSplit;
+      Instant hold = tester.getWatermarkHold();
+      if (hold != null) {
+        assertThat(hold, greaterThanOrEqualTo(new Instant(watermark)));
+        assertThat(watermark, lessThan((maxTs + gapDuration.getMillis())));
+      }
+    }
+    tester.setAutoAdvanceOutputWatermark(true);
+    watermark = gapDuration.getMillis() + maxTs;
+    tester.advanceInputWatermark(new Instant(watermark));
+    LOG.info("Output {}", tester.extractOutput());
+    if (tester.getWatermarkHold() != null) {
+      assertThat(
+          tester.getWatermarkHold(),
+          equalTo(new Instant(watermark).plus(allowedLateness)));
+    }
+    // Nothing dropped.
+    long droppedElements =
+        container
+            .getCounter(
+                MetricName.named(ReduceFnRunner.class, ReduceFnRunner.DROPPED_DUE_TO_CLOSED_WINDOW))
+            .getCumulative()
+            .longValue();
+    assertEquals(0, droppedElements);
   }
 
   /** Make sure that if data comes in too late to make it on time, the hold is the GC time. */
@@ -2037,7 +2255,7 @@ public class ReduceFnRunnerTest {
 
     tester.advanceInputWatermark(new Instant(109));
     tester.advanceOutputWatermark(new Instant(109));
-    tester.injectElements(TimestampedValue.of(2,  new Instant(2)));
+    tester.injectElements(TimestampedValue.of(2, new Instant(2)));
     // We should have set a garbage collection hold for the final pane.
     Instant hold = tester.getWatermarkHold();
     assertEquals(new Instant(109), hold);
@@ -2100,7 +2318,9 @@ public class ReduceFnRunnerTest {
    * A {@link PipelineOptions} to test combining with context.
    */
   public interface TestOptions extends PipelineOptions {
+
     int getValue();
+
     void setValue(int value);
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnTester.java
@@ -533,13 +533,15 @@ public class ReduceFnTester<InputT, OutputT, W extends BoundedWindow> {
    */
   @SafeVarargs
   public final void injectElements(TimestampedValue<InputT>... values) throws Exception {
+    injectElements(Arrays.asList(values));
+  }
+
+  public final void injectElements(List<TimestampedValue<InputT>> values) throws Exception {
     for (TimestampedValue<InputT> value : values) {
       WindowTracing.trace("TriggerTester.injectElements: {}", value);
     }
 
-    Iterable<WindowedValue<InputT>> inputs =
-        Arrays.asList(values)
-            .stream()
+    Iterable<WindowedValue<InputT>> inputs = values.stream()
             .map(
                 input -> {
                   try {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/StateInternalsTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/StateInternalsTest.java
@@ -544,48 +544,6 @@ public abstract class StateInternalsTest {
   }
 
   @Test
-  public void testMergeEarliestWatermarkIntoSource() throws Exception {
-    WatermarkHoldState value1 =
-        underTest.state(NAMESPACE_1, WATERMARK_EARLIEST_ADDR);
-    WatermarkHoldState value2 =
-        underTest.state(NAMESPACE_2, WATERMARK_EARLIEST_ADDR);
-
-    value1.add(new Instant(3000));
-    value2.add(new Instant(5000));
-    value1.add(new Instant(4000));
-    value2.add(new Instant(2000));
-
-    // Merging clears the old values and updates the merged value.
-    StateMerging.mergeWatermarks(Arrays.asList(value1, value2), value1, WINDOW_1);
-
-    assertThat(value1.read(), equalTo(new Instant(2000)));
-    assertThat(value2.read(), equalTo(null));
-  }
-
-  @Test
-  public void testMergeLatestWatermarkIntoSource() throws Exception {
-    WatermarkHoldState value1 =
-        underTest.state(NAMESPACE_1, WATERMARK_LATEST_ADDR);
-    WatermarkHoldState value2 =
-        underTest.state(NAMESPACE_2, WATERMARK_LATEST_ADDR);
-    WatermarkHoldState value3 =
-        underTest.state(NAMESPACE_3, WATERMARK_LATEST_ADDR);
-
-    value1.add(new Instant(3000));
-    value2.add(new Instant(5000));
-    value1.add(new Instant(4000));
-    value2.add(new Instant(2000));
-
-    // Merging clears the old values and updates the result value.
-    StateMerging.mergeWatermarks(Arrays.asList(value1, value2), value3, WINDOW_1);
-
-    // Merging clears the old values and updates the result value.
-    assertThat(value3.read(), equalTo(new Instant(5000)));
-    assertThat(value1.read(), equalTo(null));
-    assertThat(value2.read(), equalTo(null));
-  }
-
-  @Test
   public void testSetReadable() throws Exception {
     SetState<String> value = underTest.state(NAMESPACE_1, STRING_SET_ADDR);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
@@ -86,14 +86,6 @@ public class FlinkBroadcastStateInternalsTest extends StateInternalsTest {
 
   @Override
   @Ignore
-  public void testMergeEarliestWatermarkIntoSource() {}
-
-  @Override
-  @Ignore
-  public void testMergeLatestWatermarkIntoSource() {}
-
-  @Override
-  @Ignore
   public void testSetReadable() {}
 
   @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkKeyGroupStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkKeyGroupStateInternalsTest.java
@@ -132,14 +132,6 @@ public class FlinkKeyGroupStateInternalsTest {
 
     @Override
     @Ignore
-    public void testMergeEarliestWatermarkIntoSource() {}
-
-    @Override
-    @Ignore
-    public void testMergeLatestWatermarkIntoSource() {}
-
-    @Override
-    @Ignore
     public void testSetReadable() {}
 
     @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkSplitStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkSplitStateInternalsTest.java
@@ -114,14 +114,6 @@ public class FlinkSplitStateInternalsTest extends StateInternalsTest {
 
   @Override
   @Ignore
-  public void testMergeEarliestWatermarkIntoSource() {}
-
-  @Override
-  @Ignore
-  public void testMergeLatestWatermarkIntoSource() {}
-
-  @Override
-  @Ignore
   public void testSetReadable() {}
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/ReadTest.java
@@ -201,6 +201,11 @@ public class ReadTest implements Serializable{
     }
 
     @Override
+    public boolean requiresDeduping() {
+      return true;
+    }
+
+    @Override
     public Coder<String> getOutputCoder() {
       return StringUtf8Coder.of();
     }


### PR DESCRIPTION
In particular, testMergingLateWatermarkHolds illustrates a bug
where merging windows for which the hold only depends on the
window can lead to holds being added before the input watermark.

This PR currently doesn't fix the issue just adds a test illustrating the problem.