### PR TITLE
Remove _starting_signal and _random

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -155,7 +155,6 @@ public class PubsubIO {
    * Class representing a Cloud Pub/Sub Subscription.
    */
   public static class PubsubSubscription implements Serializable {
-    private final Type type;
     private final String project;
     private final String subscription;
 
@@ -202,7 +201,7 @@ public class PubsubIO {
 
       validateProjectName(projectName);
       validatePubsubName(subscriptionName);
-      return new PubsubSubscription(Type.NORMAL, projectName, subscriptionName);
+      return new PubsubSubscription(projectName, subscriptionName);
     }
 
     /**
@@ -213,11 +212,7 @@ public class PubsubIO {
      */
     @Deprecated
     public String asV1Beta1Path() {
-      if (type == Type.NORMAL) {
-        return "/subscriptions/" + project + "/" + subscription;
-      } else {
-        return subscription;
-      }
+      return "/subscriptions/" + project + "/" + subscription;
     }
 
     /**
@@ -228,11 +223,7 @@ public class PubsubIO {
      */
     @Deprecated
     public String asV1Beta2Path() {
-      if (type == Type.NORMAL) {
-        return "projects/" + project + "/subscriptions/" + subscription;
-      } else {
-        return subscription;
-      }
+      return "projects/" + project + "/subscriptions/" + subscription;
     }
 
     /**
@@ -240,11 +231,7 @@ public class PubsubIO {
      * API.
      */
     public String asPath() {
-      if (type == Type.NORMAL) {
-        return "projects/" + project + "/subscriptions/" + subscription;
-      } else {
-        return subscription;
-      }
+      return "projects/" + project + "/subscriptions/" + subscription;
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -107,8 +107,6 @@ public class PubsubIO {
   private static final int PUBSUB_NAME_MIN_LENGTH = 3;
   private static final int PUBSUB_NAME_MAX_LENGTH = 255;
 
-  private static final String SUBSCRIPTION_RANDOM_TEST_PREFIX = "_random/";
-  private static final String SUBSCRIPTION_STARTING_SIGNAL = "_starting_signal/";
   private static final String TOPIC_DEV_NULL_TEST_NAME = "/topics/dev/null";
 
   private static void validateProjectName(String project) {
@@ -157,15 +155,11 @@ public class PubsubIO {
    * Class representing a Cloud Pub/Sub Subscription.
    */
   public static class PubsubSubscription implements Serializable {
-
-    private enum Type {NORMAL, FAKE}
-
     private final Type type;
     private final String project;
     private final String subscription;
 
-    private PubsubSubscription(Type type, String project, String subscription) {
-      this.type = type;
+    private PubsubSubscription(String project, String subscription) {
       this.project = project;
       this.subscription = subscription;
     }
@@ -188,11 +182,6 @@ public class PubsubIO {
      * </ul>
      */
     public static PubsubSubscription fromPath(String path) {
-      if (path.startsWith(SUBSCRIPTION_RANDOM_TEST_PREFIX)
-          || path.startsWith(SUBSCRIPTION_STARTING_SIGNAL)) {
-        return new PubsubSubscription(Type.FAKE, "", path);
-      }
-
       String projectName, subscriptionName;
 
       Matcher v1beta1Match = V1BETA1_SUBSCRIPTION_REGEXP.matcher(path);

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -427,8 +427,11 @@ class DataflowRunner(PipelineRunner):
     if standard_options.streaming:
       step = self._add_step(
           TransformNames.READ, transform_node.full_label, transform_node)
-      step.add_property(PropertyNames.FORMAT, 'pubsub')
-      step.add_property(PropertyNames.PUBSUB_SUBSCRIPTION, '_starting_signal/')
+      step.add_property(PropertyNames.FORMAT, 'impulse')
+      encoded_impulse = coders.WindowedValueCoder(
+          coders.BytesCoder(),
+          coders.coders.GlobalWindowCoder()).encode('')  # pylint: disable=protected-access
+      step.add_property(PropertyNames.IMPULSE_ELEMENT, encoded_impulse)
 
       step.encoding = self._get_encoded_output_coder(transform_node)
       step.add_property(

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -189,8 +189,9 @@ class DataflowRunnerTest(unittest.TestCase):
 
     self.assertEqual(job_dict[u'steps'][0][u'kind'], u'ParallelRead')
     self.assertEqual(
-        job_dict[u'steps'][0][u'properties'][u'pubsub_subscription'],
-        '_starting_signal/')
+        job_dict[u'steps'][0][u'properties'][u'format'],
+        'impulse/')
+    self.assertTrue('impulse_element' in job_dict[u'steps'][0][u'properties'])
     self.assertEqual(job_dict[u'steps'][1][u'kind'], u'ParallelDo')
 
   def test_remote_runner_display_data(self):


### PR DESCRIPTION
R:@lukecwik
In PubsubIO, _starting_signal and _random were Dataflow-specific hacks that have never worked in 2.x, so they are fine to remove
In DataflowRunner, _starting_signal is no longer the only way to generate an initial element for a pipeline, and the Dataflow backend supports the "impulse" parallel_read.
