### PR TITLE
[BEAM-3872] Change Exception.message --> Exception.args[0]

### DIFF
--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -176,7 +176,7 @@ class TypeCheckWrapperDoFn(AbstractDoFnWrapper):
     try:
       check_constraint(type_constraint, datum)
     except CompositeTypeHintError as e:
-      six.raise_from(TypeCheckError(e.message), sys.exc_info()[2])
+      six.raise_from(TypeCheckError(e.args[0]), sys.exc_info()[2])
     except SimpleTypeHintError:
       error_msg = ("According to type-hint expected %s should be of type %s. "
                    "Instead, received '%s', an instance of type %s."


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/BEAM-3872

Replace __Exception.message__ with __Exception.args[0]__ for Python 3.

__Exception.message__ deprecated as of Python 2.6 and removed in Python 3 in favor of __Exception.args[0]__ as discussed in [PEP 352](https://www.python.org/dev/peps/pep-0352/#id8).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

