### PR TITLE
[BEAM-3326] Add an InProcess SdkHarness Rule

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
@@ -18,9 +18,9 @@
 package org.apache.beam.runners.fnexecution.control;
 
 import io.grpc.stub.StreamObserver;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnControlGrpc;
@@ -34,7 +34,7 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
   private static final Logger LOGGER = LoggerFactory.getLogger(FnApiControlClientPoolService.class);
 
   private final BlockingQueue<FnApiControlClient> clientPool;
-  private final Collection<FnApiControlClient> vendedClients = new ArrayList<>();
+  private final Collection<FnApiControlClient> vendedClients = new CopyOnWriteArrayList<>();
   private AtomicBoolean closed = new AtomicBoolean();
 
   private FnApiControlClientPoolService(BlockingQueue<FnApiControlClient> clientPool) {
@@ -67,7 +67,10 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
     FnApiControlClient newClient = FnApiControlClient.forRequestObserver(requestObserver);
     try {
       // Add the client to the pool of vended clients before making it available - we should close
-      // the client when we close even if no one has picked it up yet.
+      // the client when we close even if no one has picked it up yet. This can occur after the
+      // service is closed, in which case the client will be discarded when the service is
+      // discarded, which should be performed by a call to #shutdownNow. The remote caller must be
+      // able to handle an unexpectedly terminated connection.
       vendedClients.add(newClient);
       clientPool.put(newClient);
     } catch (InterruptedException e) {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
@@ -53,8 +53,7 @@ public class GrpcDataService extends BeamFnDataGrpc.BeamFnDataImplBase
     implements FnService, FnDataService {
   private static final Logger LOG = LoggerFactory.getLogger(GrpcDataService.class);
 
-  public static GrpcDataService create(
-      ExecutorService executor) {
+  public static GrpcDataService create(ExecutorService executor) {
     return new GrpcDataService(executor);
   }
 
@@ -62,6 +61,9 @@ public class GrpcDataService extends BeamFnDataGrpc.BeamFnDataImplBase
   /**
    * A collection of multiplexers which are not used to send data. A handle to these multiplexers is
    * maintained in order to perform an orderly shutdown.
+   *
+   * <p>TODO(BEAM-3811): Replace with some cancellable collection, to ensure that new clients of a
+   * closed {@link GrpcDataService} are closed with that {@link GrpcDataService}.
    */
   private final Queue<BeamFnDataGrpcMultiplexer> additionalMultiplexers;
 
@@ -132,16 +134,17 @@ public class GrpcDataService extends BeamFnDataGrpc.BeamFnDataImplBase
         throw new RuntimeException(e.getCause());
       }
     } else {
-      executor.submit(() -> {
-        try {
-          connectedClient.get().registerConsumer(inputLocation, observer);
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          throw new RuntimeException(e);
-        } catch (ExecutionException e) {
-          throw new RuntimeException(e.getCause());
-        }
-      });
+      executor.submit(
+          () -> {
+            try {
+              connectedClient.get().registerConsumer(inputLocation, observer);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+              throw new RuntimeException(e.getCause());
+            }
+          });
     }
     return observer;
   }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
@@ -105,7 +105,9 @@ public class GrpcDataService extends BeamFnDataGrpc.BeamFnDataImplBase
         // Shutdown remaining clients
       }
     }
-    connectedClient.get().close();
+    if (!connectedClient.isCancelled()) {
+      connectedClient.get().close();
+    }
   }
 
   @Override

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/data/GrpcDataService.java
@@ -62,7 +62,7 @@ public class GrpcDataService extends BeamFnDataGrpc.BeamFnDataImplBase
    * A collection of multiplexers which are not used to send data. A handle to these multiplexers is
    * maintained in order to perform an orderly shutdown.
    *
-   * <p>TODO(BEAM-3811): Replace with some cancellable collection, to ensure that new clients of a
+   * <p>TODO: (BEAM-3811) Replace with some cancellable collection, to ensure that new clients of a
    * closed {@link GrpcDataService} are closed with that {@link GrpcDataService}.
    */
   private final Queue<BeamFnDataGrpcMultiplexer> additionalMultiplexers;

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/InProcessSdkHarness.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/InProcessSdkHarness.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.grpc.ManagedChannel;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import org.apache.beam.fn.harness.FnHarness;
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.apache.beam.runners.fnexecution.control.FnApiControlClient;
+import org.apache.beam.runners.fnexecution.control.FnApiControlClientPoolService;
+import org.apache.beam.runners.fnexecution.control.SdkHarnessClient;
+import org.apache.beam.runners.fnexecution.data.GrpcDataService;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.logging.Slf4jLogWriter;
+import org.apache.beam.sdk.fn.channel.ManagedChannelFactory;
+import org.apache.beam.sdk.fn.stream.StreamObserverFactory;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A {@link TestRule} which creates an {@link FnHarness} in a thread, services required for that
+ * {@link FnHarness} to properly execute, and provides access to the associated client and harness
+ * during test execution.
+ */
+public class InProcessSdkHarness implements TestRule {
+  public static InProcessSdkHarness create() {
+    return new InProcessSdkHarness();
+  }
+
+  private GrpcFnServer<GrpcLoggingService> loggingServer;
+  private GrpcFnServer<GrpcDataService> dataServer;
+  private GrpcFnServer<FnApiControlClientPoolService> controlServer;
+
+  private SdkHarnessClient client;
+
+  private InProcessSdkHarness() {}
+
+  public SdkHarnessClient client() {
+    return client;
+  }
+
+  public ApiServiceDescriptor dataEndpoint() {
+    return dataServer.getApiServiceDescriptor();
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+
+      @Override
+      public void evaluate() throws Throwable {
+        InProcessServerFactory serverFactory = InProcessServerFactory.create();
+        ExecutorService executor =
+            Executors.newCachedThreadPool(new ThreadFactoryBuilder().setDaemon(true).build());
+        SynchronousQueue<FnApiControlClient> clientPool = new SynchronousQueue<>();
+        FnApiControlClientPoolService clientPoolService =
+            FnApiControlClientPoolService.offeringClientsToPool(clientPool);
+
+        loggingServer =
+            GrpcFnServer.allocatePortAndCreateFor(
+                GrpcLoggingService.forWriter(Slf4jLogWriter.getDefault()), serverFactory);
+        dataServer =
+            GrpcFnServer.allocatePortAndCreateFor(GrpcDataService.create(executor), serverFactory);
+        controlServer = GrpcFnServer.allocatePortAndCreateFor(clientPoolService, serverFactory);
+
+        executor.submit(
+            () -> {
+              FnHarness.main(
+                  PipelineOptionsFactory.create(),
+                  loggingServer.getApiServiceDescriptor(),
+                  controlServer.getApiServiceDescriptor(),
+                  new ManagedChannelFactory() {
+                    @Override
+                    public ManagedChannel forDescriptor(ApiServiceDescriptor apiServiceDescriptor) {
+                      return InProcessChannelBuilder.forName(apiServiceDescriptor.getUrl()).build();
+                    }
+                  },
+                  StreamObserverFactory.direct());
+              return null;
+            });
+
+        client = SdkHarnessClient.usingFnApiClient(clientPool.take(), dataServer.getService());
+        try {
+          base.evaluate();
+        } finally {
+          client.close();
+          controlServer.close();
+          dataServer.close();
+          loggingServer.close();
+          executor.shutdownNow();
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
This spins up an SDK harness and required servers, makes them available
during the test, and tears them down after the test completes.

Improve `DataService#close` to shut down without throwing an exception more reliably.

Close existing control clients to speed shutdown.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

