### PR TITLE
[BEAM-3485] Fix split generation for Cassandra clusters

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImpl.java
@@ -25,7 +25,6 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
-import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.querybuilder.Select;
@@ -38,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,21 +48,17 @@ import org.slf4j.LoggerFactory;
 public class CassandraServiceImpl<T> implements CassandraService<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraServiceImpl.class);
-
-  private static final long MIN_TOKEN = Long.MIN_VALUE;
-  private static final long MAX_TOKEN = Long.MAX_VALUE;
-  private static final BigInteger TOTAL_TOKEN_COUNT =
-      BigInteger.valueOf(MAX_TOKEN).subtract(BigInteger.valueOf(MIN_TOKEN));
+  private static final String MURMUR3PARTITIONER = "org.apache.cassandra.dht.Murmur3Partitioner";
 
   private class CassandraReaderImpl<T> extends BoundedSource.BoundedReader<T> {
 
     private final CassandraIO.CassandraSource<T> source;
-
     private Cluster cluster;
     private Session session;
     private ResultSet resultSet;
     private Iterator<T> iterator;
     private T current;
+    private String partitioner;
 
     public CassandraReaderImpl(CassandraIO.CassandraSource<T> source) {
       this.source = source;
@@ -74,6 +70,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
       cluster = getCluster(source.spec.hosts(), source.spec.port(), source.spec.username(),
           source.spec.password(), source.spec.localDc(), source.spec.consistencyLevel());
       session = cluster.connect();
+      partitioner = cluster.getMetadata().getPartitioner();
       LOG.debug("Query: " + source.splitQuery);
       resultSet = session.execute(source.splitQuery);
 
@@ -165,7 +162,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
         spec.localDc(), spec.consistencyLevel())) {
       if (isMurmur3Partitioner(cluster)) {
         LOG.info("Murmur3Partitioner detected, splitting");
-        return split(spec, desiredBundleSizeBytes, getEstimatedSizeBytes(spec));
+        return split(spec, desiredBundleSizeBytes, getEstimatedSizeBytes(spec), cluster);
       } else {
         LOG.warn("Only Murmur3Partitioner is supported for splitting, using an unique source for "
             + "the read");
@@ -184,7 +181,17 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
   @VisibleForTesting
   protected List<BoundedSource<T>> split(CassandraIO.Read<T> spec,
                                                 long desiredBundleSizeBytes,
-                                                long estimatedSizeBytes) {
+                                                long estimatedSizeBytes,
+                                                Cluster cluster) {
+    String partitionKey =
+        cluster.getMetadata()
+            .getKeyspace(spec.keyspace())
+            .getTable(spec.table())
+            .getPartitionKey()
+            .stream()
+              .map(partitionKeyColumn -> partitionKeyColumn.getName())
+              .collect(Collectors.joining(","));
+
     long numSplits = 1;
     List<BoundedSource<T>> sourceList = new ArrayList<>();
     if (desiredBundleSizeBytes > 0) {
@@ -197,32 +204,23 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
 
     LOG.info("Number of splits is {}", numSplits);
 
-    double startRange = MIN_TOKEN;
-    double endRange = MAX_TOKEN;
-    double startToken, endToken;
+    SplitGenerator splitGenerator = new SplitGenerator(cluster.getMetadata().getPartitioner());
+    List<BigInteger> tokens = cluster.getMetadata().getTokenRanges().stream()
+        .map(tokenRange -> new BigInteger(tokenRange.getEnd().getValue().toString()))
+        .collect(Collectors.toList());
+    List<RingRange> splits = splitGenerator.generateSplits(numSplits, tokens);
 
-    endToken = startRange;
-    double incrementValue = endRange - startRange / numSplits;
-    String splitQuery;
-    if (numSplits == 1) {
-      // we have an unique split
-      splitQuery = QueryBuilder.select().from(spec.keyspace(), spec.table()).toString();
-      sourceList.add(new CassandraIO.CassandraSource<>(spec, splitQuery));
-    } else {
-      // we have more than one split
-      for (int i = 0; i < numSplits; i++) {
-        startToken = endToken;
-        endToken = startToken + incrementValue;
-        Select.Where builder = QueryBuilder.select().from(spec.keyspace(), spec.table()).where();
-        if (i > 0) {
-          builder = builder.and(QueryBuilder.gte("token($pk)", startToken));
-        }
-        if (i < (numSplits - 1)) {
-          builder = builder.and(QueryBuilder.lt("token($pk)", endToken));
-        }
-        sourceList.add(new CassandraIO.CassandraSource(spec, builder.toString()));
-      }
+    for (RingRange split:splits) {
+      Select.Where builder = QueryBuilder.select().from(spec.keyspace(), spec.table()).where();
+        builder = builder.and(QueryBuilder.gte("token(" + partitionKey + ")", split.getStart()));
+        builder = builder.and(QueryBuilder.lt("token(" + partitionKey + ")", split.getEnd()));
+
+      String query = builder.toString();
+
+      LOG.info("Cassandra generated read query : {}", query);
+      sourceList.add(new CassandraIO.CassandraSource(spec, query));
     }
+
     return sourceList;
   }
 
@@ -239,12 +237,13 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
       builder.withAuthProvider(new PlainTextAuthProvider(username, password));
     }
 
+    DCAwareRoundRobinPolicy.Builder dcAwarePolicyBuilder = new DCAwareRoundRobinPolicy.Builder();
     if (localDc != null) {
-      builder.withLoadBalancingPolicy(
-          new TokenAwarePolicy(new DCAwareRoundRobinPolicy.Builder().withLocalDc(localDc).build()));
-    } else {
-      builder.withLoadBalancingPolicy(new TokenAwarePolicy(new RoundRobinPolicy()));
+      dcAwarePolicyBuilder.withLocalDc(localDc);
     }
+
+    builder.withLoadBalancingPolicy(
+        new TokenAwarePolicy(dcAwarePolicyBuilder.build()));
 
     if (consistencyLevel != null) {
       builder.withQueryOptions(
@@ -274,8 +273,8 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
             new TokenRange(
                 row.getLong("partitions_count"),
                 row.getLong("mean_partition_size"),
-                row.getLong("range_start"),
-                row.getLong("range_end"));
+                new BigInteger(row.getString("range_start")),
+                new BigInteger(row.getString("range_end")));
         tokenRanges.add(tokenRange);
       }
       // The table may not contain the estimates yet
@@ -299,7 +298,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
     double ringFraction = 0;
     for (TokenRange tokenRange : tokenRanges) {
       ringFraction = ringFraction + (distance(tokenRange.rangeStart, tokenRange.rangeEnd)
-          .doubleValue() / TOTAL_TOKEN_COUNT.doubleValue());
+          .doubleValue() / SplitGenerator.getRangeSize(MURMUR3PARTITIONER).doubleValue());
     }
     return ringFraction;
   }
@@ -308,11 +307,11 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
    * Measure distance between two tokens.
    */
   @VisibleForTesting
-  protected static BigInteger distance(long left, long right) {
-    if (right > left) {
-      return BigInteger.valueOf(right).subtract(BigInteger.valueOf(left));
+  protected static BigInteger distance(BigInteger left, BigInteger right) {
+    if (right.compareTo(left) > 0) {
+      return right.subtract(left);
     } else {
-      return BigInteger.valueOf(right).subtract(BigInteger.valueOf(left)).add(TOTAL_TOKEN_COUNT);
+      return right.subtract(left).add(SplitGenerator.getRangeSize(MURMUR3PARTITIONER));
     }
   }
 
@@ -321,7 +320,7 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
    */
   @VisibleForTesting
   protected static boolean isMurmur3Partitioner(Cluster cluster) {
-    return "org.apache.cassandra.dht.Murmur3Partitioner".equals(
+    return MURMUR3PARTITIONER.equals(
         cluster.getMetadata().getPartitioner());
   }
 
@@ -333,11 +332,11 @@ public class CassandraServiceImpl<T> implements CassandraService<T> {
   protected static class TokenRange {
     private final long partitionCount;
     private final long meanPartitionSize;
-    private final long rangeStart;
-    private final long rangeEnd;
+    private final BigInteger rangeStart;
+    private final BigInteger rangeEnd;
 
     public TokenRange(
-        long partitionCount, long meanPartitionSize, long rangeStart, long
+        long partitionCount, long meanPartitionSize, BigInteger rangeStart, BigInteger
         rangeEnd) {
       this.partitionCount = partitionCount;
       this.meanPartitionSize = meanPartitionSize;

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Models a Cassandra token range.
+ */
+public final class RingRange {
+
+  /**
+   * Allows to order token ranges by start token.
+   */
+  public static final Comparator<RingRange> START_COMPARATOR =
+      (RingRange o1, RingRange o2) -> o1.start.compareTo(o2.start);
+
+  private final BigInteger start;
+  private final BigInteger end;
+
+  public RingRange(BigInteger start, BigInteger end) {
+    this.start = start;
+    this.end = end;
+  }
+
+  public RingRange(String... range) {
+    start = new BigInteger(range[0]);
+    end = new BigInteger(range[1]);
+  }
+
+  public BigInteger getStart() {
+    return start;
+  }
+
+  public BigInteger getEnd() {
+    return end;
+  }
+
+  /**
+   * Returns the size of this range.
+   *
+   * @return size of the range, max - range, in case of wrap
+   */
+  public BigInteger span(BigInteger ringSize) {
+    if (SplitGenerator.greaterThanOrEqual(start, end)) {
+      return end.subtract(start).add(ringSize);
+    } else {
+      return end.subtract(start);
+    }
+  }
+
+  /**
+   * @return true if other is enclosed in this range.
+   */
+  public boolean encloses(RingRange other) {
+    if (!isWrapping()) {
+      return !other.isWrapping()
+          && SplitGenerator.greaterThanOrEqual(other.start, start)
+          && SplitGenerator.lowerThanOrEqual(other.end, end);
+    } else {
+      return (!other.isWrapping()
+          && (SplitGenerator.greaterThanOrEqual(other.start, start)
+          || SplitGenerator.lowerThanOrEqual(other.end, end)))
+          || (SplitGenerator.greaterThanOrEqual(other.start, start)
+          && SplitGenerator.lowerThanOrEqual(other.end, end));
+    }
+  }
+
+  /**
+   * @return true if 0 is inside of this range. Note that if start == end, then wrapping is true
+   */
+  public boolean isWrapping() {
+    return SplitGenerator.greaterThanOrEqual(start, end);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(%s,%s]", start.toString(), end.toString());
+  }
+
+  public static RingRange merge(List<RingRange> ranges) {
+    // sor
+    Collections.sort(ranges, START_COMPARATOR);
+
+    // find gap
+    int gap = 0;
+    for (; gap < ranges.size() - 1; gap++) {
+      RingRange left = ranges.get(gap);
+      RingRange right = ranges.get(gap + 1);
+      if (!left.end.equals(right.start)) {
+        break;
+      }
+    }
+
+    // return merged
+    if (gap == ranges.size() - 1) {
+      return new RingRange(ranges.get(0).start, ranges.get(gap).end);
+    } else {
+      return new RingRange(ranges.get(gap + 1).start, ranges.get(gap).end);
+    }
+  }
+
+  /**
+   * Builder for the RingRange class.
+   */
+  public static final class Builder {
+
+    private BigInteger start;
+    private BigInteger end;
+
+    public Builder() {}
+
+    public Builder withStart(BigInteger start) {
+      this.start = start;
+      return this;
+    }
+
+    public Builder withStart(String start) {
+      this.start = new BigInteger(start);
+      return this;
+    }
+
+    public Builder withEnd(BigInteger end) {
+      this.end = end;
+      return this;
+    }
+
+    public Builder withEnd(String end) {
+      this.end = new BigInteger(end);
+      return this;
+    }
+
+    public RingRange build() {
+      return new RingRange(this.start, this.end);
+    }
+  }
+}

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/SplitGenerator.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/SplitGenerator.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import com.google.common.collect.Lists;
+import java.math.BigInteger;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Splits given Cassandra table's token range into splits.
+ */
+final class SplitGenerator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SplitGenerator.class);
+
+  private final String partitioner;
+  private final BigInteger rangeMin;
+  private final BigInteger rangeMax;
+  private final BigInteger rangeSize;
+
+  SplitGenerator(String partitioner){
+    rangeMin = getRangeMin(partitioner);
+    rangeMax = getRangeMax(partitioner);
+    rangeSize = getRangeSize(partitioner);
+    this.partitioner = partitioner;
+  }
+
+  SplitGenerator(BigInteger rangeMin, BigInteger rangeMax) {
+    this.rangeMin = rangeMin;
+    this.rangeMax = rangeMax;
+    rangeSize = rangeMax.subtract(rangeMin).add(BigInteger.ONE);
+    partitioner = "(" + rangeMin + "," + rangeMax + ")";
+  }
+
+  static BigInteger getRangeMin(String partitioner) {
+    if (partitioner.endsWith("RandomPartitioner")) {
+      return BigInteger.ZERO;
+    } else if (partitioner.endsWith("Murmur3Partitioner")) {
+      return new BigInteger("2").pow(63).negate();
+    } else {
+      throw new UnsupportedOperationException("Unsupported partitioner. "
+          + "Only Random and Murmur3 are supported");
+    }
+  }
+
+  static BigInteger getRangeMax(String partitioner) {
+    if (partitioner.endsWith("RandomPartitioner")) {
+      return new BigInteger("2").pow(127).subtract(BigInteger.ONE);
+    } else if (partitioner.endsWith("Murmur3Partitioner")) {
+      return new BigInteger("2").pow(63).subtract(BigInteger.ONE);
+    } else {
+      throw new UnsupportedOperationException("Unsupported partitioner. "
+          + "Only Random and Murmur3 are supported");
+    }
+  }
+
+  static BigInteger getRangeSize(String partitioner) {
+    return getRangeMax(partitioner).subtract(getRangeMin(partitioner)).add(BigInteger.ONE);
+  }
+
+  static BigInteger max(BigInteger big0, BigInteger big1) {
+    return greaterThan(big0, big1) ? big0 : big1;
+  }
+
+  static BigInteger min(BigInteger big0, BigInteger big1) {
+    return lowerThan(big0, big1) ? big0 : big1;
+  }
+
+  static boolean lowerThan(BigInteger big0, BigInteger big1) {
+    return big0.compareTo(big1) < 0;
+  }
+
+  static boolean lowerThanOrEqual(BigInteger big0, BigInteger big1) {
+    return big0.compareTo(big1) <= 0;
+  }
+
+  static boolean greaterThan(BigInteger big0, BigInteger big1) {
+    return big0.compareTo(big1) > 0;
+  }
+
+  static boolean greaterThanOrEqual(BigInteger big0, BigInteger big1) {
+    return big0.compareTo(big1) >= 0;
+  }
+
+  /**
+   * Given big0 properly ordered list of tokens, compute at least {@code totalSplitCount} splits.
+   *
+   * @param totalSplitCount requested total amount of splits. This function may generate
+   *                        more splits.
+   * @param ringTokens list of all start tokens in big0 cluster. They have to be in ring order.
+   * @return big0 list containing at least {@code totalSplitCount} splits.
+   */
+  List<RingRange> generateSplits(long totalSplitCount, List<BigInteger> ringTokens) {
+
+    int tokenRangeCount = ringTokens.size();
+
+    List<RingRange> splits = Lists.newArrayList();
+    for (int i = 0; i < tokenRangeCount; i++) {
+      BigInteger start = ringTokens.get(i);
+      BigInteger stop = ringTokens.get((i + 1) % tokenRangeCount);
+
+      if (!inRange(start) || !inRange(stop)) {
+        throw new RuntimeException(String.format("Tokens (%s,%s) not in range of %s", start, stop,
+            partitioner));
+      }
+      if (start.equals(stop) && tokenRangeCount != 1) {
+        throw new RuntimeException(String.format("Tokens (%s,%s): two nodes have the same token",
+            start, stop));
+      }
+
+      BigInteger rs = stop.subtract(start);
+      if (lowerThanOrEqual(rs, BigInteger.ZERO)) {
+        // wrap around case
+        rs = rs.add(rangeSize);
+      }
+
+      // the below, in essence, does this:
+      // splitCount = ceiling((rangeSize / RANGE_SIZE) * totalSplitCount)
+      BigInteger[] splitCountAndRemainder =
+          rs.multiply(BigInteger.valueOf(totalSplitCount)).divideAndRemainder(rangeSize);
+
+      int splitCount = splitCountAndRemainder[0].intValue()
+          + (splitCountAndRemainder[1].equals(
+              BigInteger.ZERO) ? 0 : 1);
+
+      LOG.info("Dividing token range [{},{}) into {} splits", start, stop, splitCount);
+
+      // Make big0 list of all the endpoints for the splits, including both start and stop
+      List<BigInteger> endpointTokens = Lists.newArrayList();
+      for (int j = 0; j <= splitCount; j++) {
+        BigInteger offset = rs.multiply(BigInteger.valueOf(j)).divide(
+            BigInteger.valueOf(splitCount));
+        BigInteger token = start.add(offset);
+        if (greaterThan(token, rangeMax)) {
+          token = token.subtract(rangeSize);
+        }
+        endpointTokens.add(token);
+      }
+
+      // Append the splits between the endpoints
+      for (int j = 0; j < splitCount; j++) {
+        splits.add(new RingRange(endpointTokens.get(j), endpointTokens.get(j + 1)));
+        LOG.debug("Split #{}: [{},{})", j + 1, endpointTokens.get(j), endpointTokens.get(j + 1));
+      }
+    }
+
+    BigInteger total = BigInteger.ZERO;
+    for (RingRange split : splits) {
+      BigInteger size = split.span(rangeSize);
+      total = total.add(size);
+    }
+    if (!total.equals(rangeSize)) {
+      throw new RuntimeException("Some tokens are missing from the splits. "
+          + "This should not happen.");
+    }
+    return splits;
+  }
+
+  protected boolean inRange(BigInteger token) {
+    return !(lowerThan(token, rangeMin) || greaterThan(token, rangeMax));
+  }
+}

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImplTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraServiceImplTest.java
@@ -21,9 +21,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.TableMetadata;
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -41,7 +45,15 @@ public class CassandraServiceImplTest {
 
   private Cluster createClusterMock() {
     Metadata metadata = Mockito.mock(Metadata.class);
+    KeyspaceMetadata keyspaceMetadata = Mockito.mock(KeyspaceMetadata.class);
+    TableMetadata tableMetadata = Mockito.mock(TableMetadata.class);
+    ColumnMetadata columnMetadata = Mockito.mock(ColumnMetadata.class);
+
     Mockito.when(metadata.getPartitioner()).thenReturn(MURMUR3_PARTITIONER);
+    Mockito.when(metadata.getKeyspace(Mockito.anyString())).thenReturn(keyspaceMetadata);
+    Mockito.when(keyspaceMetadata.getTable(Mockito.anyString())).thenReturn(tableMetadata);
+    Mockito.when(tableMetadata.getPartitionKey()).thenReturn(Arrays.asList(columnMetadata));
+    Mockito.when(columnMetadata.getName()).thenReturn("$pk");
     Cluster cluster = Mockito.mock(Cluster.class);
     Mockito.when(cluster.getMetadata()).thenReturn(metadata);
     return cluster;
@@ -54,22 +66,25 @@ public class CassandraServiceImplTest {
 
   @Test
   public void testDistance() throws Exception {
-    BigInteger distance = CassandraServiceImpl.distance(10L, 100L);
+    BigInteger distance = CassandraServiceImpl.distance(new BigInteger("10"),
+        new BigInteger("100"));
     assertEquals(BigInteger.valueOf(90), distance);
 
-    distance = CassandraServiceImpl.distance(100L, 10L);
-    assertEquals(new BigInteger("18446744073709551525"), distance);
+    distance = CassandraServiceImpl.distance(new BigInteger("100"), new BigInteger("10"));
+    assertEquals(new BigInteger("18446744073709551526"), distance);
   }
 
   @Test
   public void testRingFraction() throws Exception {
     // simulate a first range taking "half" of the available tokens
     List<CassandraServiceImpl.TokenRange> tokenRanges = new ArrayList<>();
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1, Long.MIN_VALUE, 0));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1,
+        BigInteger.valueOf(Long.MIN_VALUE), new BigInteger("0")));
     assertEquals(0.5, CassandraServiceImpl.getRingFraction(tokenRanges), 0);
 
     // add a second range to cover all tokens available
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1, 0, Long.MAX_VALUE));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1,
+        new BigInteger("0"), BigInteger.valueOf(Long.MAX_VALUE)));
     assertEquals(1.0, CassandraServiceImpl.getRingFraction(tokenRanges), 0);
   }
 
@@ -77,60 +92,25 @@ public class CassandraServiceImplTest {
   public void testEstimatedSizeBytes() throws Exception {
     List<CassandraServiceImpl.TokenRange> tokenRanges = new ArrayList<>();
     // one partition containing all tokens, the size is actually the size of the partition
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000, Long.MIN_VALUE, Long.MAX_VALUE));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000,
+        BigInteger.valueOf(Long.MIN_VALUE), BigInteger.valueOf(Long.MAX_VALUE)));
     assertEquals(1000, CassandraServiceImpl.getEstimatedSizeBytes(tokenRanges));
 
     // one partition with half of the tokens, we estimate the size to the double of this partition
     tokenRanges = new ArrayList<>();
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000, Long.MIN_VALUE, 0));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000,
+        BigInteger.valueOf(Long.MIN_VALUE), new BigInteger("0")));
     assertEquals(2000, CassandraServiceImpl.getEstimatedSizeBytes(tokenRanges));
 
     // we have three partitions covering all tokens, the size is the sum of partition size *
     // partition count
     tokenRanges = new ArrayList<>();
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000, Long.MIN_VALUE, -3));
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000, -2, 10000));
-    tokenRanges.add(new CassandraServiceImpl.TokenRange(2, 3000, 10001, Long.MAX_VALUE));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000,
+        BigInteger.valueOf(Long.MIN_VALUE), new BigInteger("-3")));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(1, 1000,
+        new BigInteger("-2"), new BigInteger("10000")));
+    tokenRanges.add(new CassandraServiceImpl.TokenRange(2, 3000,
+        new BigInteger("10001"), BigInteger.valueOf(Long.MAX_VALUE)));
     assertEquals(8000, CassandraServiceImpl.getEstimatedSizeBytes(tokenRanges));
   }
-
-  @Test
-  public void testThreeSplits() throws Exception {
-    CassandraServiceImpl service = new CassandraServiceImpl();
-    CassandraIO.Read spec = CassandraIO.read().withKeyspace("beam").withTable("test");
-    List<CassandraIO.CassandraSource> sources = service.split(spec, 50, 150);
-    assertEquals(3, sources.size());
-    assertTrue(sources.get(0).splitQuery.matches("SELECT \\* FROM beam.test WHERE token\\"
-        + "(\\$pk\\)<(.*)"));
-    assertTrue(sources.get(1).splitQuery.matches("SELECT \\* FROM beam.test WHERE token\\"
-        + "(\\$pk\\)>=(.*) AND token\\(\\$pk\\)<(.*)"));
-    assertTrue(sources.get(2).splitQuery.matches("SELECT \\* FROM beam.test WHERE token\\"
-        + "(\\$pk\\)>=(.*)"));
-  }
-
-  @Test
-  public void testTwoSplits() throws Exception {
-    CassandraServiceImpl service = new CassandraServiceImpl();
-    CassandraIO.Read spec = CassandraIO.read().withKeyspace("beam").withTable("test");
-    List<CassandraIO.CassandraSource> sources = service.split(spec, 50, 100);
-    assertEquals(2, sources.size());
-    LOG.info("TOKEN: " + ((double) Long.MAX_VALUE / 2));
-    LOG.info(sources.get(0).splitQuery);
-    LOG.info(sources.get(1).splitQuery);
-    assertEquals("SELECT * FROM beam.test WHERE token($pk)<" + ((double) Long.MAX_VALUE / 2) + ";",
-        sources.get(0).splitQuery);
-    assertEquals("SELECT * FROM beam.test WHERE token($pk)>=" + ((double) Long.MAX_VALUE / 2)
-            + ";",
-        sources.get(1).splitQuery);
-  }
-
-  @Test
-  public void testUniqueSplit() throws Exception {
-    CassandraServiceImpl service = new CassandraServiceImpl();
-    CassandraIO.Read spec = CassandraIO.read().withKeyspace("beam").withTable("test");
-    List<CassandraIO.CassandraSource> sources = service.split(spec, 100, 100);
-    assertEquals(1, sources.size());
-    assertEquals("SELECT * FROM beam.test;", sources.get(0).splitQuery);
-  }
-
 }

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/SplitGeneratorTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/SplitGeneratorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.cassandra;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.Lists;
+import java.math.BigInteger;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ * Tests on {@link SplitGenerator}.
+ */
+public final class SplitGeneratorTest {
+
+  @Test
+  public void testGenerateSegments() throws Exception {
+
+    List<BigInteger> tokens = Lists.transform(Lists.newArrayList(
+        "0",
+        "1",
+        "56713727820156410577229101238628035242",
+        "56713727820156410577229101238628035243",
+        "113427455640312821154458202477256070484",
+        "113427455640312821154458202477256070485"),
+        (String string) -> new BigInteger(string));
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    List<RingRange> segments = generator.generateSplits(10, tokens);
+    assertEquals(15, segments.size());
+
+    assertEquals(
+        "(0,1]",
+        segments.get(0).toString());
+
+    assertEquals(
+        "(56713727820156410577229101238628035242,56713727820156410577229101238628035243]",
+        segments.get(5).toString());
+
+    assertEquals(
+        "(113427455640312821154458202477256070484,113427455640312821154458202477256070485]",
+        segments.get(10).toString());
+
+    tokens = Lists.transform(Lists.newArrayList(
+        "5",
+        "6",
+        "56713727820156410577229101238628035242",
+        "56713727820156410577229101238628035243",
+        "113427455640312821154458202477256070484",
+        "113427455640312821154458202477256070485"),
+        (String string) -> new BigInteger(string));
+
+    segments = generator.generateSplits(10, tokens);
+    assertEquals(15, segments.size());
+
+    assertEquals(
+        "(5,6]",
+        segments.get(0).toString());
+
+    assertEquals(
+        "(56713727820156410577229101238628035242,56713727820156410577229101238628035243]",
+        segments.get(5).toString());
+
+    assertEquals(
+        "(113427455640312821154458202477256070484,113427455640312821154458202477256070485]",
+        segments.get(10).toString());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testZeroSizeRange() throws Exception {
+
+    List<String> tokenStrings = Lists.newArrayList(
+        "0",
+        "1",
+        "56713727820156410577229101238628035242",
+        "56713727820156410577229101238628035242",
+        "113427455640312821154458202477256070484",
+        "113427455640312821154458202477256070485");
+
+    List<BigInteger> tokens = Lists.transform(tokenStrings,
+        (String string) -> new BigInteger(string));
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    generator.generateSplits(10, tokens);
+  }
+
+  @Test
+  public void testRotatedRing() throws Exception {
+    List<String> tokenStrings = Lists.newArrayList(
+        "56713727820156410577229101238628035243",
+        "113427455640312821154458202477256070484",
+        "113427455640312821154458202477256070485",
+        "5",
+        "6",
+        "56713727820156410577229101238628035242");
+
+    List<BigInteger> tokens = Lists.transform(tokenStrings,
+        (String string) -> new BigInteger(string));
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    List<RingRange> segments = generator.generateSplits(10, tokens);
+    assertEquals(15, segments.size());
+
+    assertEquals(
+        "(113427455640312821154458202477256070484,113427455640312821154458202477256070485]",
+        segments.get(4).toString());
+
+    assertEquals(
+
+        "(5,6]",
+        segments.get(9).toString());
+
+    assertEquals(
+        "(56713727820156410577229101238628035242,56713727820156410577229101238628035243]",
+        segments.get(14).toString());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testDisorderedRing() throws Exception {
+
+    List<String> tokenStrings = Lists.newArrayList(
+        "0",
+        "113427455640312821154458202477256070485",
+        "1",
+        "56713727820156410577229101238628035242",
+        "56713727820156410577229101238628035243",
+        "113427455640312821154458202477256070484");
+
+    List<BigInteger> tokens = Lists.transform(tokenStrings,
+        (String string) -> new BigInteger(string));
+
+    SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
+    generator.generateSplits(10, tokens);
+    // Will throw an exception when concluding that the repair segments don't add up.
+    // This is because the tokens were supplied out of order.
+  }
+
+  @Test
+  public void testMax() throws Exception {
+    BigInteger one = BigInteger.ONE;
+    BigInteger ten = BigInteger.TEN;
+    assertEquals(ten, SplitGenerator.max(one, ten));
+    assertEquals(ten, SplitGenerator.max(ten, one));
+    assertEquals(one, SplitGenerator.max(one, one));
+    BigInteger minusTen = BigInteger.TEN.negate();
+    assertEquals(one, SplitGenerator.max(one, minusTen));
+  }
+
+  @Test
+  public void testMin() throws Exception {
+    BigInteger one = BigInteger.ONE;
+    BigInteger ten = BigInteger.TEN;
+    assertEquals(one, SplitGenerator.min(one, ten));
+    assertEquals(one, SplitGenerator.min(ten, one));
+    assertEquals(one, SplitGenerator.min(one, one));
+    BigInteger minusTen = BigInteger.TEN.negate();
+    assertEquals(minusTen, SplitGenerator.min(one, minusTen));
+  }
+
+  @Test
+  public void testLowerThan() throws Exception {
+    BigInteger one = BigInteger.ONE;
+    BigInteger ten = BigInteger.TEN;
+    assertTrue(SplitGenerator.lowerThan(one, ten));
+    assertFalse(SplitGenerator.lowerThan(ten, one));
+    assertFalse(SplitGenerator.lowerThan(ten, ten));
+    BigInteger minusTen = BigInteger.TEN.negate();
+    assertTrue(SplitGenerator.lowerThan(minusTen, one));
+    assertFalse(SplitGenerator.lowerThan(one, minusTen));
+  }
+
+  @Test
+  public void testGreaterThan() throws Exception {
+    BigInteger one = BigInteger.ONE;
+    BigInteger ten = BigInteger.TEN;
+    assertTrue(SplitGenerator.greaterThan(ten, one));
+    assertFalse(SplitGenerator.greaterThan(one, ten));
+    assertFalse(SplitGenerator.greaterThan(one, one));
+    BigInteger minusTen = BigInteger.TEN.negate();
+    assertFalse(SplitGenerator.greaterThan(minusTen, one));
+    assertTrue(SplitGenerator.greaterThan(one, minusTen));
+  }
+}
+


### PR DESCRIPTION
The existing code for generating splits was broken in several ways and couldn't ever generate splits.
This commit uses the token range splitter that has been used for years in Reaper and will safely generate subranges as needed.
It will respect data locality and avoid generating splits that would cover several token ranges as it would involve potentially many nodes in the cluster.
The default load balancing policy has been switched to DCAware in all cases to avoid cross DC queries.

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

