### PR TITLE
[BEAM-4049] Improve CassandraIO write throughput by performing async queries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1951,6 +1951,9 @@
                     <shadedPattern>
                       org.apache.${renderedArtifactId}.repackaged.com.google.common
                     </shadedPattern>
+                      <excludes>
+                          <exclude>com.google.common.util.concurrent.ListenableFuture</exclude>
+                      </excludes>
                   </relocation>
                   <relocation>
                     <pattern>com.google.thirdparty</pattern>

--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -24,7 +24,7 @@ enableJavaPerformanceTesting()
 description = "Apache Beam :: SDKs :: Java :: IO :: Cassandra"
 ext.summary = "IO to read and write with Apache Cassandra database"
 
-def cassandra_version = "3.2.0"
+def cassandra_version = "3.4.0"
 
 dependencies {
   compile library.java.guava

--- a/sdks/java/io/cassandra/pom.xml
+++ b/sdks/java/io/cassandra/pom.xml
@@ -31,7 +31,7 @@
   <description>IO to read and write with Apache Cassandra database</description>
 
   <properties>
-    <cassandra.driver.version>3.2.0</cassandra.driver.version>
+    <cassandra.driver.version>3.4.0</cassandra.driver.version>
   </properties>
 
   <dependencies>
@@ -55,12 +55,13 @@
 
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
-      <artifactId>cassandra-driver-mapping</artifactId>
+      <artifactId>cassandra-driver-core</artifactId>
       <version>${cassandra.driver.version}</version>
     </dependency>
+
     <dependency>
       <groupId>com.datastax.cassandra</groupId>
-      <artifactId>cassandra-driver-core</artifactId>
+      <artifactId>cassandra-driver-mapping</artifactId>
       <version>${cassandra.driver.version}</version>
     </dependency>
 

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraIO.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.coders.Coder;
@@ -462,7 +463,8 @@ public class CassandraIO {
     }
 
     @ProcessElement
-    public void processElement(ProcessContext processContext) {
+    public void processElement(ProcessContext processContext)
+        throws ExecutionException, InterruptedException {
       T entity = processContext.element();
       writer.write(entity);
     }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraService.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraService.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.cassandra;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import org.apache.beam.sdk.io.BoundedSource;
 
 /**
@@ -58,7 +59,7 @@ public interface CassandraService<T> extends Serializable {
      * This method should be synchronous. It means you have to be sure that the entity is fully
      * stored (and committed) into the Cassandra instance when you exit from this method.
      */
-    void write(T entity);
+    void write(T entity) throws ExecutionException, InterruptedException;
 
   }
 


### PR DESCRIPTION
The current design uses synchronous queries which serializes all queries and is not the recommended way to perform writes in Cassandra.
This commit makes use of asynchronous queries instead and protects the cluster from being overwhelmed by sending no more than 100 queries at the same time.
It was necessary to exclude the ListenableFuture interface from the guava relocation that the Datastax Java driver uses, but since it's not included in the shaded jar invocation of `saveAsync()` would otherwise fail at runtime. 
