### PR TITLE
BEAM-3863: AfterProcessingTime trigger firing at delayedUntil time

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -230,9 +230,10 @@ public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStat
   @Override
   public boolean shouldFire(TriggerStateMachine.TriggerContext context) throws Exception {
     Instant delayedUntil = context.state().access(DELAYED_UNTIL_TAG).read();
+    Instant currentTime = getCurrentTime(context);
     return delayedUntil != null
-        && getCurrentTime(context) != null
-        && getCurrentTime(context).isAfter(delayedUntil);
+            && currentTime != null
+            && (currentTime.isEqual(delayedUntil) || currentTime.isAfter(delayedUntil));
   }
 
   @Override

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/AfterProcessingTimeStateMachineTest.java
@@ -72,7 +72,7 @@ public class AfterProcessingTimeStateMachineTest {
     tester.injectElements(2, 3);
 
     // Advance past the first timer and fire, finishing the first window
-    tester.advanceProcessingTime(new Instant(16));
+    tester.advanceProcessingTime(new Instant(15));
     assertTrue(tester.shouldFire(firstWindow));
     assertFalse(tester.shouldFire(secondWindow));
     tester.fireIfShouldFire(firstWindow);


### PR DESCRIPTION
The issue with the current logic is that if `delayedUntil` timestamp is equal to the current time when `shouldFire` method is called than `shouldFire` method returns false and trigger doesn't fire and  never fires again unless there is some new element for the the same <key, window> or allowed lateness is hit. In reality when I tested with Flink runner on a cluster it's very likely on the powerful enough machines that it's actually the same millisecond timer fires at `delayedUntil` timestamp and  calls a method `public void onTimers(Iterable<TimerData> timers) throws Exception` from `ReduceFnRunner` and the time current time is probed via `getCurrentTime(context)` in `AfterDelayFromFirstElementStateMachine.shouldFire()` method. The suggested fix is to check if current timestamp is equal or greater than `delayedUntil` timestamp.

I created a test job that replicates the issue: https://github.com/pbartoszek/BEAM-3863_late_trigger 

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

