### PR TITLE
[BEAM-3995] Add basic Gradle run task to Nexmark

### DIFF
--- a/sdks/java/nexmark/build.gradle
+++ b/sdks/java/nexmark/build.gradle
@@ -21,6 +21,26 @@ applyJavaNature()
 
 description = "Apache Beam :: SDKs :: Java :: Nexmark"
 
+// When running via Gradle, this property can be used to pass commandline arguments
+// to the nexmark launch
+def nexmarkArgsProperty = "nexmark.args"
+def nexmarkArgs = project.hasProperty(nexmarkArgsProperty) ?
+    project.getProperty(nexmarkArgsProperty).split() : []
+
+// When running via Gradle, this property sets the runner dependency
+def nexmarkRunnerProperty = "nexmark.runner"
+def nexmarkRunnerDependency = (project.hasProperty(nexmarkRunnerProperty)
+        ? project.getProperty(nexmarkRunnerProperty)
+        : ":beam-runners-direct-java")
+def shouldProvideSpark = ":beam-runners-spark".equals(nexmarkRunnerDependency)
+
+configurations {
+  // A configuration for running the Nexmark launcher directly from Gradle, which
+  // uses Gradle to put the appropriate dependencies on the Classpath rather than
+  // bundling them into a fat jar
+  gradleRun
+}
+
 dependencies {
   compile library.java.guava
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
@@ -43,8 +63,43 @@ dependencies {
   shadow project(path: ":beam-runners-direct-java", configuration: "shadow")
   shadow library.java.slf4j_jdk14
   testCompile library.java.hamcrest_core
+
+  gradleRun project(path: project.path, configuration: "shadow")
+  gradleRun project(path: nexmarkRunnerDependency, configuration: "shadow")
+
+  // The Spark runner requires the user to provide a Spark dependency. For self-contained
+  // runs with the Spark runner, we can provide such a dependency. This is deliberately phrased
+  // to not hardcode any runner other than :beam-runners-direct-java
+  if (shouldProvideSpark) {
+    gradleRun library.java.spark_streaming
+    gradleRun library.java.spark_core, {
+      exclude group:"org.slf4j", module:"jul-to-slf4j"
+    }
+  }
+}
+
+if (shouldProvideSpark) {
+  configurations.gradleRun {
+    // Using Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
+    exclude group: "org.slf4j", module: "slf4j-jdk14"
+  }
 }
 
 test {
   jvmArgs "-da"
+}
+
+// Execute the Nexmark queries or suites via Gradle.
+//
+// Parameters:
+//   -Pnexmark.runner
+//       Specify a runner subproject, such as ":beam-runners-spark" or ":beam-runners-flink"
+//       Defaults to ":beam-runners-direct-java"
+//
+//   -Pnexmark.args
+//       Specify the command line for invoking org.apache.beam.sdk.nexmark.Main
+task run(type: JavaExec) {
+  main = "org.apache.beam.sdk.nexmark.Main"
+  classpath = configurations.gradleRun
+  args nexmarkArgs
 }


### PR DESCRIPTION
Adds a basic run gradle task to Nexmark so it can be run with the DirectRunner (aka the default classpath). In follow-ups, I will need to add configurations for different runners that can be selected to pull in the right transitive dependencies.

The command to run it is `./gradlew :sdks:java:nexmark:run -Pnexmark.args="..."` so it is very similar to what is documented on the Beam site.

@jbonofre @iemejia I think you run it with the directrunner most often so you might know any pitfalls to consider.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

