### PR TITLE
[BEAM-3851] Option to preserve element timestamp while publishing to Kafka.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -435,8 +435,11 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
       void sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
         try {
-          Long timestampMillis = spec.isElementTimestampEnabled()
-              ? record.getTimestamp().getMillis() : null;
+          Long timestampMillis = spec.getPublishTimestampFunction() != null
+            ? spec.getPublishTimestampFunction().getTimestamp(record.getValue(),
+                                                              record.getTimestamp()).getMillis()
+            : null;
+
           producer.send(
               new ProducerRecord<>(
                   spec.getTopic(), null, timestampMillis,

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -64,6 +64,8 @@ import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.sdk.values.TimestampedValue.TimestampedValueCoder;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -173,7 +175,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   /**
    * Shuffle messages assigning each randomly to a shard.
    */
-  private static class Reshard<K, V> extends DoFn<KV<K, V>, KV<Integer, KV<K, V>>> {
+  private static class Reshard<K, V>
+      extends DoFn<KV<K, V>, KV<Integer, TimestampedValue<KV<K, V>>>> {
 
     private final int numShards;
     private transient int shardId;
@@ -190,12 +193,13 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     @ProcessElement
     public void processElement(ProcessContext ctx) {
       shardId = (shardId + 1) % numShards; // round-robin among shards.
-      ctx.output(KV.of(shardId, ctx.element()));
+      ctx.output(KV.of(shardId, TimestampedValue.of(ctx.element(), ctx.timestamp())));
     }
   }
 
-  private static class Sequencer<K, V>
-    extends DoFn<KV<Integer, Iterable<KV<K, V>>>, KV<Integer, KV<Long, KV<K, V>>>> {
+  private static class Sequencer<K, V> extends DoFn<
+      KV<Integer, Iterable<TimestampedValue<KV<K, V>>>>,
+      KV<Integer, KV<Long, TimestampedValue<KV<K, V>>>>> {
 
     private static final String NEXT_ID = "nextId";
     @StateId(NEXT_ID)
@@ -205,7 +209,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     public void processElement(@StateId(NEXT_ID) ValueState<Long> nextIdState, ProcessContext ctx) {
       long nextId = MoreObjects.firstNonNull(nextIdState.read(), 0L);
       int shard = ctx.element().getKey();
-      for (KV<K, V> value : ctx.element().getValue()) {
+      for (TimestampedValue<KV<K, V>> value : ctx.element().getValue()) {
         ctx.output(KV.of(shard, KV.of(nextId, value)));
         nextId++;
       }
@@ -214,7 +218,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   }
 
   private static class ExactlyOnceWriter<K, V>
-    extends DoFn<KV<Integer, Iterable<KV<Long, KV<K, V>>>>, Void> {
+    extends DoFn<KV<Integer, Iterable<KV<Long, TimestampedValue<KV<K, V>>>>>, Void> {
 
     private static final String NEXT_ID = "nextId";
     private static final String MIN_BUFFERED_ID = "minBufferedId";
@@ -230,7 +234,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     @StateId(MIN_BUFFERED_ID)
     private final StateSpec<ValueState<Long>> minBufferedIdSpec = StateSpecs.value();
     @StateId(OUT_OF_ORDER_BUFFER)
-    private final StateSpec<BagState<KV<Long, KV<K, V>>>> outOfOrderBufferSpec;
+    private final StateSpec<BagState<KV<Long, TimestampedValue<KV<K, V>>>>> outOfOrderBufferSpec;
     // A random id assigned to each shard. Helps with detecting when multiple jobs are mistakenly
     // started with same groupId used for storing state on Kafka side, including the case where
     // a job is restarted with same groupId, but the metadata from previous run was not cleared.
@@ -248,7 +252,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
     ExactlyOnceWriter(Write<K, V> spec, Coder<KV<K, V>> elemCoder) {
       this.spec = spec;
-      this.outOfOrderBufferSpec = StateSpecs.bag(KvCoder.of(BigEndianLongCoder.of(), elemCoder));
+      this.outOfOrderBufferSpec = StateSpecs.bag(
+          KvCoder.of(BigEndianLongCoder.of(), TimestampedValueCoder.of(elemCoder)));
     }
 
     @Setup
@@ -261,7 +266,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     public void processElement(@StateId(NEXT_ID) ValueState<Long> nextIdState,
                                @StateId(MIN_BUFFERED_ID) ValueState<Long> minBufferedIdState,
                                @StateId(OUT_OF_ORDER_BUFFER)
-                                 BagState<KV<Long, KV<K, V>>> oooBufferState,
+                                 BagState<KV<Long, TimestampedValue<KV<K, V>>>> oooBufferState,
                                @StateId(WRITER_ID) ValueState<String> writerIdState,
                                ProcessContext ctx)
       throws IOException {
@@ -297,10 +302,10 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         // There might be out of order messages buffered in earlier iterations. These
         // will get merged if and when minBufferedId matches nextId.
 
-        Iterator<KV<Long, KV<K, V>>> iter = ctx.element().getValue().iterator();
+        Iterator<KV<Long, TimestampedValue<KV<K, V>>>> iter = ctx.element().getValue().iterator();
 
         while (iter.hasNext()) {
-          KV<Long, KV<K, V>> kv = iter.next();
+          KV<Long, TimestampedValue<KV<K, V>>> kv = iter.next();
           long recordId = kv.getKey();
 
           if (recordId < nextId) {
@@ -339,7 +344,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
             // Read all of them in to memory and sort them. Reading into memory
             // might be problematic in extreme cases. Might need to improve it in future.
 
-            List<KV<Long, KV<K, V>>> buffered = Lists.newArrayList(oooBufferState.read());
+            List<KV<Long, TimestampedValue<KV<K, V>>>> buffered =
+                Lists.newArrayList(oooBufferState.read());
             buffered.sort(new KV.OrderByKey<>());
 
             LOG.info("{} : merging {} buffered records (min buffered id is {}).",
@@ -349,8 +355,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
             minBufferedIdState.clear();
             minBufferedId = Long.MAX_VALUE;
 
-            iter =
-              Iterators.mergeSorted(
+            iter = Iterators.mergeSorted(
                 ImmutableList.of(iter, buffered.iterator()), new KV.OrderByKey<>());
           }
         }
@@ -428,10 +433,14 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         ProducerSpEL.beginTransaction(producer);
       }
 
-      void sendRecord(KV<K, V> record, Counter sendCounter) {
+      void sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
         try {
+          Long timestampMillis = spec.isElementTimestampEnabled()
+              ? record.getTimestamp().getMillis() : null;
           producer.send(
-            new ProducerRecord<>(spec.getTopic(), record.getKey(), record.getValue()));
+              new ProducerRecord<>(
+                  spec.getTopic(), null, timestampMillis,
+                  record.getValue().getKey(), record.getValue().getValue()));
           sendCounter.inc();
         } catch (KafkaException e) {
           ProducerSpEL.abortTransaction(producer);

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -258,6 +258,7 @@ public class KafkaIO {
         .setProducerConfig(Write.DEFAULT_PRODUCER_PROPERTIES)
         .setEOS(false)
         .setNumShards(0)
+        .setElementTimestampEnabled(false)
         .setConsumerFactoryFn(Read.KAFKA_CONSUMER_FACTORY_FN)
         .build();
   }
@@ -813,6 +814,8 @@ public class KafkaIO {
     @Nullable abstract Class<? extends Serializer<K>> getKeySerializer();
     @Nullable abstract Class<? extends Serializer<V>> getValueSerializer();
 
+    abstract boolean isElementTimestampEnabled();
+
     // Configuration for EOS sink
     abstract boolean isEOS();
     @Nullable abstract String getSinkGroupId();
@@ -830,6 +833,7 @@ public class KafkaIO {
           SerializableFunction<Map<String, Object>, Producer<K, V>> fn);
       abstract Builder<K, V> setKeySerializer(Class<? extends Serializer<K>> serializer);
       abstract Builder<K, V> setValueSerializer(Class<? extends Serializer<V>> serializer);
+      abstract Builder<K, V> setElementTimestampEnabled(boolean tsEnabled);
       abstract Builder<K, V> setEOS(boolean eosEnabled);
       abstract Builder<K, V> setSinkGroupId(String sinkGroupId);
       abstract Builder<K, V> setNumShards(int numShards);
@@ -887,6 +891,13 @@ public class KafkaIO {
     public Write<K, V> withProducerFactoryFn(
         SerializableFunction<Map<String, Object>, Producer<K, V>> producerFactoryFn) {
       return toBuilder().setProducerFactoryFn(producerFactoryFn).build();
+    }
+
+    /**
+     * The timestamp for each published message is set to timestamp of the input element.
+     */
+    public Write<K, V> withInputTimestamp() {
+      return toBuilder().setElementTimestampEnabled(true).build();
     }
 
     /**

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaPublishTimestampFunction.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaPublishTimestampFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.joda.time.Instant;
+
+/**
+ * An interface for providing custom timestamp for elements written to Kafka.
+ */
+public interface KafkaPublishTimestampFunction<T> extends Serializable {
+
+  /**
+   * Returns timestamp for element being published to Kafka.
+   * See @{@link org.apache.kafka.clients.producer.ProducerRecord}.
+   *
+   * @param element The element being published.
+   * @param elementTimestamp Timestamp of the element from the context
+   *                         (i.e. @{@link DoFn.ProcessContext#timestamp()}
+   */
+  Instant getTimestamp(T element, Instant elementTimestamp);
+
+  /**
+   * Returns {@link KafkaPublishTimestampFunction} returns element timestamp from ProcessContext.
+   */
+  static <T> KafkaPublishTimestampFunction<T> withElementTimestamp() {
+    return (element, elementTimestamp) -> elementTimestamp;
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -54,8 +54,9 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
     checkForFailures();
 
     KV<K, V> kv = ctx.element();
-    Long timestampMillis = spec.isElementTimestampEnabled()
-        ? ctx.timestamp().getMillis() : null;
+    Long timestampMillis = spec.getPublishTimestampFunction() != null
+      ? spec.getPublishTimestampFunction().getTimestamp(kv, ctx.timestamp()).getMillis()
+      : null;
 
     producer.send(new ProducerRecord<>(
         spec.getTopic(), null, timestampMillis, kv.getKey(), kv.getValue()), new SendCallback());

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -54,8 +54,11 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
     checkForFailures();
 
     KV<K, V> kv = ctx.element();
-    producer.send(
-        new ProducerRecord<>(spec.getTopic(), kv.getKey(), kv.getValue()), new SendCallback());
+    Long timestampMillis = spec.isElementTimestampEnabled()
+        ? ctx.timestamp().getMillis() : null;
+
+    producer.send(new ProducerRecord<>(
+        spec.getTopic(), null, timestampMillis, kv.getKey(), kv.getValue()), new SendCallback());
 
     elementsWritten.inc();
   }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -854,13 +854,14 @@ public class KafkaIOTest {
             .withTopic(topic)
             .withKeySerializer(IntegerSerializer.class)
             .withValueSerializer(LongSerializer.class)
+            .withInputTimestamp()
             .withProducerFactoryFn(new ProducerFactoryFn(producerWrapper.producerKey)));
 
       p.run();
 
       completionThread.shutdown();
 
-      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, false);
+      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, false, true);
     }
   }
 
@@ -891,7 +892,7 @@ public class KafkaIOTest {
 
       completionThread.shutdown();
 
-      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, true);
+      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, true, false);
     }
   }
 
@@ -930,13 +931,14 @@ public class KafkaIOTest {
                  .withEOS(1, "test")
                  .withConsumerFactoryFn(new ConsumerFactoryFn(
                    Lists.newArrayList(topic), 10, 10, OffsetResetStrategy.EARLIEST))
+                 .withInputTimestamp()
                  .withProducerFactoryFn(new ProducerFactoryFn(producerWrapper.producerKey)));
 
       p.run();
 
       completionThread.shutdown();
 
-      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, false);
+      verifyProducerRecords(producerWrapper.mockProducer, topic, numElements, false, true);
     }
   }
 
@@ -1198,7 +1200,10 @@ public class KafkaIOTest {
   }
 
   private static void verifyProducerRecords(MockProducer<Integer, Long> mockProducer,
-                                            String topic, int numElements, boolean keyIsAbsent) {
+                                            String topic,
+                                            int numElements,
+                                            boolean keyIsAbsent,
+                                            boolean verifyTimestamp) {
 
     // verify that appropriate messages are written to kafka
     List<ProducerRecord<Integer, Long>> sent = mockProducer.history();
@@ -1215,6 +1220,9 @@ public class KafkaIOTest {
         assertEquals(i, record.key().intValue());
       }
       assertEquals(i, record.value().longValue());
+      if (verifyTimestamp) {
+        assertEquals(i, record.timestamp().intValue());
+      }
     }
   }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -931,7 +931,7 @@ public class KafkaIOTest {
                  .withEOS(1, "test")
                  .withConsumerFactoryFn(new ConsumerFactoryFn(
                    Lists.newArrayList(topic), 10, 10, OffsetResetStrategy.EARLIEST))
-                 .withInputTimestamp()
+                 .withPublishTimestampFunction((e, ts) -> ts)
                  .withProducerFactoryFn(new ProducerFactoryFn(producerWrapper.producerKey)));
 
       p.run();


### PR DESCRIPTION
KafkaIO sink support for setting Kafka message timestamps based on element timestamp. Otherwise there is no way for user to influence the timestamp of the messages in Kafka sink.

The implementation for for normal sink (`KafkaWriter.java`) is trivial: Just need to read the timestamp from the context. But EOS sink (`KafkaExactlyOnceWriter.java`) changes are a bit more involved. 

In the case of the latter, the elements go through couple of shuffles and we need to include timestamp along with the the actual value. The implementation wraps timestamp and input KVs in `TimestampedValue<>`. This changes serialization of the elements shuffles. As a result EOS changes are not backward compatible (with upgrade or while using save points). I think the use of EOS sink is pretty minimal and this will have very little impact. I am not sure what the best practice is for handling such incompatibility in Beam. Ideally we want to error out early if a pipeline with exactly-once sink is being updated from version 2.3 to 2.4. PLMK. I can move timestamp support in EOS to Beam 3.0.
