### PR TITLE
[BEAM-3818] Add support for streaming side inputs in the DirectRunner (part 2: unblock tasks as the _SideInputsContainer gets updated) 

### DIFF
--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -87,16 +87,16 @@ class _SideInputsContainer(object):
   def get_value_or_block_until_ready(self, side_input, task, block_until):
     """Returns the value of a view whose task is unblocked or blocks its task.
 
-    It returns the value of a view whose watermark has been updated and
+    It gets the value of a view whose watermark has been updated and
     surpasses a given value.
 
     Args:
-      side_input: (_UnpickledSideInput) value.
-      task: (TransformExecutor) task waiting on a side input.
+      side_input: ``_UnpickledSideInput`` value.
+      task: ``TransformExecutor`` task waiting on a side input.
       block_until: Timestamp after which the task gets unblocked.
 
     Returns:
-      The (SideInputMap) value of a view when the tasks it blocks are unblocked
+      The ``SideInputMap`` value of a view when the tasks it blocks are unblocked
       Otherwise, None.
     """
     with self._lock:
@@ -144,7 +144,7 @@ class _SideInputsContainer(object):
     recorded when the watermark moved and unblocks tasks accordingly.
 
     Args:
-      side_input: (_UnpickledSideInput) value.
+      side_input: ``_UnpickledSideInput`` value.
       watermark: Value of the watermark after an update for a PTransform.
 
     Returns:

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -96,7 +96,8 @@ class _SideInputsContainer(object):
       block_until: Timestamp after which the task gets unblocked.
 
     Returns:
-      The value of a view when 'its' task is unblocked (otherwise, None).
+      The (SideInputMap) value of a view when the tasks it blocks are unblocked
+      Otherwise, None.
     """
     with self._lock:
       view = self._views[side_input]
@@ -154,16 +155,15 @@ class _SideInputsContainer(object):
       view = self._views[side_input]
       view.watermark = watermark
 
-      # Unblock and finalize tasks
       view = self._views[side_input]
-      tasks_to_remove = []
+      tasks_just_unblocked = []
       for task, block_until in view.blocked_tasks:
-        if watermark.input_watermark >= block_until and view.elements:
+        if watermark.input_watermark >= block_until:
           view.value = self._pvalue_to_value(side_input, view.elements)
           unblocked_tasks.append(task)
-          tasks_to_remove.append((task, block_until))
+          tasks_just_unblocked.append((task, block_until))
           task.blocked = False
-      for task in tasks_to_remove:
+      for task in tasks_just_unblocked:
         view.blocked_tasks.remove(task)
       return unblocked_tasks
 

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -96,12 +96,12 @@ class _SideInputsContainer(object):
       block_until: Timestamp after which the task gets unblocked.
 
     Returns:
-      The ``SideInputMap`` value of a view when the tasks it blocks are unblocked
-      Otherwise, None.
+      The ``SideInputMap`` value of a view when the tasks it blocks are
+      unblocked. Otherwise, None.
     """
     with self._lock:
       view = self._views[side_input]
-      if view.watermark and view.watermark.input_watermark >= block_until:
+      if view.watermark and view.watermark.output_watermark >= block_until:
         view.value = self._pvalue_to_value(side_input, view.elements)
         return view.value
       else:
@@ -158,7 +158,7 @@ class _SideInputsContainer(object):
       view = self._views[side_input]
       tasks_just_unblocked = []
       for task, block_until in view.blocked_tasks:
-        if watermark.input_watermark >= block_until:
+        if watermark.output_watermark >= block_until:
           view.value = self._pvalue_to_value(side_input, view.elements)
           unblocked_tasks.append(task)
           tasks_just_unblocked.append((task, block_until))

--- a/sdks/python/apache_beam/runners/direct/evaluation_context.py
+++ b/sdks/python/apache_beam/runners/direct/evaluation_context.py
@@ -151,11 +151,10 @@ class _SideInputsContainer(object):
       Tasks that get unblocked as a result of the watermark advancing.
     """
     with self._lock:
-      unblocked_tasks = []
       view = self._views[side_input]
       view.watermark = watermark
 
-      view = self._views[side_input]
+      unblocked_tasks = []
       tasks_just_unblocked = []
       for task, block_until in view.blocked_tasks:
         if watermark.output_watermark >= block_until:

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -302,7 +302,7 @@ class TransformExecutor(_ExecutorService.CallableTask):
       block_until = main_onto_side_window.end
 
       if side_input not in self._side_input_values:
-        value = self._evaluation_context.get_value_or_schedule_after_output(
+        value = self._evaluation_context.get_value_or_block_until_ready(
             side_input, self, block_until)
         if not value:
           # Monitor task will reschedule this executor once the side input is

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -272,7 +272,8 @@ class TransformExecutor(_ExecutorService.CallableTask):
     self._transform_evaluator_registry = transform_evaluator_registry
     self._evaluation_context = evaluation_context
     self._input_bundle = input_bundle
-    # For non-empty bundles, store the window of the max EOW
+    # For non-empty bundles, store the window of the max EOW.
+    # TODO(mariagh): Move to class _Bundle's inner _StackedWindowedValues
     if input_bundle._elements:
       self._latest_main_input_window = input_bundle._elements[0].windows[0]
       for elem in input_bundle.get_elements_iterable():
@@ -295,7 +296,7 @@ class TransformExecutor(_ExecutorService.CallableTask):
     scoped_metrics_container = ScopedMetricsContainer(metrics_container)
 
     for side_input in self._applied_ptransform.side_inputs:
-      # Find the projection of main's window onto the side input's window
+      # Find the projection of main's window onto the side input's window.
       window_mapping_fn = side_input._view_options().get(
           'window_mapping_fn', sideinputs._global_window_mapping_fn)
       main_onto_side_window = window_mapping_fn(self._latest_main_input_window)

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -274,7 +274,8 @@ class TransformExecutor(_ExecutorService.CallableTask):
     self._input_bundle = input_bundle
     # For non-empty bundles, store the window of the max EOW.
     # TODO(mariagh): Move to class _Bundle's inner _StackedWindowedValues
-    if input_bundle._elements:
+    # if input_bundle._elements:
+    if input_bundle.has_elements():
       self._latest_main_input_window = input_bundle._elements[0].windows[0]
       for elem in input_bundle.get_elements_iterable():
         if elem.windows[0].end > self._latest_main_input_window.end:

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -274,7 +274,6 @@ class TransformExecutor(_ExecutorService.CallableTask):
     self._input_bundle = input_bundle
     # For non-empty bundles, store the window of the max EOW.
     # TODO(mariagh): Move to class _Bundle's inner _StackedWindowedValues
-    # if input_bundle._elements:
     if input_bundle.has_elements():
       self._latest_main_input_window = input_bundle._elements[0].windows[0]
       for elem in input_bundle.get_elements_iterable():

--- a/sdks/python/apache_beam/runners/direct/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/direct/watermark_manager.py
@@ -144,7 +144,7 @@ class WatermarkManager(object):
             for consumer in consumers:
               unblocked_tasks.extend(
                   self._refresh_watermarks(consumer, side_inputs_container))
-      # notify the side_inputs_container
+      # Notify the side_inputs_container.
       unblocked_tasks.extend(
           side_inputs_container
           .update_watermarks_for_transform_and_unblock_tasks(

--- a/sdks/python/apache_beam/runners/direct/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/direct/watermark_manager.py
@@ -144,8 +144,10 @@ class WatermarkManager(object):
             for consumer in consumers:
               unblocked_tasks.extend(
                   self._refresh_watermarks(consumer, side_inputs_container))
+      # notify the side_inputs_container
       unblocked_tasks.extend(
-          side_inputs_container.update_watermarks_for_transform(
+          side_inputs_container
+          .update_watermarks_for_transform_and_unblock_tasks(
               applied_ptransform, tw))
     return unblocked_tasks
 

--- a/sdks/python/apache_beam/testing/test_stream_test.py
+++ b/sdks/python/apache_beam/testing/test_stream_test.py
@@ -247,7 +247,7 @@ class TestStreamTest(unittest.TestCase):
     # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
     self.assertEqual([('k', ['a'])], result)
 
-  def test_basic_execution_sideinputs_batch(self):
+  def test_basic_execution_batch_sideinputs(self):
 
     # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
     global result     # pylint: disable=global-variable-undefined
@@ -301,13 +301,14 @@ class TestStreamTest(unittest.TestCase):
     main_stream = (p
                    | 'main TestStream' >> TestStream()
                    .advance_watermark_to(10)
-                   .add_elements(['e'])
-                   .advance_processing_time(11))
+                   .add_elements(['e']))
     side_stream = (p
                    | 'side TestStream' >> TestStream()
                    .add_elements([window.TimestampedValue(2, 2)])
                    .add_elements([window.TimestampedValue(1, 1)])
-                   .add_elements([window.TimestampedValue(4, 4)]))
+                   .add_elements([window.TimestampedValue(7, 7)])
+                   .add_elements([window.TimestampedValue(4, 4)])
+                  )
 
     class RecordFn(beam.DoFn):
       def process(self,
@@ -323,7 +324,103 @@ class TestStreamTest(unittest.TestCase):
     p.run()
 
     # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
-    self.assertEqual([('e', Timestamp(10), [2, 1, 4])], result)
+    self.assertEqual([('e', Timestamp(10), [2, 1, 7, 4])], result)
+
+  def test_basic_execution_batch_sideinputs_fixed_windows(self):
+
+    # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
+    global result     # pylint: disable=global-variable-undefined
+    result = []
+
+    def recorded_elements(elem):
+      result.append(elem)
+      return elem
+
+    options = PipelineOptions()
+    options.view_as(StandardOptions).streaming = True
+    p = TestPipeline(options=options)
+
+    main_stream = (p
+                   | 'main TestStream' >> TestStream()
+                   .advance_watermark_to(2)
+                   .add_elements(['a'])
+                   .advance_watermark_to(4)
+                   .add_elements(['b'])
+                   | 'main window' >> beam.WindowInto(window.FixedWindows(1)))
+    side = (p
+            | beam.Create([2, 1, 4])
+            | beam.Map(lambda t: window.TimestampedValue(t, t))
+            | beam.WindowInto(window.FixedWindows(2)))
+
+    class RecordFn(beam.DoFn):
+      def process(self,
+                  elm=beam.DoFn.ElementParam,
+                  ts=beam.DoFn.TimestampParam,
+                  side=beam.DoFn.SideInputParam):
+        yield (elm, ts, side)
+
+    records = (main_stream     # pylint: disable=unused-variable
+               | beam.ParDo(RecordFn(), beam.pvalue.AsList(side))
+               | beam.Map(recorded_elements))
+    p.run()
+
+    # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
+    self.assertEqual([('a', Timestamp(2), [2]),
+                      ('b', Timestamp(4), [4])], result)
+
+  def test_basic_execution_sideinputs_fixed_windows(self):
+
+    # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
+    global result     # pylint: disable=global-variable-undefined
+    result = []
+
+    def recorded_elements(elem):
+      result.append(elem)
+      return elem
+
+    options = PipelineOptions()
+    options.view_as(StandardOptions).streaming = True
+    p = TestPipeline(options=options)
+
+    main_stream = (p
+                   | 'main TestStream' >> TestStream()
+                   .advance_watermark_to(9)
+                   .add_elements(['a1', 'a2', 'a3', 'a4'])
+                   .add_elements(['b'])
+                   .advance_watermark_to(18)
+                   .add_elements('c')
+                   | 'main windowInto' >> beam.WindowInto(
+                       window.FixedWindows(1))
+                  )
+    side_stream = (p
+                   | 'side TestStream' >> TestStream()
+                   .advance_watermark_to(12)
+                   .add_elements([window.TimestampedValue('s1', 10)])
+                   .advance_watermark_to(20)
+                   .add_elements([window.TimestampedValue('s2', 20)])
+                   | 'side windowInto' >> beam.WindowInto(
+                       window.FixedWindows(3))
+                  )
+
+    class RecordFn(beam.DoFn):
+      def process(self,
+                  elm=beam.DoFn.ElementParam,
+                  ts=beam.DoFn.TimestampParam,
+                  side=beam.DoFn.SideInputParam):
+        yield (elm, ts, side)
+
+    records = (main_stream     # pylint: disable=unused-variable
+               | beam.ParDo(RecordFn(), beam.pvalue.AsList(side_stream))
+               | beam.Map(recorded_elements))
+    p.run()
+
+    # TODO(BEAM-3377): Remove after assert_that in streaming is fixed.
+    self.assertEqual([('a1', Timestamp(9), ['s1']),
+                      ('a2', Timestamp(9), ['s1']),
+                      ('a3', Timestamp(9), ['s1']),
+                      ('a4', Timestamp(9), ['s1']),
+                      ('b', Timestamp(9), ['s1']),
+                      ('c', Timestamp(18), ['s2'])], result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- [x] Unblock tasks as the `_SideInputsContainer` gets updated.
  - [x] Add attribute `watermark` to `view`.
  - [x] Add condition for blocking (`view.watermark < block_until`).
- [x] Add projection of main input onto side input.
- [x] Change names of variables to have consistency between `view` (type is `_SideInputView`) and `side_input` (type is `_UnpickledSideInput`).
- [x] Add tests 
  - [x] `test_basic_execution_batch_sideinputs_fixed_windows`
  - [x] `test_basic_execution_sideinputs_fixed_windows`