### PR TITLE
Put the String literal first when comparing it to an Object

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficRoutes.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/TrafficRoutes.java
@@ -193,7 +193,7 @@ public class TrafficRoutes {
       String[] items = c.element().split(",");
       String stationType = tryParseStationType(items);
       // For this analysis, use only 'main line' station types
-      if (stationType != null && stationType.equals("ML")) {
+      if ("ML".equals(stationType)) {
         Double avgSpeed = tryParseAvgSpeed(items);
         String stationId = tryParseStationId(items);
         // For this simple example, filter out everything but some hardwired routes.

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
@@ -101,7 +101,7 @@ public class UserScore {
       return this.score;
     }
     public String getKey(String keyname) {
-      if (keyname.equals("team")) {
+      if ("team".equals(keyname)) {
         return this.team;
       } else {  // return username as default
         return this.user;

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/injector/Injector.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/injector/Injector.java
@@ -371,7 +371,7 @@ class Injector {
     String fileName = args[2];
     // The Injector writes either to a PubSub topic, or a file. It will use the PubSub topic if
     // specified; otherwise, it will try to write to a file.
-    if (topicName.equalsIgnoreCase("none")) {
+    if ("none".equalsIgnoreCase(topicName)) {
       writeToFile = true;
       writeToPubsub = false;
     }
@@ -383,7 +383,7 @@ class Injector {
       InjectorUtils.createTopic(pubsub, topic);
       System.out.println("Injecting to topic: " + topic);
     } else {
-      if (fileName.equalsIgnoreCase("none")) {
+      if ("none".equalsIgnoreCase(fileName)) {
         System.out.println("Filename not specified.");
         System.exit(1);
       }

--- a/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/translators/functions/DoFnFunction.java
+++ b/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/translators/functions/DoFnFunction.java
@@ -119,7 +119,7 @@ public class DoFnFunction<InputT, OutputT> extends
 
     for (RawUnionValue unionValue: inputs) {
       final String tag = unionValue.getUnionTag();
-      if (tag.equals("0")) {
+      if ("0".equals(tag)) {
         // main input
         pushedBackValues.add((WindowedValue<InputT>) unionValue.getValue());
       } else {

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
@@ -246,7 +246,7 @@ public class ResumeFromCheckpointStreamingTest implements Serializable {
                   // at EOF move WM to infinity.
                   String key = kv.getKey();
                   Instant instant = kv.getValue();
-                  return key.equals("EOF") ? BoundedWindow.TIMESTAMP_MAX_VALUE : instant;
+                  return "EOF".equals(key) ? BoundedWindow.TIMESTAMP_MAX_VALUE : instant;
                 });
 
     TestSparkPipelineOptions options =
@@ -321,7 +321,7 @@ public class ResumeFromCheckpointStreamingTest implements Serializable {
       // assert that side input is passed correctly before/after resuming from checkpoint.
       assertThat(c.sideInput(view), containsInAnyOrder("side1", "side2"));
       counter.inc();
-      if (!element.equals("EOF")) {
+      if (!"EOF".equals(element)) {
         aggregator.inc();
         c.output(c.element());
       }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -579,7 +579,7 @@ public class CombineTest implements Serializable {
   }
 
   private static final SerializableFunction<String, Integer> hotKeyFanout =
-      input -> input.equals("a") ? 3 : 0;
+      input -> "a".equals(input) ? 3 : 0;
 
   private static final SerializableFunction<String, Integer> splitHotKeyFanout =
       input -> Math.random() < 0.5 ? 3 : 0;

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
@@ -157,7 +157,7 @@ public interface GcpOptions extends GoogleApiDebugOptions, PipelineOptions {
           Matcher matcher = sectionPattern.matcher(line);
           if (matcher.matches()) {
             section = matcher.group(1);
-          } else if (section == null || section.equals("core")) {
+          } else if (section == null || "core".equals(section)) {
             matcher = projectPattern.matcher(line);
             if (matcher.matches()) {
               String project = matcher.group(1).trim();

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -397,7 +397,7 @@ public class ElasticsearchIO {
      */
     public Read withScrollKeepalive(String scrollKeepalive) {
       checkArgument(scrollKeepalive != null, "scrollKeepalive can not be null");
-      checkArgument(!scrollKeepalive.equals("0m"), "scrollKeepalive can not be 0m");
+      checkArgument(!"0m".equals(scrollKeepalive), "scrollKeepalive can not be 0m");
       return builder().setScrollKeepalive(scrollKeepalive).build();
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
@@ -111,13 +111,13 @@ class SpannerSchema implements Serializable {
 
     private static Type parseSpannerType(String spannerType) {
       spannerType = spannerType.toUpperCase();
-      if (spannerType.equals("BOOL")) {
+      if ("BOOL".equals(spannerType)) {
         return Type.bool();
       }
-      if (spannerType.equals("INT64")) {
+      if ("INT64".equals(spannerType)) {
         return Type.int64();
       }
-      if (spannerType.equals("FLOAT64")) {
+      if ("FLOAT64".equals(spannerType)) {
         return Type.float64();
       }
       if (spannerType.startsWith("STRING")) {
@@ -126,10 +126,10 @@ class SpannerSchema implements Serializable {
       if (spannerType.startsWith("BYTES")) {
         return Type.bytes();
       }
-      if (spannerType.equals("TIMESTAMP")) {
+      if ("TIMESTAMP".equals(spannerType)) {
         return Type.timestamp();
       }
-      if (spannerType.equals("DATE")) {
+      if ("DATE".equals(spannerType)) {
         return Type.date();
       }
 

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -301,7 +301,7 @@ public class RedisIO {
         }
 
         cursor = scanResult.getStringCursor();
-        if (cursor.equals("0")) {
+        if ("0".equals(cursor)) {
           finished = true;
         }
       }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3.java
@@ -110,9 +110,9 @@ public class Query3 extends NexmarkQuery {
                 name + ".InState",
                 Filter.by(
                     person ->
-                        person.state.equals("OR")
-                            || person.state.equals("ID")
-                            || person.state.equals("CA")))
+                        "OR".equals(person.state)
+                            || "ID".equals(person.state)
+                            || "CA".equals(person.state)))
 
             // Key people by their id.
             .apply("PersonById", PERSON_BY_ID);

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3Model.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3Model.java
@@ -91,8 +91,8 @@ public class Query3Model extends NexmarkQueryModel implements Serializable {
         }
       } else {
         // Only want people in OR, ID or CA.
-        if (event.newPerson.state.equals("OR") || event.newPerson.state.equals("ID")
-            || event.newPerson.state.equals("CA")) {
+        if ("OR".equals(event.newPerson.state) || "ID".equals(event.newPerson.state)
+            || "CA".equals(event.newPerson.state)) {
           // Join new person with existing auctions.
           for (Auction auction : newAuctions.get(event.newPerson.id)) {
             addResult(auction, event.newPerson, timestamp);


### PR DESCRIPTION
To avoid possible NPEs, it's considered good practice to put the String literal first when comparing it to an Object (that could potentially be null).