### PR TITLE
Fixing data race in statesampler_fast.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -206,11 +206,11 @@ cdef class ScopedState(object):
     self.old_state_index = self.sampler.current_state_index
     pythread.PyThread_acquire_lock(self.sampler.lock, pythread.WAIT_LOCK)
     self.sampler.current_state_index = self.state_index
-    pythread.PyThread_release_lock(self.sampler.lock)
     self.sampler.state_transition_count += 1
+    pythread.PyThread_release_lock(self.sampler.lock)
 
   cpdef __exit__(self, unused_exc_type, unused_exc_value, unused_traceback):
     pythread.PyThread_acquire_lock(self.sampler.lock, pythread.WAIT_LOCK)
     self.sampler.current_state_index = self.old_state_index
-    pythread.PyThread_release_lock(self.sampler.lock)
     self.sampler.state_transition_count += 1
+    pythread.PyThread_release_lock(self.sampler.lock)


### PR DESCRIPTION
Thread Sanitizer tests have started pointing at a data race occurring because `state_transition_count` is being updated outside of a lock. I believe we had accepted this as benign, but even 'benign' data races are discouraged, so we should probably remove this..
r: @charlesccychen 