### PR TITLE
Fixing counter string name.

### DIFF
--- a/sdks/python/apache_beam/utils/counters.py
+++ b/sdks/python/apache_beam/utils/counters.py
@@ -98,6 +98,9 @@ class CounterName(_CounterName):
   def __repr__(self):
     return '<CounterName<%s> at %s>' % (self._str_internal(), hex(id(self)))
 
+  def __str__(self):
+    return self._str_internal()
+
   def _str_internal(self):
     if self.origin == CounterName.USER:
       return 'user-%s-%s' % (self.step_name, self.name)


### PR DESCRIPTION
The string representation of CounterName is used in Dataflow to gather statistics about counters. Adding this representation once more.
