### PR TITLE
[BEAM-3255] Enabling gradle-based release process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ buildscript {
     maven { url "http://repo.spring.io/plugins-release" }
   }
   dependencies {
+    classpath 'net.researchgate:gradle-release:2.6.0'                                                   // Enable gradle-based release management
     classpath "com.gradle:build-scan-plugin:1.13.1"                                                     // Enable publishing build scans
     classpath "net.ltgt.gradle:gradle-apt-plugin:0.13"                                                  // Enable a Java annotation processor
     classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.1"                                        // Enable proto code generation
@@ -160,3 +161,11 @@ task pythonPreCommit() {
   dependsOn ":beam-sdks-python:check"
 }
 
+apply plugin: 'net.researchgate.release'
+release {
+  revertOnFail = true
+  tagTemplate = 'v${version}'
+  git {
+    requireBranch = 'release-.*|master'
+  }
+}

--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -62,7 +62,7 @@ buildscript {
 
 // Create a function which returns true iff we are performing a release.
 def isRelease() {
-  return project.hasProperty('release')
+  return project.hasProperty('isRelease')
 }
 
 group = 'org.apache.beam'

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ offlineRepositoryRoot=offline-repository
 signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true
 
+version=2.5.0-SNAPSHOT


### PR DESCRIPTION
This creates a `release` task that emulates the workflow to create release candidates. The workflow for this is as follows:

```
# Create environment variables. Supposing that we're preparing the 2.5.0 release:
RELEASE=2.5.0
NEXT_VERSION=2.6.0
CANDIDATE=1
BRANCH=release-${RELEASE}

# Create a release branch
git branch ${BRANCH}

# Now change the version in existing gradle files, and Python files
sed -i 's/'$RELEASE'/'${NEXT_VERSION}'/g' build_rules.gradle
sed -i 's/'$RELEASE'/'${NEXT_VERSION}'/g' gradle.properties
sed -i 's/'$RELEASE'/'${NEXT_VERSION}'/g' sdks/python/apache_beam/version.py

# Save changes in master branch
git add gradle.properties build_rules.gradle sdks/python/apache_beam/version.py
git commit -m "Moving to ${NEXT_VERSION}-SNAPSHOT on master branch."

# RELEASE TASK
# In the release branch, run the release task
git checkout ${BRANCH}
./gradlew release -Prelease.newVersion=${RELEASE}-SNAPSHOT \
                  -Prelease.releaseVersion=${RELEASE}-RC${CANDIDATE} \
                  -Prelease.useAutomaticVersion=true --info --no-daemon
```

The release task must be performed each time a new Release Candidate is created, and once one is approved, then it's just necessary to add a new tag for the release:

```
git tag ${RELEASE} ${RELEASE}-RC${CANDIDATE}
```

The release task does the following:
- Checks that no commits / updates are needed to the code
- Checks that project has no SNAPSHOT dependencies
- Runs build
- Changes version in gradle.properties to remove `-SNAPSHOT`
- Performs a commit
- Adds a tag like so: `v${RELEASE}-RC${CANDIDATE}`
- Changes version in gradle.properties back to contain `-SNAPSHOT`
- Performs a commit