### PR TITLE
[BEAM-3874] Switched AvroIO default codec to snappyCodec.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -184,7 +184,7 @@ import org.joda.time.Duration;
  * custom file naming policy.
  *
  * <p>By default, {@link AvroIO.Write} produces output files that are compressed using the {@link
- * org.apache.avro.file.Codec CodecFactory.deflateCodec(6)}. This default can be changed or
+ * org.apache.avro.file.Codec CodecFactory.snappyCodec()}. This default can be changed or
  * overridden using {@link AvroIO.Write#withCodec}.
  *
  * <h3>Writing specific or generic records</h3>
@@ -848,7 +848,7 @@ public class AvroIO {
   @AutoValue
   public abstract static class TypedWrite<UserT, DestinationT, OutputT>
       extends PTransform<PCollection<UserT>, WriteFilesResult<DestinationT>> {
-    static final CodecFactory DEFAULT_CODEC = CodecFactory.deflateCodec(6);
+    static final CodecFactory DEFAULT_CODEC = CodecFactory.snappyCodec();
     static final SerializableAvroCodecFactory DEFAULT_SERIALIZABLE_CODEC =
         new SerializableAvroCodecFactory(DEFAULT_CODEC);
 
@@ -1409,7 +1409,7 @@ public class AvroIO {
 
     /**
      * Specifies to use the given {@link CodecFactory} for each generated file. By default, {@code
-     * CodecFactory.deflateCodec(6)}.
+     * CodecFactory.snappyCodec()}.
      */
     public Sink<ElementT> withCodec(CodecFactory codec) {
       return toBuilder().setCodec(new SerializableAvroCodecFactory(codec)).build();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -1055,7 +1055,7 @@ public class AvroIOTest implements Serializable {
   @Test
   public void testWriteWithDefaultCodec() throws Exception {
     AvroIO.Write<String> write = AvroIO.write(String.class).to("/tmp/foo/baz");
-    assertEquals(CodecFactory.deflateCodec(6).toString(), write.inner.getCodec().toString());
+    assertEquals(CodecFactory.snappyCodec().toString(), write.inner.getCodec().toString());
   }
 
   @Test
@@ -1222,7 +1222,7 @@ public class AvroIOTest implements Serializable {
             .withShardNameTemplate("-SS-of-NN-")
             .withSuffix("bar")
             .withNumShards(100)
-            .withCodec(CodecFactory.snappyCodec());
+            .withCodec(CodecFactory.deflateCodec(6));
 
     DisplayData displayData = DisplayData.from(write);
 
@@ -1237,6 +1237,6 @@ public class AvroIOTest implements Serializable {
                 + ".AvroIOTest$\",\"fields\":[{\"name\":\"intField\",\"type\":\"int\"},"
                 + "{\"name\":\"stringField\",\"type\":\"string\"}]}"));
     assertThat(displayData, hasDisplayItem("numShards", 100));
-    assertThat(displayData, hasDisplayItem("codec", CodecFactory.snappyCodec().toString()));
+    assertThat(displayData, hasDisplayItem("codec", CodecFactory.deflateCodec(6).toString()));
   }
 }


### PR DESCRIPTION
Snappy is much faster than deflate, although it generally compresses worse. In many cases, the CPU savings from Snappy are worth the worse compression ratio except for very long lived files or files transferred across expensive networks. 

Snappy is also the default avro codec in Spark. 
 
R: @jkff
CC: @ravwojdyla 