### PR TITLE
[BEAM-4086]: KafkaIO tests:  Avoid busy loop in MockConsumer.poll(), reduce flakes.

### DIFF
--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assume.assumeTrue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -248,13 +249,22 @@ public class KafkaIOTest {
       @Override
       public void run() {
         // add all the records with offset >= current partition position.
+        int recordsAdded = 0;
         for (TopicPartition tp : assignedPartitions.get()) {
           long curPos = consumer.position(tp);
           for (ConsumerRecord<byte[], byte[]> r : records.get(tp)) {
             if (r.offset() >= curPos) {
               consumer.addRecord(r);
+              recordsAdded++;
             }
           }
+        }
+        if (recordsAdded == 0) {
+          // MockConsumer.poll(timeout) does not actually wait even when there aren't any records.
+          // Add a small wait here in order to avoid busy looping in the reader.
+          Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+          //TODO: BEAM-4086: testUnboundedSourceWithoutBoundedWrapper() occasionally hangs
+          //     without this wait. Need to look into it.
         }
         consumer.schedulePollTask(this);
       }
@@ -605,10 +615,12 @@ public class KafkaIOTest {
 
   @Test
   public void testUnboundedSourceWithoutBoundedWrapper() {
+    // This is same as testUnboundedSource() without the BoundedSource wrapper.
     // Most of the tests in this file set 'maxNumRecords' on the source, which wraps
     // the unbounded source in a bounded source. As a result, the test pipeline run as
     // bounded/batch pipelines under direct-runner.
-    // This is same as testUnboundedSource() without the BoundedSource wrapper.
+    // This tests runs without such a wrapper over unbounded wrapper, and depends on watermark
+    // progressing to infinity to end the test (see TimestampPolicyWithEndOfSource above).
 
     final int numElements = 1000;
     final int numPartitions = 10;


### PR DESCRIPTION
Add 10 millis sleep when there are no elements left in a partition. `MockConsumer.poll()` does not actually respect 'timeout' argument, and as result 'cosumerPollLoop() in KafkaIO kept spinning once all the records are read.

In addition, this seems to avoid flakes in `testUnboundedSourceWithoutBoundedWrapper()` (BEAM-4086).




