### PR TITLE
[BEAM-3738] Enable py3 lint

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,8 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-# TODO (after BEAM-3671) add lint_py3 back in.
-envlist = py27,py27gcp,py27cython,lint_py2,docs
+envlist = py27,py27gcp,py27cython,lint_py2,lint_py3,docs
 toxworkdir = {toxinidir}/target/.tox
 
 [pycodestyle]


### PR DESCRIPTION
Since we verified that Jenkins workers have python3 installed (https://issues.apache.org/jira/browse/BEAM-3671) we should be able to enable py3 lint.

R: @alanmyrvold 

