### PR TITLE
avoid infinite recursion if cls.__dict__ refers to cls

### DIFF
--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -48,13 +48,15 @@ def _is_nested_class(cls):
 def _find_containing_class(nested_class):
   """Finds containing class of a nested class passed as argument."""
 
+  # Keep track of seen classes, to avoid infinite recursion.
+  seen = set()
+
   def _find_containing_class_inner(outer):
+    seen.add(outer)
     for k, v in outer.__dict__.items():
-      if v is outer:
-        continue
       if v is nested_class:
         return outer, k
-      elif isinstance(v, type) and hasattr(v, '__dict__'):
+      elif isinstance(v, type) and hasattr(v, '__dict__') and not v in seen:
         res = _find_containing_class_inner(v)
         if res: return res
 

--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -46,10 +46,12 @@ def _is_nested_class(cls):
 
 
 def _find_containing_class(nested_class):
-  """Finds containing class of a nestec class passed as argument."""
+  """Finds containing class of a nested class passed as argument."""
 
   def _find_containing_class_inner(outer):
     for k, v in outer.__dict__.items():
+      if v is outer:
+        continue
       if v is nested_class:
         return outer, k
       elif isinstance(v, type) and hasattr(v, '__dict__'):


### PR DESCRIPTION
The python pickler does a recursive check through a class's __dict__ to find containing classes. Some classes (issue discovered via typing.List) contain a self-reference within their __dict__, leading to infinite recursion.

This PR fixes the simple case of a single level of self-reference; checking for mutually recursive classes seems like overkill.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

