### PR TITLE
Clean up terminal state check in TestDataflowRunner

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -192,7 +192,7 @@ class DataflowMetrics(MetricResults):
 
     job_metrics = self._dataflow_client.get_job_metrics(job_id)
     # If the job has terminated, metrics will not change and we can cache them.
-    if self.job_result._is_in_terminal_state():
+    if self.job_result.is_in_terminal_state():
       self._cached_metrics = job_metrics
     return job_metrics
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics_test.py
@@ -205,7 +205,7 @@ class TestDataflowMetrics(unittest.TestCase):
     mock_client.get_job_metrics.return_value = mock_query_result
     mock_job_result = mock.Mock()
     mock_job_result.job_id.return_value = 1
-    mock_job_result._is_in_terminal_state.return_value = False
+    mock_job_result.is_in_terminal_state.return_value = False
     return mock_client, mock_job_result
 
   def test_cache_functions(self):
@@ -221,7 +221,7 @@ class TestDataflowMetrics(unittest.TestCase):
     self.assertTrue(dm._cached_metrics is None)
 
     # The job has ended. The query should not run again after this.
-    mock_job_result._is_in_terminal_state.return_value = True
+    mock_job_result.is_in_terminal_state.return_value = True
     dm.query()
     self.assertTrue(dm._cached_metrics)
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -997,7 +997,7 @@ class DataflowPipelineResult(PipelineResult):
   def _update_job(self):
     # We need the job id to be able to update job information. There is no need
     # to update the job if we are in a known terminal state.
-    if self.has_job and not self._is_in_terminal_state():
+    if self.has_job and not self.is_in_terminal_state():
       self._job = self._runner.dataflow_client.get_job(self.job_id())
 
   def job_id(self):
@@ -1043,7 +1043,7 @@ class DataflowPipelineResult(PipelineResult):
     return (api_jobstate_map[self._job.currentState] if self._job.currentState
             else PipelineState.UNKNOWN)
 
-  def _is_in_terminal_state(self):
+  def is_in_terminal_state(self):
     if not self.has_job:
       return True
 
@@ -1054,7 +1054,7 @@ class DataflowPipelineResult(PipelineResult):
         values_enum.JOB_STATE_UPDATED, values_enum.JOB_STATE_DRAINED]
 
   def wait_until_finish(self, duration=None):
-    if not self._is_in_terminal_state():
+    if not self.is_in_terminal_state():
       if not self.has_job:
         raise IOError('Failed to get the Dataflow job id.')
 
@@ -1071,8 +1071,8 @@ class DataflowPipelineResult(PipelineResult):
         time.sleep(5.0)
 
       # TODO: Merge the termination code in poll_for_job_completion and
-      # _is_in_terminal_state.
-      terminated = self._is_in_terminal_state()
+      # is_in_terminal_state.
+      terminated = self.is_in_terminal_state()
       assert duration or terminated, (
           'Job did not reach to a terminal state after waiting indefinitely.')
 
@@ -1090,7 +1090,7 @@ class DataflowPipelineResult(PipelineResult):
 
     self._update_job()
 
-    if self._is_in_terminal_state():
+    if self.is_in_terminal_state():
       logging.warning(
           'Cancel failed because job %s is already terminated in state %s.',
           self.job_id(), self.state)

--- a/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
@@ -65,13 +65,6 @@ class TestDataflowRunner(DataflowRunner):
 
     return self.result
 
-  def _is_in_terminate_state(self, job_state):
-    return job_state in [
-        PipelineState.STOPPED, PipelineState.DONE,
-        PipelineState.FAILED, PipelineState.CANCELLED,
-        PipelineState.UPDATED, PipelineState.DRAINED,
-    ]
-
   def wait_until_running(self):
     """Wait until Dataflow pipeline terminate or enter RUNNING state."""
     if not self.result.has_job:
@@ -80,8 +73,8 @@ class TestDataflowRunner(DataflowRunner):
     start_time = time.time()
     while time.time() - start_time <= WAIT_TIMEOUT:
       job_state = self.result.state
-      if (self._is_in_terminate_state(job_state) or
-          self.result.state == PipelineState.RUNNING):
+      if (self.result.is_in_terminal_state() or
+          job_state == PipelineState.RUNNING):
         return job_state
       time.sleep(5)
 


### PR DESCRIPTION
A clean up of job terminal state check in TestDataflowRunner in Python SDK as discussion in [PR](https://github.com/apache/beam/pull/4874#discussion_r175590831).

- Make `DataflowPipelineResult._is_in_terminal_state` public.
- Use it in TestDataflowRunner instead of creating own state check function.
- This change can also help to address this [TODO](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py#L1073).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

