### PR TITLE
[BEAM-4035] Fix spark validatesrunner

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -61,7 +61,6 @@ repositories {
     return
   }
 
-  mavenLocal()
   mavenCentral()
   jcenter()
 

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -61,6 +61,7 @@ repositories {
     return
   }
 
+  mavenLocal()
   mavenCentral()
   jcenter()
 

--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -77,7 +77,7 @@ dependencies {
   provided library.java.commons_lang3
   provided library.java.commons_io_2x
   provided library.java.hamcrest_core
-  provided "org.apache.zookeeper:zookeeper:3.4.6"
+  provided "org.apache.zookeeper:zookeeper:3.4.11"
   provided "org.scala-lang:scala-library:2.11.8"
   provided "com.esotericsoftware.kryo:kryo:2.21"
   shadowTest project(path: ":beam-sdks-java-io-kafka", configuration: "shadow")


### PR DESCRIPTION
Fix https://builds.apache.org/view/A-D/view/Beam/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle by upgrading the version to 3.4.11.
The logs on the failures showed that 3.4.10 zookeeper jar was resolved from .m2, but never showed up in the classpath during tests.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

