### PR TITLE
[BEAM-3983] [SQL] Tables interface supports BigQuery

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
@@ -22,7 +22,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamIOType;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 
@@ -46,7 +46,7 @@ public interface BeamSqlTable {
    * create a {@code IO.write()} instance to write to target.
    *
    */
-   PTransform<? super PCollection<Row>, PDone> buildIOWriter();
+   PTransform<? super PCollection<Row>, POutput> buildIOWriter();
 
   /**
    * Get the schema info of the table.

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.extensions.sql.impl.parser;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONObject;
 import com.google.common.base.Strings;
-import java.net.URI;
 import java.util.List;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
@@ -109,8 +108,8 @@ public class SqlCreateTable extends SqlCall {
     return tblName.toString();
   }
 
-  public URI location() {
-    return location == null ? null : URI.create(getString(location));
+  public String location() {
+    return location == null ? null : getString(location);
   }
 
   public String type() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
@@ -21,7 +21,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 
@@ -56,7 +56,7 @@ public class BeamPCollectionTable extends BaseBeamTable {
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     throw new IllegalArgumentException("cannot use [BeamPCollectionTable] as target");
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
@@ -21,7 +21,6 @@ package org.apache.beam.sdk.extensions.sql.meta;
 import com.alibaba.fastjson.JSONObject;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
-import java.net.URI;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -37,20 +36,12 @@ public abstract class Table implements Serializable {
   @Nullable
   public abstract String getComment();
   @Nullable
-  public abstract URI getLocation();
+  public abstract String getLocation();
   @Nullable
   public abstract JSONObject getProperties();
 
   public static Builder builder() {
     return new org.apache.beam.sdk.extensions.sql.meta.AutoValue_Table.Builder();
-  }
-
-  public String getLocationAsString() {
-    if (getLocation() == null) {
-      return null;
-    }
-
-    return "/" + getLocation().getHost() + getLocation().getPath();
   }
 
   /**
@@ -62,7 +53,7 @@ public abstract class Table implements Serializable {
     public abstract Builder name(String name);
     public abstract Builder columns(List<Column> columns);
     public abstract Builder comment(String name);
-    public abstract Builder location(URI location);
+    public abstract Builder location(String location);
     public abstract Builder properties(JSONObject properties);
     public abstract Table build();
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.extensions.sql.meta.provider.kafka;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
@@ -32,6 +31,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 import org.apache.kafka.common.TopicPartition;
@@ -43,7 +43,7 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
  * extend to convert between {@code BeamSqlRow} and {@code KV<byte[], byte[]>}.
  *
  */
-public abstract class BeamKafkaTable extends BaseBeamTable implements Serializable {
+public abstract class BeamKafkaTable extends BaseBeamTable {
   private String bootstrapServers;
   private List<String> topics;
   private List<TopicPartition> topicPartitions;
@@ -109,11 +109,11 @@ public abstract class BeamKafkaTable extends BaseBeamTable implements Serializab
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     checkArgument(topics != null && topics.size() == 1,
         "Only one topic can be acceptable as output.");
 
-    return new PTransform<PCollection<Row>, PDone>() {
+    return new PTransform<PCollection<Row>, POutput>() {
       @Override
       public PDone expand(PCollection<Row> input) {
         return input.apply("out_reformat", getPTransformForOutput()).apply("persistent",

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
@@ -23,7 +23,7 @@ import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 import org.apache.commons.csv.CSVFormat;
@@ -62,7 +62,7 @@ public class BeamTextCSVTable extends BeamTextTable {
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     return new BeamTextCSVTableIOWriter(rowType, filePattern, csvFormat);
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOWriter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOWriter.java
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 import org.apache.commons.csv.CSVFormat;
@@ -34,7 +34,7 @@ import org.apache.commons.csv.CSVFormat;
 /**
  * IOWriter for {@code BeamTextCSVTable}.
  */
-public class BeamTextCSVTableIOWriter extends PTransform<PCollection<Row>, PDone>
+public class BeamTextCSVTableIOWriter extends PTransform<PCollection<Row>, POutput>
     implements Serializable {
   private String filePattern;
   protected RowType rowType;
@@ -49,7 +49,7 @@ public class BeamTextCSVTableIOWriter extends PTransform<PCollection<Row>, PDone
   }
 
   @Override
-  public PDone expand(PCollection<Row> input) {
+  public POutput expand(PCollection<Row> input) {
     return input.apply("encodeRecord", ParDo.of(new DoFn<Row, String>() {
 
       @ProcessElement

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextTable.java
@@ -18,7 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.meta.provider.text;
 
-import java.io.Serializable;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamIOType;
 import org.apache.beam.sdk.values.RowType;
@@ -26,7 +25,7 @@ import org.apache.beam.sdk.values.RowType;
 /**
  * {@code BeamTextTable} represents a text file/directory(backed by {@code TextIO}).
  */
-public abstract class BeamTextTable extends BaseBeamTable implements Serializable {
+public abstract class BeamTextTable extends BaseBeamTable {
   protected String filePattern;
 
   protected BeamTextTable(RowType rowType, String filePattern) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProvider.java
@@ -40,7 +40,7 @@ import org.apache.commons.csv.CSVFormat;
  * )
  * TYPE 'text'
  * COMMENT 'this is the table orders'
- * LOCATION 'text://home/admin/orders'
+ * LOCATION '/home/admin/orders'
  * TBLPROPERTIES '{"format": "Excel"}' -- format of each text line(csv format)
  * }</pre>
  */
@@ -53,7 +53,7 @@ public class TextTableProvider implements TableProvider {
   @Override public BeamSqlTable buildBeamSqlTable(Table table) {
     RowType rowType = getRowTypeFromTable(table);
 
-    String filePattern = table.getLocationAsString();
+    String filePattern = table.getLocation();
     CSVFormat format = CSVFormat.DEFAULT;
     JSONObject properties = table.getProperties();
     String csvFormatStr = properties.getString("format");

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamSqlParserTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamSqlParserTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.google.common.collect.ImmutableList;
-import java.net.URI;
 import org.apache.beam.sdk.extensions.sql.meta.Column;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
 import org.apache.calcite.sql.SqlNode;
@@ -50,7 +49,7 @@ public class BeamSqlParserTest {
             + "name varchar(31) COMMENT 'name') \n"
             + "TYPE 'text' \n"
             + "COMMENT 'person table' \n"
-            + "LOCATION 'text://home/admin/person'\n"
+            + "LOCATION '/home/admin/person'\n"
             + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
     );
     assertEquals(
@@ -66,7 +65,7 @@ public class BeamSqlParserTest {
             + "id int COMMENT 'id', \n"
             + "name varchar(31) COMMENT 'name') \n"
             + "COMMENT 'person table' \n"
-            + "LOCATION 'text://home/admin/person'\n"
+            + "LOCATION '/home/admin/person'\n"
             + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
     );
   }
@@ -84,7 +83,7 @@ public class BeamSqlParserTest {
             + "id int COMMENT 'id', \n"
             + "name varchar(31) COMMENT 'name') \n"
             + "TYPE 'text' \n"
-            + "LOCATION 'text://home/admin/person'\n"
+            + "LOCATION '/home/admin/person'\n"
             + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
     );
     assertEquals(mockTable("person", "text", null, properties), table);
@@ -98,7 +97,7 @@ public class BeamSqlParserTest {
             + "name varchar(31) COMMENT 'name') \n"
             + "TYPE 'text' \n"
             + "COMMENT 'person table' \n"
-            + "LOCATION 'text://home/admin/person'\n"
+            + "LOCATION '/home/admin/person'\n"
     );
     assertEquals(
         mockTable("person", "text", "person table", new JSONObject()),
@@ -145,21 +144,17 @@ public class BeamSqlParserTest {
   }
 
   private static Table mockTable(String name, String type, String comment, JSONObject properties) {
-    return mockTable(name, type, comment, properties, "text://home/admin/" + name);
+    return mockTable(name, type, comment, properties, "/home/admin/" + name);
   }
 
   private static Table mockTable(String name, String type, String comment, JSONObject properties,
       String location) {
-    URI locationURI = null;
-    if (location != null) {
-      locationURI = URI.create(location);
-    }
 
     return Table.builder()
         .name(name)
         .type(type)
         .comment(comment)
-        .location(locationURI)
+        .location(location)
         .columns(ImmutableList.of(
             Column.builder()
                 .name("id")

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -36,7 +36,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 import org.joda.time.Duration;
@@ -123,7 +123,7 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     }
 
     @Override
-    public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+    public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
       throw new UnsupportedOperationException();
     }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProviderTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertTrue;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 import com.google.common.collect.ImmutableList;
-import java.net.URI;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.meta.Column;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
@@ -65,7 +64,7 @@ public class KafkaTableProviderTest {
     return Table.builder()
         .name(name)
         .comment(name + " table")
-        .location(URI.create("kafka://localhost:2181/brokers?topic=test"))
+        .location("kafka://localhost:2181/brokers?topic=test")
         .columns(ImmutableList.of(
             Column.builder().name("id").coder(INTEGER).primaryKey(true).build(),
             Column.builder().name("name").coder(VARCHAR).primaryKey(false).build()

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.alibaba.fastjson.JSONObject;
 import com.google.common.collect.ImmutableList;
-import java.net.URI;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.meta.Column;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
@@ -76,7 +75,7 @@ public class TextTableProviderTest {
     return Table.builder()
         .name(name)
         .comment(name + " table")
-        .location(URI.create("text://home/admin/" + name))
+        .location("/home/admin/" + name)
         .columns(ImmutableList.of(
             Column.builder().name("id").coder(INTEGER).primaryKey(true).build(),
             Column.builder().name("name").coder(VARCHAR).primaryKey(false).build()

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStoreTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStoreTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertThat;
 
 import com.alibaba.fastjson.JSONObject;
 import com.google.common.collect.ImmutableList;
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
@@ -129,7 +128,7 @@ public class InMemoryMetaStoreTest {
     return Table.builder()
         .name(name)
         .comment(name + " table")
-        .location(URI.create("text://home/admin/" + name))
+        .location("/home/admin/" + name)
         .columns(ImmutableList.of(
             Column.builder().name("id").coder(INTEGER).primaryKey(true).build(),
             Column.builder().name("name").coder(VARCHAR).primaryKey(false).build()

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 
@@ -104,7 +105,7 @@ public class MockedBoundedTable extends MockedTable {
         "MockedBoundedTable_Reader_" + COUNTER.incrementAndGet(), Create.of(rows));
   }
 
-  @Override public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+  @Override public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     return new OutputStore();
   }
 
@@ -112,7 +113,7 @@ public class MockedBoundedTable extends MockedTable {
    * Keep output in {@code CONTENT} for validation.
    *
    */
-  public static class OutputStore extends PTransform<PCollection<Row>, PDone> {
+  public static class OutputStore extends PTransform<PCollection<Row>, POutput> {
 
     @Override
     public PDone expand(PCollection<Row> input) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.RowType;
 
@@ -36,7 +36,7 @@ public abstract class MockedTable extends BaseBeamTable {
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, PDone> buildIOWriter() {
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     throw new UnsupportedOperationException("buildIOWriter unsupported!");
   }
 }


### PR DESCRIPTION
A few changes to the tables interface to support adding BigQuery as a table type.

1. IOWriter outputs the POutput interfaces instead of the PDone type. PDone is just one of the POutput types, BigQuery has its own implementation of POutput.
2. Treat Location as a string instead of a URI. The format of a BigQuery table name is `[PROJECT_ID]:[DATASET].[TABLE]`. Treating the field as a type specific opaque string allows us to support this format as well.

Followup PR #4947 adds actual BigQuery support.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

