### PR TITLE
BEAM-3855: Add Protocol Buffer support

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -25,11 +25,14 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/coderx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/golang/protobuf/proto"
 )
 
 func init() {
 	RegisterFunction(JSONDec)
 	RegisterFunction(JSONEnc)
+	RegisterFunction(ProtoEnc)
+	RegisterFunction(ProtoDec)
 }
 
 // Coder defines how to encode and decode values of type 'A' into byte streams.
@@ -87,6 +90,8 @@ func NewCoder(t FullType) Coder {
 	return Coder{c}
 }
 
+var protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
+
 func inferCoder(t FullType) (*coder.Coder, error) {
 	switch t.Class() {
 	case typex.Concrete, typex.Container:
@@ -108,6 +113,16 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 			// conversions at runtime in inconvenient places.
 			return &coder.Coder{Kind: coder.Bytes, T: t}, nil
 		default:
+			// TODO(BEAM-3306): the coder registry should be consulted here for user
+			// specified types and their coders.
+			if t.Type().Implements(protoMessageType) {
+				c, err := newProtoCoder(t.Type())
+				if err != nil {
+					return nil, err
+				}
+				return &coder.Coder{Kind: coder.Custom, T: t, Custom: c}, nil
+			}
+
 			c, err := newJSONCoder(t.Type())
 			if err != nil {
 				return nil, err
@@ -153,6 +168,26 @@ func inferCoders(list []FullType) ([]*coder.Coder, error) {
 // we'll use exploded form coders only using typex.T. We might also need a
 // form that doesn't require LengthPrefix'ing to cut up the bytestream from
 // the FnHarness.
+
+func ProtoEnc(in typex.T) ([]byte, error) {
+	return proto.Marshal(in.(proto.Message))
+}
+
+func ProtoDec(t reflect.Type, in []byte) (typex.T, error) {
+	val := reflect.New(t.Elem()).Interface().(proto.Message)
+	if err := proto.Unmarshal(in, val); err != nil {
+		return nil, err
+	}
+	return val, nil
+}
+
+func newProtoCoder(t reflect.Type) (*coder.CustomCoder, error) {
+	c, err := coder.NewCustomCoder("proto", t, ProtoEnc, ProtoDec)
+	if err != nil {
+		return nil, fmt.Errorf("invalid coder: %v", err)
+	}
+	return c, nil
+}
 
 // Concrete and universal custom coders both have a similar signature.
 // Conversion is handled by reflection.

--- a/sdks/go/pkg/beam/core/typex/class.go
+++ b/sdks/go/pkg/beam/core/typex/class.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/golang/protobuf/proto"
 )
 
 // Class is the type "class" of data as distinguished by the runtime. The class
@@ -44,6 +46,8 @@ const (
 	// that cannot be represented as a single reflect.Type.
 	Composite
 )
+
+var protoMessageType = reflect.TypeOf((*proto.Message)(nil)).Elem()
 
 // TODO(herohde) 5/16/2017: maybe we should add more classes, so that every
 // reasonable type (such as error) is not Invalid, even though it is not
@@ -74,6 +78,12 @@ func ClassOf(t reflect.Type) Class {
 func IsConcrete(t reflect.Type) bool {
 	if t == nil || t == EventTimeType {
 		return false
+	}
+
+	// TODO(BEAM-3306): the coder registry should be consulted here for user
+	// specified types and their coders.
+	if t.Implements(protoMessageType) {
+		return true
 	}
 
 	switch t.Kind() {


### PR DESCRIPTION
This allows the Go SDK to use protocol buffer messages as a concrete
type. This creates a compile-time dependency on the protocol buffer
libraries. Internally, to build the SDK, you'd need protobuf support
to run "go generate" but this is a more direct dependency.

Adding a registration hook could move this dependency to be handled
differently, but this dep is lightweight and should be OK for the
immediate future.
