### PR TITLE
Updated to Ubuntu 16 version of python 2

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM python:2
+FROM python:2-stretch
 MAINTAINER "Apache Beam <dev@beam.apache.org>"
 
 # Install native bindings required for dependencies.


### PR DESCRIPTION
Update to a modern version, with new glibc library.

R: @alanmyrvold 
