### PR TITLE
[BEAM-4028] Transitioning MapTask objects to NameContext

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -56,7 +56,7 @@ class NameContext(object):
     return not self == other
 
   def __repr__(self):
-    return 'NameContext(%s)' % self.__dict__()
+    return 'NameContext(%s)' % self.__dict__
 
   def __hash__(self):
     return hash(self.step_name)
@@ -101,7 +101,7 @@ class DataflowNameContext(NameContext):
     return hash((self.step_name, self.user_name, self.system_name))
 
   def __repr__(self):
-    return 'DataflowNameContext(%s)' % self.__dict__()
+    return 'DataflowNameContext(%s)' % self.__dict__
 
   def logging_name(self):
     """Stackdriver logging relies on user-given step names (e.g. Foo/Bar)."""

--- a/sdks/python/apache_beam/runners/worker/operation_specs.py
+++ b/sdks/python/apache_beam/runners/worker/operation_specs.py
@@ -24,6 +24,7 @@ source, write to a sink, parallel do, etc.
 import collections
 
 from apache_beam import coders
+from apache_beam.runners import common
 
 # This module is experimental. No backwards-compatibility guarantees.
 
@@ -359,17 +360,57 @@ class MapTask(object):
     stage_name: The name of this map task execution stage.
     system_names: The system names of the step corresponding to each map task
       operation in the execution graph.
-    step_names: The names of the step corresponding to each map task operation.
+    step_names: The user-given names of the step corresponding to each map task
+      operation (e.g. Foo/Bar/ParDo).
     original_names: The internal name of a step in the original workflow graph.
+    name_contexts: A common.NameContext object containing name information
+      about a step.
   """
 
-  def __init__(
-      self, operations, stage_name, system_names, step_names, original_names):
+  def __init__(self, operations, stage_name,
+               system_names=None,
+               step_names=None,
+               original_names=None,
+               name_contexts=None):
     self.operations = operations
     self.stage_name = stage_name
-    self.system_names = system_names
-    self.step_names = step_names
-    self.original_names = original_names
+    # TODO(BEAM-4028): Remove arguments other than name_contexts.
+    self.name_contexts = name_contexts or self._make_name_contexts(
+        original_names, step_names, system_names)
+
+  @staticmethod
+  def _make_name_contexts(original_names, user_names, system_names):
+    # TODO(BEAM-4028): Remove method once map task relies on name contexts.
+    return [common.DataflowNameContext(step_name, user_name, system_name)
+            for step_name, user_name, system_name in zip(original_names,
+                                                         user_names,
+                                                         system_names)]
+
+  @property
+  def system_names(self):
+    """Returns a list containing the system names of steps.
+
+    A System name is the name of a step in the optimized Dataflow graph.
+    """
+    return [nc.system_name for nc in self.name_contexts]
+
+  @property
+  def original_names(self):
+    """Returns a list containing the original names of steps.
+
+    An original name is the internal name of a step in the Dataflow graph
+    (e.g. 's2').
+    """
+    return [nc.step_name for nc in self.name_contexts]
+
+  @property
+  def step_names(self):
+    """Returns a list containing the user names of steps.
+
+    In this context, a step name is the user-given name of a step in the
+    Dataflow graph (e.g. 's2').
+    """
+    return [nc.user_name for nc in self.name_contexts]
 
   def __str__(self):
     return '<%s %s steps=%s>' % (self.__class__.__name__, self.stage_name,

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -700,20 +700,9 @@ class SimpleMapTaskExecutor(object):
     # operations is a list of operation_specs.Worker* instances.
     # The order of the elements is important because the inputs use
     # list indexes as references.
-    # TODO(BEAM-4028): Remove extra conversion once all map tasks are
-    # transitioned to use name_contexts.
-    def get_name_context(map_task, index):
-      if getattr(map_task, 'name_contexts'):
-        return getattr(map_task, 'name_contexts')[index]
-      else:
-        return common.DataflowNameContext(
-            step_name=map_task.original_names[index],
-            user_name=map_task.step_names[index],
-            system_name=map_task.system_names[index])
-
-    for ix, spec in enumerate(self._map_task.operations):
+    for name_context, spec in zip(self._map_task.name_contexts,
+                                  self._map_task.operations):
       # This is used for logging and assigning names to counters.
-      name_context = get_name_context(self._map_task, ix)
       op = create_operation(
           name_context, spec, self._counter_factory, None,
           self._state_sampler,


### PR DESCRIPTION
Transitioning the `operation_specs.MapTask` to rely fully on `NameContext` for step naming.
r: @aaltay 

The plan is to use NameContext wherever we need a step name (e.g. operations, ssampler), instead of passing operation_name, step_name etc around like we do atm. Classes were created in https://github.com/apache/beam/pull/5043, and this is further progress.

Followup will be internal changes in dataflow code to rely on and pass NameContexts around.