### PR TITLE
Avoid losing precision in several places

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/IsmFormat.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/internal/IsmFormat.java
@@ -711,7 +711,7 @@ public class IsmFormat {
         throws Exception {
       checkNotNull(value);
       return VarInt.getLength(value.getSharedKeySize())
-          + VarInt.getLength(value.getUnsharedKeySize());
+          + (long) VarInt.getLength(value.getUnsharedKeySize());
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RandomAccessData.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RandomAccessData.java
@@ -117,7 +117,7 @@ public class RandomAccessData {
       if (value == null) {
         throw new CoderException("cannot encode a null in memory stream");
       }
-      return VarInt.getLength(value.size) + value.size;
+      return (long) VarInt.getLength(value.size) + value.size;
     }
   }
 
@@ -206,7 +206,7 @@ public class RandomAccessData {
     RandomAccessData copy = copy();
     for (int i = copy.size - 1; i >= 0; --i) {
       if (copy.buffer[i] != UnsignedBytes.MAX_VALUE) {
-        copy.buffer[i] = UnsignedBytes.checkedCast(UnsignedBytes.toInt(copy.buffer[i]) + 1);
+        copy.buffer[i] = UnsignedBytes.checkedCast(UnsignedBytes.toInt(copy.buffer[i]) + 1L);
         return copy;
       }
     }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SourceRDD.java
@@ -96,7 +96,7 @@ public class SourceRDD {
       this.metricsAccum = MetricsAccumulator.getInstance();
     }
 
-    private static final long DEFAULT_BUNDLE_SIZE = 64 * 1024 * 1024;
+    private static final long DEFAULT_BUNDLE_SIZE = 64L * 1024L * 1024L;
 
     @Override
     public Partition[] getPartitions() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSource.java
@@ -135,7 +135,7 @@ public class AvroSource<T> extends BlockBasedSource<T> {
   // Default minimum bundle size (chosen as two default-size Avro blocks to attempt to
   // ensure that every source has at least one block of records).
   // The default sync interval is 64k.
-  private static final long DEFAULT_MIN_BUNDLE_SIZE = 2 * DataFileConstants.DEFAULT_SYNC_INTERVAL;
+  private static final long DEFAULT_MIN_BUNDLE_SIZE = 2L * DataFileConstants.DEFAULT_SYNC_INTERVAL;
 
   // Use cases of AvroSource are:
   // 1) AvroSource<GenericRecord> Reading GenericRecord records with a specified schema.

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ByteStringCoder.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ByteStringCoder.java
@@ -89,7 +89,7 @@ public class ByteStringCoder extends AtomicCoder<ByteString> {
   @Override
   protected long getEncodedElementByteSize(ByteString value) throws Exception {
     int size = value.size();
-    return VarInt.getLength(size) + size;
+    return (long) VarInt.getLength(size) + size;
   }
 
   @Override

--- a/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/InMemorySorter.java
+++ b/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/InMemorySorter.java
@@ -100,7 +100,7 @@ class InMemorySorter implements Sorter {
     checkState(!sortCalled, "Records can only be added before sort()");
 
     long recordBytes = estimateRecordBytes(record);
-    if (roomInBuffer(numBytes + recordBytes, records.size() + 1)) {
+    if (roomInBuffer(numBytes + recordBytes, records.size() + 1L)) {
       records.add(record);
       numBytes += recordBytes;
       return true;

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/windowing/EncodedBoundedWindow.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/windowing/EncodedBoundedWindow.java
@@ -88,7 +88,8 @@ public abstract class EncodedBoundedWindow extends BoundedWindow {
 
     @Override
     protected long getEncodedElementByteSize(EncodedBoundedWindow value) throws Exception {
-      return VarInt.getLength(value.getEncodedWindow().size()) + value.getEncodedWindow().size();
+      return (long) VarInt.getLength(value.getEncodedWindow().size())
+        + value.getEncodedWindow().size();
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -348,7 +348,7 @@ class BigQueryServicesImpl implements BigQueryServices {
   @VisibleForTesting
   static class DatasetServiceImpl implements DatasetService {
     // Approximate amount of table data to upload per InsertAll request.
-    private static final long UPLOAD_BATCH_SIZE_BYTES = 64 * 1024;
+    private static final long UPLOAD_BATCH_SIZE_BYTES = 64L * 1024L;
 
     // The maximum number of rows to upload per InsertAll request.
     private static final long MAX_ROWS_PER_BATCH = 500;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -271,7 +271,7 @@ public class DatastoreV1 {
     static final int NUM_QUERY_SPLITS_MIN = 12;
 
     /** Default bundle size of 64MB. */
-    static final long DEFAULT_BUNDLE_SIZE_BYTES = 64 * 1024 * 1024;
+    static final long DEFAULT_BUNDLE_SIZE_BYTES = 64L * 1024L * 1024L;
 
     /**
      * Maximum number of results to request per query.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
@@ -127,9 +127,9 @@ class MutationSizeEstimator {
       case BOOL:
         return v.getBoolArray().size();
       case INT64:
-        return 8 * v.getInt64Array().size();
+        return 8L * v.getInt64Array().size();
       case FLOAT64:
-        return 8 * v.getFloat64Array().size();
+        return 8L * v.getFloat64Array().size();
       case STRING:
         long totalLength = 0;
         for (String s : v.getStringArray()) {
@@ -149,9 +149,9 @@ class MutationSizeEstimator {
         }
         return totalLength;
       case DATE:
-        return 12 * v.getDateArray().size();
+        return 12L * v.getDateArray().size();
       case TIMESTAMP:
-        return 12 * v.getTimestampArray().size();
+        return 12L * v.getTimestampArray().size();
     }
     throw new IllegalArgumentException("Unsupported type " + v.getType());
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -179,7 +179,7 @@ import org.joda.time.Duration;
 @Experimental(Experimental.Kind.SOURCE_SINK)
 public class SpannerIO {
 
-  private static final long DEFAULT_BATCH_SIZE_BYTES = 1024 * 1024; // 1 MB
+  private static final long DEFAULT_BATCH_SIZE_BYTES = 1024L * 1024L; // 1 MB
   // Max number of mutations to batch together.
   private static final int MAX_NUM_MUTATIONS = 10000;
   // The maximum number of keys to fit in memory when computing approximate quantiles.

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -316,8 +316,8 @@ public class MongoDbIO {
         }
 
         // the desired batch size is small, using default chunk size of 1MB
-        if (desiredBundleSizeBytes < 1024 * 1024) {
-          desiredBundleSizeBytes = 1 * 1024 * 1024;
+        if (desiredBundleSizeBytes < 1024L * 1024L) {
+          desiredBundleSizeBytes = 1L * 1024L * 1024L;
         }
 
         // now we have the batch size (provided by user or provided by the runner)

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Auction.java
@@ -172,8 +172,8 @@ public class Auction implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + itemName.length() + 1 + description.length() + 1 + 8 + 8 + 8 + 8 + 8 + 8
-        + extra.length() + 1;
+    return 8L + itemName.length() + 1L + description.length() + 1L + 8L + 8L + 8L + 8L + 8L + 8L
+        + extra.length() + 1L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionCount.java
@@ -90,7 +90,7 @@ public class AuctionCount implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + 8;
+    return 8L + 8L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/AuctionPrice.java
@@ -94,7 +94,7 @@ public class AuctionPrice implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + 8;
+    return 8L + 8L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Bid.java
@@ -181,7 +181,7 @@ public class Bid implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + 8 + 8 + 8 + extra.length() + 1;
+    return 8L + 8L + 8L + 8L + extra.length() + 1L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/BidsPerSession.java
@@ -73,7 +73,7 @@ public class BidsPerSession implements KnownSize, Serializable {
   @Override
   public long sizeInBytes() {
     // Two longs.
-    return 8 + 8;
+    return 8L + 8L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/CategoryPrice.java
@@ -83,7 +83,7 @@ public class CategoryPrice implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + 8 + 1;
+    return 8L + 8L + 1L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/IdNameReserve.java
@@ -84,7 +84,7 @@ public class IdNameReserve implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + name.length() + 1 + 8;
+    return 8L + name.length() + 1L + 8L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/NameCityStateId.java
@@ -111,7 +111,7 @@ public class NameCityStateId implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return name.length() + 1 + city.length() + 1 + state.length() + 1 + 8;
+    return name.length() + 1L + city.length() + 1L + state.length() + 1L + 8L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/Person.java
@@ -148,8 +148,8 @@ public class Person implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + name.length() + 1 + emailAddress.length() + 1 + creditCard.length() + 1
-        + city.length() + 1 + state.length() + 8 + 1 + extra.length() + 1;
+    return 8L + name.length() + 1L + emailAddress.length() + 1L + creditCard.length() + 1L
+        + city.length() + 1L + state.length() + 8L + 1L + extra.length() + 1L;
   }
 
   @Override

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/model/SellerPrice.java
@@ -75,7 +75,7 @@ public class SellerPrice implements KnownSize, Serializable {
 
   @Override
   public long sizeInBytes() {
-    return 8 + 8;
+    return 8L + 8L;
   }
 
   @Override


### PR DESCRIPTION
We're potentially losing precision in a few places, e.g.

a) summing two ints and returning a long without casting one of the ints to a long first
b) Calling new BigDecimal(double) instead of BigDecimal.valueOf(double).