### PR TITLE
[BEAM-3895] Add Side Inputs to ExecutableStage

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -214,11 +214,14 @@ message ExecutableStagePayload {
   // Input PCollection id.
   string input = 2;
 
+  // Side Input PCollection ids.
+  repeated string side_inputs = 3;
+
   // PTransform ids contained within this executable stage.
-  repeated string transforms = 3;
+  repeated string transforms = 4;
 
   // Output PCollection ids.
-  repeated string outputs = 4;
+  repeated string outputs = 5;
 
 }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStage.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStage.java
@@ -31,10 +31,15 @@ abstract class ImmutableExecutableStage implements ExecutableStage {
   static ImmutableExecutableStage of(
       Environment environment,
       PCollectionNode input,
+      Collection<PCollectionNode> sideInputs,
       Collection<PTransformNode> transforms,
       Collection<PCollectionNode> outputs) {
     return new AutoValue_ImmutableExecutableStage(
-        environment, input, ImmutableSet.copyOf(transforms), ImmutableSet.copyOf(outputs));
+        environment,
+        input,
+        ImmutableSet.copyOf(sideInputs),
+        ImmutableSet.copyOf(transforms),
+        ImmutableSet.copyOf(outputs));
   }
 
   // Redefine the methods to have a known order.
@@ -43,6 +48,9 @@ abstract class ImmutableExecutableStage implements ExecutableStage {
 
   @Override
   public abstract PCollectionNode getInputPCollection();
+
+  @Override
+  public abstract Collection<PCollectionNode> getSideInputPCollections();
 
   @Override
   public abstract Collection<PTransformNode> getTransforms();


### PR DESCRIPTION
This is a cache of the side inputs present within the stage, meaning the
runner does not need to inspect the transforms within the stage to
determine the side inputs it must provide.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

