### PR TITLE
Add time_per_element_counter to python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker.pxd
+++ b/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker.pxd
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=True
+# distutils: language=c++
+# distutils: extra_compile_args=['-std=c++11']
+
+cimport cython
+from libc.stdint cimport int64_t
+from libcpp.deque cimport deque
+from libcpp.unordered_map cimport unordered_map
+from libcpp.vector cimport vector
+
+
+ctypedef char* CharPtr
+
+"""Tracking object for the execution of a single input element in a step.
+Each ElementExecution instance represents a distinct element. Instances
+compare using reference(address) equality rather than value equality.
+"""
+cdef struct ElementExecution:
+  char* operation_name
+
+ctypedef ElementExecution* ElementExecutionPtr
+
+"""Journal entry.
+IDLE execution: execution_ptr = NULL.
+"""
+cdef struct SnapshottedExecution:
+  int64_t snapshot
+  ElementExecutionPtr execution_ptr
+
+ctypedef SnapshottedExecution* SnapshottedExecutionPtr
+
+cdef class Journal(object):
+  cdef deque[SnapshottedExecutionPtr] journal
+  cdef int64_t max_snapshot
+  cdef void add_journal(self, ElementExecutionPtr execution_ptr,
+                        int64_t snapshot)
+
+cdef class ReaderWriterState(object):
+  cdef Journal execution_journal
+  cdef Journal done_journal
+  cdef int64_t latest_snapshot
+
+cdef class ExecutionJournalReader(object):
+  cdef ReaderWriterState shared_state
+  cdef unordered_map[ElementExecutionPtr, int64_t] execution_duration
+  cdef void take_sample(self, int64_t sample_time,
+      unordered_map[CharPtr, vector[int64_t]]& counter_cache) nogil
+  cdef void attribute_processing_time(self, int64_t sample_time,
+                                      int64_t latest_snapshot) nogil
+  cdef void update_counter_cache(self, int64_t latest_snapshot,
+      unordered_map[CharPtr, vector[int64_t]]& counter_cache) nogil
+
+cdef class ExecutionJournalWriter(object):
+  cdef ReaderWriterState shared_state
+  cdef deque[ElementExecutionPtr] execution_stack
+  cdef void add_execution(self, ElementExecutionPtr execution_ptr)
+  cdef void start_processing(self, char* operation_name)
+  cdef void done_processing(self)
+
+cdef class DataflowElementExecutionTracker(object):
+  cdef ReaderWriterState shared_state
+  cdef ExecutionJournalWriter execution_writer
+  cdef ExecutionJournalReader execution_reader
+  cdef unordered_map[CharPtr, vector[int64_t]] counter_cache
+  cdef unordered_map[CharPtr, int64_t] cache_start_index
+  cdef void enter(self, char* operation_name)
+  cdef void exit(self)
+  cdef void take_sample(self, int64_t nanos_sampling_duration) nogil
+  cpdef void enter_for_test(self, char* operation_name)
+  cpdef void exit_for_test(self)
+  cpdef void take_sample_for_test(self, int64_t nanos_sampling_duration)
+  cpdef report_counter(self, counter_factory)

--- a/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker.pyx
+++ b/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker.pyx
@@ -1,0 +1,350 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# cython: profile=True
+
+"""Element execution tracker for Dataflow service.
+
+Each processed element through each step in the fused stage gets tracked as a
+ScopedState. Processing time is sampled using StateSampler and distributed
+among all elements which are executed since the last sample period.
+
+Elements are processed in potentially many fragments of execution as we move up
+and down the stage graph via outputting. Each fragment of execution is counted
+equally for attributing sampled processing time.
+
+When an element is finished processing it is held in the doneJournal collection
+until the next sampling round in order to calculate the final processing time.
+Eventually the total element processing time is reported to the counter and the
+state is cleaned up.
+
+Implementation itself is not thread-safe.
+
+Concurrency situation: For multiple execution threads and execution threads with
+sampling thread, we use StateSampler.lock to ensure safety. For report_progress
+thread, we only report counters(access to counter_cache) when a work_item
+completed, which means, there is no other executions and sampling at the same
+time.
+
+For internal use only; no backwards-compatibility guarantees.
+
+"""
+
+cimport cython
+from libc.stdlib cimport malloc, free
+
+from apache_beam.utils.counters import Counter
+from apache_beam.utils.counters import CounterName
+from apache_beam.transforms.cy_dataflow_distribution_counter cimport DataflowDistributionCounter
+
+from cython.operator cimport dereference as dref
+from cython.operator cimport preincrement as iref
+
+cdef class Journal(object):
+  """A collection of elements
+
+  Deque-based data structure for passing journaled events between a single
+  journal reader and single journal writer.
+
+  Each event is journaled with an externally-managed snapshot version. Snapshot
+  versions are unique and monotonically increasing.
+
+  No thread-safe guarantees. Needs lock during operation.
+
+  Attributes:
+    max_snapshot: keep track of latest snapshot
+    journal: a deque keeping SnapshottedExecutionPtrs
+  """
+  def __init__(self):
+    self.max_snapshot = -1
+    self.journal = deque[SnapshottedExecutionPtr]()
+
+  cdef void add_journal(self, ElementExecutionPtr execution_ptr,
+                        int64_t snapshot):
+    """Create SnapshottedExecutionPtr and append to journal.
+    
+    Args:
+      execution_ptr: Pointer of ElementExecution for new journal element.
+                     Could be NULL if current element is IDLE.
+      snapshot: New snapshot for journal element.
+    """
+    if snapshot <= self.max_snapshot:
+      raise ValueError('Timestamps must be monotonically increasing.'
+                       + 'Input snapshot %d is not greater than max snapshot %d'
+                       % (snapshot, self.max_snapshot))
+    cdef SnapshottedExecutionPtr snapshotted_ptr = (
+      <SnapshottedExecutionPtr> malloc(sizeof(SnapshottedExecution)))
+    assert(snapshotted_ptr != NULL)
+    snapshotted_ptr.execution_ptr = execution_ptr
+    snapshotted_ptr.snapshot = snapshot
+    self.journal.push_back(snapshotted_ptr)
+    self.max_snapshot = snapshot
+
+cdef class ReaderWriterState(object):
+  """State shared between ExecutionJournalReader and ExecutionJournalWriter.
+
+  Attributes:
+    execution_journal: Journal of fragments of execution per element to count
+    for attributing processing time. Each time we transition up or down
+    the stage fusion graph we add an execution fragment for the currently
+    processing element with an incremented snapshot version. Each snapshot
+    version must have a representative value, or NULL to represent completion
+    of processing.
+    done_journal: Elements which have completed processing but are still pending
+    final timing calculation. The elements are moved here when they exit the
+    ExecutionJournalWriter.execution_stack and are held here until the counter
+    value can be reported in the next sampling round.
+    latest_snapshot: Monotonically increasing snapshot version number which
+    tracks the latest execution state ready to be reported. Snapshot versions
+    are associated with values in the execution_journal and done_journal.
+    This value written by ExecutionJournalWriter, and read by the
+    ExecutionJournalReader.
+  """
+  def __init__(self):
+    self.latest_snapshot = 0
+    self.execution_journal = Journal()
+    self.done_journal = Journal()
+
+cdef class ExecutionJournalReader(object):
+  """Accounts sampled time to processed elements based on execution journal
+  entries.
+
+  Attributes:
+    shared_state: Shared journals with ExecutionJournalWriter.
+    execution_duration: Accumulated execution time per element. Once an element
+    has finished processing and execution time has been attributed, the total
+    execution time is reported via the counter and removed from the collection.
+
+  Args:
+    shared_state: Initialized in DataflowElementExecutionTracker.
+  """
+  def __init__(self, ReaderWriterState shared_state):
+    self.shared_state = shared_state
+    self.execution_duration = unordered_map[ElementExecutionPtr, int64_t]()
+
+  cdef void take_sample(self, int64_t sample_time,
+      unordered_map[CharPtr, vector[int64_t]]& counter_cache) nogil:
+    """Sampling execution elements
+    
+    Account the specified processing time duration to elements which have 
+    processed since the last sampling round, and update counter_cache for 
+    completed elements.
+    
+    Args:
+      sample_time: Total sampling time since last time.
+      counter_cache: Initialized in DataflowElementExecutionTracker.
+    """
+    latest_snapshot = self.shared_state.latest_snapshot
+    self.attribute_processing_time(sample_time, latest_snapshot)
+    self.update_counter_cache(latest_snapshot, counter_cache)
+
+  cdef void attribute_processing_time(self, int64_t sample_time,
+                                      int64_t latest_snapshot) nogil:
+    """Attribute processing time to elements from execution_journal up to the 
+    specified snapshot. 
+    """
+    cdef int64_t total_execution = 0
+    cdef unordered_map[ElementExecutionPtr, int64_t] executions_per_element
+    cdef SnapshottedExecutionPtr snapshotted_ptr = NULL
+    # Calculate total execution counts and prune execution_journal.
+    while not self.shared_state.execution_journal.journal.empty():
+      if (self.shared_state.execution_journal.journal.front().snapshot
+          <= latest_snapshot):
+        # Clean up SnapshottedExecutionPtr before reassigning new value.
+        if snapshotted_ptr != NULL:
+          free(snapshotted_ptr)
+        total_execution += 1
+        snapshotted_ptr = self.shared_state.execution_journal.journal.front()
+        self.shared_state.execution_journal.journal.pop_front()
+        if snapshotted_ptr.execution_ptr == NULL:
+          continue
+        executions_per_element[snapshotted_ptr.execution_ptr] += 1
+      else:
+        break
+    # Keep the currently executing element in the journal.
+    # So its remaining execution time is counted in the next sampling round.
+    if snapshotted_ptr != NULL and snapshotted_ptr.snapshot == latest_snapshot:
+      self.shared_state.execution_journal.journal.push_front(snapshotted_ptr)
+    cdef unordered_map[ElementExecutionPtr, int64_t].iterator it = (
+      executions_per_element.begin())
+    cdef ElementExecutionPtr element_ptr = NULL
+    cdef int64_t attribution_time = 0
+    # Attribute processing time.
+    while it != executions_per_element.end():
+      element_ptr = dref(it).first # get key of current map_item
+      attribution_time = (sample_time / total_execution
+                         * executions_per_element[element_ptr])
+      self.execution_duration[element_ptr] += attribution_time
+      iref(it) # next
+
+  cdef void update_counter_cache(self, int64_t latest_snapshot,
+      unordered_map[CharPtr, vector[int64_t]]& counter_cache) nogil:
+    """Update counter_cache with values of done elements up to the given 
+    snapshot and prune done_journals.
+    """
+    cdef SnapshottedExecutionPtr snapshotted_ptr = NULL
+    cdef ElementExecutionPtr element_ptr = NULL
+    while not self.shared_state.done_journal.journal.empty():
+      snapshotted_ptr = self.shared_state.done_journal.journal.front()
+      if snapshotted_ptr.snapshot <= latest_snapshot:
+        self.shared_state.done_journal.journal.pop_front()
+        element_ptr = snapshotted_ptr.execution_ptr
+        # Unit of sampling time is nano secs, we update counter_cache with ms.
+        (counter_cache[element_ptr.operation_name]
+         .push_back(self.execution_duration[element_ptr]/1000000))
+        # Clean up SnapshottedExecutionPtr & ElementExecutionPtr after updating
+        # counter
+        free(snapshotted_ptr)
+        free(element_ptr)
+      else:
+        break
+
+
+cdef class ExecutionJournalWriter(object):
+  """Writes journal entries on element processing state changes.
+
+  Attributes:
+    shared_state: Shared journals with ExecutionJournalReader.
+    execution_stack: Execution stack of processing elements. Elements are pushed
+    onto the stack when scoped_process_state.__enter__ and popped on
+    scoped_process_state.__exit__. This stack mirrors the actual runtime stack
+    and contains the step + element context in order to attribute sampled
+    execution time.
+
+  Args:
+    shared_state: Initialized in DataflowElementExecutionTracker.
+  """
+  def __init__(self, ReaderWriterState shared_state):
+    self.shared_state = shared_state
+    self.execution_stack = deque[ElementExecutionPtr]()
+    self.add_execution(NULL)
+
+  cdef void add_execution(self, ElementExecutionPtr execution_ptr):
+    """Push current ElementExecution onto top of the execution_stack and add
+    new entry into journal.
+    """
+    cdef int64_t next_snapshot = self.shared_state.latest_snapshot + 1
+    self.execution_stack.push_back(execution_ptr)
+    self.shared_state.execution_journal.add_journal(execution_ptr,
+                                                    next_snapshot)
+    self.shared_state.latest_snapshot = next_snapshot
+
+  cdef void start_processing(self, char* operation_name):
+    """ Called when processing_scoped_state.__enter__
+    
+    Create and journal a new ElementExecution to track a processing element.
+    """
+    cdef ElementExecutionPtr execution_ptr = (
+      <ElementExecutionPtr> malloc(sizeof(ElementExecution)))
+    assert (execution_ptr != NULL)
+    execution_ptr.operation_name = operation_name
+    self.add_execution(execution_ptr)
+
+  cdef void done_processing(self):
+    """ Called when processing_scoped_state.__exit__
+    
+    Indicates that the execution thread has exited the process method for 
+    an element.When an element is finished processing, it is popped from the 
+    execution stack, but will be tracked in the done_journal collection 
+    until the next sampling round in order to account timing for the final 
+    fragment of execution.
+    """
+    if self.execution_stack.size() <= 1:
+      raise ValueError('No processing elements currently tracked.')
+    cdef ElementExecutionPtr last_execution = self.execution_stack.back()
+    cdef ElementExecutionPtr next_execution = NULL
+    self.execution_stack.pop_back()
+    cdef int64_t next_snapshot = self.shared_state.latest_snapshot + 1
+    self.shared_state.done_journal.add_journal(last_execution, next_snapshot)
+    next_execution = self.execution_stack.back()
+    self.shared_state.execution_journal.add_journal(next_execution,
+                                                    next_snapshot)
+    self.shared_state.latest_snapshot = next_snapshot
+
+
+cdef class DataflowElementExecutionTracker(object):
+  """Implementation of DataflowElementExecutionTracker.
+
+  Attributes:
+    counter_cache: An map to cache processing time per element per step.
+    cache_start_index: An map used for finding the range of time list to update.
+    shared_state: ReaderWriterState shared between execution_reader
+    and execution_writer.
+    execution_reader: ExecutionJournalReader.
+    execution_writer: ExecutionJournalWriter.
+  """
+  def __init__(self):
+    self.counter_cache = unordered_map[CharPtr, vector[int64_t]]()
+    self.cache_start_index = unordered_map[CharPtr, int64_t]()
+    self.shared_state = ReaderWriterState()
+    self.execution_reader = ExecutionJournalReader(self.shared_state)
+    self.execution_writer = ExecutionJournalWriter(self.shared_state)
+
+  cdef void enter(self, char* operation_name):
+    self.execution_writer.start_processing(operation_name)
+
+  cdef void exit(self):
+    self.execution_writer.done_processing()
+
+  cdef void take_sample(self, int64_t nanos_sampling_duration) nogil:
+    self.execution_reader.take_sample(nanos_sampling_duration,
+                                      self.counter_cache)
+
+  cpdef void enter_for_test(self, char* operation_name):
+    """Only visible for unit test.
+    
+    Need to keep enter func as cdef to making calling fast enough.
+    """
+    self.enter(operation_name)
+
+  cpdef void exit_for_test(self):
+    """Only visible for unit test.
+    
+    Need to keep exit func as cdef to make calling fast enough.
+    """
+    self.exit()
+
+  cpdef void take_sample_for_test(self, int64_t nanos_sampling_duration):
+    """Only visible for unit test.
+    
+    Need to keep take_sample as cdef to get rid of gil.
+    """
+    self.execution_reader.take_sample(nanos_sampling_duration,
+                                      self.counter_cache)
+
+  cpdef report_counter(self, counter_factory):
+    """Only report counter when a work_item complete"""
+    cdef unordered_map[CharPtr, vector[int64_t]].iterator map_it = (
+      self.counter_cache.begin())
+    cdef int64_t start_index = 0, end_index = 0
+    cdef char* op_name
+    cdef vector[int64_t] values
+    cdef DataflowDistributionCounter time_counter = None
+    while map_it != self.counter_cache.end():
+      op_name = dref(map_it).first # get key of map_item
+      values = dref(map_it).second # get value of map_item
+      end_index = values.size()
+      start_index = self.cache_start_index[op_name]
+      counter_name = CounterName('per-element-processing-time',
+                                 step_name=op_name)
+      time_counter = counter_factory.get_counter(
+          counter_name, Counter.DATAFLOW_DISTRIBUTION).accumulator
+      while start_index < end_index:
+        time_counter.add_input(values[start_index])
+        start_index += 1
+      self.cache_start_index[op_name] = end_index
+      iref(map_it) # next

--- a/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker_test.py
+++ b/sdks/python/apache_beam/runners/worker/dataflow_element_execution_tracker_test.py
@@ -1,0 +1,202 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for DataflowElementExecutionTracker"""
+from __future__ import absolute_import
+
+import unittest
+
+from mock import Mock
+from nose.plugins.skip import SkipTest
+
+from apache_beam.transforms import DataflowDistributionCounter
+from apache_beam.utils.counters import Counter
+from apache_beam.utils.counters import CounterFactory
+from apache_beam.utils.counters import CounterName
+
+
+class DataflowElementExecutionTrackerTest(unittest.TestCase):
+  class _FakeScopedState(object):
+    def __init__(self, sampler, name, state_index, counter=None):
+      self.sampler = sampler
+      self.name = name
+      self.state_index = state_index
+      self.counter = counter
+
+  def setUp(self):
+    self.counter_factory = CounterFactory()
+    try:
+      from apache_beam.runners.worker.dataflow_element_execution_tracker \
+        import DataflowElementExecutionTracker
+      self.tracker = DataflowElementExecutionTracker()
+    except ImportError:
+      raise SkipTest('DataflowElementExecutionTracker not compiled.')
+
+  def _create_state(self, operation_name):
+    return self._FakeScopedState(None,
+                                 CounterName(operation_name,
+                                             step_name=operation_name),
+                                 0)
+
+  def _get_counter_value(self, op_name):
+    counter_name = CounterName('per-element-processing-time', step_name=op_name)
+    return self.counter_factory.get_counter(
+        counter_name, Counter.DATAFLOW_DISTRIBUTION).accumulator
+
+  def test_typical_usage(self):
+    """Typical usage scenario
+
+    Format info: execution_journal[] | partial timings not yet reported{}
+    """
+    state_a = 'A'
+    state_b = 'B'
+    state_c = 'C'
+    state_d = 'D'
+    self.tracker.enter_for_test(state_a)  # IDLE A1 | {}
+    self.tracker.enter_for_test(state_b)  # IDLE A1 B1 | {}
+    self.tracker.exit_for_test()  # IDLE A1 B1 A1 | {}
+    self.tracker.take_sample_for_test(40*1000000)
+    self.tracker.report_counter(self.counter_factory)  # A1 | {A1:2}
+    self._assert_distribution_equals(self._get_counter_value(state_b),
+                                     self._get_expected_distribution([10]))
+
+    self.tracker.enter_for_test(state_b)  # A1 B2 | {A1:2}
+    self.tracker.exit_for_test()  # A1 B2 A1 | {A1:2}
+    self.tracker.enter_for_test(state_c)  # A1 B2 A1 C1 | {A1:2}
+    self.tracker.enter_for_test(state_d)  # A1 B2 A1 C1 D1 | {A1:2}
+    self.tracker.take_sample_for_test(50*1000000)
+    self.tracker.report_counter(self.counter_factory) # D1 | {A1:4 C1:1 D1:1}
+    self._assert_distribution_equals(self._get_counter_value(state_b),
+                                     self._get_expected_distribution([10, 10]))
+
+    self.tracker.exit_for_test()  # D1 C1 | {A1:4 C1:1 D1:1}
+    self.tracker.exit_for_test()  # D1 C1 A1 | {A1:4 C1:1 D1:1}
+    self.tracker.enter_for_test(state_c)  # D1 C1 A1 C2 | {A1:4 C1:1 D1:1}
+    self.tracker.take_sample_for_test(40*1000000)
+    self.tracker.report_counter(self.counter_factory)  # C2 | {A1:5 C2:1}
+    self._assert_distribution_equals(self._get_counter_value(state_c),
+                                     self._get_expected_distribution([20]))
+    self._assert_distribution_equals(self._get_counter_value(state_d),
+                                     self._get_expected_distribution([20]))
+
+    self.tracker.exit_for_test()  # C2 A1 | {A1:5 C2:1
+    self.tracker.exit_for_test()  # C2 A1 IDLE | {A1:5 C2:1}
+
+    self.tracker.take_sample_for_test(30*1000000)
+    self.tracker.report_counter(self.counter_factory)  # All reported
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([60]))
+    self._assert_distribution_equals(self._get_counter_value(state_b),
+                                     self._get_expected_distribution([10, 10]))
+    self._assert_distribution_equals(self._get_counter_value(state_c),
+                                     self._get_expected_distribution([20, 20]))
+    self._assert_distribution_equals(self._get_counter_value(state_d),
+                                     self._get_expected_distribution([20]))
+
+  def test_counter_reported_on_close(self):
+    state_a = 'A'
+    self.tracker.enter_for_test(state_a)
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([]))
+
+    self.tracker.exit_for_test()
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([10]))
+
+  def test_distributed_sampled_time(self):
+    state_a = 'A'
+    state_b = 'B'
+    self.tracker.enter_for_test(state_a)
+    self.tracker.exit_for_test()
+    self.tracker.enter_for_test(state_b)
+    self.tracker.exit_for_test()
+    self.tracker.take_sample_for_test(50*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([10]))
+    self._assert_distribution_equals(self._get_counter_value(state_b),
+                                     self._get_expected_distribution([10]))
+
+  def test_element_tracked_individually_for_state(self):
+    state_a = 'A'
+    state_b = 'B'
+    self.tracker.enter_for_test(state_a)
+    self.tracker.enter_for_test(state_b)
+    self.tracker.exit_for_test()
+    self.tracker.enter_for_test(state_b)
+    self.tracker.exit_for_test()
+    self.tracker.exit_for_test()
+    self.tracker.take_sample_for_test(70*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([30]))
+    self._assert_distribution_equals(self._get_counter_value(state_b),
+                                     self._get_expected_distribution([10, 10]))
+
+  def test_current_operation_counted_in_next_sample(self):
+    state_a = 'A'
+    self.tracker.enter_for_test(state_a)
+    self.tracker.take_sample_for_test(20*1000000)
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.exit_for_test()
+    self.tracker.take_sample_for_test(20*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([30]))
+
+  def test_no_execution_since_last_sample(self):
+    self.tracker.take_sample_for_test(10*1000000)
+    state_a = 'A'
+    self.tracker.enter_for_test(state_a)
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.exit_for_test()
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([20]))
+    self.tracker.take_sample_for_test(10*1000000)
+    self.tracker.report_counter(self.counter_factory)
+    self._assert_distribution_equals(self._get_counter_value(state_a),
+                                     self._get_expected_distribution([20]))
+
+  def _get_expected_distribution(self, values):
+    distribution = DataflowDistributionCounter()
+    for value in values:
+      distribution.add_input(value)
+    return distribution
+
+  def _assert_distribution_equals(self, counter, expected_distribution):
+    self.assertEquals(counter.min, expected_distribution.min)
+    self.assertEquals(counter.max, expected_distribution.max)
+    self.assertEquals(counter.count, expected_distribution.count)
+    self.assertEquals(counter.sum, expected_distribution.sum)
+    histogram = Mock(firstBucketOffset=None, bucketCounts=None)
+    expected_histogram = Mock(firstBucketOffset=None, bucketCounts=None)
+    counter.translate_to_histogram(histogram)
+    expected_distribution.translate_to_histogram(expected_histogram)
+    self.assertEquals(histogram.bucketCounts, expected_histogram.bucketCounts)
+    self.assertEquals(histogram.firstBucketOffset,
+                      expected_histogram.firstBucketOffset)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -142,7 +142,7 @@ class Operation(object):
         metrics_container=self.metrics_container)
     self.scoped_process_state = self.state_sampler.scoped_state(
         self.name_context.metrics_name(), 'process',
-        metrics_container=self.metrics_container)
+        metrics_container=self.metrics_container, is_processing_state=True)
     self.scoped_finish_state = self.state_sampler.scoped_state(
         self.name_context.metrics_name(), 'finish',
         metrics_container=self.metrics_container)

--- a/sdks/python/apache_beam/runners/worker/statesampler.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler.py
@@ -92,7 +92,8 @@ class StateSampler(statesampler_impl.StateSampler):
                    step_name,
                    state_name,
                    io_target=None,
-                   metrics_container=None):
+                   metrics_container=None,
+                   is_processing_state=False):
     counter_name = CounterName(state_name + '-msecs',
                                stage_name=self._prefix,
                                step_name=step_name,
@@ -105,7 +106,8 @@ class StateSampler(statesampler_impl.StateSampler):
       self._states_by_name[counter_name] = super(
           StateSampler, self)._scoped_state(counter_name,
                                             output_counter,
-                                            metrics_container)
+                                            metrics_container,
+                                            is_processing_state)
       return self._states_by_name[counter_name]
 
   def commit_counters(self):

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -112,7 +112,7 @@ cdef class StateSampler(object):
     self.element_tracker = DataflowElementExecutionTracker()
     # TODO(BEAM-4111): Remove experimental flag once time_counter release.
     experiments = RuntimeValueProvider.get_value('experiments', str, [])
-    if 'time_per_element_counter_v0' in experiments:
+    if 'per_element_instrumentation' in experiments:
       self.has_time_counter_experiment = True
     else:
       self.has_time_counter_experiment = False

--- a/sdks/python/apache_beam/runners/worker/statesampler_slow.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_slow.py
@@ -37,8 +37,10 @@ class StateSampler(object):
   def _scoped_state(self,
                     counter_name,
                     output_counter,
-                    metrics_container=None):
-    return ScopedState(self, counter_name, output_counter, metrics_container)
+                    metrics_container=None,
+                    is_processing_state=False):
+    return ScopedState(self, counter_name, output_counter, metrics_container,
+                       is_processing_state)
 
   def _enter_state(self, state):
     self.state_transition_count += 1
@@ -58,7 +60,12 @@ class StateSampler(object):
 
 class ScopedState(object):
 
-  def __init__(self, sampler, name, counter=None, metrics_container=None):
+  def __init__(self,
+               sampler,
+               name,
+               counter=None,
+               metrics_container=None,
+               is_processing_state=False):
     self.state_sampler = sampler
     self.name = name
     self.counter = counter

--- a/sdks/python/run_tox_cleanup.sh
+++ b/sdks/python/run_tox_cleanup.sh
@@ -23,7 +23,7 @@ set -e
 
 for dir in apache_beam target/build; do
     if [ -d "${dir}" ]; then
-        for ext in pyc c so; do
+        for ext in pyc c cpp so; do
             find ${dir} -type f -name "*.${ext}" -delete
         done
     fi


### PR DESCRIPTION
Add time_counter behind time_per_element_counter experimental flag

What does time_counter do:
Collect processing_time per element for each step.

r: @pabloem @robertwb