### PR TITLE
Real-time timers shouldn't stall completed step in DirectRunner

### DIFF
--- a/sdks/python/apache_beam/runners/direct/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/direct/watermark_manager.py
@@ -160,7 +160,8 @@ class WatermarkManager(object):
       fired_timers, had_realtime_timer = tw.extract_transform_timers()
       if fired_timers:
         all_timers.append((applied_ptransform, fired_timers))
-      if had_realtime_timer:
+      if (had_realtime_timer
+          and tw.output_watermark < WatermarkManager.WATERMARK_POS_INF):
         has_realtime_timer = True
     return all_timers, has_realtime_timer
 


### PR DESCRIPTION
This change fixes an issue where real-time timers block pipeline completion in the Python DirectRunner, even after the step containing the timer has completed.