### PR TITLE
Remove accidentally forgotten binding for log4j12 on SolrIO

### DIFF
--- a/sdks/java/io/solr/build.gradle
+++ b/sdks/java/io/solr/build.gradle
@@ -35,7 +35,6 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.junit
   testCompile library.java.slf4j_api
-  testCompile library.java.slf4j_log4j12
   testCompile "org.apache.solr:solr-test-framework:5.5.4"
   testCompile "org.apache.solr:solr-core:5.5.4"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.3.2"


### PR DESCRIPTION
When merging #4905 I fixed manually the gradle build file but forgot to remove this line, this can produce repeated logs, so far I haven't found that it breaks the tests, but better to fix it.