### PR TITLE
[BEAM-1251] Upgrade from buffer to memoryview for Python 3

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -52,6 +52,8 @@ from avro import io as avroio
 from avro import datafile
 from avro import schema
 
+from six import binary_type
+
 import apache_beam as beam
 from apache_beam.io import filebasedsink
 from apache_beam.io import filebasedsource
@@ -309,8 +311,8 @@ class _AvroBlock(object):
 
       # Compressed data includes a 4-byte CRC32 checksum which we verify.
       # We take care to avoid extra copies of data while slicing large objects
-      # by use of a buffer.
-      result = snappy.decompress(buffer(data)[:-4])
+      # by use of a memoryview.
+      result = snappy.decompress(binary_type(memoryview(data)[:-4]))
       avroio.BinaryDecoder(cStringIO.StringIO(data[-4:])).check_crc32(result)
       return result
     else:


### PR DESCRIPTION
__buffer__ was removed in Python 3 in favor of __memoryview__.
* http://portingguide.readthedocs.io/en/latest/etc.html#raw-buffer-protocol-buffer-and-memoryview

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

