### PR TITLE
[BEAM-591] Support custom timestamps & CreateTime support

### DIFF
--- a/sdks/java/io/kafka/pom.xml
+++ b/sdks/java/io/kafka/pom.xml
@@ -122,11 +122,19 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
@@ -44,7 +44,7 @@ public class CustomTimestampPolicyWithLimitedDelay<K, V> extends TimestampPolicy
    * time is {@code Min(now(), max_event_timestamp) - maxDelay}.
    * @param timestampFunction A function to extract timestamp from the record
    * @param maxDelay For any record in the Kafka partition, the timestamp of any subsequent
-   *                 record is expected to be >= {@code current record timestamp - maxDelay}.
+   *                 record is expected to be after {@code current record timestamp - maxDelay}.
    * @param previousWatermark Latest check-pointed watermark, see
    *                {@link TimestampPolicyFactory#createTimestampPolicy(TopicPartition, Optional)}
    */

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io.kafka;
 
 import com.google.common.annotations.VisibleForTesting;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelay.java
@@ -1,0 +1,84 @@
+package org.apache.beam.sdk.io.kafka;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Optional;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.kafka.common.TopicPartition;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * A policy for custom record timestamps where timestamps within a partition are expected to be
+ * roughly monotonically increasing with a cap on out of order event delays (say 1 minute).
+ * The watermark at any time is '({@code Min(now(), Max(event timestamp so far)) - max delay})'.
+ * However, watermark is never set in future and capped to 'now - max delay'. In addition,
+ * watermark advanced to 'now - max delay' when a partition is idle.
+ */
+public class CustomTimestampPolicyWithLimitedDelay<K, V> extends TimestampPolicy<K, V> {
+
+  private final Duration maxDelay;
+  private final SerializableFunction<KafkaRecord<K, V>, Instant> timestampFunction;
+  private Instant maxEventTimestamp;
+
+  /**
+   * A policy for custom record timestamps where timestamps are expected to be roughly monotonically
+   * increasing with out of order event delays less than {@code maxDelay}. The watermark at any
+   * time is {@code Min(now(), max_event_timestamp) - maxDelay}.
+   * @param timestampFunction A function to extract timestamp from the record
+   * @param maxDelay For any record in the Kafka partition, the timestamp of any subsequent
+   *                 record is expected to be >= {@code current record timestamp - maxDelay}.
+   * @param previousWatermark Latest check-pointed watermark, see
+   *                {@link TimestampPolicyFactory#createTimestampPolicy(TopicPartition, Optional)}
+   */
+  public CustomTimestampPolicyWithLimitedDelay(
+    SerializableFunction<KafkaRecord<K, V>, Instant> timestampFunction,
+    Duration maxDelay,
+    Optional<Instant> previousWatermark) {
+    this.maxDelay = maxDelay;
+    this.timestampFunction = timestampFunction;
+
+    // 'previousWatermark' is not the same as maxEventTimestamp (e.g. it could have been in future).
+    // Initialize it such that watermark before reading any event same as previousWatermark.
+    maxEventTimestamp = previousWatermark
+      .orElse(BoundedWindow.TIMESTAMP_MIN_VALUE)
+      .plus(maxDelay);
+  }
+
+  @Override
+  public Instant getTimestampForRecord(PartitionContext ctx, KafkaRecord<K, V> record) {
+    Instant ts = timestampFunction.apply(record);
+    if (ts.isAfter(maxEventTimestamp)) {
+      maxEventTimestamp = ts;
+    }
+    return ts;
+  }
+
+  @Override
+  public Instant getWatermark(PartitionContext ctx) {
+    // Watermark == maxEventTime - maxDelay, except in two special cases:
+    //   a) maxEventTime in future : probably due to incorrect timestamps. Cap it to 'now'.
+    //   b) partition is idle : Need to advance watermark if there are no records in the partition.
+    //         We assume that future records will have timestamp >= 'now - maxDelay' and advance
+    //         the watermark accordingly.
+    // The above handles majority of common use cases for custom timestamps. Users can implement
+    // their own policy if this does not work.
+
+    Instant now = Instant.now();
+    return getWatermark(ctx, now);
+  }
+
+  @VisibleForTesting
+  Instant getWatermark(PartitionContext ctx, Instant now) {
+    if (maxEventTimestamp.isAfter(now)) {
+      return now.minus(maxDelay);  // (a) above.
+    } else if (
+      ctx.getMessageBacklog() == 0
+      && ctx.getBacklogCheckTime().minus(maxDelay).isAfter(maxEventTimestamp) // Idle
+      && maxEventTimestamp.getMillis() > 0) { // Read at least one record with positive timestamp.
+      return ctx.getBacklogCheckTime().minus(maxDelay);
+    } else {
+      return maxEventTimestamp.minus(maxDelay);
+    }
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -111,8 +111,9 @@ import org.slf4j.LoggerFactory;
  *       // settings for ConsumerConfig. e.g :
  *       .updateConsumerProperties(ImmutableMap.of("group.id", "my_beam_app_1"))
  *
- *       // set event times and watermark based on LogAppendTime. To provide a custom
+ *       // set event times and watermark based on 'LogAppendTime'. To provide a custom
  *       // policy see withTimestampPolicyFactory(). withProcessingTime() is the default.
+ *       // Use withCreateTime() with topics that have 'CreateTime' timestamps.
  *       .withLogAppendTime()
  *
  *       // restrict reader to committed messages on Kafka (see method documentation).
@@ -482,7 +483,6 @@ public class KafkaIO {
       return withTimestampPolicyFactory(TimestampPolicyFactory.withLogAppendTime());
     }
 
-
     /**
      * Sets {@link TimestampPolicy} to {@link TimestampPolicyFactory.ProcessingTimePolicy}.
      * This is the default timestamp policy. It assigns processing time to each record.
@@ -515,7 +515,9 @@ public class KafkaIO {
      * Provide custom {@link TimestampPolicyFactory} to set event times and watermark for each
      * partition. {@link TimestampPolicyFactory#createTimestampPolicy(TopicPartition, Optional)}
      * is invoked for each partition when the reader starts.
-     * @see #withLogAppendTime() and {@link #withProcessingTime()}
+     * @see #withLogAppendTime()
+     * @see #withCreateTime(Duration)
+     * @see #withProcessingTime()
      */
     public Read<K, V> withTimestampPolicyFactory(
       TimestampPolicyFactory<K, V> timestampPolicyFactory) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -505,7 +505,7 @@ public class KafkaIO {
      * 'now - max delay' when a partition is idle.
      *
      * @param maxDelay For any record in the Kafka partition, the timestamp of any subsequent
-     *                 record is expected to be >= {@code current record timestamp - maxDelay}.
+     *                 record is expected to be after {@code current record timestamp - maxDelay}.
      */
     public Read<K, V> withCreateTime(Duration maxDelay) {
       return withTimestampPolicyFactory(TimestampPolicyFactory.withCreateTime(maxDelay));

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicyFactory.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicyFactory.java
@@ -45,7 +45,6 @@ public interface TimestampPolicyFactory<KeyT, ValueT> extends Serializable {
    *           is resuming from a checkpoint. This is a good value to return by implementations
    *           of {@link TimestampPolicy#getWatermark(PartitionContext)} until a better watermark
    *           can be established as more records are read.
-   * @return
    */
   TimestampPolicy<KeyT, ValueT> createTimestampPolicy(
     TopicPartition tp, Optional<Instant> previousWatermark);
@@ -87,20 +86,6 @@ public interface TimestampPolicyFactory<KeyT, ValueT> extends Serializable {
     return (tp, previousWatermark) ->
       new CustomTimestampPolicyWithLimitedDelay<>(timestampFunction, maxDelay, previousWatermark);
   }
-
-  /*
-   * TODO
-   * Provide a another built in implementation where the watermark is based on all the timestamps
-   * seen in last 1 minute of wall clock time (this duration could be configurable). This is
-   * similar to watermark set by PubsubIO.
-   *
-   * public static <K, V> TimestampPolicyFactory<K, V> withCreateTime() {
-   *   return withCustomTypestamp(...);
-   * }
-   *
-   * public static <K, V> TimestampPolicyFactory<K, V> withCustomTimestamp() {
-   * }
-   */
 
   /**
    * Used by the Read transform to support old timestamp functions API.

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
@@ -16,8 +16,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Tests for {@link CustomTimestampPolicyWithLimitedDelay}. */
 @RunWith(JUnit4.class)
-class CustomTimestampPolicyWithLimitedDelayTest {
+public class CustomTimestampPolicyWithLimitedDelayTest {
 
   // Takes offsets of timestamps from now returns the results as offsets from 'now'.
   private static List<Long> getTimestampsForRecords(
@@ -36,7 +37,7 @@ class CustomTimestampPolicyWithLimitedDelayTest {
 
 
   @Test
-  void testCustomTimestampPolicyWithLimitedDelay() {
+  public void testCustomTimestampPolicyWithLimitedDelay() {
     // Verifies that max delay is applies appropriately for reporting watermark
 
     Duration maxDelay = Duration.standardSeconds(60);

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
@@ -1,0 +1,99 @@
+package org.apache.beam.sdk.io.kafka;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+class CustomTimestampPolicyWithLimitedDelayTest {
+
+  // Takes offsets of timestamps from now returns the results as offsets from 'now'.
+  private static List<Long> getTimestampsForRecords(
+    TimestampPolicy<String, String> policy, Instant now, List<Long> timestampOffsets) {
+
+    return timestampOffsets
+      .stream()
+      .map(ts -> {
+        Instant result = policy.getTimestampForRecord(
+          null, new KafkaRecord<>("topic", 0, 0, now.getMillis() + ts,
+                                  KafkaTimestampType.CREATE_TIME, "key", "value"));
+        return result.getMillis() - now.getMillis();
+      })
+      .collect(Collectors.toList());
+  }
+
+
+  @Test
+  void testCustomTimestampPolicyWithLimitedDelay() {
+    // Verifies that max delay is applies appropriately for reporting watermark
+
+    Duration maxDelay = Duration.standardSeconds(60);
+
+    CustomTimestampPolicyWithLimitedDelay<String, String> policy =
+      new CustomTimestampPolicyWithLimitedDelay<>(
+        (record -> new Instant(record.getTimestamp())),
+        maxDelay,
+        Optional.empty());
+
+    Instant now = Instant.now();
+
+    TimestampPolicy.PartitionContext ctx = mock(TimestampPolicy.PartitionContext.class);
+    when(ctx.getMessageBacklog()).thenReturn(100L);
+    when(ctx.getBacklogCheckTime()).thenReturn(now);
+
+    assertThat(policy.getWatermark(ctx), is(BoundedWindow.TIMESTAMP_MIN_VALUE));
+
+    // (1) Test simple case : watermark == max_timesatmp - max_delay
+
+    List<Long> input = ImmutableList.of(-200_000L,
+                                        -150_000L,
+                                        -120_000L,
+                                        -140_000L,
+                                        -100_000L,  // <<< Max timestamp
+                                        -110_000L);
+    assertThat(getTimestampsForRecords(policy, now, input), is(input));
+
+    // Watermark should be max_timestamp - maxDelay
+    assertThat(policy.getWatermark(ctx), is(now
+                                              .minus(Duration.standardSeconds(100))
+                                              .minus(maxDelay)));
+
+    // (2) Verify future timestamps
+
+    input = ImmutableList.of(-200_000L,
+                             -150_000L,
+                             -120_000L,
+                             -140_000L,
+                              100_000L,  // <<< timestamp is in future
+                             -100_000L,
+                             -110_000L);
+
+    assertThat(getTimestampsForRecords(policy, now, input), is(input));
+
+    // Watermark should be now - max_delay (backlog in context still non zero)
+    assertThat(policy.getWatermark(ctx, now), is(now.minus(maxDelay)));
+
+    // (3) Verify that Watermark advances when there is no backlog
+
+    // advance current time by 5 minutes
+    now = now.plus(Duration.standardSeconds(300));
+    Instant backlogCheckTime = now.minus(Duration.standardSeconds(10));
+
+    when(ctx.getMessageBacklog()).thenReturn(0L);
+    when(ctx.getBacklogCheckTime()).thenReturn(backlogCheckTime);
+
+    assertThat(policy.getWatermark(ctx, now), is(backlogCheckTime.minus(maxDelay)));
+  }
+}

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io.kafka;
 
 import static org.hamcrest.core.Is.is;

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -549,7 +549,7 @@ public class KafkaIOTest {
       p.apply(mkKafkaReadTransform(numElements, null)
                 .withCreateTime(Duration.millis(0))
                 .updateConsumerProperties(ImmutableMap.of(
-                  TIMESTAMP_TYPE_CONFIG, "LogAppendTime",
+                  TIMESTAMP_TYPE_CONFIG, "CreateTime",
                   TIMESTAMP_START_MILLIS_CONFIG, createTimestampStartMillis))
                 .withoutMetadata())
         .apply(Values.create());

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -499,7 +499,7 @@ public class KafkaIOTest {
   }
 
   // Returns TIMESTAMP_MAX_VALUE for watermark when all the records are read from a partition.
-  static class TimestampPolicyWithEndOfSource<K, V> extends TimestampPolicyFactory<K, V> {
+  static class TimestampPolicyWithEndOfSource<K, V> implements TimestampPolicyFactory<K, V> {
     private final long maxOffset;
 
     TimestampPolicyWithEndOfSource(long maxOffset) {
@@ -553,10 +553,9 @@ public class KafkaIOTest {
       .withTimestampPolicyFactory(
         new TimestampPolicyWithEndOfSource<>(numElements / numPartitions - 1));
 
-    PCollection <Long> input =
-      p.apply("readFromKafka", reader.withoutMetadata())
-        .apply(Values.create())
-        .apply(Window.into(FixedWindows.of(Duration.standardDays(100))));
+    p.apply("readFromKafka", reader.withoutMetadata())
+      .apply(Values.create())
+      .apply(Window.into(FixedWindows.of(Duration.standardDays(100))));
 
     PipelineResult result = p.run();
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -151,12 +151,14 @@ public class KafkaIOTest {
   public ExpectedException thrown = ExpectedException.none();
 
   private static final Instant LOG_APPEND_START_TIME = new Instant(600 * 1000);
+  private static final String TIMESTAMP_START_MILLIS_CONFIG = "test.timestamp.start.millis";
+  private static final String TIMESTAMP_TYPE_CONFIG = "test.timestamp.type";
 
   // Update mock consumer with records distributed among the given topics, each with given number
   // of partitions. Records are assigned in round-robin order among the partitions.
   private static MockConsumer<byte[], byte[]> mkMockConsumer(
       List<String> topics, int partitionsPerTopic, int numElements,
-      OffsetResetStrategy offsetResetStrategy) {
+      OffsetResetStrategy offsetResetStrategy, Map<String, Object> config) {
 
     final List<TopicPartition> partitions = new ArrayList<>();
     final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records = new HashMap<>();
@@ -176,6 +178,10 @@ public class KafkaIOTest {
     int numPartitions = partitions.size();
     final long[] offsets = new long[numPartitions];
 
+    long timestampStartMillis = (Long) config.getOrDefault(TIMESTAMP_START_MILLIS_CONFIG,
+                                                           LOG_APPEND_START_TIME.getMillis());
+    TimestampType timestampType = TimestampType.forName((String)
+      config.getOrDefault(TIMESTAMP_TYPE_CONFIG, TimestampType.LOG_APPEND_TIME.toString()));
 
     for (int i = 0; i < numElements; i++) {
       int pIdx = i % numPartitions;
@@ -189,8 +195,8 @@ public class KafkaIOTest {
               tp.topic(),
               tp.partition(),
               offsets[pIdx]++,
-              LOG_APPEND_START_TIME.plus(Duration.standardSeconds(i)).getMillis(),
-              TimestampType.LOG_APPEND_TIME,
+              timestampStartMillis + Duration.standardSeconds(i).getMillis(),
+              timestampType,
               0, key.length, value.length, key, value));
     }
 
@@ -277,7 +283,7 @@ public class KafkaIOTest {
 
     @Override
     public Consumer<byte[], byte[]> apply(Map<String, Object> config) {
-      return mkMockConsumer(topics, partitionsPerTopic, numElements, offsetResetStrategy);
+      return mkMockConsumer(topics, partitionsPerTopic, numElements, offsetResetStrategy, config);
     }
   }
 
@@ -489,6 +495,71 @@ public class KafkaIOTest {
       input
         .apply(MapElements.into(TypeDescriptors.longs()).via(t ->
           LOG_APPEND_START_TIME.plus(Duration.standardSeconds(t)).getMillis()))
+        .apply("TimestampDiff", ParDo.of(new ElementValueDiff()))
+        .apply("DistinctTimestamps", Distinct.create());
+
+    // This assert also confirms that diff only has one unique value.
+    PAssert.thatSingleton(diffs).isEqualTo(0L);
+
+    p.run();
+  }
+
+  @Test
+  public void testUnboundedSourceCustomTimestamps() {
+    // The custom timestamps is set to customTimestampStartMillis + value.
+    // Tests basic functionality of custom timestamps.
+
+    final int numElements = 1000;
+    final long customTimestampStartMillis = 80000L;
+
+    PCollection<Long> input =
+      p.apply(mkKafkaReadTransform(numElements, null)
+                .withTimestampPolicyFactory(
+                  (tp, prevWatermark) -> new CustomTimestampPolicyWithLimitedDelay<Integer, Long>(
+                    (record -> new Instant(TimeUnit.SECONDS.toMillis(record.getKV().getValue())
+                                             + customTimestampStartMillis)),
+                   Duration.millis(0),
+                   prevWatermark))
+                .withoutMetadata())
+        .apply(Values.create());
+
+    addCountingAsserts(input, numElements);
+
+    PCollection<Long> diffs =
+      input
+        .apply(MapElements.into(TypeDescriptors.longs())
+                 .via(t -> TimeUnit.SECONDS.toMillis(t) + customTimestampStartMillis))
+        .apply("TimestampDiff", ParDo.of(new ElementValueDiff()))
+        .apply("DistinctTimestamps", Distinct.create());
+
+    // This assert also confirms that diff only has one unique value.
+    PAssert.thatSingleton(diffs).isEqualTo(0L);
+
+    p.run();
+  }
+
+  @Test
+  public void testUnboundedSourceCreateTimestamps() {
+    // Same as testUnboundedSourceCustomTimestamps with create timestamp.
+
+    final int numElements = 1000;
+    final long createTimestampStartMillis = 50000L;
+
+    PCollection<Long> input =
+      p.apply(mkKafkaReadTransform(numElements, null)
+                .withCreateTime(Duration.millis(0))
+                .updateConsumerProperties(ImmutableMap.of(
+                  TIMESTAMP_TYPE_CONFIG, "LogAppendTime",
+                  TIMESTAMP_START_MILLIS_CONFIG, createTimestampStartMillis))
+                .withoutMetadata())
+        .apply(Values.create());
+
+    addCountingAsserts(input, numElements);
+
+    PCollection<Long> diffs =
+      input
+        .apply(MapElements.into(TypeDescriptors.longs())
+                 .via(t -> TimeUnit.SECONDS.toMillis(t) + createTimestampStartMillis))
         .apply("TimestampDiff", ParDo.of(new ElementValueDiff()))
         .apply("DistinctTimestamps", Distinct.create());
 


### PR DESCRIPTION
Adds a policy for  custom timestamps & `CreateTime` timestamps. This is useful most common situations for users to use directly.  Changes in this PR:

-  `TimestampPolicyFactory` is changed to a `@FunctionalInterface` so that it is lambda friendly. (e.g. `.withTimetstampFactory((ts, prevWatermark) -> new MyTimestampPolicy(..))`
- Added `CustomTimestmpPolicyWithLimitedDelay` : built in custom timestamp policy where the timestamps are expected to be roughly monotonic, with a bound on maximum delay/skew. This handles advancing watermark when a partition is idle. 
   - The policy itself is fairly simple : keep advancing the watermark to `max_event_time - maxDelay`. The two special cases are future timestamps & idle partitions.
 - '.withCreateTime(maxDelay)` method for reader builder. This is useful to handle `CREATE_TIME` timestamps in Kafka. An instance of  `CustomTimestmpPolicyWithLimitedDelay`.


