### PR TITLE
[BEAM-3946] Fix pubsub_matcher_test which depends on GOOGLE_APPLICATION_CREDENTIALS

### DIFF
--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher.py
@@ -73,13 +73,13 @@ class PubSubMessageMatcher(BaseMatcher):
 
   def _matches(self, _):
     if self.messages is None:
-      subscription = (pubsub
-                      .Client(project=self.project)
-                      .subscription(self.sub_name))
-      self.messages = self._wait_for_messages(subscription,
+      self.messages = self._wait_for_messages(self._get_subscription(),
                                               len(self.expected_msg),
                                               self.timeout)
     return Counter(self.messages) == Counter(self.expected_msg)
+
+  def _get_subscription(self):
+    return pubsub.Client(project=self.project).subscription(self.sub_name)
 
   def _wait_for_messages(self, subscription, expected_num, timeout):
     """Wait for messages from given subscription."""

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
@@ -44,10 +44,11 @@ class PubSubMatcherTest(unittest.TestCase):
                                                ['mock_expected_msg'])
 
   @mock.patch('time.sleep', return_value=None)
-  @mock.patch('google.cloud.pubsub.Client.subscription')
-  def test_message_matcher_success(self, mock_sub_cls, unsued_mock):
+  @mock.patch('apache_beam.io.gcp.tests.pubsub_matcher.'
+              'PubSubMessageMatcher._get_subscription')
+  def test_message_matcher_success(self, mock_get_sub, unsued_mock):
     self.pubsub_matcher.expected_msg = ['a', 'b']
-    mock_sub = mock_sub_cls.return_value
+    mock_sub = mock_get_sub.return_value
     mock_sub.pull.side_effect = [
         [(1, pubsub.message.Message(b'a', 'unused_id'))],
         [(2, pubsub.message.Message(b'b', 'unused_id'))],
@@ -56,10 +57,11 @@ class PubSubMatcherTest(unittest.TestCase):
     self.assertEqual(mock_sub.pull.call_count, 2)
 
   @mock.patch('time.sleep', return_value=None)
-  @mock.patch('google.cloud.pubsub.Client.subscription')
-  def test_message_matcher_mismatch(self, mock_sub_cls, unused_mock):
+  @mock.patch('apache_beam.io.gcp.tests.pubsub_matcher.'
+              'PubSubMessageMatcher._get_subscription')
+  def test_message_matcher_mismatch(self, mock_get_sub, unused_mock):
     self.pubsub_matcher.expected_msg = ['a']
-    mock_sub = mock_sub_cls.return_value
+    mock_sub = mock_get_sub.return_value
     mock_sub.pull.return_value = [
         (1, pubsub.message.Message(b'c', 'unused_id')),
         (1, pubsub.message.Message(b'd', 'unused_id')),
@@ -73,9 +75,10 @@ class PubSubMatcherTest(unittest.TestCase):
         in str(error.exception.args[0]))
 
   @mock.patch('time.sleep', return_value=None)
-  @mock.patch('google.cloud.pubsub.Client.subscription')
-  def test_message_metcher_timeout(self, mock_sub_cls, unused_mock):
-    mock_sub = mock_sub_cls.return_value
+  @mock.patch('apache_beam.io.gcp.tests.pubsub_matcher.'
+              'PubSubMessageMatcher._get_subscription')
+  def test_message_metcher_timeout(self, mock_get_sub, unused_mock):
+    mock_sub = mock_get_sub.return_value
     mock_sub.return_value.full_name.return_value = 'mock_sub'
     self.pubsub_matcher.timeout = 0.1
     with self.assertRaises(AssertionError) as error:


### PR DESCRIPTION
Fix PubsubMatcher unittest which depends on GOOGLE_APPLICATION_CREDENTIALS when running tests.

Verified fix in a non GOOGLE_APPLICATION_CREDENTIALS installed Ubuntu environment.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

