### PR TITLE
[BEAM-3882] Fix StateRequestHandler interface to be idiomatic

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/StateRequestHandler.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/state/StateRequestHandler.java
@@ -34,7 +34,6 @@ public interface StateRequestHandler {
    * <p>Throwing an error during handling will complete the handler result {@link CompletionStage}
    * exceptionally.
    */
-  void accept(
-      BeamFnApi.StateRequest request, CompletionStage<BeamFnApi.StateResponse.Builder> result)
+  CompletionStage<BeamFnApi.StateResponse.Builder> handle(BeamFnApi.StateRequest request)
       throws Exception;
 }


### PR DESCRIPTION
The previous implementation of StateRequestHandler did not conform
to Beam coding conventions.  It should not have accepted a return
value as a parameter.  This fix updates the interface to instead
return a CompletableStage.

R: @tgroh 
CC: @aljoscha, @bsidhom, @lukecwik 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

