### PR TITLE
Remove some unnecessary autoboxing calls

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/WriteWithShardingFactory.java
@@ -138,7 +138,7 @@ class WriteWithShardingFactory<InputT, DestinationT>
         return (int) totalRecords;
       }
       // 100mil records before >7 output files
-      int floorLogRecs = Double.valueOf(Math.log10(totalRecords)).intValue();
+      int floorLogRecs = (int) Math.log10(totalRecords);
       return Math.max(floorLogRecs, MIN_SHARDS_FOR_LOG) + extraShards;
     }
   }

--- a/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/translators/utils/TranslatorUtils.java
+++ b/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/translators/utils/TranslatorUtils.java
@@ -85,7 +85,7 @@ public class TranslatorUtils {
     // tag 0 is reserved for main input
     int tag = 1;
     for (PCollectionView<?> sideInput: sideInputs) {
-      tagsToSideInputs.put(tag + "", sideInput);
+      tagsToSideInputs.put(Integer.toString(tag), sideInput);
       tag++;
     }
     return tagsToSideInputs;


### PR DESCRIPTION
Instead of creating a new Double and then calling intValue(), we can just cast the double instead to an int.