### PR TITLE
Add _from_runtime_iterable to DataflowSideInput

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -948,6 +948,10 @@ class _DataflowSideInput(beam.pvalue.AsSideInput):
   def _side_input_data(self):
     return self._data
 
+  @staticmethod
+  def _from_runtime_iterable(it, options):
+    return options['data'].view_fn(it)
+
 
 class _DataflowIterableSideInput(_DataflowSideInput):
   """Wraps an iterable side input as dataflow-compatible side input."""


### PR DESCRIPTION
This change adds the missing `_from_runtime_iterable` method which is needed in `_DataflowSideInput`, which was missing in https://github.com/apache/beam/pull/4781.