### PR TITLE
[BEAM-3866] Remove WindowedValue on PCollections for Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/graph/bind_test.go
+++ b/sdks/go/pkg/beam/core/graph/bind_test.go
@@ -31,109 +31,109 @@ func TestBind(t *testing.T) {
 		Out []typex.FullType // Outgoing Node type; nil == cannot bind
 	}{
 		{ // Direct
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(int) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // Direct w/ KV out
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(int) (int, string) { return 0, "" },
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
 		},
 		{ // KV Emitter
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(int, func(int, string)) {},
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
 		},
 		{ // Direct with optionals time/error
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(typex.EventTime, int) (typex.EventTime, int, error) { return typex.EventTime{}, 0, nil },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // Emitter w/ optionals
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(typex.EventTime, int, func(typex.EventTime, int)) error { return nil },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(string) int { return 0 },
 			nil, // int cannot bind to string
 		},
 		{
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(int, int) int { return 0 },
 			nil, // int cannot bind to int x int
 		},
 		{ // Generic
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			func(x typex.X) typex.X { return x },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
 			func(x typex.X) typex.X { return x },
 			nil, // structural mismatch
 		},
 		{ // Generic swap
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int), typex.New(reflectx.String))},
 			func(x typex.X, y typex.Y) (typex.Y, typex.X) { return y, x },
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.String), typex.New(reflectx.Int))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int))},
 		},
 		{ // Side input (as singletons)
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32)},
 			func(int8, int16, int32, func(string, int)) {},
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.String), typex.New(reflectx.Int))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int))},
 		},
 		{ // Side input (as slice and iter)
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32)},
 			func(int8, []int16, func(*int32) bool, func(int8, []int16)) {},
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16)))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16)))},
 		},
 		{ // Generic side input (as iter and re-iter)
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32)},
 			func(typex.X, func(*typex.Y) bool, func() func(*typex.T) bool, func(typex.X, []typex.Y)) {},
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16)))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16)))},
 		},
 		{ // Generic side output
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32)},
 			func(typex.X, typex.Y, typex.Z, func(typex.X, []typex.Y), func(int), func(typex.Z)) {},
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16))), typex.NewW(typex.New(reflectx.Int)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int8), typex.New(reflect.SliceOf(reflectx.Int16))), typex.New(reflectx.Int), typex.New(reflectx.Int32)},
 		},
 		{ // Bind as (K, V) ..
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
 			func(int8, int16) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // .. bind same input as (V, SI) ..
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16)},
 			func(int8, int16) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // .. and allow other SI forms ..
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int8)), typex.NewW(typex.New(reflectx.Int16))},
+			[]typex.FullType{typex.New(reflectx.Int8), typex.New(reflectx.Int16)},
 			func(int8, func(*int16) bool) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // .. which won't work as (K, V).
-			[]typex.FullType{typex.NewWKV(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
+			[]typex.FullType{typex.NewKV(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
 			func(int8, func(*int16) bool) int { return 0 },
 			nil,
 		},
 		{ // GBK binding
-			[]typex.FullType{typex.NewWCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
+			[]typex.FullType{typex.NewCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16))},
 			func(int8, func(*int16) bool) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // CoGBK binding
-			[]typex.FullType{typex.NewWCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.NewCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16), typex.New(reflectx.Int32))},
 			func(int8, func(*int16) bool, func(*int32) bool) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{ // GBK binding with side input
-			[]typex.FullType{typex.NewWCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16)), typex.NewW(typex.New(reflectx.Int32))},
+			[]typex.FullType{typex.NewCoGBK(typex.New(reflectx.Int8), typex.New(reflectx.Int16)), typex.New(reflectx.Int32)},
 			func(int8, func(*int16) bool, func(*int32) bool) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 	}
 
@@ -166,16 +166,16 @@ func TestBindWithTypedefs(t *testing.T) {
 		Out     []typex.FullType // Outgoing Node type; nil == cannot bind
 	}{
 		{ // Typedefs are ignored, if not used
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 			map[string]reflect.Type{"X": reflectx.Int},
 			func(int) int { return 0 },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{
 			nil,
 			map[string]reflect.Type{"X": reflectx.Int},
 			func() typex.X { return nil },
-			[]typex.FullType{typex.NewW(typex.New(reflectx.Int))},
+			[]typex.FullType{typex.New(reflectx.Int)},
 		},
 		{
 			nil,

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -214,8 +214,6 @@ func NewVarInt() *Coder {
 	return &Coder{Kind: VarInt, T: typex.New(reflectx.Int32)}
 }
 
-// Convenience methods to operate through the top-level WindowedValue.
-
 // IsW returns true iff the coder is for a WindowedValue.
 func IsW(c *Coder) bool {
 	return c.Kind == WindowedValue
@@ -238,36 +236,34 @@ func NewW(c *Coder, w *window.Window) *Coder {
 	}
 }
 
-// IsWKV returns true iff the coder is for a WindowedValue key-value pair.
-func IsWKV(c *Coder) bool {
-	return IsW(c) && SkipW(c).Kind == KV
+// IsKV returns true iff the coder is for key-value pairs.
+func IsKV(c *Coder) bool {
+	return c.Kind == KV
 }
 
-// NewWKV returns a WindowedValue coder for the window of KV elements.
-func NewWKV(components []*Coder, w *window.Window) *Coder {
+// NewKV returns a coder for key-value pairs.
+func NewKV(components []*Coder) *Coder {
 	checkCodersNotNil(components)
-	c := &Coder{
+	return &Coder{
 		Kind:       KV,
 		T:          typex.New(typex.KVType, Types(components)...),
 		Components: components,
 	}
-	return NewW(c, w)
 }
 
-// IsWCoGBK returns true iff the coder is for a windowed CoGBK type.
-func IsWCoGBK(c *Coder) bool {
-	return IsW(c) && SkipW(c).Kind == CoGBK
+// IsCoGBK returns true iff the coder is for a CoGBK type.
+func IsCoGBK(c *Coder) bool {
+	return c.Kind == CoGBK
 }
 
-// NewWCoGBK returns a WindowedValue coder for the window of CoGBK elements.
-func NewWCoGBK(components []*Coder, w *window.Window) *Coder {
+// NewCoGBK returns a coder for CoGBK elements.
+func NewCoGBK(components []*Coder) *Coder {
 	checkCodersNotNil(components)
-	c := &Coder{
+	return &Coder{
 		Kind:       CoGBK,
 		T:          typex.New(typex.CoGBKType, Types(components)...),
 		Components: components,
 	}
-	return NewW(c, w)
 }
 
 // SkipW returns the data coder used by a WindowedValue, or returns the coder. This

--- a/sdks/go/pkg/beam/core/graph/edge.go
+++ b/sdks/go/pkg/beam/core/graph/edge.go
@@ -333,13 +333,13 @@ func NewCombine(g *Graph, s *Scope, u *CombineFn, in *Node) (*MultiEdge, error) 
 	isPerKey := typex.IsCoGBK(inT)
 	if isPerKey {
 		// For per-key combine, the shape of the inbound type and the type of the
-		// inbound node are different: a node type of W<CoGBK<A,B>> will become W<B>
-		// or W<KV<A,B>>, depending on whether the combineFn is keyed or not.
+		// inbound node are different: a node type of CoGBK<A,B> will become B
+		// or KV<A,B>, depending on whether the combineFn is keyed or not.
 		// Per-key combines may omit the key in the signature. In such a case,
 		// it is ignored for the purpose of binding. The runtime will later look at
 		// these types to decide whether to add the key or not.
 		//
-		// However, the outbound type will be W<KV<A,O>> (where O is the output
+		// However, the outbound type will be KV<A,O> (where O is the output
 		// type) regardless of whether the combineFn is keyed or not.
 
 		if len(inT.Components()) > 2 {

--- a/sdks/go/pkg/beam/core/graph/node.go
+++ b/sdks/go/pkg/beam/core/graph/node.go
@@ -25,12 +25,12 @@ import (
 
 // Node is a typed connector describing the data type and encoding. A node
 // may have multiple inbound and outbound connections. The underlying type
-// must be a complete windowed type, i.e., not include any type variables.
+// must be a complete type, i.e., not include any type variables.
 type Node struct {
 	id int
 	// t is the type of underlying data and cannot change. It must be equal to
-	// the coder type. A node type root would always be a WindowedValue. The
-	// type must be bound, i.e., it cannot contain any type variables.
+	// the coder type. The type must be bound, i.e., it cannot contain any
+	// type variables.
 	t typex.FullType
 
 	// Coder defines the data encoding. It can be changed, but must be of
@@ -46,7 +46,7 @@ func (n *Node) ID() int {
 	return n.id
 }
 
-// Type returns the underlying full type of the data, such as W<KV<int,string>>.
+// Type returns the underlying full type of the data, such as KV<int,string>.
 func (n *Node) Type() typex.FullType {
 	return n.t
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -278,8 +278,8 @@ func (c *kvDecoder) Decode(r io.Reader) (FullValue, error) {
 
 // TODO(herohde) 4/7/2017: actually handle windows.
 
-// EncodeWindowedValueHeader uses the supplied coder to serialize a windowed value header.
-func EncodeWindowedValueHeader(c *coder.Coder, t typex.EventTime, w io.Writer) error {
+// EncodeWindowedValueHeader serializes a windowed value header.
+func EncodeWindowedValueHeader(t typex.EventTime, w io.Writer) error {
 	// Encoding: Timestamp, Window, Pane (header) + Element
 
 	if (time.Time)(t).IsZero() {
@@ -297,8 +297,8 @@ func EncodeWindowedValueHeader(c *coder.Coder, t typex.EventTime, w io.Writer) e
 	return err
 }
 
-// DecodeWindowedValueHeader uses the supplied coder to deserialize a windowed value header.
-func DecodeWindowedValueHeader(c *coder.Coder, r io.Reader) (typex.EventTime, error) {
+// DecodeWindowedValueHeader deserializes a windowed value header.
+func DecodeWindowedValueHeader(r io.Reader) (typex.EventTime, error) {
 	// Encoding: Timestamp, Window, Pane (header) + Element
 
 	t, err := coder.DecodeEventTime(r)

--- a/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/combine_test.go
@@ -37,7 +37,7 @@ func TestCombine(t *testing.T) {
 	}
 
 	g := graph.New()
-	in := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
+	in := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
 
 	edge, err := graph.NewCombine(g, g.Root(), fn, in)
 	if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasink.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasink.go
@@ -40,8 +40,7 @@ func (n *DataSink) ID() UnitID {
 }
 
 func (n *DataSink) Up(ctx context.Context) error {
-	c := coder.SkipW(n.Coder)
-	n.enc = MakeElementEncoder(c)
+	n.enc = MakeElementEncoder(coder.SkipW(n.Coder))
 	return nil
 }
 
@@ -61,8 +60,7 @@ func (n *DataSink) ProcessElement(ctx context.Context, value FullValue, values .
 	// unit.
 	var b bytes.Buffer
 
-	c := n.Coder
-	if err := EncodeWindowedValueHeader(c, value.Timestamp, &b); err != nil {
+	if err := EncodeWindowedValueHeader(value.Timestamp, &b); err != nil {
 		return err
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -63,14 +63,14 @@ func (n *DataSource) Process(ctx context.Context) error {
 	}
 	defer r.Close()
 
-	c := n.Coder
+	c := coder.SkipW(n.Coder)
 	switch {
-	case coder.IsWCoGBK(c):
-		ck := MakeElementDecoder(coder.SkipW(c).Components[0])
-		cv := MakeElementDecoder(coder.SkipW(c).Components[1])
+	case coder.IsCoGBK(c):
+		ck := MakeElementDecoder(c.Components[0])
+		cv := MakeElementDecoder(c.Components[1])
 
 		for {
-			t, err := DecodeWindowedValueHeader(c, r)
+			t, err := DecodeWindowedValueHeader(r)
 			if err != nil {
 				if err == io.EOF {
 					return nil
@@ -143,11 +143,11 @@ func (n *DataSource) Process(ctx context.Context) error {
 		}
 
 	default:
-		ec := MakeElementDecoder(coder.SkipW(c))
+		ec := MakeElementDecoder(c)
 
 		for {
 			atomic.AddInt64(&n.count, 1)
-			t, err := DecodeWindowedValueHeader(c, r)
+			t, err := DecodeWindowedValueHeader(r)
 			if err != nil {
 				if err == io.EOF {
 					return nil

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
@@ -53,11 +53,11 @@ func TestParDo(t *testing.T) {
 	}
 
 	g := graph.New()
-	nN := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
-	aN := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
-	bN := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
-	cN := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
-	dN := g.NewNode(typex.NewW(typex.New(reflectx.Int)), window.NewGlobalWindow())
+	nN := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
+	aN := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
+	bN := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
+	cN := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
+	dN := g.NewNode(typex.New(reflectx.Int), window.NewGlobalWindow())
 
 	edge, err := graph.NewParDo(g, g.Root(), fn, []*graph.Node{nN, aN, bN, cN, dN}, nil)
 	if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
@@ -67,16 +67,16 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			coder.NewW(coder.NewBytes(), window.NewGlobalWindow()),
 		},
 		{
-			"W<KV<foo,bar>>",
-			coder.NewWKV([]*coder.Coder{foo, bar}, window.NewGlobalWindow()),
+			"KV<foo,bar>",
+			coder.NewKV([]*coder.Coder{foo, bar}),
 		},
 		{
-			"W<CoGBK<foo,bar>>",
-			coder.NewWCoGBK([]*coder.Coder{foo, bar}, window.NewGlobalWindow()),
+			"CoGBK<foo,bar>",
+			coder.NewCoGBK([]*coder.Coder{foo, bar}),
 		},
 		{
-			"W<CoGBK<foo,bar,baz>>",
-			coder.NewWCoGBK([]*coder.Coder{foo, bar, baz}, window.NewGlobalWindow()),
+			"CoGBK<foo,bar,baz>",
+			coder.NewCoGBK([]*coder.Coder{foo, bar, baz}),
 		},
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
@@ -59,11 +59,11 @@ func pick(t *testing.T, g *graph.Graph) *graph.MultiEdge {
 }
 
 func intT() typex.FullType {
-	return typex.NewW(typex.New(reflectx.Int))
+	return typex.New(reflectx.Int)
 }
 
 func intCoder() *coder.Coder {
-	return coder.NewW(custom("int", reflectx.Int), window.NewGlobalWindow())
+	return custom("int", reflectx.Int)
 }
 
 // TestParDo verifies that ParDo can be serialized.

--- a/sdks/go/pkg/beam/core/typex/class.go
+++ b/sdks/go/pkg/beam/core/typex/class.go
@@ -163,7 +163,7 @@ func IsUniversal(t reflect.Type) bool {
 }
 
 // IsComposite returns true iff the given type is one of the predefined
-// Composite marker types: KV, GBK, CoGBK or WindowedValue.
+// Composite marker types: KV, CoGBK or WindowedValue.
 func IsComposite(t reflect.Type) bool {
 	switch t {
 	case KVType, CoGBKType, WindowedValueType:

--- a/sdks/go/pkg/beam/core/typex/fulltype.go
+++ b/sdks/go/pkg/beam/core/typex/fulltype.go
@@ -157,37 +157,44 @@ func isAnyNonKVComposite(list []FullType) bool {
 	return false
 }
 
-// Convenience methods to operate through the top-level WindowedValue.
+// Convenience functions.
 
+// IsW returns true iff the type is a WindowedValue.
 func IsW(t FullType) bool {
 	return t.Type() == WindowedValueType
 }
 
+// NewW constructs a new WindowedValue of the given type.
 func NewW(t FullType) FullType {
 	return New(WindowedValueType, t)
 }
 
-func IsWKV(t FullType) bool {
-	return IsW(t) && SkipW(t).Type() == KVType
-}
-
-func NewWKV(components ...FullType) FullType {
-	return NewW(New(KVType, components...))
-}
-
-func IsWCoGBK(t FullType) bool {
-	return IsW(t) && SkipW(t).Type() == CoGBKType
-}
-
-func NewWCoGBK(components ...FullType) FullType {
-	return NewW(New(CoGBKType, components...))
-}
-
+// SkipW skips a WindowedValue layer, if present. If no, returns the input.
 func SkipW(t FullType) FullType {
 	if t.Type() == WindowedValueType {
 		return t.Components()[0]
 	}
 	return t
+}
+
+// IsKV returns true iff the type is a KV.
+func IsKV(t FullType) bool {
+	return t.Type() == KVType
+}
+
+// NewKV constructs a new KV of the given key and value types.
+func NewKV(components ...FullType) FullType {
+	return New(KVType, components...)
+}
+
+// IsCoGBK returns true iff the type is a CoGBK.
+func IsCoGBK(t FullType) bool {
+	return t.Type() == CoGBKType
+}
+
+// NewCoGBK constructs a new CoGBK of the given component types.
+func NewCoGBK(components ...FullType) FullType {
+	return New(CoGBKType, components...)
 }
 
 // IsStructurallyAssignable returns true iff a from value is structurally

--- a/sdks/go/pkg/beam/core/typex/fulltype_test.go
+++ b/sdks/go/pkg/beam/core/typex/fulltype_test.go
@@ -29,11 +29,11 @@ func TestIsBound(t *testing.T) {
 	}{
 		{New(reflectx.Int), true},
 		{New(TType), false},
-		{NewWCoGBK(New(TType), New(reflectx.String)), false},
-		{NewWCoGBK(New(reflectx.String), New(reflectx.String)), true},
-		{NewWKV(New(reflectx.String), New(reflect.SliceOf(reflectx.Int))), true},
-		{NewWKV(New(reflectx.String), New(reflect.SliceOf(XType))), false},
-		{NewWKV(New(reflectx.String), New(reflectx.String)), true},
+		{NewCoGBK(New(TType), New(reflectx.String)), false},
+		{NewCoGBK(New(reflectx.String), New(reflectx.String)), true},
+		{NewKV(New(reflectx.String), New(reflect.SliceOf(reflectx.Int))), true},
+		{NewKV(New(reflectx.String), New(reflect.SliceOf(XType))), false},
+		{NewKV(New(reflectx.String), New(reflectx.String)), true},
 	}
 
 	for _, test := range tests {
@@ -53,13 +53,13 @@ func TestIsStructurallyAssignable(t *testing.T) {
 		{New(reflectx.Int64), New(reflectx.Int32), false}, // from Go assignability
 		{New(reflectx.Int), New(TType), true},
 		{New(XType), New(TType), true},
-		{NewWKV(New(XType), New(YType)), New(TType), false},                                                    // T cannot match composites
-		{NewWKV(New(reflectx.Int), New(reflectx.Int)), NewWCoGBK(New(reflectx.Int), New(reflectx.Int)), false}, // structural mismatch
-		{NewWKV(New(XType), New(reflectx.Int)), NewWKV(New(TType), New(UType)), true},
-		{NewWKV(New(XType), New(reflectx.Int)), NewWKV(New(TType), New(XType)), true},
-		{NewWKV(New(reflectx.String), New(reflectx.Int)), NewWKV(New(TType), New(TType)), true},
-		{NewWKV(New(reflectx.Int), New(reflectx.Int)), NewWKV(New(TType), New(TType)), true},
-		{NewWKV(New(reflectx.Int), New(reflectx.String)), NewWKV(New(TType), New(reflectx.String)), true},
+		{NewKV(New(XType), New(YType)), New(TType), false},                                                   // T cannot match composites
+		{NewKV(New(reflectx.Int), New(reflectx.Int)), NewCoGBK(New(reflectx.Int), New(reflectx.Int)), false}, // structural mismatch
+		{NewKV(New(XType), New(reflectx.Int)), NewKV(New(TType), New(UType)), true},
+		{NewKV(New(XType), New(reflectx.Int)), NewKV(New(TType), New(XType)), true},
+		{NewKV(New(reflectx.String), New(reflectx.Int)), NewKV(New(TType), New(TType)), true},
+		{NewKV(New(reflectx.Int), New(reflectx.Int)), NewKV(New(TType), New(TType)), true},
+		{NewKV(New(reflectx.Int), New(reflectx.String)), NewKV(New(TType), New(reflectx.String)), true},
 	}
 
 	for _, test := range tests {
@@ -76,32 +76,32 @@ func TestBindSubstitute(t *testing.T) {
 		{
 			New(reflectx.String),
 			New(XType),
-			NewWKV(New(reflectx.Int), New(XType)),
-			NewWKV(New(reflectx.Int), New(reflectx.String)),
+			NewKV(New(reflectx.Int), New(XType)),
+			NewKV(New(reflectx.Int), New(reflectx.String)),
 		},
 		{
 			New(reflectx.String),
 			New(XType),
-			NewWKV(New(reflectx.Int), New(reflectx.Int)),
-			NewWKV(New(reflectx.Int), New(reflectx.Int)),
+			NewKV(New(reflectx.Int), New(reflectx.Int)),
+			NewKV(New(reflectx.Int), New(reflectx.Int)),
 		},
 		{
-			NewWKV(New(reflectx.Int), New(reflectx.String)),
-			NewWKV(New(XType), New(YType)),
-			NewWCoGBK(New(XType), New(XType)),
-			NewWCoGBK(New(reflectx.Int), New(reflectx.Int)),
+			NewKV(New(reflectx.Int), New(reflectx.String)),
+			NewKV(New(XType), New(YType)),
+			NewCoGBK(New(XType), New(XType)),
+			NewCoGBK(New(reflectx.Int), New(reflectx.Int)),
 		},
 		{
-			NewWCoGBK(New(reflectx.Int), New(reflectx.String)),
-			NewWCoGBK(New(XType), New(YType)),
-			NewWCoGBK(New(YType), New(XType)),
-			NewWCoGBK(New(reflectx.String), New(reflectx.Int)),
+			NewCoGBK(New(reflectx.Int), New(reflectx.String)),
+			NewCoGBK(New(XType), New(YType)),
+			NewCoGBK(New(YType), New(XType)),
+			NewCoGBK(New(reflectx.String), New(reflectx.Int)),
 		},
 		{
-			NewWCoGBK(New(ZType), New(XType)),
-			NewWCoGBK(New(XType), New(YType)),
-			NewWCoGBK(New(YType), New(XType)),
-			NewWCoGBK(New(XType), New(ZType)),
+			NewCoGBK(New(ZType), New(XType)),
+			NewCoGBK(New(XType), New(YType)),
+			NewCoGBK(New(YType), New(XType)),
+			NewCoGBK(New(XType), New(ZType)),
 		},
 	}
 

--- a/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
+++ b/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
@@ -27,7 +27,6 @@ import (
 
 	"cloud.google.com/go/bigquery"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/iterator"
@@ -163,7 +162,7 @@ func mustParseTable(table string) QualifiedTableName {
 // Write writes the elements of the given PCollection<T> to bigquery. T is required
 // to be the schema type.
 func Write(s beam.Scope, project, table string, col beam.PCollection) {
-	t := typex.SkipW(col.Type()).Type()
+	t := col.Type().Type()
 	mustInferSchema(t)
 	qn := mustParseTable(table)
 

--- a/sdks/go/pkg/beam/partition.go
+++ b/sdks/go/pkg/beam/partition.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
@@ -44,7 +43,7 @@ func Partition(s Scope, n int, fn interface{}, col PCollection) []PCollection {
 	if n < 1 {
 		panic(fmt.Sprintf("n must be > 0"))
 	}
-	t := typex.SkipW(col.Type()).Type()
+	t := col.Type().Type()
 	funcx.MustSatisfy(fn, funcx.Replace(sig, TType, t))
 
 	// The partitionFn is a DoFn with a signature that is dependent on the input, so

--- a/sdks/go/pkg/beam/pcollection.go
+++ b/sdks/go/pkg/beam/pcollection.go
@@ -23,12 +23,12 @@ import (
 )
 
 // PCollection is an immutable collection of values of type 'A', which must be
-// a concrete Windowed Value type, such as W<int> or W<KV<int,string>>. A
-// PCollection can contain either a bounded or unbounded number of elements.
-// Bounded and unbounded PCollections are produced as the output of PTransforms
-// (including root PTransforms like textio.Read), and can be passed as the
-// inputs of other PTransforms. Some root transforms produce bounded
-// PCollections and others produce unbounded ones.
+// a concrete type, such as int or KV<int,string>. A PCollection can contain
+// either a bounded or unbounded number of elements. Bounded and unbounded
+// PCollections are produced as the output of PTransforms (including root
+// PTransforms like textio.Read), and can be passed as the inputs of other
+// PTransforms. Some root transforms produce bounded PCollections and others
+// produce unbounded ones.
 //
 // Each element in a PCollection has an associated timestamp. Sources assign
 // timestamps to elements when they create PCollections, and other PTransforms
@@ -53,7 +53,7 @@ func (p PCollection) IsValid() bool {
 // TODO(herohde) 5/30/2017: add windowing strategy and documentation.
 
 // Type returns the full type 'A' of the elements. 'A' must be a concrete
-// Windowed Value type, such as W<int> or W<KV<int,string>>.
+// type, such as int or KV<int,string>.
 func (p PCollection) Type() FullType {
 	if !p.IsValid() {
 		panic("Invalid PCollection")

--- a/sdks/go/pkg/beam/runners/direct/direct.go
+++ b/sdks/go/pkg/beam/runners/direct/direct.go
@@ -231,8 +231,8 @@ func (b *builder) makeLink(id linkID) (exec.Node, error) {
 		return b.links[id], nil
 
 	case graph.Combine:
-		isPerKey := typex.IsWCoGBK(edge.Input[0].From.Type())
-		usesKey := typex.IsWKV(edge.Input[0].Type)
+		isPerKey := typex.IsCoGBK(edge.Input[0].From.Type())
+		usesKey := typex.IsKV(edge.Input[0].Type)
 
 		u = &exec.Combine{UID: b.idgen.New(), Fn: edge.CombineFn, IsPerKey: isPerKey, UsesKey: usesKey, Out: out[0]}
 

--- a/sdks/go/pkg/beam/runners/direct/gbk.go
+++ b/sdks/go/pkg/beam/runners/direct/gbk.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec"
 )
 
@@ -45,7 +44,7 @@ func (n *CoGBK) ID() exec.UnitID {
 }
 
 func (n *CoGBK) Up(ctx context.Context) error {
-	n.enc = exec.MakeElementEncoder(coder.SkipW(n.Edge.Input[0].From.Coder).Components[0])
+	n.enc = exec.MakeElementEncoder(n.Edge.Input[0].From.Coder.Components[0])
 	n.m = make(map[string]*group)
 	return nil
 }

--- a/sdks/go/pkg/beam/testing/passert/passert.go
+++ b/sdks/go/pkg/beam/testing/passert/passert.go
@@ -79,7 +79,7 @@ type diffFn struct {
 }
 
 func (f *diffFn) ProcessElement(_ []byte, ls, rs func(*beam.T) bool, left, both, right func(t beam.T)) error {
-	c := coder.SkipW(beam.UnwrapCoder(f.Coder.Coder))
+	c := beam.UnwrapCoder(f.Coder.Coder)
 
 	indexL, err := index(c, ls)
 	if err != nil {
@@ -178,10 +178,10 @@ func Empty(s beam.Scope, col beam.PCollection) beam.PCollection {
 
 func fail(s beam.Scope, col beam.PCollection, format string) {
 	switch {
-	case typex.IsWKV(col.Type()):
+	case typex.IsKV(col.Type()):
 		beam.ParDo0(s, &failKVFn{Format: format}, col)
 
-	case typex.IsWCoGBK(col.Type()):
+	case typex.IsCoGBK(col.Type()):
 		beam.ParDo0(s, &failGBKFn{Format: format}, col)
 
 	default:

--- a/sdks/go/pkg/beam/transforms/filter/filter.go
+++ b/sdks/go/pkg/beam/transforms/filter/filter.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
 
@@ -48,9 +47,7 @@ func init() {
 func Include(s beam.Scope, col beam.PCollection, fn interface{}) beam.PCollection {
 	s = s.Scope("filter.Include")
 
-	t := typex.SkipW(col.Type()).Type()
-	funcx.MustSatisfy(fn, funcx.Replace(sig, beam.TType, t))
-
+	funcx.MustSatisfy(fn, funcx.Replace(sig, beam.TType, col.Type().Type()))
 	return beam.ParDo(s, &filterFn{Predicate: beam.EncodedFunc{Fn: reflectx.MakeFunc(fn)}, Include: true}, col)
 }
 
@@ -68,9 +65,7 @@ func Include(s beam.Scope, col beam.PCollection, fn interface{}) beam.PCollectio
 func Exclude(s beam.Scope, col beam.PCollection, fn interface{}) beam.PCollection {
 	s = s.Scope("filter.Exclude")
 
-	t := typex.SkipW(col.Type()).Type()
-	funcx.MustSatisfy(fn, funcx.Replace(sig, beam.TType, t))
-
+	funcx.MustSatisfy(fn, funcx.Replace(sig, beam.TType, col.Type().Type()))
 	return beam.ParDo(s, &filterFn{Predicate: beam.EncodedFunc{Fn: reflectx.MakeFunc(fn)}, Include: false}, col)
 }
 

--- a/sdks/go/pkg/beam/validate.go
+++ b/sdks/go/pkg/beam/validate.go
@@ -25,17 +25,17 @@ import (
 // ValidateKVType panics if the type of the PCollection is not KV<A,B>.
 // It returns (A,B).
 func ValidateKVType(col PCollection) (typex.FullType, typex.FullType) {
-	if !typex.IsWKV(col.Type()) {
+	t := col.Type()
+	if !typex.IsKV(t) {
 		panic(fmt.Sprintf("pcollection must be of KV type: %v", col))
 	}
-	t := typex.SkipW(col.Type())
 	return t.Components()[0], t.Components()[1]
 }
 
 // ValidateConcreteType panics if the type of the PCollection is not a
 // composite type. It returns the type.
 func ValidateNonCompositeType(col PCollection) typex.FullType {
-	t := typex.SkipW(col.Type())
+	t := col.Type()
 	if typex.IsComposite(t.Type()) {
 		panic(fmt.Sprintf("pcollection must be of non-composite type: %v", col))
 	}

--- a/sdks/go/pkg/beam/x/debug/head.go
+++ b/sdks/go/pkg/beam/x/debug/head.go
@@ -33,7 +33,7 @@ func Head(s beam.Scope, col beam.PCollection, n int) beam.PCollection {
 	s = s.Scope("debug.Head")
 
 	switch {
-	case typex.IsWKV(col.Type()):
+	case typex.IsKV(col.Type()):
 		return beam.ParDo(s, &headKVFn{N: n}, beam.Impulse(s), beam.SideInput{Input: col})
 	default:
 		return beam.ParDo(s, &headFn{N: n}, beam.Impulse(s), beam.SideInput{Input: col})

--- a/sdks/go/pkg/beam/x/debug/print.go
+++ b/sdks/go/pkg/beam/x/debug/print.go
@@ -43,9 +43,9 @@ func Printf(s beam.Scope, format string, col beam.PCollection) beam.PCollection 
 	s = s.Scope("debug.Print")
 
 	switch {
-	case typex.IsWKV(col.Type()):
+	case typex.IsKV(col.Type()):
 		return beam.ParDo(s, &printKVFn{Format: format}, col)
-	case typex.IsWCoGBK(col.Type()):
+	case typex.IsCoGBK(col.Type()):
 		return beam.ParDo(s, &printGBKFn{Format: format}, col)
 	default:
 		return beam.ParDo(s, &printFn{Format: format}, col)


### PR DESCRIPTION
This is what the Model pipeline expects, although Dataflow expects the old way.