### PR TITLE
Secure GRPC channel for SDK worker

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -34,6 +34,7 @@ import six
 from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
+from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
 
 # This module is experimental. No backwards-compatibility guarantees.
 
@@ -327,6 +328,9 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
                 # is controlled in a layer above.
                 options=[("grpc.max_receive_message_length", -1),
                          ("grpc.max_send_message_length", -1)])
+            # Add workerId to the grpc channel
+            grpc_channel = grpc.intercept_channel(grpc_channel,
+                                                  WorkerIdInterceptor())
             self._data_channel_cache[url] = GrpcClientDataChannel(
                 beam_fn_api_pb2_grpc.BeamFnDataStub(grpc_channel))
 

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -318,6 +318,9 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
                 # is controlled in a layer above.
                 options=[("grpc.max_receive_message_length", -1),
                          ("grpc.max_send_message_length", -1)])
+            # Add workerId to the grpc channel
+            grpc_channel = grpc.intercept_channel(grpc_channel,
+                                                  WorkerIdInterceptor())
             self._data_channel_cache[url] = GrpcClientDataChannel(
                 beam_fn_api_pb2_grpc.BeamFnDataStub(grpc_channel))
           else:

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -312,8 +312,8 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
           # Options to have no limits (-1) on the size of the messages
           # received or sent over the data plane. The actual buffer size
           # is controlled in a layer above.
-          channel_options=[("grpc.max_receive_message_length", -1),
-                           ("grpc.max_send_message_length", -1)]
+          channel_options = [("grpc.max_receive_message_length", -1),
+                             ("grpc.max_send_message_length", -1)]
           grpc_channel = None
           if self._credentials is not None:
             grpc_channel = grpc.secure_channel(

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -315,11 +315,11 @@ class GrpcClientDataChannelFactory(DataChannelFactory):
           channel_options = [("grpc.max_receive_message_length", -1),
                              ("grpc.max_send_message_length", -1)]
           grpc_channel = None
-          if self._credentials is not None:
+          if self._credentials is None:
+            grpc_channel = grpc.insecure_channel(url, options=channel_options)
+          else:
             grpc_channel = grpc.secure_channel(
                 url, self._credentials, options=channel_options)
-          else:
-            grpc_channel = grpc.insecure_channel(url, options=channel_options)
           # Add workerId to the grpc channel
           grpc_channel = grpc.intercept_channel(grpc_channel,
                                                 WorkerIdInterceptor())

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -34,6 +34,7 @@ from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker import bundle_processor
 from apache_beam.runners.worker import data_plane
+from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
 
 
 class SdkHarness(object):
@@ -45,13 +46,14 @@ class SdkHarness(object):
     self._worker_index = 0
     if control_channel is None:
       logging.info('Creating insecure channel.')
-      self._control_channel = grpc.insecure_channel(control_address)
+      self._control_channel = grpc.intercept_channel(
+          grpc.insecure_channel(control_address), WorkerIdInterceptor())
+      self._data_channel_factory = data_plane.GrpcClientDataChannelFactory()
     else:
       logging.info('Using provided channel.')
       self._control_channel = control_channel
-
-    self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
-        credentials)
+      self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
+          credentials)
     self.workers = queue.Queue()
     # one thread is enough for getting the progress report.
     # Assumption:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -67,6 +67,7 @@ class SdkHarness(object):
     self._fns = {}
     self._responses = queue.Queue()
     self._process_bundle_queue = queue.Queue()
+    self._unscheduled_process_bundle = set()
     logging.info('Initializing SDKHarness with %s workers.', self._worker_count)
 
   def run(self):
@@ -157,6 +158,7 @@ class SdkHarness(object):
       work = self._process_bundle_queue.get()
       # add the instuction_id vs worker map for progress reporting lookup
       self._instruction_id_vs_worker[work.instruction_id] = worker
+      self._unscheduled_process_bundle.discard(work.instruction_id)
       try:
         self._execute(lambda: worker.do_instruction(work), work)
       finally:
@@ -167,14 +169,26 @@ class SdkHarness(object):
 
     # Create a task for each process_bundle request and schedule it
     self._process_bundle_queue.put(request)
+    self._unscheduled_process_bundle.add(request.instruction_id)
     self._process_thread_pool.submit(task)
 
   def _request_process_bundle_progress(self, request):
 
     def task():
-      self._execute(lambda: self._instruction_id_vs_worker[getattr(
-          request, request.WhichOneof('request')
-      ).instruction_reference].do_instruction(request), request)
+      instruction_reference = getattr(
+          request, request.WhichOneof('request')).instruction_reference
+      if self._instruction_id_vs_worker.has_key(instruction_reference):
+        self._execute(
+            lambda: self._instruction_id_vs_worker[
+                instruction_reference
+            ].do_instruction(request), request)
+      else:
+        self._execute(lambda: beam_fn_api_pb2.InstructionResponse(
+            instruction_id=request.instruction_id, error=(
+                'Process bundle request not yet scheduled for instruction {}' if
+                instruction_reference in self._unscheduled_process_bundle else
+                'Unknown process bundle instruction {}').format(
+                    instruction_reference)), request)
 
     self._progress_thread_pool.submit(task)
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -51,7 +51,8 @@ class SdkHarness(object):
       self._data_channel_factory = data_plane.GrpcClientDataChannelFactory()
     else:
       logging.info('Using provided channel.')
-      self._control_channel = control_channel
+      self._control_channel = grpc.intercept_channel(
+          control_channel, WorkerIdInterceptor())
       self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
           credentials)
     self.workers = queue.Queue()

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -46,15 +46,14 @@ class SdkHarness(object):
     self._worker_index = 0
     if control_channel is None:
       logging.info('Creating insecure channel.')
-      self._control_channel = grpc.intercept_channel(
-          grpc.insecure_channel(control_address), WorkerIdInterceptor())
-      self._data_channel_factory = data_plane.GrpcClientDataChannelFactory()
+      self._control_channel = grpc.insecure_channel(control_address)
     else:
       logging.info('Using provided channel.')
-      self._control_channel = grpc.intercept_channel(
-          control_channel, WorkerIdInterceptor())
-      self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
-          credentials)
+      self._control_channel = control_channel
+    self._control_channel = grpc.intercept_channel(
+        self._control_channel, WorkerIdInterceptor())
+    self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(
+        credentials)
     self.workers = queue.Queue()
     # one thread is enough for getting the progress report.
     # Assumption:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -40,16 +40,16 @@ from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
 class SdkHarness(object):
   REQUEST_METHOD_PREFIX = '_request_'
 
-  def __init__(self, control_address, worker_count,
-               control_channel=None, credentials=None):
+  def __init__(self, control_address, worker_count, credentials=None):
     self._worker_count = worker_count
     self._worker_index = 0
-    if control_channel is None:
+    if credentials is None:
       logging.info('Creating insecure channel.')
       self._control_channel = grpc.insecure_channel(control_address)
     else:
-      logging.info('Using provided channel.')
-      self._control_channel = control_channel
+      logging.info('Creating secure channel.')
+      self._control_channel = grpc.secure_channel(control_address, credentials)
+      grpc.channel_ready_future(self._control_channel).result()
     self._control_channel = grpc.intercept_channel(
         self._control_channel, WorkerIdInterceptor())
     self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -50,6 +50,7 @@ class SdkHarness(object):
       logging.info('Creating secure channel.')
       self._control_channel = grpc.secure_channel(control_address, credentials)
       grpc.channel_ready_future(self._control_channel).result()
+      logging.info('Secure channel established.')
     self._control_channel = grpc.intercept_channel(
         self._control_channel, WorkerIdInterceptor())
     self._data_channel_factory = data_plane.GrpcClientDataChannelFactory(


### PR DESCRIPTION
This change adds the ability to connect over secure GRPC when credentials are provided. This can be used to establish a secure connection between the SDK and RunnerHarness. The default is still the regular, non-secure connection. 
