### PR TITLE
[BEAM-3746] Added error message for using Count.globally() on non-global windows

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFnBase.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFnBase.java
@@ -120,7 +120,9 @@ public class CombineFnBase {
         + "PCollection is not windowed by GlobalWindows. Instead, use "
         + "Combine.globally().withoutDefaults() to output an empty PCollection if the input "
         + "PCollection is empty, or Combine.globally().asSingletonView() to get the default "
-        + "output of the CombineFn if the input PCollection is empty.";
+        + "output of the CombineFn if the input PCollection is empty. If this error is "
+        + "called from Count.globally(), use"
+        + "Combine.globally(Count.<T>combineFn()).withoutDefaults() instead.";
 
     @Override
     public Coder<AccumT> getAccumulatorCoder(CoderRegistry registry, Coder<InputT> inputCoder)


### PR DESCRIPTION
Quickest fix for https://issues.apache.org/jira/browse/BEAM-3746. This added error message will inform users to use Combine.globally(Count.<T>combineFn()).withoutDefaults() instead of Count.globally() if the windowing is not global.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

