### PR TITLE
[BEAM-3513] Removing PrimitiveCombineGroupedValues override w/ FnAPI.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -447,12 +447,17 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     overridesBuilder
         .add(
             PTransformOverride.of(
-                PTransformMatchers.classEqualTo(Reshuffle.class), new ReshuffleOverrideFactory()))
-        // Order is important. Streaming views almost all use Combine internally.
-        .add(
-            PTransformOverride.of(
-                PTransformMatchers.classEqualTo(Combine.GroupedValues.class),
-                new PrimitiveCombineGroupedValuesOverrideFactory()))
+                PTransformMatchers.classEqualTo(Reshuffle.class), new ReshuffleOverrideFactory()));
+    // Order is important. Streaming views almost all use Combine internally.
+    // TODO (BEAM-4118) Remove this check once combiner lifting is implemented for the FnAPI.
+    if (!hasExperiment(options, "beam_fn_api")) {
+      overridesBuilder
+          .add(
+              PTransformOverride.of(
+                  PTransformMatchers.classEqualTo(Combine.GroupedValues.class),
+                  new PrimitiveCombineGroupedValuesOverrideFactory()));
+    }
+    overridesBuilder
         .add(
             PTransformOverride.of(
                 PTransformMatchers.classEqualTo(ParDo.SingleOutput.class),


### PR DESCRIPTION
When using the FnAPI, make it so that Combine.GroupedValues are not
replaced by the Dataflow specific PTransforms. The reason for this is
to allow the Combines to be translated to a Dataflow pipeline as the
constituent parts of the composite transform (in other words, send
Dataflow a GBK and a ParDo, instead of a CombineGroupedValues black
box).

This does not fully accomplish the final goal of portable combines since
this method doesn't do anything to help Combiner lifting, but it works
for the case of the basic Combine that has been implemented. It
successfully treats the Combine as a GBK and ParDo when not lifted.

Additional changes will need to be made to detect when we want to lift
Combines and in those situations handle that properly, which may mean
putting the Combines in the black box.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

