### PR TITLE
[BEAM-4075] Fixes run_pylint to run on Mac

### DIFF
--- a/sdks/python/run_pylint.sh
+++ b/sdks/python/run_pylint.sh
@@ -26,7 +26,7 @@
 set -o errexit
 set -o pipefail
 
-MODULE=$(ls --directory -C apache_beam *.py)
+MODULE=$(ls -d -C apache_beam *.py)
 
 usage(){ echo "Usage: $0 [MODULE|--help]  # The default MODULE is $MODULE"; }
 


### PR DESCRIPTION
Mac ls doesn't support --directory, but supports -d.

R: @udim 