### PR TITLE
[BEAM-4040][BEAM-4047] ensure direct runner wait teardown calls even on exception

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
@@ -153,7 +153,7 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
   }
 
   @Override
-  public <InputT> TransformEvaluator<InputT> forApplication(
+  public synchronized <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application, CommittedBundle<?> inputBundle)
       throws Exception {
     checkState(
@@ -168,7 +168,7 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
   }
 
   @Override
-  public void cleanup() throws Exception {
+  public synchronized void cleanup() throws Exception {
     Collection<Exception> thrownInCleanup = new ArrayList<>();
     for (TransformEvaluatorFactory factory : factories.values()) {
       try {


### PR DESCRIPTION
if an exception occurs in finish bundle or other the teardown is not waited cause the event loop in the direct runner driver exit when exception state is set.

This PR ensures that waitUntilFinish() wait the execution is actually finished before exiting.
