### PR TITLE
Reduce Usage of AppliedPTransform Methods in the DirectRunner

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CommittedResult.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CommittedResult.java
@@ -28,11 +28,11 @@ import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
  * A {@link TransformResult} that has been committed.
  */
 @AutoValue
-abstract class CommittedResult {
+abstract class CommittedResult<ExecutableT> {
   /**
    * Returns the {@link AppliedPTransform} that produced this result.
    */
-  public abstract AppliedPTransform<?, ?, ?> getTransform();
+  public abstract ExecutableT getExecutable();
 
   /**
    * Returns the {@link CommittedBundle} that contains the input elements that could not be
@@ -55,15 +55,13 @@ abstract class CommittedResult {
    */
   public abstract Set<OutputType> getProducedOutputTypes();
 
-  public static CommittedResult create(
+  public static CommittedResult<AppliedPTransform<?, ?, ?>> create(
       TransformResult<?> original,
       Optional<? extends CommittedBundle<?>> unprocessedElements,
       Iterable<? extends CommittedBundle<?>> outputs,
       Set<OutputType> producedOutputs) {
-    return new AutoValue_CommittedResult(original.getTransform(),
-        unprocessedElements,
-        outputs,
-        producedOutputs);
+    return new AutoValue_CommittedResult<>(
+        original.getTransform(), unprocessedElements, outputs, producedOutputs);
   }
 
   enum OutputType {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraph.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraph.java
@@ -17,13 +17,12 @@
  */
 package org.apache.beam.runners.direct;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.common.collect.ListMultimap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.beam.runners.core.construction.TransformInputs;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.values.PCollection;
@@ -35,11 +34,10 @@ import org.apache.beam.sdk.values.PValue;
  * Methods for interacting with the underlying structure of a {@link Pipeline} that is being
  * executed with the {@link DirectRunner}.
  */
-class DirectGraph {
+class DirectGraph implements ExecutableGraph<AppliedPTransform<?, ?, ?>, PValue> {
   private final Map<PCollection<?>, AppliedPTransform<?, ?, ?>> producers;
   private final Map<PCollectionView<?>, AppliedPTransform<?, ?, ?>> viewWriters;
   private final ListMultimap<PInput, AppliedPTransform<?, ?, ?>> perElementConsumers;
-  private final ListMultimap<PValue, AppliedPTransform<?, ?, ?>> allConsumers;
 
   private final Set<AppliedPTransform<?, ?, ?>> rootTransforms;
   private final Map<AppliedPTransform<?, ?, ?>, String> stepNames;
@@ -48,63 +46,72 @@ class DirectGraph {
       Map<PCollection<?>, AppliedPTransform<?, ?, ?>> producers,
       Map<PCollectionView<?>, AppliedPTransform<?, ?, ?>> viewWriters,
       ListMultimap<PInput, AppliedPTransform<?, ?, ?>> perElementConsumers,
-      ListMultimap<PValue, AppliedPTransform<?, ?, ?>> allConsumers,
       Set<AppliedPTransform<?, ?, ?>> rootTransforms,
       Map<AppliedPTransform<?, ?, ?>, String> stepNames) {
     return new DirectGraph(
-        producers, viewWriters, perElementConsumers, allConsumers, rootTransforms, stepNames);
+        producers, viewWriters, perElementConsumers, rootTransforms, stepNames);
   }
 
   private DirectGraph(
       Map<PCollection<?>, AppliedPTransform<?, ?, ?>> producers,
       Map<PCollectionView<?>, AppliedPTransform<?, ?, ?>> viewWriters,
       ListMultimap<PInput, AppliedPTransform<?, ?, ?>> perElementConsumers,
-      ListMultimap<PValue, AppliedPTransform<?, ?, ?>> allConsumers,
       Set<AppliedPTransform<?, ?, ?>> rootTransforms,
       Map<AppliedPTransform<?, ?, ?>, String> stepNames) {
     this.producers = producers;
     this.viewWriters = viewWriters;
     this.perElementConsumers = perElementConsumers;
-    this.allConsumers = allConsumers;
     this.rootTransforms = rootTransforms;
     this.stepNames = stepNames;
-    for (AppliedPTransform<?, ?, ?> step : stepNames.keySet()) {
-      for (PValue input : step.getInputs().values()) {
-        checkArgument(
-            allConsumers.get(input).contains(step),
-            "Step %s lists value %s as input, but it is not in the graph of consumers",
-            step.getFullName(),
-            input);
-      }
+  }
+
+  @Override
+  public AppliedPTransform<?, ?, ?> getProducer(PValue produced) {
+    if (produced instanceof PCollection) {
+      return producers.get(produced);
+    } else if (produced instanceof PCollectionView) {
+      return getWriter((PCollectionView<?>) produced);
     }
+    throw new IllegalArgumentException(
+        String.format(
+            "Unknown %s type %s. Known types: %s and %s",
+            PValue.class.getSimpleName(),
+            produced.getClass().getName(),
+            PCollection.class.getSimpleName(),
+            PCollectionView.class.getSimpleName()));
   }
 
-  AppliedPTransform<?, ?, ?> getProducer(PCollection<?> produced) {
-    return producers.get(produced);
-  }
-
-  AppliedPTransform<?, ?, ?> getWriter(PCollectionView<?> view) {
-    return viewWriters.get(view);
-  }
-
-  Collection<PValue> getOutputs(AppliedPTransform<?, ?, ?> toRefresh) {
+  @Override
+  public Collection<PValue> getProduced(AppliedPTransform<?, ?, ?> toRefresh) {
+    // TODO: This must only be called on primitive transforms; composites should return empty
+    // values.
     return toRefresh.getOutputs().values();
   }
 
-  List<AppliedPTransform<?, ?, ?>> getPerElementConsumers(PValue consumed) {
+  @Override
+  public Collection<PValue> getPerElementInputs(AppliedPTransform<?, ?, ?> transform) {
+    // TODO: Make this actually track this type of edge, because this isn't quite the right
+    // generic possibility, but is for ParDos
+    return TransformInputs.nonAdditionalInputs(transform);
+  }
+
+  private AppliedPTransform<?, ?, ?> getWriter(PCollectionView<?> view) {
+    return viewWriters.get(view);
+  }
+
+  @Override
+  public List<AppliedPTransform<?, ?, ?>> getPerElementConsumers(PValue consumed) {
     return perElementConsumers.get(consumed);
   }
 
-  List<AppliedPTransform<?, ?, ?>> getAllConsumers(PValue consumed) {
-    return allConsumers.get(consumed);
-  }
-
-  Set<AppliedPTransform<?, ?, ?>> getRootTransforms() {
+  @Override
+  public Set<AppliedPTransform<?, ?, ?>> getRootTransforms() {
     return rootTransforms;
   }
 
-  Set<PCollection<?>> getPCollections() {
-    return producers.keySet();
+  @Override
+  public Collection<AppliedPTransform<?, ?, ?>> getExecutables() {
+    return stepNames.keySet();
   }
 
   Set<PCollectionView<?>> getViews() {
@@ -113,9 +120,5 @@ class DirectGraph {
 
   String getStepName(AppliedPTransform<?, ?, ?> step) {
     return stepNames.get(step);
-  }
-
-  Collection<AppliedPTransform<?, ?, ?>> getPrimitiveTransforms() {
-    return stepNames.keySet();
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraph.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraph.java
@@ -87,6 +87,10 @@ class DirectGraph {
     return viewWriters.get(view);
   }
 
+  Collection<PValue> getOutputs(AppliedPTransform<?, ?, ?> toRefresh) {
+    return toRefresh.getOutputs().values();
+  }
+
   List<AppliedPTransform<?, ?, ?>> getPerElementConsumers(PValue consumed) {
     return perElementConsumers.get(consumed);
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
@@ -149,6 +149,6 @@ class DirectGraphVisitor extends PipelineVisitor.Defaults {
   public DirectGraph getGraph() {
     checkState(finalized, "Can't get a graph before the Pipeline has been completely traversed");
     return DirectGraph.create(
-        producers, viewWriters, perElementConsumers, allConsumers, rootTransforms, stepNames);
+        producers, viewWriters, perElementConsumers, rootTransforms, stepNames);
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/EvaluationContext.java
@@ -78,8 +78,9 @@ class EvaluationContext {
   private final Clock clock;
 
   private final BundleFactory bundleFactory;
+
   /** The current processing time and event time watermarks and timers. */
-  private final WatermarkManager watermarkManager;
+  private final WatermarkManager<AppliedPTransform<?, ?, ?>, PValue> watermarkManager;
 
   /** Executes callbacks based on the progression of the watermark. */
   private final WatermarkCallbackExecutor callbackExecutor;
@@ -144,7 +145,7 @@ class EvaluationContext {
    * @param result the result of evaluating the input bundle
    * @return the committed bundles contained within the handled {@code result}
    */
-  public CommittedResult handleResult(
+  public CommittedResult<AppliedPTransform<?, ?, ?>> handleResult(
       @Nullable CommittedBundle<?> completedBundle,
       Iterable<TimerData> completedTimers,
       TransformResult<?> result) {
@@ -159,7 +160,7 @@ class EvaluationContext {
     } else {
       outputTypes.add(OutputType.BUNDLE);
     }
-    CommittedResult committedResult =
+    CommittedResult<AppliedPTransform<?, ?, ?>> committedResult =
         CommittedResult.create(
             result, getUnprocessedInput(completedBundle, result), committedBundles, outputTypes);
     // Update state internals
@@ -220,7 +221,7 @@ class EvaluationContext {
   }
 
   private void fireAllAvailableCallbacks() {
-    for (AppliedPTransform<?, ?, ?> transform : graph.getPrimitiveTransforms()) {
+    for (AppliedPTransform<?, ?, ?> transform : graph.getExecutables()) {
       fireAvailableCallbacks(transform);
     }
   }
@@ -304,7 +305,7 @@ class EvaluationContext {
       BoundedWindow window,
       WindowingStrategy<?, ?> windowingStrategy,
       Runnable runnable) {
-    AppliedPTransform<?, ?, ?> producing = graph.getWriter(view);
+    AppliedPTransform<?, ?, ?> producing = graph.getProducer(view);
     callbackExecutor.callOnGuaranteedFiring(producing, window, windowingStrategy, runnable);
 
     fireAvailableCallbacks(producing);
@@ -355,7 +356,7 @@ class EvaluationContext {
 
   /** Returns all of the steps in this {@link Pipeline}. */
   Collection<AppliedPTransform<?, ?, ?>> getSteps() {
-    return graph.getPrimitiveTransforms();
+    return graph.getExecutables();
   }
 
   /**
@@ -389,7 +390,7 @@ class EvaluationContext {
    * <p>This is a destructive operation. Timers will only appear in the result of this method once
    * for each time they are set.
    */
-  public Collection<FiredTimers> extractFiredTimers() {
+  public Collection<FiredTimers<AppliedPTransform<?, ?, ?>>> extractFiredTimers() {
     forceRefresh();
     return watermarkManager.extractFiredTimers();
   }
@@ -407,7 +408,7 @@ class EvaluationContext {
    * Returns true if all steps are done.
    */
   public boolean isDone() {
-    for (AppliedPTransform<?, ?, ?> transform : graph.getPrimitiveTransforms()) {
+    for (AppliedPTransform<?, ?, ?> transform : graph.getExecutables()) {
       if (!isDone(transform)) {
         return false;
       }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutableGraph.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutableGraph.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.direct;
+
+import java.util.Collection;
+import org.apache.beam.runners.core.construction.graph.QueryablePipeline;
+
+/**
+ * The interface that enables querying of a graph of independently executable stages and the inputs
+ * and outputs of those stages.
+ *
+ * <p>Similar to {@link QueryablePipeline}. This exists primarily for legacy reasons, as an adapter
+ * interface between the 'native' and 'portable' execution models that the DirectRunner supports.
+ */
+public interface ExecutableGraph<ExecutableT, CollectionT> {
+  Collection<ExecutableT> getRootTransforms();
+
+  Collection<ExecutableT> getExecutables();
+
+  ExecutableT getProducer(CollectionT collection);
+
+  Collection<CollectionT> getProduced(ExecutableT toRefresh);
+
+  Collection<CollectionT> getPerElementInputs(ExecutableT transform);
+
+  Collection<ExecutableT> getPerElementConsumers(CollectionT pCollection);
+}

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/QuiescenceDriver.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/QuiescenceDriver.java
@@ -150,7 +150,8 @@ class QuiescenceDriver implements ExecutionDriver {
   /** Fires any available timers. */
   private void fireTimers() {
     try {
-      for (FiredTimers transformTimers : evaluationContext.extractFiredTimers()) {
+      for (FiredTimers<AppliedPTransform<?, ?, ?>> transformTimers :
+          evaluationContext.extractFiredTimers()) {
         Collection<TimerData> delivery = transformTimers.getTimers();
         KeyedWorkItem<?, Object> work =
             KeyedWorkItems.timersWorkItem(transformTimers.getKey().getKey(), delivery);
@@ -255,7 +256,8 @@ class QuiescenceDriver implements ExecutionDriver {
     @Override
     public final CommittedResult handleResult(
         CommittedBundle<?> inputBundle, TransformResult<?> result) {
-      CommittedResult committedResult = evaluationContext.handleResult(inputBundle, timers, result);
+      CommittedResult<AppliedPTransform<?, ?, ?>> committedResult =
+          evaluationContext.handleResult(inputBundle, timers, result);
       for (CommittedBundle<?> outputBundle : committedResult.getOutputs()) {
         pendingWork.offer(
             WorkUpdate.fromBundle(
@@ -270,7 +272,7 @@ class QuiescenceDriver implements ExecutionDriver {
         } else {
           pendingWork.offer(
               WorkUpdate.fromBundle(
-                  unprocessedInputs.get(), Collections.singleton(committedResult.getTransform())));
+                  unprocessedInputs.get(), Collections.singleton(committedResult.getExecutable())));
         }
       }
       if (!committedResult.getProducedOutputTypes().isEmpty()) {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -1053,7 +1053,7 @@ class WatermarkManager {
     WatermarkUpdate updateResult = myWatermarks.refresh();
     if (updateResult.isAdvanced()) {
       Set<AppliedPTransform<?, ?, ?>> additionalRefreshes = new HashSet<>();
-      for (PValue outputPValue : toRefresh.getOutputs().values()) {
+      for (PValue outputPValue : graph.getOutputs(toRefresh)) {
         additionalRefreshes.addAll(graph.getPerElementConsumers(outputPValue));
       }
       return additionalRefreshes;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WatermarkManager.java
@@ -54,7 +54,6 @@ import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.TimerInternals;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
-import org.apache.beam.runners.core.construction.TransformInputs;
 import org.apache.beam.runners.local.StructuralKey;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -62,7 +61,6 @@ import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PValue;
 import org.joda.time.Instant;
 
@@ -128,7 +126,7 @@ import org.joda.time.Instant;
  * Watermark_PCollection = Watermark_Out_ProducingPTransform
  * </pre>
  */
-class WatermarkManager {
+class WatermarkManager<ExecutableT, CollectionT> {
   // The number of updates to apply in #tryApplyPendingUpdates
   private static final int MAX_INCREMENTAL_UPDATES = 10;
 
@@ -755,12 +753,12 @@ class WatermarkManager {
    * The {@link DirectGraph} representing the {@link Pipeline} this {@link WatermarkManager} tracks
    * watermarks for.
    */
-  private final DirectGraph graph;
+  private final ExecutableGraph<ExecutableT, CollectionT> graph;
 
   /**
    * The input and output watermark of each {@link AppliedPTransform}.
    */
-  private final Map<AppliedPTransform<?, ?, ?>, TransformWatermarks> transformToWatermarks;
+  private final Map<ExecutableT, TransformWatermarks> transformToWatermarks;
 
   /**
    * A queue of pending updates to the state of this {@link WatermarkManager}.
@@ -777,7 +775,7 @@ class WatermarkManager {
    * stale data.
    */
   @GuardedBy("refreshLock")
-  private final Set<AppliedPTransform<?, ?, ?>> pendingRefreshes;
+  private final Set<ExecutableT> pendingRefreshes;
 
   /**
    * Creates a new {@link WatermarkManager}. All watermarks within the newly created {@link
@@ -787,11 +785,12 @@ class WatermarkManager {
    * @param clock the clock to use to determine processing time
    * @param graph the graph representing this pipeline
    */
-  public static WatermarkManager create(Clock clock, DirectGraph graph) {
-    return new WatermarkManager(clock, graph);
+  public static WatermarkManager<AppliedPTransform<?, ?, ?>, PValue> create(
+      Clock clock, DirectGraph graph) {
+    return new WatermarkManager<>(clock, graph);
   }
 
-  private WatermarkManager(Clock clock, DirectGraph graph) {
+  private WatermarkManager(Clock clock, ExecutableGraph<ExecutableT, CollectionT> graph) {
     this.clock = clock;
     this.graph = graph;
 
@@ -802,27 +801,19 @@ class WatermarkManager {
 
     transformToWatermarks = new HashMap<>();
 
-    for (AppliedPTransform<?, ?, ?> rootTransform : graph.getRootTransforms()) {
+    for (ExecutableT rootTransform : graph.getRootTransforms()) {
       getTransformWatermark(rootTransform);
     }
-    for (AppliedPTransform<?, ?, ?> primitiveTransform : graph.getPrimitiveTransforms()) {
+    for (ExecutableT primitiveTransform : graph.getExecutables()) {
       getTransformWatermark(primitiveTransform);
     }
   }
 
-  private TransformWatermarks getValueWatermark(PValue pvalue) {
-    if (pvalue instanceof PCollection) {
-      return getTransformWatermark(graph.getProducer((PCollection<?>) pvalue));
-    } else if (pvalue instanceof PCollectionView<?>) {
-      return getTransformWatermark(graph.getWriter((PCollectionView<?>) pvalue));
-    } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Unknown type of %s %s", PValue.class.getSimpleName(), pvalue.getClass()));
-    }
+  private TransformWatermarks getValueWatermark(CollectionT value) {
+    return getTransformWatermark(graph.getProducer(value));
   }
 
-  private TransformWatermarks getTransformWatermark(AppliedPTransform<?, ?, ?> transform) {
+  private TransformWatermarks getTransformWatermark(ExecutableT transform) {
     TransformWatermarks wms = transformToWatermarks.get(transform);
     if (wms == null) {
       List<Watermark> inputCollectionWatermarks = getInputWatermarks(transform);
@@ -848,52 +839,50 @@ class WatermarkManager {
     return wms;
   }
 
-  private Collection<Watermark> getInputProcessingWatermarks(AppliedPTransform<?, ?, ?> transform) {
+  private Collection<Watermark> getInputProcessingWatermarks(ExecutableT transform) {
     ImmutableList.Builder<Watermark> inputWmsBuilder = ImmutableList.builder();
-    Collection<PValue> inputs = TransformInputs.nonAdditionalInputs(transform);
+    Collection<CollectionT> inputs = graph.getPerElementInputs(transform);
     if (inputs.isEmpty()) {
       inputWmsBuilder.add(THE_END_OF_TIME);
     }
-    for (PValue pvalue : inputs) {
+    for (CollectionT input : inputs) {
       Watermark producerOutputWatermark =
-          getValueWatermark(pvalue).synchronizedProcessingOutputWatermark;
+          getValueWatermark(input).synchronizedProcessingOutputWatermark;
       inputWmsBuilder.add(producerOutputWatermark);
     }
     return inputWmsBuilder.build();
   }
 
-  private List<Watermark> getInputWatermarks(AppliedPTransform<?, ?, ?> transform) {
+  private List<Watermark> getInputWatermarks(ExecutableT transform) {
     ImmutableList.Builder<Watermark> inputWatermarksBuilder = ImmutableList.builder();
-    Collection< PValue> inputs = TransformInputs.nonAdditionalInputs(transform);
+    Collection<CollectionT> inputs = graph.getPerElementInputs(transform);
     if (inputs.isEmpty()) {
       inputWatermarksBuilder.add(THE_END_OF_TIME);
     }
-    for (PValue pvalue : inputs) {
-      Watermark producerOutputWatermark = getValueWatermark(pvalue).outputWatermark;
+    for (CollectionT input : inputs) {
+      Watermark producerOutputWatermark = getValueWatermark(input).outputWatermark;
       inputWatermarksBuilder.add(producerOutputWatermark);
     }
-    List<Watermark> inputCollectionWatermarks = inputWatermarksBuilder.build();
-    return inputCollectionWatermarks;
+    return inputWatermarksBuilder.build();
   }
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
   /**
-   * Gets the input and output watermarks for an {@link AppliedPTransform}. If the
-   * {@link AppliedPTransform PTransform} has not processed any elements, return a watermark of
-   * {@link BoundedWindow#TIMESTAMP_MIN_VALUE}.
+   * Gets the input and output watermarks for an {@link AppliedPTransform}. If the {@link
+   * AppliedPTransform PTransform} has not processed any elements, return a watermark of {@link
+   * BoundedWindow#TIMESTAMP_MIN_VALUE}.
    *
    * @return a snapshot of the input watermark and output watermark for the provided transform
    */
-  public TransformWatermarks getWatermarks(AppliedPTransform<?, ?, ?> transform) {
+  public TransformWatermarks getWatermarks(ExecutableT transform) {
     return transformToWatermarks.get(transform);
   }
 
-  public void initialize(
-      Map<AppliedPTransform<?, ?, ?>, ? extends Iterable<CommittedBundle<?>>> initialBundles) {
+  public void initialize(Map<ExecutableT, ? extends Iterable<CommittedBundle<?>>> initialBundles) {
     refreshLock.lock();
     try {
-      for (Map.Entry<AppliedPTransform<?, ?, ?>, ? extends Iterable<CommittedBundle<?>>> rootEntry :
+      for (Map.Entry<ExecutableT, ? extends Iterable<CommittedBundle<?>>> rootEntry :
           initialBundles.entrySet()) {
         TransformWatermarks rootWms = transformToWatermarks.get(rootEntry.getKey());
         for (CommittedBundle<?> initialBundle : rootEntry.getValue()) {
@@ -929,9 +918,11 @@ class WatermarkManager {
   public void updateWatermarks(
       @Nullable CommittedBundle<?> completed,
       TimerUpdate timerUpdate,
-      CommittedResult result,
+      CommittedResult<ExecutableT> result,
       Instant earliestHold) {
-    pendingUpdates.offer(PendingWatermarkUpdate.create(completed,
+    pendingUpdates.offer(PendingWatermarkUpdate.create(
+        result.getExecutable(),
+        completed,
         timerUpdate,
         result,
         earliestHold));
@@ -967,15 +958,15 @@ class WatermarkManager {
    */
   private void applyNUpdates(int numUpdates) {
     for (int i = 0; !pendingUpdates.isEmpty() && (i < numUpdates || numUpdates <= 0); i++) {
-      PendingWatermarkUpdate pending = pendingUpdates.poll();
+      PendingWatermarkUpdate<ExecutableT> pending = pendingUpdates.poll();
       applyPendingUpdate(pending);
-      pendingRefreshes.add(pending.getTransform());
+      pendingRefreshes.add(pending.getExecutable());
     }
   }
 
-  private void applyPendingUpdate(PendingWatermarkUpdate pending) {
-    CommittedResult result = pending.getResult();
-    AppliedPTransform<?, ?, ?> transform = result.getTransform();
+  private void applyPendingUpdate(PendingWatermarkUpdate<ExecutableT> pending) {
+    CommittedResult<ExecutableT> result = pending.getResult();
+    ExecutableT transform = result.getExecutable();
     CommittedBundle<?> inputBundle = pending.getInputBundle();
 
     updatePending(inputBundle, pending.getTimerUpdate(), result);
@@ -1000,19 +991,20 @@ class WatermarkManager {
   private void updatePending(
       CommittedBundle<?> input,
       TimerUpdate timerUpdate,
-      CommittedResult result) {
+      CommittedResult<ExecutableT> result) {
     // Newly pending elements must be added before completed elements are removed, as the two
     // do not share a Mutex within this call and thus can be interleaved with external calls to
     // refresh.
     for (CommittedBundle<?> bundle : result.getOutputs()) {
-      for (AppliedPTransform<?, ?, ?> consumer :
-          graph.getPerElementConsumers(bundle.getPCollection())) {
+      for (ExecutableT consumer :
+          // TODO: Remove this cast once CommittedBundle returns a CollectionT
+          graph.getPerElementConsumers((CollectionT) bundle.getPCollection())) {
         TransformWatermarks watermarks = transformToWatermarks.get(consumer);
         watermarks.addPending(bundle);
       }
     }
 
-    TransformWatermarks completedTransform = transformToWatermarks.get(result.getTransform());
+    TransformWatermarks completedTransform = transformToWatermarks.get(result.getExecutable());
     if (result.getUnprocessedInputs().isPresent()) {
       // Add the unprocessed inputs
       completedTransform.addPending(result.getUnprocessedInputs().get());
@@ -1031,7 +1023,7 @@ class WatermarkManager {
     refreshLock.lock();
     try {
       applyAllPendingUpdates();
-      Set<AppliedPTransform<?, ?, ?>> toRefresh = pendingRefreshes;
+      Set<ExecutableT> toRefresh = pendingRefreshes;
       while (!toRefresh.isEmpty()) {
         toRefresh = refreshAllOf(toRefresh);
       }
@@ -1040,20 +1032,20 @@ class WatermarkManager {
     }
   }
 
-  private Set<AppliedPTransform<?, ?, ?>> refreshAllOf(Set<AppliedPTransform<?, ?, ?>> toRefresh) {
-    Set<AppliedPTransform<?, ?, ?>> newRefreshes = new HashSet<>();
-    for (AppliedPTransform<?, ?, ?> transform : toRefresh) {
+  private Set<ExecutableT> refreshAllOf(Set<ExecutableT> toRefresh) {
+    Set<ExecutableT> newRefreshes = new HashSet<>();
+    for (ExecutableT transform : toRefresh) {
       newRefreshes.addAll(refreshWatermarks(transform));
     }
     return newRefreshes;
   }
 
-  private Set<AppliedPTransform<?, ?, ?>> refreshWatermarks(AppliedPTransform<?, ?, ?> toRefresh) {
+  private Set<ExecutableT> refreshWatermarks(ExecutableT toRefresh) {
     TransformWatermarks myWatermarks = transformToWatermarks.get(toRefresh);
     WatermarkUpdate updateResult = myWatermarks.refresh();
     if (updateResult.isAdvanced()) {
-      Set<AppliedPTransform<?, ?, ?>> additionalRefreshes = new HashSet<>();
-      for (PValue outputPValue : graph.getOutputs(toRefresh)) {
+      Set<ExecutableT> additionalRefreshes = new HashSet<>();
+      for (CollectionT outputPValue : graph.getProduced(toRefresh)) {
         additionalRefreshes.addAll(graph.getPerElementConsumers(outputPValue));
       }
       return additionalRefreshes;
@@ -1065,13 +1057,14 @@ class WatermarkManager {
    * Returns a map of each {@link PTransform} that has pending timers to those timers. All of the
    * pending timers will be removed from this {@link WatermarkManager}.
    */
-  public Collection<FiredTimers> extractFiredTimers() {
-    Collection<FiredTimers> allTimers = new ArrayList<>();
+  public Collection<FiredTimers<ExecutableT>> extractFiredTimers() {
+    Collection<FiredTimers<ExecutableT>> allTimers = new ArrayList<>();
     refreshLock.lock();
     try {
-      for (Map.Entry<AppliedPTransform<?, ?, ?>, TransformWatermarks> watermarksEntry
+      for (Map.Entry<ExecutableT, TransformWatermarks> watermarksEntry
           : transformToWatermarks.entrySet()) {
-        Collection<FiredTimers> firedTimers = watermarksEntry.getValue().extractFiredTimers();
+        Collection<FiredTimers<ExecutableT>> firedTimers =
+            watermarksEntry.getValue().extractFiredTimers();
         allTimers.addAll(firedTimers);
       }
       return allTimers;
@@ -1186,7 +1179,7 @@ class WatermarkManager {
    * A reference to the input and output watermarks of an {@link AppliedPTransform}.
    */
   public class TransformWatermarks {
-    private final AppliedPTransform<?, ?, ?> transform;
+    private final ExecutableT transform;
 
     private final AppliedPTransformInputWatermark inputWatermark;
     private final AppliedPTransformOutputWatermark outputWatermark;
@@ -1198,7 +1191,7 @@ class WatermarkManager {
     private Instant latestSynchronizedOutputWm;
 
     private TransformWatermarks(
-        AppliedPTransform<?, ?, ?> transform,
+        ExecutableT transform,
         AppliedPTransformInputWatermark inputWatermark,
         AppliedPTransformOutputWatermark outputWatermark,
         SynchronizedProcessingTimeInputWatermark inputSynchProcessingWatermark,
@@ -1275,7 +1268,7 @@ class WatermarkManager {
       synchronizedProcessingInputWatermark.addPending(bundle);
     }
 
-    private Collection<FiredTimers> extractFiredTimers() {
+    private Collection<FiredTimers<ExecutableT>> extractFiredTimers() {
       Map<StructuralKey<?>, List<TimerData>> eventTimeTimers =
           inputWatermark.extractFiredEventTimeTimers();
       Map<StructuralKey<?>, List<TimerData>> processingTimers;
@@ -1287,11 +1280,11 @@ class WatermarkManager {
 
       Map<StructuralKey<?>, List<TimerData>> timersPerKey =
           groupFiredTimers(eventTimeTimers, processingTimers, synchronizedTimers);
-      Collection<FiredTimers> keyFiredTimers = new ArrayList<>(timersPerKey.size());
+      Collection<FiredTimers<ExecutableT>> keyFiredTimers = new ArrayList<>(timersPerKey.size());
       for (Map.Entry<StructuralKey<?>, List<TimerData>> firedTimers :
           timersPerKey.entrySet()) {
         keyFiredTimers.add(
-            new FiredTimers(transform, firedTimers.getKey(), firedTimers.getValue()));
+            new FiredTimers<>(transform, firedTimers.getKey(), firedTimers.getValue()));
       }
       return keyFiredTimers;
     }
@@ -1481,21 +1474,21 @@ class WatermarkManager {
    * the time domain in which it lives progresses past a specified time, as determined by the
    * {@link WatermarkManager}.
    */
-  public static class FiredTimers {
+  public static class FiredTimers<ExecutableT> {
     /** The transform the timers were set at and will be delivered to. */
-    private final AppliedPTransform<?, ?, ?> transform;
+    private final ExecutableT transform;
     /** The key the timers were set for and will be delivered to. */
     private final StructuralKey<?> key;
     private final Collection<TimerData> timers;
 
     private FiredTimers(
-        AppliedPTransform<?, ?, ?> transform, StructuralKey<?> key, Collection<TimerData> timers) {
+        ExecutableT transform, StructuralKey<?> key, Collection<TimerData> timers) {
       this.transform = transform;
       this.key = key;
       this.timers = timers;
     }
 
-    public AppliedPTransform<?, ?, ?> getTransform() {
+    public ExecutableT getTransform() {
       return transform;
     }
 
@@ -1529,9 +1522,9 @@ class WatermarkManager {
     }
   }
 
-  public Set<AppliedPTransform<?, ?, ?>> getCompletedTransforms() {
-    Set<AppliedPTransform<?, ?, ?>> result = new HashSet<>();
-    for (Map.Entry<AppliedPTransform<?, ?, ?>, TransformWatermarks> wms :
+  public Set<ExecutableT> getCompletedTransforms() {
+    Set<ExecutableT> result = new HashSet<>();
+    for (Map.Entry<ExecutableT, TransformWatermarks> wms :
         transformToWatermarks.entrySet()) {
       if (wms.getValue().getOutputWatermark().equals(THE_END_OF_TIME.get())) {
         result.add(wms.getKey());
@@ -1541,28 +1534,26 @@ class WatermarkManager {
   }
 
   @AutoValue
-  abstract static class PendingWatermarkUpdate {
+  abstract static class PendingWatermarkUpdate<ExecutableT> {
+    abstract ExecutableT getExecutable();
+
     @Nullable
-    public abstract CommittedBundle<?> getInputBundle();
-    public abstract TimerUpdate getTimerUpdate();
-    public abstract CommittedResult getResult();
-    public abstract Instant getEarliestHold();
+    abstract CommittedBundle<?> getInputBundle();
 
-    /**
-     * Gets the {@link AppliedPTransform} that generated this result.
-     */
-    public AppliedPTransform<?, ?, ?> getTransform() {
-      return getResult().getTransform();
-    }
+    abstract TimerUpdate getTimerUpdate();
 
-    public static PendingWatermarkUpdate create(
+    abstract CommittedResult<ExecutableT> getResult();
+
+    abstract Instant getEarliestHold();
+
+    public static <ExecutableT> PendingWatermarkUpdate<ExecutableT> create(
+        ExecutableT executable,
         CommittedBundle<?> inputBundle,
         TimerUpdate timerUpdate,
-        CommittedResult result, Instant earliestHold) {
-      return new AutoValue_WatermarkManager_PendingWatermarkUpdate(inputBundle,
-          timerUpdate,
-          result,
-          earliestHold);
+        CommittedResult<ExecutableT> result,
+        Instant earliestHold) {
+      return new AutoValue_WatermarkManager_PendingWatermarkUpdate(
+          executable, inputBundle, timerUpdate, result, earliestHold);
     }
   }
 }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/CommittedResultTest.java
@@ -70,14 +70,14 @@ public class CommittedResultTest implements Serializable {
 
   @Test
   public void getTransformExtractsFromResult() {
-    CommittedResult result =
+    CommittedResult<AppliedPTransform<?, ?, ?>> result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
             Optional.absent(),
             Collections.emptyList(),
             EnumSet.noneOf(OutputType.class));
 
-    assertThat(result.getTransform(), Matchers.<AppliedPTransform<?, ?, ?>>equalTo(transform));
+    assertThat(result.getExecutable(), Matchers.<AppliedPTransform<?, ?, ?>>equalTo(transform));
   }
 
   @Test
@@ -86,7 +86,7 @@ public class CommittedResultTest implements Serializable {
         bundleFactory.createBundle(created)
             .add(WindowedValue.valueInGlobalWindow(2))
             .commit(Instant.now());
-    CommittedResult result =
+    CommittedResult<AppliedPTransform<?, ?, ?>> result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
             Optional.of(bundle),
@@ -98,7 +98,7 @@ public class CommittedResultTest implements Serializable {
 
   @Test
   public void getUncommittedElementsNull() {
-    CommittedResult result =
+    CommittedResult<AppliedPTransform<?, ?, ?>> result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
             Optional.absent(),
@@ -128,7 +128,7 @@ public class CommittedResultTest implements Serializable {
                         PCollection.IsBounded.UNBOUNDED,
                         VarIntCoder.of()))
                 .commit(Instant.now()));
-    CommittedResult result =
+    CommittedResult<AppliedPTransform<?, ?, ?>> result =
         CommittedResult.create(
             StepTransformResult.withoutHold(transform).build(),
             Optional.absent(),

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectGraphs.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectGraphs.java
@@ -20,8 +20,6 @@ package org.apache.beam.runners.direct;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.AppliedPTransform;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PValue;
 
 /** Test utilities for the {@link DirectRunner}. */
@@ -39,12 +37,6 @@ final class DirectGraphs {
   }
 
   public static AppliedPTransform<?, ?, ?> getProducer(PValue value) {
-    if (value instanceof PCollection) {
-      return getGraph(value.getPipeline()).getProducer((PCollection<?>) value);
-    } else if (value instanceof PCollectionView) {
-      return getGraph(value.getPipeline()).getWriter((PCollectionView<?>) value);
-    }
-    throw new IllegalArgumentException(
-        String.format("Unexpected type of %s %s", PValue.class.getSimpleName(), value.getClass()));
+    return getGraph(value.getPipeline()).getProducer(value);
   }
 }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
@@ -123,7 +123,7 @@ public class EvaluationContextTest {
 
     createdProducer = graph.getProducer(created);
     downstreamProducer = graph.getProducer(downstream);
-    viewProducer = graph.getWriter(view);
+    viewProducer = graph.getProducer(view);
     unboundedProducer = graph.getProducer(unbounded);
   }
 
@@ -364,10 +364,10 @@ public class EvaluationContextTest {
     // Should cause the downstream timer to fire
     context.handleResult(null, ImmutableList.of(), advanceResult);
 
-    Collection<FiredTimers> fired = context.extractFiredTimers();
+    Collection<FiredTimers<AppliedPTransform<?, ?, ?>>> fired = context.extractFiredTimers();
     assertThat(Iterables.getOnlyElement(fired).getKey(), Matchers.equalTo(key));
 
-    FiredTimers firedForKey = Iterables.getOnlyElement(fired);
+    FiredTimers<AppliedPTransform<?, ?, ?>> firedForKey = Iterables.getOnlyElement(fired);
     // Contains exclusively the fired timer
     assertThat(firedForKey.getTimers(), contains(toFire));
 


### PR DESCRIPTION
The portable execution in the DirectRunner shouldn't go through graph rehydration
to construct executable tokens. This change reduces the prevalence of the Java
SDK types within the DirectRunner for the WatermarkManager and some related
components.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

