### PR TITLE
[BEAM-3738] Add more flake8 tests to run_pylint.sh

### DIFF
--- a/sdks/python/run_mini_py3lint.sh
+++ b/sdks/python/run_mini_py3lint.sh
@@ -37,4 +37,5 @@ if test $# -gt 0; then
 fi
 
 echo "Running flake8 for module $MODULE:"
-flake8 $MODULE --count --select=E999 --show-source --statistics
+# TODO: Add F821 (undefined names) as soon as that test passes
+flake8 $MODULE --count --select=E9,F822,F823 --show-source --statistics

--- a/sdks/python/run_pylint.sh
+++ b/sdks/python/run_pylint.sh
@@ -63,7 +63,8 @@ pylint -j8 "$MODULE" --ignore-patterns="$FILES_TO_IGNORE"
 echo "Running pycodestyle for module $MODULE:"
 pycodestyle "$MODULE" --exclude="$FILES_TO_IGNORE"
 echo "Running flake8 for module $MODULE:"
-flake8 $MODULE --count --select=E999 --show-source --statistics
+# TODO: Add F821 (undefined names) as soon as that test passes
+flake8 $MODULE --count --select=E9,F822,F823 --show-source --statistics
 
 echo "Running isort for module $MODULE:"
 # Skip files where isort is behaving weirdly


### PR DESCRIPTION
My sense is that __E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. The other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.

This PR therefore recommends replacing __--select=E999__ with __--select=E901,E999,F822,F823__ because the codebase currently passes all of these tests and we would like to avoid any backsliding. We would also want to add __F821__ (undefined names!) to that list but work must be completed on basestring, buffer(), cmp(), file(), reduce(), unicode, xrange(), and #4561 before that can be done.

* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

