### PR TITLE
Stop implementing EvaluatorFactory in Registry

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTransformExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectTransformExecutor.java
@@ -72,7 +72,7 @@ class DirectTransformExecutor<T> implements TransformExecutor {
     }
   }
 
-  private final TransformEvaluatorFactory evaluatorFactory;
+  private final TransformEvaluatorRegistry evaluatorRegistry;
   private final Iterable<? extends ModelEnforcementFactory> modelEnforcements;
 
   /** The transform that will be evaluated. */
@@ -87,13 +87,13 @@ class DirectTransformExecutor<T> implements TransformExecutor {
   @VisibleForTesting
   DirectTransformExecutor(
       EvaluationContext context,
-      TransformEvaluatorFactory factory,
+      TransformEvaluatorRegistry factory,
       Iterable<? extends ModelEnforcementFactory> modelEnforcements,
       CommittedBundle<T> inputBundle,
       AppliedPTransform<?, ?, ?> transform,
       CompletionCallback completionCallback,
       TransformExecutorService transformEvaluationState) {
-    this.evaluatorFactory = factory;
+    this.evaluatorRegistry = factory;
     this.modelEnforcements = modelEnforcements;
 
     this.inputBundle = inputBundle;
@@ -115,7 +115,7 @@ class DirectTransformExecutor<T> implements TransformExecutor {
         enforcements.add(enforcement);
       }
       TransformEvaluator<T> evaluator =
-          evaluatorFactory.forApplication(transform, inputBundle);
+          evaluatorRegistry.forApplication(transform, inputBundle);
       if (evaluator == null) {
         onComplete.handleEmpty(transform);
         // Nothing to do

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
@@ -56,7 +56,7 @@ import org.slf4j.LoggerFactory;
  * A {@link TransformEvaluatorFactory} that delegates to primitive {@link TransformEvaluatorFactory}
  * implementations based on the type of {@link PTransform} of the application.
  */
-class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
+class TransformEvaluatorRegistry {
   private static final Logger LOG = LoggerFactory.getLogger(TransformEvaluatorRegistry.class);
 
   /**
@@ -164,7 +164,6 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
     this.factories = factories;
   }
 
-  @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
       AppliedPTransform<?, ?, ?> application, CommittedBundle<?> inputBundle)
       throws Exception {
@@ -179,7 +178,6 @@ class TransformEvaluatorRegistry implements TransformEvaluatorFactory {
     return factory.forApplication(application, inputBundle);
   }
 
-  @Override
   public void cleanup() throws Exception {
     Collection<Exception> thrownInCleanup = new ArrayList<>();
     for (TransformEvaluatorFactory factory : factories.values()) {


### PR DESCRIPTION
This isn't a necessary interface, as the actual caller will always know
if it's asking the registry. It has the same signatures as
TransformEvaluatorFactory, but isn't appropriate to use in places where
those factories are appropriate.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

