### PR TITLE
- Go SDK Datastore IO reader

### DIFF
--- a/sdks/go/pkg/beam/io/datastoreio/datastore.go
+++ b/sdks/go/pkg/beam/io/datastoreio/datastore.go
@@ -1,0 +1,195 @@
+package datastoreio
+
+import (
+	"reflect"
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"sort"
+	"google.golang.org/api/iterator"
+	"encoding/json"
+	"fmt"
+	"cloud.google.com/go/datastore"
+	"context"
+	"math"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
+	"strconv"
+)
+
+const (
+	scatterPropertyName = "__scatter__"
+)
+
+// Read reads all rows from the given kind. The kind must have a schema  compatible with the given type, t, and Read
+// returns a PCollection<t>. You must also register your type with runtime.RegisterType which allows you to implement
+// datastore.PropertyLoadSaver
+//
+//
+// Example:
+// type Item struct {}
+// itemKey = runtime.RegisterType(reflect.TypeOf((*Item)(nil)).Elem())
+//
+// datastoreio.Read(s, "project", "Item", 256, reflect.TypeOf(Item{}), itemKey)
+func Read(s beam.Scope, project, kind string, shards int, t reflect.Type, typeKey string) beam.PCollection {
+	s = s.Scope("datastore.Read")
+	return query(s, project, kind, shards, t, typeKey)
+}
+
+func query(s beam.Scope, project, kind string, shards int, t reflect.Type, typeKey string) beam.PCollection {
+	imp := beam.Impulse(s)
+	ex := beam.ParDo(s, &splitQueryFn{Project: project, Kind: kind, Shards: shards}, imp)
+	g := beam.GroupByKey(s, ex)
+	return beam.ParDo(s, &queryFn{Project: project, Kind: kind, Type: typeKey}, g, beam.TypeDefinition{Var: beam.XType, T: t})
+}
+
+type splitQueryFn struct {
+	Project string `json:"project"`
+	Kind    string `json:"kind"`
+	Shards  int    `json:"shards"`
+}
+
+// BoundedQuery represents a datastore Query with a bounded key range between [Start, End)
+type BoundedQuery struct {
+	Start *datastore.Key `json:"start"`
+	End   *datastore.Key `json:"end"`
+}
+
+func (s *splitQueryFn) ProcessElement(ctx context.Context, _ []byte, emit func(k string, val string)) error {
+	client, err := datastore.NewClient(ctx, s.Project)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	splits := []*datastore.Key{}
+	iter := client.Run(ctx, datastore.NewQuery(s.Kind).Order(scatterPropertyName).Limit((s.Shards - 1) * 32).KeysOnly())
+	for {
+		k, err := iter.Next(nil)
+		if err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return err
+		}
+		splits = append(splits, k)
+	}
+	sort.Slice(splits, func(i, j int) bool {
+		return keyLessThan(splits[i], splits[j])
+	})
+
+	splitKeys := getSplits(splits, s.Shards)
+
+	queries := []*BoundedQuery{}
+	var lastKey *datastore.Key
+	for _, k := range splitKeys {
+		q := BoundedQuery{End: k}
+		if lastKey != nil {
+			q.Start = lastKey
+		}
+		queries = append(queries, &q)
+		lastKey = k
+	}
+	queries = append(queries, &BoundedQuery{End: lastKey})
+
+	for n, q := range queries {
+		b, err := json.Marshal(q)
+		if err != nil {
+			return err
+		}
+		emit(strconv.Itoa(n), string(b))
+	}
+	return nil
+}
+
+func keyLessThan(a *datastore.Key, b *datastore.Key) bool {
+	af, bf := flatten(a), flatten(b)
+	for n, k1 := range af {
+		if n >= len(bf) {
+			return true
+		}
+		k2 := bf[n]
+		if k1.Name < k2.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func flatten(k *datastore.Key) []*datastore.Key {
+	pieces := []*datastore.Key{}
+	if k.Parent != nil {
+		pieces = append(pieces, flatten(k.Parent)...)
+	}
+	pieces = append(pieces, k)
+	return pieces
+}
+
+func getSplits(keys []*datastore.Key, numSplits int) []*datastore.Key {
+	if len(keys) == 0 || (len(keys) < (numSplits - 1)) {
+		return keys
+	}
+
+	numKeysPerSplit := math.Max(1.0, float64(len(keys))) / float64((numSplits))
+
+	splitKeys := make([]*datastore.Key, numSplits)
+	for n := 1; n <= len(splitKeys); n++ {
+		i := int(math.Round(float64(n) * float64(numKeysPerSplit)))
+		splitKeys[n-1] = keys[i-1]
+	}
+	return splitKeys
+
+}
+
+type queryFn struct {
+	// Project is the project
+	Project string `json:"project"`
+	// Kind is the datastore kind
+	Kind string `json:"kind"`
+	// Type is the name of the global schema type
+	Type string `json:"type"`
+}
+
+func (f *queryFn) ProcessElement(ctx context.Context, _ string, v func(*string) bool, emit func(beam.X)) error {
+
+	client, err := datastore.NewClient(ctx, f.Project)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	// deserialize Query
+	var k string
+	v(&k)
+	q := BoundedQuery{}
+	err = json.Unmarshal([]byte(k), &q)
+	if err != nil {
+		return err
+	}
+
+	// lookup type
+	t, ok := runtime.LookupType(f.Type)
+	if !ok {
+		fmt.Errorf("No type registered %s", f.Type)
+	}
+
+	// Translate BoundedQuery to datastore.Query
+	dq := datastore.NewQuery(f.Kind)
+	if q.Start != nil {
+		dq = dq.Filter("__key__ >=", q.Start)
+	}
+	if q.End != nil {
+		dq = dq.Filter("__key__ <", q.End)
+	}
+
+	// Run Query
+	iter := client.Run(ctx, dq)
+	for {
+		val := reflect.New(t).Interface() // val : *T
+		if _, err := iter.Next(val); err != nil {
+			if err == iterator.Done {
+				break
+			}
+			return err
+		}
+		emit(reflect.ValueOf(val).Elem().Interface()) // emit(*val)
+	}
+	return nil
+}

--- a/sdks/go/pkg/beam/io/datastoreio/datastore_test.go
+++ b/sdks/go/pkg/beam/io/datastoreio/datastore_test.go
@@ -1,0 +1,79 @@
+package datastoreio
+
+import (
+	"testing"
+	"cloud.google.com/go/datastore"
+)
+
+func Test_keyLessThan(t *testing.T) {
+	tsts := []struct {
+		a      *datastore.Key
+		b      *datastore.Key
+		expect bool
+		name   string
+	}{
+		{
+			name:   "a<b",
+			a:      datastore.NameKey("A", "a", nil),
+			b:      datastore.NameKey("A", "b", nil),
+			expect: true,
+		},
+		{
+			name:   "b>a",
+			a:      datastore.NameKey("A", "b", nil),
+			b:      datastore.NameKey("A", "a", nil),
+			expect: false,
+		},
+		{
+			name:   "a=a",
+			a:      datastore.NameKey("A", "a", nil),
+			b:      datastore.NameKey("A", "a", nil),
+			expect: false,
+		},
+		{
+			name:   "a.a<b",
+			a:      datastore.NameKey("A", "a", nil),
+			b:      datastore.NameKey("A", "a", datastore.NameKey("A", "b", nil)),
+			expect: true,
+		},
+		{
+			name:   "a.a<a.b",
+			a:      datastore.NameKey("A", "a", datastore.NameKey("A", "a", nil)),
+			b:      datastore.NameKey("A", "a", datastore.NameKey("A", "b", nil)),
+			expect: true,
+		},
+		{
+			name:   "a.b>a.a",
+			a:      datastore.NameKey("A", "a", datastore.NameKey("A", "b", nil)),
+			b:      datastore.NameKey("A", "a", datastore.NameKey("A", "a", nil)),
+			expect: false,
+		},
+		{
+			name:   "a.a=a.a",
+			a:      datastore.NameKey("A", "a", datastore.NameKey("A", "a", nil)),
+			b:      datastore.NameKey("A", "a", datastore.NameKey("A", "a", nil)),
+			expect: false,
+		},
+		{
+			name:   "a.a>a",
+			a:      datastore.NameKey("A", "a", datastore.NameKey("A", "a", nil)),
+			b:      datastore.NameKey("A", "a", nil),
+			expect: true,
+		},
+		{
+			name:   "b>b.a",
+			a:      datastore.NameKey("A", "b", nil),
+			b:      datastore.NameKey("A", "b", datastore.NameKey("A", "a", nil)),
+			expect: false,
+		},
+	}
+	for n := range tsts {
+		index := n
+		t.Run(tsts[index].name, func(t *testing.T) {
+			got := keyLessThan(tsts[index].a, tsts[index].b)
+			if tsts[index].expect != got {
+				t.Fail()
+			}
+		})
+	}
+}


### PR DESCRIPTION
@herohde 

This is based on the python input reader but is not feature complete and needs more work. I am mostly opening this if anyone else would find it useful but also to provide feedback on the go sdk.

1) Parallelism looks to be missing? Running this on Dataflow on an entity with 90 million items takes a long time (12+ hours). I've tried with 256, 512, and 1024 shards and the dataflow typically always runs with 4 workers no matter the shard size, I would have expected it to fan out and process at a much faster rate. Is this because of the compat runtime? Am I doing something wrong with my pipeline? Any insight would be great. I want to start using this for much larger size datasets, but the throughput isn't at a level that I could start using it.

2) `beam.EncodeType` should not serialize the type and reconstruct on the other end. I can't think of a time that i would ever use this, losing the methods is a deal breaker, as well as not being able to handle complex structures. For example the `datastore.Key` has a recursive definition, and can't be put into this format. I might be missing something on this one but I am working on very little documentation(which is fine for now). The other example is that my struct implements `datastore.PropertyLoadSaver` which is lost when using `beam.EncodeType`. There doesn't seem to be an API to take advantage of `runtime.RegisterType` when using generics.


Thanks!


