### PR TITLE
Enable input subscription in Python streaming wordcount

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordcount.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount.py
@@ -52,7 +52,7 @@ def run(argv=None):
       help=('Input PubSub topic of the form '
             '"projects/<PROJECT>/topics/<TOPIC>".'))
   group.add_argument(
-      '--input_sub',
+      '--input_subscription',
       help=('Input PubSub subscription of the form '
             '"projects/<PROJECT>/subscriptions/<SUBSCRIPTION>."'))
   known_args, pipeline_args = parser.parse_known_args(argv)
@@ -62,8 +62,9 @@ def run(argv=None):
   with beam.Pipeline(options=options) as p:
 
     # Read from PubSub into a PCollection.
-    if known_args.input_sub:
-      lines = p | beam.io.ReadStringsFromPubSub(subscription=known_args.input_sub)
+    if known_args.input_subscription:
+      lines = p | beam.io.ReadStringsFromPubSub(
+          subscription=known_args.input_subscription)
     else:
       lines = p | beam.io.ReadStringsFromPubSub(topic=known_args.input_topic)
 


### PR DESCRIPTION
Enable `input_sub` flag in Python streaming wordcount example so that PubSub subscription can be a choice of input sources. People can choose to use either `input_topic` or `input_sub`, but can not use both.

The future work of integration test (for streaming wordcount) can also take advantage of this change to be able to set up pipeline environment easier.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

