### PR TITLE
[BEAM-3952][BEAM-3988] Fix GreedyPipelineFuser test

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/QueryablePipeline.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/QueryablePipeline.java
@@ -110,16 +110,9 @@ public class QueryablePipeline {
     return ids;
   }
 
-  /**
-   * Returns true if the provided transform is a primitive. A primitive has no subtransforms and
-   * produces a new {@link PCollection}.
-   *
-   * <p>Note that this precludes primitive transforms which only consume input and produce no
-   * PCollections as output.
-   */
+  /** Returns true if the provided transform is a primitive. A primitive has no subtransforms. */
   private static boolean isPrimitiveTransform(PTransform transform) {
-    return transform.getSubtransformsCount() == 0
-        && !transform.getInputsMap().values().containsAll(transform.getOutputsMap().values());
+    return transform.getSubtransformsCount() == 0;
   }
 
   private MutableNetwork<PipelineNode, PipelineEdge> buildNetwork(


### PR DESCRIPTION
The test was not considering the downstream `Window` in a different
environment as a primitive, and thus it was being dropped by the
construction of the `QueryablePipeline`.

Also, updated `QueryablePipeline` to consider any node with no
subtransforms as a primitive.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

