### PR TITLE
[BEAM-3824] Convert big query writes to beam.io.WriteToBigQuery in mobile gaming example

### DIFF
--- a/sdks/python/apache_beam/examples/complete/game/leader_board.py
+++ b/sdks/python/apache_beam/examples/complete/game/leader_board.py
@@ -48,7 +48,7 @@ The PubSub topic you specify should be the same topic to which the Injector is
 publishing.
 
 To run the Java injector:
-<beam_root>/examples/java8$ mvn compile exec:java \
+<beam_root>/examples/java$ mvn compile exec:java \
     -Dexec.mainClass=org.apache.beam.examples.complete.game.injector.Injector \
     -Dexec.args="$PROJECT_ID $PUBSUB_TOPIC none"
 
@@ -76,12 +76,6 @@ python leader_board.py \
     --dataset $BIGQUERY_DATASET \
     --runner DataflowRunner \
     --temp_location gs://$BUCKET/user_score/temp
-
---------------------------------------------------------------------------------
-NOTE [BEAM-2354]: This example is not yet runnable by DataflowRunner.
-    The runner still needs support for:
-      * the --save_main_session flag when streaming is enabled
---------------------------------------------------------------------------------
 """
 
 from __future__ import absolute_import
@@ -190,22 +184,14 @@ class WriteToBigQuery(beam.PTransform):
     return ', '.join(
         '%s:%s' % (col, self.schema[col]) for col in self.schema)
 
-  def get_table(self, pipeline):
-    """Utility to construct an output table reference."""
-    project = pipeline.options.view_as(GoogleCloudOptions).project
-    return '%s:%s.%s' % (project, self.dataset, self.table_name)
-
   def expand(self, pcoll):
-    table = self.get_table(pcoll.pipeline)
+    project = pcoll.pipeline.options.view_as(GoogleCloudOptions).project
     return (
         pcoll
         | 'ConvertToRow' >> beam.Map(
             lambda elem: {col: elem[col] for col in self.schema})
-        | beam.io.Write(beam.io.BigQuerySink(
-            table,
-            schema=self.get_schema(),
-            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-            write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND)))
+        | beam.io.WriteToBigQuery(
+            self.table_name, self.dataset, project, self.get_schema()))
 
 
 # [START window_and_trigger]


### PR DESCRIPTION
- Replaced `BigQuerySink` with `beam.io.WriteToBigQuery`. Examples could be cleaned up a little more, removing the example wrapper for `WriteToBigQuery` but this is not as important as removing the use of native sink.
- Removed the warnings related to DataflowRunner as this is no longer applicable.

Tested 4 examples on both Direct and Dataflow runners.