### PR TITLE
[BEAM-2852] Add support for Kafka as source/sink on Nexmark

### DIFF
--- a/sdks/java/nexmark/build.gradle
+++ b/sdks/java/nexmark/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   shadow project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-extensions-sql", configuration: "shadow")
+  shadow project(path: ":beam-sdks-java-io-kafka", configuration: "shadow")
   shadow library.java.google_api_services_bigquery
   shadow library.java.jackson_core
   shadow library.java.jackson_annotations
@@ -38,6 +39,7 @@ dependencies {
   shadow library.java.junit
   shadow library.java.hamcrest_core
   shadow library.java.commons_lang3
+  shadow library.java.kafka_clients
   shadow project(path: ":beam-runners-direct-java", configuration: "shadow")
   shadow library.java.slf4j_jdk14
   testCompile library.java.hamcrest_core

--- a/sdks/java/nexmark/pom.xml
+++ b/sdks/java/nexmark/pom.xml
@@ -192,8 +192,21 @@
           <argLine>-da</argLine> <!-- disable assert in Calcite converter validation -->
         </configuration>
       </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
+
+  <properties>
+    <kafka.clients.version>0.10.1.0</kafka.clients.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -274,13 +287,13 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.apache.beam</groupId>
       <artifactId>beam-runners-direct-java</artifactId>
@@ -303,5 +316,23 @@
       <artifactId>commons-lang3</artifactId>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-kafka</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.clients.version}</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/sdks/java/nexmark/pom.xml
+++ b/sdks/java/nexmark/pom.xml
@@ -204,10 +204,6 @@
     </plugins>
   </build>
 
-  <properties>
-    <kafka.clients.version>0.10.1.0</kafka.clients.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.beam</groupId>

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkLauncher.java
@@ -820,18 +820,17 @@ public class NexmarkLauncher<OptionT extends NexmarkOptions> {
   private PCollection<Event> sourceEventsFromKafka(Pipeline p) {
     NexmarkUtils.console("Reading events from Kafka Topic %s", options.getKafkaSourceTopic());
 
-    if (Strings.isNullOrEmpty(options.getBootstrapServers())) {
-      throw new RuntimeException("Missing --bootstrapServers");
-    }
+    checkArgument(!Strings.isNullOrEmpty(options.getBootstrapServers()),
+        "Missing --bootstrapServers");
 
-    KafkaIO.Read<Long, byte[]> io = KafkaIO.<Long, byte[]>read()
+    KafkaIO.Read<Long, byte[]> read = KafkaIO.<Long, byte[]>read()
             .withBootstrapServers(options.getBootstrapServers())
             .withTopic(options.getKafkaSourceTopic())
             .withKeyDeserializer(LongDeserializer.class)
             .withValueDeserializer(ByteArrayDeserializer.class);
 
     return p
-      .apply(queryName + ".ReadKafkaEvents", io.withoutMetadata())
+      .apply(queryName + ".ReadKafkaEvents", read.withoutMetadata())
       .apply(queryName + ".KafkaToEvents", ParDo.of(BYTEARRAY_TO_EVENT));
   }
 

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
@@ -406,4 +406,24 @@ public interface NexmarkOptions
   String getQueryLanguage();
 
   void setQueryLanguage(String value);
+
+  @Description("Base name of Kafka source topic in streaming mode.")
+  @Nullable
+  @Default.String("nexmark-source")
+  String getKafkaSourceTopic();
+
+  void setKafkaSourceTopic(String value);
+
+  @Description("Base name of Kafka sink topic in streaming mode.")
+  @Nullable
+  @Default.String("nexmark-sink")
+  String getKafkaSinkTopic();
+
+  void setKafkaSinkTopic(String value);
+
+  @Description("Kafka Bootstrap Server domains.")
+  @Nullable
+  String getBootstrapServers();
+
+  void setBootstrapServers(String value);
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
@@ -99,7 +99,11 @@ public class NexmarkUtils {
     /**
      * Read from a PubSub topic. It will be fed the same synthetic events by this pipeline.
      */
-    PUBSUB
+    PUBSUB,
+    /**
+     * Read events from a Kafka topic. It will be fed the same synthetic events by this pipeline.
+     */
+    KAFKA
   }
 
   /**
@@ -119,6 +123,10 @@ public class NexmarkUtils {
      */
     PUBSUB,
     /**
+     * Write to a Kafka topic. It will be drained by this pipeline.
+     */
+    KAFKA,
+    /**
      * Write to a text file. Only works in batch mode.
      */
     TEXT,
@@ -129,7 +137,7 @@ public class NexmarkUtils {
     /**
      * Write raw Events to BigQuery.
      */
-    BIGQUERY,
+    BIGQUERY
   }
 
   /**


### PR DESCRIPTION
Allows to use Kafka as as source/sink for Nexmark benchmark.
Based on original implementation of #3937 by @vectorijk 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

