### PR TITLE
[BEAM-1251] Fix basestring for Python 3 - again

### DIFF
--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -19,6 +19,8 @@
 
 import re
 
+from six import string_types
+
 from apache_beam.io.filesystem import BeamIOError
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileSystem
@@ -261,7 +263,7 @@ class FileSystems(object):
     Raises:
       ``BeamIOError`` if any of the delete operations fail
     """
-    if isinstance(paths, basestring):
+    if isinstance(paths, string_types):
       raise BeamIOError('Delete passed string argument instead of list: %s' %
                         paths)
     if len(paths) == 0:


### PR DESCRIPTION
__basestring__ was removed in Python 3 because all __str__ are Unicode so this PR is changing one instance of __basestring__ to __six.string_types__.

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

