### PR TITLE
[BEAM-3819] Add withRequestRecordsLimit() option to KinesisIO

### DIFF
--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClient.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/SimplifiedKinesisClient.java
@@ -58,15 +58,18 @@ class SimplifiedKinesisClient {
   private static final String STREAM_NAME_DIMENSION = "StreamName";
   private final AmazonKinesis kinesis;
   private final AmazonCloudWatch cloudWatch;
+  private final Integer limit;
 
-  public SimplifiedKinesisClient(AmazonKinesis kinesis, AmazonCloudWatch cloudWatch) {
+  public SimplifiedKinesisClient(AmazonKinesis kinesis, AmazonCloudWatch cloudWatch,
+      Integer limit) {
     this.kinesis = checkNotNull(kinesis, "kinesis");
     this.cloudWatch = checkNotNull(cloudWatch, "cloudWatch");
+    this.limit = limit;
   }
 
-  public static SimplifiedKinesisClient from(AWSClientsProvider provider) {
+  public static SimplifiedKinesisClient from(AWSClientsProvider provider, Integer limit) {
     return new SimplifiedKinesisClient(provider.getKinesisClient(),
-        provider.getCloudWatchClient());
+        provider.getCloudWatchClient(), limit);
   }
 
   public String getShardIterator(final String streamName, final String shardId,
@@ -113,7 +116,7 @@ class SimplifiedKinesisClient {
    */
   public GetKinesisRecordsResult getRecords(String shardIterator, String streamName,
       String shardId) throws TransientKinesisException {
-    return getRecords(shardIterator, streamName, shardId, null);
+    return getRecords(shardIterator, streamName, shardId, limit);
   }
 
   /**

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisIOIT.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisIOIT.java
@@ -86,7 +86,8 @@ public class KinesisIOIT implements Serializable {
                     // to prevent endless running in case of error
                     .withMaxReadTime(Duration.standardMinutes(5))
                     .withInitialPositionInStream(InitialPositionInStream.AT_TIMESTAMP)
-                    .withInitialTimestampInStream(now))
+                    .withInitialTimestampInStream(now)
+                    .withRequestRecordsLimit(1000))
             .apply(
                 ParDo.of(
                     new DoFn<KinesisRecord, byte[]>() {


### PR DESCRIPTION
Add `KinesisIO.Read.withLimit()` to limit maximum number of fetched records in `GetRecordsResult`. It should help to reduce a load on Kinesis if needed.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

