### PR TITLE
[BEAM-2831] Do not wrap IOException in SerializableCoder

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -161,15 +161,10 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
   }
 
   @Override
-  public void encode(T value, OutputStream outStream)
-      throws IOException, CoderException {
-    try {
+  public void encode(T value, OutputStream outStream) throws IOException {
       ObjectOutputStream oos = new ObjectOutputStream(outStream);
       oos.writeObject(value);
       oos.flush();
-    } catch (IOException exn) {
-      throw new CoderException("unable to serialize record " + value, exn);
-    }
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SerializableCoderTest.java
@@ -21,9 +21,12 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -47,6 +50,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mockito.stubbing.Answer;
 
 /**
  * Tests SerializableCoder.
@@ -295,5 +299,16 @@ public class SerializableCoderTest implements Serializable {
   public void coderChecksForEquals() throws Exception {
     SerializableCoder.of(ProperEquals.class);
     expectedLogs.verifyNotLogged("Can't verify serialized elements of type");
+  }
+
+  @Test(expected = IOException.class)
+  public void coderDoesNotWrapIoException() throws Exception {
+    final SerializableCoder<String> coder = SerializableCoder.of(String.class);
+
+    final OutputStream outputStream = mock(OutputStream.class, (Answer) invocationOnMock -> {
+      throw new IOException();
+    });
+
+    coder.encode("", outputStream);
   }
 }


### PR DESCRIPTION
No longer wrap `IOException` with `CoderException` so that Flink can mange memory aproprietaly.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

