### PR TITLE
Simplify the Beam and/or SQL Expressions

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
@@ -37,8 +37,8 @@ public class BeamSqlAndExpression extends BeamSqlLogicalExpression {
     boolean result = true;
     for (BeamSqlExpression exp : operands) {
       BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window);
-      result = result && expOut.getValue();
-      if (!result) {
+      if (!expOut.getValue()) {
+        result = false;
         break;
       }
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
@@ -37,7 +37,7 @@ public class BeamSqlOrExpression extends BeamSqlLogicalExpression {
     boolean result = false;
     for (BeamSqlExpression exp : operands) {
       BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window);
-        result = result || expOut.getValue();
+        result = expOut.getValue();
         if (result) {
           break;
         }


### PR DESCRIPTION
The boolean logic in the BeamSqlAndExpression + BeamSqlOrExpression classes can be simpified.