### PR TITLE
Put String literals first when comparing using String.equals

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/TfIdf.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/TfIdf.java
@@ -119,13 +119,13 @@ public class TfIdf {
     }
 
     Set<URI> uris = new HashSet<>();
-    if (absoluteUri.getScheme().equals("file")) {
+    if ("file".equals(absoluteUri.getScheme())) {
       File directory = new File(absoluteUri);
       for (String entry : Optional.fromNullable(directory.list()).or(new String[] {})) {
         File path = new File(directory, entry);
         uris.add(path.toURI());
       }
-    } else if (absoluteUri.getScheme().equals("gs")) {
+    } else if ("gs".equals(absoluteUri.getScheme())) {
       GcsUtil gcsUtil = options.as(GcsOptions.class).getGcsUtil();
       URI gcsUriGlob = new URI(
           absoluteUri.getScheme(),
@@ -167,7 +167,7 @@ public class TfIdf {
       //  - gs: URIs on the service
       for (final URI uri : uris) {
         String uriString;
-        if (uri.getScheme().equals("file")) {
+        if ("file".equals(uri.getScheme())) {
           uriString = new File(uri).getPath();
         } else {
           uriString = uri.toString();
@@ -221,7 +221,7 @@ public class TfIdf {
                   String line = c.element().getValue();
                   for (String word : line.split("\\W+")) {
                     // Log INFO messages when the word “love” is found.
-                    if (word.toLowerCase().equals("love")) {
+                    if ("love".equals(word.toLowerCase())) {
                       LOG.info("Found {}", word.toLowerCase());
                     }
 

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/TriggerExample.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/TriggerExample.java
@@ -394,7 +394,7 @@ public class TriggerExample {
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
       String[] laneInfo = c.element().split(",");
-      if (laneInfo[0].equals("timestamp")) {
+      if ("timestamp".equals(laneInfo[0])) {
         // Header row
         return;
       }

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexYarnLauncher.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexYarnLauncher.java
@@ -262,7 +262,7 @@ public class ApexYarnLauncher {
             if (!relativePath.endsWith("/")) {
               relativePath += "/";
             }
-            if (!relativePath.equals("META-INF/")) {
+            if (!"META-INF/".equals(relativePath)) {
               final Path dstDir = zipfs.getPath(relativePath);
               Files.createDirectory(dstDir);
             }

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/SideInputTranslationTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/SideInputTranslationTest.java
@@ -157,7 +157,7 @@ public class SideInputTranslationTest implements Serializable {
 
     DAG.InputPortMeta sideInput = null;
     for (DAG.InputPortMeta input : om.getInputStreams().keySet()) {
-      if (((LogicalPlan.InputPortMeta) input).getPortName().equals("sideInput1")) {
+      if ("sideInput1".equals(((LogicalPlan.InputPortMeta) input).getPortName())) {
         sideInput = input;
       }
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -142,11 +142,11 @@ class FlinkPipelineExecutionEnvironment {
     ExecutionEnvironment flinkBatchEnv;
 
     // depending on the master, create the right environment.
-    if (masterUrl.equals("[local]")) {
+    if ("[local]".equals(masterUrl)) {
       flinkBatchEnv = ExecutionEnvironment.createLocalEnvironment();
-    } else if (masterUrl.equals("[collection]")) {
+    } else if ("[collection]".equals(masterUrl)) {
       flinkBatchEnv = new CollectionEnvironment();
-    } else if (masterUrl.equals("[auto]")) {
+    } else if ("[auto]".equals(masterUrl)) {
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
       String[] parts = masterUrl.split(":");
@@ -189,9 +189,9 @@ class FlinkPipelineExecutionEnvironment {
     StreamExecutionEnvironment flinkStreamEnv = null;
 
     // depending on the master, create the right environment.
-    if (masterUrl.equals("[local]")) {
+    if ("[local]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.createLocalEnvironment();
-    } else if (masterUrl.equals("[auto]")) {
+    } else if ("[auto]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
       String[] parts = masterUrl.split(":");

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DoFnOperatorTest.java
@@ -939,9 +939,9 @@ public class DoFnOperatorTest {
 
     @ProcessElement
     public void processElement(ProcessContext c) throws Exception {
-      if (c.element().equals("one")) {
+      if ("one".equals(c.element())) {
         c.output(additionalOutput1, "extra: one");
-      } else if (c.element().equals("two")) {
+      } else if ("two".equals(c.element())) {
         c.output(additionalOutput2, "extra: two");
       } else {
         c.output("got: " + c.element());

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -278,7 +278,7 @@ class DataflowMetrics extends MetricResults {
       // actual metrics counters.
       for (com.google.api.services.dataflow.model.MetricUpdate update : metricUpdates) {
         if (update.getName().getOrigin() != null
-            && (!update.getName().getOrigin().toLowerCase().equals("user")
+            && (!"user".equals(update.getName().getOrigin().toLowerCase())
             || !update.getName().getContext().containsKey("namespace"))) {
           // Skip non-user metrics, which should have both a "user" origin and a namespace.
           continue;

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -701,7 +701,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     DataflowRunnerInfo dataflowRunnerInfo = DataflowRunnerInfo.getDataflowRunnerInfo();
     String version = dataflowRunnerInfo.getVersion();
     checkState(
-        !version.equals("${pom.version}"),
+        !"${pom.version}".equals(version),
         "Unable to submit a job to the Dataflow service with unset version ${pom.version}");
     System.out.println("Dataflow SDK version: " + version);
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TestDataflowRunner.java
@@ -333,8 +333,7 @@ public class TestDataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     public void process(List<JobMessage> messages) {
       messageHandler.process(messages);
       for (JobMessage message : messages) {
-        if (message.getMessageImportance() != null
-            && message.getMessageImportance().equals("JOB_MESSAGE_ERROR")) {
+        if ("JOB_MESSAGE_ERROR".equals(message.getMessageImportance())) {
           LOG.info(
               "Dataflow job {} threw exception. Failure message was: {}",
               job.getJobId(),

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -780,7 +780,7 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     List<Step> steps = job.getSteps();
     Step processKeyedStep = null;
     for (Step step : steps) {
-      if (step.getKind().equals("SplittableProcessKeyed")) {
+      if ("SplittableProcessKeyed".equals(step.getKind())) {
         assertNull(processKeyedStep);
         processKeyedStep = step;
       }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
@@ -570,9 +570,9 @@ public class SdkHarnessClientTest {
   private static class TestFn extends DoFn<String, String> {
     @ProcessElement
     public void processElement(ProcessContext context) {
-      if (context.element().equals("foo")) {
+      if ("foo".equals(context.element())) {
         context.output("spam");
-      } else if (context.element().equals("bar")) {
+      } else if ("bar".equals(context.element())) {
         context.output("ham");
       } else {
         context.output("eggs");

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
@@ -134,7 +134,7 @@ public class SparkNativePipelineVisitor extends SparkRunner.Evaluator {
     public String toString() {
       try {
         Class<? extends PTransform> transformClass = transform.getClass();
-        if (node.getFullName().equals("KafkaIO.Read")) {
+        if ("KafkaIO.Read".equals(node.getFullName())) {
           return "KafkaUtils.createDirectStream(...)";
         }
         if (composite) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ClassPath.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ClassPath.java
@@ -426,7 +426,7 @@ final class ClassPath {
             LOG.warn("Invalid Class-Path entry: " + path);
             continue;
           }
-          if (url.getProtocol().equals("file")) {
+          if ("file".equals(url.getProtocol())) {
             builder.add(toFile(url));
           }
         }
@@ -445,7 +445,7 @@ final class ClassPath {
       if (classloader instanceof URLClassLoader) {
         URLClassLoader urlClassLoader = (URLClassLoader) classloader;
         for (URL entry : urlClassLoader.getURLs()) {
-          if (entry.getProtocol().equals("file")) {
+          if ("file".equals(entry.getProtocol())) {
             File file = toFile(entry);
             if (!entries.containsKey(file)) {
               entries.put(file, classloader);
@@ -529,7 +529,7 @@ final class ClassPath {
 
   @VisibleForTesting
   static File toFile(URL url) {
-    checkArgument(url.getProtocol().equals("file"));
+    checkArgument("file".equals(url.getProtocol()));
     try {
       return new File(url.toURI());  // Accepts escaped characters like %20.
     } catch (URISyntaxException e) {  // URL.toURI() doesn't escape chars.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/ZipFiles.java
@@ -165,7 +165,7 @@ public final class ZipFiles {
       // name like "foo..bar" or even "foo..", which should be fine.
       File file = new File(name);
       while (file != null) {
-        if (file.getName().equals("..")) {
+        if ("..".equals(file.getName())) {
           throw new IOException("Cannot unzip file containing an entry with "
               + "\"..\" in the name: " + name);
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TupleTag.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/TupleTag.java
@@ -130,7 +130,7 @@ public class TupleTag<V> implements Serializable {
     // this case we can assign deterministic ids.
     StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
     for (StackTraceElement frame : stackTrace) {
-      if (frame.getMethodName().equals("<clinit>")) {
+      if ("<clinit>".equals(frame.getMethodName())) {
         int counter = staticInits.add(frame.getClassName(), 1);
         return frame.getClassName() + "#" + counter;
       }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
@@ -110,7 +110,7 @@ public class DistinctTest {
         values.put(kv.getKey(), kv.getValue());
       }
       assertEquals(2, values.size());
-      assertTrue(values.get("k1").equals("v1") || values.get("k1").equals("v2"));
+      assertTrue("v1".equals(values.get("k1")) || "v2".equals(values.get("k1")));
       assertEquals("v1", values.get("k2"));
       return null;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -1444,12 +1444,12 @@ public class ParDoTest implements Serializable {
       boolean foundElement = false;
       boolean foundFinish = false;
       for (String str : input) {
-        if (str.equals("elem:1:1")) {
+        if ("elem:1:1".equals(str)) {
           if (foundElement) {
             throw new AssertionError("Received duplicate element");
           }
           foundElement = true;
-        } else if (str.equals("finish:3:3")) {
+        } else if ("finish:3:3".equals(str)) {
           foundFinish = true;
         } else {
           throw new AssertionError("Got unexpected value: " + str);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTestUtils.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTestUtils.java
@@ -45,7 +45,7 @@ class DoFnSignaturesTestUtils {
   static class AnonymousMethod {
     final Method getMethod() throws Exception {
       for (Method method : getClass().getDeclaredMethods()) {
-        if (method.getName().equals("method")) {
+        if ("method".equals(method.getName())) {
           return method;
         }
       }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsPathValidator.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsPathValidator.java
@@ -64,7 +64,7 @@ public class GcsPathValidator implements PathValidator {
   @Override
   public void validateOutputResourceSupported(ResourceId resourceId) {
     checkArgument(
-        resourceId.getScheme().equals("gs"),
+        "gs".equals(resourceId.getScheme()),
         "Expected a valid 'gs://' path but was given: '%s'",
         resourceId);
     verifyPath(resourceId.toString());

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
@@ -321,8 +321,8 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
    */
   @VisibleForTesting
   protected static boolean isMurmur3Partitioner(Cluster cluster) {
-    return cluster.getMetadata().getPartitioner()
-        .equals("org.apache.cassandra.dht.Murmur3Partitioner");
+    return "org.apache.cassandra.dht.Murmur3Partitioner".equals(
+        cluster.getMetadata().getPartitioner());
   }
 
   /**

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
@@ -271,11 +271,11 @@ class BigQueryAvroUtils {
       elementSchema = Schema.create(avroType);
     }
     Schema fieldSchema;
-    if (bigQueryField.getMode() == null || bigQueryField.getMode().equals("NULLABLE")) {
+    if (bigQueryField.getMode() == null || "NULLABLE".equals(bigQueryField.getMode())) {
       fieldSchema = Schema.createUnion(Schema.create(Type.NULL), elementSchema);
-    } else if (bigQueryField.getMode().equals("REQUIRED")) {
+    } else if ("REQUIRED".equals(bigQueryField.getMode())) {
       fieldSchema = elementSchema;
-    } else if (bigQueryField.getMode().equals("REPEATED")) {
+    } else if ("REPEATED".equals(bigQueryField.getMode())) {
       fieldSchema = Schema.createArray(elementSchema);
     } else {
       throw new IllegalArgumentException(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -258,7 +258,7 @@ class BigQueryServicesImpl implements BigQueryServices {
                   jobRef.getProjectId(), jobRef.getJobId()).setLocation(
                           jobRef.getLocation()).execute();
           JobStatus status = job.getStatus();
-          if (status != null && status.getState() != null && status.getState().equals("DONE")) {
+          if (status != null && "DONE".equals(status.getState())) {
             LOG.info("BigQuery job {} completed in state DONE", jobRef);
             return job;
           }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
@@ -129,7 +129,7 @@ abstract class PubsubClient implements Closeable {
     ProjectPath(String path) {
       String[] splits = path.split("/");
       checkArgument(
-          splits.length == 2 && splits[0].equals("projects"),
+          splits.length == 2 && "projects".equals(splits[0]),
           "Malformed project path \"%s\": must be of the form \"projects/\" + <project id>",
           path);
       this.projectId = splits[1];
@@ -186,7 +186,7 @@ abstract class PubsubClient implements Closeable {
     SubscriptionPath(String path) {
       String[] splits = path.split("/");
       checkState(
-          splits.length == 4 && splits[0].equals("projects") && splits[2].equals("subscriptions"),
+          splits.length == 4 && "projects".equals(splits[0]) && "subscriptions".equals(splits[2]),
           "Malformed subscription path %s: "
           + "must be of the form \"projects/\" + <project id> + \"subscriptions\"", path);
       this.projectId = splits[1];

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadSpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadSpannerSchema.java
@@ -69,7 +69,7 @@ class ReadSpannerSchema extends DoFn<Void, SpannerSchema> {
         String columnName = resultSet.getString(1);
         String ordering = resultSet.getString(2);
 
-        builder.addKeyPart(tableName, columnName, ordering.toUpperCase().equals("DESC"));
+        builder.addKeyPart(tableName, columnName, "DESC".equals(ordering.toUpperCase()));
       }
     }
     c.output(builder.build());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/FakeJobService.java
@@ -145,7 +145,7 @@ class FakeJobService implements JobService, Serializable {
   @Override
   public void startExtractJob(JobReference jobRef, JobConfigurationExtract extractConfig)
       throws InterruptedException, IOException {
-    checkArgument(extractConfig.getDestinationFormat().equals("AVRO"),
+    checkArgument("AVRO".equals(extractConfig.getDestinationFormat()),
         "Only extract to AVRO is supported");
     synchronized (allJobs) {
       verifyUniqueJobId(jobRef.getJobId());
@@ -209,8 +209,8 @@ class FakeJobService implements JobService, Serializable {
         Job job = getJob(jobRef);
         if (job != null) {
           JobStatus status = job.getStatus();
-          if (status != null && status.getState() != null
-              && (status.getState().equals("DONE") || status.getState().equals("FAILED"))) {
+          if (status != null
+              && ("DONE".equals(status.getState()) || "FAILED".equals(status.getState()))) {
             return job;
           }
         }
@@ -312,7 +312,7 @@ class FakeJobService implements JobService, Serializable {
     List<ResourceId> sourceFiles = filesForLoadJobs.get(jobRef.getProjectId(), jobRef.getJobId());
     WriteDisposition writeDisposition = WriteDisposition.valueOf(load.getWriteDisposition());
     CreateDisposition createDisposition = CreateDisposition.valueOf(load.getCreateDisposition());
-    checkArgument(load.getSourceFormat().equals("NEWLINE_DELIMITED_JSON"));
+    checkArgument("NEWLINE_DELIMITED_JSON".equals(load.getSourceFormat()));
     Table existingTable = datasetService.getTable(destination);
     if (!validateDispositions(existingTable, createDisposition, writeDisposition)) {
       return new JobStatus().setState("FAILED").setErrorResult(new ErrorProto());

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -195,7 +195,7 @@ public class JdbcIO {
   public static class DefaultRetryStrategy implements RetryStrategy {
     @Override
     public boolean apply(SQLException e) {
-      return (e.getSQLState().equals("40001"));
+      return "40001".equals(e.getSQLState());
     }
   }
 

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -334,7 +334,7 @@ public class JdbcIOTest implements Serializable {
                         "jdbc:derby://localhost:" + port + "/target/beam"))
                 .withStatement(String.format("insert into %s values(?, ?)", tableName))
                 .withRetryStrategy((JdbcIO.RetryStrategy) e -> {
-                  return e.getSQLState().equals("XJ208"); // we fake a deadlock with a lock here
+                  return "XJ208".equals(e.getSQLState()); // we fake a deadlock with a lock here
                 })
                 .withPreparedStatementSetter(
                     (element, statement) -> {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1041,7 +1041,7 @@ public class KafkaIO {
     public void validate(PipelineOptions options) {
       if (isEOS()) {
         String runner = options.getRunner().getName();
-        if (runner.equals("org.apache.beam.runners.direct.DirectRunner")
+        if ("org.apache.beam.runners.direct.DirectRunner".equals(runner)
           || runner.startsWith("org.apache.beam.runners.dataflow.")
           || runner.startsWith("org.apache.beam.runners.spark.")) {
           return;

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardReadersPoolTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/ShardReadersPoolTest.java
@@ -141,7 +141,7 @@ public class ShardReadersPoolTest {
       if (nextRecord.isPresent()) {
         recordsFound++;
         KinesisRecord kinesisRecord = nextRecord.get();
-        if (kinesisRecord.getShardId().equals("shard1")) {
+        if ("shard1".equals(kinesisRecord.getShardId())) {
           verify(firstIterator).ackRecord(kinesisRecord);
         } else {
           verify(secondIterator).ackRecord(kinesisRecord);


### PR DESCRIPTION
A previous commit put String literals first when calling equals():

commit daf82fcbb0067f9fb6e7235c326db4707cb3e3f7
Author: Colm O hEigeartaigh <coheigea@apache.org>
Date:   Mon Mar 12 17:49:46 2018 +0000

    Put the String literal first when comparing it to an Object

However it appears I missed a few instances - here are the remainder.