### PR TITLE
Fixes null pointer exception on empty pubsub message data

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
@@ -185,6 +185,9 @@ public class PubsubJsonClient extends PubsubClient {
 
       // Payload.
       byte[] elementBytes = pubsubMessage.decodeData();
+      if (elementBytes == null) {
+        elementBytes = new byte[0];
+      }
 
       // Timestamp.
       long timestampMsSinceEpoch =


### PR DESCRIPTION
This PR prevents a null pointer exception from being thrown when using the PubsubJsonClient and an incoming pubsub message has no message data. This is achieved by mimicking the PubsubGrpcClient behaviour of interpreting empty message data as an empty byte array instead of null.