### PR TITLE
[BEAM-2264] Credentials were not being reused between GCS calls

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -146,6 +146,8 @@ class GcsIOError(IOError, retry.PermanentException):
 class GcsIO(object):
   """Google Cloud Storage I/O client."""
 
+  local_state = threading.local()
+
   def __new__(cls, storage_client=None):
     if storage_client:
       # This path is only used for testing.
@@ -155,7 +157,7 @@ class GcsIO(object):
       # creating more than one storage client for each thread, since each
       # initialization requires the relatively expensive step of initializing
       # credentaials.
-      local_state = threading.local()
+      local_state = GcsIO.local_state
       if getattr(local_state, 'gcsio_instance', None) is None:
         credentials = auth.get_service_credentials()
         storage_client = storage.StorageV1(


### PR DESCRIPTION
In the Python SDK, the `threading.local()` used for storing the `storage_client` in `GcsIO` was being recreated for every `GcsIO` instance. The consequence was that the client need to re-authorize for every request. Fixing this improves performance reading GCS datasets by roughly 15% for me.

`threading.local()` should only be fetched once for all instances.

This Stack Overflow answer describes the mistake in how `threading.local()` was used:
https://stackoverflow.com/questions/1408171/thread-local-storage-in-python#answer-13240093

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

