### PR TITLE
Properly clean up HBase IO test data

### DIFF
--- a/sdks/java/io/hbase/build.gradle
+++ b/sdks/java/io/hbase/build.gradle
@@ -28,6 +28,7 @@ test {
   if (System.getProperty("beamSurefireArgline")) {
     jvmArgs System.getProperty("beamSurefireArgline")
   }
+  jvmArgs "-Dtest.build.data.basedirectory=build/test-data"
 }
 
 def hbase_version = "1.2.6"

--- a/sdks/java/io/hbase/pom.xml
+++ b/sdks/java/io/hbase/pom.xml
@@ -43,7 +43,7 @@
           <parallel>all</parallel>
           <threadCount>4</threadCount>
           <!-- Need to redefine log configuration because it gets lost on parallel tests -->
-          <argLine>-Dlog4j.configuration=log4j-test.properties  -XX:-UseGCOverheadLimit ${beamSurefireArgline}</argLine>
+          <argLine>-Dlog4j.configuration=log4j-test.properties  -XX:-UseGCOverheadLimit ${beamSurefireArgline} -Dtest.build.data.basedirectory=target/test-data</argLine>
         </configuration>
       </plugin>
     </plugins>

--- a/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
+++ b/sdks/java/io/hbase/src/test/java/org/apache/beam/sdk/io/hbase/HBaseIOTest.java
@@ -118,6 +118,7 @@ public class HBaseIOTest {
     if (htu != null) {
       htu.shutdownMiniHBaseCluster();
       htu.shutdownMiniZKCluster();
+      htu.cleanupTestDir();
       htu = null;
     }
   }


### PR DESCRIPTION
There are two problems with the HBaseIO java tests:

a) After a successful run, the test data (stored in target/test-data) is not cleaned up. So it will accumulate if the test is run multiple times.
b) When run with gradle, the data is still stored in target/test-data, which is bad. Instead, this commit changes the directory to build/test-data when run via gradle.