### PR TITLE
Increase Dataflow max parallelism

### DIFF
--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -48,9 +48,12 @@ job('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle') {
       rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':beam-runners-google-cloud-dataflow-java:validatesRunner')
       common_job_properties.setGradleSwitches(delegate)
-      // Increase parallel worker threads above processor limit sinc most time is
-      // spent waiting on Dataflow jobs.
-      switches("--max-workers=${3*Runtime.runtime.availableProcessors()}")
+      // Increase parallel worker threads above processor limit since most time is
+      // spent waiting on Dataflow jobs. ValidatesRunner tests on Dataflow are slow
+      // because each one launches a Dataflow job with about 3 mins of overhead.
+      // 3 x num_cores strikes a good balance between maxing out parallelism without
+      // overloading the machines.
+      switches("--max-workers=${3 * Runtime.runtime.availableProcessors()}")
     }
   }
 }

--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -48,6 +48,9 @@ job('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle') {
       rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':beam-runners-google-cloud-dataflow-java:validatesRunner')
       common_job_properties.setGradleSwitches(delegate)
+      // Increase parallel worker threads above processor limit sinc most time is
+      // spent waiting on Dataflow jobs.
+      switches("--max-workers=${3*Runtime.runtime.availableProcessors()}")
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -112,7 +112,9 @@ task validatesRunnerTest(type: Test) {
           "--tempRoot=${dataflowTempRoot}",
   ])
 
-  maxParallelForks 4
+  // Increase test parallelism up to the number of Gradle workers. By default this is equal
+  // to the number of CPU cores, but can be increased by setting --max-workers=N.
+  maxParallelForks Integer.MAX_VALUE
   classpath = configurations.validatesRunner
   testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
   useJUnit {


### PR DESCRIPTION
The majority of time executing Dataflow post-commits is spent waiting
for jobs executing within the Dataflow service. And each job has
significant overhead while waiting for worker VM's to spin up. As a
result, the overall test suite has been timing out over 3 hours.

We can do much better by parallelizing executing. Starting with
3\*num\_cores for now; we can go higher if needed.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

