### PR TITLE
Remove panic when mutating a global option a second time.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/options.go
+++ b/sdks/go/pkg/beam/core/runtime/options.go
@@ -16,7 +16,6 @@
 package runtime
 
 import (
-	"fmt"
 	"sync"
 )
 
@@ -98,9 +97,6 @@ func (o *Options) Set(key, value string) {
 
 	if o.ro {
 		return // ignore silently to allow init-time set of options
-	}
-	if _, ok := o.opt[key]; ok {
-		panic(fmt.Sprintf("option %v already defined", key))
 	}
 	o.opt[key] = value
 }


### PR DESCRIPTION
Hooks could  be serialized at pipeline start, triggering a second set of a Global Option if a second+ pipeline is executed in the same binary, or the binary runs the same pipeline multiple times, triggering the multiple set panic.
