### PR TITLE
Fix golint issues

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -415,7 +415,7 @@ func unmarshalKeyedValues(m map[string]string) []string {
 	index := make(map[string]int)
 	complete := true
 
-	for key, _ := range m {
+	for key := range m {
 		if i, err := strconv.Atoi(strings.TrimPrefix(key, "i")); !strings.HasPrefix(key, "i") || err != nil {
 			complete = false
 			break

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -118,7 +118,7 @@ func (b *CoderUnmarshaller) Coder(id string) (*coder.Coder, error) {
 	return ret, nil
 }
 
-// Coder unmarshals a window with the given id.
+// Window unmarshals a window with the given id.
 func (b *CoderUnmarshaller) Window(id string) (*window.Window, error) {
 	if w, exists := b.windows[id]; exists {
 		return w, nil

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -39,6 +39,7 @@ const (
 
 	// SDK constants
 
+	// URNJavaDoFn is the legacy constant for marking a DoFn.
 	// TODO: remove URNJavaDoFN when the Dataflow runner
 	// uses the model pipeline and no longer falls back to Java.
 	URNJavaDoFn = "urn:beam:dofn:javasdk:0.1"

--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	// Importing to get the side effect of the remote execution hook. See init().
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
+	// Importing to get the side effect of the remote execution hook. See init().
 	_ "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/harness/init"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/compile.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/compile.go
@@ -30,7 +30,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 )
 
-// BuildWorkerTempBinary creates a local worker binary in the tmp directory
+// BuildTempWorkerBinary creates a local worker binary in the tmp directory
 // for linux/amd64. Caller responsible for deleting the binary.
 func BuildTempWorkerBinary(ctx context.Context) (string, error) {
 	filename := filepath.Join(os.TempDir(), fmt.Sprintf("beam-go-%v", time.Now().UnixNano()))

--- a/sdks/go/pkg/beam/runners/universal/universal.go
+++ b/sdks/go/pkg/beam/runners/universal/universal.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
+	// Importing to get the side effect of the remote execution hook. See init().
 	_ "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/harness/init"
 	"github.com/apache/beam/sdks/go/pkg/beam/options/jobopts"
 	"github.com/apache/beam/sdks/go/pkg/beam/runners/universal/runnerlib"

--- a/sdks/go/pkg/beam/validate.go
+++ b/sdks/go/pkg/beam/validate.go
@@ -32,7 +32,7 @@ func ValidateKVType(col PCollection) (typex.FullType, typex.FullType) {
 	return t.Components()[0], t.Components()[1]
 }
 
-// ValidateConcreteType panics if the type of the PCollection is not a
+// ValidateNonCompositeType panics if the type of the PCollection is not a
 // composite type. It returns the type.
 func ValidateNonCompositeType(col PCollection) typex.FullType {
 	t := col.Type()


### PR DESCRIPTION
golint ./...|grep -v unexported|grep -v underscore
should return 0 hits. This CL makes that statement true.
