### PR TITLE
[BEAM-3869] Fix Go Dataflow break due to zero timestamps

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -282,6 +282,9 @@ func (c *kvDecoder) Decode(r io.Reader) (FullValue, error) {
 func EncodeWindowedValueHeader(c *coder.Coder, t typex.EventTime, w io.Writer) error {
 	// Encoding: Timestamp, Window, Pane (header) + Element
 
+	if (time.Time)(t).IsZero() {
+		t = typex.EventTime(time.Now())
+	}
 	if err := coder.EncodeEventTime(t, w); err != nil {
 		return err
 	}

--- a/sdks/go/pkg/beam/runners/dataflow/translate.go
+++ b/sdks/go/pkg/beam/runners/dataflow/translate.go
@@ -309,7 +309,7 @@ func translateEdge(edge *graph.MultiEdge) (string, properties, error) {
 		// URL Query-escaped windowed _unnested_ value. It is read back in
 		// a nested context at runtime.
 		var buf bytes.Buffer
-		if err := exec.EncodeWindowedValueHeader(c, beam.EventTime(time.Time{}), &buf); err != nil {
+		if err := exec.EncodeWindowedValueHeader(c, beam.EventTime(time.Now()), &buf); err != nil {
 			return "", properties{}, err
 		}
 		value := string(append(buf.Bytes(), edge.Value...))


### PR DESCRIPTION
The merge of #4693 broke Go Dataflow.