### PR TITLE
[BEAM-4028] Adding NameContext to Python SDK.

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -39,6 +39,75 @@ from apache_beam.transforms.window import WindowFn
 from apache_beam.utils.windowed_value import WindowedValue
 
 
+class NameContext(object):
+  """Holds the name information for a step."""
+
+  def __init__(self, step_name):
+    """Creates a new step NameContext.
+
+    Args:
+      step_name: The name of the step.
+    """
+    self.step_name = step_name
+
+  def __eq__(self, other):
+    return self.step_name == other.step_name
+
+  def __ne__(self, other):
+    return not self == other
+
+  def __repr__(self):
+    return 'NameContext(%s)' % self.__dict__()
+
+  def __hash__(self):
+    return hash(self.step_name)
+
+  def metrics_name(self):
+    """Returns the step name used for metrics reporting."""
+    return self.step_name
+
+  def logging_name(self):
+    """Returns the step name used for logging."""
+    return self.step_name
+
+
+class DataflowNameContext(NameContext):
+  """Holds the name information for a step in Dataflow.
+
+  This includes a step_name (e.g. s2), a user_name (e.g. Foo/Bar/ParDo(Fab)),
+  and a system_name (e.g. s2-shuffle-read34)."""
+
+  def __init__(self, step_name, user_name, system_name):
+    """Creates a new step NameContext.
+
+    Args:
+      step_name: The internal name of the step (e.g. s2).
+      user_name: The full user-given name of the step (e.g. Foo/Bar/ParDo(Far)).
+      system_name: The step name in the optimized graph (e.g. s2-1).
+    """
+    super(DataflowNameContext, self).__init__(step_name)
+    self.user_name = user_name
+    self.system_name = system_name
+
+  def __eq__(self, other):
+    return (self.step_name == other.step_name and
+            self.user_name == other.user_name and
+            self.system_name == other.system_name)
+
+  def __ne__(self, other):
+    return not self == other
+
+  def __hash__(self):
+    return hash((self.step_name, self.user_name, self.system_name))
+
+  def __repr__(self):
+    return 'DataflowNameContext(%s)' % self.__dict__()
+
+  def logging_name(self):
+    """Stackdriver logging relies on user-given step names (e.g. Foo/Bar)."""
+    return self.user_name
+
+
 class LoggingContext(object):
   """For internal use only; no backwards-compatibility guarantees."""
 

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -71,6 +71,7 @@ class NameContext(object):
     return self.step_name
 
 
+# TODO(BEAM-4028): Move DataflowNameContext to Dataflow internal code.
 class DataflowNameContext(NameContext):
   """Holds the name information for a step in Dataflow.
 

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -39,6 +39,7 @@ cdef class ConsumerSet(Receiver):
 
 
 cdef class Operation(object):
+  cdef readonly name_context
   cdef readonly operation_name
   cdef readonly spec
   cdef object consumers

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -123,7 +123,7 @@ class Operation(object):
       logging.info('Creating namecontext within operation')
       self.name_context = common.NameContext(name_context)
 
-    #TODO(pabloem) - Remove from operations. Rely on name context.
+    #TODO(pabloem): Remove following two lines. Rely on name context.
     self.operation_name = self.name_context.step_name
     self.step_name = self.name_context.logging_name()
 

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -115,7 +115,7 @@ class Operation(object):
       state_sampler: The StateSampler for the current operation.
     """
     if isinstance(name_context, common.NameContext):
-      #TODO(pabloem) - Clean this up once it's completely migrated.
+      # TODO(BEAM-4028): Clean this up once it's completely migrated.
       # We use the specific operation name that is used for metrics and state
       # sampling.
       self.name_context = name_context
@@ -123,7 +123,7 @@ class Operation(object):
       logging.info('Creating namecontext within operation')
       self.name_context = common.NameContext(name_context)
 
-    #TODO(pabloem): Remove following two lines. Rely on name context.
+    # TODO(BEAM-4028): Remove following two lines. Rely on name context.
     self.operation_name = self.name_context.step_name
     self.step_name = self.name_context.logging_name()
 
@@ -588,7 +588,7 @@ def create_operation(name_context, spec, counter_factory, step_name,
                      test_shuffle_sink=None, is_streaming=False):
   """Create Operation object for given operation specification."""
   if not isinstance(name_context, common.NameContext):
-    #TODO(pabloem): Remove this ad-hoc NameContext once all has been migrated.
+    # TODO(BEAM-4028): Remove ad-hoc NameContext once all has been migrated.
     name_context = common.DataflowNameContext(step_name=name_context,
                                               user_name=step_name,
                                               system_name=None)


### PR DESCRIPTION
Steps can have different names depending on the runner (stage, step, user, system name...). Depending on the needs of different components (operations, logging, metrics, statesampling) these step names are passed around without a specific order.

This change starts by creating name context classes and passing them into operations.

Some design decisions:
- `metrics_name()` and `logging_name()` return the step names used for each of those particular functionalities. They're a bit odd to have, but they come from the fact that our name-usage is already somewhat odd. Having them allows us to remove runner-specific code in the `create_operation` functions.
- I have not added `stage_name` to the name context, but it may be warranted: is stage name a concept in portable Beam? If so, I'll make sure to add `stage_name` to NameContext.

Next steps are:

- Migrating operations away from using their operation names, and removing them from the object definition in `operations.pxd`, and clean all the operation creating logic.
- Ensuring that the `MapTask` object has a list of `NameContext`s instead of three lists with the different step names.

r: @charlesccychen 