### PR TITLE
Remove redundant traceback logging in Python SDK

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -122,8 +122,7 @@ class SdkHarness(object):
       logging.error(
           'Error processing instruction %s. Original traceback is\n%s\n',
           request.instruction_id,
-          traceback.format_exc(e),
-          exc_info=True)
+          traceback.format_exc(e))
       response = beam_fn_api_pb2.InstructionResponse(
           instruction_id=request.instruction_id, error=str(e))
     self._responses.put(response)


### PR DESCRIPTION
All passing ``exc_info=True`` to ``logging.error()`` does is append the
current traceback to the log message. But the traceback was already explicitly
appended to the log message, so it currently ends up in the log message twice.

This removes the redundant traceback.

Example of current behavior, from https://github.com/apache/beam/pull/4959:
```
ERROR:root:Error processing instruction bundle_1. Original traceback is
Traceback (most recent call last):
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 119, in _execute
    response = task()
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 155, in <lambda>
    self._execute(lambda: worker.do_instruction(work), work)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 201, in do_instruction
    request.instruction_id)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 218, in process_bundle
    processor.process_bundle(instruction_id)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/bundle_processor.py", line 286, in process_bundle
    op.start()
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 238, in start
    self.output(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 159, in output
    cython.cast(Receiver, self.receivers[output_index]).receive(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 85, in receive
    cython.cast(Operation, consumer).process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 392, in process
    self.dofn_receiver.receive(o)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 488, in receive
    self.process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 496, in process
    self._reraise_augmented(exn)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 547, in _reraise_augmented
    six.reraise(type(new_exn), new_exn, original_traceback)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 494, in process
    self.do_fn_invoker.invoke_process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 284, in invoke_process
    windowed_value, self.process_method(windowed_value.value))
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/transforms/core.py", line 972, in <lambda>
    wrapper = lambda x: [fn(x)]
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 287, in first
    return second(x)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 290, in second
    return third(x)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 293, in third
    raise ValueError('x')
ValueError: x [while running 'Map(first)']

Traceback (most recent call last):
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 119, in _execute
    response = task()
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 155, in <lambda>
    self._execute(lambda: worker.do_instruction(work), work)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 201, in do_instruction
    request.instruction_id)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/sdk_worker.py", line 218, in process_bundle
    processor.process_bundle(instruction_id)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/bundle_processor.py", line 286, in process_bundle
    op.start()
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 238, in start
    self.output(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 159, in output
    cython.cast(Receiver, self.receivers[output_index]).receive(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 85, in receive
    cython.cast(Operation, consumer).process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/worker/operations.py", line 392, in process
    self.dofn_receiver.receive(o)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 488, in receive
    self.process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 496, in process
    self._reraise_augmented(exn)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 547, in _reraise_augmented
    six.reraise(type(new_exn), new_exn, original_traceback)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 494, in process
    self.do_fn_invoker.invoke_process(windowed_value)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/common.py", line 284, in invoke_process
    windowed_value, self.process_method(windowed_value.value))
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/transforms/core.py", line 972, in <lambda>
    wrapper = lambda x: [fn(x)]
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 287, in first
    return second(x)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 290, in second
    return third(x)
  File "/usr/local/google/home/shoyer/open-source/beam/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py", line 293, in third
    raise ValueError('x')
ValueError: x [while running 'Map(first)']
```

After this change, the second traceback is removed.