### PR TITLE
Revert "[BEAM-3182] Ensure nexmark model tests produce output"

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/NexmarkQueryModel.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/NexmarkQueryModel.java
@@ -102,7 +102,6 @@ public abstract class NexmarkQueryModel implements Serializable {
   /** Return assertion to use on results of pipeline for this query. */
   public SerializableFunction<Iterable<TimestampedValue<KnownSize>>, Void> assertionFor() {
     final Collection<String> expectedStrings = toCollection(simulator().results());
-    Assert.assertFalse(expectedStrings.isEmpty());
 
     return new SerializableFunction<Iterable<TimestampedValue<KnownSize>>, Void>() {
       @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query6Model.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query6Model.java
@@ -21,8 +21,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.TreeMap;
 import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
 import org.apache.beam.sdk.nexmark.NexmarkUtils;
@@ -44,17 +42,17 @@ public class Query6Model extends NexmarkQueryModel implements Serializable {
    * Simulator for query 6.
    */
   private static class Simulator extends AbstractSimulator<AuctionBid, SellerPrice> {
-    /** The last 10 winning bids ordered by age, indexed by seller id. */
-    private final Map<Long, Queue<Bid>> winningBidsPerSeller;
+    /** The cumulative count of winning bids, indexed by seller id. */
+    private final Map<Long, Long> numWinningBidsPerSeller;
 
-    /** The cumulative total of last 10 winning bid prices, indexed by seller id. */
+    /** The cumulative total of winning bid prices, indexed by seller id. */
     private final Map<Long, Long> totalWinningBidPricesPerSeller;
 
     private Instant lastTimestamp;
 
     public Simulator(NexmarkConfiguration configuration) {
       super(new WinningBidsSimulator(configuration).results());
-      winningBidsPerSeller = new TreeMap<>();
+      numWinningBidsPerSeller = new TreeMap<>();
       totalWinningBidPricesPerSeller = new TreeMap<>();
       lastTimestamp = BoundedWindow.TIMESTAMP_MIN_VALUE;
     }
@@ -64,24 +62,19 @@ public class Query6Model extends NexmarkQueryModel implements Serializable {
      */
     private void captureWinningBid(Auction auction, Bid bid, Instant timestamp) {
       NexmarkUtils.info("winning auction, bid: %s, %s", auction, bid);
-      Queue<Bid> queue = winningBidsPerSeller.get(auction.seller);
-      if (queue == null) {
-        queue = new PriorityQueue<Bid>(10,
-            (Bid b1, Bid b2) -> Long.compare(b1.dateTime, b2.dateTime));
-      }
-      Long total = totalWinningBidPricesPerSeller.get(auction.seller);
-      if (total == null) {
-        total = 0L;
-      }
-      int count = queue.size();
-      if (count == 10) {
-        total -= queue.remove().price;
+      Long count = numWinningBidsPerSeller.get(auction.seller);
+      if (count == null) {
+        count = 1L;
       } else {
         count += 1;
       }
-      queue.add(bid);
-      total += bid.price;
-      winningBidsPerSeller.put(auction.seller, queue);
+      numWinningBidsPerSeller.put(auction.seller, count);
+      Long total = totalWinningBidPricesPerSeller.get(auction.seller);
+      if (total == null) {
+        total = bid.price;
+      } else {
+        total += bid.price;
+      }
       totalWinningBidPricesPerSeller.put(auction.seller, total);
       TimestampedValue<SellerPrice> intermediateResult = TimestampedValue.of(
           new SellerPrice(auction.seller, Math.round((double) total / count)), timestamp);
@@ -93,9 +86,9 @@ public class Query6Model extends NexmarkQueryModel implements Serializable {
     protected void run() {
       TimestampedValue<AuctionBid> timestampedWinningBid = nextInput();
       if (timestampedWinningBid == null) {
-        for (Map.Entry<Long, Queue<Bid>> entry : winningBidsPerSeller.entrySet()) {
+        for (Map.Entry<Long, Long> entry : numWinningBidsPerSeller.entrySet()) {
           long seller = entry.getKey();
-          long count = entry.getValue().size();
+          long count = entry.getValue();
           long total = totalWinningBidPricesPerSeller.get(seller);
           addResult(TimestampedValue.of(
               new SellerPrice(seller, Math.round((double) total / count)), lastTimestamp));

--- a/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/QueryTest.java
+++ b/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/queries/QueryTest.java
@@ -48,7 +48,7 @@ public class QueryTest {
   static {
     // careful, results of tests are linked to numEventGenerators because of timestamp generation
     CONFIG.numEventGenerators = 1;
-    CONFIG.numEvents = 5000;
+    CONFIG.numEvents = 1000;
   }
 
   @Rule public TestPipeline p = TestPipeline.create();


### PR DESCRIPTION
Reverts apache/beam#4745 it causes flakes.