### PR TITLE
[BEAM-4122] Tune Gradle resource usage on Jenkins

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -170,11 +170,10 @@ class common_job_properties {
     "--info",
     // Continue the build even if there is a failure to show as many potential failures as possible.
     '--continue',
-    // Until we verify the build cache is working appropriately, force rerunning all tasks
-    '--rerun-tasks',
-    // Disable daemon, which helps ensure hermetic environment at small startup performance penalty.
-    // This needs to be disabled if we move to incremental builds.
-    "--no-daemon",
+    // Limit background number of workers to prevent exhausting machine memory.
+    // Jenkins machines have 15GB memory, and run 2 jobs in parallel; workers are configured with
+    // JVM max heap size 3.5GB. So 2 jobs * 2 workers * 3.5GB heap = 14GB
+    '--maxWorkers=2',
   ]
 
   static void setGradleSwitches(context) {

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -173,7 +173,7 @@ class common_job_properties {
     // Limit background number of workers to prevent exhausting machine memory.
     // Jenkins machines have 15GB memory, and run 2 jobs in parallel; workers are configured with
     // JVM max heap size 3.5GB. So 2 jobs * 2 workers * 3.5GB heap = 14GB
-    '--maxWorkers=2',
+    '--max-workers=2',
   ]
 
   static void setGradleSwitches(context) {

--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -48,12 +48,6 @@ job('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle') {
       rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':beam-runners-google-cloud-dataflow-java:validatesRunner')
       common_job_properties.setGradleSwitches(delegate)
-      // Increase parallel worker threads above processor limit since most time is
-      // spent waiting on Dataflow jobs. ValidatesRunner tests on Dataflow are slow
-      // because each one launches a Dataflow job with about 3 mins of overhead.
-      // 3 x num_cores strikes a good balance between maxing out parallelism without
-      // overloading the machines.
-      switches("--max-workers=${3 * Runtime.runtime.availableProcessors()}")
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 offlineRepositoryRoot=offline-repository


### PR DESCRIPTION
The new Gradle build seems to be exhausting memory on the Jenkins machines, causing them to lose their connection and die. This has made our tests extremely flaky.

We need to tune the Gradle build such that it does not exhaust Jenkins machine resources.

See [BEAM-4122](https://issues.apache.org/jira/browse/BEAM-4122) JIRA for more details.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

