### PR TITLE
KafkaIO : fix a typo in method name.

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConsumerSpEL.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConsumerSpEL.java
@@ -101,7 +101,7 @@ class ConsumerSpEL {
     return -1L; // This is the timestamp used in Kafka for older messages without timestamps.
   }
 
-  public KafkaTimestampType getRecordTimestamptType(
+  public KafkaTimestampType getRecordTimestampType(
     ConsumerRecord<byte[], byte[]> rawRecord) {
     if (hasRecordTimestamp) {
       return KafkaTimestampType.forOrdinal(rawRecord.timestampType().ordinal());

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -164,7 +164,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   }
 
   @Override
-  public boolean advance() throws IOException {
+  public boolean advance() {
     /* Read first record (if any). we need to loop here because :
      *  - (a) some records initially need to be skipped if they are before consumedOffset
      *  - (b) if curBatch is empty, we want to fetch next batch and then advance.
@@ -211,7 +211,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
             rawRecord.partition(),
             rawRecord.offset(),
             consumerSpEL.getRecordTimestamp(rawRecord),
-            consumerSpEL.getRecordTimestamptType(rawRecord),
+            consumerSpEL.getRecordTimestampType(rawRecord),
             keyDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.key()),
             valueDeserializerInstance.deserialize(rawRecord.topic(), rawRecord.value()));
 


### PR DESCRIPTION
Removed extra 't' in an internal method name. This does not affect user visible interface.

Also removed 'throws IOException' for 'advance()' since is not thrown in the implementation.