### PR TITLE
[BEAM-3817] Switch Go SDK BQ write to not use side input

### DIFF
--- a/sdks/go/pkg/beam/combine.go
+++ b/sdks/go/pkg/beam/combine.go
@@ -33,16 +33,11 @@ func CombinePerKey(s Scope, combinefn interface{}, col PCollection) PCollection 
 	return Must(TryCombinePerKey(s, combinefn, col))
 }
 
-// addFixedKeyFn forces all elements to a single key.
-func addFixedKeyFn(elm T) (int, T) {
-	return 0, elm
-}
-
 // TryCombine attempts to insert a global Combine transform into the pipeline. It may fail
 // for multiple reasons, notably that the combinefn is not valid or cannot be bound
 // -- due to type mismatch, say -- to the incoming PCollections.
 func TryCombine(s Scope, combinefn interface{}, col PCollection) (PCollection, error) {
-	pre := ParDo(s, addFixedKeyFn, col)
+	pre := AddFixedKey(s, col)
 	post, err := TryCombinePerKey(s, combinefn, pre)
 	if err != nil {
 		return PCollection{}, err

--- a/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
+++ b/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
@@ -169,6 +169,8 @@ func Write(s beam.Scope, project, table string, col beam.PCollection) {
 
 	s = s.Scope("bigquery.Write")
 
+	// TODO(BEAM-3860) 3/15/2018: use side input instead of GBK.
+
 	pre := beam.AddFixedKey(s, col)
 	post := beam.GroupByKey(s, pre)
 	beam.ParDo0(s, &writeFn{Project: project, Table: qn, Type: beam.EncodedType{T: t}}, post)

--- a/sdks/go/pkg/beam/io/textio/textio.go
+++ b/sdks/go/pkg/beam/io/textio/textio.go
@@ -139,13 +139,9 @@ func Write(s beam.Scope, filename string, col beam.PCollection) {
 	// FinishBundle doesn't have the right granularity. We therefore
 	// perform a GBK with a fixed key to get all values in a single invocation.
 
-	pre := beam.ParDo(s, addFixedKey, col)
+	pre := beam.AddFixedKey(s, col)
 	post := beam.GroupByKey(s, pre)
 	beam.ParDo0(s, &writeFileFn{Filename: filename}, post)
-}
-
-func addFixedKey(elm beam.T) (int, beam.T) {
-	return 0, elm
 }
 
 type writeFileFn struct {

--- a/sdks/go/pkg/beam/io/textio/textio.go
+++ b/sdks/go/pkg/beam/io/textio/textio.go
@@ -139,6 +139,8 @@ func Write(s beam.Scope, filename string, col beam.PCollection) {
 	// FinishBundle doesn't have the right granularity. We therefore
 	// perform a GBK with a fixed key to get all values in a single invocation.
 
+	// TODO(BEAM-3860) 3/15/2018: use side input instead of GBK.
+
 	pre := beam.AddFixedKey(s, col)
 	post := beam.GroupByKey(s, pre)
 	beam.ParDo0(s, &writeFileFn{Filename: filename}, post)

--- a/sdks/go/pkg/beam/util.go
+++ b/sdks/go/pkg/beam/util.go
@@ -41,6 +41,15 @@ func Seq(s Scope, col PCollection, dofns ...interface{}) PCollection {
 	return cur
 }
 
+// AddFixedKey adds a fixed key (0) to every element.
+func AddFixedKey(s Scope, col PCollection) PCollection {
+	return ParDo(s, addFixedKeyFn, col)
+}
+
+func addFixedKeyFn(elm T) (int, T) {
+	return 0, elm
+}
+
 // DropKey drops the key for an input PCollection<KV<A,B>>. It returns
 // a PCollection<B>.
 func DropKey(s Scope, col PCollection) PCollection {


### PR DESCRIPTION
Otherwise, it does not do currently run on non-direct runners. Also consolidated the use of adding a fixed key for this purpose.