### PR TITLE
[BEAM-3042] Fixing check for sideinput_io_metrics experiment flag.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -289,8 +289,7 @@ class DoOperation(Operation):
     assert self.side_input_maps is None
 
     # Get experiments active in the worker to check for side input metrics exp.
-    experiments = set(
-        RuntimeValueProvider.get_value('experiments', str, '').split(','))
+    experiments = RuntimeValueProvider.get_value('experiments', list, [])
 
     # We will read the side inputs in the order prescribed by the
     # tags_and_types argument because this is exactly the order needed to

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -105,8 +105,7 @@ class PrefetchingSourceSetIterable(object):
 
   def _reader_thread(self):
     # pylint: disable=too-many-nested-blocks
-    experiments = set(
-        RuntimeValueProvider.get_value('experiments', str, '').split(','))
+    experiments = RuntimeValueProvider.get_value('experiments', list, [])
     try:
       while True:
         try:

--- a/sdks/python/apache_beam/runners/worker/sideinputs_test.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs_test.py
@@ -92,7 +92,7 @@ class PrefetchingSourceIteratorTest(unittest.TestCase):
 
   def test_bytes_read_are_reported(self):
     RuntimeValueProvider.set_runtime_options(
-        {'experiments': 'sideinput_io_metrics,other'})
+        {'experiments': ['sideinput_io_metrics', 'other']})
     mock_read_counter = mock.MagicMock()
     source_records = ['a', 'b', 'c', 'd']
     sources = [


### PR DESCRIPTION
Fixing a bug that did not check for experiments properly in the worker. Experiments are read in as a list.