### PR TITLE
Add equals, hashCode, and structuralValue to Nexmark model objects

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -70,6 +71,11 @@ public class Auction implements KnownSize, Serializable {
       return new Auction(
           id, itemName, description, initialBid, reserve, dateTime, expires, seller, category,
           extra);
+    }
+
+    @Override
+    public Object structuralValue(Auction v) {
+      return v;
     }
   };
 
@@ -183,5 +189,32 @@ public class Auction implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Auction auction = (Auction) o;
+    return id == auction.id
+        && initialBid == auction.initialBid
+        && reserve == auction.reserve
+        && dateTime == auction.dateTime
+        && expires == auction.expires
+        && seller == auction.seller
+        && category == auction.category
+        && Objects.equal(itemName, auction.itemName)
+        && Objects.equal(description, auction.description)
+        && Objects.equal(extra, auction.extra);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(
+        id, itemName, description, initialBid, reserve, dateTime, expires, seller, category, extra);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionBid.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionBid.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -48,6 +49,11 @@ public class AuctionBid implements KnownSize, Serializable {
       Auction auction = Auction.CODER.decode(inStream);
       Bid bid = Bid.CODER.decode(inStream);
       return new AuctionBid(auction, bid);
+    }
+
+    @Override
+    public Object structuralValue(AuctionBid v) {
+      return v;
     }
   };
 
@@ -81,5 +87,22 @@ public class AuctionBid implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    AuctionBid that = (AuctionBid) o;
+    return Objects.equal(auction, that.auction) && Objects.equal(bid, that.bid);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(auction, bid);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
@@ -51,6 +51,11 @@ public class AuctionCount implements KnownSize, Serializable {
       long num = LONG_CODER.decode(inStream);
       return new AuctionCount(auction, num);
     }
+
+    @Override
+    public Object structuralValue(AuctionCount v) {
+      return v;
+    }
   };
 
   @JsonProperty public final long auction;

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
@@ -52,6 +52,11 @@ public class AuctionPrice implements KnownSize, Serializable {
       long price = LONG_CODER.decode(inStream);
       return new AuctionPrice(auction, price);
     }
+
+    @Override
+    public Object structuralValue(AuctionPrice v) {
+      return v;
+    }
   };
 
   @JsonProperty

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
@@ -63,6 +63,11 @@ public class Bid implements KnownSize, Serializable {
     }
 
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(Bid v) {
+      return v;
+    }
   };
 
   /**

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -51,7 +52,13 @@ public class BidsPerSession implements KnownSize, Serializable {
       long bidsPerSession = LONG_CODER.decode(inStream);
       return new BidsPerSession(personId, bidsPerSession);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(BidsPerSession v) {
+      return v;
+    }
   };
 
   @JsonProperty
@@ -83,5 +90,22 @@ public class BidsPerSession implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BidsPerSession that = (BidsPerSession) o;
+    return personId == that.personId && bidsPerSession == that.bidsPerSession;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(personId, bidsPerSession);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -54,7 +55,13 @@ public class CategoryPrice implements KnownSize, Serializable {
       boolean isLast = INT_CODER.decode(inStream) != 0;
       return new CategoryPrice(category, price, isLast);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(CategoryPrice v) {
+      return v;
+    }
   };
 
   @JsonProperty
@@ -93,5 +100,22 @@ public class CategoryPrice implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CategoryPrice that = (CategoryPrice) o;
+    return category == that.category && price == that.price && isLast == that.isLast;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(category, price, isLast);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Done.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Done.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -49,6 +50,10 @@ public class Done implements KnownSize, Serializable {
       return new Done(message);
     }
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+    @Override
+    public Object structuralValue(Done v) {
+      return v;
+    }
   };
 
   @JsonProperty
@@ -76,5 +81,22 @@ public class Done implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Done done = (Done) o;
+    return Objects.equal(message, done.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(message);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Event.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.nexmark.model;
 
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -31,6 +32,25 @@ import org.apache.beam.sdk.coders.VarIntCoder;
  * {@link Bid}.
  */
 public class Event implements KnownSize, Serializable {
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Event event = (Event) o;
+    return Objects.equal(newPerson, event.newPerson)
+        && Objects.equal(newAuction, event.newAuction)
+        && Objects.equal(bid, event.bid);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(newPerson, newAuction, bid);
+  }
 
   private enum Tag {
     PERSON(0),
@@ -83,6 +103,11 @@ public class Event implements KnownSize, Serializable {
 
         @Override
         public void verifyDeterministic() throws NonDeterministicException {}
+
+        @Override
+        public Object structuralValue(Event v) {
+          return v;
+        }
       };
 
   @Nullable

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -55,7 +56,13 @@ public class IdNameReserve implements KnownSize, Serializable {
       long reserve = LONG_CODER.decode(inStream);
       return new IdNameReserve(id, name, reserve);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(IdNameReserve v) {
+      return v;
+    }
   };
 
   @JsonProperty
@@ -94,5 +101,22 @@ public class IdNameReserve implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    IdNameReserve that = (IdNameReserve) o;
+    return id == that.id && reserve == that.reserve && Objects.equal(name, that.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, name, reserve);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
@@ -57,7 +57,13 @@ public class NameCityStateId implements KnownSize, Serializable {
       long id = LONG_CODER.decode(inStream);
       return new NameCityStateId(name, city, state, id);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(NameCityStateId v) {
+      return v;
+    }
   };
 
   @JsonProperty

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -63,7 +64,13 @@ public class Person implements KnownSize, Serializable {
       String extra = STRING_CODER.decode(inStream);
       return new Person(id, name, emailAddress, creditCard, city, state, dateTime, extra);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(Person v) {
+      return v;
+    }
   };
 
   /** Id of person. */
@@ -159,5 +166,29 @@ public class Person implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Person person = (Person) o;
+    return id == person.id
+        && dateTime == person.dateTime
+        && Objects.equal(name, person.name)
+        && Objects.equal(emailAddress, person.emailAddress)
+        && Objects.equal(creditCard, person.creditCard)
+        && Objects.equal(city, person.city)
+        && Objects.equal(state, person.state)
+        && Objects.equal(extra, person.extra);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(id, name, emailAddress, creditCard, city, state, dateTime, extra);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.nexmark.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Objects;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -51,7 +52,13 @@ public class SellerPrice implements KnownSize, Serializable {
       long price = LONG_CODER.decode(inStream);
       return new SellerPrice(seller, price);
     }
+
     @Override public void verifyDeterministic() throws NonDeterministicException {}
+
+    @Override
+    public Object structuralValue(SellerPrice v) {
+      return v;
+    }
   };
 
   @JsonProperty
@@ -85,5 +92,22 @@ public class SellerPrice implements KnownSize, Serializable {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SellerPrice that = (SellerPrice) o;
+    return seller == that.seller && price == that.price;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(seller, price);
   }
 }


### PR DESCRIPTION
Experiment to see if good equals, hashCode, and structuralValue improves Query10 performance regression.

Unless I am missing something in how I invoke it - no.

@iemejia 