### PR TITLE
[BEAM-3798] Remove error check on dataflow when getting batch job state

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
@@ -181,7 +181,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   }
 
   /**
-   * Return {@code true} if the job succeeded or {@code false} if it terminated in any other manner.
+   * Return {@code true} if job state is {@code State.DONE}. {@code false} otherwise.
    */
   private boolean waitForBatchJobTermination(
       DataflowPipelineJob job, ErrorMonitorMessagesHandler messageHandler) {
@@ -195,7 +195,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         return false;
       }
 
-      return job.getState() == State.DONE && !messageHandler.hasSeenError();
+      return job.getState() == State.DONE;
     }
   }
 


### PR DESCRIPTION
In TestDataflowRunner beam can rely solely on Dataflow job state (for
batch jobs). It it's "DONE", then it means that Dataflow handled any
errors on it's own (eg. by retrying failed bundles). We don't need to
throw them further.

This PR does not fix a streaming scenario. We should fix it on separate
PR later. It still fixes Performance tests that we have now.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

