### PR TITLE
Add documentaton for quickstart tasks

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -1220,6 +1220,8 @@ ext.createJavaExamplesArchetypeValidationTask = {
   }
   project.evaluationDependsOn(':release')
   task "${taskName}" (dependsOn: ':release:classes', type: JavaExec) {
+    group = "Verification"
+    description = "Run the Beam ${config.type} with the ${config.runner} runner"
     main = "${config.type}-java-${config.runner}".toLowerCase()
     classpath = project(':release').sourceSets.main.runtimeClasspath
     args argsNeeded

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 }
 
 task runJavaExamplesValidationTask {
+  group = "Verification"
+  description = "Run the Beam quickstart across all Java runners"
   dependsOn ":beam-runners-direct-java:runQuickstartJavaDirect"
   dependsOn ":beam-runners-google-cloud-dataflow-java:runQuickstartJavaDataflow"
   dependsOn ":beam-runners-apex:runQuickstartJavaApex"


### PR DESCRIPTION
These show up when running `./gradlew tasks`:


```
> Task :tasks                                                          
            
------------------------------------------------------------
All tasks runnable from root project                   
------------------------------------------------------------                              

// ...                     
            
Verification tasks
------------------
check - Runs all checks.
examplesJavaIntegrationTest
googleCloudPlatformIntegrationTest
jacocoTestCoverageVerification - Verifies code coverage metrics based on specified rules for the test task.
jacocoTestReport - Generates code coverage report for the test task.
needsRunnerTests - Runs tests that require a runner to validate that piplines/transforms work correctly
postCommit - Various integration tests using the Dataflow runner.
runQuickstartJavaApex - Run the Beam quickstart with the Apex runner
runQuickstartJavaDataflow - Run the Beam quickstart with the Dataflow runner
runQuickstartJavaDirect - Run the Beam quickstart with the Direct runner
runQuickstartJavaFlinkLocal - Run the Beam quickstart with the FlinkLocal runner
runQuickstartJavaSpark - Run the Beam quickstart with the Spark runner
runQuickstartsJava - Run the Beam quickstart across all Java runners
spotlessApply - Applies code formatting steps to sourcecode in-place.
spotlessCheck - Checks that sourcecode satisfies formatting steps.
test - Runs the unit tests.
validatesRunner - Validates Apex runner
validatesRunnerBatch
validatesRunnerStreaming - Validates the streaming runner
validatesRunnerTest

// ...
```