### PR TITLE
[BEAM-3909] Add tests for Flink DoFnOperator side-input checkpointing

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -483,6 +483,11 @@ public class DoFnOperator<InputT, OutputT>
   @Override
   public final void processElement2(
       StreamRecord<RawUnionValue> streamRecord) throws Exception {
+    // we finish the bundle because the newly arrived side-input might
+    // make a view available that was previously not ready.
+    // The PushbackSideInputRunner will only reset it's cache of non-ready windows when
+    // finishing a bundle.
+    invokeFinishBundle();
     checkInvokeStartBundle();
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
We test both checkpointing of pushed-back data and of side-input data.

This extends `PushbackSideInputDoFnRunner` to allow resetting any cached information we keep about ready windows. Otherwise, it will not consider side inputs that might have become ready in the same bundle.

Other than that, this only adds tests. The structure of the tests is:
 - Feed in some data
 - Checkpoint the operator and throw it away
 - Restore the operator
 - Send in some new data and verify that we get what we expect

In the first two tests we first send in side-input data, which tests that side-inputs are correctly checkpointed. In the second set of tests we first send in main-input data, which is retained because side inputs are not ready.