### PR TITLE
Support staging binary distributions (wheel files) of Beam SDK.

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency.py
@@ -481,7 +481,7 @@ def _stage_beam_sdk(sdk_remote_location, staging_location, temp_dir):
   """Stages a Beam SDK file with the appropriate version.
 
   Args:
-    sdk_remote_location: A GCS path to a SDK file or a URL from
+    sdk_remote_location: A GCS path to a SDK file or a URL from which
       the file can be downloaded. The SDK file can be a tarball or a wheel.
       Set to 'pypi' to download and stage a wheel and source SDK from PyPi.
     staging_location: A GCS bucket where the SDK file should be copied.
@@ -676,6 +676,6 @@ def _download_pypi_sdk_package(temp_dir, fetch_binary=False,
     if os.path.exists(tgz_expected):
       return tgz_expected
     raise RuntimeError(
-        'Failed to download a distribution for the running SDK. Expected '
-        'either %s or %s to be found in the download folder.' % (
+        'Failed to download a source distribution for the running SDK. '
+        'Expected either %s or %s to be found in the download folder.' % (
             zip_expected, tgz_expected))

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
@@ -291,7 +291,7 @@ class SetupTest(unittest.TestCase):
           elif args[7] == '--only-binary' and len(args) >= 18:
             if not has_wheels:
               # Imitate the case when desired wheel distribution is not in PyPI.
-              raise RuntimeError("No matching distribution.")
+              raise RuntimeError('No matching distribution.')
 
             # Per PEP-0427 in wheel filenames non-alphanumeric characters
             # in distribution name are replaced with underscore.
@@ -304,9 +304,9 @@ class SetupTest(unittest.TestCase):
                 args[17]   # platform
             )
 
-      assert package_file, "Pip fake does not support the command: " + str(args)
+      assert package_file, 'Pip fake does not support the command: ' + str(args)
       self.create_temp_file(
-          FileSystems.join(args[5], package_file), "SDK from PyPi.")
+          FileSystems.join(args[5], package_file), 'Package content.')
 
     return pip_fake
 
@@ -328,7 +328,7 @@ class SetupTest(unittest.TestCase):
 
     with open(os.path.join(
         staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)) as f:
-      self.assertEqual(f.read(), 'SDK from PyPi.')
+      self.assertEqual(f.read(), 'Package content.')
 
   def test_sdk_location_default_with_wheels(self):
     staging_dir = self.make_temp_dir()
@@ -351,7 +351,7 @@ class SetupTest(unittest.TestCase):
       self.assertTrue(staged_resources[1].endswith('whl'))
       for name in staged_resources:
         with open(os.path.join(staging_dir, name)) as f:
-          self.assertEqual(f.read(), 'SDK from PyPi.')
+          self.assertEqual(f.read(), 'Package content.')
 
   def test_sdk_location_local_directory(self):
     staging_dir = self.make_temp_dir()
@@ -360,7 +360,7 @@ class SetupTest(unittest.TestCase):
         os.path.join(
             sdk_location,
             names.DATAFLOW_SDK_TARBALL_FILE),
-        'contents')
+        'Package content.')
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir
@@ -373,14 +373,14 @@ class SetupTest(unittest.TestCase):
     tarball_path = os.path.join(
         staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
     with open(tarball_path) as f:
-      self.assertEqual(f.read(), 'contents')
+      self.assertEqual(f.read(), 'Package content.')
 
   def test_sdk_location_local_source_file(self):
     staging_dir = self.make_temp_dir()
     sdk_directory = self.make_temp_dir()
     sdk_filename = 'apache-beam-3.0.0.tar.gz'
     sdk_location = os.path.join(sdk_directory, sdk_filename)
-    self.create_temp_file(sdk_location, 'contents')
+    self.create_temp_file(sdk_location, 'Package content.')
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir
@@ -393,14 +393,14 @@ class SetupTest(unittest.TestCase):
     tarball_path = os.path.join(
         staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
     with open(tarball_path) as f:
-      self.assertEqual(f.read(), 'contents')
+      self.assertEqual(f.read(), 'Package content.')
 
   def test_sdk_location_local_wheel_file(self):
     staging_dir = self.make_temp_dir()
     sdk_directory = self.make_temp_dir()
     sdk_filename = 'apache_beam-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl'
     sdk_location = os.path.join(sdk_directory, sdk_filename)
-    self.create_temp_file(sdk_location, 'contents')
+    self.create_temp_file(sdk_location, 'Package content.')
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir
@@ -413,7 +413,7 @@ class SetupTest(unittest.TestCase):
     tarball_path = os.path.join(
         staging_dir, sdk_filename)
     with open(tarball_path) as f:
-      self.assertEqual(f.read(), 'contents')
+      self.assertEqual(f.read(), 'Package content.')
 
   def test_sdk_location_local_directory_not_present(self):
     staging_dir = self.make_temp_dir()
@@ -458,7 +458,7 @@ class SetupTest(unittest.TestCase):
     def file_download(_, to_folder):
       tarball_path = os.path.join(to_folder, 'sdk-tarball')
       with open(tarball_path, 'w') as f:
-        f.write('SDK from HTTP location.')
+        f.write('Package content.')
       return tarball_path
 
     with mock.patch('apache_beam.runners.dataflow.internal.'
@@ -470,7 +470,7 @@ class SetupTest(unittest.TestCase):
     tarball_path = os.path.join(
         staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
     with open(tarball_path) as f:
-      self.assertEqual(f.read(), 'SDK from HTTP location.')
+      self.assertEqual(f.read(), 'Package content.')
 
   def test_with_extra_packages(self):
     staging_dir = self.make_temp_dir()

--- a/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/dependency_test.py
@@ -23,6 +23,8 @@ import shutil
 import tempfile
 import unittest
 
+import mock
+
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.options.pipeline_options import PipelineOptions
@@ -252,57 +254,106 @@ class SetupTest(unittest.TestCase):
             'The --setup_file option expects the full path to a file named '
             'setup.py instead of '))
 
-  def override_file_copy(self, expected_from_path, expected_to_dir):
-    def file_copy(from_path, to_path):
-      if not from_path.endswith(names.PICKLED_MAIN_SESSION_FILE):
-        self.assertEqual(expected_from_path, from_path)
-        self.assertEqual(FileSystems.join(expected_to_dir,
-                                          names.DATAFLOW_SDK_TARBALL_FILE),
-                         to_path)
-      if from_path.startswith('gs://') or to_path.startswith('gs://'):
-        logging.info('Faking file_copy(%s, %s)', from_path, to_path)
-      else:
-        shutil.copyfile(from_path, to_path)
-    dependency._dependency_file_copy = file_copy
+  def build_fake_pip_download_command_handler(self, has_wheels):
+    """A stub for apache_beam.utils.processes.check_call that imitates pip.
 
-  def override_file_download(self, expected_from_url, expected_to_folder):
-    def file_download(from_url, _):
-      self.assertEqual(expected_from_url, from_url)
-      tarball_path = os.path.join(expected_to_folder, 'sdk-tarball')
-      with open(tarball_path, 'w') as f:
-        f.write('Some contents.')
-      return tarball_path
-    dependency._dependency_file_download = file_download
-    return os.path.join(expected_to_folder, 'sdk-tarball')
+    Args:
+      has_wheels: Whether pip fake should have a whl distribution of packages.
+    """
 
-  def override_pypi_download(self, expected_from_url, expected_to_folder):
-    def pypi_download(_):
-      tarball_path = os.path.join(expected_to_folder, 'sdk-tarball')
-      with open(tarball_path, 'w') as f:
-        f.write('Some contents.')
-      return tarball_path
-    dependency._download_pypi_sdk_package = pypi_download
-    return os.path.join(expected_to_folder, 'sdk-tarball')
+    def pip_fake(args):
+      """Fakes fetching a package from pip by creating a temporary file.
+
+      Args:
+        args: a complete list of command line arguments to invoke pip.
+          The fake is sensitive to the order of the arguments.
+          Supported commands:
+
+          1) Download SDK sources file:
+          python pip -m download --dest /tmp/dir apache-beam==2.0.0 \
+              --no-binary :all: --no-deps
+
+          2) Download SDK binary wheel file:
+          python pip -m download --dest /tmp/dir apache-beam==2.0.0 \
+              --no-binary :all: --no-deps --python-version 27 \
+              --implementation cp --abi cp27mu --platform manylinux1_x86_64
+      """
+      package_file = None
+      if len(args) >= 8:
+        # package_name==x.y.z
+        if '==' in args[6]:
+          distribution_name = args[6][0:args[6].find('==')]
+          distribution_version = args[6][args[6].find('==')+2:]
+
+          if args[7] == '--no-binary':
+            package_file = '%s-%s.zip' % (
+                distribution_name, distribution_version)
+          elif args[7] == '--only-binary' and len(args) >= 18:
+            if not has_wheels:
+              # Imitate the case when desired wheel distribution is not in PyPI.
+              raise RuntimeError("No matching distribution.")
+
+            # Per PEP-0427 in wheel filenames non-alphanumeric characters
+            # in distribution name are replaced with underscore.
+            distribution_name = distribution_name.replace('-', '_')
+            package_file = '%s-%s-%s%s-%s-%s.whl' % (
+                distribution_name, distribution_version,
+                args[13],  # implementation
+                args[11],  # python version
+                args[15],  # abi tag
+                args[17]   # platform
+            )
+
+      assert package_file, "Pip fake does not support the command: " + str(args)
+      self.create_temp_file(
+          FileSystems.join(args[5], package_file), "SDK from PyPi.")
+
+    return pip_fake
 
   def test_sdk_location_default(self):
     staging_dir = self.make_temp_dir()
-    expected_from_url = 'pypi'
-    expected_from_path = self.override_pypi_download(
-        expected_from_url, staging_dir)
-    self.override_file_copy(expected_from_path, staging_dir)
+    options = PipelineOptions()
+    options.view_as(GoogleCloudOptions).staging_location = staging_dir
+    self.update_options(options)
+    options.view_as(SetupOptions).sdk_location = 'default'
+
+    with mock.patch('apache_beam.utils.processes.check_call',
+                    self.build_fake_pip_download_command_handler(
+                        has_wheels=False)):
+      staged_resources = dependency.stage_job_resources(
+          options, temp_dir=self.make_temp_dir())
+
+    self.assertEqual(
+        [names.DATAFLOW_SDK_TARBALL_FILE], staged_resources)
+
+    with open(os.path.join(
+        staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)) as f:
+      self.assertEqual(f.read(), 'SDK from PyPi.')
+
+  def test_sdk_location_default_with_wheels(self):
+    staging_dir = self.make_temp_dir()
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir
     self.update_options(options)
     options.view_as(SetupOptions).sdk_location = 'default'
 
-    self.assertEqual(
-        [names.DATAFLOW_SDK_TARBALL_FILE],
-        dependency.stage_job_resources(
-            options,
-            file_copy=dependency._dependency_file_copy))
+    with mock.patch(
+        'apache_beam.utils.processes.check_call',
+        self.build_fake_pip_download_command_handler(has_wheels=True)):
+      staged_resources = dependency.stage_job_resources(
+          options,
+          temp_dir=self.make_temp_dir())
 
-  def test_sdk_location_local(self):
+      self.assertTrue(len(staged_resources), 2)
+      self.assertEqual(staged_resources[0], names.DATAFLOW_SDK_TARBALL_FILE)
+      # Exact name depends on the version of the SDK.
+      self.assertTrue(staged_resources[1].endswith('whl'))
+      for name in staged_resources:
+        with open(os.path.join(staging_dir, name)) as f:
+          self.assertEqual(f.read(), 'SDK from PyPi.')
+
+  def test_sdk_location_local_directory(self):
     staging_dir = self.make_temp_dir()
     sdk_location = self.make_temp_dir()
     self.create_temp_file(
@@ -324,7 +375,47 @@ class SetupTest(unittest.TestCase):
     with open(tarball_path) as f:
       self.assertEqual(f.read(), 'contents')
 
-  def test_sdk_location_local_not_present(self):
+  def test_sdk_location_local_source_file(self):
+    staging_dir = self.make_temp_dir()
+    sdk_directory = self.make_temp_dir()
+    sdk_filename = 'apache-beam-3.0.0.tar.gz'
+    sdk_location = os.path.join(sdk_directory, sdk_filename)
+    self.create_temp_file(sdk_location, 'contents')
+
+    options = PipelineOptions()
+    options.view_as(GoogleCloudOptions).staging_location = staging_dir
+    self.update_options(options)
+    options.view_as(SetupOptions).sdk_location = sdk_location
+
+    self.assertEqual(
+        [names.DATAFLOW_SDK_TARBALL_FILE],
+        dependency.stage_job_resources(options))
+    tarball_path = os.path.join(
+        staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
+    with open(tarball_path) as f:
+      self.assertEqual(f.read(), 'contents')
+
+  def test_sdk_location_local_wheel_file(self):
+    staging_dir = self.make_temp_dir()
+    sdk_directory = self.make_temp_dir()
+    sdk_filename = 'apache_beam-1.0.0-cp27-cp27mu-manylinux1_x86_64.whl'
+    sdk_location = os.path.join(sdk_directory, sdk_filename)
+    self.create_temp_file(sdk_location, 'contents')
+
+    options = PipelineOptions()
+    options.view_as(GoogleCloudOptions).staging_location = staging_dir
+    self.update_options(options)
+    options.view_as(SetupOptions).sdk_location = sdk_location
+
+    self.assertEqual(
+        [sdk_filename],
+        dependency.stage_job_resources(options))
+    tarball_path = os.path.join(
+        staging_dir, sdk_filename)
+    with open(tarball_path) as f:
+      self.assertEqual(f.read(), 'contents')
+
+  def test_sdk_location_local_directory_not_present(self):
     staging_dir = self.make_temp_dir()
     sdk_location = 'nosuchdir'
     with self.assertRaises(RuntimeError) as cm:
@@ -343,16 +434,43 @@ class SetupTest(unittest.TestCase):
   def test_sdk_location_gcs(self):
     staging_dir = self.make_temp_dir()
     sdk_location = 'gs://my-gcs-bucket/tarball.tar.gz'
-    self.override_file_copy(sdk_location, staging_dir)
 
     options = PipelineOptions()
     options.view_as(GoogleCloudOptions).staging_location = staging_dir
     self.update_options(options)
     options.view_as(SetupOptions).sdk_location = sdk_location
 
-    self.assertEqual(
-        [names.DATAFLOW_SDK_TARBALL_FILE],
-        dependency.stage_job_resources(options))
+    with mock.patch('apache_beam.runners.dataflow.internal.'
+                    'dependency._dependency_file_copy'):
+      self.assertEqual(
+          [names.DATAFLOW_SDK_TARBALL_FILE],
+          dependency.stage_job_resources(options))
+
+  def test_sdk_location_http(self):
+    staging_dir = self.make_temp_dir()
+    sdk_location = 'http://storage.googleapis.com/my-gcs-bucket/tarball.tar.gz'
+
+    options = PipelineOptions()
+    options.view_as(GoogleCloudOptions).staging_location = staging_dir
+    self.update_options(options)
+    options.view_as(SetupOptions).sdk_location = sdk_location
+
+    def file_download(_, to_folder):
+      tarball_path = os.path.join(to_folder, 'sdk-tarball')
+      with open(tarball_path, 'w') as f:
+        f.write('SDK from HTTP location.')
+      return tarball_path
+
+    with mock.patch('apache_beam.runners.dataflow.internal.'
+                    'dependency._dependency_file_download', file_download):
+      self.assertEqual(
+          [names.DATAFLOW_SDK_TARBALL_FILE],
+          dependency.stage_job_resources(options))
+
+    tarball_path = os.path.join(
+        staging_dir, names.DATAFLOW_SDK_TARBALL_FILE)
+    with open(tarball_path) as f:
+      self.assertEqual(f.read(), 'SDK from HTTP location.')
 
   def test_with_extra_packages(self):
     staging_dir = self.make_temp_dir()


### PR DESCRIPTION
[BEAM-3950] Support staging binary (wheel) distributions of  Beam SDK to Dataflow. This can help reduce worker startup time latency for Beam users on Dataflow runner.

This PR introduces two changes to current behavior:
1) If `--sdk_location points to a wheel`, the staged SDK file name will not be renamed to `dataflow_python_sdk.tar`, instead original name will be used.
2) If `--sdk_location` is not set, try to download and stage both SDK sources and SDK wheel from PyPi. Wheel file is downloaded and staged on a best effort - if PyPi does not have desired wheel, only the sources will be staged, and pipeline execution will continue.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

