### PR TITLE
BEAM-3119 ensure the metrics thread pool is related to an execution

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -22,6 +22,8 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,6 +31,8 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
 import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
@@ -172,48 +176,53 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
     }
     pipeline.replaceAll(defaultTransformOverrides());
     MetricsEnvironment.setMetricsSupported(true);
-    DirectGraphVisitor graphVisitor = new DirectGraphVisitor();
-    pipeline.traverseTopologically(graphVisitor);
+    try {
+      DirectGraphVisitor graphVisitor = new DirectGraphVisitor();
+      pipeline.traverseTopologically(graphVisitor);
 
-    @SuppressWarnings("rawtypes")
-    KeyedPValueTrackingVisitor keyedPValueVisitor = KeyedPValueTrackingVisitor.create();
-    pipeline.traverseTopologically(keyedPValueVisitor);
+      @SuppressWarnings("rawtypes")
+      KeyedPValueTrackingVisitor keyedPValueVisitor = KeyedPValueTrackingVisitor.create();
+      pipeline.traverseTopologically(keyedPValueVisitor);
 
-    DisplayDataValidator.validatePipeline(pipeline);
-    DisplayDataValidator.validateOptions(getPipelineOptions());
+      DisplayDataValidator.validatePipeline(pipeline);
+      DisplayDataValidator.validateOptions(getPipelineOptions());
 
-    DirectGraph graph = graphVisitor.getGraph();
-    EvaluationContext context =
-        EvaluationContext.create(
-            getPipelineOptions(),
-            clockSupplier.get(),
-            Enforcement.bundleFactoryFor(enabledEnforcements, graph),
-            graph,
-            keyedPValueVisitor.getKeyedPValues());
+      DirectGraph graph = graphVisitor.getGraph();
+      ExecutorService metricsPool = Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+            .setThreadFactory(MoreExecutors.platformThreadFactory())
+            .setDaemon(false) // otherwise you say you want to leak, please don't!
+            .setNameFormat("direct-metrics-counter-committer")
+            .build());
+      EvaluationContext context = EvaluationContext.create(
+          getPipelineOptions(), clockSupplier.get(),
+          Enforcement.bundleFactoryFor(enabledEnforcements, graph),
+          graph, keyedPValueVisitor.getKeyedPValues(),
+          metricsPool);
 
-    TransformEvaluatorRegistry registry = TransformEvaluatorRegistry.defaultRegistry(context);
-    PipelineExecutor executor =
-        ExecutorServiceParallelExecutor.create(
-            options.getTargetParallelism(),
-            registry,
-            Enforcement.defaultModelEnforcements(enabledEnforcements),
-            context);
-    executor.start(graph, RootProviderRegistry.defaultRegistry(context));
+      TransformEvaluatorRegistry registry = TransformEvaluatorRegistry.defaultRegistry(context);
+      PipelineExecutor executor = ExecutorServiceParallelExecutor.create(
+          options.getTargetParallelism(), registry,
+          Enforcement.defaultModelEnforcements(enabledEnforcements), context, metricsPool);
+      executor.start(graph, RootProviderRegistry.defaultRegistry(context));
 
-    DirectPipelineResult result = new DirectPipelineResult(executor, context);
-    if (options.isBlockOnRun()) {
-      try {
-        result.waitUntilFinish();
-      } catch (UserCodeException userException) {
-        throw new PipelineExecutionException(userException.getCause());
-      } catch (Throwable t) {
-        if (t instanceof RuntimeException) {
-          throw (RuntimeException) t;
+      DirectPipelineResult result = new DirectPipelineResult(executor, context);
+      if (options.isBlockOnRun()) {
+        try {
+          result.waitUntilFinish();
+        } catch (UserCodeException userException) {
+          throw new PipelineExecutionException(userException.getCause());
+        } catch (Throwable t) {
+          if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+          }
+          throw new RuntimeException(t);
         }
-        throw new RuntimeException(t);
       }
+      return result;
+    } finally {
+      MetricsEnvironment.setMetricsSupported(false);
     }
-    return result;
   }
 
   /**

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectMetricsTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectMetricsTest.java
@@ -26,6 +26,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.beam.runners.core.construction.metrics.MetricKey;
 import org.apache.beam.runners.core.metrics.DistributionData;
 import org.apache.beam.runners.core.metrics.GaugeData;
@@ -37,6 +39,7 @@ import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.joda.time.Instant;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,11 +63,19 @@ public class DirectMetricsTest {
   private static final MetricName NAME3 = MetricName.named("ns2", "name1");
   private static final MetricName NAME4 = MetricName.named("ns2", "name2");
 
-  private DirectMetrics metrics = new DirectMetrics();
+  private DirectMetrics metrics;
+  private ExecutorService executor;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
+    executor = Executors.newSingleThreadExecutor();
+    metrics = new DirectMetrics(executor);
+  }
+
+  @After
+  public void tearDown() {
+    executor.shutdownNow();
   }
 
   @SuppressWarnings("unchecked")

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.core.StateNamespaces;
@@ -119,7 +120,8 @@ public class EvaluationContextTest {
             NanosOffsetClock.create(),
             bundleFactory,
             graph,
-            keyedPValueTrackingVisitor.getKeyedPValues());
+            keyedPValueTrackingVisitor.getKeyedPValues(),
+            Executors.newSingleThreadExecutor());
 
     createdProducer = graph.getProducer(created);
     downstreamProducer = graph.getProducer(downstream);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.direct;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
+
+import com.google.common.collect.LinkedListMultimap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.ThreadLeakTracker;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.rules.TestRule;
+
+/**
+ * Validates some basic behavior for the ExecutorServiceParallelExecutor.
+ */
+public class ExecutorServiceParallelExecutorTest {
+
+  @Rule
+  public final TestRule threadTracker = new ThreadLeakTracker();
+
+  @Rule
+  public final TestName testName = new TestName();
+
+  @Test
+  public void ensureMetricsThreadDoesntLeak() {
+    final DirectGraph graph = DirectGraph.create(
+      emptyMap(), emptyMap(), LinkedListMultimap.create(),
+      LinkedListMultimap.create(), emptySet(), emptyMap());
+    final ExecutorService executorService = Executors.newSingleThreadExecutor(
+      new ThreadFactoryBuilder()
+        .setDaemon(false)
+        .setNameFormat("dontleak_" + getClass().getName() + "#" + testName.getMethodName())
+        .build());
+
+    // fake a metrics usage
+    executorService.submit(() -> {});
+
+    final EvaluationContext context = EvaluationContext.create(
+      PipelineOptionsFactory.create().as(DirectOptions.class),
+      MockClock.fromInstant(Instant.now()),
+      CloningBundleFactory.create(), graph, emptySet(), executorService);
+    ExecutorServiceParallelExecutor
+      .create(
+        2,
+              TransformEvaluatorRegistry.defaultRegistry(context),
+              emptyMap(),
+              context,
+              executorService)
+      .stop();
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ThreadLeakTracker.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ThreadLeakTracker.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Tracks the threads created during a test method execution (or class using @ClassRule)
+ * and fails if some still exists after the test method execution.
+ */
+public class ThreadLeakTracker implements TestRule {
+  private final Field groupField;
+
+  public ThreadLeakTracker() {
+    try {
+      groupField = Thread.class.getDeclaredField("group");
+      if (!groupField.isAccessible()) {
+        groupField.setAccessible(true);
+      }
+    } catch (final NoSuchFieldException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public Statement apply(final Statement base, final Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        final Thread thread = Thread.currentThread();
+        final ThreadGroup threadGroup = thread.getThreadGroup();
+        final ThreadGroup testGroup = new ThreadGroup(threadGroup, Long.toString(thread.getId()));
+        groupField.set(thread, testGroup);
+        try {
+          base.evaluate();
+        } finally {
+          groupField.set(thread, threadGroup);
+          final Thread[] threads = listThreads();
+          final List<Thread> leaked = Stream.of(threads)
+            .filter(t -> t.getThreadGroup() == testGroup)
+            .collect(toList());
+          if (!leaked.isEmpty()) {
+            fail("Some threads leaked: " + leaked.stream().map(Thread::getName)
+              .collect(joining("\n- ", "\n- ", "")));
+          }
+        }
+      }
+    };
+  }
+
+  private Thread[] listThreads() {
+    final int count = Thread.activeCount();
+    final Thread[] threads = new Thread[Math.max(count * 2, 16)];
+    final int threadCount = Thread.enumerate(threads);
+    final Thread[] array = new Thread[threadCount];
+    System.arraycopy(threads, 0, array, 0, threadCount);
+    return array;
+  }
+}


### PR DESCRIPTION
metrics counter thread leaks in direct runner, this PR binds this pool to an execution

IMPORTANT: it depends on  https://github.com/apache/beam/pull/4790 to work

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

