### PR TITLE
[BEAM-4011] Normalize Filesystems.match() glob behavior.

### DIFF
--- a/sdks/python/apache_beam/io/filesystem_test.py
+++ b/sdks/python/apache_beam/io/filesystem_test.py
@@ -27,6 +27,154 @@ from StringIO import StringIO
 
 from apache_beam.io.filesystem import CompressedFile
 from apache_beam.io.filesystem import CompressionTypes
+from apache_beam.io.filesystem import FileMetadata
+from apache_beam.io.filesystem import FileSystem
+
+
+class TestingFileSystem(FileSystem):
+
+  def __init__(self, pipeline_options):
+    super(TestingFileSystem, self).__init__(pipeline_options)
+    self._files = {}
+
+  @classmethod
+  def scheme(cls):
+    # Required for FileSystems.get_filesystem().
+    return 'test'
+
+  def join(self, basepath, *paths):
+    raise NotImplementedError
+
+  def split(self, path):
+    raise NotImplementedError
+
+  def mkdirs(self, path):
+    raise NotImplementedError
+
+  def has_dirs(self):
+    return False
+
+  def _insert_random_file(self, path, size):
+    self._files[path] = size
+
+  def list(self, dir_or_prefix):
+    for path, size in self._files.iteritems():
+      if path.startswith(dir_or_prefix):
+        yield FileMetadata(path, size)
+
+  def create(self, path, mime_type='application/octet-stream',
+             compression_type=CompressionTypes.AUTO):
+    raise NotImplementedError
+
+  def open(self, path, mime_type='application/octet-stream',
+           compression_type=CompressionTypes.AUTO):
+    raise NotImplementedError
+
+  def copy(self, source_file_names, destination_file_names):
+    raise NotImplementedError
+
+  def rename(self, source_file_names, destination_file_names):
+    raise NotImplementedError
+
+  def exists(self, path):
+    raise NotImplementedError
+
+  def size(self, path):
+    raise NotImplementedError
+
+  def checksum(self, path):
+    raise NotImplementedError
+
+  def delete(self, paths):
+    raise NotImplementedError
+
+
+class TestFileSystem(unittest.TestCase):
+
+  def setUp(self):
+    self.fs = TestingFileSystem(pipeline_options=None)
+
+  def _flatten_match(self, match_results):
+    return [file_metadata
+            for match_result in match_results
+            for file_metadata in match_result.metadata_list]
+
+  def test_match_glob(self):
+    bucket_name = 'gcsio-test'
+    objects = [
+        ('cow/cat/fish', 2),
+        ('cow/cat/blubber', 3),
+        ('cow/dog/blubber', 4),
+        ('apple/dog/blubber', 5),
+        ('apple/fish/blubber', 6),
+        ('apple/fish/blowfish', 7),
+        ('apple/fish/bambi', 8),
+        ('apple/fish/balloon', 9),
+        ('apple/fish/cat', 10),
+        ('apple/fish/cart', 11),
+        ('apple/fish/carl', 12),
+        ('apple/dish/bat', 13),
+        ('apple/dish/cat', 14),
+        ('apple/dish/carl', 15),
+    ]
+    for (object_name, size) in objects:
+      file_name = 'gs://%s/%s' % (bucket_name, object_name)
+      self.fs._insert_random_file(file_name, size)
+    test_cases = [
+        ('gs://gcsio-test/*', objects),
+        ('gs://gcsio-test/cow/*', [
+            ('cow/cat/fish', 2),
+            ('cow/cat/blubber', 3),
+            ('cow/dog/blubber', 4),
+        ]),
+        ('gs://gcsio-test/cow/ca*', [
+            ('cow/cat/fish', 2),
+            ('cow/cat/blubber', 3),
+        ]),
+        ('gs://gcsio-test/apple/[df]ish/ca*', [
+            ('apple/fish/cat', 10),
+            ('apple/fish/cart', 11),
+            ('apple/fish/carl', 12),
+            ('apple/dish/cat', 14),
+            ('apple/dish/carl', 15),
+        ]),
+        ('gs://gcsio-test/apple/fish/car?', [
+            ('apple/fish/cart', 11),
+            ('apple/fish/carl', 12),
+        ]),
+        ('gs://gcsio-test/apple/fish/b*', [
+            ('apple/fish/blubber', 6),
+            ('apple/fish/blowfish', 7),
+            ('apple/fish/bambi', 8),
+            ('apple/fish/balloon', 9),
+        ]),
+        ('gs://gcsio-test/apple/f*/b*', [
+            ('apple/fish/blubber', 6),
+            ('apple/fish/blowfish', 7),
+            ('apple/fish/bambi', 8),
+            ('apple/fish/balloon', 9),
+        ]),
+        ('gs://gcsio-test/apple/dish/[cb]at', [
+            ('apple/dish/bat', 13),
+            ('apple/dish/cat', 14),
+        ]),
+    ]
+    for file_pattern, expected_object_names in test_cases:
+      expected_file_names = [('gs://%s/%s' % (bucket_name, object_name), size)
+                             for (object_name, size) in expected_object_names]
+      self.assertEqual(
+          set([(file_metadata.path, file_metadata.size_in_bytes)
+               for file_metadata in
+               self._flatten_match(self.fs.match([file_pattern]))]),
+          set(expected_file_names))
+
+    # Check if limits are followed correctly
+    limit = 3
+    for file_pattern, expected_object_names in test_cases:
+      expected_num_items = min(len(expected_object_names), limit)
+      self.assertEqual(
+          len(self._flatten_match(self.fs.match([file_pattern], [limit]))),
+          expected_num_items)
 
 
 class TestCompressedFile(unittest.TestCase):

--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -141,6 +141,9 @@ class FileSystems(object):
   def match(patterns, limits=None):
     """Find all matching paths to the patterns provided.
 
+    Pattern matching is done using fnmatch.fnmatch.
+    Patterns ending with '/' will be appended with '*'.
+
     Args:
       patterns: list of string for the file path pattern to match against
       limits: list of maximum number of responses that need to be fetched

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -23,7 +23,6 @@ from apache_beam.io.filesystem import CompressedFile
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileMetadata
 from apache_beam.io.filesystem import FileSystem
-from apache_beam.io.filesystem import MatchResult
 from apache_beam.io.gcp import gcsio
 
 __all__ = ['GCSFileSystem']
@@ -98,45 +97,30 @@ class GCSFileSystem(FileSystem):
     """
     pass
 
-  def match(self, patterns, limits=None):
-    """Find all matching paths to the pattern provided.
+  def has_dirs(self):
+    """Whether this FileSystem supports directories."""
+    return False
+
+  def list(self, dir_or_prefix):
+    """List files in a location.
+
+    Listing is non-recursive, for filesystems that support directories.
 
     Args:
-      pattern: string for the file path pattern to match against
-      limit: Maximum number of responses that need to be fetched
+      dir_or_prefix: (string) A directory or location prefix (for filesystems
+        that don't have directories).
 
-    Returns: list of ``MatchResult`` objects.
+    Returns:
+      Generator of ``FileMetadata`` objects.
 
     Raises:
-      ``BeamIOError`` if any of the pattern match operations fail
+      ``BeamIOError`` if listing fails, but not if no files were found.
     """
-    if limits is None:
-      limits = [None] * len(patterns)
-    else:
-      err_msg = "Patterns and limits should be equal in length"
-      assert len(patterns) == len(limits), err_msg
-
-    def _match(pattern, limit):
-      """Find all matching paths to the pattern provided.
-      """
-      if pattern.endswith('/'):
-        pattern += '*'
-      file_sizes = gcsio.GcsIO().size_of_files_in_glob(pattern, limit)
-      metadata_list = [FileMetadata(path, size)
-                       for path, size in file_sizes.iteritems()]
-      return MatchResult(pattern, metadata_list)
-
-    exceptions = {}
-    result = []
-    for pattern, limit in zip(patterns, limits):
-      try:
-        result.append(_match(pattern, limit))
-      except Exception as e:  # pylint: disable=broad-except
-        exceptions[pattern] = e
-
-    if exceptions:
-      raise BeamIOError("Match operation failed", exceptions)
-    return result
+    try:
+      for path, size in gcsio.GcsIO().list_prefix(dir_or_prefix).iteritems():
+        yield FileMetadata(path, size)
+    except Exception as e:  # pylint: disable=broad-except
+      raise BeamIOError("List operation failed", {dir_or_prefix: e})
 
   def _path_open(self, path, mode, mime_type='application/octet-stream',
                  compression_type=CompressionTypes.AUTO):
@@ -264,6 +248,19 @@ class GCSFileSystem(FileSystem):
     Returns: boolean flag indicating if path exists
     """
     return gcsio.GcsIO().exists(path)
+
+  def size(self, path):
+    """Get size of path on the FileSystem.
+
+    Args:
+      path: string path in question.
+
+    Returns: int size of path according to the FileSystem.
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    return gcsio.GcsIO().size(path)
 
   def checksum(self, path):
     """Fetch checksum metadata of a file on the

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import
 
-import glob
 import os
 import shutil
 
@@ -27,7 +26,6 @@ from apache_beam.io.filesystem import CompressedFile
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileMetadata
 from apache_beam.io.filesystem import FileSystem
-from apache_beam.io.filesystem import MatchResult
 
 __all__ = ['LocalFileSystem']
 
@@ -79,42 +77,34 @@ class LocalFileSystem(FileSystem):
     except OSError as err:
       raise IOError(err)
 
-  def match(self, patterns, limits=None):
-    """Find all matching paths to the pattern provided.
+  def has_dirs(self):
+    """Whether this FileSystem supports directories."""
+    return True
+
+  def list(self, dir_or_prefix):
+    """List files in a location.
+
+    Listing is non-recursive, for filesystems that support directories.
 
     Args:
-      patterns: list of string for the file path pattern to match against
-      limits: list of maximum number of responses that need to be fetched
+      dir_or_prefix: (string) A directory or location prefix (for filesystems
+        that don't have directories).
 
-    Returns: list of ``MatchResult`` objects.
+    Returns:
+      Generator of ``FileMetadata`` objects.
 
     Raises:
-      ``BeamIOError`` if any of the pattern match operations fail
+      ``BeamIOError`` if listing fails, but not if no files were found.
     """
-    if limits is None:
-      limits = [None] * len(patterns)
-    else:
-      err_msg = "Patterns and limits should be equal in length"
-      assert len(patterns) == len(limits), err_msg
+    if not self.exists(dir_or_prefix):
+      return
 
-    def _match(pattern, limit):
-      """Find all matching paths to the pattern provided.
-      """
-      files = glob.glob(pattern)
-      metadata = [FileMetadata(f, os.path.getsize(f)) for f in files[:limit]]
-      return MatchResult(pattern, metadata)
-
-    exceptions = {}
-    result = []
-    for pattern, limit in zip(patterns, limits):
-      try:
-        result.append(_match(pattern, limit))
-      except Exception as e:  # pylint: disable=broad-except
-        exceptions[pattern] = e
-
-    if exceptions:
-      raise BeamIOError("Match operation failed", exceptions)
-    return result
+    try:
+      for f in os.listdir(dir_or_prefix):
+        f = self.join(dir_or_prefix, f)
+        yield FileMetadata(f, os.path.getsize(f))
+    except Exception as e:  # pylint: disable=broad-except
+      raise BeamIOError("List operation failed", {dir_or_prefix: e})
 
   def _path_open(self, path, mode, mime_type='application/octet-stream',
                  compression_type=CompressionTypes.AUTO):
@@ -234,6 +224,22 @@ class LocalFileSystem(FileSystem):
     Returns: boolean flag indicating if path exists
     """
     return os.path.exists(path)
+
+  def size(self, path):
+    """Get size of path on the FileSystem.
+
+    Args:
+      path: string path in question.
+
+    Returns: int size of path according to the FileSystem.
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    try:
+      return os.path.getsize(path)
+    except Exception as e:  # pylint: disable=broad-except
+      raise BeamIOError("Size operation failed", {path: e})
 
   def checksum(self, path):
     """Fetch checksum metadata of a file on the

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -165,6 +165,16 @@ class LocalFileSystemTest(unittest.TestCase):
     files = [f.path for f in result.metadata_list]
     self.assertEqual(files, [self.tmpdir])
 
+  def test_match_directory_contents(self):
+    path1 = os.path.join(self.tmpdir, 'f1')
+    path2 = os.path.join(self.tmpdir, 'f2')
+    open(path1, 'a').close()
+    open(path2, 'a').close()
+
+    result = self.fs.match([self.tmpdir + '/'])[0]
+    files = [f.path for f in result.metadata_list]
+    self.assertEqual(files, [path1, path2])
+
   def test_copy(self):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')


### PR DESCRIPTION
- Introduces FileSystem.list() abstract method. Lists a directory or
prefix.
- Implement FileSystem.match() - no longer abstract, unifies glob
behavior using fnmatch.fnmatch.

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

