### PR TITLE
[BEAM-4036] Fix pickling for "recursive" classes.

### DIFF
--- a/sdks/python/apache_beam/internal/module_test.py
+++ b/sdks/python/apache_beam/internal/module_test.py
@@ -61,3 +61,15 @@ def create_class(datum):
 
 
 XYZ_OBJECT = Xyz()
+
+
+class RecursiveClass(object):
+  """A class that contains a reference to itself."""
+
+  SELF_TYPE = None
+
+  def __init__(self, datum):
+    self.datum = 'RecursiveClass:%s' % datum
+
+
+RecursiveClass.SELF_TYPE = RecursiveClass

--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -46,9 +46,14 @@ def _is_nested_class(cls):
 
 
 def _find_containing_class(nested_class):
-  """Finds containing class of a nestec class passed as argument."""
+  """Finds containing class of a nested class passed as argument."""
+
+  seen = set()
 
   def _find_containing_class_inner(outer):
+    if outer in seen:
+      return None
+    seen.add(outer)
     for k, v in outer.__dict__.items():
       if v is nested_class:
         return outer, k

--- a/sdks/python/apache_beam/internal/pickler_test.py
+++ b/sdks/python/apache_beam/internal/pickler_test.py
@@ -80,6 +80,10 @@ class PicklerTest(unittest.TestCase):
     with self.assertRaises(TypeError):
       dumps((_ for _ in range(10)))
 
+  def test_recursive_class(self):
+    self.assertEquals('RecursiveClass:abc',
+                      loads(dumps(module_test.RecursiveClass('abc').datum)))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Fix pickling for recursive classes by maintaining a dict of already seen classes and not revisiting classes that have already been seen.