### PR TITLE
[BEAM-3913] Allow Fusion to Continue with unknown PTransforms

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
@@ -27,17 +27,22 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Pipeline;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
 import org.apache.beam.sdk.transforms.Flatten;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Fuser that constructs a fused pipeline by fusing as many PCollections into a stage as possible.
  */
 class GreedyPCollectionFusers {
+  private static final Logger LOG = LoggerFactory.getLogger(GreedyPCollectionFusers.class);
+
   private static final Map<String, FusibilityChecker> URN_FUSIBILITY_CHECKERS =
       ImmutableMap.<String, FusibilityChecker>builder()
           .put(PTransformTranslation.PAR_DO_TRANSFORM_URN, GreedyPCollectionFusers::canFuseParDo)
@@ -276,16 +281,27 @@ class GreedyPCollectionFusers {
       @SuppressWarnings("unused") Environment environment,
       @SuppressWarnings("unused") Collection<PCollectionNode> stagePCollections,
       @SuppressWarnings("unused") QueryablePipeline pipeline) {
-    throw new IllegalArgumentException(
-        String.format("Unknown URN %s", transform.getTransform().getSpec().getUrn()));
+    LOG.debug(
+        "Unknown {} {} will not fuse into an existing {}",
+        PTransform.class.getSimpleName(),
+        transform.getTransform(),
+        ExecutableStage.class.getSimpleName(),
+        PTransform.class.getSimpleName());
+    return false;
   }
 
+  // Things with unknown URNs either execute within their own stage or are executed by the runner.
+  // In either case, assume the
   private static boolean unknownTransformCompatibility(
       PTransformNode transform,
       @SuppressWarnings("unused") PTransformNode other,
       @SuppressWarnings("unused") QueryablePipeline pipeline) {
-    throw new IllegalArgumentException(
-        String.format(
-            "Unknown or unsupported URN %s", transform.getTransform().getSpec().getUrn()));
+    LOG.debug(
+        "Unknown {} {} will not root a {} with other {}",
+        PTransform.class.getSimpleName(),
+        transform.getTransform(),
+        ExecutableStage.class.getSimpleName(),
+        PTransform.class.getSimpleName());
+    return false;
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPCollectionFusers.java
@@ -276,6 +276,8 @@ class GreedyPCollectionFusers {
     return false;
   }
 
+  // Things with unknown URNs either execute within their own stage or are executed by the runner.
+  // In either case, assume the system is capable of executing the expressed transform
   private static boolean unknownTransformFusion(
       PTransformNode transform,
       @SuppressWarnings("unused") Environment environment,
@@ -291,7 +293,7 @@ class GreedyPCollectionFusers {
   }
 
   // Things with unknown URNs either execute within their own stage or are executed by the runner.
-  // In either case, assume the
+  // In either case, assume the system is capable of executing the expressed transform
   private static boolean unknownTransformCompatibility(
       PTransformNode transform,
       @SuppressWarnings("unused") PTransformNode other,


### PR DESCRIPTION
If the transforms are executed in a Runner, they should be handled by
the runner. If they are executed in an Environment, the environment
should be able to handle them, but we should be maximally restrictive in
terms of what Stage they are placed in.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

