### PR TITLE
Fix Python streaming sordcount IT to unblock PostCommit

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
@@ -15,17 +15,9 @@
 # limitations under the License.
 #
 
-"""End-to-end test for the streaming wordcount example.
+"""End-to-end test for the streaming wordcount example."""
 
-Important: End-to-end test infrastructure for streaming pipeine in Python SDK
-is in development and is not yet available for use.
-
-Currently, this test blocks until the job is manually terminated.
-"""
-
-import datetime
 import logging
-import random
 import unittest
 import uuid
 
@@ -67,11 +59,6 @@ class StreamingWordCountIT(unittest.TestCase):
     test_utils.wait_for_topics_created([self.input_topic, self.output_topic])
     self.input_sub.create()
     self.output_sub.create()
-
-  def _generate_identifier(self):
-    seed = random.randint(0, 999)
-    current_time = datetime.datetime.now().strftime('%m%d%H%M%S')
-    return '%s%d' % (current_time, seed)
 
   def _inject_numbers(self, topic, num_messages):
     """Inject numbers as test data to PubSub."""

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -59,7 +59,7 @@ class WordExtractingDoFn(beam.DoFn):
     text_line = element.strip()
     if not text_line:
       self.empty_line_counter.inc(1)
-    words = re.findall(r'[A-Za-z\']+', text_line)
+    words = re.findall(r'[A-Za-z0-9\']+', text_line)
     for w in words:
       self.words_counter.inc()
       self.word_lengths_counter.inc(len(w))

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
@@ -72,7 +72,7 @@ class PubSubMessageMatcher(BaseMatcher):
     self.messages = None
 
   def _matches(self, _):
-    if not self.messages:
+    if self.messages is None:
       subscription = (pubsub
                       .Client(project=self.project)
                       .subscription(self.sub_name))

--- a/sdks/python/run_postcommit.sh
+++ b/sdks/python/run_postcommit.sh
@@ -71,7 +71,7 @@ python setup.py nosetests \
   --attr IT \
   --nocapture \
   --processes=4 \
-  --process-timeout=900 \
+  --process-timeout=1800 \
   --test-pipeline-options=" \
     --runner=TestDataflowRunner \
     --project=$PROJECT \


### PR DESCRIPTION
- Cleanup docs and unused functions in `streaming_wordcount_it_test`
- Extend overall PostCommit IT test timeout to 1800s.
- Change WordExtractingDoFn filter to accept number.
- Fix minor issues in `TestDataflowRunner`
  - Fix `wait_until_in_state`
  - Fix resource cleanup when hamcrest matchers are failed. Jobs can be canceled now even verification step is broken.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

