### PR TITLE
[BEAM-3802] Move metrics caching up a level

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -63,7 +63,7 @@ class DataflowMetrics extends MetricResults {
    * After the job has finished running, Metrics no longer will change, so their results are
    * cached here.
    */
-  private MetricQueryResults cachedMetricResults = null;
+  private JobMetrics cachedMetricResults = null;
 
   /**
    * Constructor for the DataflowMetrics class.
@@ -88,14 +88,15 @@ class DataflowMetrics extends MetricResults {
         .build();
   }
 
-  private MetricQueryResults queryServiceForMetrics(MetricsFilter filter) {
+  @Override
+  public MetricQueryResults queryMetrics(MetricsFilter filter) {
     List<com.google.api.services.dataflow.model.MetricUpdate> metricUpdates;
     ImmutableList<MetricResult<Long>> counters = ImmutableList.of();
     ImmutableList<MetricResult<DistributionResult>> distributions = ImmutableList.of();
     ImmutableList<MetricResult<GaugeResult>> gauges = ImmutableList.of();
     JobMetrics jobMetrics;
     try {
-      jobMetrics = dataflowClient.getJobMetrics(dataflowPipelineJob.jobId);
+      jobMetrics = getJobMetrics();
     } catch (IOException e) {
       LOG.warn("Unable to query job metrics.\n");
       return DataflowMetricQueryResults.create(counters, distributions, gauges);
@@ -106,17 +107,12 @@ class DataflowMetrics extends MetricResults {
     return populateMetricQueryResults(metricUpdates, filter);
   }
 
-  public MetricQueryResults queryMetrics() {
-    return queryMetrics(null);
-  }
-
-  @Override
-  public MetricQueryResults queryMetrics(MetricsFilter filter) {
+  private JobMetrics getJobMetrics() throws IOException {
     if (cachedMetricResults != null) {
       // Metric results have been cached after the job ran.
       return cachedMetricResults;
     }
-    MetricQueryResults result = queryServiceForMetrics(filter);
+    JobMetrics result = dataflowClient.getJobMetrics(dataflowPipelineJob.jobId);
     if (dataflowPipelineJob.getState().isTerminal()) {
       // Add current query result to the cache.
       cachedMetricResults = result;

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowMetricsTest.java
@@ -109,7 +109,7 @@ public class DataflowMetricsTest {
     when(dataflowClient.getJobMetrics(JOB_ID)).thenReturn(jobMetrics);
 
     DataflowMetrics dataflowMetrics = new DataflowMetrics(job, dataflowClient);
-    MetricQueryResults result = dataflowMetrics.queryMetrics();
+    MetricQueryResults result = dataflowMetrics.queryMetrics(null);
     assertThat(ImmutableList.copyOf(result.counters()), is(empty()));
     assertThat(ImmutableList.copyOf(result.distributions()), is(empty()));
   }


### PR DESCRIPTION
The caching of metric results in the Dataflow runner makes some bad assumptions. It assumes `queryMetrics` will always be called with the same filter which leads to the wrong results in common cases, including the nexmark benchmark.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.