### PR TITLE
[BEAM-3914] Deduplicate Unzipped Flattens after Pipeline Fusion

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/FusedPipeline.java
@@ -98,28 +98,16 @@ public abstract class FusedPipeline {
   private Map<String, PTransform> getEnvironmentExecutedTransforms() {
     Map<String, PTransform> topLevelTransforms = new HashMap<>();
     for (ExecutableStage stage : getFusedStages()) {
+      String baseName =
+          String.format(
+              "%s/%s",
+              stage.getInputPCollection().getPCollection().getUniqueName(),
+              stage.getEnvironment().getUrl());
+      Set<String> usedNames =
+          Sets.union(topLevelTransforms.keySet(), getComponents().getTransformsMap().keySet());
       topLevelTransforms.put(
-          generateStageId(
-              stage,
-              Sets.union(getComponents().getTransformsMap().keySet(), topLevelTransforms.keySet())),
-          stage.toPTransform());
+          SyntheticNodes.uniqueId(baseName, usedNames::contains), stage.toPTransform());
     }
     return topLevelTransforms;
-  }
-
-  private String generateStageId(ExecutableStage stage, Set<String> existingIds) {
-    int i = 0;
-    String name;
-    do {
-      // Instead this could include the name of the root transforms
-      name =
-          String.format(
-              "%s/%s.%s",
-              stage.getInputPCollection().getPCollection().getUniqueName(),
-              stage.getEnvironment().getUrl(),
-              i);
-      i++;
-    } while (existingIds.contains(name));
-    return name;
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
@@ -304,7 +304,7 @@ class OutputDeduplicator {
         updatedStageComponents,
         stage.getEnvironment(),
         stage.getInputPCollection(),
-        stage.getSideInputPCollections(),
+        stage.getSideInputs(),
         updatedTransforms,
         updatedOutputs);
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicator.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+
+/**
+ * Utilities to insert synthetic {@link PCollectionNode PCollections} for {@link PCollection
+ * PCollections} which are produced by multiple independently executable stages.
+ */
+class OutputDeduplicator {
+
+  /**
+   * Ensure that no {@link PCollection} output by any of the {@code stages} or {@code
+   * unfusedTransforms} is produced by more than one of those stages or transforms.
+   *
+   * <p>For each {@link PCollection} output by multiple stages and/or transforms, each producer is
+   * rewritten to produce a partial {@link PCollection}, which are then flattened together via an
+   * introduced Flatten node which produces the original output.
+   */
+  static DeduplicationResult ensureSingleProducer(
+      QueryablePipeline pipeline,
+      Collection<ExecutableStage> stages,
+      Collection<PTransformNode> unfusedTransforms) {
+    RunnerApi.Components.Builder unzippedComponents = pipeline.getComponents().toBuilder();
+
+    Multimap<PCollectionNode, StageOrTransform> pcollectionProducers =
+        getProducers(pipeline, stages, unfusedTransforms);
+    Multimap<StageOrTransform, PCollectionNode> requiresNewOutput = HashMultimap.create();
+    // Create a synthetic PCollection for each of these nodes. The transforms in the runner
+    // portion of the graph that creates them should be replaced in the result components. The
+    // ExecutableStage must also be rewritten to have updated outputs and transforms.
+    for (Map.Entry<PCollectionNode, Collection<StageOrTransform>> collectionProducer :
+        pcollectionProducers.asMap().entrySet()) {
+      if (collectionProducer.getValue().size() > 1) {
+        for (StageOrTransform producer : collectionProducer.getValue()) {
+          requiresNewOutput.put(producer, collectionProducer.getKey());
+        }
+      }
+    }
+
+    Map<ExecutableStage, ExecutableStage> updatedStages = new LinkedHashMap<>();
+    Map<String, PTransformNode> updatedTransforms = new LinkedHashMap<>();
+    Multimap<String, PCollectionNode> originalToPartial = HashMultimap.create();
+    for (Map.Entry<StageOrTransform, Collection<PCollectionNode>> deduplicationTargets :
+        requiresNewOutput.asMap().entrySet()) {
+      if (deduplicationTargets.getKey().getStage() != null) {
+        StageDeduplication deduplication =
+            deduplicatePCollections(
+                deduplicationTargets.getKey().getStage(),
+                deduplicationTargets.getValue(),
+                unzippedComponents::containsPcollections);
+        for (Entry<String, PCollectionNode> originalToPartialReplacement :
+            deduplication.getOriginalToPartialPCollections().entrySet()) {
+          originalToPartial.put(
+              originalToPartialReplacement.getKey(), originalToPartialReplacement.getValue());
+          unzippedComponents.putPcollections(
+              originalToPartialReplacement.getValue().getId(),
+              originalToPartialReplacement.getValue().getPCollection());
+        }
+        updatedStages.put(
+            deduplicationTargets.getKey().getStage(), deduplication.getUpdatedStage());
+      } else if (deduplicationTargets.getKey().getTransform() != null) {
+        PTransformDeduplication deduplication =
+            deduplicatePCollections(
+                deduplicationTargets.getKey().getTransform(),
+                deduplicationTargets.getValue(),
+                unzippedComponents::containsPcollections);
+        for (Entry<String, PCollectionNode> originalToPartialReplacement :
+            deduplication.getOriginalToPartialPCollections().entrySet()) {
+          originalToPartial.put(
+              originalToPartialReplacement.getKey(), originalToPartialReplacement.getValue());
+          unzippedComponents.putPcollections(
+              originalToPartialReplacement.getValue().getId(),
+              originalToPartialReplacement.getValue().getPCollection());
+        }
+        updatedTransforms.put(
+            deduplicationTargets.getKey().getTransform().getId(),
+            deduplication.getUpdatedTransform());
+      } else {
+        throw new IllegalStateException(
+            String.format(
+                "%s with no %s or %s",
+                StageOrTransform.class.getSimpleName(),
+                ExecutableStage.class.getSimpleName(),
+                PTransformNode.class.getSimpleName()));
+      }
+    }
+
+    Set<PTransformNode> introducedFlattens = new LinkedHashSet<>();
+    for (Map.Entry<String, Collection<PCollectionNode>> partialFlattenTargets :
+        originalToPartial.asMap().entrySet()) {
+      PTransform flattenPartialPCollections =
+          createFlattenOfPartials(partialFlattenTargets.getKey(), partialFlattenTargets.getValue());
+      String flattenId =
+          SyntheticNodes.uniqueId("unzipped_flatten", unzippedComponents::containsTransforms);
+      unzippedComponents.putTransforms(flattenId, flattenPartialPCollections);
+      introducedFlattens.add(PipelineNode.pTransform(flattenId, flattenPartialPCollections));
+    }
+
+    Components components = unzippedComponents.build();
+    return DeduplicationResult.of(components, introducedFlattens, updatedStages, updatedTransforms);
+  }
+
+  @AutoValue
+  abstract static class DeduplicationResult {
+    private static DeduplicationResult of(
+        RunnerApi.Components components,
+        Set<PTransformNode> introducedTransforms,
+        Map<ExecutableStage, ExecutableStage> stages,
+        Map<String, PTransformNode> unfused) {
+      return new AutoValue_OutputDeduplicator_DeduplicationResult(
+          components, introducedTransforms, stages, unfused);
+    }
+
+    abstract RunnerApi.Components getDeduplicatedComponents();
+
+    abstract Set<PTransformNode> getIntroducedTransforms();
+
+    abstract Map<ExecutableStage, ExecutableStage> getDeduplicatedStages();
+
+    abstract Map<String, PTransformNode> getDeduplicatedTransforms();
+  }
+
+  private static PTransform createFlattenOfPartials(
+      String outputId, Collection<PCollectionNode> generatedInputs) {
+    PTransform.Builder newFlattenBuilder = PTransform.newBuilder();
+    int i = 0;
+    for (PCollectionNode generatedInput : generatedInputs) {
+      String localInputId = String.format("input_%s", i);
+      i++;
+      newFlattenBuilder.putInputs(localInputId, generatedInput.getId());
+    }
+    // Flatten all of the new partial nodes together.
+    return newFlattenBuilder
+        .putOutputs("output", outputId)
+        .setSpec(FunctionSpec.newBuilder().setUrn(PTransformTranslation.FLATTEN_TRANSFORM_URN))
+        .build();
+  }
+
+  /**
+   * Returns the map from each {@link PCollectionNode} produced by any of the {@link ExecutableStage
+   * stages} or {@link PTransformNode transforms} to all of the {@link ExecutableStage stages} or
+   * {@link PTransformNode transforms} that produce it.
+   */
+  private static Multimap<PCollectionNode, StageOrTransform> getProducers(
+      QueryablePipeline pipeline,
+      Iterable<ExecutableStage> stages,
+      Iterable<PTransformNode> unfusedTransforms) {
+    Multimap<PCollectionNode, StageOrTransform> pcollectionProducers = HashMultimap.create();
+    for (ExecutableStage stage : stages) {
+      for (PCollectionNode output : stage.getOutputPCollections()) {
+        pcollectionProducers.put(output, StageOrTransform.stage(stage));
+      }
+    }
+    for (PTransformNode unfused : unfusedTransforms) {
+      for (PCollectionNode output : pipeline.getOutputPCollections(unfused)) {
+        pcollectionProducers.put(output, StageOrTransform.transform(unfused));
+      }
+    }
+    return pcollectionProducers;
+  }
+
+  private static PTransformDeduplication deduplicatePCollections(
+      PTransformNode transform,
+      Collection<PCollectionNode> duplicates,
+      Predicate<String> existingPCollectionIds) {
+    Map<String, PCollectionNode> unzippedOutputs =
+        createPartialPCollections(duplicates, existingPCollectionIds);
+    PTransform pTransform = updateOutputs(transform.getTransform(), unzippedOutputs);
+    return PTransformDeduplication.of(
+        PipelineNode.pTransform(transform.getId(), pTransform), unzippedOutputs);
+  }
+
+  @AutoValue
+  abstract static class PTransformDeduplication {
+    public static PTransformDeduplication of(
+        PTransformNode updatedTransform, Map<String, PCollectionNode> originalToPartial) {
+      return new AutoValue_OutputDeduplicator_PTransformDeduplication(
+          updatedTransform, originalToPartial);
+    }
+
+    abstract PTransformNode getUpdatedTransform();
+
+    abstract Map<String, PCollectionNode> getOriginalToPartialPCollections();
+  }
+
+  private static StageDeduplication deduplicatePCollections(
+      ExecutableStage stage,
+      Collection<PCollectionNode> duplicates,
+      Predicate<String> existingPCollectionIds) {
+    Map<String, PCollectionNode> unzippedOutputs =
+        createPartialPCollections(duplicates, existingPCollectionIds);
+    ExecutableStage updatedStage = deduplicateStageOutput(stage, unzippedOutputs);
+    return StageDeduplication.of(updatedStage, unzippedOutputs);
+  }
+
+  @AutoValue
+  abstract static class StageDeduplication {
+    public static StageDeduplication of(
+        ExecutableStage updatedStage, Map<String, PCollectionNode> originalToPartial) {
+      return new AutoValue_OutputDeduplicator_StageDeduplication(updatedStage, originalToPartial);
+    }
+
+    abstract ExecutableStage getUpdatedStage();
+
+    abstract Map<String, PCollectionNode> getOriginalToPartialPCollections();
+  }
+
+  /**
+   * Returns a {@link Map} from the ID of a {@link PCollectionNode PCollection} to a {@link
+   * PCollectionNode} that contains part of that {@link PCollectionNode PCollection}.
+   */
+  private static Map<String, PCollectionNode> createPartialPCollections(
+      Collection<PCollectionNode> duplicates, Predicate<String> existingPCollectionIds) {
+    Map<String, PCollectionNode> unzippedOutputs = new LinkedHashMap<>();
+    Predicate<String> existingOrNewIds =
+        existingPCollectionIds.or(
+            id ->
+                unzippedOutputs.values().stream().map(PCollectionNode::getId).anyMatch(id::equals));
+    for (PCollectionNode duplicateOutput : duplicates) {
+      String id = SyntheticNodes.uniqueId(duplicateOutput.getId(), existingOrNewIds);
+      PCollection partial = duplicateOutput.getPCollection().toBuilder().setUniqueName(id).build();
+      // Check to make sure there is only one duplicated output with the same id - which ensures we
+      // only introduce one 'partial output' per producer of that output.
+      PCollectionNode alreadyDeduplicated =
+          unzippedOutputs.put(duplicateOutput.getId(), PipelineNode.pCollection(id, partial));
+      checkArgument(alreadyDeduplicated == null, "a duplicate should only appear once per stage");
+    }
+    return unzippedOutputs;
+  }
+
+  /**
+   * Returns an {@link ExecutableStage} where all of the {@link PCollectionNode PCollections}
+   * matching the original are replaced with the introduced partial {@link PCollection} in all
+   * references made within the {@link ExecutableStage}.
+   */
+  private static ExecutableStage deduplicateStageOutput(
+      ExecutableStage stage, Map<String, PCollectionNode> originalToPartial) {
+    Collection<PTransformNode> updatedTransforms = new ArrayList<>();
+    for (PTransformNode transform : stage.getTransforms()) {
+      PTransform updatedTransform = updateOutputs(transform.getTransform(), originalToPartial);
+      updatedTransforms.add(PipelineNode.pTransform(transform.getId(), updatedTransform));
+    }
+    Collection<PCollectionNode> updatedOutputs = new ArrayList<>();
+    for (PCollectionNode output : stage.getOutputPCollections()) {
+      updatedOutputs.add(originalToPartial.getOrDefault(output.getId(), output));
+    }
+    RunnerApi.Components updatedStageComponents =
+        stage
+            .getComponents()
+            .toBuilder()
+            .clearTransforms()
+            .putAllTransforms(
+                updatedTransforms
+                    .stream()
+                    .collect(Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform)))
+            .putAllPcollections(
+                originalToPartial
+                    .values()
+                    .stream()
+                    .collect(
+                        Collectors.toMap(PCollectionNode::getId, PCollectionNode::getPCollection)))
+            .build();
+    return ImmutableExecutableStage.of(
+        updatedStageComponents,
+        stage.getEnvironment(),
+        stage.getInputPCollection(),
+        stage.getSideInputPCollections(),
+        updatedTransforms,
+        updatedOutputs);
+  }
+
+  /**
+   * Returns a {@link PTransform} like the input {@link PTransform}, but with each output to {@code
+   * originalPCollection} replaced with an output (with the same local name) to {@code
+   * newPCollection}.
+   */
+  private static PTransform updateOutputs(
+      PTransform transform, Map<String, PCollectionNode> originalToPartial) {
+    PTransform.Builder updatedTransformBuilder = transform.toBuilder();
+    for (Map.Entry<String, String> output : transform.getOutputsMap().entrySet()) {
+      if (originalToPartial.containsKey(output.getValue())) {
+        updatedTransformBuilder.putOutputs(
+            output.getKey(), originalToPartial.get(output.getValue()).getId());
+      }
+    }
+    return updatedTransformBuilder.build();
+  }
+
+  @AutoValue
+  abstract static class StageOrTransform {
+    public static StageOrTransform stage(ExecutableStage stage) {
+      return new AutoValue_OutputDeduplicator_StageOrTransform(stage, null);
+    }
+
+    public static StageOrTransform transform(PTransformNode transform) {
+      return new AutoValue_OutputDeduplicator_StageOrTransform(null, transform);
+    }
+
+    @Nullable
+    abstract ExecutableStage getStage();
+
+    @Nullable
+    abstract PTransformNode getTransform();
+  }
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SyntheticNodes.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SyntheticNodes.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import java.util.function.Predicate;
+
+/**
+ * A utility class to interact with synthetic {@link PipelineNode Pipeline Nodes}.
+ */
+class SyntheticNodes {
+  private SyntheticNodes() {}
+
+  /**
+   * Generate an ID which does not collide with any existing ID, as determined by the input
+   * predicate.
+   *
+   * <p>The returned ID will be in the form "${baseName}:${number}".
+   */
+  public static String uniqueId(String baseName, Predicate<String> existingIds) {
+    int i = 0;
+    String name;
+    do {
+      name = String.format("%s:%s", baseName, i);
+      i++;
+    } while (existingIds.test(name));
+    return name;
+  }
+}

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuserTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuserTest.java
@@ -18,12 +18,22 @@
 
 package org.apache.beam.runners.core.construction.graph;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyIterable;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
@@ -38,6 +48,10 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.StateSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.TimerSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.WindowIntoPayload;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.AnyOf;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -242,7 +256,7 @@ public class GreedyPipelineFuserTest {
 
     assertThat(
         fused.getRunnerExecutedTransforms(),
-        contains(
+        containsInAnyOrder(
             PipelineNode.pTransform("impulse", components.getTransformsOrThrow("impulse")),
             PipelineNode.pTransform("groupByKey", components.getTransformsOrThrow("groupByKey"))));
     assertThat(
@@ -342,8 +356,9 @@ public class GreedyPipelineFuserTest {
    * pyImpulse -> .out -> pyRead -> .out /                    -> pyParDo -> .out
    *
    * becomes
-   * (goImpulse.out) -> goRead -> goRead.out -> flatten -> (flatten.out)
-   * (pyImpulse.out) -> pyRead -> pyRead.out -> flatten -> (flatten.out)
+   * (goImpulse.out) -> goRead -> goRead.out -> flatten -> (flatten.out_synthetic0)
+   * (pyImpulse.out) -> pyRead -> pyRead.out -> flatten -> (flatten.out_synthetic1)
+   * flatten.out_synthetic0 & flatten.out_synthetic1 -> synthetic_flatten -> flatten.out
    * (flatten.out) -> goParDo
    * (flatten.out) -> pyParDo
    */
@@ -453,19 +468,39 @@ public class GreedyPipelineFuserTest {
     FusedPipeline fused =
         GreedyPipelineFuser.fuse(Pipeline.newBuilder().setComponents(components).build());
 
+    assertThat(fused.getRunnerExecutedTransforms(), hasSize(3));
     assertThat(
+        "The runner should include the impulses for both languages, plus an introduced flatten",
         fused.getRunnerExecutedTransforms(),
-        containsInAnyOrder(
+        hasItems(
             PipelineNode.pTransform("pyImpulse", components.getTransformsOrThrow("pyImpulse")),
             PipelineNode.pTransform("goImpulse", components.getTransformsOrThrow("goImpulse"))));
+
+    PTransformNode flattenNode = null;
+    for (PTransformNode runnerTransform : fused.getRunnerExecutedTransforms()) {
+      if (getOnlyElement(runnerTransform.getTransform().getOutputsMap().values())
+          .equals("flatten.out")) {
+        flattenNode = runnerTransform;
+      }
+    }
+
+    assertThat(flattenNode, not(nullValue()));
+    assertThat(
+        flattenNode.getTransform().getSpec().getUrn(),
+        equalTo(PTransformTranslation.FLATTEN_TRANSFORM_URN));
+    assertThat(new HashSet<>(flattenNode.getTransform().getInputsMap().values()), hasSize(2));
+
+    Collection<String> introducedOutputs = flattenNode.getTransform().getInputsMap().values();
+    AnyOf<String> anyIntroducedPCollection =
+        anyOf(introducedOutputs.stream().map(Matchers::equalTo).collect(Collectors.toSet()));
     assertThat(
         fused.getFusedStages(),
         containsInAnyOrder(
             ExecutableStageMatcher.withInput("goImpulse.out")
-                .withOutputs("flatten.out")
+                .withOutputs(anyIntroducedPCollection)
                 .withTransforms("goRead", "flatten"),
             ExecutableStageMatcher.withInput("pyImpulse.out")
-                .withOutputs("flatten.out")
+                .withOutputs(anyIntroducedPCollection)
                 .withTransforms("pyRead", "flatten"),
             ExecutableStageMatcher.withInput("flatten.out")
                 .withNoOutputs()
@@ -473,6 +508,19 @@ public class GreedyPipelineFuserTest {
             ExecutableStageMatcher.withInput("flatten.out")
                 .withNoOutputs()
                 .withTransforms("pyParDo")));
+    Set<String> materializedStageOutputs =
+        fused
+            .getFusedStages()
+            .stream()
+            .flatMap(executableStage -> executableStage.getOutputPCollections().stream())
+            .map(PCollectionNode::getId)
+            .collect(Collectors.toSet());
+
+    assertThat(
+        "All materialized stage outputs should be flattened, and no more",
+        materializedStageOutputs,
+        containsInAnyOrder(
+            flattenNode.getTransform().getInputsMap().values().toArray(new String[0])));
   }
 
   /*

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicatorTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/OutputDeduplicatorTest.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.core.construction.graph;
+
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.construction.graph.OutputDeduplicator.DeduplicationResult;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
+import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link OutputDeduplicator}. */
+@RunWith(JUnit4.class)
+public class OutputDeduplicatorTest {
+  @Test
+  public void unchangedWithNoDuplicates() {
+    /* When all the PCollections are produced by only one transform or stage, the result should be
+     * empty//identical to the input.
+     */
+    PTransform one =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "one.out").build();
+    PCollection oneOut = PCollection.newBuilder().setUniqueName("one.out").build();
+    PTransform two =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "two.out").build();
+    PCollection twoOut = PCollection.newBuilder().setUniqueName("two.out").build();
+    PTransform red = PTransform.newBuilder().putOutputs("out", "red.out").build();
+    PCollection redOut = PCollection.newBuilder().setUniqueName("red.out").build();
+    PTransform blue =
+        PTransform.newBuilder()
+            .putInputs("one", "one.out")
+            .putInputs("two", "two.out")
+            .putOutputs("out", "blue.out")
+            .build();
+    PCollection blueOut = PCollection.newBuilder().setUniqueName("blue.out").build();
+    RunnerApi.Components components =
+        Components.newBuilder()
+            .putTransforms("one", one)
+            .putPcollections("one.out", oneOut)
+            .putTransforms("two", two)
+            .putPcollections("two.out", twoOut)
+            .putTransforms("red", red)
+            .putPcollections("red.out", redOut)
+            .putTransforms("blue", blue)
+            .putPcollections("blue.out", blueOut)
+            .build();
+    ExecutableStage oneStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(PipelineNode.pTransform("one", one)),
+            ImmutableList.of(PipelineNode.pCollection("one.out", oneOut)));
+    ExecutableStage twoStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(PipelineNode.pTransform("two", two)),
+            ImmutableList.of(PipelineNode.pCollection("two.out", twoOut)));
+    PTransformNode redTransform = PipelineNode.pTransform("red", red);
+    PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
+    QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
+    DeduplicationResult result =
+        OutputDeduplicator.ensureSingleProducer(
+            pipeline,
+            ImmutableList.of(oneStage, twoStage),
+            ImmutableList.of(redTransform, blueTransform));
+
+    assertThat(result.getDeduplicatedComponents(), equalTo(components));
+    assertThat(result.getDeduplicatedStages().keySet(), empty());
+    assertThat(result.getDeduplicatedTransforms().keySet(), empty());
+    assertThat(result.getIntroducedTransforms(), empty());
+  }
+
+  @Test
+  public void duplicateOverStages() {
+    /* When multiple stages and a runner-executed transform produce a PCollection, all should be
+     * replaced with synthetic flattens.
+     * S -> A; T -> A becomes S -> A'; T -> A''; A', A'' -> Flatten -> A
+     */
+    PTransform one =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "one.out").build();
+    PCollection oneOut = PCollection.newBuilder().setUniqueName("one.out").build();
+    PTransform two =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "two.out").build();
+    PCollection twoOut = PCollection.newBuilder().setUniqueName("two.out").build();
+    PCollection sharedOut = PCollection.newBuilder().setUniqueName("shared.out").build();
+    PTransform shared =
+        PTransform.newBuilder()
+            .putInputs("one", "one.out")
+            .putInputs("two", "two.out")
+            .putOutputs("shared", sharedOut.getUniqueName())
+            .build();
+    PTransform red = PTransform.newBuilder().putOutputs("out", "red.out").build();
+    PCollection redOut = PCollection.newBuilder().setUniqueName("red.out").build();
+    PTransform blue =
+        PTransform.newBuilder()
+            .putInputs("in", sharedOut.getUniqueName())
+            .putOutputs("out", "blue.out")
+            .build();
+    PCollection blueOut = PCollection.newBuilder().setUniqueName("blue.out").build();
+    RunnerApi.Components components =
+        Components.newBuilder()
+            .putTransforms("one", one)
+            .putPcollections("one.out", oneOut)
+            .putTransforms("two", two)
+            .putPcollections("two.out", twoOut)
+            .putTransforms("shared", shared)
+            .putPcollections(sharedOut.getUniqueName(), sharedOut)
+            .putTransforms("red", red)
+            .putPcollections("red.out", redOut)
+            .putTransforms("blue", blue)
+            .putPcollections("blue.out", blueOut)
+            .build();
+    ExecutableStage oneStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(
+                PipelineNode.pTransform("one", one), PipelineNode.pTransform("shared", shared)),
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+    ExecutableStage twoStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(
+                PipelineNode.pTransform("two", two), PipelineNode.pTransform("shared", shared)),
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+    PTransformNode redTransform = PipelineNode.pTransform("red", red);
+    PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
+    QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
+    DeduplicationResult result =
+        OutputDeduplicator.ensureSingleProducer(
+            pipeline,
+            ImmutableList.of(oneStage, twoStage),
+            ImmutableList.of(redTransform, blueTransform));
+
+    assertThat(result.getIntroducedTransforms(), hasSize(1));
+    PTransformNode introduced = getOnlyElement(result.getIntroducedTransforms());
+    assertThat(introduced.getTransform().getOutputsMap().size(), equalTo(1));
+    assertThat(
+        getOnlyElement(introduced.getTransform().getOutputsMap().values()),
+        equalTo(sharedOut.getUniqueName()));
+
+    assertThat(
+        result.getDeduplicatedComponents().getPcollectionsMap().keySet(),
+        hasItems(introduced.getTransform().getInputsMap().values().toArray(new String[0])));
+
+    assertThat(result.getDeduplicatedStages().keySet(), hasSize(2));
+    List<String> stageOutputs =
+        result
+            .getDeduplicatedStages()
+            .values()
+            .stream()
+            .flatMap(stage -> stage.getOutputPCollections().stream().map(PCollectionNode::getId))
+            .collect(Collectors.toList());
+    assertThat(
+        stageOutputs,
+        containsInAnyOrder(introduced.getTransform().getInputsMap().values().toArray()));
+    assertThat(result.getDeduplicatedTransforms().keySet(), empty());
+
+    assertThat(
+        result.getDeduplicatedComponents().getPcollectionsMap().keySet(),
+        hasItems(stageOutputs.toArray(new String[0])));
+    assertThat(
+        result.getDeduplicatedComponents().getTransformsMap(),
+        hasEntry(introduced.getId(), introduced.getTransform()));
+  }
+
+  @Test
+  public void duplicateOverStagesAndTransforms() {
+    /* When both a stage and a runner-executed transform produce a PCollection, all should be
+     * replaced with synthetic flattens.
+     * S -> A; GBK -> A becomes S -> A'; GBK -> A''; A', A'' -> Flatten -> A
+     */
+    PTransform red = PTransform.newBuilder().putOutputs("out", "red.out").build();
+    PCollection redOut = PCollection.newBuilder().setUniqueName("red.out").build();
+    PTransform one =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "one.out").build();
+    PCollection oneOut = PCollection.newBuilder().setUniqueName("one.out").build();
+    PCollection sharedOut = PCollection.newBuilder().setUniqueName("shared.out").build();
+    PTransform shared =
+        PTransform.newBuilder()
+            .putInputs("one", "one.out")
+            .putInputs("red", "red.out")
+            .putOutputs("shared", sharedOut.getUniqueName())
+            .build();
+    PTransform blue =
+        PTransform.newBuilder()
+            .putInputs("in", sharedOut.getUniqueName())
+            .putOutputs("out", "blue.out")
+            .build();
+    PCollection blueOut = PCollection.newBuilder().setUniqueName("blue.out").build();
+    RunnerApi.Components components =
+        Components.newBuilder()
+            .putTransforms("one", one)
+            .putPcollections("one.out", oneOut)
+            .putTransforms("red", red)
+            .putPcollections("red.out", redOut)
+            .putTransforms("shared", shared)
+            .putPcollections(sharedOut.getUniqueName(), sharedOut)
+            .putTransforms("blue", blue)
+            .putPcollections("blue.out", blueOut)
+            .build();
+    PTransformNode sharedTransform = PipelineNode.pTransform("shared", shared);
+    ExecutableStage oneStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(PipelineNode.pTransform("one", one), sharedTransform),
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+    PTransformNode redTransform = PipelineNode.pTransform("red", red);
+    PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
+    QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
+    DeduplicationResult result =
+        OutputDeduplicator.ensureSingleProducer(
+            pipeline,
+            ImmutableList.of(oneStage),
+            ImmutableList.of(redTransform, blueTransform, sharedTransform));
+
+    assertThat(result.getIntroducedTransforms(), hasSize(1));
+    PTransformNode introduced = getOnlyElement(result.getIntroducedTransforms());
+    assertThat(introduced.getTransform().getOutputsMap().size(), equalTo(1));
+    assertThat(
+        getOnlyElement(introduced.getTransform().getOutputsMap().values()),
+        equalTo(sharedOut.getUniqueName()));
+
+    assertThat(
+        result.getDeduplicatedComponents().getPcollectionsMap().keySet(),
+        hasItems(introduced.getTransform().getInputsMap().values().toArray(new String[0])));
+
+    assertThat(result.getDeduplicatedStages().keySet(), hasSize(1));
+    assertThat(result.getDeduplicatedTransforms().keySet(), containsInAnyOrder("shared"));
+
+    List<String> introducedOutputs = new ArrayList<>();
+    introducedOutputs.addAll(
+        result.getDeduplicatedTransforms().get("shared").getTransform().getOutputsMap().values());
+    introducedOutputs.addAll(
+        result
+            .getDeduplicatedStages()
+            .get(oneStage)
+            .getOutputPCollections()
+            .stream()
+            .map(PCollectionNode::getId)
+            .collect(Collectors.toList()));
+    assertThat(
+        introduced.getTransform().getInputsMap().values(),
+        containsInAnyOrder(introducedOutputs.toArray(new String[0])));
+    assertThat(
+        result.getDeduplicatedComponents().getPcollectionsMap().keySet(),
+        hasItems(introducedOutputs.toArray(new String[0])));
+    assertThat(
+        result.getDeduplicatedComponents().getTransformsMap(),
+        hasEntry(introduced.getId(), introduced.getTransform()));
+  }
+
+  @Test
+  public void multipleDuplicatesInStages() {
+    /* A stage that produces multiple duplicates should have them all synthesized.
+     * S -> A, B, C; T -> B, D; U -> A
+     * becomes
+     * S -> A', B', C; T -> B'', D; U -> A'', and A', A'' -> A; B', B'' -> B
+     */
+    PCollection multiOut = PCollection.newBuilder().setUniqueName("multi.out").build();
+    PCollection multiOutOther = PCollection.newBuilder().setUniqueName("multi.out0").build();
+    PTransform multi =
+        PTransform.newBuilder()
+            .putInputs("in", "red.out")
+            .putOutputs("left", multiOut.getUniqueName())
+            .putOutputs("right", multiOutOther.getUniqueName())
+            .build();
+    PTransform one =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "one.out").build();
+    PCollection oneOut = PCollection.newBuilder().setUniqueName("one.out").build();
+    PTransform two =
+        PTransform.newBuilder().putInputs("in", "red.out").putOutputs("out", "two.out").build();
+    PCollection twoOut = PCollection.newBuilder().setUniqueName("two.out").build();
+    PCollection sharedOut = PCollection.newBuilder().setUniqueName("shared.out").build();
+    PTransform shared =
+        PTransform.newBuilder()
+            .putInputs("one", "one.out")
+            .putInputs("two", "two.out")
+            .putOutputs("shared", sharedOut.getUniqueName())
+            .build();
+    PCollection otherSharedOut = PCollection.newBuilder().setUniqueName("shared.out2").build();
+    PTransform otherShared =
+        PTransform.newBuilder()
+            .putInputs("multi", multiOutOther.getUniqueName())
+            .putInputs("two", twoOut.getUniqueName())
+            .putOutputs("out", otherSharedOut.getUniqueName())
+            .build();
+    PTransform red = PTransform.newBuilder().putOutputs("out", "red.out").build();
+    PCollection redOut = PCollection.newBuilder().setUniqueName("red.out").build();
+    PTransform blue =
+        PTransform.newBuilder()
+            .putInputs("in", sharedOut.getUniqueName())
+            .putOutputs("out", "blue.out")
+            .build();
+    PCollection blueOut = PCollection.newBuilder().setUniqueName("blue.out").build();
+    RunnerApi.Components components =
+        Components.newBuilder()
+            .putTransforms("one", one)
+            .putPcollections("one.out", oneOut)
+            .putTransforms("two", two)
+            .putPcollections("two.out", twoOut)
+            .putTransforms("multi", multi)
+            .putPcollections(multiOut.getUniqueName(), multiOut)
+            .putPcollections(multiOutOther.getUniqueName(), multiOutOther)
+            .putTransforms("shared", shared)
+            .putPcollections(sharedOut.getUniqueName(), sharedOut)
+            .putTransforms("otherShared", otherShared)
+            .putPcollections(otherSharedOut.getUniqueName(), otherSharedOut)
+            .putTransforms("red", red)
+            .putPcollections("red.out", redOut)
+            .putTransforms("blue", blue)
+            .putPcollections("blue.out", blueOut)
+            .build();
+    ExecutableStage multiStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(
+                PipelineNode.pTransform("multi", multi),
+                PipelineNode.pTransform("shared", shared),
+                PipelineNode.pTransform("otherShared", otherShared)),
+            ImmutableList.of(
+                PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut),
+                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)));
+    ExecutableStage oneStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(
+                PipelineNode.pTransform("one", one), PipelineNode.pTransform("shared", shared)),
+            ImmutableList.of(PipelineNode.pCollection(sharedOut.getUniqueName(), sharedOut)));
+    ExecutableStage twoStage =
+        ImmutableExecutableStage.of(
+            components,
+            Environment.getDefaultInstance(),
+            PipelineNode.pCollection("red.out", redOut),
+            ImmutableList.of(),
+            ImmutableList.of(
+                PipelineNode.pTransform("two", two),
+                PipelineNode.pTransform("otherShared", otherShared)),
+            ImmutableList.of(
+                PipelineNode.pCollection(otherSharedOut.getUniqueName(), otherSharedOut)));
+    PTransformNode redTransform = PipelineNode.pTransform("red", red);
+    PTransformNode blueTransform = PipelineNode.pTransform("blue", blue);
+    QueryablePipeline pipeline = QueryablePipeline.forPrimitivesIn(components);
+    DeduplicationResult result =
+        OutputDeduplicator.ensureSingleProducer(
+            pipeline,
+            ImmutableList.of(oneStage, twoStage, multiStage),
+            ImmutableList.of(redTransform, blueTransform));
+
+    assertThat(result.getIntroducedTransforms(), hasSize(2));
+    assertThat(
+        result.getDeduplicatedStages().keySet(),
+        containsInAnyOrder(multiStage, oneStage, twoStage));
+    assertThat(result.getDeduplicatedTransforms().keySet(), empty());
+
+    Collection<String> introducedIds =
+        result
+            .getIntroducedTransforms()
+            .stream()
+            .flatMap(pt -> pt.getTransform().getInputsMap().values().stream())
+            .collect(Collectors.toList());
+    String[] stageOutputs =
+        result
+            .getDeduplicatedStages()
+            .values()
+            .stream()
+            .flatMap(s -> s.getOutputPCollections().stream().map(PCollectionNode::getId))
+            .toArray(String[]::new);
+    assertThat(introducedIds, containsInAnyOrder(stageOutputs));
+
+    assertThat(
+        result.getDeduplicatedComponents().getPcollectionsMap().keySet(),
+        hasItems(introducedIds.toArray(new String[0])));
+    assertThat(
+        result.getDeduplicatedComponents().getTransformsMap().entrySet(),
+        hasItems(
+            result
+                .getIntroducedTransforms()
+                .stream()
+                .collect(Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform))
+                .entrySet()
+                .toArray(new Map.Entry[0])));
+  }
+}


### PR DESCRIPTION
Flattens are implicitly unzipped during fusion, by as aggressively as possible
fusing them into any stage that produces one of their inputs. This may lead
to multiple stages producing the same output PCollection (in fact, if a flatten
has inputs that are not all in the same stage, this is guaranteed to happen).

Because utilities expect exactly one PTransform to produce any given PCollection,
this behavior breaks those utilities due to mismatched preconditions. This inserts
a synthetic flatten node to flatten together all of the partial PCollections produced
by each flatten input, executed in the runner, and introduces a synthetic PCollection
for each of the locations the flatten exists within as the only producer of that output.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

