### PR TITLE
Reduce Dataflow Resource Usage in Wordcount Validation

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -745,6 +745,10 @@ class JavaQuickstartConfiguration {
 
   // gcsBucket sets the gcsProject argument when executing the quickstart.
   String gcsBucket
+
+  // additional arguments useful for the specific quickstart, as a map of option name, value
+  // pairs
+  Map<String,String> additionalArgs
 }
 
 // Creates a task to run the quickstart for a runner.
@@ -757,6 +761,9 @@ ext.createJavaQuickstartValidationTask = {
   def releaseVersion = project.findProperty('ver') ?: version
   def releaseRepo = project.findProperty('repourl') ?: 'https://repository.apache.org/content/repositories/snapshots'
   def argsNeeded = ["--ver=${releaseVersion}", "--repourl=${releaseRepo}"]
+  if (config.additionalArgs) {
+    argsNeeded.add("--additionalArgs=${config.additionalArgs}")
+  }
   if (config.gcpProject) {
     argsNeeded.add("--gcpProject=${config.gcpProject}")
   }

--- a/release/src/main/groovy/TestScripts.groovy
+++ b/release/src/main/groovy/TestScripts.groovy
@@ -34,6 +34,7 @@ class TestScripts {
      static String ver
      static String gcpProject
      static String gcsBucket
+     static Map<String,String> additionalArgs
    }
 
    def TestScripts(String[] args) {
@@ -42,7 +43,10 @@ class TestScripts {
      cli.repourl(args:1, 'Repository URL')
      cli.gcpProject(args:1, 'Google Cloud Project')
      cli.gcsBucket(args:1, 'Google Cloud Storage Bucket')
+     cli.additionalArgs(args:1, 'Additional Pipeline Arguments')
+     println "args: ${args}"
      def options = cli.parse(args)
+     println "options: ${options}"
      var.repoUrl = options.repourl
      var.ver = options.ver
      println "Repository URL: ${var.repoUrl}"
@@ -54,6 +58,19 @@ class TestScripts {
      if (options.gcsBucket) {
        var.gcsBucket = options.gcsBucket
        println "GCS Storage bucket: ${var.gcsBucket}"
+     }
+
+     var.additionalArgs = new HashMap()
+     if (options.additionalArgs) {
+       // Assumes that this is created from the string of a groovy Map<String,String>
+       // ie is in the format "[key0:value0,key1:value1,...]"
+       def mapStr = options.additionalArgs.substring(1, options.additionalArgs.size() - 1)
+       mapStr.split(",").each {
+         arg -> var.additionalArgs[arg.trim().split(":")[0].trim()] = arg.trim().split(":")[1].trim()
+       }
+       println "Additional Arguments: ${var.additionalArgs}"
+     } else {
+       println "No Additional Arguments"
      }
    }
 
@@ -67,6 +84,11 @@ class TestScripts {
 
    def gcsBucket() {
      return var.gcsBucket
+   }
+
+   def formatArgs(Map<String,String> args) {
+       // Add the explicit args to the additional args, with preference to the explicit ones
+     return (var.additionalArgs.plus(args).collect { k, v -> "--${k}=${v}" }).join(" \\\n")
    }
 
    // Both documents the overal scenario and creates a clean temp directory

--- a/release/src/main/groovy/quickstart-java-dataflow.groovy
+++ b/release/src/main/groovy/quickstart-java-dataflow.groovy
@@ -33,14 +33,17 @@ t.describe 'Run Apache Beam Java SDK Quickstart - Dataflow'
     // Remove any count files
     t.run """gsutil rm gs://${t.gcsBucket()}/count* || echo 'No files'"""
 
+    constantArgs = [
+            "runner": "DataflowRunner",
+            "project": "${t.gcpProject()}",
+            "gcpTempLocation": "gs://${t.gcsBucket()}/tmp",
+            "output": "gs://${t.gcsBucket()}/counts",
+            "inputFile": "gs://apache-beam-samples/shakespeare/*"]
+    args = t.formatArgs(constantArgs)
     // Run the wordcount example with the Dataflow runner
     t.run """mvn compile exec:java \
       -Dexec.mainClass=org.apache.beam.examples.WordCount \
-      -Dexec.args="--runner=DataflowRunner \
-                   --project=${t.gcpProject()} \
-                   --gcpTempLocation=gs://${t.gcsBucket()}/tmp \
-                   --output=gs://${t.gcsBucket()}/counts \
-                   --inputFile=gs://apache-beam-samples/shakespeare/*" \
+      -Dexec.args="${args}" \
                     -Pdataflow-runner"""
 
     // Verify wordcount text

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -90,4 +90,4 @@ test {
 // Generates :runners:google-cloud-dataflow-java:runQuickstartJavaDataflow
 def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
 def gcsBucket = project.findProperty('gcsBucket') ?: 'temp-storage-for-release-validation-tests/quickstart'
-createJavaQuickstartValidationTask(name: 'Dataflow', gcpProject: gcpProject, gcsBucket: gcsBucket)
+createJavaQuickstartValidationTask(name: 'Dataflow', gcpProject: gcpProject, gcsBucket: gcsBucket, additionalArgs: ["diskSizeGb": "25"])


### PR DESCRIPTION
This lets runner quickstarts include additional freeform configuration,
for runner-specific needs.

Reduce the disk size of dataflow quickstarts to 25gb.

This might be the wrong place to put this spec, and instead it should be explicitly in the args of the `t.run "mvn compile -Dexec.args="...""`, which would also simplify some of the introduced code.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

