### PR TITLE
[BEAM-2281][Sql] Use SqlFunctions.toBigDecimal not toString

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpre
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
+import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 /**
@@ -53,10 +54,8 @@ public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
 
   @Override public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow,
       BoundedWindow window) {
-    BigDecimal left = BigDecimal.valueOf(
-        Double.valueOf(opValueEvaluated(0, inputRow, window).toString()));
-    BigDecimal right = BigDecimal.valueOf(
-        Double.valueOf(opValueEvaluated(1, inputRow, window).toString()));
+    BigDecimal left = SqlFunctions.toBigDecimal((Object) opValueEvaluated(0, inputRow, window));
+    BigDecimal right = SqlFunctions.toBigDecimal((Object) opValueEvaluated(1, inputRow, window));
 
     BigDecimal result = calc(left, right);
     return getCorrectlyTypedResult(result);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAbsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAbsExpression.java
@@ -18,7 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
-import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -60,7 +59,7 @@ public class BeamSqlAbsExpression extends BeamSqlMathUnaryExpression {
         break;
       case DECIMAL:
         result = BeamSqlPrimitive
-            .of(SqlTypeName.DECIMAL, SqlFunctions.abs(new BigDecimal(op.getValue().toString())));
+            .of(SqlTypeName.DECIMAL, SqlFunctions.abs(op.getDecimal()));
         break;
       case DOUBLE:
         result = BeamSqlPrimitive

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/CovarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/CovarianceFn.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
+import org.apache.calcite.runtime.SqlFunctions;
 
 /**
  * {@link Combine.CombineFn} for <em>Covariance</em> on {@link Number} types.
@@ -83,7 +84,8 @@ public class CovarianceFn<T extends Number>
         }
 
         return currentVariance.combineWith(CovarianceAccumulator.ofSingleElement(
-                toBigDecimal(rawInput.getKey()), toBigDecimal(rawInput.getValue())));
+                SqlFunctions.toBigDecimal(rawInput.getKey()),
+                SqlFunctions.toBigDecimal(rawInput.getValue())));
     }
 
     @Override
@@ -112,9 +114,5 @@ public class CovarianceFn<T extends Number>
                 : covariance.count();
 
         return covariance.covariance().divide(adjustedCount, MATH_CTX);
-    }
-
-    private BigDecimal toBigDecimal(T rawInput) {
-        return new BigDecimal(rawInput.toString());
     }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.calcite.runtime.SqlFunctions;
 
 /**
  * {@link Combine.CombineFn} for <em>Variance</em> on {@link Number} types.
@@ -102,7 +103,8 @@ public class VarianceFn<T extends Number>
       return currentVariance;
     }
 
-    return currentVariance.combineWith(VarianceAccumulator.ofSingleElement(toBigDecimal(rawInput)));
+    return currentVariance.combineWith(VarianceAccumulator.ofSingleElement(
+        SqlFunctions.toBigDecimal(rawInput)));
   }
 
   @Override
@@ -130,9 +132,5 @@ public class VarianceFn<T extends Number>
         : variance.count();
 
     return variance.variance().divide(adjustedCount, MATH_CTX);
-  }
-
-  private BigDecimal toBigDecimal(T rawInput) {
-    return new BigDecimal(rawInput.toString());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlArithmeticOperatorsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlArithmeticOperatorsIntegrationTest.java
@@ -34,6 +34,7 @@ public class BeamSqlArithmeticOperatorsIntegrationTest
   private static final BigDecimal ONE10 = BigDecimal.ONE.divide(
       BigDecimal.ONE, 10, RoundingMode.HALF_EVEN);
   private static final BigDecimal TWO = BigDecimal.valueOf(2.0);
+  private static final BigDecimal TWO0 = BigDecimal.ONE.add(BigDecimal.ONE);
 
   @Test
   public void testPlus() throws Exception {
@@ -45,8 +46,8 @@ public class BeamSqlArithmeticOperatorsIntegrationTest
         .addExpr("c_tinyint + c_tinyint", (byte) 2)
         .addExpr("c_smallint + c_smallint", (short) 2)
         .addExpr("c_bigint + c_bigint", 2L)
-        .addExpr("c_decimal + c_decimal", TWO)
-        .addExpr("c_tinyint + c_decimal", TWO)
+        .addExpr("c_decimal + c_decimal", TWO0)
+        .addExpr("c_tinyint + c_decimal", TWO0)
         .addExpr("c_float + c_decimal", 2.0)
         .addExpr("c_double + c_decimal", 2.0)
         .addExpr("c_float + c_float", 2.0f)
@@ -65,9 +66,7 @@ public class BeamSqlArithmeticOperatorsIntegrationTest
         .addExpr("c_tinyint_max + c_tinyint_max", (byte) -2)
         .addExpr("c_smallint_max + c_smallint_max", (short) -2)
         .addExpr("c_integer_max + c_integer_max", -2)
-        // yeah, I know 384L is strange, but since it is already overflowed
-        // what the actualy result is not so important, it is wrong any way.
-        .addExpr("c_bigint_max + c_bigint_max", 384L)
+        .addExpr("c_bigint_max + c_bigint_max", -2L)
         ;
 
     checker.buildRunAndCheck();
@@ -83,8 +82,8 @@ public class BeamSqlArithmeticOperatorsIntegrationTest
         .addExpr("c_tinyint - c_tinyint", (byte) 0)
         .addExpr("c_smallint - c_smallint", (short) 0)
         .addExpr("c_bigint - c_bigint", 0L)
-        .addExpr("c_decimal - c_decimal", ZERO)
-        .addExpr("c_tinyint - c_decimal", ZERO)
+        .addExpr("c_decimal - c_decimal", BigDecimal.ZERO)
+        .addExpr("c_tinyint - c_decimal", BigDecimal.ZERO)
         .addExpr("c_float - c_decimal", 0.0)
         .addExpr("c_double - c_decimal", 0.0)
         .addExpr("c_float - c_float", 0.0f)
@@ -101,14 +100,14 @@ public class BeamSqlArithmeticOperatorsIntegrationTest
   public void testMultiply() throws Exception {
     ExpressionChecker checker = new ExpressionChecker()
         .addExpr("1 * 1", 1)
-        .addExpr("1.0 * 1", ONE2)
-        .addExpr("1 * 1.0", ONE2)
+        .addExpr("1.0 * 1", ONE)
+        .addExpr("1 * 1.0", ONE)
         .addExpr("1.0 * 1.0", ONE2)
         .addExpr("c_tinyint * c_tinyint", (byte) 1)
         .addExpr("c_smallint * c_smallint", (short) 1)
         .addExpr("c_bigint * c_bigint", 1L)
-        .addExpr("c_decimal * c_decimal", ONE2)
-        .addExpr("c_tinyint * c_decimal", ONE2)
+        .addExpr("c_decimal * c_decimal", BigDecimal.ONE)
+        .addExpr("c_tinyint * c_decimal", BigDecimal.ONE)
         .addExpr("c_float * c_decimal", 1.0)
         .addExpr("c_double * c_decimal", 1.0)
         .addExpr("c_float * c_float", 1.0f)


### PR DESCRIPTION
Instead of using BigDecimal(object.toString()) to convert, use SqlFunctions.toBigDecimal which converts directly between numeric types. This speeds up the Nexmark Query 2 parDo by 2x.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.