### PR TITLE
[BEAM-3697] Add errorprone to Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ buildscript {
     classpath "com.github.jengelman.gradle.plugins:shadow:2.0.1"                                        // Enable shading Java dependencies
     classpath "ca.coglinc:javacc-gradle-plugin:2.4.0"                                                   // Enable the JavaCC parser generator
     classpath "gradle.plugin.io.pry.gradle.offline_dependencies:gradle-offline-dependencies-plugin:0.3" // Enable creating an offline repository
+    classpath "net.ltgt.gradle:gradle-errorprone-plugin:0.0.13"                                         // Enable errorprone Java static analysis
   }
 }
 

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -336,6 +336,8 @@ ext.DEFAULT_SHADOW_CLOSURE = {
 class JavaNatureConfiguration {
   double javaVersion = 1.8        // Controls the JDK source language and target compatibility
   boolean enableFindbugs = true   // Controls whether the findbugs plugin is enabled and configured
+  boolean enableErrorProne = true // Controls whether the errorprone plugin is enabled and configured
+
   // The shadowJar / shadowTestJar tasks execute the following closure to configure themselves.
   // Users can compose their closure with the default closure via:
   // DEFAULT_SHADOW_CLOSURE << {
@@ -498,6 +500,11 @@ ext.applyJavaNature = {
         xml.enabled = false
       }
     }
+  }
+
+  // Enable errorprone, not by default right now
+  if (configuration.enableErrorProne) {
+    apply plugin: 'net.ltgt.errorprone'
   }
 
   // Enables a plugin which can perform shading of classes. See the general comments
@@ -813,9 +820,13 @@ ext.applyJavaNature = {
   //
   // TODO: Figure out whether we should force all dependency conflict resolution
   // to occur in the "shadow" and "shadowTest" configurations.
-  configurations.all {
-    resolutionStrategy {
-      force library.java.values()
+  configurations.all { config ->
+    // The "errorprone" configuration controls the classpath used by errorprone static analysis, which
+    // has different dependencies than our project.
+    if (config.getName() != "errorprone") {
+      config.resolutionStrategy {
+        force library.java.values()
+      }
     }
   }
 

--- a/examples/java/src/test/java/org/apache/beam/examples/subprocess/ExampleEchoPipelineTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/subprocess/ExampleEchoPipelineTest.java
@@ -58,6 +58,7 @@ import org.slf4j.LoggerFactory;
  * it is not factored or testable. This test file should be maintained with a copy of its
  * code for a basic smoke test.
  **/
+@RunWith(JUnit4.class)
 public class ExampleEchoPipelineTest {
 
   static final Logger LOG = LoggerFactory.getLogger(ExampleEchoPipelineTest.class);
@@ -124,7 +125,7 @@ public class ExampleEchoPipelineTest {
   /**
    * Simple DoFn that echos the element, used as an example of running a C++ library.
    */
-  @SuppressWarnings("serial") @RunWith(JUnit4.class) public static class EchoInputDoFn
+  @SuppressWarnings("serial") private static class EchoInputDoFn
       extends DoFn<KV<String, String>, KV<String, String>> {
 
     static final Logger LOG = LoggerFactory.getLogger(EchoInputDoFn.class);

--- a/model/fn-execution/build.gradle
+++ b/model/fn-execution/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false)
+applyJavaNature(enableFindbugs: false, enableErrorProne: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Fn Execution"

--- a/model/job-management/build.gradle
+++ b/model/job-management/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false)
+applyJavaNature(enableFindbugs: false, enableErrorProne: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Job Management"

--- a/model/pipeline/build.gradle
+++ b/model/pipeline/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false)
+applyJavaNature(enableFindbugs: false, enableErrorProne: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Pipeline"

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
@@ -187,7 +187,7 @@ public class PipelineTranslationTest {
     }
 
     private void addCoders(Coder<?> coder) {
-      coders.add(Equivalence.<Coder<?>>identity().wrap(coder));
+      coders.add(Equivalence.identity().wrap(coder));
       if (CoderTranslation.KNOWN_CODER_URNS.containsKey(coder.getClass())) {
         for (Coder<?> component : ((StructuredCoder<?>) coder).getComponents()) {
           addCoders(component);

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/ReduceFnRunnerTest.java
@@ -255,7 +255,7 @@ public class ReduceFnRunnerTest {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(
             Sessions.withGapDuration(Duration.millis(10)),
-            DefaultTriggerStateMachine.<IntervalWindow>of(),
+            DefaultTriggerStateMachine.of(),
             AccumulationMode.ACCUMULATING_FIRED_PANES,
             Duration.millis(50),
             ClosingBehavior.FIRE_ALWAYS);
@@ -282,7 +282,7 @@ public class ReduceFnRunnerTest {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(
             FixedWindows.of(Duration.millis(10)),
-            DefaultTriggerStateMachine.<IntervalWindow>of(),
+            DefaultTriggerStateMachine.of(),
             AccumulationMode.ACCUMULATING_FIRED_PANES,
             Duration.millis(50),
             ClosingBehavior.FIRE_ALWAYS);
@@ -309,7 +309,7 @@ public class ReduceFnRunnerTest {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester =
         ReduceFnTester.nonCombining(
             FixedWindows.of(Duration.millis(10)),
-            DefaultTriggerStateMachine.<IntervalWindow>of(),
+            DefaultTriggerStateMachine.of(),
             AccumulationMode.ACCUMULATING_FIRED_PANES,
             Duration.millis(50),
             ClosingBehavior.FIRE_IF_NON_EMPTY);
@@ -1022,7 +1022,7 @@ public class ReduceFnRunnerTest {
   public void noEmptyPanesFinalIfNonEmpty() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester = ReduceFnTester.nonCombining(
         WindowingStrategy.of(FixedWindows.of(Duration.millis(10)))
-            .withTrigger(Repeatedly.<IntervalWindow>forever(AfterFirst.<IntervalWindow>of(
+            .withTrigger(Repeatedly.forever(AfterFirst.of(
                 AfterPane.elementCountAtLeast(2),
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
@@ -1049,7 +1049,7 @@ public class ReduceFnRunnerTest {
   public void noEmptyPanesFinalAlways() throws Exception {
     ReduceFnTester<Integer, Iterable<Integer>, IntervalWindow> tester = ReduceFnTester.nonCombining(
         WindowingStrategy.of(FixedWindows.of(Duration.millis(10)))
-            .withTrigger(Repeatedly.<IntervalWindow>forever(AfterFirst.<IntervalWindow>of(
+            .withTrigger(Repeatedly.forever(AfterFirst.of(
                 AfterPane.elementCountAtLeast(2),
                 AfterWatermark.pastEndOfWindow())))
             .withMode(AccumulationMode.ACCUMULATING_FIRED_PANES)
@@ -1650,7 +1650,7 @@ public class ReduceFnRunnerTest {
         WindowingStrategy.of((WindowFn<?, IntervalWindow>) FixedWindows.of(Duration.millis(10)))
             .withTimestampCombiner(TimestampCombiner.EARLIEST)
             .withTrigger(
-                AfterEach.<IntervalWindow>inOrder(
+                AfterEach.inOrder(
                     Repeatedly.forever(
                             AfterProcessingTime.pastFirstElementInPane()
                                 .plusDelayOf(new Duration(5)))
@@ -1703,7 +1703,7 @@ public class ReduceFnRunnerTest {
         WindowingStrategy.of((WindowFn<?, IntervalWindow>) FixedWindows.of(Duration.millis(10)))
             .withTimestampCombiner(TimestampCombiner.EARLIEST)
             .withTrigger(
-                AfterEach.<IntervalWindow>inOrder(
+                AfterEach.inOrder(
                     Repeatedly.forever(
                         AfterProcessingTime.pastFirstElementInPane()
                             .plusDelayOf(new Duration(5)))
@@ -1803,7 +1803,7 @@ public class ReduceFnRunnerTest {
         WindowingStrategy.of((WindowFn<?, IntervalWindow>) FixedWindows.of(Duration.millis(10)))
             .withTimestampCombiner(TimestampCombiner.EARLIEST)
             .withTrigger(
-                AfterEach.<IntervalWindow>inOrder(
+                AfterEach.inOrder(
                     Repeatedly.forever(
                         AfterProcessingTime.pastFirstElementInPane()
                             .plusDelayOf(new Duration(5)))
@@ -1865,7 +1865,7 @@ public class ReduceFnRunnerTest {
         WindowingStrategy.of((WindowFn<?, IntervalWindow>) FixedWindows.of(Duration.millis(10)))
             .withTimestampCombiner(TimestampCombiner.EARLIEST)
             .withTrigger(
-                AfterEach.<IntervalWindow>inOrder(
+                AfterEach.inOrder(
                     Repeatedly.forever(
                             AfterProcessingTime.pastFirstElementInPane()
                                 .plusDelayOf(new Duration(5)))
@@ -1948,7 +1948,7 @@ public class ReduceFnRunnerTest {
     ReduceFnTester<Integer, Iterable<Integer>, GlobalWindow> tester =
         ReduceFnTester.nonCombining(
             WindowingStrategy.of(new GlobalWindows())
-                             .withTrigger(Repeatedly.<GlobalWindow>forever(
+                             .withTrigger(Repeatedly.forever(
                                  AfterPane.elementCountAtLeast(3)))
                              .withMode(AccumulationMode.DISCARDING_FIRED_PANES));
 
@@ -1985,7 +1985,7 @@ public class ReduceFnRunnerTest {
     ReduceFnTester<Integer, Iterable<Integer>, GlobalWindow> tester =
         ReduceFnTester.nonCombining(
             WindowingStrategy.of(new GlobalWindows())
-                             .withTrigger(Repeatedly.<GlobalWindow>forever(
+                             .withTrigger(Repeatedly.forever(
                                  AfterProcessingTime.pastFirstElementInPane().plusDelayOf(
                                      new Duration(3))))
                              .withMode(AccumulationMode.DISCARDING_FIRED_PANES));

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -64,6 +64,7 @@ import org.apache.beam.sdk.values.ValueInSingleWindow;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -440,6 +441,7 @@ public class SplittableParDoProcessFnTest {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4144")
   public void testResumeCarriesOverState() throws Exception {
     DoFn<Integer, String> fn = new CounterFn(1);
     Instant base = Instant.now();

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -439,6 +439,7 @@ public class SplittableParDoProcessFnTest {
     }
   }
 
+  @Test
   public void testResumeCarriesOverState() throws Exception {
     DoFn<Integer, String> fn = new CounterFn(1);
     Instant base = Instant.now();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
@@ -70,9 +70,10 @@ class DirectMetrics extends MetricResults {
     private final AtomicReference<UpdateT> finishedCommitted;
 
     private final Object attemptedLock = new Object();
+
     @GuardedBy("attemptedLock")
     private volatile UpdateT finishedAttempted;
-    @GuardedBy("attemptedLock")
+
     private final ConcurrentMap<CommittedBundle<?>, UpdateT> inflightAttempted =
         new ConcurrentHashMap<>();
 
@@ -91,7 +92,7 @@ class DirectMetrics extends MetricResults {
      * @param tentativeCumulative The new cumulative value for the given bundle.
      */
     public void updatePhysical(CommittedBundle<?> bundle, UpdateT tentativeCumulative) {
-      // Add (or update) the cumulatiev value for the given bundle.
+      // Add (or update) the cumulative value for the given bundle.
       inflightAttempted.put(bundle, tentativeCumulative);
     }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
@@ -79,9 +79,10 @@ class DirectMetrics extends MetricResults {
     private final AtomicReference<UpdateT> finishedCommitted;
 
     private final Object attemptedLock = new Object();
+
     @GuardedBy("attemptedLock")
     private volatile UpdateT finishedAttempted;
-    @GuardedBy("attemptedLock")
+
     private final ConcurrentMap<CommittedBundle<?>, UpdateT> inflightAttempted =
         new ConcurrentHashMap<>();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
@@ -776,6 +776,7 @@ public class WatermarkManagerTest implements Serializable {
     manager.refreshAll();
   }
 
+  @Test
   public void updateWatermarkWithDifferentWindowedValueInstances() {
     manager.updateWatermarks(
         null,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WatermarkManagerTest.java
@@ -72,6 +72,7 @@ import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -777,6 +778,7 @@ public class WatermarkManagerTest implements Serializable {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4191")
   public void updateWatermarkWithDifferentWindowedValueInstances() {
     manager.updateWatermarks(
         null,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/WatermarkManagerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/WatermarkManagerTest.java
@@ -777,6 +777,7 @@ public class WatermarkManagerTest implements Serializable {
     manager.refreshAll();
   }
 
+  @Test
   public void updateWatermarkWithDifferentWindowedValueInstances() {
     manager.updateWatermarks(
         null,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/WatermarkManagerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/WatermarkManagerTest.java
@@ -74,6 +74,7 @@ import org.hamcrest.Matchers;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -778,6 +779,7 @@ public class WatermarkManagerTest implements Serializable {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4191")
   public void updateWatermarkWithDifferentWindowedValueInstances() {
     manager.updateWatermarks(
         null,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/fs/ResourceIdTester.java
@@ -108,7 +108,7 @@ public final class ResourceIdTester {
     try {
       ResourceId badFile = baseDirectory.resolve("file/", RESOLVE_FILE);
       fail(String.format("Resolving badFile %s should have failed", badFile));
-    } catch (Throwable t) {
+    } catch (IllegalArgumentException e) {
       // expected
     }
 
@@ -116,7 +116,7 @@ public final class ResourceIdTester {
     try {
       baseDirectory.resolve("file2", RESOLVE_FILE);
       fail(String.format("Should not be able to resolve against file resource %s", file));
-    } catch (Throwable t) {
+    } catch (IllegalArgumentException e) {
       // expected
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CollectionCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/CollectionCoderTest.java
@@ -93,6 +93,7 @@ public class CollectionCoderTest {
     CoderProperties.coderSerializable(CollectionCoder.of(GlobalWindow.Coder.INSTANCE));
   }
 
+  @Test
   public void testEncodedTypeDescriptor() throws Exception {
     TypeDescriptor<Collection<Integer>> expectedTypeDescriptor =
         new TypeDescriptor<Collection<Integer>>() {};

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/LocalResourceIdTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdTester;
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -261,6 +262,7 @@ public class LocalResourceIdTest {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4110")
   public void testResourceIdTester() throws Exception {
     ResourceIdTester.runResourceIdBattery(toResourceIdentifier("/tmp/foo/"));
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
@@ -207,18 +207,23 @@ public class ViewTest implements Serializable {
         pipeline.apply("CreateSideInput", Create.of(11, 13, 17, 23)).apply(View.asList());
 
     PCollection<Integer> output =
-        pipeline.apply("CreateMainInput", Create.of(29, 31))
-            .apply("OutputSideInputs",
-                ParDo.of(new DoFn<Integer, Integer>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    checkArgument(c.sideInput(view).size() == 4);
-                    checkArgument(c.sideInput(view).get(0) == c.sideInput(view).get(0));
-                    for (Integer i : c.sideInput(view)) {
-                      c.output(i);
-                    }
-                  }
-                }).withSideInputs(view));
+        pipeline
+            .apply("CreateMainInput", Create.of(29, 31))
+            .apply(
+                "OutputSideInputs",
+                ParDo.of(
+                        new DoFn<Integer, Integer>() {
+                          @ProcessElement
+                          public void processElement(ProcessContext c) {
+                            checkArgument(c.sideInput(view).size() == 4);
+                            checkArgument(
+                                c.sideInput(view).get(0).equals(c.sideInput(view).get(0)));
+                            for (Integer i : c.sideInput(view)) {
+                              c.output(i);
+                            }
+                          }
+                        })
+                    .withSideInputs(view));
 
     PAssert.that(output).containsInAnyOrder(11, 13, 17, 23, 11, 13, 17, 23);
 
@@ -260,7 +265,8 @@ public class ViewTest implements Serializable {
                           @ProcessElement
                           public void processElement(ProcessContext c) {
                             checkArgument(c.sideInput(view).size() == 4);
-                            checkArgument(c.sideInput(view).get(0) == c.sideInput(view).get(0));
+                            checkArgument(
+                                c.sideInput(view).get(0).equals(c.sideInput(view).get(0)));
                             for (Integer i : c.sideInput(view)) {
                               c.output(i);
                             }

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdTester;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.gcsfs.GcsPath;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -167,6 +168,7 @@ public class GcsResourceIdTest {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4143")
   public void testResourceIdTester() throws Exception {
     FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create());
     ResourceIdTester.runResourceIdBattery(toResourceIdentifier("gs://bucket/foo/"));

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
@@ -239,7 +239,7 @@ public class RetryHttpRequestInitializerTest {
     try {
       result.executeUnparsed();
       fail();
-    } catch (Throwable t) {
+    } catch (IOException e) {
     }
 
     verify(mockHttpResponseInterceptor).interceptResponse(any(HttpResponse.class));

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -87,9 +87,10 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
       Runtime.getRuntime().maxMemory() < 512 * 1024 * 1024
           ? MINIMUM_UPLOAD_BUFFER_SIZE_BYTES
           : 64 * 1024 * 1024;
+
   // Amazon S3 API: You can create a copy of your object up to 5 GB in a single atomic operation
   // Ref. https://docs.aws.amazon.com/AmazonS3/latest/dev/CopyingObjectsExamples.html
-  private static final int MAX_COPY_OBJECT_SIZE_BYTES = 5 * 1024 * 1024 * 1024;
+  private static final long MAX_COPY_OBJECT_SIZE_BYTES = 5L * 1024L * 1024L * 1024L;
 
   // S3 API, delete-objects: "You may specify up to 1000 keys."
   private static final int MAX_DELETE_OBJECTS_PER_REQUEST = 1000;

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3ResourceIdTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3ResourceIdTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.fs.ResourceIdTester;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -281,18 +282,21 @@ public class S3ResourceIdTest {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4184")
   public void testInvalidBucket() {
     thrown.expect(IllegalArgumentException.class);
     S3ResourceId.fromComponents("invalid/", "");
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4184")
   public void testInvalidBucketWithUnderscore() {
     thrown.expect(IllegalArgumentException.class);
     S3ResourceId.fromComponents("invalid_bucket", "");
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4184")
   public void testResourceIdTester() throws Exception {
     S3Options options = PipelineOptionsFactory.create().as(S3Options.class);
     options.setAwsRegion("us-west-1");

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3ResourceIdTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3ResourceIdTest.java
@@ -274,16 +274,19 @@ public class S3ResourceIdTest {
     assertNotEquals(b, a);
   }
 
+  @Test
   public void testInvalidS3ResourceId() {
     thrown.expect(IllegalArgumentException.class);
     S3ResourceId.fromUri("file://invalid/s3/path");
   }
 
+  @Test
   public void testInvalidBucket() {
     thrown.expect(IllegalArgumentException.class);
     S3ResourceId.fromComponents("invalid/", "");
   }
 
+  @Test
   public void testInvalidBucketWithUnderscore() {
     thrown.expect(IllegalArgumentException.class);
     S3ResourceId.fromComponents("invalid_bucket", "");

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
@@ -208,7 +208,7 @@ public class CassandraIOIT implements Serializable {
     }
 
     public Scientist(int id) {
-      this(0, "");
+      this(id, "");
     }
 
     public Scientist(int id, String name) {

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -62,6 +63,7 @@ public class HadoopResourceIdTest {
   }
 
   @Test
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4142")
   public void testResourceIdTester() throws Exception {
     ResourceId baseDirectory =
         FileSystems.matchNewResource(

--- a/sdks/java/io/jdbc/build.gradle
+++ b/sdks/java/io/jdbc/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(enableFindbugs: false)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockWriteTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockWriteTest.java
@@ -29,8 +29,8 @@ import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionIn
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.producer.IKinesisProducer;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import org.apache.beam.sdk.testing.PAssert;
@@ -131,7 +131,7 @@ public class KinesisMockWriteTest {
 
   @Test
   public void testNotExistedStream() {
-    Iterable<byte[]> data = Arrays.asList("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -149,7 +149,7 @@ public class KinesisMockWriteTest {
     Properties properties = new Properties();
     properties.setProperty("KinesisPort", "qwe");
 
-    Iterable<byte[]> data = Arrays.asList("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -171,7 +171,7 @@ public class KinesisMockWriteTest {
     properties.setProperty("KinesisPort", "4567");
     properties.setProperty("VerifyCertificate", "false");
 
-    Iterable<byte[]> data = Arrays.asList("1".getBytes(), "2".getBytes(), "3".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes(), "2".getBytes(), "3".getBytes());
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -186,7 +186,7 @@ public class KinesisMockWriteTest {
 
   @Test
   public void testWriteFailed() {
-    Iterable<byte[]> data = Arrays.asList("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -203,7 +203,7 @@ public class KinesisMockWriteTest {
   public void testWriteAndReadFromMockKinesis() {
     KinesisServiceMock kinesisService = KinesisServiceMock.getInstance();
 
-    Iterable<byte[]> data = Arrays.asList("1".getBytes(), "2".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes(), "2".getBytes());
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -179,7 +179,7 @@ public class MongoDBGridFSIOTest implements Serializable {
   public void testFullRead() throws Exception {
 
     PCollection<String> output = pipeline.apply(
-        MongoDbGridFSIO.<String>read()
+        MongoDbGridFSIO.read()
             .withUri("mongodb://localhost:" + port)
             .withDatabase(DATABASE));
 
@@ -203,7 +203,7 @@ public class MongoDBGridFSIOTest implements Serializable {
 
     PCollection<KV<String, Integer>> output =
         pipeline.apply(
-            MongoDbGridFSIO.<KV<String, Integer>>read()
+            MongoDbGridFSIO.read()
                 .withUri("mongodb://localhost:" + port)
                 .withDatabase(DATABASE)
                 .withBucket("mapBucket")
@@ -244,7 +244,7 @@ public class MongoDBGridFSIOTest implements Serializable {
   @Test
   public void testSplit() throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
-    MongoDbGridFSIO.Read<String> read = MongoDbGridFSIO.<String>read()
+    MongoDbGridFSIO.Read<String> read = MongoDbGridFSIO.read()
         .withUri("mongodb://localhost:" + port)
         .withDatabase(DATABASE);
 


### PR DESCRIPTION
This adds the nice errorprone tool to our builds. It is faster and more meaningful than findbugs. If this gets in, I would drop findbugs to save analysis time and false warnings.

I have run this tool over the codebase and there are lots of actual bugs. I fixed the ones deemed "error" in the core SDK. Likely Jenkins will hit a few more and I will fix them.

It also uncovered a minor issue with our Gradle config that I have worked around as it will take more work to actually redesign the build.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

