### PR TITLE
Add lint checks for modules under sdks/python/.

### DIFF
--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -21,8 +21,6 @@ import glob
 import logging
 import multiprocessing
 import os
-import pip
-import pkg_resources
 import platform
 import pprint
 import shutil
@@ -31,12 +29,15 @@ import sys
 import time
 import warnings
 
+import pip
+import pkg_resources
+
 GRPC_TOOLS = 'grpcio-tools>=1.3.5,<2'
 
 BEAM_PROTO_PATHS = [
-  os.path.join('..', '..', 'model', 'pipeline', 'src', 'main', 'proto'),
-  os.path.join('..', '..', 'model', 'job-management', 'src', 'main', 'proto'),
-  os.path.join('..', '..', 'model', 'fn-execution', 'src', 'main', 'proto'),
+    os.path.join('..', '..', 'model', 'pipeline', 'src', 'main', 'proto'),
+    os.path.join('..', '..', 'model', 'job-management', 'src', 'main', 'proto'),
+    os.path.join('..', '..', 'model', 'fn-execution', 'src', 'main', 'proto'),
 ]
 
 PYTHON_OUTPUT_PATH = os.path.join('apache_beam', 'portability', 'api')
@@ -45,7 +46,7 @@ PYTHON_OUTPUT_PATH = os.path.join('apache_beam', 'portability', 'api')
 def generate_proto_files(force=False):
 
   try:
-    import grpc_tools
+    import grpc_tools  # pylint: disable=unused-variable
   except ImportError:
     warnings.warn('Installing grpcio-tools is recommended for development.')
 
@@ -98,27 +99,27 @@ def generate_proto_files(force=False):
       logging.info('Regenerating out-of-date Python proto definitions.')
       builtin_protos = pkg_resources.resource_filename('grpc_tools', '_proto')
       args = (
-        [sys.executable] +  # expecting to be called from command line
-        ['--proto_path=%s' % builtin_protos] +
-        ['--proto_path=%s' % d for d in proto_dirs] +
-        ['--python_out=%s' % out_dir] +
-        # TODO(robertwb): Remove the prefix once it's the default.
-        ['--grpc_python_out=grpc_2_0:%s' % out_dir] +
-        proto_files)
+          [sys.executable] +  # expecting to be called from command line
+          ['--proto_path=%s' % builtin_protos] +
+          ['--proto_path=%s' % d for d in proto_dirs] +
+          ['--python_out=%s' % out_dir] +
+          # TODO(robertwb): Remove the prefix once it's the default.
+          ['--grpc_python_out=grpc_2_0:%s' % out_dir] +
+          proto_files)
       ret_code = protoc.main(args)
       if ret_code:
         raise RuntimeError(
             'Protoc returned non-zero status (see logs for details): '
             '%s' % ret_code)
 
-
     if sys.version_info[0] >= 3:
       ret_code = subprocess.call(
-        ["futurize", "--both-stages", "--write", "--verbose", "--no-diff", out_dir])
+          ["futurize", "--both-stages", "--write", "--verbose", "--no-diff",
+           out_dir])
 
       if ret_code:
         raise RuntimeError(
-          'Error applying futurize to generated protobuf python files.')
+            'Error applying futurize to generated protobuf python files.')
 
 
 # Though wheels are available for grpcio-tools, setup_requires uses
@@ -133,7 +134,7 @@ def _install_grpcio_tools_and_generate_proto_files():
   build_path = install_path + '-build'
   if os.path.exists(build_path):
     shutil.rmtree(build_path)
-  logging.warning('Installing grpcio-tools into %s' % install_path)
+  logging.warning('Installing grpcio-tools into %s', install_path)
   try:
     start = time.time()
     pprint.pprint(pip.pep425tags.get_supported())
@@ -142,7 +143,7 @@ def _install_grpcio_tools_and_generate_proto_files():
          '--target', install_path, '--build', build_path,
          '--upgrade', GRPC_TOOLS])
     logging.warning(
-        'Installing grpcio-tools took %0.2f seconds.' % (time.time() - start))
+        'Installing grpcio-tools took %0.2f seconds.', time.time() - start)
   finally:
     sys.stderr.flush()
     shutil.rmtree(build_path)

--- a/sdks/python/run_pylint.sh
+++ b/sdks/python/run_pylint.sh
@@ -26,7 +26,7 @@
 set -o errexit
 set -o pipefail
 
-MODULE=apache_beam
+MODULE=$(ls --directory -C apache_beam *.py)
 
 usage(){ echo "Usage: $0 [MODULE|--help]  # The default MODULE is $MODULE"; }
 
@@ -59,12 +59,12 @@ done
 echo "Skipping lint for generated files: $FILES_TO_IGNORE"
 
 echo "Running pylint for module $MODULE:"
-pylint -j8 "$MODULE" --ignore-patterns="$FILES_TO_IGNORE"
+pylint -j8 ${MODULE} --ignore-patterns="$FILES_TO_IGNORE"
 echo "Running pycodestyle for module $MODULE:"
-pycodestyle "$MODULE" --exclude="$FILES_TO_IGNORE"
+pycodestyle ${MODULE} --exclude="$FILES_TO_IGNORE"
 echo "Running flake8 for module $MODULE:"
 # TODO(BEAM-3959): Add F821 (undefined names) as soon as that test passes
-flake8 $MODULE --count --select=E9,F822,F823 --show-source --statistics
+flake8 ${MODULE} --count --select=E9,F822,F823 --show-source --statistics
 
 echo "Running isort for module $MODULE:"
 # Skip files where isort is behaving weirdly
@@ -86,9 +86,8 @@ done
 for file in "${EXCLUDED_GENERATED_FILES[@]}"; do
   SKIP_PARAM="$SKIP_PARAM --skip $(basename $file)"
 done
-pushd "$MODULE"
-isort -p apache_beam --line-width 120 --check-only --order-by-type --combine-star --force-single-line-imports --diff ${SKIP_PARAM}
-popd
+isort ${MODULE} -p apache_beam --line-width 120 --check-only --order-by-type \
+    --combine-star --force-single-line-imports --diff --recursive ${SKIP_PARAM}
 
 FUTURIZE_EXCLUDED=(
   "typehints.py"

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -17,31 +17,29 @@
 
 """Apache Beam SDK for Python setup file."""
 
-from distutils.version import StrictVersion
+from __future__ import print_function
 
-import glob
 import os
-import pkg_resources
 import platform
 import re
-import shutil
-import subprocess
-import sys
 import warnings
+from distutils.version import StrictVersion
 
+# Pylint and isort disagree here.
+# pylint: disable=ungrouped-imports
 import setuptools
-
+from pkg_resources import DistributionNotFound
+from pkg_resources import get_distribution
 from setuptools.command.build_py import build_py
 from setuptools.command.sdist import sdist
 from setuptools.command.test import test
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 
 def get_version():
   global_names = {}
-  exec(open(os.path.normpath('./apache_beam/version.py')).read(), global_names)
+  exec(open(os.path.normpath('./apache_beam/version.py')).read(), global_names)  # pylint: disable=exec-used
   return global_names['__version__']
+
 
 PACKAGE_NAME = 'apache-beam'
 PACKAGE_VERSION = get_version()
@@ -120,14 +118,14 @@ REQUIRED_TEST_PACKAGES = [
     ]
 
 GCP_REQUIREMENTS = [
-  # oauth2client >=4 only works with google-apitools>=0.5.18.
-  'google-apitools>=0.5.18,<=0.5.20',
-  'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4',
-  'googledatastore==7.0.1',
-  'google-cloud-pubsub==0.26.0',
-  'proto-google-cloud-pubsub-v1==0.15.4',
-  # GCP packages required by tests
-  'google-cloud-bigquery==0.25.0',
+    # oauth2client >=4 only works with google-apitools>=0.5.18.
+    'google-apitools>=0.5.18,<=0.5.20',
+    'proto-google-cloud-datastore-v1>=0.90.0,<=0.90.4',
+    'googledatastore==7.0.1',
+    'google-cloud-pubsub==0.26.0',
+    'proto-google-cloud-pubsub-v1==0.15.4',
+    # GCP packages required by tests
+    'google-cloud-bigquery==0.25.0',
 ]
 
 
@@ -137,6 +135,7 @@ def generate_protos_first(original_cmd):
     # See https://issues.apache.org/jira/browse/BEAM-2366
     # pylint: disable=wrong-import-position
     import gen_protos
+
     class cmd(original_cmd, object):
       def run(self):
         gen_protos.generate_proto_files()
@@ -153,8 +152,8 @@ def generate_common_urns():
       '../../'
       'model/pipeline/src/main/resources/org/apache/beam/model/common_urns.md')
   out = os.path.join(
-    os.path.dirname(__file__),
-    'apache_beam/portability/common_urns.py')
+      os.path.dirname(__file__),
+      'apache_beam/portability/common_urns.py')
   src_time = os.path.getmtime(src) if os.path.exists(src) else -1
   out_time = os.path.getmtime(out) if os.path.exists(out) else -1
   if src_time > out_time:
@@ -173,6 +172,8 @@ def generate_common_urns():
         + '\n'.join('%s = "%s"' % urn
                     for urn in sorted(urns.items(), key=lambda kv: kv[1]))
         + '\n')
+
+
 generate_common_urns()
 
 python_requires = '>=2.7'
@@ -226,8 +227,8 @@ setuptools.setup(
     keywords=PACKAGE_KEYWORDS,
     entry_points={
         'nose.plugins.0.10': [
-            'beam_test_plugin = test_config:BeamTestPlugin'
-    ]},
+            'beam_test_plugin = test_config:BeamTestPlugin',
+        ]},
     cmdclass={
         'build_py': generate_protos_first(build_py),
         'sdist': generate_protos_first(sdist),


### PR DESCRIPTION
Currently only modules under sdks/python/apache_beam/ are linted.

