### PR TITLE
[BEAM-3418] Support multiple SDKHarness in RunnerHarness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -847,6 +847,12 @@
 
       <dependency>
         <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
         <artifactId>grpc-core</artifactId>
         <version>${grpc.version}</version>
       </dependency>

--- a/runners/java-fn-execution/pom.xml
+++ b/runners/java-fn-execution/pom.xml
@@ -65,6 +65,11 @@
 
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-core</artifactId>
     </dependency>
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/GrpcContextHeaderAccessorProvider.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/GrpcContextHeaderAccessorProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution;
+
+import io.grpc.Context;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+
+/**
+ * A HeaderAccessorProvider which intercept the header in a GRPC request and expose the relevant
+ * fields.
+ */
+public class GrpcContextHeaderAccessorProvider {
+
+  private static final Key<String> WORKER_ID_KEY =
+      Key.of("worker_id", Metadata.ASCII_STRING_MARSHALLER);
+  private static final Context.Key<String> SDK_WORKER_CONTEXT_KEY = Context.key("worker_id");
+  private static final GrpcHeaderAccessor HEADER_ACCESSOR = new GrpcHeaderAccessor();
+  private static final ServerInterceptor INTERCEPTOR =
+      new ServerInterceptor() {
+        @Override
+        public <ReqT, RespT> Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata requestHeaders,
+            ServerCallHandler<ReqT, RespT> next) {
+          String workerId = requestHeaders.get(WORKER_ID_KEY);
+          Context context = Context.current().withValue(SDK_WORKER_CONTEXT_KEY, workerId);
+          return Contexts.interceptCall(context, call, requestHeaders, next);
+        }
+      };
+
+  public static ServerInterceptor interceptor() {
+    return INTERCEPTOR;
+  }
+
+  public static HeaderAccessor getHeaderAccessor() {
+    return HEADER_ACCESSOR;
+  }
+
+  private static class GrpcHeaderAccessor implements HeaderAccessor {
+
+    @Override
+    /** This method should be called from the request method. */
+    public String getSdkWorkerId() {
+      return SDK_WORKER_CONTEXT_KEY.get();
+    }
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/HeaderAccessor.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/HeaderAccessor.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution;
+
+/** Interface to access headers in the client request. */
+public interface HeaderAccessor {
+  /** This method should be called from the request method. */
+  String getSdkWorkerId();
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/InProcessServerFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/InProcessServerFactory.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.fnexecution;
 
 import io.grpc.BindableService;
 import io.grpc.Server;
+import io.grpc.ServerInterceptors;
 import io.grpc.inprocess.InProcessServerBuilder;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,7 +51,8 @@ public class InProcessServerFactory extends ServerFactory {
   public Server create(BindableService service, ApiServiceDescriptor serviceDescriptor)
       throws IOException {
     return InProcessServerBuilder.forName(serviceDescriptor.getUrl())
-        .addService(service)
+        .addService(
+            ServerInterceptors.intercept(service, GrpcContextHeaderAccessorProvider.interceptor()))
         .build()
         .start();
   }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java
@@ -22,12 +22,15 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.sdk.fn.stream.SynchronizedStreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,23 +54,25 @@ public class FnApiControlClient implements Closeable, InstructionRequestHandler 
   private final ResponseStreamObserver responseObserver = new ResponseStreamObserver();
   private final ConcurrentMap<String, CompletableFuture<BeamFnApi.InstructionResponse>>
       outstandingRequests;
+  private final Set<Consumer<FnApiControlClient>> onCloseListeners = ConcurrentHashMap.newKeySet();
+  private final String workerId;
   private AtomicBoolean isClosed = new AtomicBoolean(false);
 
-  private FnApiControlClient(StreamObserver<BeamFnApi.InstructionRequest> requestReceiver) {
+  private FnApiControlClient(String workerId, StreamObserver<InstructionRequest> requestReceiver) {
+    this.workerId = workerId;
     this.requestReceiver = SynchronizedStreamObserver.wrapping(requestReceiver);
     this.outstandingRequests = new ConcurrentHashMap<>();
   }
 
   /**
-   * Returns a {@link FnApiControlClient} which will submit its requests to the provided
-   * observer.
+   * Returns a {@link FnApiControlClient} which will submit its requests to the provided observer.
    *
    * <p>It is the responsibility of the caller to register this object as an observer of incoming
    * responses (this will generally be done as part of fulfilling the contract of a gRPC service).
    */
   public static FnApiControlClient forRequestObserver(
-      StreamObserver<BeamFnApi.InstructionRequest> requestObserver) {
-    return new FnApiControlClient(requestObserver);
+      String workerId, StreamObserver<BeamFnApi.InstructionRequest> requestObserver) {
+    return new FnApiControlClient(workerId, requestObserver);
   }
 
   public CompletionStage<BeamFnApi.InstructionResponse> handle(
@@ -88,32 +93,46 @@ public class FnApiControlClient implements Closeable, InstructionRequestHandler 
     closeAndTerminateOutstandingRequests(new IllegalStateException("Runner closed connection"));
   }
 
+  public String getWorkerId() {
+    return workerId;
+  }
+
   /** Closes this client and terminates any outstanding requests exceptionally. */
   private void closeAndTerminateOutstandingRequests(Throwable cause) {
     if (isClosed.getAndSet(true)) {
       return;
     }
 
-    // Make a copy of the map to make the view of the outstanding requests consistent.
-    Map<String, CompletableFuture<BeamFnApi.InstructionResponse>> outstandingRequestsCopy =
-        new ConcurrentHashMap<>(outstandingRequests);
-    outstandingRequests.clear();
+    try {
+      // Make a copy of the map to make the view of the outstanding requests consistent.
+      Map<String, CompletableFuture<BeamFnApi.InstructionResponse>> outstandingRequestsCopy =
+          new ConcurrentHashMap<>(outstandingRequests);
+      outstandingRequests.clear();
 
-    if (outstandingRequestsCopy.isEmpty()) {
-      requestReceiver.onCompleted();
-      return;
-    }
-    requestReceiver.onError(
-        new StatusRuntimeException(Status.CANCELLED.withDescription(cause.getMessage())));
+      if (outstandingRequestsCopy.isEmpty()) {
+        requestReceiver.onCompleted();
+        return;
+      }
+      requestReceiver.onError(
+          new StatusRuntimeException(Status.CANCELLED.withDescription(cause.getMessage())));
 
-    LOG.error(
-        "{} closed, clearing outstanding requests {}",
-        FnApiControlClient.class.getSimpleName(),
-        outstandingRequestsCopy);
-    for (CompletableFuture<BeamFnApi.InstructionResponse> outstandingRequest :
-        outstandingRequestsCopy.values()) {
-      outstandingRequest.completeExceptionally(cause);
+      LOG.error(
+          "{} closed, clearing outstanding requests {}",
+          FnApiControlClient.class.getSimpleName(),
+          outstandingRequestsCopy);
+      for (CompletableFuture<BeamFnApi.InstructionResponse> outstandingRequest :
+          outstandingRequestsCopy.values()) {
+        outstandingRequest.completeExceptionally(cause);
+      }
+    } finally {
+      for (Consumer<FnApiControlClient> onCloseListener : onCloseListeners) {
+        onCloseListener.accept(this);
+      }
     }
+  }
+
+  public void onClose(Consumer<FnApiControlClient> onCloseListener) {
+    onCloseListeners.add(onCloseListener);
   }
 
   /**

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientControlService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientControlService.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.function.Supplier;
 import org.apache.beam.runners.fnexecution.FnService;
+import org.apache.beam.runners.fnexecution.HeaderAccessor;
 import org.apache.beam.runners.fnexecution.data.FnDataService;
 
 /**
@@ -39,15 +40,18 @@ public class SdkHarnessClientControlService implements FnService {
 
   private final Collection<SdkHarnessClient> activeClients;
 
-  public static SdkHarnessClientControlService create(Supplier<FnDataService> dataService) {
-    return new SdkHarnessClientControlService(dataService);
+  public static SdkHarnessClientControlService create(
+      Supplier<FnDataService> dataService, HeaderAccessor headerAccessor) {
+    return new SdkHarnessClientControlService(dataService, headerAccessor);
   }
 
-  private SdkHarnessClientControlService(Supplier<FnDataService> dataService) {
+  private SdkHarnessClientControlService(
+      Supplier<FnDataService> dataService, HeaderAccessor headerAccessor) {
     this.dataService = dataService;
     activeClients = new ConcurrentLinkedQueue<>();
     pendingClients = new SynchronousQueue<>();
-    clientPoolService = FnApiControlClientPoolService.offeringClientsToPool(pendingClients);
+    clientPoolService =
+        FnApiControlClientPoolService.offeringClientsToPool(pendingClients, headerAccessor);
   }
 
   public SdkHarnessClient getClient() {

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/GrpcContextHeaderAccessorProviderTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/GrpcContextHeaderAccessorProviderTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.apache.beam.runners.fnexecution;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Elements;
+import org.apache.beam.model.fnexecution.v1.BeamFnDataGrpc;
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** Tests for {@link GrpcContextHeaderAccessorProvider}. */
+@RunWith(JUnit4.class)
+public class GrpcContextHeaderAccessorProviderTest {
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testWorkerIdOnConnect() throws Exception {
+    final String worker1 = "worker1";
+    CompletableFuture<String> workerId = new CompletableFuture<>();
+    Consumer<StreamObserver<Elements>> consumer =
+        elementsStreamObserver ->
+            workerId.complete(
+                GrpcContextHeaderAccessorProvider.getHeaderAccessor().getSdkWorkerId());
+    TestDataService testService = new TestDataService(Mockito.mock(StreamObserver.class), consumer);
+    ApiServiceDescriptor serviceDescriptor =
+        ApiServiceDescriptor.newBuilder().setUrl("testServer").build();
+    Server server = InProcessServerFactory.create().create(testService, serviceDescriptor);
+    final Metadata.Key<String> workerIdKey =
+        Metadata.Key.of("worker_id", Metadata.ASCII_STRING_MARSHALLER);
+    Channel channel =
+        InProcessChannelBuilder.forName(serviceDescriptor.getUrl())
+            .intercept(
+                new ClientInterceptor() {
+                  @Override
+                  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+                    ClientCall<ReqT, RespT> call = next.newCall(method, callOptions);
+                    return new SimpleForwardingClientCall<ReqT, RespT>(call) {
+                      @Override
+                      public void start(
+                          ClientCall.Listener<RespT> responseListener, Metadata headers) {
+                        headers.put(workerIdKey, worker1);
+                        super.start(responseListener, headers);
+                      }
+                    };
+                  }
+                })
+            .build();
+    BeamFnDataGrpc.BeamFnDataStub stub = BeamFnDataGrpc.newStub(channel);
+    stub.data(Mockito.mock(StreamObserver.class));
+    server.shutdown();
+
+    Assert.assertEquals(worker1, workerId.get());
+  }
+
+  /** A test gRPC service that uses the provided inbound observer for all clients. */
+  private static class TestDataService extends BeamFnDataGrpc.BeamFnDataImplBase {
+    private final StreamObserver<BeamFnApi.Elements> inboundObserver;
+    private final Consumer<StreamObserver<Elements>> consumer;
+
+    private TestDataService(
+        StreamObserver<BeamFnApi.Elements> inboundObserver,
+        Consumer<StreamObserver<BeamFnApi.Elements>> consumer) {
+      this.inboundObserver = inboundObserver;
+      this.consumer = consumer;
+    }
+
+    @Override
+    public StreamObserver<BeamFnApi.Elements> data(
+        StreamObserver<BeamFnApi.Elements> outboundObserver) {
+      consumer.accept(outboundObserver);
+      return inboundObserver;
+    }
+  }
+}

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/InProcessSdkHarness.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/InProcessSdkHarness.java
@@ -72,7 +72,8 @@ public class InProcessSdkHarness extends ExternalResource implements TestRule {
     executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setDaemon(true).build());
     SynchronousQueue<FnApiControlClient> clientPool = new SynchronousQueue<>();
     FnApiControlClientPoolService clientPoolService =
-        FnApiControlClientPoolService.offeringClientsToPool(clientPool);
+        FnApiControlClientPoolService.offeringClientsToPool(
+            clientPool, GrpcContextHeaderAccessorProvider.getHeaderAccessor());
 
     loggingServer =
         GrpcFnServer.allocatePortAndCreateFor(

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolServiceTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnControlGrpc;
+import org.apache.beam.runners.fnexecution.GrpcContextHeaderAccessorProvider;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.InProcessServerFactory;
 import org.apache.beam.sdk.util.MoreFutures;
@@ -52,7 +53,8 @@ public class FnApiControlClientPoolServiceTest {
   // for matching incoming connections and server threads is likely.
   private final BlockingQueue<FnApiControlClient> pool = new LinkedBlockingQueue<>();
   private final FnApiControlClientPoolService controlService =
-      FnApiControlClientPoolService.offeringClientsToPool(pool);
+      FnApiControlClientPoolService.offeringClientsToPool(
+          pool, GrpcContextHeaderAccessorProvider.getHeaderAccessor());
   private GrpcFnServer<FnApiControlClientPoolService> server;
   private BeamFnControlGrpc.BeamFnControlStub stub;
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -47,6 +47,7 @@ import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.FusedPipeline;
 import org.apache.beam.runners.core.construction.graph.GreedyPipelineFuser;
+import org.apache.beam.runners.fnexecution.GrpcContextHeaderAccessorProvider;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.InProcessServerFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors.ExecutableProcessBundleDescriptor;
@@ -110,7 +111,9 @@ public class RemoteExecutionTest implements Serializable {
     BlockingQueue<FnApiControlClient> clientPool = new SynchronousQueue<>();
     controlServer =
         GrpcFnServer.allocatePortAndCreateFor(
-            FnApiControlClientPoolService.offeringClientsToPool(clientPool), serverFactory);
+            FnApiControlClientPoolService.offeringClientsToPool(
+                clientPool, GrpcContextHeaderAccessorProvider.getHeaderAccessor()),
+            serverFactory);
 
     // Create the SDK harness, and wait until it connects
     sdkHarnessExecutor = Executors.newSingleThreadExecutor(threadFactory);


### PR DESCRIPTION
To Support Multiple SDKHarness on a single RunnerHarness we introduced a worker_id in GRPC header for ControlChannel, DataChannel, LoggingChannel and StateChannel.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

