### PR TITLE
[BEAM-3433] Allow a GCP project to be explicitly set for a load job

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -129,14 +129,14 @@ class BatchLoads<DestinationT>
   private int numFileShards;
   private Duration triggeringFrequency;
   private ValueProvider<String> customGcsTempLocation;
-  private final String loadJobProjectId;
+  private ValueProvider<String> loadJobProjectId;
 
   BatchLoads(WriteDisposition writeDisposition, CreateDisposition createDisposition,
              boolean singletonTable,
              DynamicDestinations<?, DestinationT> dynamicDestinations,
              Coder<DestinationT> destinationCoder,
              ValueProvider<String> customGcsTempLocation,
-             @Nullable String loadJobProjectId) {
+             @Nullable ValueProvider<String> loadJobProjectId) {
     bigQueryServices = new BigQueryServicesImpl();
     this.writeDisposition = writeDisposition;
     this.createDisposition = createDisposition;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -28,6 +28,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
@@ -73,7 +74,6 @@ import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 
 /** PTransform that uses BigQuery batch-load jobs to write a PCollection to BigQuery. */
 class BatchLoads<DestinationT>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1122,6 +1122,8 @@ public class BigQueryIO {
 
     abstract Method getMethod();
 
+    @Nullable abstract String getLoadJobProjectId();
+
     @Nullable abstract InsertRetryPolicy getFailedInsertRetryPolicy();
 
     @Nullable abstract ValueProvider<String> getCustomGcsTempLocation();
@@ -1151,6 +1153,7 @@ public class BigQueryIO {
       abstract Builder<T> setTriggeringFrequency(Duration triggeringFrequency);
 
       abstract Builder<T> setMethod(Method method);
+      abstract Builder<T> setLoadJobProjectId(String loadJobProjectId);
 
       abstract Builder<T> setFailedInsertRetryPolicy(InsertRetryPolicy retryPolicy);
 
@@ -1392,6 +1395,16 @@ public class BigQueryIO {
     }
 
     /**
+     * Set the project the BigQuery load job will be initiated from. This is only applicable when
+     * the write method is set to {@link Method#FILE_LOADS}. If omitted, the project of the
+     * destination table is used.
+     */
+    public Write<T> withLoadJobProjectId(String loadJobProjectId) {
+      checkArgument(loadJobProjectId != null, "loadJobProjectId can not be null");
+      return toBuilder().setLoadJobProjectId(loadJobProjectId).build();
+    }
+
+    /**
      * Choose the frequency at which file writes are triggered.
      *
      * <p>This is only applicable when the write method is set to {@link Method#FILE_LOADS}, and
@@ -1620,7 +1633,8 @@ public class BigQueryIO {
             getJsonTableRef() != null,
             dynamicDestinations,
             destinationCoder,
-            getCustomGcsTempLocation());
+            getCustomGcsTempLocation(),
+            getLoadJobProjectId());
         batchLoads.setTestServices(getBigQueryServices());
         if (getMaxFilesPerBundle() != null) {
           batchLoads.setMaxNumWritersPerBundle(getMaxFilesPerBundle());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1122,7 +1122,7 @@ public class BigQueryIO {
 
     abstract Method getMethod();
 
-    @Nullable abstract String getLoadJobProjectId();
+    @Nullable abstract ValueProvider<String> getLoadJobProjectId();
 
     @Nullable abstract InsertRetryPolicy getFailedInsertRetryPolicy();
 
@@ -1153,7 +1153,7 @@ public class BigQueryIO {
       abstract Builder<T> setTriggeringFrequency(Duration triggeringFrequency);
 
       abstract Builder<T> setMethod(Method method);
-      abstract Builder<T> setLoadJobProjectId(String loadJobProjectId);
+      abstract Builder<T> setLoadJobProjectId(ValueProvider<String> loadJobProjectId);
 
       abstract Builder<T> setFailedInsertRetryPolicy(InsertRetryPolicy retryPolicy);
 
@@ -1400,6 +1400,10 @@ public class BigQueryIO {
      * destination table is used.
      */
     public Write<T> withLoadJobProjectId(String loadJobProjectId) {
+      return withLoadJobProjectId(StaticValueProvider.of(loadJobProjectId));
+    }
+
+    public Write<T> withLoadJobProjectId(ValueProvider<String> loadJobProjectId) {
       checkArgument(loadJobProjectId != null, "loadJobProjectId can not be null");
       return toBuilder().setLoadJobProjectId(loadJobProjectId).build();
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -90,6 +90,7 @@ class WriteTables<DestinationT>
   private final List<PCollectionView<?>> sideInputs;
   private final TupleTag<KV<TableDestination, String>> mainOutputTag;
   private final TupleTag<String> temporaryFilesTag;
+  private final String loadJobProjectId;
 
 
   private class WriteTablesDoFn
@@ -187,7 +188,8 @@ class WriteTables<DestinationT>
       WriteDisposition writeDisposition,
       CreateDisposition createDisposition,
       List<PCollectionView<?>> sideInputs,
-      DynamicDestinations<?, DestinationT> dynamicDestinations) {
+      DynamicDestinations<?, DestinationT> dynamicDestinations,
+      @Nullable String loadJobProjectId) {
     this.singlePartition = singlePartition;
     this.bqServices = bqServices;
     this.loadJobIdPrefixView = loadJobIdPrefixView;
@@ -197,6 +199,7 @@ class WriteTables<DestinationT>
     this.dynamicDestinations = dynamicDestinations;
     this.mainOutputTag = new TupleTag<>("WriteTablesMainOutput");
     this.temporaryFilesTag = new TupleTag<>("TemporaryFiles");
+    this.loadJobProjectId = loadJobProjectId;
   }
 
   @Override
@@ -251,7 +254,7 @@ class WriteTables<DestinationT>
     if (timePartitioning != null) {
       loadConfig.setTimePartitioning(timePartitioning);
     }
-    String projectId = ref.getProjectId();
+    String projectId = loadJobProjectId == null ? ref.getProjectId() : loadJobProjectId;
     Job lastFailedLoadJob = null;
     String bqLocation =
         BigQueryHelpers.getDatasetLocation(datasetService, ref.getProjectId(), ref.getDatasetId());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -44,6 +44,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
+import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -90,7 +91,7 @@ class WriteTables<DestinationT>
   private final List<PCollectionView<?>> sideInputs;
   private final TupleTag<KV<TableDestination, String>> mainOutputTag;
   private final TupleTag<String> temporaryFilesTag;
-  private final String loadJobProjectId;
+  private final ValueProvider<String> loadJobProjectId;
 
 
   private class WriteTablesDoFn
@@ -189,7 +190,7 @@ class WriteTables<DestinationT>
       CreateDisposition createDisposition,
       List<PCollectionView<?>> sideInputs,
       DynamicDestinations<?, DestinationT> dynamicDestinations,
-      @Nullable String loadJobProjectId) {
+      @Nullable ValueProvider<String> loadJobProjectId) {
     this.singlePartition = singlePartition;
     this.bqServices = bqServices;
     this.loadJobIdPrefixView = loadJobIdPrefixView;
@@ -254,7 +255,7 @@ class WriteTables<DestinationT>
     if (timePartitioning != null) {
       loadConfig.setTimePartitioning(timePartitioning);
     }
-    String projectId = loadJobProjectId == null ? ref.getProjectId() : loadJobProjectId;
+    String projectId = loadJobProjectId == null ? ref.getProjectId() : loadJobProjectId.get();
     Job lastFailedLoadJob = null;
     String bqLocation =
         BigQueryHelpers.getDatasetLocation(datasetService, ref.getProjectId(), ref.getDatasetId());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -1168,7 +1168,7 @@ public class BigQueryIOWriteTest implements Serializable {
             BigQueryIO.Write.WriteDisposition.WRITE_EMPTY,
             BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED,
             sideInputs,
-            new IdentityDynamicTables());
+            new IdentityDynamicTables(), null);
 
     PCollection<KV<TableDestination, String>> writeTablesOutput =
         writeTablesInput.apply(writeTables);


### PR DESCRIPTION
I've added the needed string parameter to the BigQueryIO.write() function, and passed it through to the underlying class. Wanted to get some feedback before trying to write a test.

1. Should I also add a ValueProvider<String> interface?
2. I've modified the constructor for WriteTables, which is public. Should I instead add a setter for that function or overload the constructor?
3. Should I validate the this parameter is not set unless the Method is FILE_LOADS? It isn't harmful to set it otherwise, it is just ignored. Not sure what the recommendation is in that case.