### PR TITLE
[BEAM-4059] Reduce number of ValidatesRunner tests and reorganize them for better parallelization

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -99,6 +99,9 @@ task needsRunnerTests(type: Test) {
   }
 }
 
+// NOTE: This will also run 'NeedsRunner' tests, which are run in the :needsRunnerTests task as well.
+// The intention of this task is to mirror the :validatesRunner configuration for other runners,
+// such that the test suite can be validated on the in-process DirectRunner.
 task validatesRunner(type: Test) {
   group = "Verification"
   description "Validates Direct runner"

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -47,6 +47,7 @@ evaluationDependsOn(":beam-sdks-java-core")
 
 configurations {
   needsRunner
+  validatesRunner
 }
 
 dependencies {
@@ -75,6 +76,8 @@ dependencies {
   needsRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
   needsRunner project(path: project.path, configuration: "shadow")
   needsRunner project(path: project.path, configuration: "shadowTest")
+  validatesRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  validatesRunner project(path: project.path, configuration: "shadow")
 }
 
 task needsRunnerTests(type: Test) {
@@ -92,6 +95,19 @@ task needsRunnerTests(type: Test) {
   testClassesDirs += files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
   useJUnit {
     includeCategories "org.apache.beam.sdk.testing.NeedsRunner"
+    excludeCategories "org.apache.beam.sdk.testing.LargeKeys\$Above100MB"
+  }
+}
+
+task validatesRunner(type: Test) {
+  group = "Verification"
+  description "Validates Direct runner"
+
+  // Run in parallel up to configured --max-workers
+  maxParallelForks Integer.MAX_VALUE
+  testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs)
+  useJUnit {
+    includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
     excludeCategories "org.apache.beam.sdk.testing.LargeKeys\$Above100MB"
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroIOTest.java
@@ -672,13 +672,13 @@ public class AvroIOTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testWriteWindowed() throws Throwable {
     testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_WRITE);
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testWindowedAvroIOWriteViaSink() throws Throwable {
     testWindowedAvroIOWriteUsingMethod(WriteMethod.AVROIO_SINK);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CountingSourceTest.java
@@ -75,7 +75,7 @@ public class CountingSourceTest {
   public TestPipeline p = TestPipeline.create();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testBoundedSource() {
     long numElements = 1000;
     PCollection<Long> input = p.apply(Read.from(CountingSource.upTo(numElements)));
@@ -85,7 +85,7 @@ public class CountingSourceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testEmptyBoundedSource() {
     PCollection<Long> input = p.apply(Read.from(CountingSource.upTo(0)));
 
@@ -147,7 +147,7 @@ public class CountingSourceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testUnboundedSource() {
     long numElements = 1000;
 
@@ -166,7 +166,7 @@ public class CountingSourceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testUnboundedSourceTimestamps() {
     long numElements = 1000;
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/GenerateSequenceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/GenerateSequenceTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertThat;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Distinct;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -61,7 +60,7 @@ public class GenerateSequenceTest {
   @Rule public TestPipeline p = TestPipeline.create();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testBoundedInput() {
     long numElements = 1000;
     PCollection<Long> input = p.apply(GenerateSequence.from(0).to(numElements));
@@ -71,7 +70,7 @@ public class GenerateSequenceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testEmptyBoundedInput() {
     PCollection<Long> input = p.apply(GenerateSequence.from(0).to(0));
 
@@ -80,7 +79,7 @@ public class GenerateSequenceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testEmptyBoundedInputSubrange() {
     PCollection<Long> input = p.apply(GenerateSequence.from(42).to(42));
 
@@ -89,7 +88,7 @@ public class GenerateSequenceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testBoundedInputSubrange() {
     long start = 10;
     long end = 1000;
@@ -141,7 +140,7 @@ public class GenerateSequenceTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testUnboundedInputTimestamps() {
     long numElements = 1000;
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.Serializable;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.GenerateSequence;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesAttemptedMetrics;
 import org.apache.beam.sdk.testing.UsesCommittedMetrics;
@@ -48,12 +49,16 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 /**
  * Tests for {@link Metrics}.
  */
+@RunWith(Enclosed.class)
 public class MetricsTest implements Serializable {
 
   private static final String NS = "test";
@@ -69,216 +74,286 @@ public class MetricsTest implements Serializable {
             .build());
   }
 
-  @Rule
-  public final transient TestPipeline pipeline = TestPipeline.create();
+  /** Shared test helpers and setup/teardown. */
+  public abstract static class SharedTestBase {
+    @Rule
+    public final transient ExpectedException thrown = ExpectedException.none();
 
-  @Rule
-  public final transient ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public final transient TestPipeline pipeline = TestPipeline.create();
 
-  @After
-  public void tearDown() {
-    MetricsEnvironment.setCurrentContainer(null);
+    @After
+    public void tearDown() {
+      MetricsEnvironment.setCurrentContainer(null);
+    }
+
+    protected PipelineResult runPipelineWithMetrics() {
+      final Counter count = Metrics.counter(MetricsTest.class, "count");
+      final TupleTag<Integer> output1 = new TupleTag<Integer>(){};
+      final TupleTag<Integer> output2 = new TupleTag<Integer>(){};
+      pipeline
+          .apply(Create.of(5, 8, 13))
+          .apply("MyStep1", ParDo.of(new DoFn<Integer, Integer>() {
+            Distribution bundleDist = Metrics.distribution(MetricsTest.class, "bundle");
+
+            @StartBundle
+            public void startBundle() {
+              bundleDist.update(10L);
+            }
+
+            @SuppressWarnings("unused")
+            @ProcessElement
+            public void processElement(ProcessContext c) {
+              Distribution values = Metrics.distribution(MetricsTest.class, "input");
+              count.inc();
+              values.update(c.element());
+
+              c.output(c.element());
+              c.output(c.element());
+            }
+
+            @DoFn.FinishBundle
+            public void finishBundle() {
+              bundleDist.update(40L);
+            }
+          }))
+          .apply("MyStep2", ParDo
+              .of(new DoFn<Integer, Integer>() {
+                @SuppressWarnings("unused")
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  Distribution values = Metrics.distribution(MetricsTest.class, "input");
+                  Gauge gauge = Metrics.gauge(MetricsTest.class, "my-gauge");
+                  Integer element = c.element();
+                  count.inc();
+                  values.update(element);
+                  gauge.set(12L);
+                  c.output(element);
+                  c.output(output2, element);
+                }
+              })
+              .withOutputTags(output1, TupleTagList.of(output2)));
+      PipelineResult result = pipeline.run();
+
+      result.waitUntilFinish();
+      return result;
+    }
   }
 
-  @Test
-  public void testDistributionWithoutContainer() {
-    assertNull(MetricsEnvironment.getCurrentContainer());
-    // Should not fail even though there is no metrics container.
-    Metrics.distribution(NS, NAME).update(5L);
+  /** Tests validating basic metric scenarios. */
+  @RunWith(JUnit4.class)
+  public static class BasicTests extends SharedTestBase {
+    @Test
+    public void testDistributionWithoutContainer() {
+      assertNull(MetricsEnvironment.getCurrentContainer());
+      // Should not fail even though there is no metrics container.
+      Metrics.distribution(NS, NAME).update(5L);
+    }
+    @Test
+    public void testCounterWithoutContainer() {
+      assertNull(MetricsEnvironment.getCurrentContainer());
+      // Should not fail even though there is no metrics container.
+      Counter counter = Metrics.counter(NS, NAME);
+      counter.inc();
+      counter.inc(5L);
+      counter.dec();
+      counter.dec(5L);
+    }
+
+    @Test
+    public void testCounterWithEmptyName() {
+      thrown.expect(IllegalArgumentException.class);
+      Metrics.counter(NS, "");
+    }
+
+    @Test
+    public void testCounterWithEmptyNamespace() {
+      thrown.expect(IllegalArgumentException.class);
+      Metrics.counter("", NAME);
+    }
+
+    @Test
+    public void testDistributionWithEmptyName() {
+      thrown.expect(IllegalArgumentException.class);
+      Metrics.distribution(NS, "");
+    }
+
+    @Test
+    public void testDistributionWithEmptyNamespace() {
+      thrown.expect(IllegalArgumentException.class);
+      Metrics.distribution("", NAME);
+    }
+
+    @Test
+    public void testDistributionToCell() {
+      MetricsContainer mockContainer = Mockito.mock(MetricsContainer.class);
+      Distribution mockDistribution = Mockito.mock(Distribution.class);
+      when(mockContainer.getDistribution(METRIC_NAME)).thenReturn(mockDistribution);
+
+      Distribution distribution = Metrics.distribution(NS, NAME);
+
+      MetricsEnvironment.setCurrentContainer(mockContainer);
+      distribution.update(5L);
+
+      verify(mockDistribution).update(5L);
+
+      distribution.update(36L);
+      distribution.update(1L);
+      verify(mockDistribution).update(36L);
+      verify(mockDistribution).update(1L);
+    }
+
+    @Test
+    public void testCounterToCell() {
+      MetricsContainer mockContainer = Mockito.mock(MetricsContainer.class);
+      Counter mockCounter = Mockito.mock(Counter.class);
+      when(mockContainer.getCounter(METRIC_NAME)).thenReturn(mockCounter);
+
+      Counter counter = Metrics.counter(NS, NAME);
+
+      MetricsEnvironment.setCurrentContainer(mockContainer);
+      counter.inc();
+      verify(mockCounter).inc(1);
+
+      counter.inc(47L);
+      verify(mockCounter).inc(47);
+
+      counter.dec(5L);
+      verify(mockCounter).inc(-5);
+    }
   }
 
-  @Test
-  public void testCounterWithoutContainer() {
-    assertNull(MetricsEnvironment.getCurrentContainer());
-    // Should not fail even though there is no metrics container.
-    Counter counter = Metrics.counter(NS, NAME);
-    counter.inc();
-    counter.inc(5L);
-    counter.dec();
-    counter.dec(5L);
+  /** Tests for committed metrics. */
+  @RunWith(JUnit4.class)
+  public static class CommittedMetricTests extends SharedTestBase {
+    @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesCounterMetrics.class,
+        UsesDistributionMetrics.class, UsesGaugeMetrics.class})
+    @Test
+    public void testAllCommittedMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+
+      assertAllMetrics(metrics, true);
+    }
+
+    @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesCounterMetrics.class})
+    @Test
+    public void testCommittedCounterMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertCounterMetrics(metrics, true);
+    }
+
+    @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesDistributionMetrics.class})
+    @Test
+    public void testCommittedDistributionMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertDistributionMetrics(metrics, true);
+    }
+
+    @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesGaugeMetrics.class})
+    @Test
+    public void testCommittedGaugeMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertGaugeMetrics(metrics, true);
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
+    public void testBoundedSourceMetrics() {
+      long numElements = 1000;
+
+      pipeline.apply(GenerateSequence.from(0).to(numElements));
+
+      PipelineResult pipelineResult = pipeline.run();
+
+      MetricQueryResults metrics =
+          pipelineResult
+              .metrics()
+              .queryMetrics(
+                  MetricsFilter.builder()
+                      .addNameFilter(
+                          MetricNameFilter.named(
+                              ELEMENTS_READ.getNamespace(), ELEMENTS_READ.getName()))
+                      .build());
+
+      assertThat(metrics.getCounters(), hasItem(
+          attemptedMetricsResult(
+              ELEMENTS_READ.getNamespace(),
+              ELEMENTS_READ.getName(),
+              "Read(BoundedCountingSource)",
+              1000L)));
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
+    public void testUnboundedSourceMetrics() {
+      long numElements = 1000;
+
+      // Use withMaxReadTime to force unbounded mode.
+      pipeline.apply(
+          GenerateSequence.from(0).to(numElements).withMaxReadTime(Duration.standardDays(1)));
+
+      PipelineResult pipelineResult = pipeline.run();
+
+      MetricQueryResults metrics =
+          pipelineResult
+              .metrics()
+              .queryMetrics(
+                  MetricsFilter.builder()
+                      .addNameFilter(
+                          MetricNameFilter.named(
+                              ELEMENTS_READ.getNamespace(), ELEMENTS_READ.getName()))
+                      .build());
+
+      assertThat(metrics.getCounters(), hasItem(
+          attemptedMetricsResult(
+              ELEMENTS_READ.getNamespace(),
+              ELEMENTS_READ.getName(),
+              "Read(UnboundedCountingSource)",
+              1000L)));
+    }
   }
 
-  @Test
-  public void testCounterWithEmptyName() {
-    thrown.expect(IllegalArgumentException.class);
-    Metrics.counter(NS, "");
-  }
+  /** Tests for attempted metrics. */
+  @RunWith(JUnit4.class)
+  public static class AttemptedMetricTests extends SharedTestBase {
+    @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class,
+        UsesDistributionMetrics.class, UsesGaugeMetrics.class})
+    @Test
+    public void testAllAttemptedMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
 
-  @Test
-  public void testCounterWithEmptyNamespace() {
-    thrown.expect(IllegalArgumentException.class);
-    Metrics.counter("", NAME);
-  }
+      // TODO: BEAM-1169: Metrics shouldn't verify the physical values tightly.
+      assertAllMetrics(metrics, false);
+    }
 
-  @Test
-  public void testDistributionWithEmptyName() {
-    thrown.expect(IllegalArgumentException.class);
-    Metrics.distribution(NS, "");
-  }
+    @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
+    @Test
+    public void testAttemptedCounterMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertCounterMetrics(metrics, false);
+    }
 
-  @Test
-  public void testDistributionWithEmptyNamespace() {
-    thrown.expect(IllegalArgumentException.class);
-    Metrics.distribution("", NAME);
-  }
+    @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesDistributionMetrics.class})
+    @Test
+    public void testAttemptedDistributionMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertDistributionMetrics(metrics, false);
+    }
 
-  @Test
-  public void testDistributionToCell() {
-    MetricsContainer mockContainer = Mockito.mock(MetricsContainer.class);
-    Distribution mockDistribution = Mockito.mock(Distribution.class);
-    when(mockContainer.getDistribution(METRIC_NAME)).thenReturn(mockDistribution);
-
-    Distribution distribution = Metrics.distribution(NS, NAME);
-
-    MetricsEnvironment.setCurrentContainer(mockContainer);
-    distribution.update(5L);
-
-    verify(mockDistribution).update(5L);
-
-    distribution.update(36L);
-    distribution.update(1L);
-    verify(mockDistribution).update(36L);
-    verify(mockDistribution).update(1L);
-  }
-
-  @Test
-  public void testCounterToCell() {
-    MetricsContainer mockContainer = Mockito.mock(MetricsContainer.class);
-    Counter mockCounter = Mockito.mock(Counter.class);
-    when(mockContainer.getCounter(METRIC_NAME)).thenReturn(mockCounter);
-
-    Counter counter = Metrics.counter(NS, NAME);
-
-    MetricsEnvironment.setCurrentContainer(mockContainer);
-    counter.inc();
-    verify(mockCounter).inc(1);
-
-    counter.inc(47L);
-    verify(mockCounter).inc(47);
-
-    counter.dec(5L);
-    verify(mockCounter).inc(-5);
-  }
-
-  @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesCounterMetrics.class,
-      UsesDistributionMetrics.class, UsesGaugeMetrics.class})
-  @Test
-  public void testAllCommittedMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-
-    assertAllMetrics(metrics, true);
-  }
-
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class,
-      UsesDistributionMetrics.class, UsesGaugeMetrics.class})
-  @Test
-  public void testAllAttemptedMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-
-    // TODO: BEAM-1169: Metrics shouldn't verify the physical values tightly.
-    assertAllMetrics(metrics, false);
-  }
-
-  @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesCounterMetrics.class})
-  @Test
-  public void testCommittedCounterMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertCounterMetrics(metrics, true);
-  }
-
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
-  @Test
-  public void testAttemptedCounterMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertCounterMetrics(metrics, false);
-  }
-
-  @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesDistributionMetrics.class})
-  @Test
-  public void testCommittedDistributionMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertDistributionMetrics(metrics, true);
-  }
-
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesDistributionMetrics.class})
-  @Test
-  public void testAttemptedDistributionMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertDistributionMetrics(metrics, false);
-  }
-
-  @Category({ValidatesRunner.class, UsesCommittedMetrics.class, UsesGaugeMetrics.class})
-  @Test
-  public void testCommittedGaugeMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertGaugeMetrics(metrics, true);
-  }
-
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesGaugeMetrics.class})
-  @Test
-  public void testAttemptedGaugeMetrics() {
-    PipelineResult result = runPipelineWithMetrics();
-    MetricQueryResults metrics = queryTestMetrics(result);
-    assertGaugeMetrics(metrics, false);
-  }
-
-  private PipelineResult runPipelineWithMetrics() {
-    final Counter count = Metrics.counter(MetricsTest.class, "count");
-    final TupleTag<Integer> output1 = new TupleTag<Integer>(){};
-    final TupleTag<Integer> output2 = new TupleTag<Integer>(){};
-    pipeline
-        .apply(Create.of(5, 8, 13))
-        .apply("MyStep1", ParDo.of(new DoFn<Integer, Integer>() {
-          Distribution bundleDist = Metrics.distribution(MetricsTest.class, "bundle");
-
-          @StartBundle
-          public void startBundle() {
-            bundleDist.update(10L);
-          }
-
-          @SuppressWarnings("unused")
-          @ProcessElement
-          public void processElement(ProcessContext c) {
-            Distribution values = Metrics.distribution(MetricsTest.class, "input");
-            count.inc();
-            values.update(c.element());
-
-            c.output(c.element());
-            c.output(c.element());
-          }
-
-          @DoFn.FinishBundle
-          public void finishBundle() {
-            bundleDist.update(40L);
-          }
-        }))
-        .apply("MyStep2", ParDo
-            .of(new DoFn<Integer, Integer>() {
-              @SuppressWarnings("unused")
-              @ProcessElement
-              public void processElement(ProcessContext c) {
-                Distribution values = Metrics.distribution(MetricsTest.class, "input");
-                Gauge gauge = Metrics.gauge(MetricsTest.class, "my-gauge");
-                Integer element = c.element();
-                count.inc();
-                values.update(element);
-                gauge.set(12L);
-                c.output(element);
-                c.output(output2, element);
-              }
-            })
-            .withOutputTags(output1, TupleTagList.of(output2)));
-    PipelineResult result = pipeline.run();
-
-    result.waitUntilFinish();
-    return result;
+    @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesGaugeMetrics.class})
+    @Test
+    public void testAttemptedGaugeMetrics() {
+      PipelineResult result = runPipelineWithMetrics();
+      MetricQueryResults metrics = queryTestMetrics(result);
+      assertGaugeMetrics(metrics, false);
+    }
   }
 
   private static void assertCounterMetrics(MetricQueryResults metrics, boolean isCommitted) {
@@ -312,59 +387,4 @@ public class MetricsTest implements Serializable {
     assertGaugeMetrics(metrics, isCommitted);
   }
 
-  @Test
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
-  public void testBoundedSourceMetrics() {
-    long numElements = 1000;
-
-    pipeline.apply(GenerateSequence.from(0).to(numElements));
-
-    PipelineResult pipelineResult = pipeline.run();
-
-    MetricQueryResults metrics =
-        pipelineResult
-            .metrics()
-            .queryMetrics(
-                MetricsFilter.builder()
-                    .addNameFilter(
-                        MetricNameFilter.named(
-                            ELEMENTS_READ.getNamespace(), ELEMENTS_READ.getName()))
-                    .build());
-
-    assertThat(metrics.getCounters(), hasItem(
-        attemptedMetricsResult(
-            ELEMENTS_READ.getNamespace(),
-            ELEMENTS_READ.getName(),
-            "Read(BoundedCountingSource)",
-            1000L)));
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesAttemptedMetrics.class, UsesCounterMetrics.class})
-  public void testUnboundedSourceMetrics() {
-    long numElements = 1000;
-
-    // Use withMaxReadTime to force unbounded mode.
-    pipeline.apply(
-        GenerateSequence.from(0).to(numElements).withMaxReadTime(Duration.standardDays(1)));
-
-    PipelineResult pipelineResult = pipeline.run();
-
-    MetricQueryResults metrics =
-        pipelineResult
-            .metrics()
-            .queryMetrics(
-                MetricsFilter.builder()
-                    .addNameFilter(
-                        MetricNameFilter.named(
-                            ELEMENTS_READ.getNamespace(), ELEMENTS_READ.getName()))
-                    .build());
-
-    assertThat(metrics.getCounters(), hasItem(
-        attemptedMetricsResult(
-            ELEMENTS_READ.getNamespace(),
-            ELEMENTS_READ.getName(),
-            "Read(UnboundedCountingSource)",
-            1000L)));
-  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestPipelineTest.java
@@ -208,21 +208,21 @@ public class TestPipelineTest implements Serializable {
       @Rule
       public final transient RuleChain chain = RuleChain.outerRule(exception).around(pipeline);
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testNormalFlow() throws Exception {
         addTransform(pCollection(pipeline));
         pipeline.run();
       }
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testMissingRun() throws Exception {
         exception.expect(TestPipeline.PipelineRunMissingException.class);
         addTransform(pCollection(pipeline));
       }
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testMissingRunWithDisabledEnforcement() throws Exception {
         pipeline.enableAbandonedNodeEnforcement(false);
@@ -231,7 +231,7 @@ public class TestPipelineTest implements Serializable {
         // disable abandoned node detection
       }
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testMissingRunAutoAdd() throws Exception {
         pipeline.enableAutoRunIfMissing(true);
@@ -240,7 +240,7 @@ public class TestPipelineTest implements Serializable {
         // have the pipeline.run() auto-added
       }
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testDanglingPTransformValidatesRunner() throws Exception {
         final PCollection<String> pCollection = pCollection(pipeline);
@@ -266,7 +266,7 @@ public class TestPipelineTest implements Serializable {
         addTransform(pCollection);
       }
 
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testDanglingPAssertValidatesRunner() throws Exception {
         final PCollection<String> pCollection = pCollection(pipeline);
@@ -283,7 +283,7 @@ public class TestPipelineTest implements Serializable {
        * Tests that a {@link TestPipeline} rule behaves as expected when there is no pipeline usage
        * within a test that has a {@link ValidatesRunner} annotation.
        */
-      @Category(ValidatesRunner.class)
+      @Category(NeedsRunner.class)
       @Test
       public void testNoTestPipelineUsedValidatesRunner() {}
 
@@ -332,7 +332,7 @@ public class TestPipelineTest implements Serializable {
     @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testNewProvider() {
       ValueProvider<String> foo = pipeline.newProvider("foo");
       ValueProvider<String> foobar =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ApproximateUniqueTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ApproximateUniqueTest.java
@@ -43,7 +43,6 @@ import org.apache.beam.sdk.testing.CombineFnTester;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.ApproximateUnique.ApproximateUniqueCombineFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.KV;
@@ -355,7 +354,7 @@ public class ApproximateUniqueTest implements Serializable {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testApproximateUniqueWithSmallInput() {
       final PCollection<Integer> input = p.apply(
           Create.of(Arrays.asList(1, 2, 3, 3)));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -62,7 +62,7 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
-import org.apache.beam.sdk.transforms.CombineTest.TestCombineFn.Accumulator;
+import org.apache.beam.sdk.transforms.CombineTest.SharedTestBase.TestCombineFn.Accumulator;
 import org.apache.beam.sdk.transforms.CombineWithContext.CombineFnWithContext;
 import org.apache.beam.sdk.transforms.CombineWithContext.Context;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -90,1279 +90,1315 @@ import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
  * Tests for {@link Combine} transforms.
  */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class CombineTest implements Serializable {
   // This test is Serializable, just so that it's easy to have
   // anonymous inner classes inside the non-static test methods.
 
+  /** Base class to share setup/teardown and helpers. */
+  public abstract static class SharedTestBase {
+    @Rule
+    public final transient TestPipeline pipeline = TestPipeline.create();
+
+    protected void runTestSimpleCombine(
+        List<KV<String, Integer>> table,
+        int globalSum,
+        List<KV<String, String>> perKeyCombines) {
+      PCollection<KV<String, Integer>> input = createInput(pipeline, table);
+
+      PCollection<Integer> sum = input
+          .apply(Values.create())
+          .apply(Combine.globally(new SumInts()));
+
+      PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
+
+      PAssert.that(sum).containsInAnyOrder(globalSum);
+      PAssert.that(sumPerKey).containsInAnyOrder(perKeyCombines);
+
+      pipeline.run();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected void runTestBasicCombine(List<KV<String, Integer>> table,
+        Set<Integer> globalUnique, List<KV<String, Set<Integer>>> perKeyUnique) {
+      PCollection<KV<String, Integer>> input = createInput(pipeline, table);
+
+      PCollection<Set<Integer>> unique =
+          input.apply(Values.create()).apply(Combine.globally(new UniqueInts()));
+
+      PCollection<KV<String, Set<Integer>>> uniquePerKey =
+          input.apply(Combine.perKey(new UniqueInts()));
+
+      PAssert.that(unique).containsInAnyOrder(globalUnique);
+      PAssert.that(uniquePerKey).containsInAnyOrder(perKeyUnique);
+
+      pipeline.run();
+    }
+
+    protected void runTestSimpleCombineWithContext(
+        List<KV<String, Integer>> table, int globalSum, List<KV<String, String>> perKeyCombines,
+        String[] globallyCombines) {
+      PCollection<KV<String, Integer>> perKeyInput = createInput(pipeline, table);
+      PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
+
+      PCollection<Integer> sum = globallyInput.apply("Sum", Combine.globally(new SumInts()));
+
+      PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
+
+      PCollection<KV<String, String>> combinePerKey =
+          perKeyInput.apply(
+              Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
+                  .withSideInputs(globallySumView));
+
+      PCollection<String> combineGlobally = globallyInput
+          .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
+              .withoutDefaults()
+              .withSideInputs(globallySumView));
+
+      PAssert.that(sum).containsInAnyOrder(globalSum);
+      PAssert.that(combinePerKey).containsInAnyOrder(perKeyCombines);
+      PAssert.that(combineGlobally).containsInAnyOrder(globallyCombines);
+
+      pipeline.run();
+    }
+
+    protected void runTestAccumulatingCombine(
+        List<KV<String, Integer>> table, Double globalMean, List<KV<String, Double>> perKeyMeans) {
+      PCollection<KV<String, Integer>> input = createInput(pipeline, table);
+
+      PCollection<Double> mean = input
+          .apply(Values.create())
+          .apply(Combine.globally(new MeanInts()));
+
+      PCollection<KV<String, Double>> meanPerKey = input.apply(Combine.perKey(new MeanInts()));
+
+      PAssert.that(mean).containsInAnyOrder(globalMean);
+      PAssert.that(meanPerKey).containsInAnyOrder(perKeyMeans);
+
+      pipeline.run();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Test classes, for different kinds of combining fns.
+
+    /** Another example AccumulatingCombineFn. */
+    public static class TestCounter extends
+        Combine.AccumulatingCombineFn<
+            Integer, TestCounter.Counter, Iterable<Long>> {
+
+      /** An accumulator that observes its merges and outputs. */
+      public class Counter implements
+          Combine.AccumulatingCombineFn.Accumulator<Integer, Counter, Iterable<Long>>,
+          Serializable {
+
+        public long sum = 0;
+        public long inputs = 0;
+        public long merges = 0;
+        public long outputs = 0;
+
+        public Counter(long sum, long inputs, long merges, long outputs) {
+          this.sum = sum;
+          this.inputs = inputs;
+          this.merges = merges;
+          this.outputs = outputs;
+        }
+
+        @Override
+        public void addInput(Integer element) {
+          checkState(merges == 0);
+          checkState(outputs == 0);
+
+          inputs++;
+          sum += element;
+        }
+
+        @Override
+        public void mergeAccumulator(Counter accumulator) {
+          checkState(outputs == 0);
+          assertEquals(0, accumulator.outputs);
+
+          merges += accumulator.merges + 1;
+          inputs += accumulator.inputs;
+          sum += accumulator.sum;
+        }
+
+        @Override
+        public Iterable<Long> extractOutput() {
+          checkState(outputs == 0);
+
+          return Arrays.asList(sum, inputs, merges, outputs);
+        }
+
+        @Override
+        public int hashCode() {
+          return (int) (sum * 17 + inputs * 31 + merges * 43 + outputs * 181);
+        }
+
+        @Override
+        public boolean equals(Object otherObj) {
+          if (otherObj instanceof Counter) {
+            Counter other = (Counter) otherObj;
+            return (sum == other.sum
+                && inputs == other.inputs
+                && merges == other.merges
+                && outputs == other.outputs);
+          }
+          return false;
+        }
+
+        @Override
+        public String toString() {
+          return sum + ":" + inputs + ":" + merges + ":" + outputs;
+        }
+      }
+
+      @Override
+      public Counter createAccumulator() {
+        return new Counter(0, 0, 0, 0);
+      }
+
+      @Override
+      public Coder<Counter> getAccumulatorCoder(
+          CoderRegistry registry, Coder<Integer> inputCoder) {
+        // This is a *very* inefficient encoding to send over the wire, but suffices
+        // for tests.
+        return SerializableCoder.of(Counter.class);
+      }
+    }
+
+    /**
+     * A {@link CombineFn} that results in a sorted list of all characters occurring in the key and
+     * the decimal representations of each value.
+     */
+    public static class TestCombineFn
+        extends CombineFn<Integer, TestCombineFn.Accumulator, String> {
+
+      // Not serializable.
+      static class Accumulator {
+        final String seed;
+        String value;
+        public Accumulator(String seed, String value) {
+          this.seed = seed;
+          this.value = value;
+        }
+
+        public static Coder<Accumulator> getCoder() {
+          return new AtomicCoder<Accumulator>() {
+            @Override
+            public void encode(Accumulator accumulator, OutputStream outStream) throws IOException {
+              StringUtf8Coder.of().encode(accumulator.seed, outStream);
+              StringUtf8Coder.of().encode(accumulator.value, outStream);
+            }
+
+            @Override
+            public Accumulator decode(InputStream inStream) throws IOException {
+              String seed = StringUtf8Coder.of().decode(inStream);
+              String value = StringUtf8Coder.of().decode(inStream);
+              return new Accumulator(seed, value);
+            }
+          };
+        }
+      }
+
+      @Override
+      public Coder<Accumulator> getAccumulatorCoder(
+          CoderRegistry registry, Coder<Integer> inputCoder) {
+        return Accumulator.getCoder();
+      }
+
+      @Override
+      public Accumulator createAccumulator() {
+        return new Accumulator("", "");
+      }
+
+      @Override
+      public Accumulator addInput(Accumulator accumulator, Integer value) {
+        try {
+          return new Accumulator(accumulator.seed, accumulator.value + String.valueOf(value));
+        } finally {
+          accumulator.value = "cleared in addInput";
+        }
+      }
+
+      @Override
+      public Accumulator mergeAccumulators(Iterable<Accumulator> accumulators) {
+        Accumulator seedAccumulator = null;
+        StringBuilder all = new StringBuilder();
+        for (Accumulator accumulator : accumulators) {
+          if (seedAccumulator == null) {
+            seedAccumulator = accumulator;
+          } else {
+            assertEquals(
+                String.format(
+                    "Different seed values in accumulator: %s vs. %s",
+                    seedAccumulator, accumulator),
+                seedAccumulator.seed,
+                accumulator.seed);
+          }
+          all.append(accumulator.value);
+          accumulator.value = "cleared in mergeAccumulators";
+        }
+        return new Accumulator(checkNotNull(seedAccumulator).seed, all.toString());
+      }
+
+      @Override
+      public String extractOutput(Accumulator accumulator) {
+        char[] chars = accumulator.value.toCharArray();
+        Arrays.sort(chars);
+        return new String(chars);
+      }
+    }
+
+    /**
+     * A {@link CombineFnWithContext} that produces a sorted list of all characters occurring in the
+     * key and the decimal representations of main and side inputs values.
+     */
+    public static class TestCombineFnWithContext
+        extends CombineFnWithContext<Integer, Accumulator, String> {
+      private final PCollectionView<Integer> view;
+
+      public TestCombineFnWithContext(PCollectionView<Integer> view) {
+        this.view = view;
+      }
+
+      @Override
+      public Coder<TestCombineFn.Accumulator> getAccumulatorCoder(
+          CoderRegistry registry, Coder<Integer> inputCoder) {
+        return TestCombineFn.Accumulator.getCoder();
+      }
+
+      @Override
+      public TestCombineFn.Accumulator createAccumulator(Context c) {
+        Integer sideInputValue = c.sideInput(view);
+        return new TestCombineFn.Accumulator(sideInputValue.toString(), "");
+      }
+
+      @Override
+      public TestCombineFn.Accumulator addInput(
+          TestCombineFn.Accumulator accumulator, Integer value, Context c) {
+        try {
+          assertThat(
+              "Not expecting view contents to change",
+              accumulator.seed,
+              Matchers.equalTo(Integer.toString(c.sideInput(view))));
+          return new TestCombineFn.Accumulator(
+              accumulator.seed, accumulator.value + String.valueOf(value));
+        } finally {
+          accumulator.value = "cleared in addInput";
+        }
+      }
+
+      @Override
+      public TestCombineFn.Accumulator mergeAccumulators(
+          Iterable<TestCombineFn.Accumulator> accumulators, Context c) {
+        String sideInputValue = c.sideInput(view).toString();
+        StringBuilder all = new StringBuilder();
+        for (TestCombineFn.Accumulator accumulator : accumulators) {
+          assertThat(
+              "Accumulators should all have the same Side Input Value",
+              accumulator.seed,
+              Matchers.equalTo(sideInputValue));
+          all.append(accumulator.value);
+          accumulator.value = "cleared in mergeAccumulators";
+        }
+        return new TestCombineFn.Accumulator(sideInputValue, all.toString());
+      }
+
+      @Override
+      public String extractOutput(TestCombineFn.Accumulator accumulator, Context c) {
+        assertThat(accumulator.seed, Matchers.startsWith(c.sideInput(view).toString()));
+        char[] chars = accumulator.value.toCharArray();
+        Arrays.sort(chars);
+        return accumulator.seed + ":" + new String(chars);
+      }
+    }
+
+    /** Sample DoFn for testing combine. */
+    protected static class FormatPaneInfo extends DoFn<Integer, String> {
+      @ProcessElement
+      public void processElement(ProcessContext c) {
+        c.output(c.element() + ": " + c.pane().isLast());
+      }
+    }
+
+    protected static final SerializableFunction<String, Integer> HOT_KEY_FANOUT =
+        input -> "a".equals(input) ? 3 : 0;
+
+    protected static final SerializableFunction<String, Integer> SPLIT_HOT_KEY_FANOUT =
+        input -> Math.random() < 0.5 ? 3 : 0;
+
+    /** Sample DoFn for testing hot keys. */
+    protected static class GetLast extends DoFn<Integer, Integer> {
+      @ProcessElement
+      public void processElement(ProcessContext c) {
+        if (c.pane().isLast()) {
+          c.output(c.element());
+        }
+      }
+    }
+
+    /** Sample BinaryCombineFn for testing int inputs. */
+    protected static final class TestProdInt extends Combine.BinaryCombineIntegerFn {
+      @Override
+      public int apply(int left, int right) {
+        return left * right;
+      }
+
+      @Override
+      public int identity() {
+        return 1;
+      }
+    }
+
+    /** Sample BinaryCombineFn for testing Integer inputs. */
+    protected static final class TestProdObj extends Combine.BinaryCombineFn<Integer> {
+      @Override
+      public Integer apply(Integer left, Integer right) {
+        return left * right;
+      }
+    }
+
+    /**
+     * Computes the product, considering null values to be 2.
+     */
+    protected static final class NullCombiner extends Combine.BinaryCombineFn<Integer> {
+      @Override
+      public Integer apply(Integer left, Integer right) {
+        return (left == null ? 2 : left) * (right == null ? 2 : right);
+      }
+    }
+
+
+    /** Example SerializableFunction combiner. */
+    public static class SumInts
+        implements SerializableFunction<Iterable<Integer>, Integer> {
+      @Override
+      public Integer apply(Iterable<Integer> input) {
+        int sum = 0;
+        for (int item : input) {
+          sum += item;
+        }
+        return sum;
+      }
+    }
+
+    /** Example CombineFn. */
+    public static class UniqueInts extends
+        Combine.CombineFn<Integer, Set<Integer>, Set<Integer>> {
+
+      @Override
+      public Set<Integer> createAccumulator() {
+        return new HashSet<>();
+      }
+
+      @Override
+      public Set<Integer> addInput(Set<Integer> accumulator, Integer input) {
+        accumulator.add(input);
+        return accumulator;
+      }
+
+      @Override
+      public Set<Integer> mergeAccumulators(Iterable<Set<Integer>> accumulators) {
+        Set<Integer> all = new HashSet<>();
+        for (Set<Integer> part : accumulators) {
+          all.addAll(part);
+        }
+        return all;
+      }
+
+      @Override
+      public Set<Integer> extractOutput(Set<Integer> accumulator) {
+        return accumulator;
+      }
+    }
+
+    /** Example AccumulatingCombineFn. */
+    protected static class MeanInts extends
+        Combine.AccumulatingCombineFn<Integer, MeanInts.CountSum, Double> {
+      private static final Coder<Long> LONG_CODER = BigEndianLongCoder.of();
+      private static final Coder<Double> DOUBLE_CODER = DoubleCoder.of();
+
+      class CountSum implements
+          Combine.AccumulatingCombineFn.Accumulator<Integer, CountSum, Double> {
+        long count = 0;
+        double sum = 0.0;
+
+        CountSum(long count, double sum) {
+          this.count = count;
+          this.sum = sum;
+        }
+
+        @Override
+        public void addInput(Integer element) {
+          count++;
+          sum += element.doubleValue();
+        }
+
+        @Override
+        public void mergeAccumulator(CountSum accumulator) {
+          count += accumulator.count;
+          sum += accumulator.sum;
+        }
+
+        @Override
+        public Double extractOutput() {
+          return count == 0 ? 0.0 : sum / count;
+        }
+
+        @Override
+        public int hashCode() {
+          return Objects.hash(count, sum);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+          if (obj == this) {
+            return true;
+          }
+          if (!(obj instanceof CountSum)) {
+            return false;
+          }
+          CountSum other = (CountSum) obj;
+          return this.count == other.count
+              && (Math.abs(this.sum - other.sum) < 0.1);
+        }
+
+        @Override
+        public String toString() {
+          return MoreObjects.toStringHelper(this)
+              .add("count", count)
+              .add("sum", sum)
+              .toString();
+        }
+      }
+
+      @Override
+      public CountSum createAccumulator() {
+        return new CountSum(0, 0.0);
+      }
+
+      @Override
+      public Coder<CountSum> getAccumulatorCoder(
+          CoderRegistry registry, Coder<Integer> inputCoder) {
+        return new CountSumCoder();
+      }
+
+      /**
+       * A {@link Coder} for {@link CountSum}.
+       */
+      private class CountSumCoder extends AtomicCoder<CountSum> {
+        @Override
+        public void encode(CountSum value, OutputStream outStream) throws IOException {
+          LONG_CODER.encode(value.count, outStream);
+          DOUBLE_CODER.encode(value.sum, outStream);
+        }
+
+        @Override
+        public CountSum decode(InputStream inStream) throws IOException {
+          long count = LONG_CODER.decode(inStream);
+          double sum = DOUBLE_CODER.decode(inStream);
+          return new CountSum(count, sum);
+        }
+
+        @Override
+        public void verifyDeterministic() throws NonDeterministicException { }
+
+        @Override
+        public boolean isRegisterByteSizeObserverCheap(
+            CountSum value) {
+          return true;
+        }
+
+        @Override
+        public void registerByteSizeObserver(
+            CountSum value, ElementByteSizeObserver observer)
+            throws Exception {
+          LONG_CODER.registerByteSizeObserver(value.count, observer);
+          DOUBLE_CODER.registerByteSizeObserver(value.sum, observer);
+        }
+      }
+    }
+
+
+    protected static <T> PCollection<T> copy(PCollection<T> pc, final int n) {
+      return pc.apply(ParDo.of(new DoFn<T, T>() {
+        @ProcessElement
+        public void processElement(ProcessContext c) throws Exception {
+          for (int i = 0; i < n; i++) {
+            c.output(c.element());
+          }
+        }
+      }));
+    }
+
+    /**
+     * Class for use in testing use of Java 8 method references.
+     */
+    protected static class Summer implements Serializable {
+      public int sum(Iterable<Integer> integers) {
+        int sum = 0;
+        for (int i : integers) {
+          sum += i;
+        }
+        return sum;
+      }
+    }
+  }
+
   static final List<KV<String, Integer>> EMPTY_TABLE = Collections.emptyList();
 
-  @Rule
-  public final transient TestPipeline pipeline = TestPipeline.create();
-
-  PCollection<KV<String, Integer>> createInput(Pipeline p,
+  private static PCollection<KV<String, Integer>> createInput(Pipeline p,
                                                List<KV<String, Integer>> table) {
     return p.apply(Create.of(table).withCoder(
         KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
   }
 
-  private void runTestSimpleCombine(List<KV<String, Integer>> table,
-                                    int globalSum,
-                                    List<KV<String, String>> perKeyCombines) {
-    PCollection<KV<String, Integer>> input = createInput(pipeline, table);
-
-    PCollection<Integer> sum = input.apply(Values.create()).apply(Combine.globally(new SumInts()));
-
-    PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
-
-    PAssert.that(sum).containsInAnyOrder(globalSum);
-    PAssert.that(sumPerKey).containsInAnyOrder(perKeyCombines);
-
-    pipeline.run();
-  }
-
-  private void runTestSimpleCombineWithContext(List<KV<String, Integer>> table,
-                                               int globalSum,
-                                               List<KV<String, String>> perKeyCombines,
-                                               String[] globallyCombines) {
-    PCollection<KV<String, Integer>> perKeyInput = createInput(pipeline, table);
-    PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
-
-    PCollection<Integer> sum = globallyInput.apply("Sum", Combine.globally(new SumInts()));
-
-    PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
-
-    PCollection<KV<String, String>> combinePerKey =
-        perKeyInput.apply(
-            Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
-                .withSideInputs(globallySumView));
-
-    PCollection<String> combineGlobally = globallyInput
-        .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
-            .withoutDefaults()
-            .withSideInputs(globallySumView));
-
-    PAssert.that(sum).containsInAnyOrder(globalSum);
-    PAssert.that(combinePerKey).containsInAnyOrder(perKeyCombines);
-    PAssert.that(combineGlobally).containsInAnyOrder(globallyCombines);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  public void testSimpleCombine() {
-    runTestSimpleCombine(Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    ), 20, Arrays.asList(KV.of("a", "114"), KV.of("b", "113")));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  public void testSimpleCombineWithContext() {
-    runTestSimpleCombineWithContext(Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    ), 20,
-        Arrays.asList(KV.of("a", "20:114"), KV.of("b", "20:113")),
-        new String[] {"20:111134"});
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSimpleCombineWithContextEmpty() {
-    runTestSimpleCombineWithContext(EMPTY_TABLE, 0, Collections.emptyList(), new String[] {});
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSimpleCombineEmpty() {
-    runTestSimpleCombine(EMPTY_TABLE, 0, Collections.emptyList());
-  }
-
-  @SuppressWarnings("unchecked")
-  private void runTestBasicCombine(List<KV<String, Integer>> table,
-                                   Set<Integer> globalUnique,
-                                   List<KV<String, Set<Integer>>> perKeyUnique) {
-    PCollection<KV<String, Integer>> input = createInput(pipeline, table);
-
-    PCollection<Set<Integer>> unique =
-        input.apply(Values.create()).apply(Combine.globally(new UniqueInts()));
-
-    PCollection<KV<String, Set<Integer>>> uniquePerKey =
-        input.apply(Combine.perKey(new UniqueInts()));
-
-    PAssert.that(unique).containsInAnyOrder(globalUnique);
-    PAssert.that(uniquePerKey).containsInAnyOrder(perKeyUnique);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testBasicCombine() {
-    runTestBasicCombine(Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    ), ImmutableSet.of(1, 13, 4), Arrays.asList(
-        KV.of("a", (Set<Integer>) ImmutableSet.of(1, 4)),
-        KV.of("b", (Set<Integer>) ImmutableSet.of(1, 13))));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testBasicCombineEmpty() {
-    runTestBasicCombine(EMPTY_TABLE, ImmutableSet.of(), Collections.emptyList());
-  }
-
-  private void runTestAccumulatingCombine(List<KV<String, Integer>> table,
-                                          Double globalMean,
-                                          List<KV<String, Double>> perKeyMeans) {
-    PCollection<KV<String, Integer>> input = createInput(pipeline, table);
-
-    PCollection<Double> mean = input.apply(Values.create()).apply(Combine.globally(new MeanInts()));
-
-    PCollection<KV<String, Double>> meanPerKey = input.apply(Combine.perKey(new MeanInts()));
-
-    PAssert.that(mean).containsInAnyOrder(globalMean);
-    PAssert.that(meanPerKey).containsInAnyOrder(perKeyMeans);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testFixedWindowsCombine() {
-    PCollection<KV<String, Integer>> input =
-        pipeline
-            .apply(
-                Create.timestamped(
-                        TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
-                        TimestampedValue.of(KV.of("a", 1), new Instant(1L)),
-                        TimestampedValue.of(KV.of("a", 4), new Instant(6L)),
-                        TimestampedValue.of(KV.of("b", 1), new Instant(7L)),
-                        TimestampedValue.of(KV.of("b", 13), new Instant(8L)))
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(FixedWindows.of(Duration.millis(2))));
-
-    PCollection<Integer> sum =
-        input.apply(Values.create()).apply(Combine.globally(new SumInts()).withoutDefaults());
-
-    PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
-
-    PAssert.that(sum).containsInAnyOrder(2, 5, 13);
-    PAssert.that(sumPerKey)
-        .containsInAnyOrder(
-            Arrays.asList(KV.of("a", "11"), KV.of("a", "4"), KV.of("b", "1"), KV.of("b", "13")));
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testFixedWindowsCombineWithContext() {
-    PCollection<KV<String, Integer>> perKeyInput =
-        pipeline
-            .apply(
-                Create.timestamped(
-                        TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
-                        TimestampedValue.of(KV.of("a", 1), new Instant(1L)),
-                        TimestampedValue.of(KV.of("a", 4), new Instant(6L)),
-                        TimestampedValue.of(KV.of("b", 1), new Instant(7L)),
-                        TimestampedValue.of(KV.of("b", 13), new Instant(8L)))
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(FixedWindows.of(Duration.millis(2))));
-
-    PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
-
-    PCollection<Integer> sum = globallyInput
-        .apply("Sum", Combine.globally(new SumInts()).withoutDefaults());
-
-    PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
-
-    PCollection<KV<String, String>> combinePerKeyWithContext =
-        perKeyInput.apply(
-            Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
-                .withSideInputs(globallySumView));
-
-    PCollection<String> combineGloballyWithContext = globallyInput
-        .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
-            .withoutDefaults()
-            .withSideInputs(globallySumView));
-
-    PAssert.that(sum).containsInAnyOrder(2, 5, 13);
-    PAssert.that(combinePerKeyWithContext)
-        .containsInAnyOrder(
-            Arrays.asList(
-                KV.of("a", "2:11"), KV.of("a", "5:4"), KV.of("b", "5:1"), KV.of("b", "13:13")));
-    PAssert.that(combineGloballyWithContext).containsInAnyOrder("2:11", "5:14", "13:13");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSlidingWindowsCombine() {
-    PCollection<String> input =
-        pipeline
-            .apply(
-                Create.timestamped(
-                    TimestampedValue.of("a", new Instant(1L)),
-                    TimestampedValue.of("b", new Instant(2L)),
-                    TimestampedValue.of("c", new Instant(3L))))
-            .apply(Window.into(SlidingWindows.of(Duration.millis(3)).every(Duration.millis(1L))));
-    PCollection<List<String>> combined =
-        input.apply(
-            Combine.globally(
-                    new CombineFn<String, List<String>, List<String>>() {
-                      @Override
-                      public List<String> createAccumulator() {
-                        return new ArrayList<>();
-                      }
-
-                      @Override
-                      public List<String> addInput(List<String> accumulator, String input) {
-                        accumulator.add(input);
-                        return accumulator;
-                      }
-
-                      @Override
-                      public List<String> mergeAccumulators(Iterable<List<String>> accumulators) {
-                        // Mutate all of the accumulators. Instances should be used in only one
-                        // place, and not
-                        // reused after merging.
-                        List<String> cur = createAccumulator();
-                        for (List<String> accumulator : accumulators) {
-                          accumulator.addAll(cur);
-                          cur = accumulator;
-                        }
-                        return cur;
-                      }
-
-                      @Override
-                      public List<String> extractOutput(List<String> accumulator) {
-                        List<String> result = new ArrayList<>(accumulator);
-                        Collections.sort(result);
-                        return result;
-                      }
-                    })
-                .withoutDefaults());
-
-    PAssert.that(combined)
-        .containsInAnyOrder(
-            ImmutableList.of("a"),
-            ImmutableList.of("a", "b"),
-            ImmutableList.of("a", "b", "c"),
-            ImmutableList.of("b", "c"),
-            ImmutableList.of("c"));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSlidingWindowsCombineWithContext() {
-    // [a: 1, 1], [a: 4; b: 1], [b: 13]
-    PCollection<KV<String, Integer>> perKeyInput =
-        pipeline
-            .apply(
-                Create.timestamped(
-                        TimestampedValue.of(KV.of("a", 1), new Instant(2L)),
-                        TimestampedValue.of(KV.of("a", 1), new Instant(3L)),
-                        TimestampedValue.of(KV.of("a", 4), new Instant(8L)),
-                        TimestampedValue.of(KV.of("b", 1), new Instant(9L)),
-                        TimestampedValue.of(KV.of("b", 13), new Instant(10L)))
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(SlidingWindows.of(Duration.millis(2))));
-
-    PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
-
-    PCollection<Integer> sum = globallyInput.apply("Sum", Sum.integersGlobally().withoutDefaults());
-
-    PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
-
-    PCollection<KV<String, String>> combinePerKeyWithContext =
-        perKeyInput.apply(
-            Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
-                .withSideInputs(globallySumView));
-
-    PCollection<String> combineGloballyWithContext = globallyInput
-        .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
-            .withoutDefaults()
-            .withSideInputs(globallySumView));
-
-    PAssert.that(sum).containsInAnyOrder(1, 2, 1, 4, 5, 14, 13);
-    PAssert.that(combinePerKeyWithContext)
-        .containsInAnyOrder(
-            Arrays.asList(
-                KV.of("a", "1:1"),
-                KV.of("a", "2:11"),
-                KV.of("a", "1:1"),
-                KV.of("a", "4:4"),
-                KV.of("a", "5:4"),
-                KV.of("b", "5:1"),
-                KV.of("b", "14:113"),
-                KV.of("b", "13:13")));
-    PAssert.that(combineGloballyWithContext).containsInAnyOrder(
-      "1:1", "2:11", "1:1", "4:4", "5:14", "14:113", "13:13");
-    pipeline.run();
-  }
-
-  private static class FormatPaneInfo extends DoFn<Integer, String> {
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      c.output(c.element() + ": " + c.pane().isLast());
-    }
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGlobalCombineWithDefaultsAndTriggers() {
-    PCollection<Integer> input = pipeline.apply(Create.of(1, 1));
-
-    PCollection<String> output = input
-        .apply(Window.<Integer>into(new GlobalWindows())
-            .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
-            .accumulatingFiredPanes()
-            .withAllowedLateness(new Duration(0), ClosingBehavior.FIRE_ALWAYS))
-        .apply(Sum.integersGlobally())
-        .apply(ParDo.of(new FormatPaneInfo()));
-
-    // The actual elements produced are nondeterministic. Could be one, could be two.
-    // But it should certainly have a final element with the correct final sum.
-    PAssert.that(output)
-        .satisfies(
-            input1 -> {
-              assertThat(input1, hasItem("2: true"));
-              return null;
-            });
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSessionsCombine() {
-    PCollection<KV<String, Integer>> input =
-        pipeline
-            .apply(
-                Create.timestamped(
-                        TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
-                        TimestampedValue.of(KV.of("a", 1), new Instant(4L)),
-                        TimestampedValue.of(KV.of("a", 4), new Instant(7L)),
-                        TimestampedValue.of(KV.of("b", 1), new Instant(10L)),
-                        TimestampedValue.of(KV.of("b", 13), new Instant(16L)))
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(Sessions.withGapDuration(Duration.millis(5))));
-
-    PCollection<Integer> sum =
-        input.apply(Values.create()).apply(Combine.globally(new SumInts()).withoutDefaults());
-
-    PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
-
-    PAssert.that(sum).containsInAnyOrder(7, 13);
-    PAssert.that(sumPerKey)
-        .containsInAnyOrder(Arrays.asList(KV.of("a", "114"), KV.of("b", "1"), KV.of("b", "13")));
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSessionsCombineWithContext() {
-    PCollection<KV<String, Integer>> perKeyInput =
-        pipeline.apply(
-            Create.timestamped(
-                    TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
-                    TimestampedValue.of(KV.of("a", 1), new Instant(4L)),
-                    TimestampedValue.of(KV.of("a", 4), new Instant(7L)),
-                    TimestampedValue.of(KV.of("b", 1), new Instant(10L)),
-                    TimestampedValue.of(KV.of("b", 13), new Instant(16L)))
-                .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
-
-    PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
-
-    PCollection<Integer> fixedWindowsSum =
-        globallyInput
-            .apply("FixedWindows", Window.into(FixedWindows.of(Duration.millis(5))))
-            .apply("Sum", Combine.globally(new SumInts()).withoutDefaults());
-
-    PCollectionView<Integer> globallyFixedWindowsView =
-        fixedWindowsSum.apply(View.<Integer>asSingleton().withDefaultValue(0));
-
-    PCollection<KV<String, String>> sessionsCombinePerKey =
-        perKeyInput
-            .apply(
-                "PerKey Input Sessions", Window.into(Sessions.withGapDuration(Duration.millis(5))))
-            .apply(
-                Combine.<String, Integer, String>perKey(
-                        new TestCombineFnWithContext(globallyFixedWindowsView))
-                    .withSideInputs(globallyFixedWindowsView));
-
-    PCollection<String> sessionsCombineGlobally =
-        globallyInput
-            .apply(
-                "Globally Input Sessions",
-                Window.into(Sessions.withGapDuration(Duration.millis(5))))
-            .apply(
-                Combine.globally(new TestCombineFnWithContext(globallyFixedWindowsView))
-                    .withoutDefaults()
-                    .withSideInputs(globallyFixedWindowsView));
-
-    PAssert.that(fixedWindowsSum).containsInAnyOrder(2, 4, 1, 13);
-    PAssert.that(sessionsCombinePerKey)
-        .containsInAnyOrder(
-            Arrays.asList(KV.of("a", "1:114"), KV.of("b", "1:1"), KV.of("b", "0:13")));
-    PAssert.that(sessionsCombineGlobally).containsInAnyOrder("1:1114", "0:13");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testWindowedCombineEmpty() {
-    PCollection<Double> mean =
-        pipeline
-            .apply(Create.empty(BigEndianIntegerCoder.of()))
-            .apply(Window.into(FixedWindows.of(Duration.millis(1))))
-            .apply(Combine.globally(new MeanInts()).withoutDefaults());
-
-    PAssert.that(mean).empty();
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testAccumulatingCombine() {
-    runTestAccumulatingCombine(Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    ), 4.0, Arrays.asList(KV.of("a", 2.0), KV.of("b", 7.0)));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testAccumulatingCombineEmpty() {
-    runTestAccumulatingCombine(EMPTY_TABLE, 0.0, Collections.emptyList());
-  }
-
-  // Checks that Min, Max, Mean, Sum (operations that pass-through to Combine) have good names.
-  @Test
-  public void testCombinerNames() {
-    Combine.PerKey<String, Integer, Integer> min = Min.integersPerKey();
-    Combine.PerKey<String, Integer, Integer> max = Max.integersPerKey();
-    Combine.PerKey<String, Integer, Double> mean = Mean.perKey();
-    Combine.PerKey<String, Integer, Integer> sum = Sum.integersPerKey();
-
-    assertThat(min.getName(), equalTo("Combine.perKey(MinInteger)"));
-    assertThat(max.getName(), equalTo("Combine.perKey(MaxInteger)"));
-    assertThat(mean.getName(), equalTo("Combine.perKey(Mean)"));
-    assertThat(sum.getName(), equalTo("Combine.perKey(SumInteger)"));
-  }
-
-  private static final SerializableFunction<String, Integer> hotKeyFanout =
-      input -> "a".equals(input) ? 3 : 0;
-
-  private static final SerializableFunction<String, Integer> splitHotKeyFanout =
-      input -> Math.random() < 0.5 ? 3 : 0;
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testHotKeyCombining() {
-    PCollection<KV<String, Integer>> input = copy(createInput(pipeline, Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    )), 10);
-
-    CombineFn<Integer, ?, Double> mean = new MeanInts();
-    PCollection<KV<String, Double>> coldMean = input.apply("ColdMean",
-        Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(0));
-    PCollection<KV<String, Double>> warmMean = input.apply("WarmMean",
-        Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(hotKeyFanout));
-    PCollection<KV<String, Double>> hotMean = input.apply("HotMean",
-        Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(5));
-    PCollection<KV<String, Double>> splitMean = input.apply("SplitMean",
-        Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(splitHotKeyFanout));
-
-    List<KV<String, Double>> expected = Arrays.asList(KV.of("a", 2.0), KV.of("b", 7.0));
-    PAssert.that(coldMean).containsInAnyOrder(expected);
-    PAssert.that(warmMean).containsInAnyOrder(expected);
-    PAssert.that(hotMean).containsInAnyOrder(expected);
-    PAssert.that(splitMean).containsInAnyOrder(expected);
-
-    pipeline.run();
-  }
-
-  private static class GetLast extends DoFn<Integer, Integer> {
-    @ProcessElement
-    public void processElement(ProcessContext c) {
-      if (c.pane().isLast()) {
-        c.output(c.element());
-      }
-    }
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testHotKeyCombiningWithAccumulationMode() {
-    PCollection<Integer> input = pipeline.apply(Create.of(1, 2, 3, 4, 5));
-
-    PCollection<Integer> output = input
-        .apply(Window.<Integer>into(new GlobalWindows())
-            .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
-            .accumulatingFiredPanes()
-            .withAllowedLateness(new Duration(0), ClosingBehavior.FIRE_ALWAYS))
-        .apply(Sum.integersGlobally().withoutDefaults().withFanout(2))
-        .apply(ParDo.of(new GetLast()));
-
-    PAssert.that(output)
-        .satisfies(
-            input1 -> {
-              assertThat(input1, hasItem(15));
-              return null;
-            });
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testBinaryCombineFn() {
-    PCollection<KV<String, Integer>> input = copy(createInput(pipeline, Arrays.asList(
-      KV.of("a", 1),
-      KV.of("a", 1),
-      KV.of("a", 4),
-      KV.of("b", 1),
-      KV.of("b", 13)
-    )), 2);
-    PCollection<KV<String, Integer>> intProduct =
-        input.apply("IntProduct", Combine.perKey(new TestProdInt()));
-    PCollection<KV<String, Integer>> objProduct =
-        input.apply("ObjProduct", Combine.perKey(new TestProdObj()));
-
-    List<KV<String, Integer>> expected = Arrays.asList(KV.of("a", 16), KV.of("b", 169));
-    PAssert.that(intProduct).containsInAnyOrder(expected);
-    PAssert.that(objProduct).containsInAnyOrder(expected);
-
-    pipeline.run();
-  }
-
-  @Test
-  public void testBinaryCombineFnWithNulls() {
-    testCombineFn(new NullCombiner(), Arrays.asList(3, 3, 5), 45);
-    testCombineFn(new NullCombiner(), Arrays.asList(null, 3, 5), 30);
-    testCombineFn(new NullCombiner(), Arrays.asList(3, 3, null), 18);
-    testCombineFn(new NullCombiner(), Arrays.asList(null, 3, null), 12);
-    testCombineFn(new NullCombiner(), Arrays.asList(null, null, null), 8);
-  }
-
-  private static final class TestProdInt extends Combine.BinaryCombineIntegerFn {
-    @Override
-    public int apply(int left, int right) {
-      return left * right;
+  /** Tests validating basic Combine transform scenarios. */
+  @RunWith(JUnit4.class)
+  public static class BasicTests extends SharedTestBase {
+    @Test
+    @Category(ValidatesRunner.class)
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testSimpleCombine() {
+      runTestSimpleCombine(Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+      ), 20, Arrays.asList(KV.of("a", "114"), KV.of("b", "113")));
     }
 
-    @Override
-    public int identity() {
-      return 1;
-    }
-  }
-
-  private static final class TestProdObj extends Combine.BinaryCombineFn<Integer> {
-    @Override
-    public Integer apply(Integer left, Integer right) {
-      return left * right;
-    }
-  }
-
-  /**
-   * Computes the product, considering null values to be 2.
-   */
-  private static final class NullCombiner extends Combine.BinaryCombineFn<Integer> {
-    @Override
-    public Integer apply(Integer left, Integer right) {
-      return (left == null ? 2 : left) * (right == null ? 2 : right);
-    }
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombineGloballyAsSingletonView() {
-    final PCollectionView<Integer> view = pipeline
-        .apply("CreateEmptySideInput", Create.empty(BigEndianIntegerCoder.of()))
-        .apply(Sum.integersGlobally().asSingletonView());
-
-    PCollection<Integer> output = pipeline
-        .apply("CreateVoidMainInput", Create.of((Void) null))
-        .apply("OutputSideInput", ParDo.of(new DoFn<Void, Integer>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    c.output(c.sideInput(view));
-                  }
-                }).withSideInputs(view));
-
-    PAssert.thatSingleton(output).isEqualTo(0);
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testWindowedCombineGloballyAsSingletonView() {
-    FixedWindows windowFn = FixedWindows.of(Duration.standardMinutes(1));
-    final PCollectionView<Integer> view =
-        pipeline
-            .apply(
-                "CreateSideInput",
-                Create.timestamped(
-                    TimestampedValue.of(1, new Instant(100)),
-                    TimestampedValue.of(3, new Instant(100))))
-            .apply("WindowSideInput", Window.into(windowFn))
-            .apply("CombineSideInput", Sum.integersGlobally().asSingletonView());
-
-    TimestampedValue<Void> nonEmptyElement = TimestampedValue.of(null, new Instant(100));
-    TimestampedValue<Void> emptyElement = TimestampedValue.atMinimumTimestamp(null);
-    PCollection<Integer> output =
-        pipeline
-            .apply(
-                "CreateMainInput",
-                Create.timestamped(nonEmptyElement, emptyElement).withCoder(VoidCoder.of()))
-            .apply("WindowMainInput", Window.into(windowFn))
-            .apply(
-                "OutputSideInput",
-                ParDo.of(
-                        new DoFn<Void, Integer>() {
-                          @ProcessElement
-                          public void processElement(ProcessContext c) {
-                            c.output(c.sideInput(view));
-                          }
-                        })
-                    .withSideInputs(view));
-
-    PAssert.that(output).containsInAnyOrder(4, 0);
-    PAssert.that(output)
-        .inWindow(windowFn.assignWindow(nonEmptyElement.getTimestamp()))
-        .containsInAnyOrder(4);
-    PAssert.that(output)
-        .inWindow(windowFn.assignWindow(emptyElement.getTimestamp()))
-        .containsInAnyOrder(0);
-    pipeline.run();
-  }
-
-  @Test
-  public void testCombineGetName() {
-    assertEquals("Combine.globally(SumInts)", Combine.globally(new SumInts()).getName());
-    assertEquals(
-        "Combine.GloballyAsSingletonView",
-        Combine.globally(new SumInts()).asSingletonView().getName());
-    assertEquals("Combine.perKey(Test)", Combine.perKey(new TestCombineFn()).getName());
-    assertEquals(
-        "Combine.perKeyWithFanout(Test)",
-        Combine.perKey(new TestCombineFn()).withHotKeyFanout(10).getName());
-  }
-
-  @Test
-  public void testDisplayData() {
-    UniqueInts combineFn = new UniqueInts() {
-      @Override
-      public void populateDisplayData(DisplayData.Builder builder) {
-        builder.add(DisplayData.item("fnMetadata", "foobar"));
-      }
-    };
-    Combine.Globally<?, ?> combine = Combine.globally(combineFn)
-        .withFanout(1234);
-    DisplayData displayData = DisplayData.from(combine);
-
-    assertThat(displayData, hasDisplayItem("combineFn", combineFn.getClass()));
-    assertThat(displayData, hasDisplayItem("emitDefaultOnEmptyInput", true));
-    assertThat(displayData, hasDisplayItem("fanout", 1234));
-    assertThat(displayData, includesDisplayDataFor("combineFn", combineFn));
-  }
-
-  @Test
-  public void testDisplayDataForWrappedFn() {
-    UniqueInts combineFn = new UniqueInts() {
-      @Override
-      public void populateDisplayData(DisplayData.Builder builder) {
-        builder.add(DisplayData.item("foo", "bar"));
-      }
-    };
-    Combine.PerKey<?, ?, ?> combine = Combine.perKey(combineFn);
-    DisplayData displayData = DisplayData.from(combine);
-
-    assertThat(displayData, hasDisplayItem("combineFn", combineFn.getClass()));
-    assertThat(displayData, hasDisplayItem(hasNamespace(combineFn.getClass())));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombinePerKeyPrimitiveDisplayData() {
-    DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
-
-    CombineTest.UniqueInts combineFn = new CombineTest.UniqueInts();
-    PTransform<PCollection<KV<Integer, Integer>>, ? extends POutput> combine =
-        Combine.perKey(combineFn);
-
-    Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(combine,
-        KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
-
-    assertThat("Combine.perKey should include the combineFn in its primitive transform",
-        displayData, hasItem(hasDisplayItem("combineFn", combineFn.getClass())));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombinePerKeyWithHotKeyFanoutPrimitiveDisplayData() {
-    int hotKeyFanout = 2;
-    DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
-
-    CombineTest.UniqueInts combineFn = new CombineTest.UniqueInts();
-    PTransform<PCollection<KV<Integer, Integer>>, PCollection<KV<Integer, Set<Integer>>>> combine =
-        Combine.<Integer, Integer, Set<Integer>>perKey(combineFn).withHotKeyFanout(hotKeyFanout);
-
-    Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(combine,
-        KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
-
-    assertThat("Combine.perKey.withHotKeyFanout should include the combineFn in its primitive "
-        + "transform", displayData, hasItem(hasDisplayItem("combineFn", combineFn.getClass())));
-    assertThat("Combine.perKey.withHotKeyFanout(int) should include the fanout in its primitive "
-        + "transform", displayData, hasItem(hasDisplayItem("fanout", hotKeyFanout)));
-  }
-
-  ////////////////////////////////////////////////////////////////////////////
-  // Test classes, for different kinds of combining fns.
-
-  /** Example SerializableFunction combiner. */
-  public static class SumInts
-      implements SerializableFunction<Iterable<Integer>, Integer> {
-    @Override
-    public Integer apply(Iterable<Integer> input) {
-      int sum = 0;
-      for (int item : input) {
-        sum += item;
-      }
-      return sum;
-    }
-  }
-
-  /** Example CombineFn. */
-  public static class UniqueInts extends
-      Combine.CombineFn<Integer, Set<Integer>, Set<Integer>> {
-
-    @Override
-    public Set<Integer> createAccumulator() {
-      return new HashSet<>();
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSimpleCombineEmpty() {
+      runTestSimpleCombine(EMPTY_TABLE, 0, Collections.emptyList());
     }
 
-    @Override
-    public Set<Integer> addInput(Set<Integer> accumulator, Integer input) {
-      accumulator.add(input);
-      return accumulator;
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testBasicCombine() {
+      runTestBasicCombine(Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+      ), ImmutableSet.of(1, 13, 4), Arrays.asList(
+          KV.of("a", (Set<Integer>) ImmutableSet.of(1, 4)),
+          KV.of("b", (Set<Integer>) ImmutableSet.of(1, 13))));
     }
 
-    @Override
-    public Set<Integer> mergeAccumulators(Iterable<Set<Integer>> accumulators) {
-      Set<Integer> all = new HashSet<>();
-      for (Set<Integer> part : accumulators) {
-        all.addAll(part);
-      }
-      return all;
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testBasicCombineEmpty() {
+      runTestBasicCombine(EMPTY_TABLE, ImmutableSet.of(), Collections.emptyList());
     }
 
-    @Override
-    public Set<Integer> extractOutput(Set<Integer> accumulator) {
-      return accumulator;
+    // Checks that Min, Max, Mean, Sum (operations that pass-through to Combine) have good names.
+    @Test
+    public void testCombinerNames() {
+      Combine.PerKey<String, Integer, Integer> min = Min.integersPerKey();
+      Combine.PerKey<String, Integer, Integer> max = Max.integersPerKey();
+      Combine.PerKey<String, Integer, Double> mean = Mean.perKey();
+      Combine.PerKey<String, Integer, Integer> sum = Sum.integersPerKey();
+
+      assertThat(min.getName(), equalTo("Combine.perKey(MinInteger)"));
+      assertThat(max.getName(), equalTo("Combine.perKey(MaxInteger)"));
+      assertThat(mean.getName(), equalTo("Combine.perKey(Mean)"));
+      assertThat(sum.getName(), equalTo("Combine.perKey(SumInteger)"));
     }
-  }
 
-  /** Example AccumulatingCombineFn. */
-  private static class MeanInts extends
-      Combine.AccumulatingCombineFn<Integer, MeanInts.CountSum, Double> {
-    private static final Coder<Long> LONG_CODER = BigEndianLongCoder.of();
-    private static final Coder<Double> DOUBLE_CODER = DoubleCoder.of();
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testHotKeyCombining() {
+      PCollection<KV<String, Integer>> input = copy(createInput(pipeline, Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+      )), 10);
 
-    class CountSum implements
-        Combine.AccumulatingCombineFn.Accumulator<Integer, CountSum, Double> {
-      long count = 0;
-      double sum = 0.0;
+      CombineFn<Integer, ?, Double> mean = new MeanInts();
+      PCollection<KV<String, Double>> coldMean = input.apply("ColdMean",
+          Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(0));
+      PCollection<KV<String, Double>> warmMean = input.apply("WarmMean",
+          Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(HOT_KEY_FANOUT));
+      PCollection<KV<String, Double>> hotMean = input.apply("HotMean",
+          Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(5));
+      PCollection<KV<String, Double>> splitMean = input.apply("SplitMean",
+          Combine.<String, Integer, Double>perKey(mean).withHotKeyFanout(SPLIT_HOT_KEY_FANOUT));
 
-      CountSum(long count, double sum) {
-        this.count = count;
-        this.sum = sum;
-      }
+      List<KV<String, Double>> expected = Arrays.asList(KV.of("a", 2.0), KV.of("b", 7.0));
+      PAssert.that(coldMean).containsInAnyOrder(expected);
+      PAssert.that(warmMean).containsInAnyOrder(expected);
+      PAssert.that(hotMean).containsInAnyOrder(expected);
+      PAssert.that(splitMean).containsInAnyOrder(expected);
 
-      @Override
-      public void addInput(Integer element) {
-        count++;
-        sum += element.doubleValue();
-      }
+      pipeline.run();
+    }
 
-      @Override
-      public void mergeAccumulator(CountSum accumulator) {
-        count += accumulator.count;
-        sum += accumulator.sum;
-      }
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testHotKeyCombiningWithAccumulationMode() {
+      PCollection<Integer> input = pipeline.apply(Create.of(1, 2, 3, 4, 5));
 
-      @Override
-      public Double extractOutput() {
-        return count == 0 ? 0.0 : sum / count;
-      }
+      PCollection<Integer> output = input
+          .apply(Window.<Integer>into(new GlobalWindows())
+              .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+              .accumulatingFiredPanes()
+              .withAllowedLateness(new Duration(0), ClosingBehavior.FIRE_ALWAYS))
+          .apply(Sum.integersGlobally().withoutDefaults().withFanout(2))
+          .apply(ParDo.of(new GetLast()));
 
-      @Override
-      public int hashCode() {
-        return Objects.hash(count, sum);
-      }
+      PAssert.that(output)
+          .satisfies(
+              input1 -> {
+                assertThat(input1, hasItem(15));
+                return null;
+              });
 
-      @Override
-      public boolean equals(Object obj) {
-        if (obj == this) {
-          return true;
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testBinaryCombineFn() {
+      PCollection<KV<String, Integer>> input = copy(createInput(pipeline, Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+      )), 2);
+      PCollection<KV<String, Integer>> intProduct =
+          input.apply("IntProduct", Combine.perKey(new TestProdInt()));
+      PCollection<KV<String, Integer>> objProduct =
+          input.apply("ObjProduct", Combine.perKey(new TestProdObj()));
+
+      List<KV<String, Integer>> expected = Arrays.asList(KV.of("a", 16), KV.of("b", 169));
+      PAssert.that(intProduct).containsInAnyOrder(expected);
+      PAssert.that(objProduct).containsInAnyOrder(expected);
+
+      pipeline.run();
+    }
+
+    @Test
+    public void testBinaryCombineFnWithNulls() {
+      testCombineFn(new NullCombiner(), Arrays.asList(3, 3, 5), 45);
+      testCombineFn(new NullCombiner(), Arrays.asList(null, 3, 5), 30);
+      testCombineFn(new NullCombiner(), Arrays.asList(3, 3, null), 18);
+      testCombineFn(new NullCombiner(), Arrays.asList(null, 3, null), 12);
+      testCombineFn(new NullCombiner(), Arrays.asList(null, null, null), 8);
+    }
+
+    @Test
+    public void testCombineGetName() {
+      assertEquals("Combine.globally(SumInts)", Combine.globally(new SumInts()).getName());
+      assertEquals(
+          "Combine.GloballyAsSingletonView",
+          Combine.globally(new SumInts()).asSingletonView().getName());
+      assertEquals("Combine.perKey(Test)", Combine.perKey(new TestCombineFn()).getName());
+      assertEquals(
+          "Combine.perKeyWithFanout(Test)",
+          Combine.perKey(new TestCombineFn()).withHotKeyFanout(10).getName());
+    }
+
+    @Test
+    public void testDisplayData() {
+      UniqueInts combineFn = new UniqueInts() {
+        @Override
+        public void populateDisplayData(DisplayData.Builder builder) {
+          builder.add(DisplayData.item("fnMetadata", "foobar"));
         }
-        if (!(obj instanceof CountSum)) {
-          return false;
+      };
+      Combine.Globally<?, ?> combine = Combine.globally(combineFn)
+          .withFanout(1234);
+      DisplayData displayData = DisplayData.from(combine);
+
+      assertThat(displayData, hasDisplayItem("combineFn", combineFn.getClass()));
+      assertThat(displayData, hasDisplayItem("emitDefaultOnEmptyInput", true));
+      assertThat(displayData, hasDisplayItem("fanout", 1234));
+      assertThat(displayData, includesDisplayDataFor("combineFn", combineFn));
+    }
+
+    @Test
+    public void testDisplayDataForWrappedFn() {
+      UniqueInts combineFn = new UniqueInts() {
+        @Override
+        public void populateDisplayData(DisplayData.Builder builder) {
+          builder.add(DisplayData.item("foo", "bar"));
         }
-        CountSum other = (CountSum) obj;
-        return this.count == other.count
-            && (Math.abs(this.sum - other.sum) < 0.1);
-      }
+      };
+      Combine.PerKey<?, ?, ?> combine = Combine.perKey(combineFn);
+      DisplayData displayData = DisplayData.from(combine);
 
-      @Override
-      public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("count", count)
-            .add("sum", sum)
-            .toString();
-      }
+      assertThat(displayData, hasDisplayItem("combineFn", combineFn.getClass()));
+      assertThat(displayData, hasDisplayItem(hasNamespace(combineFn.getClass())));
     }
 
-    @Override
-    public CountSum createAccumulator() {
-      return new CountSum(0, 0.0);
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombinePerKeyPrimitiveDisplayData() {
+      DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
+
+      UniqueInts combineFn = new UniqueInts();
+      PTransform<PCollection<KV<Integer, Integer>>, ? extends POutput> combine =
+          Combine.perKey(combineFn);
+
+      Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(combine,
+          KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
+
+      assertThat("Combine.perKey should include the combineFn in its primitive transform",
+          displayData, hasItem(hasDisplayItem("combineFn", combineFn.getClass())));
     }
 
-    @Override
-    public Coder<CountSum> getAccumulatorCoder(
-        CoderRegistry registry, Coder<Integer> inputCoder) {
-      return new CountSumCoder();
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombinePerKeyWithHotKeyFanoutPrimitiveDisplayData() {
+      int hotKeyFanout = 2;
+      DisplayDataEvaluator evaluator = DisplayDataEvaluator.create();
+
+      UniqueInts combineFn = new UniqueInts();
+      PTransform<PCollection<KV<Integer, Integer>>, PCollection<KV<Integer, Set<Integer>>>>
+          combine = Combine
+            .<Integer, Integer, Set<Integer>>perKey(combineFn)
+            .withHotKeyFanout(hotKeyFanout);
+
+      Set<DisplayData> displayData = evaluator.displayDataForPrimitiveTransforms(combine,
+          KvCoder.of(VarIntCoder.of(), VarIntCoder.of()));
+
+      assertThat("Combine.perKey.withHotKeyFanout should include the combineFn in its primitive "
+          + "transform", displayData, hasItem(hasDisplayItem("combineFn", combineFn.getClass())));
+      assertThat("Combine.perKey.withHotKeyFanout(int) should include the fanout in its primitive "
+          + "transform", displayData, hasItem(hasDisplayItem("fanout", hotKeyFanout)));
     }
 
     /**
-     * A {@link Coder} for {@link CountSum}.
+     * Tests creation of a per-key {@link Combine} via a Java 8 lambda.
      */
-    private class CountSumCoder extends AtomicCoder<CountSum> {
-      @Override
-      public void encode(CountSum value, OutputStream outStream) throws IOException {
-        LONG_CODER.encode(value.count, outStream);
-        DOUBLE_CODER.encode(value.sum, outStream);
-      }
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombinePerKeyLambda() {
 
-      @Override
-      public CountSum decode(InputStream inStream) throws IOException {
-        long count = LONG_CODER.decode(inStream);
-        double sum = DOUBLE_CODER.decode(inStream);
-        return new CountSum(count, sum);
-      }
+      PCollection<KV<String, Integer>> output = pipeline
+          .apply(Create.of(KV.of("a", 1), KV.of("b", 2), KV.of("a", 3), KV.of("c", 4)))
+          .apply(Combine.perKey(integers -> {
+            int sum = 0;
+            for (int i : integers) {
+              sum += i;
+            }
+            return sum;
+          }));
 
-      @Override
-      public void verifyDeterministic() throws NonDeterministicException { }
-
-      @Override
-      public boolean isRegisterByteSizeObserverCheap(
-          CountSum value) {
-        return true;
-      }
-
-      @Override
-      public void registerByteSizeObserver(
-          CountSum value, ElementByteSizeObserver observer)
-          throws Exception {
-        LONG_CODER.registerByteSizeObserver(value.count, observer);
-        DOUBLE_CODER.registerByteSizeObserver(value.sum, observer);
-      }
-    }
-  }
-
-  /**
-   * A {@link CombineFn} that results in a sorted list of all characters occurring in the key and
-   * the decimal representations of each value.
-   */
-  public static class TestCombineFn extends CombineFn<Integer, TestCombineFn.Accumulator, String> {
-
-    // Not serializable.
-    static class Accumulator {
-      final String seed;
-      String value;
-      public Accumulator(String seed, String value) {
-        this.seed = seed;
-        this.value = value;
-      }
-
-      public static Coder<Accumulator> getCoder() {
-        return new AtomicCoder<Accumulator>() {
-          @Override
-          public void encode(Accumulator accumulator, OutputStream outStream) throws IOException {
-            StringUtf8Coder.of().encode(accumulator.seed, outStream);
-            StringUtf8Coder.of().encode(accumulator.value, outStream);
-          }
-
-          @Override
-          public Accumulator decode(InputStream inStream) throws IOException {
-            String seed = StringUtf8Coder.of().decode(inStream);
-            String value = StringUtf8Coder.of().decode(inStream);
-            return new Accumulator(seed, value);
-          }
-        };
-      }
+      PAssert.that(output).containsInAnyOrder(
+          KV.of("a", 4),
+          KV.of("b", 2),
+          KV.of("c", 4));
+      pipeline.run();
     }
 
-    @Override
-    public Coder<Accumulator> getAccumulatorCoder(
-        CoderRegistry registry, Coder<Integer> inputCoder) {
-      return Accumulator.getCoder();
+    /**
+     * Tests creation of a per-key {@link Combine} via a Java 8 method reference.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombinePerKeyInstanceMethodReference() {
+
+      PCollection<KV<String, Integer>> output = pipeline
+          .apply(Create.of(KV.of("a", 1), KV.of("b", 2), KV.of("a", 3), KV.of("c", 4)))
+          .apply(Combine.perKey(new Summer()::sum));
+
+      PAssert.that(output).containsInAnyOrder(
+          KV.of("a", 4),
+          KV.of("b", 2),
+          KV.of("c", 4));
+      pipeline.run();
     }
 
-    @Override
-    public Accumulator createAccumulator() {
-      return new Accumulator("", "");
-    }
+    /**
+     * Tests that we can serialize {@link Combine.CombineFn CombineFns} constructed from a lambda.
+     * Lambdas can be problematic because the {@link Class} object is synthetic and cannot be
+     * deserialized.
+     */
+    @Test
+    public void testLambdaSerialization() {
+      SerializableFunction<Iterable<Object>, Object> combiner = xs -> Iterables.getFirst(xs, 0);
 
-    @Override
-    public Accumulator addInput(Accumulator accumulator, Integer value) {
+      boolean lambdaClassSerializationThrows;
       try {
-        return new Accumulator(accumulator.seed, accumulator.value + String.valueOf(value));
-      } finally {
-        accumulator.value = "cleared in addInput";
+        SerializableUtils.clone(combiner.getClass());
+        lambdaClassSerializationThrows = false;
+      } catch (IllegalArgumentException e) {
+        // Expected
+        lambdaClassSerializationThrows = true;
       }
+      Assume.assumeTrue("Expected lambda class serialization to fail. "
+              + "If it's fixed, we can remove special behavior in Combine.",
+          lambdaClassSerializationThrows);
+
+
+      Combine.Globally<?, ?> combine = Combine.globally(combiner);
+      SerializableUtils.clone(combine); // should not throw.
     }
 
-    @Override
-    public Accumulator mergeAccumulators(Iterable<Accumulator> accumulators) {
-      Accumulator seedAccumulator = null;
-      StringBuilder all = new StringBuilder();
-      for (Accumulator accumulator : accumulators) {
-        if (seedAccumulator == null) {
-          seedAccumulator = accumulator;
-        } else {
-          assertEquals(
-              String.format(
-                  "Different seed values in accumulator: %s vs. %s", seedAccumulator, accumulator),
-              seedAccumulator.seed,
-              accumulator.seed);
-        }
-        all.append(accumulator.value);
-        accumulator.value = "cleared in mergeAccumulators";
-      }
-      return new Accumulator(checkNotNull(seedAccumulator).seed, all.toString());
-    }
-
-    @Override
-    public String extractOutput(Accumulator accumulator) {
-      char[] chars = accumulator.value.toCharArray();
-      Arrays.sort(chars);
-      return new String(chars);
+    @Test
+    public void testLambdaDisplayData() {
+      Combine.Globally<?, ?> combine = Combine.globally(xs -> Iterables.getFirst(xs, 0));
+      DisplayData displayData = DisplayData.from(combine);
+      MatcherAssert.assertThat(displayData.items(), not(empty()));
     }
   }
 
-  /**
-   * A {@link CombineFnWithContext} that produces a sorted list of all characters occurring in the
-   * key and the decimal representations of main and side inputs values.
-   */
-  public class TestCombineFnWithContext extends CombineFnWithContext<Integer, Accumulator, String> {
-    private final PCollectionView<Integer> view;
-
-    public TestCombineFnWithContext(PCollectionView<Integer> view) {
-      this.view = view;
+  /** Tests validating CombineWithContext behaviors. */
+  @RunWith(JUnit4.class)
+  public static class CombineWithContextTests extends SharedTestBase {
+    @Test
+    @Category(ValidatesRunner.class)
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void testSimpleCombineWithContext() {
+      runTestSimpleCombineWithContext(Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+          ), 20,
+          Arrays.asList(KV.of("a", "20:114"), KV.of("b", "20:113")),
+          new String[] {"20:111134"});
     }
 
-    @Override
-    public Coder<TestCombineFn.Accumulator> getAccumulatorCoder(
-        CoderRegistry registry, Coder<Integer> inputCoder) {
-      return TestCombineFn.Accumulator.getCoder();
-    }
-
-    @Override
-    public TestCombineFn.Accumulator createAccumulator(Context c) {
-      Integer sideInputValue = c.sideInput(view);
-      return new TestCombineFn.Accumulator(sideInputValue.toString(), "");
-    }
-
-    @Override
-    public TestCombineFn.Accumulator addInput(
-        TestCombineFn.Accumulator accumulator, Integer value, Context c) {
-      try {
-        assertThat(
-            "Not expecting view contents to change",
-            accumulator.seed,
-            Matchers.equalTo(Integer.toString(c.sideInput(view))));
-        return new TestCombineFn.Accumulator(
-            accumulator.seed, accumulator.value + String.valueOf(value));
-      } finally {
-        accumulator.value = "cleared in addInput";
-      }
-    }
-
-    @Override
-    public TestCombineFn.Accumulator mergeAccumulators(
-        Iterable<TestCombineFn.Accumulator> accumulators, Context c) {
-      String sideInputValue = c.sideInput(view).toString();
-      StringBuilder all = new StringBuilder();
-      for (TestCombineFn.Accumulator accumulator : accumulators) {
-        assertThat(
-            "Accumulators should all have the same Side Input Value",
-            accumulator.seed,
-            Matchers.equalTo(sideInputValue));
-        all.append(accumulator.value);
-        accumulator.value = "cleared in mergeAccumulators";
-      }
-      return new TestCombineFn.Accumulator(sideInputValue, all.toString());
-    }
-
-    @Override
-    public String extractOutput(TestCombineFn.Accumulator accumulator, Context c) {
-      assertThat(accumulator.seed, Matchers.startsWith(c.sideInput(view).toString()));
-      char[] chars = accumulator.value.toCharArray();
-      Arrays.sort(chars);
-      return accumulator.seed + ":" + new String(chars);
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSimpleCombineWithContextEmpty() {
+      runTestSimpleCombineWithContext(EMPTY_TABLE, 0, Collections.emptyList(), new String[] {});
     }
   }
 
-  /** Another example AccumulatingCombineFn. */
-  public static class TestCounter extends
-      Combine.AccumulatingCombineFn<
-          Integer, TestCounter.Counter, Iterable<Long>> {
+  /** Tests validating windowing behaviors. */
+  @RunWith(JUnit4.class)
+  public static class WindowingTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testFixedWindowsCombine() {
+      PCollection<KV<String, Integer>> input =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                      TimestampedValue.of(KV.of("a", 1), new Instant(1L)),
+                      TimestampedValue.of(KV.of("a", 4), new Instant(6L)),
+                      TimestampedValue.of(KV.of("b", 1), new Instant(7L)),
+                      TimestampedValue.of(KV.of("b", 13), new Instant(8L)))
+                      .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(FixedWindows.of(Duration.millis(2))));
 
-    /** An accumulator that observes its merges and outputs. */
-    public class Counter implements
-        Combine.AccumulatingCombineFn.Accumulator<Integer, Counter, Iterable<Long>>,
-        Serializable {
+      PCollection<Integer> sum =
+          input.apply(Values.create()).apply(Combine.globally(new SumInts()).withoutDefaults());
 
-      public long sum = 0;
-      public long inputs = 0;
-      public long merges = 0;
-      public long outputs = 0;
+      PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
 
-      public Counter(long sum, long inputs, long merges, long outputs) {
-        this.sum = sum;
-        this.inputs = inputs;
-        this.merges = merges;
-        this.outputs = outputs;
-      }
-
-      @Override
-      public void addInput(Integer element) {
-        checkState(merges == 0);
-        checkState(outputs == 0);
-
-        inputs++;
-        sum += element;
-      }
-
-      @Override
-      public void mergeAccumulator(Counter accumulator) {
-        checkState(outputs == 0);
-        assertEquals(0, accumulator.outputs);
-
-        merges += accumulator.merges + 1;
-        inputs += accumulator.inputs;
-        sum += accumulator.sum;
-      }
-
-      @Override
-      public Iterable<Long> extractOutput() {
-        checkState(outputs == 0);
-
-        return Arrays.asList(sum, inputs, merges, outputs);
-      }
-
-      @Override
-      public int hashCode() {
-        return (int) (sum * 17 + inputs * 31 + merges * 43 + outputs * 181);
-      }
-
-      @Override
-      public boolean equals(Object otherObj) {
-        if (otherObj instanceof Counter) {
-          Counter other = (Counter) otherObj;
-          return (sum == other.sum
-              && inputs == other.inputs
-              && merges == other.merges
-              && outputs == other.outputs);
-        }
-        return false;
-      }
-
-      @Override
-      public String toString() {
-        return sum + ":" + inputs + ":" + merges + ":" + outputs;
-      }
+      PAssert.that(sum).containsInAnyOrder(2, 5, 13);
+      PAssert.that(sumPerKey)
+          .containsInAnyOrder(
+              Arrays.asList(KV.of("a", "11"), KV.of("a", "4"), KV.of("b", "1"), KV.of("b", "13")));
+      pipeline.run();
     }
 
-    @Override
-    public Counter createAccumulator() {
-      return new Counter(0, 0, 0, 0);
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testFixedWindowsCombineWithContext() {
+      PCollection<KV<String, Integer>> perKeyInput =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                      TimestampedValue.of(KV.of("a", 1), new Instant(1L)),
+                      TimestampedValue.of(KV.of("a", 4), new Instant(6L)),
+                      TimestampedValue.of(KV.of("b", 1), new Instant(7L)),
+                      TimestampedValue.of(KV.of("b", 13), new Instant(8L)))
+                      .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(FixedWindows.of(Duration.millis(2))));
+
+      PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
+
+      PCollection<Integer> sum = globallyInput
+          .apply("Sum", Combine.globally(new SumInts()).withoutDefaults());
+
+      PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
+
+      PCollection<KV<String, String>> combinePerKeyWithContext =
+          perKeyInput.apply(
+              Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
+                  .withSideInputs(globallySumView));
+
+      PCollection<String> combineGloballyWithContext = globallyInput
+          .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
+              .withoutDefaults()
+              .withSideInputs(globallySumView));
+
+      PAssert.that(sum).containsInAnyOrder(2, 5, 13);
+      PAssert.that(combinePerKeyWithContext)
+          .containsInAnyOrder(
+              Arrays.asList(
+                  KV.of("a", "2:11"), KV.of("a", "5:4"), KV.of("b", "5:1"), KV.of("b", "13:13")));
+      PAssert.that(combineGloballyWithContext).containsInAnyOrder("2:11", "5:14", "13:13");
+      pipeline.run();
     }
 
-    @Override
-    public Coder<Counter> getAccumulatorCoder(
-        CoderRegistry registry, Coder<Integer> inputCoder) {
-      // This is a *very* inefficient encoding to send over the wire, but suffices
-      // for tests.
-      return SerializableCoder.of(Counter.class);
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSlidingWindowsCombine() {
+      PCollection<String> input =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      TimestampedValue.of("a", new Instant(1L)),
+                      TimestampedValue.of("b", new Instant(2L)),
+                      TimestampedValue.of("c", new Instant(3L))))
+              .apply(Window.into(SlidingWindows.of(Duration.millis(3)).every(Duration.millis(1L))));
+      PCollection<List<String>> combined =
+          input.apply(
+              Combine.globally(
+                  new CombineFn<String, List<String>, List<String>>() {
+                    @Override
+                    public List<String> createAccumulator() {
+                      return new ArrayList<>();
+                    }
+
+                    @Override
+                    public List<String> addInput(List<String> accumulator, String input) {
+                      accumulator.add(input);
+                      return accumulator;
+                    }
+
+                    @Override
+                    public List<String> mergeAccumulators(Iterable<List<String>> accumulators) {
+                      // Mutate all of the accumulators. Instances should be used in only one
+                      // place, and not
+                      // reused after merging.
+                      List<String> cur = createAccumulator();
+                      for (List<String> accumulator : accumulators) {
+                        accumulator.addAll(cur);
+                        cur = accumulator;
+                      }
+                      return cur;
+                    }
+
+                    @Override
+                    public List<String> extractOutput(List<String> accumulator) {
+                      List<String> result = new ArrayList<>(accumulator);
+                      Collections.sort(result);
+                      return result;
+                    }
+                  })
+                  .withoutDefaults());
+
+      PAssert.that(combined)
+          .containsInAnyOrder(
+              ImmutableList.of("a"),
+              ImmutableList.of("a", "b"),
+              ImmutableList.of("a", "b", "c"),
+              ImmutableList.of("b", "c"),
+              ImmutableList.of("c"));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSlidingWindowsCombineWithContext() {
+      // [a: 1, 1], [a: 4; b: 1], [b: 13]
+      PCollection<KV<String, Integer>> perKeyInput =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      TimestampedValue.of(KV.of("a", 1), new Instant(2L)),
+                      TimestampedValue.of(KV.of("a", 1), new Instant(3L)),
+                      TimestampedValue.of(KV.of("a", 4), new Instant(8L)),
+                      TimestampedValue.of(KV.of("b", 1), new Instant(9L)),
+                      TimestampedValue.of(KV.of("b", 13), new Instant(10L)))
+                      .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(SlidingWindows.of(Duration.millis(2))));
+
+      PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
+
+      PCollection<Integer> sum = globallyInput
+          .apply("Sum", Sum.integersGlobally().withoutDefaults());
+
+      PCollectionView<Integer> globallySumView = sum.apply(View.asSingleton());
+
+      PCollection<KV<String, String>> combinePerKeyWithContext =
+          perKeyInput.apply(
+              Combine.<String, Integer, String>perKey(new TestCombineFnWithContext(globallySumView))
+                  .withSideInputs(globallySumView));
+
+      PCollection<String> combineGloballyWithContext = globallyInput
+          .apply(Combine.globally(new TestCombineFnWithContext(globallySumView))
+              .withoutDefaults()
+              .withSideInputs(globallySumView));
+
+      PAssert.that(sum).containsInAnyOrder(1, 2, 1, 4, 5, 14, 13);
+      PAssert.that(combinePerKeyWithContext)
+          .containsInAnyOrder(
+              Arrays.asList(
+                  KV.of("a", "1:1"),
+                  KV.of("a", "2:11"),
+                  KV.of("a", "1:1"),
+                  KV.of("a", "4:4"),
+                  KV.of("a", "5:4"),
+                  KV.of("b", "5:1"),
+                  KV.of("b", "14:113"),
+                  KV.of("b", "13:13")));
+      PAssert.that(combineGloballyWithContext).containsInAnyOrder(
+          "1:1", "2:11", "1:1", "4:4", "5:14", "14:113", "13:13");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGlobalCombineWithDefaultsAndTriggers() {
+      PCollection<Integer> input = pipeline.apply(Create.of(1, 1));
+
+      PCollection<String> output = input
+          .apply(Window.<Integer>into(new GlobalWindows())
+              .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
+              .accumulatingFiredPanes()
+              .withAllowedLateness(new Duration(0), ClosingBehavior.FIRE_ALWAYS))
+          .apply(Sum.integersGlobally())
+          .apply(ParDo.of(new FormatPaneInfo()));
+
+      // The actual elements produced are nondeterministic. Could be one, could be two.
+      // But it should certainly have a final element with the correct final sum.
+      PAssert.that(output)
+          .satisfies(
+              input1 -> {
+                assertThat(input1, hasItem("2: true"));
+                return null;
+              });
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSessionsCombine() {
+      PCollection<KV<String, Integer>> input =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                      TimestampedValue.of(KV.of("a", 1), new Instant(4L)),
+                      TimestampedValue.of(KV.of("a", 4), new Instant(7L)),
+                      TimestampedValue.of(KV.of("b", 1), new Instant(10L)),
+                      TimestampedValue.of(KV.of("b", 13), new Instant(16L)))
+                      .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(Sessions.withGapDuration(Duration.millis(5))));
+
+      PCollection<Integer> sum =
+          input.apply(Values.create()).apply(Combine.globally(new SumInts()).withoutDefaults());
+
+      PCollection<KV<String, String>> sumPerKey = input.apply(Combine.perKey(new TestCombineFn()));
+
+      PAssert.that(sum).containsInAnyOrder(7, 13);
+      PAssert.that(sumPerKey)
+          .containsInAnyOrder(Arrays.asList(KV.of("a", "114"), KV.of("b", "1"), KV.of("b", "13")));
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSessionsCombineWithContext() {
+      PCollection<KV<String, Integer>> perKeyInput =
+          pipeline.apply(
+              Create.timestamped(
+                  TimestampedValue.of(KV.of("a", 1), new Instant(0L)),
+                  TimestampedValue.of(KV.of("a", 1), new Instant(4L)),
+                  TimestampedValue.of(KV.of("a", 4), new Instant(7L)),
+                  TimestampedValue.of(KV.of("b", 1), new Instant(10L)),
+                  TimestampedValue.of(KV.of("b", 13), new Instant(16L)))
+                  .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
+
+      PCollection<Integer> globallyInput = perKeyInput.apply(Values.create());
+
+      PCollection<Integer> fixedWindowsSum =
+          globallyInput
+              .apply("FixedWindows", Window.into(FixedWindows.of(Duration.millis(5))))
+              .apply("Sum", Combine.globally(new SumInts()).withoutDefaults());
+
+      PCollectionView<Integer> globallyFixedWindowsView =
+          fixedWindowsSum.apply(View.<Integer>asSingleton().withDefaultValue(0));
+
+      PCollection<KV<String, String>> sessionsCombinePerKey =
+          perKeyInput
+              .apply(
+                  "PerKey Input Sessions",
+                  Window.into(Sessions.withGapDuration(Duration.millis(5))))
+              .apply(
+                  Combine.<String, Integer, String>perKey(
+                      new TestCombineFnWithContext(globallyFixedWindowsView))
+                      .withSideInputs(globallyFixedWindowsView));
+
+      PCollection<String> sessionsCombineGlobally =
+          globallyInput
+              .apply(
+                  "Globally Input Sessions",
+                  Window.into(Sessions.withGapDuration(Duration.millis(5))))
+              .apply(
+                  Combine.globally(new TestCombineFnWithContext(globallyFixedWindowsView))
+                      .withoutDefaults()
+                      .withSideInputs(globallyFixedWindowsView));
+
+      PAssert.that(fixedWindowsSum).containsInAnyOrder(2, 4, 1, 13);
+      PAssert.that(sessionsCombinePerKey)
+          .containsInAnyOrder(
+              Arrays.asList(KV.of("a", "1:114"), KV.of("b", "1:1"), KV.of("b", "0:13")));
+      PAssert.that(sessionsCombineGlobally).containsInAnyOrder("1:1114", "0:13");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testWindowedCombineEmpty() {
+      PCollection<Double> mean =
+          pipeline
+              .apply(Create.empty(BigEndianIntegerCoder.of()))
+              .apply(Window.into(FixedWindows.of(Duration.millis(1))))
+              .apply(Combine.globally(new MeanInts()).withoutDefaults());
+
+      PAssert.that(mean).empty();
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombineGloballyAsSingletonView() {
+      final PCollectionView<Integer> view = pipeline
+          .apply("CreateEmptySideInput", Create.empty(BigEndianIntegerCoder.of()))
+          .apply(Sum.integersGlobally().asSingletonView());
+
+      PCollection<Integer> output = pipeline
+          .apply("CreateVoidMainInput", Create.of((Void) null))
+          .apply("OutputSideInput", ParDo.of(new DoFn<Void, Integer>() {
+            @ProcessElement
+            public void processElement(ProcessContext c) {
+              c.output(c.sideInput(view));
+            }
+          }).withSideInputs(view));
+
+      PAssert.thatSingleton(output).isEqualTo(0);
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testWindowedCombineGloballyAsSingletonView() {
+      FixedWindows windowFn = FixedWindows.of(Duration.standardMinutes(1));
+      final PCollectionView<Integer> view =
+          pipeline
+              .apply(
+                  "CreateSideInput",
+                  Create.timestamped(
+                      TimestampedValue.of(1, new Instant(100)),
+                      TimestampedValue.of(3, new Instant(100))))
+              .apply("WindowSideInput", Window.into(windowFn))
+              .apply("CombineSideInput", Sum.integersGlobally().asSingletonView());
+
+      TimestampedValue<Void> nonEmptyElement = TimestampedValue.of(null, new Instant(100));
+      TimestampedValue<Void> emptyElement = TimestampedValue.atMinimumTimestamp(null);
+      PCollection<Integer> output =
+          pipeline
+              .apply(
+                  "CreateMainInput",
+                  Create.timestamped(nonEmptyElement, emptyElement).withCoder(VoidCoder.of()))
+              .apply("WindowMainInput", Window.into(windowFn))
+              .apply(
+                  "OutputSideInput",
+                  ParDo.of(
+                      new DoFn<Void, Integer>() {
+                        @ProcessElement
+                        public void processElement(ProcessContext c) {
+                          c.output(c.sideInput(view));
+                        }
+                      })
+                      .withSideInputs(view));
+
+      PAssert.that(output).containsInAnyOrder(4, 0);
+      PAssert.that(output)
+          .inWindow(windowFn.assignWindow(nonEmptyElement.getTimestamp()))
+          .containsInAnyOrder(4);
+      PAssert.that(output)
+          .inWindow(windowFn.assignWindow(emptyElement.getTimestamp()))
+          .containsInAnyOrder(0);
+      pipeline.run();
+    }
+
+    /**
+     * Tests creation of a global {@link Combine} via Java 8 lambda.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombineGloballyLambda() {
+
+      PCollection<Integer> output = pipeline
+          .apply(Create.of(1, 2, 3, 4))
+          .apply(Combine.globally(integers -> {
+            int sum = 0;
+            for (int i : integers) {
+              sum += i;
+            }
+            return sum;
+          }));
+
+      PAssert.that(output).containsInAnyOrder(10);
+      pipeline.run();
+    }
+
+    /**
+     * Tests creation of a global {@link Combine} via a Java 8 method reference.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testCombineGloballyInstanceMethodReference() {
+
+      PCollection<Integer> output = pipeline
+          .apply(Create.of(1, 2, 3, 4))
+          .apply(Combine.globally(new Summer()::sum));
+
+      PAssert.that(output).containsInAnyOrder(10);
+      pipeline.run();
     }
   }
 
-  private static <T> PCollection<T> copy(PCollection<T> pc, final int n) {
-    return pc.apply(ParDo.of(new DoFn<T, T>() {
-      @ProcessElement
-      public void processElement(ProcessContext c) throws Exception {
-        for (int i = 0; i < n; i++) {
-          c.output(c.element());
-        }
-      }
-    }));
-  }
+  /** Tests validating accumulation scenarios. */
+  @RunWith(JUnit4.class)
+  public static class AccumulationTests extends SharedTestBase {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testAccumulatingCombine() {
+      runTestAccumulatingCombine(Arrays.asList(
+          KV.of("a", 1),
+          KV.of("a", 1),
+          KV.of("a", 4),
+          KV.of("b", 1),
+          KV.of("b", 13)
+      ), 4.0, Arrays.asList(KV.of("a", 2.0), KV.of("b", 7.0)));
+    }
 
-  /**
-   * Class for use in testing use of Java 8 method references.
-   */
-  private static class Summer implements Serializable {
-    public int sum(Iterable<Integer> integers) {
-      int sum = 0;
-      for (int i : integers) {
-        sum += i;
-      }
-      return sum;
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testAccumulatingCombineEmpty() {
+      runTestAccumulatingCombine(EMPTY_TABLE, 0.0, Collections.emptyList());
     }
   }
 
-  /**
-   * Tests creation of a global {@link Combine} via Java 8 lambda.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombineGloballyLambda() {
-
-    PCollection<Integer> output = pipeline
-        .apply(Create.of(1, 2, 3, 4))
-        .apply(Combine.globally(integers -> {
-          int sum = 0;
-          for (int i : integers) {
-            sum += i;
-          }
-          return sum;
-        }));
-
-    PAssert.that(output).containsInAnyOrder(10);
-    pipeline.run();
-  }
-
-  /**
-   * Tests creation of a global {@link Combine} via a Java 8 method reference.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombineGloballyInstanceMethodReference() {
-
-    PCollection<Integer> output = pipeline
-        .apply(Create.of(1, 2, 3, 4))
-        .apply(Combine.globally(new Summer()::sum));
-
-    PAssert.that(output).containsInAnyOrder(10);
-    pipeline.run();
-  }
-
-  /**
-   * Tests creation of a per-key {@link Combine} via a Java 8 lambda.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombinePerKeyLambda() {
-
-    PCollection<KV<String, Integer>> output = pipeline
-        .apply(Create.of(KV.of("a", 1), KV.of("b", 2), KV.of("a", 3), KV.of("c", 4)))
-        .apply(Combine.perKey(integers -> {
-          int sum = 0;
-          for (int i : integers) {
-            sum += i;
-          }
-          return sum;
-        }));
-
-    PAssert.that(output).containsInAnyOrder(
-        KV.of("a", 4),
-        KV.of("b", 2),
-        KV.of("c", 4));
-    pipeline.run();
-  }
-
-  /**
-   * Tests creation of a per-key {@link Combine} via a Java 8 method reference.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testCombinePerKeyInstanceMethodReference() {
-
-    PCollection<KV<String, Integer>> output = pipeline
-        .apply(Create.of(KV.of("a", 1), KV.of("b", 2), KV.of("a", 3), KV.of("c", 4)))
-        .apply(Combine.perKey(new Summer()::sum));
-
-    PAssert.that(output).containsInAnyOrder(
-        KV.of("a", 4),
-        KV.of("b", 2),
-        KV.of("c", 4));
-    pipeline.run();
-  }
-
-  /**
-   * Tests that we can serialize {@link Combine.CombineFn CombineFns} constructed from a lambda.
-   * Lambdas can be problematic because the {@link Class} object is synthetic and cannot be
-   * deserialized.
-   */
-  @Test
-  public void testLambdaSerialization() {
-    SerializableFunction<Iterable<Object>, Object> combiner = xs -> Iterables.getFirst(xs, 0);
-
-    boolean lambdaClassSerializationThrows;
-    try {
-      SerializableUtils.clone(combiner.getClass());
-      lambdaClassSerializationThrows = false;
-    } catch (IllegalArgumentException e) {
-      // Expected
-      lambdaClassSerializationThrows = true;
-    }
-    Assume.assumeTrue("Expected lambda class serialization to fail. "
-            + "If it's fixed, we can remove special behavior in Combine.",
-        lambdaClassSerializationThrows);
-
-
-    Combine.Globally<?, ?> combine = Combine.globally(combiner);
-    SerializableUtils.clone(combine); // should not throw.
-  }
-
-  @Test
-  public void testLambdaDisplayData() {
-    Combine.Globally<?, ?> combine = Combine.globally(xs -> Iterables.getFirst(xs, 0));
-    DisplayData displayData = DisplayData.from(combine);
-    MatcherAssert.assertThat(displayData.items(), not(empty()));
-  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CountTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CountTest.java
@@ -23,9 +23,9 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.Rule;
@@ -49,7 +49,7 @@ public class CountTest {
   public TestPipeline p = TestPipeline.create();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   @SuppressWarnings("unchecked")
   public void testCountPerElementBasic() {
     PCollection<String> input = p.apply(Create.of(WORDS));
@@ -68,7 +68,7 @@ public class CountTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   @SuppressWarnings("unchecked")
   public void testCountPerElementEmpty() {
     PCollection<String> input = p.apply(Create.of(NO_LINES).withCoder(StringUtf8Coder.of()));
@@ -80,7 +80,7 @@ public class CountTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCountGloballyBasic() {
     PCollection<String> input = p.apply(Create.of(WORDS));
 
@@ -92,7 +92,7 @@ public class CountTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCountGloballyEmpty() {
     PCollection<String> input = p.apply(Create.of(NO_LINES).withCoder(StringUtf8Coder.of()));
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -224,7 +224,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCreateWithUnserializableElements() throws Exception {
     List<UnserializableRecord> elements =
         ImmutableList.of(
@@ -250,7 +250,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCreateTimestamped() {
     List<TimestampedValue<String>> data = Arrays.asList(
         TimestampedValue.of("a", new Instant(1L)),
@@ -267,7 +267,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCreateTimestampedEmpty() {
     PCollection<String> output = p
         .apply(Create.timestamped(new ArrayList<TimestampedValue<String>>())
@@ -360,7 +360,7 @@ public class CreateTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testCreateOfProvider() throws Exception {
     PAssert.that(
             p.apply(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/DistinctTest.java
@@ -40,7 +40,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.testing.UsesTestStream;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -70,7 +69,7 @@ public class DistinctTest {
 
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testDistinct() {
     List<String> strings = Arrays.asList("k1", "k5", "k5", "k2", "k1", "k2", "k3");
 
@@ -83,7 +82,7 @@ public class DistinctTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testDistinctEmpty() {
     List<String> strings = Arrays.asList();
 
@@ -117,7 +116,7 @@ public class DistinctTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testDistinctWithRepresentativeValue() {
     List<KV<String, String>> strings =
         Arrays.asList(KV.of("k1", "v1"), KV.of("k1", "v2"), KV.of("k2", "v1"));
@@ -137,7 +136,7 @@ public class DistinctTest {
   @Rule public TestPipeline windowedDistinctPipeline = TestPipeline.create();
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testWindowedDistinct() {
     Instant base = new Instant(0);
     TestStream<String> values =
@@ -179,7 +178,7 @@ public class DistinctTest {
   @Rule public TestPipeline triggeredDistinctPipeline = TestPipeline.create();
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testTriggeredDistinct() {
     Instant base = new Instant(0);
     TestStream<String> values =
@@ -215,7 +214,7 @@ public class DistinctTest {
   @Rule public TestPipeline triggeredDistinctRepresentativePipeline = TestPipeline.create();
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testTriggeredDistinctRepresentativeValues() {
     Instant base = new Instant(0);
     TestStream<KV<Integer, String>> values =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
@@ -22,9 +22,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.Rule;
@@ -67,7 +67,7 @@ public class FilterTest implements Serializable {
   public transient ExpectedException thrown = ExpectedException.none();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testIdentityFilterByPredicate() {
     PCollection<Integer> output = p
         .apply(Create.of(591, 11789, 1257, 24578, 24799, 307))
@@ -78,7 +78,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testNoFilterByPredicate() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 4, 5))
@@ -89,7 +89,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterByPredicate() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -100,7 +100,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterLessThan() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -111,7 +111,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterGreaterThan() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -122,7 +122,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterLessThanEq() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -133,7 +133,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterGreaterThanEq() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -144,7 +144,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterEqual() {
     PCollection<Integer> output = p
         .apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -168,7 +168,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testIdentityFilterByPredicateWithLambda() {
 
     PCollection<Integer> output = p
@@ -180,7 +180,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testNoFilterByPredicateWithLambda() {
 
     PCollection<Integer> output = p
@@ -192,7 +192,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterByPredicateWithLambda() {
 
     PCollection<Integer> output = p
@@ -220,7 +220,7 @@ public class FilterTest implements Serializable {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testFilterByMethodReferenceWithLambda() {
 
     PCollection<Integer> output = p

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupByKeyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupByKeyTest.java
@@ -78,6 +78,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -85,139 +86,463 @@ import org.junit.runners.JUnit4;
 /**
  * Tests for GroupByKey.
  */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class GroupByKeyTest implements Serializable {
+  /** Shared test base class with setup/teardown helpers. */
+  public abstract static class SharedTestBase {
+    @Rule
+    public transient TestPipeline p = TestPipeline.create();
 
-  @Rule
-  public transient TestPipeline p = TestPipeline.create();
-
-  @Rule
-  public transient ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKey() {
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList(
-        KV.of("k1", 3),
-        KV.of("k5", Integer.MAX_VALUE),
-        KV.of("k5", Integer.MIN_VALUE),
-        KV.of("k2", 66),
-        KV.of("k1", 4),
-        KV.of("k2", -33),
-        KV.of("k3", 0));
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(Create.of(ungroupedPairs)
-            .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
-
-    PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
-
-    SerializableFunction<Iterable<KV<String, Iterable<Integer>>>, Void> checker =
-        containsKvs(
-            kv("k1", 3, 4),
-            kv("k5", Integer.MIN_VALUE, Integer.MAX_VALUE),
-            kv("k2", 66, -33),
-            kv("k3", 0));
-    PAssert.that(output).satisfies(checker);
-    PAssert.that(output).inWindow(GlobalWindow.INSTANCE).satisfies(checker);
-
-    p.run();
+    @Rule
+    public transient ExpectedException thrown = ExpectedException.none();
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKeyAndWindows() {
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList(
-        KV.of("k1", 3),  // window [0, 5)
-        KV.of("k5", Integer.MAX_VALUE), // window [0, 5)
-        KV.of("k5", Integer.MIN_VALUE), // window [0, 5)
-        KV.of("k2", 66), // window [0, 5)
-        KV.of("k1", 4),  // window [5, 10)
-        KV.of("k2", -33),  // window [5, 10)
-        KV.of("k3", 0));  // window [5, 10)
+  /** Tests validating basic {@link GroupByKey} scenarios. */
+  @RunWith(JUnit4.class)
+  public static class BasicTests extends SharedTestBase {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKey() {
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList(
+          KV.of("k1", 3),
+          KV.of("k5", Integer.MAX_VALUE),
+          KV.of("k5", Integer.MIN_VALUE),
+          KV.of("k2", 66),
+          KV.of("k1", 4),
+          KV.of("k2", -33),
+          KV.of("k3", 0));
 
-    PCollection<KV<String, Integer>> input =
-        p.apply(Create.timestamped(ungroupedPairs, Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L))
-            .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
-    PCollection<KV<String, Iterable<Integer>>> output =
-        input.apply(Window.into(FixedWindows.of(new Duration(5)))).apply(GroupByKey.create());
+      PCollection<KV<String, Integer>> input =
+          p.apply(Create.of(ungroupedPairs)
+              .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
 
-    PAssert.that(output)
-        .satisfies(
-            containsKvs(
-                kv("k1", 3),
-                kv("k1", 4),
-                kv("k5", Integer.MAX_VALUE, Integer.MIN_VALUE),
-                kv("k2", 66),
-                kv("k2", -33),
-                kv("k3", 0)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(0L), Duration.millis(5L)))
-        .satisfies(
-            containsKvs(kv("k1", 3), kv("k5", Integer.MIN_VALUE, Integer.MAX_VALUE), kv("k2", 66)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(5L), Duration.millis(5L)))
-        .satisfies(containsKvs(kv("k1", 4), kv("k2", -33), kv("k3", 0)));
+      PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
 
-    p.run();
+      SerializableFunction<Iterable<KV<String, Iterable<Integer>>>, Void> checker =
+          containsKvs(
+              kv("k1", 3, 4),
+              kv("k5", Integer.MIN_VALUE, Integer.MAX_VALUE),
+              kv("k2", 66, -33),
+              kv("k3", 0));
+      PAssert.that(output).satisfies(checker);
+      PAssert.that(output).inWindow(GlobalWindow.INSTANCE).satisfies(checker);
+
+      p.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKeyEmpty() {
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(Create.of(ungroupedPairs)
+              .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
+
+      PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
+
+      PAssert.that(output).empty();
+
+      p.run();
+    }
+
+    /**
+     * Tests that when a processing time timers comes in after a window is expired it does not cause
+     * a spurious output.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTestStream.class})
+    public void testCombiningAccumulatingProcessingTime() throws Exception {
+      PCollection<Integer> triggeredSums =
+          p.apply(
+              TestStream.create(VarIntCoder.of())
+                  .advanceWatermarkTo(new Instant(0))
+                  .addElements(
+                      TimestampedValue.of(2, new Instant(2)),
+                      TimestampedValue.of(5, new Instant(5)))
+                  .advanceWatermarkTo(new Instant(100))
+                  .advanceProcessingTime(Duration.millis(10))
+                  .advanceWatermarkToInfinity())
+              .apply(
+                  Window.<Integer>into(FixedWindows.of(Duration.millis(100)))
+                      .withTimestampCombiner(TimestampCombiner.EARLIEST)
+                      .accumulatingFiredPanes()
+                      .withAllowedLateness(Duration.ZERO)
+                      .triggering(
+                          Repeatedly.forever(
+                              AfterProcessingTime.pastFirstElementInPane()
+                                  .plusDelayOf(Duration.millis(10)))))
+              .apply(Sum.integersGlobally().withoutDefaults());
+
+      PAssert.that(triggeredSums)
+          .containsInAnyOrder(7);
+
+      p.run();
+    }
+
+    @Test
+    public void testGroupByKeyNonDeterministic() throws Exception {
+
+      List<KV<Map<String, String>, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<Map<String, String>, Integer>> input =
+          p.apply(Create.of(ungroupedPairs)
+              .withCoder(
+                  KvCoder.of(MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()),
+                      BigEndianIntegerCoder.of())));
+
+      thrown.expect(IllegalStateException.class);
+      thrown.expectMessage("must be deterministic");
+      input.apply(GroupByKey.create());
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testRemerge() {
+
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+              Create.of(ungroupedPairs)
+                  .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
+
+      PCollection<KV<String, Iterable<Iterable<Integer>>>> middle =
+          input
+              .apply("GroupByKey", GroupByKey.create())
+              .apply("Remerge", Window.remerge())
+              .apply("GroupByKeyAgain", GroupByKey.create())
+              .apply("RemergeAgain", Window.remerge());
+
+      p.run();
+
+      Assert.assertTrue(
+          middle.getWindowingStrategy().getWindowFn().isCompatible(
+              Sessions.withGapDuration(Duration.standardMinutes(1))));
+    }
+
+    @Test
+    public void testGroupByKeyDirectUnbounded() {
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+              new PTransform<PBegin, PCollection<KV<String, Integer>>>() {
+                @Override
+                public PCollection<KV<String, Integer>> expand(PBegin input) {
+                  return PCollection.createPrimitiveOutputInternal(
+                      input.getPipeline(),
+                      WindowingStrategy.globalDefault(),
+                      PCollection.IsBounded.UNBOUNDED,
+                      KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+                }
+              });
+
+      thrown.expect(IllegalStateException.class);
+      thrown.expectMessage(
+          "GroupByKey cannot be applied to non-bounded PCollection in the GlobalWindow without "
+              + "a trigger. Use a Window.into or Window.triggering transform prior to GroupByKey.");
+
+      input.apply("GroupByKey", GroupByKey.create());
+    }
+
+    /**
+     * Tests that when two elements are combined via a GroupByKey their output timestamp agrees
+     * with the windowing function customized to actually be the same as the default, the earlier of
+     * the two values.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testTimestampCombinerEarliest() {
+
+      p.apply(
+          Create.timestamped(
+              TimestampedValue.of(KV.of(0, "hello"), new Instant(0)),
+              TimestampedValue.of(KV.of(0, "goodbye"), new Instant(10))))
+          .apply(
+              Window.<KV<Integer, String>>into(FixedWindows.of(Duration.standardMinutes(10)))
+                  .withTimestampCombiner(TimestampCombiner.EARLIEST))
+          .apply(GroupByKey.create())
+          .apply(ParDo.of(new AssertTimestamp(new Instant(0))));
+
+      p.run();
+    }
+
+
+    /**
+     * Tests that when two elements are combined via a GroupByKey their output timestamp agrees
+     * with the windowing function customized to use the latest value.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testTimestampCombinerLatest() {
+      p.apply(
+          Create.timestamped(
+              TimestampedValue.of(KV.of(0, "hello"), new Instant(0)),
+              TimestampedValue.of(KV.of(0, "goodbye"), new Instant(10))))
+          .apply(
+              Window.<KV<Integer, String>>into(FixedWindows.of(Duration.standardMinutes(10)))
+                  .withTimestampCombiner(TimestampCombiner.LATEST))
+          .apply(GroupByKey.create())
+          .apply(ParDo.of(new AssertTimestamp(new Instant(10))));
+
+      p.run();
+    }
+
+    @Test
+    public void testGroupByKeyGetName() {
+      Assert.assertEquals("GroupByKey", GroupByKey.<String, Integer>create().getName());
+    }
+
+    @Test
+    public void testDisplayData() {
+      GroupByKey<String, String> groupByKey = GroupByKey.create();
+      GroupByKey<String, String> groupByFewKeys = GroupByKey.createWithFewKeys();
+
+      DisplayData gbkDisplayData = DisplayData.from(groupByKey);
+      DisplayData fewKeysDisplayData = DisplayData.from(groupByFewKeys);
+
+      assertThat(gbkDisplayData.items(), empty());
+      assertThat(fewKeysDisplayData, hasDisplayItem("fewKeys", true));
+    }
+
+
+    /**
+     * Verify that runners correctly hash/group on the encoded value
+     * and not the value itself.
+     */
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKeyWithBadEqualsHashCode() throws Exception {
+      final int numValues = 10;
+      final int numKeys = 5;
+
+      p.getCoderRegistry().registerCoderProvider(
+          CoderProviders.fromStaticMethods(BadEqualityKey.class, DeterministicKeyCoder.class));
+
+      // construct input data
+      List<KV<BadEqualityKey, Long>> input = new ArrayList<>();
+      for (int i = 0; i < numValues; i++) {
+        for (int key = 0; key < numKeys; key++) {
+          input.add(KV.of(new BadEqualityKey(key), 1L));
+        }
+      }
+
+      // We first ensure that the values are randomly partitioned in the beginning.
+      // Some runners might otherwise keep all values on the machine where
+      // they are initially created.
+      PCollection<KV<BadEqualityKey, Long>> dataset1 =
+          p.apply(Create.of(input))
+              .apply(ParDo.of(new AssignRandomKey()))
+              .apply(Reshuffle.of())
+              .apply(Values.create());
+
+      // Make the GroupByKey and Count implicit, in real-world code
+      // this would be a Count.perKey()
+      PCollection<KV<BadEqualityKey, Long>> result =
+          dataset1.apply(GroupByKey.create()).apply(Combine.groupedValues(new CountFn()));
+
+      PAssert.that(result).satisfies(new AssertThatCountPerKeyCorrect(numValues));
+
+      PAssert.that(result.apply(Keys.create())).satisfies(new AssertThatAllKeysExist(numKeys));
+
+      p.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, LargeKeys.Above10KB.class})
+    public void testLargeKeys10KB() throws Exception {
+      runLargeKeysTest(p, 10 << 10);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, LargeKeys.Above100KB.class})
+    public void testLargeKeys100KB() throws Exception {
+      runLargeKeysTest(p, 100 << 10);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, LargeKeys.Above1MB.class})
+    public void testLargeKeys1MB() throws Exception {
+      runLargeKeysTest(p, 1 << 20);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, LargeKeys.Above10MB.class})
+    public void testLargeKeys10MB() throws Exception {
+      runLargeKeysTest(p, 10 << 20);
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, LargeKeys.Above100MB.class})
+    public void testLargeKeys100MB() throws Exception {
+      runLargeKeysTest(p, 100 << 20);
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKeyMultipleWindows() {
-    PCollection<KV<String, Integer>> windowedInput =
-        p.apply(
-                Create.timestamped(
-                    TimestampedValue.of(KV.of("foo", 1), new Instant(1)),
-                    TimestampedValue.of(KV.of("foo", 4), new Instant(4)),
-                    TimestampedValue.of(KV.of("bar", 3), new Instant(3))))
-            .apply(Window.into(SlidingWindows.of(Duration.millis(5L)).every(Duration.millis(3L))));
+  /** Tests validating GroupByKey behaviors with windowing. */
+  @RunWith(JUnit4.class)
+  public static class WindowTests extends SharedTestBase{
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKeyAndWindows() {
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList(
+          KV.of("k1", 3),  // window [0, 5)
+          KV.of("k5", Integer.MAX_VALUE), // window [0, 5)
+          KV.of("k5", Integer.MIN_VALUE), // window [0, 5)
+          KV.of("k2", 66), // window [0, 5)
+          KV.of("k1", 4),  // window [5, 10)
+          KV.of("k2", -33),  // window [5, 10)
+          KV.of("k3", 0));  // window [5, 10)
 
-    PCollection<KV<String, Iterable<Integer>>> output = windowedInput.apply(GroupByKey.create());
+      PCollection<KV<String, Integer>> input =
+          p.apply(Create.timestamped(ungroupedPairs, Arrays.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L))
+              .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
+      PCollection<KV<String, Iterable<Integer>>> output =
+          input.apply(Window.into(FixedWindows.of(new Duration(5)))).apply(GroupByKey.create());
 
-    PAssert.that(output)
-        .satisfies(
-            containsKvs(kv("foo", 1, 4), kv("foo", 1), kv("foo", 4), kv("bar", 3), kv("bar", 3)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(-3L), Duration.millis(5L)))
-        .satisfies(containsKvs(kv("foo", 1)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(0L), Duration.millis(5L)))
-        .satisfies(containsKvs(kv("foo", 1, 4), kv("bar", 3)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(3L), Duration.millis(5L)))
-        .satisfies(containsKvs(kv("foo", 4), kv("bar", 3)));
+      PAssert.that(output)
+          .satisfies(
+              containsKvs(
+                  kv("k1", 3),
+                  kv("k1", 4),
+                  kv("k5", Integer.MAX_VALUE, Integer.MIN_VALUE),
+                  kv("k2", 66),
+                  kv("k2", -33),
+                  kv("k3", 0)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(0L), Duration.millis(5L)))
+          .satisfies(
+              containsKvs(
+                  kv("k1", 3),
+                  kv("k5", Integer.MIN_VALUE, Integer.MAX_VALUE),
+                  kv("k2", 66)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(5L), Duration.millis(5L)))
+          .satisfies(containsKvs(kv("k1", 4), kv("k2", -33), kv("k3", 0)));
 
-    p.run();
-  }
+      p.run();
+    }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKeyMergingWindows() {
-    PCollection<KV<String, Integer>> windowedInput =
-        p.apply(
-                Create.timestamped(
-                    TimestampedValue.of(KV.of("foo", 1), new Instant(1)),
-                    TimestampedValue.of(KV.of("foo", 4), new Instant(4)),
-                    TimestampedValue.of(KV.of("bar", 3), new Instant(3)),
-                    TimestampedValue.of(KV.of("foo", 9), new Instant(9))))
-            .apply(Window.into(Sessions.withGapDuration(Duration.millis(4L))));
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKeyMultipleWindows() {
+      PCollection<KV<String, Integer>> windowedInput =
+          p.apply(
+              Create.timestamped(
+                  TimestampedValue.of(KV.of("foo", 1), new Instant(1)),
+                  TimestampedValue.of(KV.of("foo", 4), new Instant(4)),
+                  TimestampedValue.of(KV.of("bar", 3), new Instant(3))))
+              .apply(Window.into(SlidingWindows
+                  .of(Duration.millis(5L))
+                  .every(Duration.millis(3L))));
 
-    PCollection<KV<String, Iterable<Integer>>> output = windowedInput.apply(GroupByKey.create());
+      PCollection<KV<String, Iterable<Integer>>> output = windowedInput.apply(GroupByKey.create());
 
-    PAssert.that(output).satisfies(containsKvs(kv("foo", 1, 4), kv("foo", 9), kv("bar", 3)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(1L), new Instant(8L)))
-        .satisfies(containsKvs(kv("foo", 1, 4)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(3L), new Instant(7L)))
-        .satisfies(containsKvs(kv("bar", 3)));
-    PAssert.that(output)
-        .inWindow(new IntervalWindow(new Instant(9L), new Instant(13L)))
-        .satisfies(containsKvs(kv("foo", 9)));
+      PAssert.that(output)
+          .satisfies(
+              containsKvs(kv("foo", 1, 4), kv("foo", 1), kv("foo", 4), kv("bar", 3), kv("bar", 3)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(-3L), Duration.millis(5L)))
+          .satisfies(containsKvs(kv("foo", 1)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(0L), Duration.millis(5L)))
+          .satisfies(containsKvs(kv("foo", 1, 4), kv("bar", 3)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(3L), Duration.millis(5L)))
+          .satisfies(containsKvs(kv("foo", 4), kv("bar", 3)));
 
-    p.run();
+      p.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testGroupByKeyMergingWindows() {
+      PCollection<KV<String, Integer>> windowedInput =
+          p.apply(
+              Create.timestamped(
+                  TimestampedValue.of(KV.of("foo", 1), new Instant(1)),
+                  TimestampedValue.of(KV.of("foo", 4), new Instant(4)),
+                  TimestampedValue.of(KV.of("bar", 3), new Instant(3)),
+                  TimestampedValue.of(KV.of("foo", 9), new Instant(9))))
+              .apply(Window.into(Sessions.withGapDuration(Duration.millis(4L))));
+
+      PCollection<KV<String, Iterable<Integer>>> output = windowedInput.apply(GroupByKey.create());
+
+      PAssert.that(output).satisfies(containsKvs(kv("foo", 1, 4), kv("foo", 9), kv("bar", 3)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(1L), new Instant(8L)))
+          .satisfies(containsKvs(kv("foo", 1, 4)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(3L), new Instant(7L)))
+          .satisfies(containsKvs(kv("bar", 3)));
+      PAssert.that(output)
+          .inWindow(new IntervalWindow(new Instant(9L), new Instant(13L)))
+          .satisfies(containsKvs(kv("foo", 9)));
+
+      p.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testIdentityWindowFnPropagation() {
+
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+              Create.of(ungroupedPairs)
+                  .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))));
+
+      PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
+
+      p.run();
+
+      Assert.assertTrue(output.getWindowingStrategy().getWindowFn().isCompatible(
+          FixedWindows.of(Duration.standardMinutes(1))));
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testWindowFnInvalidation() {
+
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+              Create.of(ungroupedPairs)
+                  .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
+
+      PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
+
+      p.run();
+
+      Assert.assertTrue(
+          output.getWindowingStrategy().getWindowFn().isCompatible(
+              new InvalidWindows(
+                  "Invalid",
+                  Sessions.withGapDuration(
+                      Duration.standardMinutes(1)))));
+    }
+
+    @Test
+    public void testInvalidWindowsDirect() {
+
+      List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
+
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+              Create.of(ungroupedPairs)
+                  .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
+              .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
+
+      thrown.expect(IllegalStateException.class);
+      thrown.expectMessage("GroupByKey must have a valid Window merge function");
+      input.apply("GroupByKey", GroupByKey.create()).apply("GroupByKeyAgain", GroupByKey.create());
+    }
   }
 
   private static KV<String, Collection<Integer>> kv(String key, Integer... values) {
@@ -253,225 +578,6 @@ public class GroupByKeyTest implements Serializable {
     }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKeyEmpty() {
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(Create.of(ungroupedPairs)
-            .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())));
-
-    PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
-
-    PAssert.that(output).empty();
-
-    p.run();
-  }
-
-  /**
-   * Tests that when a processing time timers comes in after a window is expired it does not cause a
-   * spurious output.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
-  public void testCombiningAccumulatingProcessingTime() throws Exception {
-    PCollection<Integer> triggeredSums =
-        p.apply(
-                TestStream.create(VarIntCoder.of())
-                    .advanceWatermarkTo(new Instant(0))
-                    .addElements(
-                        TimestampedValue.of(2, new Instant(2)),
-                        TimestampedValue.of(5, new Instant(5)))
-                    .advanceWatermarkTo(new Instant(100))
-                    .advanceProcessingTime(Duration.millis(10))
-                    .advanceWatermarkToInfinity())
-            .apply(
-                Window.<Integer>into(FixedWindows.of(Duration.millis(100)))
-                    .withTimestampCombiner(TimestampCombiner.EARLIEST)
-                    .accumulatingFiredPanes()
-                    .withAllowedLateness(Duration.ZERO)
-                    .triggering(
-                        Repeatedly.forever(
-                            AfterProcessingTime.pastFirstElementInPane()
-                                .plusDelayOf(Duration.millis(10)))))
-            .apply(Sum.integersGlobally().withoutDefaults());
-
-    PAssert.that(triggeredSums)
-        .containsInAnyOrder(7);
-
-    p.run();
-  }
-
-  @Test
-  public void testGroupByKeyNonDeterministic() throws Exception {
-
-    List<KV<Map<String, String>, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<Map<String, String>, Integer>> input =
-        p.apply(Create.of(ungroupedPairs)
-            .withCoder(
-                KvCoder.of(MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()),
-                    BigEndianIntegerCoder.of())));
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("must be deterministic");
-    input.apply(GroupByKey.create());
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testIdentityWindowFnPropagation() {
-
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(
-                Create.of(ungroupedPairs)
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))));
-
-    PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
-
-    p.run();
-
-    Assert.assertTrue(output.getWindowingStrategy().getWindowFn().isCompatible(
-        FixedWindows.of(Duration.standardMinutes(1))));
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testWindowFnInvalidation() {
-
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(
-                Create.of(ungroupedPairs)
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
-
-    PCollection<KV<String, Iterable<Integer>>> output = input.apply(GroupByKey.create());
-
-    p.run();
-
-    Assert.assertTrue(
-        output.getWindowingStrategy().getWindowFn().isCompatible(
-            new InvalidWindows(
-                "Invalid",
-                Sessions.withGapDuration(
-                    Duration.standardMinutes(1)))));
-  }
-
-  @Test
-  public void testInvalidWindowsDirect() {
-
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(
-                Create.of(ungroupedPairs)
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("GroupByKey must have a valid Window merge function");
-    input.apply("GroupByKey", GroupByKey.create()).apply("GroupByKeyAgain", GroupByKey.create());
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testRemerge() {
-
-    List<KV<String, Integer>> ungroupedPairs = Arrays.asList();
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(
-                Create.of(ungroupedPairs)
-                    .withCoder(KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of())))
-            .apply(Window.into(Sessions.withGapDuration(Duration.standardMinutes(1))));
-
-    PCollection<KV<String, Iterable<Iterable<Integer>>>> middle =
-        input
-            .apply("GroupByKey", GroupByKey.create())
-            .apply("Remerge", Window.remerge())
-            .apply("GroupByKeyAgain", GroupByKey.create())
-            .apply("RemergeAgain", Window.remerge());
-
-    p.run();
-
-    Assert.assertTrue(
-        middle.getWindowingStrategy().getWindowFn().isCompatible(
-            Sessions.withGapDuration(Duration.standardMinutes(1))));
-  }
-
-  @Test
-  public void testGroupByKeyDirectUnbounded() {
-
-    PCollection<KV<String, Integer>> input =
-        p.apply(
-            new PTransform<PBegin, PCollection<KV<String, Integer>>>() {
-              @Override
-              public PCollection<KV<String, Integer>> expand(PBegin input) {
-                return PCollection.createPrimitiveOutputInternal(
-                    input.getPipeline(),
-                    WindowingStrategy.globalDefault(),
-                    PCollection.IsBounded.UNBOUNDED,
-                    KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
-              }
-            });
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage(
-        "GroupByKey cannot be applied to non-bounded PCollection in the GlobalWindow without "
-            + "a trigger. Use a Window.into or Window.triggering transform prior to GroupByKey.");
-
-    input.apply("GroupByKey", GroupByKey.create());
-  }
-
-  /**
-   * Tests that when two elements are combined via a GroupByKey their output timestamp agrees
-   * with the windowing function customized to actually be the same as the default, the earlier of
-   * the two values.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testTimestampCombinerEarliest() {
-
-    p.apply(
-            Create.timestamped(
-                TimestampedValue.of(KV.of(0, "hello"), new Instant(0)),
-                TimestampedValue.of(KV.of(0, "goodbye"), new Instant(10))))
-        .apply(
-            Window.<KV<Integer, String>>into(FixedWindows.of(Duration.standardMinutes(10)))
-                .withTimestampCombiner(TimestampCombiner.EARLIEST))
-        .apply(GroupByKey.create())
-        .apply(ParDo.of(new AssertTimestamp(new Instant(0))));
-
-    p.run();
-  }
-
-
-  /**
-   * Tests that when two elements are combined via a GroupByKey their output timestamp agrees
-   * with the windowing function customized to use the latest value.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testTimestampCombinerLatest() {
-    p.apply(
-            Create.timestamped(
-                TimestampedValue.of(KV.of(0, "hello"), new Instant(0)),
-                TimestampedValue.of(KV.of(0, "goodbye"), new Instant(10))))
-        .apply(
-            Window.<KV<Integer, String>>into(FixedWindows.of(Duration.standardMinutes(10)))
-                .withTimestampCombiner(TimestampCombiner.LATEST))
-        .apply(GroupByKey.create())
-        .apply(ParDo.of(new AssertTimestamp(new Instant(10))));
-
-    p.run();
-  }
-
   private static class AssertTimestamp<K, V> extends DoFn<KV<K, V>, Void> {
     private final Instant timestamp;
 
@@ -483,66 +589,6 @@ public class GroupByKeyTest implements Serializable {
     public void processElement(ProcessContext c) throws Exception {
       assertThat(c.timestamp(), equalTo(timestamp));
     }
-  }
-
-  @Test
-  public void testGroupByKeyGetName() {
-    Assert.assertEquals("GroupByKey", GroupByKey.<String, Integer>create().getName());
-  }
-
-  @Test
-  public void testDisplayData() {
-    GroupByKey<String, String> groupByKey = GroupByKey.create();
-    GroupByKey<String, String> groupByFewKeys = GroupByKey.createWithFewKeys();
-
-    DisplayData gbkDisplayData = DisplayData.from(groupByKey);
-    DisplayData fewKeysDisplayData = DisplayData.from(groupByFewKeys);
-
-    assertThat(gbkDisplayData.items(), empty());
-    assertThat(fewKeysDisplayData, hasDisplayItem("fewKeys", true));
-  }
-
-
-  /**
-   * Verify that runners correctly hash/group on the encoded value
-   * and not the value itself.
-   */
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testGroupByKeyWithBadEqualsHashCode() throws Exception {
-    final int numValues = 10;
-    final int numKeys = 5;
-
-    p.getCoderRegistry().registerCoderProvider(
-        CoderProviders.fromStaticMethods(BadEqualityKey.class, DeterministicKeyCoder.class));
-
-    // construct input data
-    List<KV<BadEqualityKey, Long>> input = new ArrayList<>();
-    for (int i = 0; i < numValues; i++) {
-      for (int key = 0; key < numKeys; key++) {
-        input.add(KV.of(new BadEqualityKey(key), 1L));
-      }
-    }
-
-    // We first ensure that the values are randomly partitioned in the beginning.
-    // Some runners might otherwise keep all values on the machine where
-    // they are initially created.
-    PCollection<KV<BadEqualityKey, Long>> dataset1 =
-        p.apply(Create.of(input))
-            .apply(ParDo.of(new AssignRandomKey()))
-            .apply(Reshuffle.of())
-            .apply(Values.create());
-
-    // Make the GroupByKey and Count implicit, in real-world code
-    // this would be a Count.perKey()
-    PCollection<KV<BadEqualityKey, Long>> result =
-        dataset1.apply(GroupByKey.create()).apply(Combine.groupedValues(new CountFn()));
-
-    PAssert.that(result).satisfies(new AssertThatCountPerKeyCorrect(numValues));
-
-    PAssert.that(result.apply(Keys.create())).satisfies(new AssertThatAllKeysExist(numKeys));
-
-    p.run();
   }
 
   private static String bigString(char c, int size) {
@@ -591,36 +637,6 @@ public class GroupByKeyTest implements Serializable {
             });
 
     p.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, LargeKeys.Above10KB.class})
-  public void testLargeKeys10KB() throws Exception {
-    runLargeKeysTest(p, 10 << 10);
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, LargeKeys.Above100KB.class})
-  public void testLargeKeys100KB() throws Exception {
-    runLargeKeysTest(p, 100 << 10);
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, LargeKeys.Above1MB.class})
-  public void testLargeKeys1MB() throws Exception {
-    runLargeKeysTest(p, 1 << 20);
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, LargeKeys.Above10MB.class})
-  public void testLargeKeys10MB() throws Exception {
-    runLargeKeysTest(p, 10 << 20);
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, LargeKeys.Above100MB.class})
-  public void testLargeKeys100MB() throws Exception {
-    runLargeKeysTest(p, 100 << 20);
   }
 
   /**

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/KvSwapTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/KvSwapTest.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.ValidatesRunner;
@@ -76,7 +77,7 @@ public class KvSwapTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testKvSwapEmpty() {
     PCollection<KV<String, Integer>> input =
         p.apply(Create.of(Arrays.asList(EMPTY_TABLE)).withCoder(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoLifecycleTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoLifecycleTest.java
@@ -53,30 +53,6 @@ public class ParDoLifecycleTest implements Serializable {
   @Rule
   public final transient TestPipeline p = TestPipeline.create();
 
-  @Test
-  @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
-  public void testOldFnCallSequence() {
-    PCollectionList.of(p.apply("Impolite", Create.of(1, 2, 4)))
-        .and(p.apply("Polite", Create.of(3, 5, 6, 7)))
-        .apply(Flatten.pCollections())
-        .apply(ParDo.of(new CallSequenceEnforcingDoFn<>()));
-
-    p.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesParDoLifecycle.class})
-  public void testOldFnCallSequenceMulti() {
-    PCollectionList.of(p.apply("Impolite", Create.of(1, 2, 4)))
-        .and(p.apply("Polite", Create.of(3, 5, 6, 7)))
-        .apply(Flatten.pCollections())
-        .apply(
-            ParDo.of(new CallSequenceEnforcingDoFn<Integer>())
-                .withOutputTags(new TupleTag<Integer>() {}, TupleTagList.empty()));
-
-    p.run();
-  }
-
   private static class CallSequenceEnforcingDoFn<T> extends DoFn<T, T> {
     private boolean setupCalled = false;
     private int startBundleCalls = 0;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -119,6 +119,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -126,16 +127,19 @@ import org.junit.runners.JUnit4;
 /**
  * Tests for ParDo.
  */
-@RunWith(JUnit4.class)
+@RunWith(Enclosed.class)
 public class ParDoTest implements Serializable {
   // This test is Serializable, just so that it's easy to have
   // anonymous inner classes inside the non-static test methods.
 
-  @Rule
-  public final transient TestPipeline pipeline = TestPipeline.create();
+  /** Shared base test base with setup/teardown helpers. */
+  public abstract static class SharedTestBase {
+    @Rule
+    public final transient TestPipeline pipeline = TestPipeline.create();
 
-  @Rule
-  public transient ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public transient ExpectedException thrown = ExpectedException.none();
+  }
 
   private static class PrintingDoFn extends DoFn<String, String> {
     @ProcessElement
@@ -329,391 +333,2866 @@ public class ParDoTest implements Serializable {
     }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDo() {
+  /** Tests for basic {@link ParDo} scenarios. */
+  @RunWith(JUnit4.class)
+  public static class BasicTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDo() {
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
 
-    PCollection<String> output = pipeline
-        .apply(Create.of(inputs))
-        .apply(ParDo.of(new TestDoFn()));
+      PCollection<String> output = pipeline
+          .apply(Create.of(inputs))
+          .apply(ParDo.of(new TestDoFn()));
 
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
+      PAssert.that(output)
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
 
-    pipeline.run();
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoEmpty() {
+
+      List<Integer> inputs = Arrays.asList();
+
+      PCollection<String> output = pipeline
+          .apply(Create.of(inputs).withCoder(VarIntCoder.of()))
+          .apply("TestDoFn", ParDo.of(new TestDoFn()));
+
+      PAssert.that(output)
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoEmptyOutputs() {
+
+      List<Integer> inputs = Arrays.asList();
+
+      PCollection<String> output = pipeline
+          .apply(Create.of(inputs).withCoder(VarIntCoder.of()))
+          .apply("TestDoFn", ParDo.of(new TestNoOutputDoFn()));
+
+      PAssert.that(output).empty();
+
+      pipeline.run();
+    }
+
+    @Test
+    public void testParDoTransformNameBasedDoFnWithTrimmedSuffix() {
+      assertThat(ParDo.of(new PrintingDoFn()).getName(), containsString("ParDo(Printing)"));
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoInCustomTransform() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      PCollection<String> output = pipeline
+          .apply(Create.of(inputs))
+          .apply("CustomTransform", new PTransform<PCollection<Integer>, PCollection<String>>() {
+            @Override
+            public PCollection<String> expand(PCollection<Integer> input) {
+              return input.apply(ParDo.of(new TestDoFn()));
+            }
+          });
+
+      // Test that Coder inference of the result works through
+      // user-defined PTransforms.
+      PAssert.that(output)
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
+
+      pipeline.run();
+    }
+
+    @Test
+    public void testJsonEscaping() {
+      // Declare an arbitrary function and make sure we can serialize it
+      DoFn<Integer, Integer> doFn = new DoFn<Integer, Integer>() {
+        @ProcessElement
+        public void processElement(@Element Integer element, OutputReceiver<Integer> r) {
+          r.output(element + 1);
+        }
+      };
+
+      byte[] serializedBytes = serializeToByteArray(doFn);
+      String serializedJson = byteArrayToJsonString(serializedBytes);
+      assertArrayEquals(
+          serializedBytes, jsonStringToByteArray(serializedJson));
+    }
+
+    @Test
+    public void testDoFnDisplayData() {
+      DoFn<String, String> fn = new DoFn<String, String>() {
+        @ProcessElement
+        public void processElement(ProcessContext c) {
+        }
+
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item("doFnMetadata", "bar"));
+        }
+      };
+
+      SingleOutput<String, String> parDo = ParDo.of(fn);
+
+      DisplayData displayData = DisplayData.from(parDo);
+      assertThat(displayData, hasDisplayItem(allOf(
+          hasKey("fn"),
+          hasType(DisplayData.Type.JAVA_CLASS),
+          DisplayDataMatchers.hasValue(fn.getClass().getName()))));
+
+      assertThat(displayData, includesDisplayDataFor("fn", fn));
+    }
+
+    @Test
+    public void testDoFnWithContextDisplayData() {
+      DoFn<String, String> fn = new DoFn<String, String>() {
+        @ProcessElement
+        public void proccessElement(ProcessContext c) {}
+
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item("fnMetadata", "foobar"));
+        }
+      };
+
+      SingleOutput<String, String> parDo = ParDo.of(fn);
+
+      DisplayData displayData = DisplayData.from(parDo);
+      assertThat(displayData, includesDisplayDataFor("fn", fn));
+      assertThat(displayData, hasDisplayItem("fn", fn.getClass()));
+    }
+
+    @Test
+    public void testRejectsWrongWindowType() {
+
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(GlobalWindow.class.getSimpleName());
+      thrown.expectMessage(IntervalWindow.class.getSimpleName());
+      thrown.expectMessage("window type");
+      thrown.expectMessage("not a supertype");
+
+      pipeline
+          .apply(Create.of(1, 2, 3))
+          .apply(
+              ParDo.of(
+                  new DoFn<Integer, Integer>() {
+                    @ProcessElement
+                    public void process(ProcessContext c, IntervalWindow w) {}
+                  }));
+    }
+
+    /**
+     * Tests that it is OK to use different window types in the parameter lists to different
+     * {@link DoFn} functions, as long as they are all subtypes of the actual window type
+     * of the input.
+     *
+     * <p>Today, the only method other than {@link ProcessElement @ProcessElement} that can accept
+     * extended parameters is {@link OnTimer @OnTimer}, which is rejected before it reaches window
+     * type validation. Rather than delay validation, this test is temporarily disabled.
+     */
+    @Ignore("ParDo rejects this on account of it using timers")
+    @Test
+    public void testMultipleWindowSubtypesOK() {
+      final String timerId = "gobbledegook";
+
+      pipeline
+          .apply(Create.of(1, 2, 3))
+          .apply(Window.into(FixedWindows.of(Duration.standardSeconds(10))))
+          .apply(
+              ParDo.of(
+                  new DoFn<Integer, Integer>() {
+                    @TimerId(timerId)
+                    private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+                    @ProcessElement
+                    public void process(ProcessContext c, IntervalWindow w) {}
+
+                    @OnTimer(timerId)
+                    public void onTimer(BoundedWindow w) {}
+                  }));
+
+      // If it doesn't crash, we made it!
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testPipelineOptionsParameter() {
+      PCollection<String> results = pipeline
+          .apply(Create.of(1))
+          .apply(
+              ParDo.of(
+                  new DoFn<Integer, String>() {
+                    @ProcessElement
+                    public void process(OutputReceiver<String> r, PipelineOptions options) {
+                      r.output(options.as(MyOptions.class).getFakeOption());
+                    }
+                  }));
+
+      String testOptionValue = "not fake anymore";
+      pipeline.getOptions().as(MyOptions.class).setFakeOption(testOptionValue);
+      PAssert.that(results).containsInAnyOrder("not fake anymore");
+
+      pipeline.run();
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDo2() {
+  /** Tests to validate behaviors around multiple inputs or outputs. */
+  @RunWith(JUnit4.class)
+  public static class MultipleInputsAndOutputTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoWithTaggedOutput() {
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
 
-    PCollection<String> output = pipeline
-        .apply(Create.of(inputs))
-        .apply(ParDo.of(new TestDoFn()));
+      TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
+      TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
+      TupleTag<String> additionalOutputTag3 = new TupleTag<String>("additional3"){};
+      TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
 
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
+      PCollectionTuple outputs =
+          pipeline
+              .apply(Create.of(inputs))
+              .apply(
+                  ParDo.of(
+                      new TestDoFn(
+                          Arrays.asList(),
+                          Arrays.asList(
+                              additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
+                      .withOutputTags(
+                          mainOutputTag,
+                          TupleTagList.of(additionalOutputTag3)
+                              .and(additionalOutputTag1)
+                              .and(additionalOutputTagUnwritten)
+                              .and(additionalOutputTag2)));
 
-    pipeline.run();
-  }
+      PAssert.that(outputs.get(mainOutputTag))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoEmpty() {
+      PAssert.that(outputs.get(additionalOutputTag1))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag1));
+      PAssert.that(outputs.get(additionalOutputTag2))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag2));
+      PAssert.that(outputs.get(additionalOutputTag3))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag3));
+      PAssert.that(outputs.get(additionalOutputTagUnwritten)).empty();
 
-    List<Integer> inputs = Arrays.asList();
+      pipeline.run();
+    }
 
-    PCollection<String> output = pipeline
-        .apply(Create.of(inputs).withCoder(VarIntCoder.of()))
-        .apply("TestDoFn", ParDo.of(new TestDoFn()));
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoEmptyWithTaggedOutput() {
+      TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
+      TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
+      TupleTag<String> additionalOutputTag3 = new TupleTag<String>("additional3"){};
+      TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
 
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
+      PCollectionTuple outputs =
+          pipeline
+              .apply(Create.empty(VarIntCoder.of()))
+              .apply(
+                  ParDo.of(
+                      new TestDoFn(
+                          Arrays.asList(),
+                          Arrays.asList(
+                              additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
+                      .withOutputTags(
+                          mainOutputTag,
+                          TupleTagList.of(additionalOutputTag3)
+                              .and(additionalOutputTag1)
+                              .and(additionalOutputTagUnwritten)
+                              .and(additionalOutputTag2)));
 
-    pipeline.run();
-  }
+      List<Integer> inputs = Collections.emptyList();
+      PAssert.that(outputs.get(mainOutputTag))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoEmptyOutputs() {
+      PAssert.that(outputs.get(additionalOutputTag1))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag1));
+      PAssert.that(outputs.get(additionalOutputTag2))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag2));
+      PAssert.that(outputs.get(additionalOutputTag3))
+          .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
+              .fromOutput(additionalOutputTag3));
+      PAssert.that(outputs.get(additionalOutputTagUnwritten)).empty();
 
-    List<Integer> inputs = Arrays.asList();
+      pipeline.run();
+    }
 
-    PCollection<String> output = pipeline
-        .apply(Create.of(inputs).withCoder(VarIntCoder.of()))
-        .apply("TestDoFn", ParDo.of(new TestNoOutputDoFn()));
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoWithEmptyTaggedOutput() {
+      TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
+      TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
 
-    PAssert.that(output).empty();
+      PCollectionTuple outputs = pipeline
+          .apply(Create.empty(VarIntCoder.of()))
+          .apply(ParDo
+              .of(new TestNoOutputDoFn())
+              .withOutputTags(
+                  mainOutputTag,
+                  TupleTagList.of(additionalOutputTag1).and(additionalOutputTag2)));
 
-    pipeline.run();
-  }
+      PAssert.that(outputs.get(mainOutputTag)).empty();
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoWithTaggedOutput() {
+      PAssert.that(outputs.get(additionalOutputTag1)).empty();
+      PAssert.that(outputs.get(additionalOutputTag2)).empty();
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
-
-    TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
-    TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
-    TupleTag<String> additionalOutputTag3 = new TupleTag<String>("additional3"){};
-    TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
-
-    PCollectionTuple outputs =
-        pipeline
-            .apply(Create.of(inputs))
-            .apply(
-                ParDo.of(
-                        new TestDoFn(
-                            Arrays.asList(),
-                            Arrays.asList(
-                                additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
-                    .withOutputTags(
-                        mainOutputTag,
-                        TupleTagList.of(additionalOutputTag3)
-                            .and(additionalOutputTag1)
-                            .and(additionalOutputTagUnwritten)
-                            .and(additionalOutputTag2)));
-
-    PAssert.that(outputs.get(mainOutputTag))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
-
-    PAssert.that(outputs.get(additionalOutputTag1))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag1));
-    PAssert.that(outputs.get(additionalOutputTag2))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag2));
-    PAssert.that(outputs.get(additionalOutputTag3))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag3));
-    PAssert.that(outputs.get(additionalOutputTagUnwritten)).empty();
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoEmptyWithTaggedOutput() {
-    TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
-    TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
-    TupleTag<String> additionalOutputTag3 = new TupleTag<String>("additional3"){};
-    TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
-
-    PCollectionTuple outputs =
-        pipeline
-            .apply(Create.empty(VarIntCoder.of()))
-            .apply(
-                ParDo.of(
-                        new TestDoFn(
-                            Arrays.asList(),
-                            Arrays.asList(
-                                additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
-                    .withOutputTags(
-                        mainOutputTag,
-                        TupleTagList.of(additionalOutputTag3)
-                            .and(additionalOutputTag1)
-                            .and(additionalOutputTagUnwritten)
-                            .and(additionalOutputTag2)));
-
-    List<Integer> inputs = Collections.emptyList();
-    PAssert.that(outputs.get(mainOutputTag))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
-
-    PAssert.that(outputs.get(additionalOutputTag1))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag1));
-    PAssert.that(outputs.get(additionalOutputTag2))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag2));
-    PAssert.that(outputs.get(additionalOutputTag3))
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs)
-                   .fromOutput(additionalOutputTag3));
-    PAssert.that(outputs.get(additionalOutputTagUnwritten)).empty();
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoWithEmptyTaggedOutput() {
-    TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    TupleTag<String> additionalOutputTag1 = new TupleTag<String>("additional1"){};
-    TupleTag<String> additionalOutputTag2 = new TupleTag<String>("additional2"){};
-
-    PCollectionTuple outputs = pipeline
-        .apply(Create.empty(VarIntCoder.of()))
-        .apply(ParDo
-               .of(new TestNoOutputDoFn())
-               .withOutputTags(
-                   mainOutputTag,
-                   TupleTagList.of(additionalOutputTag1).and(additionalOutputTag2)));
-
-    PAssert.that(outputs.get(mainOutputTag)).empty();
-
-    PAssert.that(outputs.get(additionalOutputTag1)).empty();
-    PAssert.that(outputs.get(additionalOutputTag2)).empty();
-
-    pipeline.run();
-  }
+      pipeline.run();
+    }
 
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoWithOnlyTaggedOutput() {
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoWithOnlyTaggedOutput() {
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
 
-    final TupleTag<Void> mainOutputTag = new TupleTag<Void>("main"){};
-    final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additional"){};
+      final TupleTag<Void> mainOutputTag = new TupleTag<Void>("main"){};
+      final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additional"){};
 
-    PCollectionTuple outputs = pipeline
-        .apply(Create.of(inputs))
-        .apply(ParDo
-            .of(new DoFn<Integer, Void>() {
+      PCollectionTuple outputs = pipeline
+          .apply(Create.of(inputs))
+          .apply(ParDo
+              .of(new DoFn<Integer, Void>() {
                 @ProcessElement
                 public void processElement(@Element Integer element,
-                                           MultiOutputReceiver r) {
+                    MultiOutputReceiver r) {
                   r.get(additionalOutputTag).output(element);
                 }})
-            .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+              .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
 
-    PAssert.that(outputs.get(mainOutputTag)).empty();
-    PAssert.that(outputs.get(additionalOutputTag)).containsInAnyOrder(inputs);
+      PAssert.that(outputs.get(mainOutputTag)).empty();
+      PAssert.that(outputs.get(additionalOutputTag)).containsInAnyOrder(inputs);
 
-    pipeline.run();
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoWritingToUndeclaredTag() {
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      TupleTag<String> notOutputTag = new TupleTag<String>("additional"){};
+
+      pipeline
+          .apply(Create.of(inputs))
+          .apply(
+              ParDo.of(new TestDoFn(Arrays.asList(), Arrays.asList(notOutputTag)))
+              // No call to .withOutputTags - should cause error
+          );
+
+      thrown.expectMessage("additional");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoWithSideInputs() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      PCollectionView<Integer> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(11))
+              .apply("ViewSideInput1", View.asSingleton());
+      PCollectionView<Integer> sideInputUnread =
+          pipeline
+              .apply("CreateSideInputUnread", Create.of(-3333))
+              .apply("ViewSideInputUnread", View.asSingleton());
+      PCollectionView<Integer> sideInput2 =
+          pipeline
+              .apply("CreateSideInput2", Create.of(222))
+              .apply("ViewSideInput2", View.asSingleton());
+
+      PCollection<String> output =
+          pipeline
+              .apply(Create.of(inputs))
+              .apply(
+                  ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
+                      .withSideInputs(sideInput1, sideInputUnread, sideInput2));
+
+      PAssert.that(output)
+          .satisfies(ParDoTest.HasExpectedOutput
+              .forInput(inputs)
+              .andSideInputs(11, 222));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoWithSideInputsIsCumulative() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      PCollectionView<Integer> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(11))
+              .apply("ViewSideInput1", View.asSingleton());
+      PCollectionView<Integer> sideInputUnread =
+          pipeline
+              .apply("CreateSideInputUnread", Create.of(-3333))
+              .apply("ViewSideInputUnread", View.asSingleton());
+      PCollectionView<Integer> sideInput2 =
+          pipeline
+              .apply("CreateSideInput2", Create.of(222))
+              .apply("ViewSideInput2", View.asSingleton());
+
+      PCollection<String> output =
+          pipeline
+              .apply(Create.of(inputs))
+              .apply(
+                  ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
+                      .withSideInputs(sideInput1)
+                      .withSideInputs(sideInputUnread)
+                      .withSideInputs(sideInput2));
+
+      PAssert.that(output)
+          .satisfies(ParDoTest.HasExpectedOutput
+              .forInput(inputs)
+              .andSideInputs(11, 222));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testMultiOutputParDoWithSideInputs() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      final TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      final TupleTag<Void> additionalOutputTag = new TupleTag<Void>("output"){};
+
+      PCollectionView<Integer> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(11))
+              .apply("ViewSideInput1", View.asSingleton());
+      PCollectionView<Integer> sideInputUnread =
+          pipeline
+              .apply("CreateSideInputUnread", Create.of(-3333))
+              .apply("ViewSideInputUnread", View.asSingleton());
+      PCollectionView<Integer> sideInput2 =
+          pipeline
+              .apply("CreateSideInput2", Create.of(222))
+              .apply("ViewSideInput2", View.asSingleton());
+
+      PCollectionTuple outputs =
+          pipeline
+              .apply(Create.of(inputs))
+              .apply(
+                  ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
+                      .withSideInputs(sideInput1)
+                      .withSideInputs(sideInputUnread)
+                      .withSideInputs(sideInput2)
+                      .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+
+      PAssert.that(outputs.get(mainOutputTag))
+          .satisfies(ParDoTest.HasExpectedOutput
+              .forInput(inputs)
+              .andSideInputs(11, 222));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testMultiOutputParDoWithSideInputsIsCumulative() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      final TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      final TupleTag<Void> additionalOutputTag = new TupleTag<Void>("output"){};
+
+      PCollectionView<Integer> sideInput1 =
+          pipeline
+              .apply("CreateSideInput1", Create.of(11))
+              .apply("ViewSideInput1", View.asSingleton());
+      PCollectionView<Integer> sideInputUnread =
+          pipeline
+              .apply("CreateSideInputUnread", Create.of(-3333))
+              .apply("ViewSideInputUnread", View.asSingleton());
+      PCollectionView<Integer> sideInput2 =
+          pipeline
+              .apply("CreateSideInput2", Create.of(222))
+              .apply("ViewSideInput2", View.asSingleton());
+
+      PCollectionTuple outputs =
+          pipeline
+              .apply(Create.of(inputs))
+              .apply(
+                  ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
+                      .withSideInputs(sideInput1)
+                      .withSideInputs(sideInputUnread)
+                      .withSideInputs(sideInput2)
+                      .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+
+      PAssert.that(outputs.get(mainOutputTag))
+          .satisfies(ParDoTest.HasExpectedOutput
+              .forInput(inputs)
+              .andSideInputs(11, 222));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoReadingFromUnknownSideInput() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      PCollectionView<Integer> sideView =
+          pipeline.apply("Create3", Create.of(3)).apply(View.asSingleton());
+
+      pipeline
+          .apply("CreateMain", Create.of(inputs))
+          .apply(ParDo.of(new TestDoFn(Arrays.asList(sideView), Arrays.asList())));
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("calling sideInput() with unknown view");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testSideInputsWithMultipleWindows() {
+      // Tests that the runner can safely run a DoFn that uses side inputs
+      // on an input where the element is in multiple windows. The complication is
+      // that side inputs are per-window, so the runner has to make sure
+      // to process each window individually.
+
+      MutableDateTime mutableNow = Instant.now().toMutableDateTime();
+      mutableNow.setMillisOfSecond(0);
+      Instant now = mutableNow.toInstant();
+
+      SlidingWindows windowFn =
+          SlidingWindows.of(Duration.standardSeconds(5)).every(Duration.standardSeconds(1));
+      PCollectionView<Integer> view = pipeline.apply(Create.of(1)).apply(View.asSingleton());
+      PCollection<String> res =
+          pipeline
+              .apply(Create.timestamped(TimestampedValue.of("a", now)))
+              .apply(Window.into(windowFn))
+              .apply(ParDo.of(new FnWithSideInputs(view)).withSideInputs(view));
+
+      for (int i = 0; i < 4; ++i) {
+        Instant base = now.minus(Duration.standardSeconds(i));
+        IntervalWindow window = new IntervalWindow(base, base.plus(Duration.standardSeconds(5)));
+        PAssert.that(res).inWindow(window).containsInAnyOrder("a:1");
+      }
+
+      pipeline.run();
+    }
+
+    @Test
+    public void testParDoOutputNameBasedOnDoFnWithTrimmedSuffix() {
+      pipeline.enableAbandonedNodeEnforcement(false);
+
+      PCollection<String> output = pipeline.apply(Create.of(1)).apply(ParDo.of(new TestDoFn()));
+      assertThat(output.getName(), containsString("ParDo(Test)"));
+    }
+
+    @Test
+    public void testParDoOutputNameBasedOnLabel() {
+      pipeline.enableAbandonedNodeEnforcement(false);
+
+      PCollection<String> output =
+          pipeline.apply(Create.of(1)).apply("MyParDo", ParDo.of(new TestDoFn()));
+      assertThat(output.getName(), containsString("MyParDo"));
+    }
+
+    @Test
+    public void testParDoOutputNameBasedDoFnWithoutMatchingSuffix() {
+      pipeline.enableAbandonedNodeEnforcement(false);
+
+      PCollection<String> output =
+          pipeline.apply(Create.of(1)).apply(ParDo.of(new StrangelyNamedDoer()));
+      assertThat(output.getName(), containsString("ParDo(StrangelyNamedDoer)"));
+    }
+
+    @Test
+    public void testParDoMultiNameBasedDoFnWithTrimmerSuffix() {
+      assertThat(
+          ParDo.of(new TaggedOutputDummyFn(null, null)).withOutputTags(null, null).getName(),
+          containsString("ParMultiDo(TaggedOutputDummy)"));
+    }
+
+    @Test
+    public void testParDoWithTaggedOutputName() {
+      pipeline.enableAbandonedNodeEnforcement(false);
+
+      TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
+      TupleTag<String> additionalOutputTag1 = new TupleTag<String>("output1"){};
+      TupleTag<String> additionalOutputTag2 = new TupleTag<String>("output2"){};
+      TupleTag<String> additionalOutputTag3 = new TupleTag<String>("output3"){};
+      TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
+
+      PCollectionTuple outputs =
+          pipeline
+              .apply(Create.of(Arrays.asList(3, -42, 666)))
+              .setName("MyInput")
+              .apply(
+                  "MyParDo",
+                  ParDo.of(
+                      new TestDoFn(
+                          Arrays.asList(),
+                          Arrays.asList(
+                              additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
+                      .withOutputTags(
+                          mainOutputTag,
+                          TupleTagList.of(additionalOutputTag3)
+                              .and(additionalOutputTag1)
+                              .and(additionalOutputTagUnwritten)
+                              .and(additionalOutputTag2)));
+
+      assertEquals("MyParDo.main", outputs.get(mainOutputTag).getName());
+      assertEquals("MyParDo.output1", outputs.get(additionalOutputTag1).getName());
+      assertEquals("MyParDo.output2", outputs.get(additionalOutputTag2).getName());
+      assertEquals("MyParDo.output3", outputs.get(additionalOutputTag3).getName());
+      assertEquals("MyParDo.unwrittenOutput",
+          outputs.get(additionalOutputTagUnwritten).getName());
+    }
+
+    @Test
+    public void testMultiOutputAppliedMultipleTimesDifferentOutputs() {
+      pipeline.enableAbandonedNodeEnforcement(false);
+      PCollection<Long> longs = pipeline.apply(GenerateSequence.from(0));
+
+      TupleTag<Long> mainOut = new TupleTag<>();
+      final TupleTag<String> valueAsString = new TupleTag<>();
+      final TupleTag<Integer> valueAsInt = new TupleTag<>();
+      DoFn<Long, Long> fn =
+          new DoFn<Long, Long>() {
+            @ProcessElement
+            public void processElement(ProcessContext cxt, @Element Long element) {
+              cxt.output(cxt.element());
+              cxt.output(valueAsString, Long.toString(cxt.element()));
+              cxt.output(valueAsInt, element.intValue());
+            }
+          };
+
+      ParDo.MultiOutput<Long, Long> parDo =
+          ParDo.of(fn).withOutputTags(mainOut, TupleTagList.of(valueAsString).and(valueAsInt));
+      PCollectionTuple firstApplication = longs.apply("first", parDo);
+      PCollectionTuple secondApplication = longs.apply("second", parDo);
+      assertThat(firstApplication, not(equalTo(secondApplication)));
+      assertThat(
+          firstApplication.getAll().keySet(),
+          Matchers.containsInAnyOrder(mainOut, valueAsString, valueAsInt));
+      assertThat(
+          secondApplication.getAll().keySet(),
+          Matchers.containsInAnyOrder(mainOut, valueAsString, valueAsInt));
+    }
+    @Test
+    @Category(NeedsRunner.class)
+    public void testMultiOutputChaining() {
+
+      PCollectionTuple filters = pipeline
+          .apply(Create.of(Arrays.asList(3, 4, 5, 6)))
+          .apply(new MultiFilter());
+      PCollection<Integer> by2 = filters.get(MultiFilter.BY2);
+      PCollection<Integer> by3 = filters.get(MultiFilter.BY3);
+
+      // Apply additional filters to each operation.
+      PCollection<Integer> by2then3 = by2
+          .apply("Filter3sAgain", ParDo.of(new MultiFilter.FilterFn(3)));
+      PCollection<Integer> by3then2 = by3
+          .apply("Filter2sAgain", ParDo.of(new MultiFilter.FilterFn(2)));
+
+      PAssert.that(by2then3).containsInAnyOrder(6);
+      PAssert.that(by3then2).containsInAnyOrder(6);
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testTaggedOutputUnknownCoder() throws Exception {
+
+      PCollection<Integer> input = pipeline
+          .apply(Create.of(Arrays.asList(1, 2, 3)));
+
+      final TupleTag<Integer> mainOutputTag = new TupleTag<>("main");
+      final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("unknownSide");
+      input.apply(ParDo.of(new TaggedOutputDummyFn(mainOutputTag, additionalOutputTag))
+          .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+
+      thrown.expect(IllegalStateException.class);
+      thrown.expectMessage("Unable to return a default Coder");
+      pipeline.run();
+    }
+
+    @Test
+    public void testTaggedOutputUnregisteredExplicitCoder() throws Exception {
+      pipeline.enableAbandonedNodeEnforcement(false);
+
+      PCollection<Integer> input = pipeline
+          .apply(Create.of(Arrays.asList(1, 2, 3)));
+
+      final TupleTag<Integer> mainOutputTag = new TupleTag<>("main");
+      final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("unregisteredSide");
+      ParDo.MultiOutput<Integer, Integer> pardo =
+          ParDo.of(new TaggedOutputDummyFn(mainOutputTag, additionalOutputTag))
+              .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag));
+      PCollectionTuple outputTuple = input.apply(pardo);
+
+      outputTuple.get(additionalOutputTag).setCoder(new TestDummyCoder());
+
+      outputTuple.get(additionalOutputTag).apply(View.asSingleton());
+
+      assertEquals(new TestDummyCoder(), outputTuple.get(additionalOutputTag).getCoder());
+      outputTuple
+          .get(additionalOutputTag)
+          .finishSpecifyingOutput("ParDo", input, pardo); // Check for crashes
+      assertEquals(new TestDummyCoder(),
+          outputTuple.get(additionalOutputTag).getCoder()); // Check for corruption
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testMainOutputUnregisteredExplicitCoder() {
+
+      PCollection<Integer> input = pipeline
+          .apply(Create.of(Arrays.asList(1, 2, 3)));
+
+      final TupleTag<TestDummy> mainOutputTag = new TupleTag<>("unregisteredMain");
+      final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additionalOutput") {};
+      PCollectionTuple outputTuple =
+          input.apply(
+              ParDo.of(new MainOutputDummyFn(mainOutputTag, additionalOutputTag))
+                  .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+
+      outputTuple.get(mainOutputTag).setCoder(new TestDummyCoder());
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testMainOutputApplyTaggedOutputNoCoder() {
+      // Regression test: applying a transform to the main output
+      // should not cause a crash based on lack of a coder for the
+      // additional output.
+
+      final TupleTag<TestDummy> mainOutputTag = new TupleTag<>("main");
+      final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("additionalOutput");
+      PCollectionTuple tuple = pipeline
+          .apply(Create.of(new TestDummy())
+              .withCoder(TestDummyCoder.of()))
+          .apply(ParDo
+              .of(
+                  new DoFn<TestDummy, TestDummy>() {
+                    @ProcessElement
+                    public void processElement(ProcessContext context, @Element TestDummy element) {
+                      context.output(element);
+                      context.output(additionalOutputTag, element);
+                    }
+                  })
+              .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag))
+          );
+
+      // Before fix, tuple.get(mainOutputTag).apply(...) would indirectly trigger
+      // tuple.get(additionalOutputTag).finishSpecifyingOutput(), which would crash
+      // on a missing coder.
+      tuple.get(mainOutputTag)
+          .setCoder(TestDummyCoder.of())
+          .apply("Output1", ParDo.of(new DoFn<TestDummy, Integer>() {
+            @ProcessElement
+            public void processElement(ProcessContext context) {
+              context.output(1);
+            }
+          }));
+
+      tuple.get(additionalOutputTag).setCoder(TestDummyCoder.of());
+
+      pipeline.run();
+    }
+
+    @Test
+    public void testWithOutputTagsDisplayData() {
+      DoFn<String, String> fn = new DoFn<String, String>() {
+        @ProcessElement
+        public void proccessElement(ProcessContext c) {}
+
+        @Override
+        public void populateDisplayData(Builder builder) {
+          builder.add(DisplayData.item("fnMetadata", "foobar"));
+        }
+      };
+
+      ParDo.MultiOutput<String, String> parDo =
+          ParDo.of(fn).withOutputTags(new TupleTag<>(), TupleTagList.empty());
+
+      DisplayData displayData = DisplayData.from(parDo);
+      assertThat(displayData, includesDisplayDataFor("fn", fn));
+      assertThat(displayData, hasDisplayItem("fn", fn.getClass()));
+    }
   }
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoWritingToUndeclaredTag() {
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+  /** Tests for ParDo lifecycle methods. */
+  @RunWith(JUnit4.class)
+  public static class LifecycleTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoWithErrorInStartBatch() {
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
 
-    TupleTag<String> notOutputTag = new TupleTag<String>("additional"){};
+      pipeline.apply(Create.of(inputs))
+          .apply(ParDo.of(new TestStartBatchErrorDoFn()));
 
-    pipeline
-        .apply(Create.of(inputs))
-        .apply(
-            ParDo.of(new TestDoFn(Arrays.asList(), Arrays.asList(notOutputTag)))
-            // No call to .withOutputTags - should cause error
-            );
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("test error in initialize");
+      pipeline.run();
+    }
 
-    thrown.expectMessage("additional");
-    pipeline.run();
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoWithErrorInProcessElement() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      pipeline.apply(Create.of(inputs))
+          .apply(ParDo.of(new TestProcessElementErrorDoFn()));
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("test error in process");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoWithErrorInFinishBatch() {
+
+      List<Integer> inputs = Arrays.asList(3, -42, 666);
+
+      pipeline.apply(Create.of(inputs))
+          .apply(ParDo.of(new TestFinishBatchErrorDoFn()));
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("test error in finalize");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testWindowingInStartAndFinishBundle() {
+
+      final FixedWindows windowFn = FixedWindows.of(Duration.millis(1));
+      PCollection<String> output =
+          pipeline
+              .apply(Create.timestamped(TimestampedValue.of("elem", new Instant(1))))
+              .apply(Window.into(windowFn))
+              .apply(
+                  ParDo.of(
+                      new DoFn<String, String>() {
+                        @ProcessElement
+                        public void processElement(@Element String element,
+                            @Timestamp Instant timestamp,
+                            OutputReceiver<String> r) {
+                          r.output(element);
+                          System.out.println(
+                              "Process: " + element + ":" + timestamp.getMillis());
+                        }
+
+                        @FinishBundle
+                        public void finishBundle(FinishBundleContext c) {
+                          Instant ts = new Instant(3);
+                          c.output("finish", ts, windowFn.assignWindow(ts));
+                          System.out.println("Finish: 3");
+                        }
+                      }))
+              .apply(ParDo.of(new PrintingDoFn()));
+
+      PAssert.that(output).satisfies(new Checker());
+
+      pipeline.run();
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoWithSideInputs() {
+  /** Tests to validate output timestamps. */
+  @RunWith(JUnit4.class)
+  public static class TimestampTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoOutputWithTimestamp() {
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      PCollection<Integer> input =
+          pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
 
-    PCollectionView<Integer> sideInput1 =
-        pipeline
-            .apply("CreateSideInput1", Create.of(11))
-            .apply("ViewSideInput1", View.asSingleton());
-    PCollectionView<Integer> sideInputUnread =
-        pipeline
-            .apply("CreateSideInputUnread", Create.of(-3333))
-            .apply("ViewSideInputUnread", View.asSingleton());
-    PCollectionView<Integer> sideInput2 =
-        pipeline
-            .apply("CreateSideInput2", Create.of(222))
-            .apply("ViewSideInput2", View.asSingleton());
+      PCollection<String> output =
+          input
+              .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
+              .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.ZERO)))
+              .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
 
-    PCollection<String> output =
-        pipeline
-            .apply(Create.of(inputs))
-            .apply(
-                ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
-                    .withSideInputs(sideInput1, sideInputUnread, sideInput2));
+      PAssert.that(output).containsInAnyOrder(
+          "processing: 3, timestamp: 3",
+          "processing: 42, timestamp: 42",
+          "processing: 6, timestamp: 6");
 
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput
-                   .forInput(inputs)
-                   .andSideInputs(11, 222));
+      pipeline.run();
+    }
 
-    pipeline.run();
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoTaggedOutputWithTimestamp() {
+
+      PCollection<Integer> input =
+          pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
+
+      final TupleTag<Integer> mainOutputTag = new TupleTag<Integer>("main"){};
+      final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additional"){};
+
+      PCollection<String> output =
+          input
+              .apply(
+                  ParDo.of(
+                      new DoFn<Integer, Integer>() {
+                        @ProcessElement
+                        public void processElement(@Element Integer element,
+                            MultiOutputReceiver r) {
+                          r.get(additionalOutputTag)
+                              .outputWithTimestamp(
+                                  element,
+                                  new Instant(element.longValue()));
+                        }
+                      })
+                      .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)))
+              .get(additionalOutputTag)
+              .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.ZERO)))
+              .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
+
+      PAssert.that(output).containsInAnyOrder(
+          "processing: 3, timestamp: 3",
+          "processing: 42, timestamp: 42",
+          "processing: 6, timestamp: 6");
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoShiftTimestamp() {
+
+      PCollection<Integer> input =
+          pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
+
+      PCollection<String> output =
+          input
+              .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
+              .apply(
+                  ParDo.of(
+                      new TestShiftTimestampDoFn<>(Duration.millis(1000), Duration.millis(-1000))))
+              .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
+
+      PAssert.that(output).containsInAnyOrder(
+          "processing: 3, timestamp: -997",
+          "processing: 42, timestamp: -958",
+          "processing: 6, timestamp: -994");
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoShiftTimestampInvalid() {
+
+      pipeline
+          .apply(Create.of(Arrays.asList(3, 42, 6)))
+          .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
+          .apply(
+              ParDo.of(
+                  new TestShiftTimestampDoFn<>(
+                      Duration.millis(1000), // allowed skew = 1 second
+                      Duration.millis(-1001))))
+          .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Cannot output with timestamp");
+      thrown.expectMessage(
+          "Output timestamps must be no earlier than the timestamp of the current input");
+      thrown.expectMessage("minus the allowed skew (1 second).");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(NeedsRunner.class)
+    public void testParDoShiftTimestampInvalidZeroAllowed() {
+      pipeline
+          .apply(Create.of(Arrays.asList(3, 42, 6)))
+          .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
+          .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.millis(-1001))))
+          .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Cannot output with timestamp");
+      thrown.expectMessage(
+          "Output timestamps must be no earlier than the timestamp of the current input");
+      thrown.expectMessage("minus the allowed skew (0 milliseconds).");
+      pipeline.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testParDoShiftTimestampUnlimited() {
+      PCollection<Long> outputs =
+          pipeline
+              .apply(
+                  Create.of(
+                      Arrays.asList(
+                          0L,
+                          BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis(),
+                          GlobalWindow.INSTANCE.maxTimestamp().getMillis())))
+              .apply("AssignTimestampToValue", ParDo.of(new TestOutputTimestampDoFn<>()))
+              .apply(
+                  "ReassignToMinimumTimestamp",
+                  ParDo.of(
+                      new DoFn<Long, Long>() {
+                        @ProcessElement
+                        public void reassignTimestamps(ProcessContext context,
+                            @Element Long element) {
+                          // Shift the latest element as far backwards in time as the model permits
+                          context.outputWithTimestamp(
+                              element, BoundedWindow.TIMESTAMP_MIN_VALUE);
+                        }
+
+                        @Override
+                        public Duration getAllowedTimestampSkew() {
+                          return Duration.millis(Long.MAX_VALUE);
+                        }
+                      }));
+
+      PAssert.that(outputs)
+          .satisfies(
+              input -> {
+                // This element is not shifted backwards in time. It must be present in the output.
+                assertThat(input, hasItem(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()));
+                for (Long elem : input) {
+                  // Sanity check the outputs. 0L and the end of the global window are shifted
+                  // backwards in time and theoretically could be dropped.
+                  assertThat(
+                      elem,
+                      anyOf(
+                          equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()),
+                          equalTo(GlobalWindow.INSTANCE.maxTimestamp().getMillis()),
+                          equalTo(0L)));
+                }
+                return null;
+              });
+
+      pipeline.run();
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoWithSideInputsIsCumulative() {
+  /** Tests to validate ParDo state. */
+  @RunWith(JUnit4.class)
+  public static class StateTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateSimple() {
+      final String stateId = "foo";
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
 
-    PCollectionView<Integer> sideInput1 =
-        pipeline
-            .apply("CreateSideInput1", Create.of(11))
-            .apply("ViewSideInput1", View.asSingleton());
-    PCollectionView<Integer> sideInputUnread =
-        pipeline
-            .apply("CreateSideInputUnread", Create.of(-3333))
-            .apply("ViewSideInputUnread", View.asSingleton());
-    PCollectionView<Integer> sideInput2 =
-        pipeline
-            .apply("CreateSideInput2", Create.of(222))
-            .apply("ViewSideInput2", View.asSingleton());
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value(VarIntCoder.of());
 
-    PCollection<String> output =
-        pipeline
-            .apply(Create.of(inputs))
-            .apply(
-                ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
-                    .withSideInputs(sideInput1)
-                    .withSideInputs(sideInputUnread)
-                    .withSideInputs(sideInput2));
+            @ProcessElement
+            public void processElement(@StateId(stateId) ValueState<Integer> state,
+                OutputReceiver<Integer> r) {
+              Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+              r.output(currentValue);
+              state.write(currentValue + 1);
+            }
+          };
 
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput
-                   .forInput(inputs)
-                   .andSideInputs(11, 222));
+      PCollection<Integer> output =
+          pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+              .apply(ParDo.of(fn));
 
-    pipeline.run();
+      PAssert.that(output).containsInAnyOrder(0, 1, 2);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateDedup() {
+      final String stateId = "foo";
+
+      DoFn<KV<Integer, Integer>, Integer> onePerKey =
+          new DoFn<KV<Integer, Integer>, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> seenSpec =
+                StateSpecs.value(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<Integer, Integer> element,
+                @StateId(stateId) ValueState<Integer> seenState,
+                OutputReceiver<Integer> r) {
+              Integer seen = MoreObjects.firstNonNull(seenState.read(), 0);
+
+              if (seen == 0) {
+                seenState.write(seen + 1);
+                r.output(element.getValue());
+              }
+            }
+          };
+
+      int numKeys = 50;
+      // A big enough list that we can see some deduping
+      List<KV<Integer, Integer>> input = new ArrayList<>();
+
+      // The output should have no dupes
+      Set<Integer> expectedOutput = new HashSet<>();
+
+      for (int key = 0; key < numKeys; ++key) {
+        int output = 1000 + key;
+        expectedOutput.add(output);
+
+        for (int i = 0; i < 15; ++i) {
+          input.add(KV.of(key, output));
+        }
+      }
+
+      Collections.shuffle(input);
+
+      PCollection<Integer> output = pipeline.apply(Create.of(input)).apply(ParDo.of(onePerKey));
+
+      PAssert.that(output).containsInAnyOrder(expectedOutput);
+      pipeline.run();
+    }
+
+    @Test
+    public void testStateNotKeyed() {
+      final String stateId = "foo";
+
+      DoFn<String, Integer> fn =
+          new DoFn<String, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c, @StateId(stateId) ValueState<Integer> state) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage("state");
+      thrown.expectMessage("KvCoder");
+
+      pipeline.apply(Create.of("hello", "goodbye", "hello again")).apply(ParDo.of(fn));
+    }
+
+    @Test
+    public void testStateNotDeterministic() {
+      final String stateId = "foo";
+
+      // DoubleCoder is not deterministic, so this should crash
+      DoFn<KV<Double, String>, Integer> fn =
+          new DoFn<KV<Double, String>, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c, @StateId(stateId) ValueState<Integer> state) {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage("state");
+      thrown.expectMessage("deterministic");
+
+      pipeline
+          .apply(Create.of(KV.of(1.0, "hello"), KV.of(5.4, "goodbye"), KV.of(7.2, "hello again")))
+          .apply(ParDo.of(fn));
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testCoderInferenceOfList() {
+      final String stateId = "foo";
+      MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
+
+      DoFn<KV<String, Integer>, List<MyInteger>> fn =
+          new DoFn<KV<String, Integer>, List<MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<List<MyInteger>>> intState =
+                StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) ValueState<List<MyInteger>> state,
+                OutputReceiver<List<MyInteger>> r) {
+              MyInteger myInteger = new MyInteger(element.getValue());
+              List<MyInteger> currentValue = state.read();
+              List<MyInteger> newValue = currentValue != null
+                  ? ImmutableList.<MyInteger>builder().addAll(currentValue).add(myInteger).build()
+                  : Collections.singletonList(myInteger);
+              r.output(newValue);
+              state.write(newValue);
+            }
+          };
+
+      pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+          .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateFixedWindows() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(
+                @StateId(stateId) ValueState<Integer> state, OutputReceiver<Integer> r) {
+              Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+              r.output(currentValue);
+              state.write(currentValue + 1);
+            }
+          };
+
+      IntervalWindow firstWindow = new IntervalWindow(new Instant(0), new Instant(10));
+      IntervalWindow secondWindow = new IntervalWindow(new Instant(10), new Instant(20));
+
+      PCollection<Integer> output =
+          pipeline
+              .apply(
+                  Create.timestamped(
+                      // first window
+                      TimestampedValue.of(KV.of("hello", 7), new Instant(1)),
+                      TimestampedValue.of(KV.of("hello", 14), new Instant(2)),
+                      TimestampedValue.of(KV.of("hello", 21), new Instant(3)),
+
+                      // second window
+                      TimestampedValue.of(KV.of("hello", 28), new Instant(11)),
+                      TimestampedValue.of(KV.of("hello", 35), new Instant(13))))
+              .apply(Window.into(FixedWindows.of(Duration.millis(10))))
+              .apply("Stateful ParDo", ParDo.of(fn));
+
+      PAssert.that(output).inWindow(firstWindow).containsInAnyOrder(0, 1, 2);
+      PAssert.that(output).inWindow(secondWindow).containsInAnyOrder(0, 1);
+      pipeline.run();
+    }
+
+    /**
+     * Tests that there is no state bleeding between adjacent stateful {@link ParDo} transforms,
+     * which may (or may not) be executed in similar contexts after runner optimizations.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateSameId() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, Integer>, KV<String, Integer>> fn =
+          new DoFn<KV<String, Integer>, KV<String, Integer>>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(@StateId(stateId) ValueState<Integer> state,
+                OutputReceiver<KV<String, Integer>> r) {
+              Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+              r.output(KV.of("sizzle", currentValue));
+              state.write(currentValue + 1);
+            }
+          };
+
+      DoFn<KV<String, Integer>, Integer> fn2 =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(@StateId(stateId) ValueState<Integer> state,
+                OutputReceiver<Integer> r) {
+              Integer currentValue = MoreObjects.firstNonNull(state.read(), 13);
+              r.output(currentValue);
+              state.write(currentValue + 13);
+            }
+          };
+
+      PCollection<KV<String, Integer>> intermediate =
+          pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+              .apply("First stateful ParDo", ParDo.of(fn));
+
+      PCollection<Integer> output =
+          intermediate.apply("Second stateful ParDo", ParDo.of(fn2));
+
+      PAssert.that(intermediate)
+          .containsInAnyOrder(KV.of("sizzle", 0), KV.of("sizzle", 1), KV.of("sizzle", 2));
+      PAssert.that(output).containsInAnyOrder(13, 26, 39);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateTaggedOutput() {
+      final String stateId = "foo";
+
+      final TupleTag<Integer> evenTag = new TupleTag<Integer>() {};
+      final TupleTag<Integer> oddTag = new TupleTag<Integer>() {};
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> intState =
+                StateSpecs.value(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(
+                @StateId(stateId) ValueState<Integer> state, MultiOutputReceiver r) {
+              Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
+              if (currentValue % 2 == 0) {
+                r.get(evenTag).output(currentValue);
+              } else {
+                r.get(oddTag).output(currentValue);
+              }
+              state.write(currentValue + 1);
+            }
+          };
+
+      PCollectionTuple output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", 42),
+                  KV.of("hello", 97),
+                  KV.of("hello", 84),
+                  KV.of("goodbye", 33),
+                  KV.of("hello", 859),
+                  KV.of("goodbye", 83945)))
+              .apply(ParDo.of(fn).withOutputTags(evenTag, TupleTagList.of(oddTag)));
+
+      PCollection<Integer> evens = output.get(evenTag);
+      PCollection<Integer> odds = output.get(oddTag);
+
+      // There are 0 and 2 from "hello" and just 0 from "goodbye"
+      PAssert.that(evens).containsInAnyOrder(0, 2, 0);
+
+      // There are 1 and 3 from "hello" and just "1" from "goodbye"
+      PAssert.that(odds).containsInAnyOrder(1, 3, 1);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testBagState() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, Integer>, List<Integer>> fn =
+          new DoFn<KV<String, Integer>, List<Integer>>() {
+
+            @StateId(stateId)
+            private final StateSpec<BagState<Integer>> bufferState =
+                StateSpecs.bag(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) BagState<Integer> state,
+                OutputReceiver<List<Integer>> r) {
+              ReadableState<Boolean> isEmpty = state.isEmpty();
+              state.add(element.getValue());
+              assertFalse(isEmpty.read());
+              Iterable<Integer> currentValue = state.read();
+              if (Iterables.size(currentValue) >= 4) {
+                // Make sure that the cached Iterable doesn't change when new elements are added.
+                state.add(-1);
+                assertEquals(4, Iterables.size(currentValue));
+                assertEquals(5, Iterables.size(state.read()));
+
+                List<Integer> sorted = Lists.newArrayList(currentValue);
+                Collections.sort(sorted);
+                r.output(sorted);
+              }
+            }
+          };
+
+      PCollection<List<Integer>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
+              .apply(ParDo.of(fn));
+
+      PAssert.that(output).containsInAnyOrder(Lists.newArrayList(12, 42, 84, 97));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
+    public void testSetState() {
+      final String stateId = "foo";
+      final String countStateId = "count";
+
+      DoFn<KV<String, Integer>, Set<Integer>> fn =
+          new DoFn<KV<String, Integer>, Set<Integer>>() {
+
+            @StateId(stateId)
+            private final StateSpec<SetState<Integer>> setState =
+                StateSpecs.set(VarIntCoder.of());
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) SetState<Integer> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<Set<Integer>> r) {
+              ReadableState<Boolean> isEmpty = state.isEmpty();
+              state.add(element.getValue());
+              assertFalse(isEmpty.read());
+              count.add(1);
+              if (count.read() >= 4) {
+                // Make sure that the cached Iterable doesn't change when new elements are added.
+                Iterable<Integer> ints = state.read();
+                state.add(-1);
+                assertEquals(3, Iterables.size(ints));
+                assertEquals(4, Iterables.size(state.read()));
+
+                Set<Integer> set = Sets.newHashSet(ints);
+                r.output(set);
+              }
+            }
+          };
+
+      PCollection<Set<Integer>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
+              .apply(ParDo.of(fn));
+
+      PAssert.that(output).containsInAnyOrder(Sets.newHashSet(97, 42, 12));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
+    public void testMapState() {
+      final String stateId = "foo";
+      final String countStateId = "count";
+
+      DoFn<KV<String, KV<String, Integer>>, KV<String, Integer>> fn =
+          new DoFn<KV<String, KV<String, Integer>>, KV<String, Integer>>() {
+
+            @StateId(stateId)
+            private final StateSpec<MapState<String, Integer>> mapState =
+                StateSpecs.map(StringUtf8Coder.of(), VarIntCoder.of());
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c,
+                @Element KV<String, KV<String, Integer>> element,
+                @StateId(stateId) MapState<String, Integer> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<KV<String, Integer>> r) {
+              KV<String, Integer> value = element.getValue();
+              ReadableState<Iterable<Entry<String, Integer>>> entriesView = state.entries();
+              state.put(value.getKey(), value.getValue());
+              count.add(1);
+              if (count.read() >= 4) {
+                Iterable<Map.Entry<String, Integer>> iterate = state.entries().read();
+                // Make sure that the cached Iterable doesn't change when new elements are added,
+                // but that cached ReadableState views of the state do change.
+                state.put("BadKey", -1);
+                assertEquals(3, Iterables.size(iterate));
+                assertEquals(4, Iterables.size(entriesView.read()));
+                assertEquals(4, Iterables.size(state.entries().read()));
+
+                for (Map.Entry<String, Integer> entry : iterate) {
+                  r.output(KV.of(entry.getKey(), entry.getValue()));
+                }
+              }
+            }
+          };
+
+      PCollection<KV<String, Integer>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
+                  KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
+              .apply(ParDo.of(fn));
+
+      PAssert.that(output).containsInAnyOrder(KV.of("a", 97), KV.of("b", 42), KV.of("c", 12));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testCombiningState() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, Double>, String> fn =
+          new DoFn<KV<String, Double>, String>() {
+
+            private static final double EPSILON = 0.0001;
+
+            @StateId(stateId)
+            private final StateSpec<CombiningState<Double, CountSum<Double>, Double>>
+                combiningState = StateSpecs.combining(new Mean.CountSumCoder<Double>(), Mean.of());
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c,
+                @Element KV<String, Double> element,
+                @StateId(stateId) CombiningState<Double, CountSum<Double>, Double> state,
+                OutputReceiver<String> r) {
+              state.add(element.getValue());
+              Double currentValue = state.read();
+              if (Math.abs(currentValue - 0.5) < EPSILON) {
+                r.output("right on");
+              }
+            }
+          };
+
+      PCollection<String> output =
+          pipeline
+              .apply(Create.of(KV.of("hello", 0.3), KV.of("hello", 0.6), KV.of("hello", 0.6)))
+              .apply(ParDo.of(fn));
+
+      // There should only be one moment at which the average is exactly 0.5
+      PAssert.that(output).containsInAnyOrder("right on");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testCombiningStateParameterSuperclass() {
+      final String stateId = "foo";
+
+      DoFn<KV<Integer, Integer>, String> fn =
+          new DoFn<KV<Integer, Integer>, String>() {
+            private static final int EXPECTED_SUM = 8;
+
+            @StateId(stateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>> state =
+                StateSpecs.combining(Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<Integer, Integer> element,
+                @StateId(stateId) GroupingState<Integer, Integer> state,
+                OutputReceiver<String> r) {
+              state.add(element.getValue());
+              Integer currentValue = state.read();
+              if (currentValue == EXPECTED_SUM) {
+                r.output("right on");
+              }
+            }
+          };
+
+      PCollection<String> output =
+          pipeline
+              .apply(Create.of(KV.of(123, 4), KV.of(123, 7), KV.of(123, -3)))
+              .apply(ParDo.of(fn));
+
+      // There should only be one moment at which the sum is exactly 8
+      PAssert.that(output).containsInAnyOrder("right on");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testBagStateSideInput() {
+
+      final PCollectionView<List<Integer>> listView =
+          pipeline.apply("Create list for side input", Create.of(2, 1, 0)).apply(View.asList());
+
+      final String stateId = "foo";
+      DoFn<KV<String, Integer>, List<Integer>> fn =
+          new DoFn<KV<String, Integer>, List<Integer>>() {
+
+            @StateId(stateId)
+            private final StateSpec<BagState<Integer>> bufferState =
+                StateSpecs.bag(VarIntCoder.of());
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c,
+                @Element KV<String, Integer>  element,
+                @StateId(stateId) BagState<Integer> state,
+                OutputReceiver<List<Integer>> r) {
+              state.add(element.getValue());
+              Iterable<Integer> currentValue = state.read();
+              if (Iterables.size(currentValue) >= 4) {
+                List<Integer> sorted = Lists.newArrayList(currentValue);
+                Collections.sort(sorted);
+                r.output(sorted);
+
+                List<Integer> sideSorted = Lists.newArrayList(c.sideInput(listView));
+                Collections.sort(sideSorted);
+                r.output(sideSorted);
+              }
+            }
+          };
+
+      PCollection<List<Integer>> output =
+          pipeline.apply(
+              "Create main input",
+              Create.of(
+                  KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
+              .apply(ParDo.of(fn).withSideInputs(listView));
+
+      PAssert.that(output).containsInAnyOrder(
+          Lists.newArrayList(12, 42, 84, 97),
+          Lists.newArrayList(0, 1, 2));
+      pipeline.run();
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testMultiOutputParDoWithSideInputs() {
+  /** Tests for state coder inference behaviors. */
+  @RunWith(JUnit4.class)
+  public static class StateCoderInferenceTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testBagStateCoderInference() {
+      final String stateId = "foo";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      DoFn<KV<String, Integer>, List<MyInteger>> fn =
+          new DoFn<KV<String, Integer>, List<MyInteger>>() {
 
-    final TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    final TupleTag<Void> additionalOutputTag = new TupleTag<Void>("output"){};
+            @StateId(stateId)
+            private final StateSpec<BagState<MyInteger>> bufferState =
+                StateSpecs.bag();
 
-    PCollectionView<Integer> sideInput1 =
-        pipeline
-            .apply("CreateSideInput1", Create.of(11))
-            .apply("ViewSideInput1", View.asSingleton());
-    PCollectionView<Integer> sideInputUnread =
-        pipeline
-            .apply("CreateSideInputUnread", Create.of(-3333))
-            .apply("ViewSideInputUnread", View.asSingleton());
-    PCollectionView<Integer> sideInput2 =
-        pipeline
-            .apply("CreateSideInput2", Create.of(222))
-            .apply("ViewSideInput2", View.asSingleton());
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) BagState<MyInteger> state,
+                OutputReceiver<List<MyInteger>> r) {
+              state.add(new MyInteger(element.getValue()));
+              Iterable<MyInteger> currentValue = state.read();
+              if (Iterables.size(currentValue) >= 4) {
+                List<MyInteger> sorted = Lists.newArrayList(currentValue);
+                Collections.sort(sorted);
+                r.output(sorted);
+              }
+            }
+          };
 
-    PCollectionTuple outputs =
-        pipeline
-            .apply(Create.of(inputs))
-            .apply(
-                ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
-                    .withSideInputs(sideInput1)
-                    .withSideInputs(sideInputUnread)
-                    .withSideInputs(sideInput2)
-                    .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+      PCollection<List<MyInteger>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
+              .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
 
-    PAssert.that(outputs.get(mainOutputTag))
-        .satisfies(ParDoTest.HasExpectedOutput
-                   .forInput(inputs)
-                   .andSideInputs(11, 222));
+      PAssert.that(output).containsInAnyOrder(Lists.newArrayList(
+          new MyInteger(12), new MyInteger(42),
+          new MyInteger(84), new MyInteger(97)));
 
-    pipeline.run();
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testBagStateCoderInferenceFailure() throws Exception {
+      final String stateId = "foo";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+
+      DoFn<KV<String, Integer>, List<MyInteger>> fn =
+          new DoFn<KV<String, Integer>, List<MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<BagState<MyInteger>> bufferState =
+                StateSpecs.bag();
+
+            @ProcessElement
+            public void processElement(
+                @Element  KV<String, Integer> element,
+                @StateId(stateId) BagState<MyInteger> state,
+                OutputReceiver<List<MyInteger>> r) {
+              state.add(new MyInteger(element.getValue()));
+              Iterable<MyInteger> currentValue = state.read();
+              if (Iterables.size(currentValue) >= 4) {
+                List<MyInteger> sorted = Lists.newArrayList(currentValue);
+                Collections.sort(sorted);
+                r.output(sorted);
+              }
+            }
+          };
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Unable to infer a coder for BagState and no Coder was specified.");
+
+      pipeline.apply(
+          Create.of(
+              KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
+          .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
+    public void testSetStateCoderInference() {
+      final String stateId = "foo";
+      final String countStateId = "count";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
+
+      DoFn<KV<String, Integer>, Set<MyInteger>> fn =
+          new DoFn<KV<String, Integer>, Set<MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<SetState<MyInteger>> setState = StateSpecs.set();
+
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) SetState<MyInteger> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<Set<MyInteger>> r) {
+              state.add(new MyInteger(element.getValue()));
+              count.add(1);
+              if (count.read() >= 4) {
+                Set<MyInteger> set = Sets.newHashSet(state.read());
+                r.output(set);
+              }
+            }
+          };
+
+      PCollection<Set<MyInteger>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
+              .apply(ParDo.of(fn)).setCoder(SetCoder.of(myIntegerCoder));
+
+      PAssert.that(output).containsInAnyOrder(
+          Sets.newHashSet(new MyInteger(97), new MyInteger(42), new MyInteger(12)));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
+    public void testSetStateCoderInferenceFailure() throws Exception {
+      final String stateId = "foo";
+      final String countStateId = "count";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+
+      DoFn<KV<String, Integer>, Set<MyInteger>> fn =
+          new DoFn<KV<String, Integer>, Set<MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<SetState<MyInteger>> setState = StateSpecs.set();
+
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) SetState<MyInteger> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<Set<MyInteger>> r) {
+              state.add(new MyInteger(element.getValue()));
+              count.add(1);
+              if (count.read() >= 4) {
+                Set<MyInteger> set = Sets.newHashSet(state.read());
+                r.output(set);
+              }
+            }
+          };
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Unable to infer a coder for SetState and no Coder was specified.");
+
+      pipeline.apply(
+          Create.of(
+              KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
+          .apply(ParDo.of(fn)).setCoder(SetCoder.of(myIntegerCoder));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
+    public void testMapStateCoderInference() {
+      final String stateId = "foo";
+      final String countStateId = "count";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
+
+      DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>> fn =
+          new DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<MapState<String, MyInteger>> mapState = StateSpecs.map();
+
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, KV<String, Integer>> element,
+                @StateId(stateId) MapState<String, MyInteger> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<KV<String, MyInteger>> r) {
+              KV<String, Integer> value = element.getValue();
+              state.put(value.getKey(), new MyInteger(value.getValue()));
+              count.add(1);
+              if (count.read() >= 4) {
+                Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
+                for (Map.Entry<String, MyInteger> entry : iterate) {
+                  r.output(KV.of(entry.getKey(), entry.getValue()));
+                }
+              }
+            }
+          };
+
+      PCollection<KV<String, MyInteger>> output =
+          pipeline.apply(
+              Create.of(
+                  KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
+                  KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
+              .apply(ParDo.of(fn)).setCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder));
+
+      PAssert.that(output).containsInAnyOrder(KV.of("a", new MyInteger(97)),
+          KV.of("b", new MyInteger(42)), KV.of("c", new MyInteger(12)));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
+    public void testMapStateCoderInferenceFailure() throws Exception {
+      final String stateId = "foo";
+      final String countStateId = "count";
+      Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
+
+      DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>> fn =
+          new DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>>() {
+
+            @StateId(stateId)
+            private final StateSpec<MapState<String, MyInteger>> mapState = StateSpecs.map();
+
+            @StateId(countStateId)
+            private final StateSpec<CombiningState<Integer, int[], Integer>>
+                countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
+                Sum.ofIntegers());
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c,
+                @Element KV<String, KV<String, Integer>> element,
+                @StateId(stateId) MapState<String, MyInteger> state,
+                @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
+                OutputReceiver<KV<String, MyInteger>> r) {
+              KV<String, Integer> value = element.getValue();
+              state.put(value.getKey(), new MyInteger(value.getValue()));
+              count.add(1);
+              if (count.read() >= 4) {
+                Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
+                for (Map.Entry<String, MyInteger> entry : iterate) {
+                  r.output(KV.of(entry.getKey(), entry.getValue()));
+                }
+              }
+            }
+          };
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Unable to infer a coder for MapState and no Coder was specified.");
+
+      pipeline.apply(
+          Create.of(
+              KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
+              KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
+          .apply(ParDo.of(fn)).setCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder));
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testCombiningStateCoderInference() {
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, MyIntegerCoder.of());
+
+      final String stateId = "foo";
+
+      DoFn<KV<String, Integer>, String> fn =
+          new DoFn<KV<String, Integer>, String>() {
+            private static final int EXPECTED_SUM = 16;
+
+            @StateId(stateId)
+            private final StateSpec<CombiningState<Integer, MyInteger, Integer>> combiningState =
+                StateSpecs.combining(
+                    new Combine.CombineFn<Integer, MyInteger, Integer>() {
+                      @Override
+                      public MyInteger createAccumulator() {
+                        return new MyInteger(0);
+                      }
+
+                      @Override
+                      public MyInteger addInput(MyInteger accumulator, Integer input) {
+                        return new MyInteger(accumulator.getValue() + input);
+                      }
+
+                      @Override
+                      public MyInteger mergeAccumulators(Iterable<MyInteger> accumulators) {
+                        int newValue = 0;
+                        for (MyInteger myInteger : accumulators) {
+                          newValue += myInteger.getValue();
+                        }
+                        return new MyInteger(newValue);
+                      }
+
+                      @Override
+                      public Integer extractOutput(MyInteger accumulator) {
+                        return accumulator.getValue();
+                      }
+                    });
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) CombiningState<Integer, MyInteger, Integer> state,
+                OutputReceiver<String> r) {
+              state.add(element.getValue());
+              Integer currentValue = state.read();
+              if (currentValue == EXPECTED_SUM) {
+                r.output("right on");
+              }
+            }
+          };
+
+      PCollection<String> output =
+          pipeline
+              .apply(Create.of(KV.of("hello", 3), KV.of("hello", 6), KV.of("hello", 7)))
+              .apply(ParDo.of(fn));
+
+      // There should only be one moment at which the average is exactly 16
+      PAssert.that(output).containsInAnyOrder("right on");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testCombiningStateCoderInferenceFailure() throws Exception {
+      final String stateId = "foo";
+
+      DoFn<KV<String, Integer>, String> fn =
+          new DoFn<KV<String, Integer>, String>() {
+            private static final int EXPECTED_SUM = 16;
+
+            @StateId(stateId)
+            private final StateSpec<CombiningState<Integer, MyInteger, Integer>> combiningState =
+                StateSpecs.combining(
+                    new Combine.CombineFn<Integer, MyInteger, Integer>() {
+                      @Override
+                      public MyInteger createAccumulator() {
+                        return new MyInteger(0);
+                      }
+
+                      @Override
+                      public MyInteger addInput(MyInteger accumulator, Integer input) {
+                        return new MyInteger(accumulator.getValue() + input);
+                      }
+
+                      @Override
+                      public MyInteger mergeAccumulators(Iterable<MyInteger> accumulators) {
+                        int newValue = 0;
+                        for (MyInteger myInteger : accumulators) {
+                          newValue += myInteger.getValue();
+                        }
+                        return new MyInteger(newValue);
+                      }
+
+                      @Override
+                      public Integer extractOutput(MyInteger accumulator) {
+                        return accumulator.getValue();
+                      }
+                    });
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, Integer> element,
+                @StateId(stateId) CombiningState<Integer, MyInteger, Integer> state,
+                OutputReceiver<String> r) {
+              state.add(element.getValue());
+              Integer currentValue = state.read();
+              if (currentValue == EXPECTED_SUM) {
+                r.output("right on");
+              }
+            }
+          };
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage(
+          "Unable to infer a coder for CombiningState and no Coder was specified.");
+
+      pipeline
+          .apply(Create.of(KV.of("hello", 3), KV.of("hello", 6), KV.of("hello", 7)))
+          .apply(ParDo.of(fn));
+
+      pipeline.run();
+    }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testMultiOutputParDoWithSideInputsIsCumulative() {
+  /** Tests to validate ParDo timers. */
+  @RunWith(JUnit4.class)
+  public static class TimerTests extends SharedTestBase implements Serializable {
+    @Test
+    public void testTimerNotKeyed() {
+      final String timerId = "foo";
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      DoFn<String, Integer> fn =
+          new DoFn<String, Integer>() {
 
-    final TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    final TupleTag<Void> additionalOutputTag = new TupleTag<Void>("output"){};
+            @TimerId(timerId)
+            private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
 
-    PCollectionView<Integer> sideInput1 =
-        pipeline
-            .apply("CreateSideInput1", Create.of(11))
-            .apply("ViewSideInput1", View.asSingleton());
-    PCollectionView<Integer> sideInputUnread =
-        pipeline
-            .apply("CreateSideInputUnread", Create.of(-3333))
-            .apply("ViewSideInputUnread", View.asSingleton());
-    PCollectionView<Integer> sideInput2 =
-        pipeline
-            .apply("CreateSideInput2", Create.of(222))
-            .apply("ViewSideInput2", View.asSingleton());
+            @ProcessElement
+            public void processElement(
+                ProcessContext c, @TimerId(timerId) Timer timer) {}
 
-    PCollectionTuple outputs =
-        pipeline
-            .apply(Create.of(inputs))
-            .apply(
-                ParDo.of(new TestDoFn(Arrays.asList(sideInput1, sideInput2), Arrays.asList()))
-                    .withSideInputs(sideInput1)
-                    .withSideInputs(sideInputUnread)
-                    .withSideInputs(sideInput2)
-                    .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
+            @OnTimer(timerId)
+            public void onTimer() {}
+          };
 
-    PAssert.that(outputs.get(mainOutputTag))
-        .satisfies(ParDoTest.HasExpectedOutput
-                   .forInput(inputs)
-                   .andSideInputs(11, 222));
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage("timer");
+      thrown.expectMessage("KvCoder");
 
-    pipeline.run();
+      pipeline.apply(Create.of("hello", "goodbye", "hello again")).apply(ParDo.of(fn));
+    }
+
+    @Test
+    public void testTimerNotDeterministic() {
+      final String timerId = "foo";
+
+      // DoubleCoder is not deterministic, so this should crash
+      DoFn<KV<Double, String>, Integer> fn =
+          new DoFn<KV<Double, String>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext c, @TimerId(timerId) Timer timer) {}
+
+            @OnTimer(timerId)
+            public void onTimer() {}
+          };
+
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage("timer");
+      thrown.expectMessage("deterministic");
+
+      pipeline
+          .apply(Create.of(KV.of(1.0, "hello"), KV.of(5.4, "goodbye"), KV.of(7.2, "hello again")))
+          .apply(ParDo.of(fn));
+    }
+
+    /**
+     * Tests that an event time timer fires and results in supplementary output.
+     *
+     * <p>This test relies on two properties:
+     *
+     * <ol>
+     * <li>A timer that is set on time should always get a chance to fire. For this to be true,
+     *     timers per-key-and-window must be delivered in order so the timer is not wiped out until
+     *     the window is expired by the runner.
+     * <li>A {@link Create} transform sends its elements on time, and later advances the watermark
+     *     to infinity
+     * </ol>
+     *
+     * <p>Note that {@link TestStream} is not applicable because it requires very special runner
+     * hooks and is only supported by the direct runner.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testEventTimeTimerBounded() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              r.output(3);
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
+              if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
+                r.output(42);
+              }
+            }
+          };
+
+      PCollection<Integer> output = pipeline
+          .apply(Create.of(KV.of("hello", 37)))
+          .apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(3, 42);
+      pipeline.run();
+    }
+
+    /**
+     * Tests a GBK followed immediately by a {@link ParDo} that users timers. This checks a common
+     * case where both GBK and the user code share a timer delivery bundle.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testGbkFollowedByUserTimers() throws Exception {
+
+      DoFn<KV<String, Iterable<Integer>>, Integer> fn =
+          new DoFn<KV<String, Iterable<Integer>>, Integer>() {
+
+            public static final String TIMER_ID = "foo";
+
+            @TimerId(TIMER_ID)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(TIMER_ID) Timer timer, OutputReceiver<Integer> r) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              r.output(3);
+            }
+
+            @OnTimer(TIMER_ID)
+            public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
+              if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
+                r.output(42);
+              }
+            }
+          };
+
+      PCollection<Integer> output =
+          pipeline
+              .apply(Create.of(KV.of("hello", 37)))
+              .apply(GroupByKey.create())
+              .apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(3, 42);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testEventTimeTimerAlignBounded() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
+          new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer,
+                @Timestamp Instant timestamp,
+                OutputReceiver<KV<Integer, Instant>> r) {
+              timer.align(Duration.standardSeconds(1)).offset(Duration.millis(1)).setRelative();
+              r.output(KV.of(3, timestamp));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(@Timestamp Instant timestamp,
+                OutputReceiver<KV<Integer, Instant>> r) {
+              r.output(KV.of(42, timestamp));
+            }
+          };
+
+      PCollection<KV<Integer, Instant>> output =
+          pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(KV.of(3, BoundedWindow.TIMESTAMP_MIN_VALUE),
+          KV.of(42, BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1774)));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testTimerReceivedInOriginalWindow() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, BoundedWindow> fn =
+          new DoFn<KV<String, Integer>, BoundedWindow>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(BoundedWindow window, OutputReceiver<BoundedWindow> r) {
+              r.output(window);
+            }
+
+            public TypeDescriptor<BoundedWindow> getOutputTypeDescriptor() {
+              return (TypeDescriptor) TypeDescriptor.of(IntervalWindow.class);
+            }
+          };
+
+      SlidingWindows windowing =
+          SlidingWindows.of(Duration.standardMinutes(3)).every(Duration.standardMinutes(1));
+      PCollection<BoundedWindow> output =
+          pipeline
+              .apply(Create.timestamped(TimestampedValue.of(KV.of("hello", 24), new Instant(0L))))
+              .apply(Window.into(windowing))
+              .apply(ParDo.of(fn));
+
+      PAssert.that(output)
+          .containsInAnyOrder(
+              new IntervalWindow(new Instant(0), Duration.standardMinutes(3)),
+              new IntervalWindow(
+                  new Instant(0).minus(Duration.standardMinutes(1)), Duration.standardMinutes(3)),
+              new IntervalWindow(
+                  new Instant(0).minus(Duration.standardMinutes(2)), Duration.standardMinutes(3)));
+      pipeline.run();
+    }
+
+    /**
+     * Tests that an event time timer set absolutely for the last possible moment fires and results
+     * in supplementary output. The test is otherwise identical to
+     * {@link #testEventTimeTimerBounded()}.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testEventTimeTimerAbsolute() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer, BoundedWindow window,
+                OutputReceiver<Integer> r) {
+              timer.set(window.maxTimestamp());
+              r.output(3);
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(OutputReceiver<Integer> r) {
+              r.output(42);
+            }
+          };
+
+      PCollection<Integer> output = pipeline
+          .apply(Create.of(KV.of("hello", 37)))
+          .apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(3, 42);
+      pipeline.run();
+    }
+
+    @Ignore(
+        "https://issues.apache.org/jira/browse/BEAM-2791, "
+            + "https://issues.apache.org/jira/browse/BEAM-2535")
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesTimersInParDo.class})
+    public void testEventTimeTimerLoop() {
+      final String stateId = "count";
+      final String timerId = "timer";
+      final int loopCount = 5;
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec loopSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<Integer>> countSpec = StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(
+                @StateId(stateId) ValueState<Integer> countState,
+                @TimerId(timerId) Timer loopTimer) {
+              loopTimer.offset(Duration.millis(1)).setRelative();
+            }
+
+            @OnTimer(timerId)
+            public void onLoopTimer(
+                @StateId(stateId) ValueState<Integer> countState,
+                @TimerId(timerId) Timer loopTimer,
+                OutputReceiver<Integer> r) {
+              int count = MoreObjects.firstNonNull(countState.read(), 0);
+              if (count < loopCount) {
+                r.output(count);
+                countState.write(count + 1);
+                loopTimer.offset(Duration.millis(1)).setRelative();
+              }
+            }
+          };
+
+      PCollection<Integer> output = pipeline
+          .apply(Create.of(KV.of("hello", 42)))
+          .apply(ParDo.of(fn));
+
+      PAssert.that(output).containsInAnyOrder(0, 1, 2, 3, 4);
+      pipeline.run();
+    }
+
+    /**
+     * Tests that event time timers for multiple keys both fire. This particularly exercises
+     * implementations that may GC in ways not simply governed by the watermark.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testEventTimeTimerMultipleKeys() throws Exception {
+      final String timerId = "foo";
+      final String stateId = "sizzle";
+
+      final int offset = 5000;
+      final int timerOutput = 4093;
+
+      DoFn<KV<String, Integer>, KV<String, Integer>> fn =
+          new DoFn<KV<String, Integer>, KV<String, Integer>>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<String>> stateSpec =
+                StateSpecs.value(StringUtf8Coder.of());
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext context,
+                @TimerId(timerId) Timer timer,
+                @StateId(stateId) ValueState<String> state,
+                BoundedWindow window) {
+              timer.set(window.maxTimestamp());
+              state.write(context.element().getKey());
+              context.output(
+                  KV.of(context.element().getKey(), context.element().getValue() + offset));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(@StateId(stateId) ValueState<String> state,
+                OutputReceiver<KV<String, Integer>> r) {
+              r.output(KV.of(state.read(), timerOutput));
+            }
+          };
+
+      // Enough keys that we exercise interesting code paths
+      int numKeys = 50;
+      List<KV<String, Integer>> input = new ArrayList<>();
+      List<KV<String, Integer>> expectedOutput = new ArrayList<>();
+
+      for (Integer key = 0; key < numKeys; ++key) {
+        // Each key should have just one final output at GC time
+        expectedOutput.add(KV.of(key.toString(), timerOutput));
+
+        for (int i = 0; i < 15; ++i) {
+          // Each input should be output with the offset added
+          input.add(KV.of(key.toString(), i));
+          expectedOutput.add(KV.of(key.toString(), i + offset));
+        }
+      }
+
+      Collections.shuffle(input);
+
+      PCollection<KV<String, Integer>> output =
+          pipeline
+              .apply(
+                  Create.of(input))
+              .apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(expectedOutput);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testAbsoluteProcessingTimeTimerRejected() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer) {
+              timer.set(new Instant(0));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer() {}
+          };
+
+      pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+      thrown.expect(RuntimeException.class);
+      // Note that runners can reasonably vary their message - this matcher should be flexible
+      // and can be evolved.
+      thrown.expectMessage("relative timers");
+      thrown.expectMessage("processing time");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testOutOfBoundsEventTimeTimer() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(
+                ProcessContext context, BoundedWindow window, @TimerId(timerId) Timer timer) {
+              timer.set(window.maxTimestamp().plus(1L));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer() {}
+          };
+
+      pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
+      thrown.expect(RuntimeException.class);
+      // Note that runners can reasonably vary their message - this matcher should be flexible
+      // and can be evolved.
+      thrown.expectMessage("event time timer");
+      thrown.expectMessage("expiration");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testSimpleProcessingTimerTimer() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              r.output(3);
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
+              if (timeDomain.equals(TimeDomain.PROCESSING_TIME)) {
+                r.output(42);
+              }
+            }
+          };
+
+      TestStream<KV<String, Integer>> stream =
+          TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()))
+              .addElements(KV.of("hello", 37))
+              .advanceProcessingTime(Duration.standardSeconds(2))
+              .advanceWatermarkToInfinity();
+
+      PCollection<Integer> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(3, 42);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testEventTimeTimerUnbounded() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, Integer> fn =
+          new DoFn<KV<String, Integer>, Integer>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              r.output(3);
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(OutputReceiver<Integer> r) {
+              r.output(42);
+            }
+          };
+
+      TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
+          .of(StringUtf8Coder.of(), VarIntCoder.of()))
+          .advanceWatermarkTo(new Instant(0))
+          .addElements(KV.of("hello", 37))
+          .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(1)))
+          .advanceWatermarkToInfinity();
+
+      PCollection<Integer> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(3, 42);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testEventTimeTimerAlignUnbounded() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
+          new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(@TimerId(timerId) Timer timer,
+                @Timestamp Instant timestamp,
+                OutputReceiver<KV<Integer, Instant>> r) {
+              timer.align(Duration.standardSeconds(1)).offset(Duration.millis(1)).setRelative();
+              r.output(KV.of(3, timestamp));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(@Timestamp Instant timestamp,
+                OutputReceiver<KV<Integer, Instant>> r) {
+              r.output(KV.of(42, timestamp));
+            }
+          };
+
+      TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
+          .of(StringUtf8Coder.of(), VarIntCoder.of()))
+          .advanceWatermarkTo(new Instant(5))
+          .addElements(KV.of("hello", 37))
+          .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(1).plus(1)))
+          .advanceWatermarkToInfinity();
+
+      PCollection<KV<Integer, Instant>> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(KV.of(3, new Instant(5)),
+          KV.of(42, new Instant(Duration.standardSeconds(1).minus(1).getMillis())));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testEventTimeTimerAlignAfterGcTimeUnbounded() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
+          new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
+              // This aligned time will exceed the END_OF_GLOBAL_WINDOW
+              timer.align(Duration.standardDays(1)).setRelative();
+              context.output(KV.of(3, context.timestamp()));
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(@Timestamp Instant timestamp,
+                OutputReceiver<KV<Integer, Instant>> r) {
+              r.output(KV.of(42, timestamp));
+            }
+          };
+
+      TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
+          .of(StringUtf8Coder.of(), VarIntCoder.of()))
+          // See GlobalWindow,
+          // END_OF_GLOBAL_WINDOW is TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))
+          .advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1)))
+          .addElements(KV.of("hello", 37))
+          .advanceWatermarkToInfinity();
+
+      PCollection<KV<Integer, Instant>> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      PAssert.that(output).containsInAnyOrder(
+          KV.of(3, BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))),
+          KV.of(42, BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))));
+      pipeline.run();
+    }
+
+    /**
+     * A test makes sure that a processing time timer should reset rather than creating duplicate
+     * timers when a "set" method is called on it before it goes off.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testProcessingTimeTimerCanBeReset() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, String>, String> fn =
+          new DoFn<KV<String, String>, String>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+            @ProcessElement
+            public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              context.output(context.element().getValue());
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(OutputReceiver<String> r) {
+              r.output("timer_output");
+            }
+          };
+
+      TestStream<KV<String, String>> stream =
+          TestStream.create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+              .addElements(KV.of("key", "input1"))
+              .addElements(KV.of("key", "input2"))
+              .advanceProcessingTime(Duration.standardSeconds(2))
+              .advanceWatermarkToInfinity();
+
+      PCollection<String> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      // Timer "foo" is set twice because input1 and input 2 are outputted. However, only one
+      // "timer_output" is outputted. Therefore, the timer is overwritten.
+      PAssert.that(output).containsInAnyOrder("input1", "input2", "timer_output");
+      pipeline.run();
+    }
+
+    /**
+     * A test makes sure that an event time timer should reset rather than creating duplicate
+     * timers when a "set" method is called on it before it goes off.
+     */
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
+    public void testEventTimeTimerCanBeReset() throws Exception {
+      final String timerId = "foo";
+
+      DoFn<KV<String, String>, String> fn =
+          new DoFn<KV<String, String>, String>() {
+
+            @TimerId(timerId)
+            private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
+              timer.offset(Duration.standardSeconds(1)).setRelative();
+              context.output(context.element().getValue());
+            }
+
+            @OnTimer(timerId)
+            public void onTimer(OutputReceiver<String> r) {
+              r.output("timer_output");
+            }
+          };
+
+      TestStream<KV<String, String>> stream = TestStream.create(KvCoder
+          .of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+          .advanceWatermarkTo(new Instant(0))
+          .addElements(KV.of("hello", "input1"))
+          .addElements(KV.of("hello", "input2"))
+          .advanceWatermarkToInfinity();
+
+      PCollection<String> output = pipeline.apply(stream).apply(ParDo.of(fn));
+      // Timer "foo" is set twice because input1 and input 2 are outputted. However, only one
+      // "timer_output" is outputted. Therefore, the timer is overwritten.
+      PAssert.that(output).containsInAnyOrder("input1", "input2", "timer_output");
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTimersInParDo.class})
+    public void testPipelineOptionsParameterOnTimer() {
+      final String timerId = "thisTimer";
+
+      PCollection<String> results =
+          pipeline
+              .apply(Create.of(KV.of(0, 0)))
+              .apply(
+                  ParDo.of(
+                      new DoFn<KV<Integer, Integer>, String>() {
+                        @TimerId(timerId)
+                        private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+                        @ProcessElement
+                        public void process(
+                            ProcessContext c, BoundedWindow w, @TimerId(timerId) Timer timer) {
+                          timer.set(w.maxTimestamp());
+                        }
+
+                        @OnTimer(timerId)
+                        public void onTimer(OutputReceiver<String> r, PipelineOptions options) {
+                          r.output(options.as(MyOptions.class).getFakeOption());
+                        }
+                      }));
+
+      String testOptionValue = "not fake anymore";
+      pipeline.getOptions().as(MyOptions.class).setFakeOption(testOptionValue);
+      PAssert.that(results).containsInAnyOrder("not fake anymore");
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesTestStream.class})
+    public void duplicateTimerSetting() {
+      TestStream<KV<String, String>> stream = TestStream
+          .create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+          .addElements(KV.of("key1", "v1"))
+          .advanceWatermarkToInfinity();
+
+      PCollection<String> result = pipeline
+          .apply(stream)
+          .apply(ParDo.of(new TwoTimerDoFn()));
+      PAssert.that(result).containsInAnyOrder("It works");
+
+      pipeline.run().waitUntilFinish();
+    }
   }
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoReadingFromUnknownSideInput() {
+  /** Tests validating Timer coder inference behaviors. */
+  @RunWith(JUnit4.class)
+  public static class TimerCoderInferenceTests extends SharedTestBase implements Serializable {
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateCoderInference() {
+      final String stateId = "foo";
+      MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
+      pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
 
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
+      DoFn<KV<String, Integer>, MyInteger> fn =
+          new DoFn<KV<String, Integer>, MyInteger>() {
 
-    PCollectionView<Integer> sideView =
-        pipeline.apply("Create3", Create.of(3)).apply(View.asSingleton());
+            @StateId(stateId)
+            private final StateSpec<ValueState<MyInteger>> intState =
+                StateSpecs.value();
 
-    pipeline
-        .apply("CreateMain", Create.of(inputs))
-        .apply(ParDo.of(new TestDoFn(Arrays.asList(sideView), Arrays.asList())));
+            @ProcessElement
+            public void processElement(
+                ProcessContext c, @StateId(stateId) ValueState<MyInteger> state,
+                OutputReceiver<MyInteger> r) {
+              MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
+              r.output(currentValue);
+              state.write(new MyInteger(currentValue.getValue() + 1));
+            }
+          };
 
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("calling sideInput() with unknown view");
-    pipeline.run();
+      PCollection<MyInteger> output =
+          pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+              .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
+
+      PAssert.that(output).containsInAnyOrder(new MyInteger(0), new MyInteger(1), new MyInteger(2));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateCoderInferenceFailure() throws Exception {
+      final String stateId = "foo";
+      MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
+
+      DoFn<KV<String, Integer>, MyInteger> fn =
+          new DoFn<KV<String, Integer>, MyInteger>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<MyInteger>> intState =
+                StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(@StateId(stateId) ValueState<MyInteger> state,
+                OutputReceiver<MyInteger> r) {
+              MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
+              r.output(currentValue);
+              state.write(new MyInteger(currentValue.getValue() + 1));
+            }
+          };
+
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("Unable to infer a coder for ValueState and no Coder was specified.");
+
+      pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
+          .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
+
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class})
+    public void testValueStateCoderInferenceFromInputCoder() {
+      final String stateId = "foo";
+      MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
+
+      DoFn<KV<String, MyInteger>, MyInteger> fn =
+          new DoFn<KV<String, MyInteger>, MyInteger>() {
+
+            @StateId(stateId)
+            private final StateSpec<ValueState<MyInteger>> intState =
+                StateSpecs.value();
+
+            @ProcessElement
+            public void processElement(@StateId(stateId) ValueState<MyInteger> state,
+                OutputReceiver<MyInteger> r) {
+              MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
+              r.output(currentValue);
+              state.write(new MyInteger(currentValue.getValue() + 1));
+            }
+          };
+
+      pipeline
+          .apply(Create.of(KV.of("hello", new MyInteger(42)),
+              KV.of("hello", new MyInteger(97)), KV.of("hello", new MyInteger(84)))
+              .withCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder)))
+          .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
+
+      pipeline.run();
+    }
   }
 
   private static class FnWithSideInputs extends DoFn<String, String> {
@@ -727,242 +3206,6 @@ public class ParDoTest implements Serializable {
     public void processElement(ProcessContext c, @Element String element) {
       c.output(element + ":" + c.sideInput(view));
     }
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testSideInputsWithMultipleWindows() {
-    // Tests that the runner can safely run a DoFn that uses side inputs
-    // on an input where the element is in multiple windows. The complication is
-    // that side inputs are per-window, so the runner has to make sure
-    // to process each window individually.
-
-    MutableDateTime mutableNow = Instant.now().toMutableDateTime();
-    mutableNow.setMillisOfSecond(0);
-    Instant now = mutableNow.toInstant();
-
-    SlidingWindows windowFn =
-        SlidingWindows.of(Duration.standardSeconds(5)).every(Duration.standardSeconds(1));
-    PCollectionView<Integer> view = pipeline.apply(Create.of(1)).apply(View.asSingleton());
-    PCollection<String> res =
-        pipeline
-            .apply(Create.timestamped(TimestampedValue.of("a", now)))
-            .apply(Window.into(windowFn))
-            .apply(ParDo.of(new FnWithSideInputs(view)).withSideInputs(view));
-
-    for (int i = 0; i < 4; ++i) {
-      Instant base = now.minus(Duration.standardSeconds(i));
-      IntervalWindow window = new IntervalWindow(base, base.plus(Duration.standardSeconds(5)));
-      PAssert.that(res).inWindow(window).containsInAnyOrder("a:1");
-    }
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoWithErrorInStartBatch() {
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
-
-    pipeline.apply(Create.of(inputs))
-        .apply(ParDo.of(new TestStartBatchErrorDoFn()));
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("test error in initialize");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoWithErrorInProcessElement() {
-
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
-
-    pipeline.apply(Create.of(inputs))
-        .apply(ParDo.of(new TestProcessElementErrorDoFn()));
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("test error in process");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoWithErrorInFinishBatch() {
-
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
-
-    pipeline.apply(Create.of(inputs))
-        .apply(ParDo.of(new TestFinishBatchErrorDoFn()));
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("test error in finalize");
-    pipeline.run();
-  }
-
-  @Test
-  public void testParDoOutputNameBasedOnDoFnWithTrimmedSuffix() {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    PCollection<String> output = pipeline.apply(Create.of(1)).apply(ParDo.of(new TestDoFn()));
-    assertThat(output.getName(), containsString("ParDo(Test)"));
-  }
-
-  @Test
-  public void testParDoOutputNameBasedOnLabel() {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    PCollection<String> output =
-        pipeline.apply(Create.of(1)).apply("MyParDo", ParDo.of(new TestDoFn()));
-    assertThat(output.getName(), containsString("MyParDo"));
-  }
-
-  @Test
-  public void testParDoOutputNameBasedDoFnWithoutMatchingSuffix() {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    PCollection<String> output =
-        pipeline.apply(Create.of(1)).apply(ParDo.of(new StrangelyNamedDoer()));
-    assertThat(output.getName(), containsString("ParDo(StrangelyNamedDoer)"));
-  }
-
-  @Test
-  public void testParDoTransformNameBasedDoFnWithTrimmedSuffix() {
-    assertThat(ParDo.of(new PrintingDoFn()).getName(), containsString("ParDo(Printing)"));
-  }
-
-  @Test
-  public void testParDoMultiNameBasedDoFnWithTrimmerSuffix() {
-    assertThat(
-        ParDo.of(new TaggedOutputDummyFn(null, null)).withOutputTags(null, null).getName(),
-        containsString("ParMultiDo(TaggedOutputDummy)"));
-  }
-
-  @Test
-  public void testParDoWithTaggedOutputName() {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    TupleTag<String> mainOutputTag = new TupleTag<String>("main"){};
-    TupleTag<String> additionalOutputTag1 = new TupleTag<String>("output1"){};
-    TupleTag<String> additionalOutputTag2 = new TupleTag<String>("output2"){};
-    TupleTag<String> additionalOutputTag3 = new TupleTag<String>("output3"){};
-    TupleTag<String> additionalOutputTagUnwritten = new TupleTag<String>("unwrittenOutput"){};
-
-    PCollectionTuple outputs =
-        pipeline
-            .apply(Create.of(Arrays.asList(3, -42, 666)))
-            .setName("MyInput")
-            .apply(
-                "MyParDo",
-                ParDo.of(
-                        new TestDoFn(
-                            Arrays.asList(),
-                            Arrays.asList(
-                                additionalOutputTag1, additionalOutputTag2, additionalOutputTag3)))
-                    .withOutputTags(
-                        mainOutputTag,
-                        TupleTagList.of(additionalOutputTag3)
-                            .and(additionalOutputTag1)
-                            .and(additionalOutputTagUnwritten)
-                            .and(additionalOutputTag2)));
-
-    assertEquals("MyParDo.main", outputs.get(mainOutputTag).getName());
-    assertEquals("MyParDo.output1", outputs.get(additionalOutputTag1).getName());
-    assertEquals("MyParDo.output2", outputs.get(additionalOutputTag2).getName());
-    assertEquals("MyParDo.output3", outputs.get(additionalOutputTag3).getName());
-    assertEquals("MyParDo.unwrittenOutput",
-                 outputs.get(additionalOutputTagUnwritten).getName());
-  }
-
-  @Test
-  public void testMultiOutputAppliedMultipleTimesDifferentOutputs() {
-    pipeline.enableAbandonedNodeEnforcement(false);
-    PCollection<Long> longs = pipeline.apply(GenerateSequence.from(0));
-
-    TupleTag<Long> mainOut = new TupleTag<>();
-    final TupleTag<String> valueAsString = new TupleTag<>();
-    final TupleTag<Integer> valueAsInt = new TupleTag<>();
-    DoFn<Long, Long> fn =
-        new DoFn<Long, Long>() {
-          @ProcessElement
-          public void processElement(ProcessContext cxt, @Element Long element) {
-            cxt.output(cxt.element());
-            cxt.output(valueAsString, Long.toString(cxt.element()));
-            cxt.output(valueAsInt, element.intValue());
-          }
-        };
-
-    ParDo.MultiOutput<Long, Long> parDo =
-        ParDo.of(fn).withOutputTags(mainOut, TupleTagList.of(valueAsString).and(valueAsInt));
-    PCollectionTuple firstApplication = longs.apply("first", parDo);
-    PCollectionTuple secondApplication = longs.apply("second", parDo);
-    assertThat(firstApplication, not(equalTo(secondApplication)));
-    assertThat(
-        firstApplication.getAll().keySet(),
-        Matchers.containsInAnyOrder(mainOut, valueAsString, valueAsInt));
-    assertThat(
-        secondApplication.getAll().keySet(),
-        Matchers.containsInAnyOrder(mainOut, valueAsString, valueAsInt));
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoInCustomTransform() {
-
-    List<Integer> inputs = Arrays.asList(3, -42, 666);
-
-    PCollection<String> output = pipeline
-        .apply(Create.of(inputs))
-        .apply("CustomTransform", new PTransform<PCollection<Integer>, PCollection<String>>() {
-            @Override
-            public PCollection<String> expand(PCollection<Integer> input) {
-              return input.apply(ParDo.of(new TestDoFn()));
-            }
-          });
-
-    // Test that Coder inference of the result works through
-    // user-defined PTransforms.
-    PAssert.that(output)
-        .satisfies(ParDoTest.HasExpectedOutput.forInput(inputs));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testMultiOutputChaining() {
-
-    PCollectionTuple filters = pipeline
-        .apply(Create.of(Arrays.asList(3, 4, 5, 6)))
-        .apply(new MultiFilter());
-    PCollection<Integer> by2 = filters.get(MultiFilter.BY2);
-    PCollection<Integer> by3 = filters.get(MultiFilter.BY3);
-
-    // Apply additional filters to each operation.
-    PCollection<Integer> by2then3 = by2
-        .apply("Filter3sAgain", ParDo.of(new MultiFilter.FilterFn(3)));
-    PCollection<Integer> by3then2 = by3
-        .apply("Filter2sAgain", ParDo.of(new MultiFilter.FilterFn(2)));
-
-    PAssert.that(by2then3).containsInAnyOrder(6);
-    PAssert.that(by3then2).containsInAnyOrder(6);
-    pipeline.run();
-  }
-
-  @Test
-  public void testJsonEscaping() {
-    // Declare an arbitrary function and make sure we can serialize it
-    DoFn<Integer, Integer> doFn = new DoFn<Integer, Integer>() {
-      @ProcessElement
-      public void processElement(@Element Integer element, OutputReceiver<Integer> r) {
-        r.output(element + 1);
-      }
-    };
-
-    byte[] serializedBytes = serializeToByteArray(doFn);
-    String serializedJson = byteArrayToJsonString(serializedBytes);
-    assertArrayEquals(
-        serializedBytes, jsonStringToByteArray(serializedJson));
   }
 
   private static class TestDummy { }
@@ -1174,280 +3417,6 @@ public class ParDoTest implements Serializable {
     }
   }
 
-  @Test
-  @Category(NeedsRunner.class)
-  public void testTaggedOutputUnknownCoder() throws Exception {
-
-    PCollection<Integer> input = pipeline
-        .apply(Create.of(Arrays.asList(1, 2, 3)));
-
-    final TupleTag<Integer> mainOutputTag = new TupleTag<>("main");
-    final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("unknownSide");
-    input.apply(ParDo.of(new TaggedOutputDummyFn(mainOutputTag, additionalOutputTag))
-        .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
-
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Unable to return a default Coder");
-    pipeline.run();
-  }
-
-  @Test
-  public void testTaggedOutputUnregisteredExplicitCoder() throws Exception {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    PCollection<Integer> input = pipeline
-        .apply(Create.of(Arrays.asList(1, 2, 3)));
-
-    final TupleTag<Integer> mainOutputTag = new TupleTag<>("main");
-    final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("unregisteredSide");
-    ParDo.MultiOutput<Integer, Integer> pardo =
-        ParDo.of(new TaggedOutputDummyFn(mainOutputTag, additionalOutputTag))
-            .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag));
-    PCollectionTuple outputTuple = input.apply(pardo);
-
-    outputTuple.get(additionalOutputTag).setCoder(new TestDummyCoder());
-
-    outputTuple.get(additionalOutputTag).apply(View.asSingleton());
-
-    assertEquals(new TestDummyCoder(), outputTuple.get(additionalOutputTag).getCoder());
-    outputTuple
-        .get(additionalOutputTag)
-        .finishSpecifyingOutput("ParDo", input, pardo); // Check for crashes
-    assertEquals(new TestDummyCoder(),
-        outputTuple.get(additionalOutputTag).getCoder()); // Check for corruption
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testMainOutputUnregisteredExplicitCoder() {
-
-    PCollection<Integer> input = pipeline
-        .apply(Create.of(Arrays.asList(1, 2, 3)));
-
-    final TupleTag<TestDummy> mainOutputTag = new TupleTag<>("unregisteredMain");
-    final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additionalOutput") {};
-    PCollectionTuple outputTuple =
-        input.apply(
-            ParDo.of(new MainOutputDummyFn(mainOutputTag, additionalOutputTag))
-                .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)));
-
-    outputTuple.get(mainOutputTag).setCoder(new TestDummyCoder());
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testMainOutputApplyTaggedOutputNoCoder() {
-    // Regression test: applying a transform to the main output
-    // should not cause a crash based on lack of a coder for the
-    // additional output.
-
-    final TupleTag<TestDummy> mainOutputTag = new TupleTag<>("main");
-    final TupleTag<TestDummy> additionalOutputTag = new TupleTag<>("additionalOutput");
-    PCollectionTuple tuple = pipeline
-        .apply(Create.of(new TestDummy())
-            .withCoder(TestDummyCoder.of()))
-        .apply(ParDo
-            .of(
-                new DoFn<TestDummy, TestDummy>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext context, @Element TestDummy element) {
-                    context.output(element);
-                    context.output(additionalOutputTag, element);
-                  }
-                })
-            .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag))
-        );
-
-    // Before fix, tuple.get(mainOutputTag).apply(...) would indirectly trigger
-    // tuple.get(additionalOutputTag).finishSpecifyingOutput(), which would crash
-    // on a missing coder.
-    tuple.get(mainOutputTag)
-        .setCoder(TestDummyCoder.of())
-        .apply("Output1", ParDo.of(new DoFn<TestDummy, Integer>() {
-          @ProcessElement
-          public void processElement(ProcessContext context) {
-            context.output(1);
-          }
-        }));
-
-    tuple.get(additionalOutputTag).setCoder(TestDummyCoder.of());
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoOutputWithTimestamp() {
-
-    PCollection<Integer> input =
-        pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
-
-    PCollection<String> output =
-        input
-            .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
-            .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.ZERO)))
-            .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
-
-    PAssert.that(output).containsInAnyOrder(
-                   "processing: 3, timestamp: 3",
-                   "processing: 42, timestamp: 42",
-                   "processing: 6, timestamp: 6");
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoTaggedOutputWithTimestamp() {
-
-    PCollection<Integer> input =
-        pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
-
-    final TupleTag<Integer> mainOutputTag = new TupleTag<Integer>("main"){};
-    final TupleTag<Integer> additionalOutputTag = new TupleTag<Integer>("additional"){};
-
-    PCollection<String> output =
-        input
-            .apply(
-                ParDo.of(
-                        new DoFn<Integer, Integer>() {
-                          @ProcessElement
-                          public void processElement(@Element Integer element,
-                                                     MultiOutputReceiver r) {
-                            r.get(additionalOutputTag)
-                                .outputWithTimestamp(
-                                element,
-                                new Instant(element.longValue()));
-                          }
-                        })
-                    .withOutputTags(mainOutputTag, TupleTagList.of(additionalOutputTag)))
-            .get(additionalOutputTag)
-            .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.ZERO)))
-            .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
-
-    PAssert.that(output).containsInAnyOrder(
-                   "processing: 3, timestamp: 3",
-                   "processing: 42, timestamp: 42",
-                   "processing: 6, timestamp: 6");
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoShiftTimestamp() {
-
-    PCollection<Integer> input =
-        pipeline.apply(Create.of(Arrays.asList(3, 42, 6)));
-
-    PCollection<String> output =
-        input
-            .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
-            .apply(
-                ParDo.of(
-                    new TestShiftTimestampDoFn<>(Duration.millis(1000), Duration.millis(-1000))))
-            .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
-
-    PAssert.that(output).containsInAnyOrder(
-                   "processing: 3, timestamp: -997",
-                   "processing: 42, timestamp: -958",
-                   "processing: 6, timestamp: -994");
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoShiftTimestampInvalid() {
-
-    pipeline
-        .apply(Create.of(Arrays.asList(3, 42, 6)))
-        .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
-        .apply(
-            ParDo.of(
-                new TestShiftTimestampDoFn<>(
-                    Duration.millis(1000), // allowed skew = 1 second
-                    Duration.millis(-1001))))
-        .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Cannot output with timestamp");
-    thrown.expectMessage(
-        "Output timestamps must be no earlier than the timestamp of the current input");
-    thrown.expectMessage("minus the allowed skew (1 second).");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(NeedsRunner.class)
-  public void testParDoShiftTimestampInvalidZeroAllowed() {
-    pipeline
-        .apply(Create.of(Arrays.asList(3, 42, 6)))
-        .apply(ParDo.of(new TestOutputTimestampDoFn<>()))
-        .apply(ParDo.of(new TestShiftTimestampDoFn<>(Duration.ZERO, Duration.millis(-1001))))
-        .apply(ParDo.of(new TestFormatTimestampDoFn<>()));
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Cannot output with timestamp");
-    thrown.expectMessage(
-        "Output timestamps must be no earlier than the timestamp of the current input");
-    thrown.expectMessage("minus the allowed skew (0 milliseconds).");
-    pipeline.run();
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testParDoShiftTimestampUnlimited() {
-    PCollection<Long> outputs =
-        pipeline
-            .apply(
-                Create.of(
-                    Arrays.asList(
-                        0L,
-                        BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis(),
-                        GlobalWindow.INSTANCE.maxTimestamp().getMillis())))
-            .apply("AssignTimestampToValue", ParDo.of(new TestOutputTimestampDoFn<>()))
-            .apply(
-                "ReassignToMinimumTimestamp",
-                ParDo.of(
-                    new DoFn<Long, Long>() {
-                      @ProcessElement
-                      public void reassignTimestamps(ProcessContext context,
-                                                     @Element Long element) {
-                        // Shift the latest element as far backwards in time as the model permits
-                        context.outputWithTimestamp(
-                            element, BoundedWindow.TIMESTAMP_MIN_VALUE);
-                      }
-
-                      @Override
-                      public Duration getAllowedTimestampSkew() {
-                        return Duration.millis(Long.MAX_VALUE);
-                      }
-                    }));
-
-    PAssert.that(outputs)
-        .satisfies(
-            input -> {
-              // This element is not shifted backwards in time. It must be present in the output.
-              assertThat(input, hasItem(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()));
-              for (Long elem : input) {
-                // Sanity check the outputs. 0L and the end of the global window are shifted
-                // backwards in time and theoretically could be dropped.
-                assertThat(
-                    elem,
-                    anyOf(
-                        equalTo(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis()),
-                        equalTo(GlobalWindow.INSTANCE.maxTimestamp().getMillis()),
-                        equalTo(0L)));
-              }
-              return null;
-            });
-
-    pipeline.run();
-  }
-
   private static class Checker implements SerializableFunction<Iterable<String>, Void> {
     @Override
     public Void apply(Iterable<String> input) {
@@ -1476,1951 +3445,11 @@ public class ParDoTest implements Serializable {
     }
   }
 
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testWindowingInStartAndFinishBundle() {
-
-    final FixedWindows windowFn = FixedWindows.of(Duration.millis(1));
-    PCollection<String> output =
-        pipeline
-            .apply(Create.timestamped(TimestampedValue.of("elem", new Instant(1))))
-            .apply(Window.into(windowFn))
-            .apply(
-                ParDo.of(
-                    new DoFn<String, String>() {
-                      @ProcessElement
-                      public void processElement(@Element String element,
-                                                 @Timestamp Instant timestamp,
-                                                 OutputReceiver<String> r) {
-                        r.output(element);
-                        System.out.println(
-                            "Process: " + element + ":" + timestamp.getMillis());
-                      }
-
-                      @FinishBundle
-                      public void finishBundle(FinishBundleContext c) {
-                        Instant ts = new Instant(3);
-                        c.output("finish", ts, windowFn.assignWindow(ts));
-                        System.out.println("Finish: 3");
-                      }
-                    }))
-            .apply(ParDo.of(new PrintingDoFn()));
-
-    PAssert.that(output).satisfies(new Checker());
-
-    pipeline.run();
-  }
-
-  @Test
-  public void testDoFnDisplayData() {
-    DoFn<String, String> fn = new DoFn<String, String>() {
-      @ProcessElement
-      public void processElement(ProcessContext c) {
-      }
-
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("doFnMetadata", "bar"));
-      }
-    };
-
-    SingleOutput<String, String> parDo = ParDo.of(fn);
-
-    DisplayData displayData = DisplayData.from(parDo);
-    assertThat(displayData, hasDisplayItem(allOf(
-        hasKey("fn"),
-        hasType(DisplayData.Type.JAVA_CLASS),
-        DisplayDataMatchers.hasValue(fn.getClass().getName()))));
-
-    assertThat(displayData, includesDisplayDataFor("fn", fn));
-  }
-
-  @Test
-  public void testDoFnWithContextDisplayData() {
-    DoFn<String, String> fn = new DoFn<String, String>() {
-      @ProcessElement
-      public void proccessElement(ProcessContext c) {}
-
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("fnMetadata", "foobar"));
-      }
-    };
-
-    SingleOutput<String, String> parDo = ParDo.of(fn);
-
-    DisplayData displayData = DisplayData.from(parDo);
-    assertThat(displayData, includesDisplayDataFor("fn", fn));
-    assertThat(displayData, hasDisplayItem("fn", fn.getClass()));
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateSimple() {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(@StateId(stateId) ValueState<Integer> state,
-                                     OutputReceiver<Integer> r) {
-            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
-            r.output(currentValue);
-            state.write(currentValue + 1);
-          }
-        };
-
-    PCollection<Integer> output =
-        pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
-            .apply(ParDo.of(fn));
-
-    PAssert.that(output).containsInAnyOrder(0, 1, 2);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateDedup() {
-    final String stateId = "foo";
-
-    DoFn<KV<Integer, Integer>, Integer> onePerKey =
-        new DoFn<KV<Integer, Integer>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> seenSpec =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<Integer, Integer> element,
-              @StateId(stateId) ValueState<Integer> seenState,
-              OutputReceiver<Integer> r) {
-            Integer seen = MoreObjects.firstNonNull(seenState.read(), 0);
-
-            if (seen == 0) {
-              seenState.write(seen + 1);
-              r.output(element.getValue());
-            }
-          }
-        };
-
-    int numKeys = 50;
-    // A big enough list that we can see some deduping
-    List<KV<Integer, Integer>> input = new ArrayList<>();
-
-    // The output should have no dupes
-    Set<Integer> expectedOutput = new HashSet<>();
-
-    for (int key = 0; key < numKeys; ++key) {
-      int output = 1000 + key;
-      expectedOutput.add(output);
-
-      for (int i = 0; i < 15; ++i) {
-        input.add(KV.of(key, output));
-      }
-    }
-
-    Collections.shuffle(input);
-
-    PCollection<Integer> output = pipeline.apply(Create.of(input)).apply(ParDo.of(onePerKey));
-
-    PAssert.that(output).containsInAnyOrder(expectedOutput);
-    pipeline.run();
-  }
-
-  @Test
-  public void testStateNotKeyed() {
-    final String stateId = "foo";
-
-    DoFn<String, Integer> fn =
-        new DoFn<String, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c, @StateId(stateId) ValueState<Integer> state) {}
-        };
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("state");
-    thrown.expectMessage("KvCoder");
-
-    pipeline.apply(Create.of("hello", "goodbye", "hello again")).apply(ParDo.of(fn));
-  }
-
-  @Test
-  public void testStateNotDeterministic() {
-    final String stateId = "foo";
-
-    // DoubleCoder is not deterministic, so this should crash
-    DoFn<KV<Double, String>, Integer> fn =
-        new DoFn<KV<Double, String>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c, @StateId(stateId) ValueState<Integer> state) {}
-        };
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("state");
-    thrown.expectMessage("deterministic");
-
-    pipeline
-        .apply(Create.of(KV.of(1.0, "hello"), KV.of(5.4, "goodbye"), KV.of(7.2, "hello again")))
-        .apply(ParDo.of(fn));
-  }
-
-  @Test
-  public void testTimerNotKeyed() {
-    final String timerId = "foo";
-
-    DoFn<String, Integer> fn =
-        new DoFn<String, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c, @TimerId(timerId) Timer timer) {}
-
-          @OnTimer(timerId)
-          public void onTimer() {}
-        };
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("timer");
-    thrown.expectMessage("KvCoder");
-
-    pipeline.apply(Create.of("hello", "goodbye", "hello again")).apply(ParDo.of(fn));
-  }
-
-  @Test
-  public void testTimerNotDeterministic() {
-    final String timerId = "foo";
-
-    // DoubleCoder is not deterministic, so this should crash
-    DoFn<KV<Double, String>, Integer> fn =
-        new DoFn<KV<Double, String>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c, @TimerId(timerId) Timer timer) {}
-
-          @OnTimer(timerId)
-          public void onTimer() {}
-        };
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("timer");
-    thrown.expectMessage("deterministic");
-
-    pipeline
-        .apply(Create.of(KV.of(1.0, "hello"), KV.of(5.4, "goodbye"), KV.of(7.2, "hello again")))
-        .apply(ParDo.of(fn));
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateCoderInference() {
-    final String stateId = "foo";
-    MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
-
-    DoFn<KV<String, Integer>, MyInteger> fn =
-        new DoFn<KV<String, Integer>, MyInteger>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<MyInteger>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c, @StateId(stateId) ValueState<MyInteger> state,
-              OutputReceiver<MyInteger> r) {
-            MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
-            r.output(currentValue);
-            state.write(new MyInteger(currentValue.getValue() + 1));
-          }
-        };
-
-    PCollection<MyInteger> output =
-        pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
-            .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
-
-    PAssert.that(output).containsInAnyOrder(new MyInteger(0), new MyInteger(1), new MyInteger(2));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateCoderInferenceFailure() throws Exception {
-    final String stateId = "foo";
-    MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
-
-    DoFn<KV<String, Integer>, MyInteger> fn =
-        new DoFn<KV<String, Integer>, MyInteger>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<MyInteger>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(@StateId(stateId) ValueState<MyInteger> state,
-                                     OutputReceiver<MyInteger> r) {
-            MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
-            r.output(currentValue);
-            state.write(new MyInteger(currentValue.getValue() + 1));
-          }
-        };
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Unable to infer a coder for ValueState and no Coder was specified.");
-
-    pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
-        .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateCoderInferenceFromInputCoder() {
-    final String stateId = "foo";
-    MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
-
-    DoFn<KV<String, MyInteger>, MyInteger> fn =
-        new DoFn<KV<String, MyInteger>, MyInteger>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<MyInteger>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(@StateId(stateId) ValueState<MyInteger> state,
-                                     OutputReceiver<MyInteger> r) {
-            MyInteger currentValue = MoreObjects.firstNonNull(state.read(), new MyInteger(0));
-            r.output(currentValue);
-            state.write(new MyInteger(currentValue.getValue() + 1));
-          }
-        };
-
-        pipeline
-            .apply(Create.of(KV.of("hello", new MyInteger(42)),
-                KV.of("hello", new MyInteger(97)), KV.of("hello", new MyInteger(84)))
-                .withCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder)))
-            .apply(ParDo.of(fn)).setCoder(myIntegerCoder);
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testCoderInferenceOfList() {
-    final String stateId = "foo";
-    MyIntegerCoder myIntegerCoder = MyIntegerCoder.of();
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
-
-    DoFn<KV<String, Integer>, List<MyInteger>> fn =
-        new DoFn<KV<String, Integer>, List<MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<List<MyInteger>>> intState =
-              StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) ValueState<List<MyInteger>> state,
-              OutputReceiver<List<MyInteger>> r) {
-            MyInteger myInteger = new MyInteger(element.getValue());
-            List<MyInteger> currentValue = state.read();
-            List<MyInteger> newValue = currentValue != null
-                ? ImmutableList.<MyInteger>builder().addAll(currentValue).add(myInteger).build()
-                : Collections.singletonList(myInteger);
-            r.output(newValue);
-            state.write(newValue);
-          }
-        };
-
-    pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
-        .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateFixedWindows() {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(
-              @StateId(stateId) ValueState<Integer> state, OutputReceiver<Integer> r) {
-            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
-            r.output(currentValue);
-            state.write(currentValue + 1);
-          }
-        };
-
-    IntervalWindow firstWindow = new IntervalWindow(new Instant(0), new Instant(10));
-    IntervalWindow secondWindow = new IntervalWindow(new Instant(10), new Instant(20));
-
-    PCollection<Integer> output =
-        pipeline
-            .apply(
-                Create.timestamped(
-                    // first window
-                    TimestampedValue.of(KV.of("hello", 7), new Instant(1)),
-                    TimestampedValue.of(KV.of("hello", 14), new Instant(2)),
-                    TimestampedValue.of(KV.of("hello", 21), new Instant(3)),
-
-                    // second window
-                    TimestampedValue.of(KV.of("hello", 28), new Instant(11)),
-                    TimestampedValue.of(KV.of("hello", 35), new Instant(13))))
-            .apply(Window.into(FixedWindows.of(Duration.millis(10))))
-            .apply("Stateful ParDo", ParDo.of(fn));
-
-    PAssert.that(output).inWindow(firstWindow).containsInAnyOrder(0, 1, 2);
-    PAssert.that(output).inWindow(secondWindow).containsInAnyOrder(0, 1);
-    pipeline.run();
-  }
-
-  /**
-   * Tests that there is no state bleeding between adjacent stateful {@link ParDo} transforms,
-   * which may (or may not) be executed in similar contexts after runner optimizations.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateSameId() {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, KV<String, Integer>> fn =
-        new DoFn<KV<String, Integer>, KV<String, Integer>>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(@StateId(stateId) ValueState<Integer> state,
-                                     OutputReceiver<KV<String, Integer>> r) {
-            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
-            r.output(KV.of("sizzle", currentValue));
-            state.write(currentValue + 1);
-          }
-        };
-
-    DoFn<KV<String, Integer>, Integer> fn2 =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(@StateId(stateId) ValueState<Integer> state,
-                                     OutputReceiver<Integer> r) {
-            Integer currentValue = MoreObjects.firstNonNull(state.read(), 13);
-            r.output(currentValue);
-            state.write(currentValue + 13);
-          }
-        };
-
-    PCollection<KV<String, Integer>> intermediate =
-        pipeline.apply(Create.of(KV.of("hello", 42), KV.of("hello", 97), KV.of("hello", 84)))
-            .apply("First stateful ParDo", ParDo.of(fn));
-
-    PCollection<Integer> output =
-            intermediate.apply("Second stateful ParDo", ParDo.of(fn2));
-
-    PAssert.that(intermediate)
-        .containsInAnyOrder(KV.of("sizzle", 0), KV.of("sizzle", 1), KV.of("sizzle", 2));
-    PAssert.that(output).containsInAnyOrder(13, 26, 39);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testValueStateTaggedOutput() {
-    final String stateId = "foo";
-
-    final TupleTag<Integer> evenTag = new TupleTag<Integer>() {};
-    final TupleTag<Integer> oddTag = new TupleTag<Integer>() {};
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> intState =
-              StateSpecs.value(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(
-              @StateId(stateId) ValueState<Integer> state, MultiOutputReceiver r) {
-            Integer currentValue = MoreObjects.firstNonNull(state.read(), 0);
-            if (currentValue % 2 == 0) {
-              r.get(evenTag).output(currentValue);
-            } else {
-              r.get(oddTag).output(currentValue);
-            }
-            state.write(currentValue + 1);
-          }
-        };
-
-    PCollectionTuple output =
-        pipeline.apply(
-                Create.of(
-                    KV.of("hello", 42),
-                    KV.of("hello", 97),
-                    KV.of("hello", 84),
-                    KV.of("goodbye", 33),
-                    KV.of("hello", 859),
-                    KV.of("goodbye", 83945)))
-            .apply(ParDo.of(fn).withOutputTags(evenTag, TupleTagList.of(oddTag)));
-
-    PCollection<Integer> evens = output.get(evenTag);
-    PCollection<Integer> odds = output.get(oddTag);
-
-    // There are 0 and 2 from "hello" and just 0 from "goodbye"
-    PAssert.that(evens).containsInAnyOrder(0, 2, 0);
-
-    // There are 1 and 3 from "hello" and just "1" from "goodbye"
-    PAssert.that(odds).containsInAnyOrder(1, 3, 1);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testBagState() {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, List<Integer>> fn =
-        new DoFn<KV<String, Integer>, List<Integer>>() {
-
-          @StateId(stateId)
-          private final StateSpec<BagState<Integer>> bufferState =
-              StateSpecs.bag(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) BagState<Integer> state,
-              OutputReceiver<List<Integer>> r) {
-            ReadableState<Boolean> isEmpty = state.isEmpty();
-            state.add(element.getValue());
-            assertFalse(isEmpty.read());
-            Iterable<Integer> currentValue = state.read();
-            if (Iterables.size(currentValue) >= 4) {
-              // Make sure that the cached Iterable doesn't change when new elements are added.
-              state.add(-1);
-              assertEquals(4, Iterables.size(currentValue));
-              assertEquals(5, Iterables.size(state.read()));
-
-              List<Integer> sorted = Lists.newArrayList(currentValue);
-              Collections.sort(sorted);
-              r.output(sorted);
-            }
-          }
-        };
-
-    PCollection<List<Integer>> output =
-        pipeline.apply(
-                Create.of(
-                    KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
-            .apply(ParDo.of(fn));
-
-    PAssert.that(output).containsInAnyOrder(Lists.newArrayList(12, 42, 84, 97));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testBagStateCoderInference() {
-    final String stateId = "foo";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
-
-    DoFn<KV<String, Integer>, List<MyInteger>> fn =
-        new DoFn<KV<String, Integer>, List<MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<BagState<MyInteger>> bufferState =
-              StateSpecs.bag();
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) BagState<MyInteger> state,
-              OutputReceiver<List<MyInteger>> r) {
-            state.add(new MyInteger(element.getValue()));
-            Iterable<MyInteger> currentValue = state.read();
-            if (Iterables.size(currentValue) >= 4) {
-              List<MyInteger> sorted = Lists.newArrayList(currentValue);
-              Collections.sort(sorted);
-              r.output(sorted);
-            }
-          }
-        };
-
-    PCollection<List<MyInteger>> output =
-        pipeline.apply(
-            Create.of(
-                KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
-            .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
-
-    PAssert.that(output).containsInAnyOrder(Lists.newArrayList(new MyInteger(12), new MyInteger(42),
-        new MyInteger(84), new MyInteger(97)));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testBagStateCoderInferenceFailure() throws Exception {
-    final String stateId = "foo";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-
-    DoFn<KV<String, Integer>, List<MyInteger>> fn =
-        new DoFn<KV<String, Integer>, List<MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<BagState<MyInteger>> bufferState =
-              StateSpecs.bag();
-
-          @ProcessElement
-          public void processElement(
-              @Element  KV<String, Integer> element,
-              @StateId(stateId) BagState<MyInteger> state,
-              OutputReceiver<List<MyInteger>> r) {
-            state.add(new MyInteger(element.getValue()));
-            Iterable<MyInteger> currentValue = state.read();
-            if (Iterables.size(currentValue) >= 4) {
-              List<MyInteger> sorted = Lists.newArrayList(currentValue);
-              Collections.sort(sorted);
-              r.output(sorted);
-            }
-          }
-        };
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Unable to infer a coder for BagState and no Coder was specified.");
-
-    pipeline.apply(
-        Create.of(
-            KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
-        .apply(ParDo.of(fn)).setCoder(ListCoder.of(myIntegerCoder));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
-  public void testSetState() {
-    final String stateId = "foo";
-    final String countStateId = "count";
-
-    DoFn<KV<String, Integer>, Set<Integer>> fn =
-        new DoFn<KV<String, Integer>, Set<Integer>>() {
-
-          @StateId(stateId)
-          private final StateSpec<SetState<Integer>> setState =
-              StateSpecs.set(VarIntCoder.of());
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) SetState<Integer> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<Set<Integer>> r) {
-            ReadableState<Boolean> isEmpty = state.isEmpty();
-            state.add(element.getValue());
-            assertFalse(isEmpty.read());
-            count.add(1);
-            if (count.read() >= 4) {
-              // Make sure that the cached Iterable doesn't change when new elements are added.
-              Iterable<Integer> ints = state.read();
-              state.add(-1);
-              assertEquals(3, Iterables.size(ints));
-              assertEquals(4, Iterables.size(state.read()));
-
-              Set<Integer> set = Sets.newHashSet(ints);
-              r.output(set);
-            }
-          }
-        };
-
-    PCollection<Set<Integer>> output =
-        pipeline.apply(
-            Create.of(
-                KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
-            .apply(ParDo.of(fn));
-
-    PAssert.that(output).containsInAnyOrder(Sets.newHashSet(97, 42, 12));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
-  public void testSetStateCoderInference() {
-    final String stateId = "foo";
-    final String countStateId = "count";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
-
-    DoFn<KV<String, Integer>, Set<MyInteger>> fn =
-        new DoFn<KV<String, Integer>, Set<MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<SetState<MyInteger>> setState = StateSpecs.set();
-
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) SetState<MyInteger> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<Set<MyInteger>> r) {
-            state.add(new MyInteger(element.getValue()));
-            count.add(1);
-            if (count.read() >= 4) {
-              Set<MyInteger> set = Sets.newHashSet(state.read());
-              r.output(set);
-            }
-          }
-        };
-
-    PCollection<Set<MyInteger>> output =
-        pipeline.apply(
-            Create.of(
-                KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
-            .apply(ParDo.of(fn)).setCoder(SetCoder.of(myIntegerCoder));
-
-    PAssert.that(output).containsInAnyOrder(
-        Sets.newHashSet(new MyInteger(97), new MyInteger(42), new MyInteger(12)));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSetState.class})
-  public void testSetStateCoderInferenceFailure() throws Exception {
-    final String stateId = "foo";
-    final String countStateId = "count";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-
-    DoFn<KV<String, Integer>, Set<MyInteger>> fn =
-        new DoFn<KV<String, Integer>, Set<MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<SetState<MyInteger>> setState = StateSpecs.set();
-
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) SetState<MyInteger> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<Set<MyInteger>> r) {
-            state.add(new MyInteger(element.getValue()));
-            count.add(1);
-            if (count.read() >= 4) {
-              Set<MyInteger> set = Sets.newHashSet(state.read());
-              r.output(set);
-            }
-          }
-        };
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Unable to infer a coder for SetState and no Coder was specified.");
-
-    pipeline.apply(
-        Create.of(
-            KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 42), KV.of("hello", 12)))
-        .apply(ParDo.of(fn)).setCoder(SetCoder.of(myIntegerCoder));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
-  public void testMapState() {
-    final String stateId = "foo";
-    final String countStateId = "count";
-
-    DoFn<KV<String, KV<String, Integer>>, KV<String, Integer>> fn =
-        new DoFn<KV<String, KV<String, Integer>>, KV<String, Integer>>() {
-
-          @StateId(stateId)
-          private final StateSpec<MapState<String, Integer>> mapState =
-              StateSpecs.map(StringUtf8Coder.of(), VarIntCoder.of());
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c,
-              @Element KV<String, KV<String, Integer>> element,
-              @StateId(stateId) MapState<String, Integer> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<KV<String, Integer>> r) {
-            KV<String, Integer> value = element.getValue();
-            ReadableState<Iterable<Entry<String, Integer>>> entriesView = state.entries();
-            state.put(value.getKey(), value.getValue());
-            count.add(1);
-            if (count.read() >= 4) {
-              Iterable<Map.Entry<String, Integer>> iterate = state.entries().read();
-              // Make sure that the cached Iterable doesn't change when new elements are added, but
-              // that cached ReadableState views of the state do change.
-              state.put("BadKey", -1);
-              assertEquals(3, Iterables.size(iterate));
-              assertEquals(4, Iterables.size(entriesView.read()));
-              assertEquals(4, Iterables.size(state.entries().read()));
-
-              for (Map.Entry<String, Integer> entry : iterate) {
-                r.output(KV.of(entry.getKey(), entry.getValue()));
-              }
-            }
-          }
-        };
-
-    PCollection<KV<String, Integer>> output =
-        pipeline.apply(
-            Create.of(
-                KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
-                KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
-            .apply(ParDo.of(fn));
-
-    PAssert.that(output).containsInAnyOrder(KV.of("a", 97), KV.of("b", 42), KV.of("c", 12));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
-  public void testMapStateCoderInference() {
-    final String stateId = "foo";
-    final String countStateId = "count";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, myIntegerCoder);
-
-    DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>> fn =
-        new DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<MapState<String, MyInteger>> mapState = StateSpecs.map();
-
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, KV<String, Integer>> element,
-              @StateId(stateId) MapState<String, MyInteger> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<KV<String, MyInteger>> r) {
-            KV<String, Integer> value = element.getValue();
-            state.put(value.getKey(), new MyInteger(value.getValue()));
-            count.add(1);
-            if (count.read() >= 4) {
-              Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
-              for (Map.Entry<String, MyInteger> entry : iterate) {
-                r.output(KV.of(entry.getKey(), entry.getValue()));
-              }
-            }
-          }
-        };
-
-    PCollection<KV<String, MyInteger>> output =
-        pipeline.apply(
-            Create.of(
-                KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
-                KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
-            .apply(ParDo.of(fn)).setCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder));
-
-    PAssert.that(output).containsInAnyOrder(KV.of("a", new MyInteger(97)),
-        KV.of("b", new MyInteger(42)), KV.of("c", new MyInteger(12)));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesMapState.class})
-  public void testMapStateCoderInferenceFailure() throws Exception {
-    final String stateId = "foo";
-    final String countStateId = "count";
-    Coder<MyInteger> myIntegerCoder = MyIntegerCoder.of();
-
-    DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>> fn =
-        new DoFn<KV<String, KV<String, Integer>>, KV<String, MyInteger>>() {
-
-          @StateId(stateId)
-          private final StateSpec<MapState<String, MyInteger>> mapState = StateSpecs.map();
-
-          @StateId(countStateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>>
-              countState = StateSpecs.combiningFromInputInternal(VarIntCoder.of(),
-              Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c,
-              @Element KV<String, KV<String, Integer>> element,
-              @StateId(stateId) MapState<String, MyInteger> state,
-              @StateId(countStateId) CombiningState<Integer, int[], Integer> count,
-              OutputReceiver<KV<String, MyInteger>> r) {
-            KV<String, Integer> value = element.getValue();
-            state.put(value.getKey(), new MyInteger(value.getValue()));
-            count.add(1);
-            if (count.read() >= 4) {
-              Iterable<Map.Entry<String, MyInteger>> iterate = state.entries().read();
-              for (Map.Entry<String, MyInteger> entry : iterate) {
-                r.output(KV.of(entry.getKey(), entry.getValue()));
-              }
-            }
-          }
-        };
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Unable to infer a coder for MapState and no Coder was specified.");
-
-    pipeline.apply(
-        Create.of(
-            KV.of("hello", KV.of("a", 97)), KV.of("hello", KV.of("b", 42)),
-            KV.of("hello", KV.of("b", 42)), KV.of("hello", KV.of("c", 12))))
-        .apply(ParDo.of(fn)).setCoder(KvCoder.of(StringUtf8Coder.of(), myIntegerCoder));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testCombiningState() {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Double>, String> fn =
-        new DoFn<KV<String, Double>, String>() {
-
-          private static final double EPSILON = 0.0001;
-
-          @StateId(stateId)
-          private final StateSpec<CombiningState<Double, CountSum<Double>, Double>> combiningState =
-              StateSpecs.combining(new Mean.CountSumCoder<Double>(), Mean.of());
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c,
-              @Element KV<String, Double> element,
-              @StateId(stateId) CombiningState<Double, CountSum<Double>, Double> state,
-              OutputReceiver<String> r) {
-            state.add(element.getValue());
-            Double currentValue = state.read();
-            if (Math.abs(currentValue - 0.5) < EPSILON) {
-              r.output("right on");
-            }
-          }
-        };
-
-    PCollection<String> output =
-        pipeline
-            .apply(Create.of(KV.of("hello", 0.3), KV.of("hello", 0.6), KV.of("hello", 0.6)))
-            .apply(ParDo.of(fn));
-
-    // There should only be one moment at which the average is exactly 0.5
-    PAssert.that(output).containsInAnyOrder("right on");
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testCombiningStateCoderInference() {
-    pipeline.getCoderRegistry().registerCoderForClass(MyInteger.class, MyIntegerCoder.of());
-
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, String> fn =
-        new DoFn<KV<String, Integer>, String>() {
-          private static final int EXPECTED_SUM = 16;
-
-          @StateId(stateId)
-          private final StateSpec<CombiningState<Integer, MyInteger, Integer>> combiningState =
-              StateSpecs.combining(
-                  new Combine.CombineFn<Integer, MyInteger, Integer>() {
-                    @Override
-                    public MyInteger createAccumulator() {
-                      return new MyInteger(0);
-                    }
-
-                    @Override
-                    public MyInteger addInput(MyInteger accumulator, Integer input) {
-                      return new MyInteger(accumulator.getValue() + input);
-                    }
-
-                    @Override
-                    public MyInteger mergeAccumulators(Iterable<MyInteger> accumulators) {
-                      int newValue = 0;
-                      for (MyInteger myInteger : accumulators) {
-                        newValue += myInteger.getValue();
-                      }
-                      return new MyInteger(newValue);
-                    }
-
-                    @Override
-                    public Integer extractOutput(MyInteger accumulator) {
-                      return accumulator.getValue();
-                    }
-                  });
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) CombiningState<Integer, MyInteger, Integer> state,
-              OutputReceiver<String> r) {
-            state.add(element.getValue());
-            Integer currentValue = state.read();
-            if (currentValue == EXPECTED_SUM) {
-              r.output("right on");
-            }
-          }
-        };
-
-    PCollection<String> output =
-        pipeline
-            .apply(Create.of(KV.of("hello", 3), KV.of("hello", 6), KV.of("hello", 7)))
-            .apply(ParDo.of(fn));
-
-    // There should only be one moment at which the average is exactly 16
-    PAssert.that(output).containsInAnyOrder("right on");
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testCombiningStateCoderInferenceFailure() throws Exception {
-    final String stateId = "foo";
-
-    DoFn<KV<String, Integer>, String> fn =
-        new DoFn<KV<String, Integer>, String>() {
-          private static final int EXPECTED_SUM = 16;
-
-          @StateId(stateId)
-          private final StateSpec<CombiningState<Integer, MyInteger, Integer>> combiningState =
-              StateSpecs.combining(
-                  new Combine.CombineFn<Integer, MyInteger, Integer>() {
-                    @Override
-                    public MyInteger createAccumulator() {
-                      return new MyInteger(0);
-                    }
-
-                    @Override
-                    public MyInteger addInput(MyInteger accumulator, Integer input) {
-                      return new MyInteger(accumulator.getValue() + input);
-                    }
-
-                    @Override
-                    public MyInteger mergeAccumulators(Iterable<MyInteger> accumulators) {
-                      int newValue = 0;
-                      for (MyInteger myInteger : accumulators) {
-                        newValue += myInteger.getValue();
-                      }
-                      return new MyInteger(newValue);
-                    }
-
-                    @Override
-                    public Integer extractOutput(MyInteger accumulator) {
-                      return accumulator.getValue();
-                    }
-                  });
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<String, Integer> element,
-              @StateId(stateId) CombiningState<Integer, MyInteger, Integer> state,
-              OutputReceiver<String> r) {
-            state.add(element.getValue());
-            Integer currentValue = state.read();
-            if (currentValue == EXPECTED_SUM) {
-              r.output("right on");
-            }
-          }
-        };
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Unable to infer a coder for CombiningState and no Coder was specified.");
-
-    pipeline
-        .apply(Create.of(KV.of("hello", 3), KV.of("hello", 6), KV.of("hello", 7)))
-        .apply(ParDo.of(fn));
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testCombiningStateParameterSuperclass() {
-    final String stateId = "foo";
-
-    DoFn<KV<Integer, Integer>, String> fn =
-        new DoFn<KV<Integer, Integer>, String>() {
-          private static final int EXPECTED_SUM = 8;
-
-          @StateId(stateId)
-          private final StateSpec<CombiningState<Integer, int[], Integer>> state =
-              StateSpecs.combining(Sum.ofIntegers());
-
-          @ProcessElement
-          public void processElement(
-              @Element KV<Integer, Integer> element,
-              @StateId(stateId) GroupingState<Integer, Integer> state,
-              OutputReceiver<String> r) {
-            state.add(element.getValue());
-            Integer currentValue = state.read();
-            if (currentValue == EXPECTED_SUM) {
-              r.output("right on");
-            }
-          }
-        };
-
-    PCollection<String> output =
-        pipeline
-            .apply(Create.of(KV.of(123, 4), KV.of(123, 7), KV.of(123, -3)))
-            .apply(ParDo.of(fn));
-
-    // There should only be one moment at which the sum is exactly 8
-    PAssert.that(output).containsInAnyOrder("right on");
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
-  public void testBagStateSideInput() {
-
-    final PCollectionView<List<Integer>> listView =
-        pipeline.apply("Create list for side input", Create.of(2, 1, 0)).apply(View.asList());
-
-    final String stateId = "foo";
-    DoFn<KV<String, Integer>, List<Integer>> fn =
-        new DoFn<KV<String, Integer>, List<Integer>>() {
-
-          @StateId(stateId)
-          private final StateSpec<BagState<Integer>> bufferState =
-              StateSpecs.bag(VarIntCoder.of());
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext c,
-              @Element KV<String, Integer>  element,
-              @StateId(stateId) BagState<Integer> state,
-              OutputReceiver<List<Integer>> r) {
-            state.add(element.getValue());
-            Iterable<Integer> currentValue = state.read();
-            if (Iterables.size(currentValue) >= 4) {
-              List<Integer> sorted = Lists.newArrayList(currentValue);
-              Collections.sort(sorted);
-              r.output(sorted);
-
-              List<Integer> sideSorted = Lists.newArrayList(c.sideInput(listView));
-              Collections.sort(sideSorted);
-              r.output(sideSorted);
-            }
-          }
-        };
-
-    PCollection<List<Integer>> output =
-        pipeline.apply(
-                "Create main input",
-                Create.of(
-                    KV.of("hello", 97), KV.of("hello", 42), KV.of("hello", 84), KV.of("hello", 12)))
-            .apply(ParDo.of(fn).withSideInputs(listView));
-
-    PAssert.that(output).containsInAnyOrder(
-        Lists.newArrayList(12, 42, 84, 97),
-        Lists.newArrayList(0, 1, 2));
-    pipeline.run();
-  }
-
-  /**
-   * Tests that an event time timer fires and results in supplementary output.
-   *
-   * <p>This test relies on two properties:
-   *
-   * <ol>
-   * <li>A timer that is set on time should always get a chance to fire. For this to be true, timers
-   *     per-key-and-window must be delivered in order so the timer is not wiped out until the
-   *     window is expired by the runner.
-   * <li>A {@link Create} transform sends its elements on time, and later advances the watermark to
-   *     infinity
-   * </ol>
-   *
-   * <p>Note that {@link TestStream} is not applicable because it requires very special runner hooks
-   * and is only supported by the direct runner.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testEventTimeTimerBounded() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            r.output(3);
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
-            if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
-              r.output(42);
-            }
-          }
-        };
-
-    PCollection<Integer> output = pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(3, 42);
-    pipeline.run();
-  }
-
-  /**
-   * Tests a GBK followed immediately by a {@link ParDo} that users timers. This checks a common
-   * case where both GBK and the user code share a timer delivery bundle.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testGbkFollowedByUserTimers() throws Exception {
-
-    DoFn<KV<String, Iterable<Integer>>, Integer> fn =
-        new DoFn<KV<String, Iterable<Integer>>, Integer>() {
-
-          public static final String TIMER_ID = "foo";
-
-          @TimerId(TIMER_ID)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(TIMER_ID) Timer timer, OutputReceiver<Integer> r) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            r.output(3);
-          }
-
-          @OnTimer(TIMER_ID)
-          public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
-            if (timeDomain.equals(TimeDomain.EVENT_TIME)) {
-              r.output(42);
-            }
-          }
-        };
-
-    PCollection<Integer> output =
-        pipeline
-            .apply(Create.of(KV.of("hello", 37)))
-            .apply(GroupByKey.create())
-            .apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(3, 42);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testEventTimeTimerAlignBounded() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
-        new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer,
-                                     @Timestamp Instant timestamp,
-                                     OutputReceiver<KV<Integer, Instant>> r) {
-            timer.align(Duration.standardSeconds(1)).offset(Duration.millis(1)).setRelative();
-            r.output(KV.of(3, timestamp));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(@Timestamp Instant timestamp,
-                              OutputReceiver<KV<Integer, Instant>> r) {
-            r.output(KV.of(42, timestamp));
-          }
-        };
-
-    PCollection<KV<Integer, Instant>> output =
-        pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(KV.of(3, BoundedWindow.TIMESTAMP_MIN_VALUE),
-        KV.of(42, BoundedWindow.TIMESTAMP_MIN_VALUE.plus(1774)));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testTimerReceivedInOriginalWindow() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, BoundedWindow> fn =
-        new DoFn<KV<String, Integer>, BoundedWindow>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(BoundedWindow window, OutputReceiver<BoundedWindow> r) {
-            r.output(window);
-          }
-
-          public TypeDescriptor<BoundedWindow> getOutputTypeDescriptor() {
-            return (TypeDescriptor) TypeDescriptor.of(IntervalWindow.class);
-          }
-        };
-
-    SlidingWindows windowing =
-        SlidingWindows.of(Duration.standardMinutes(3)).every(Duration.standardMinutes(1));
-    PCollection<BoundedWindow> output =
-        pipeline
-            .apply(Create.timestamped(TimestampedValue.of(KV.of("hello", 24), new Instant(0L))))
-            .apply(Window.into(windowing))
-            .apply(ParDo.of(fn));
-
-    PAssert.that(output)
-        .containsInAnyOrder(
-            new IntervalWindow(new Instant(0), Duration.standardMinutes(3)),
-            new IntervalWindow(
-                new Instant(0).minus(Duration.standardMinutes(1)), Duration.standardMinutes(3)),
-            new IntervalWindow(
-                new Instant(0).minus(Duration.standardMinutes(2)), Duration.standardMinutes(3)));
-    pipeline.run();
-  }
-
-  /**
-   * Tests that an event time timer set absolutely for the last possible moment fires and results in
-   * supplementary output. The test is otherwise identical to {@link #testEventTimeTimerBounded()}.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testEventTimeTimerAbsolute() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer, BoundedWindow window,
-                                     OutputReceiver<Integer> r) {
-            timer.set(window.maxTimestamp());
-            r.output(3);
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(OutputReceiver<Integer> r) {
-            r.output(42);
-          }
-        };
-
-    PCollection<Integer> output = pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(3, 42);
-    pipeline.run();
-  }
-
-  @Ignore(
-      "https://issues.apache.org/jira/browse/BEAM-2791, "
-          + "https://issues.apache.org/jira/browse/BEAM-2535")
-  @Test
-  @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesTimersInParDo.class})
-  public void testEventTimeTimerLoop() {
-    final String stateId = "count";
-    final String timerId = "timer";
-    final int loopCount = 5;
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec loopSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<Integer>> countSpec = StateSpecs.value();
-
-          @ProcessElement
-          public void processElement(
-              @StateId(stateId) ValueState<Integer> countState, @TimerId(timerId) Timer loopTimer) {
-            loopTimer.offset(Duration.millis(1)).setRelative();
-          }
-
-          @OnTimer(timerId)
-          public void onLoopTimer(
-              @StateId(stateId) ValueState<Integer> countState,
-              @TimerId(timerId) Timer loopTimer,
-              OutputReceiver<Integer> r) {
-            int count = MoreObjects.firstNonNull(countState.read(), 0);
-            if (count < loopCount) {
-              r.output(count);
-              countState.write(count + 1);
-              loopTimer.offset(Duration.millis(1)).setRelative();
-            }
-          }
-        };
-
-    PCollection<Integer> output = pipeline.apply(Create.of(KV.of("hello", 42))).apply(ParDo.of(fn));
-
-    PAssert.that(output).containsInAnyOrder(0, 1, 2, 3, 4);
-    pipeline.run();
-  }
-
-  /**
-   * Tests that event time timers for multiple keys both fire. This particularly exercises
-   * implementations that may GC in ways not simply governed by the watermark.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testEventTimeTimerMultipleKeys() throws Exception {
-    final String timerId = "foo";
-    final String stateId = "sizzle";
-
-    final int offset = 5000;
-    final int timerOutput = 4093;
-
-    DoFn<KV<String, Integer>, KV<String, Integer>> fn =
-        new DoFn<KV<String, Integer>, KV<String, Integer>>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @StateId(stateId)
-          private final StateSpec<ValueState<String>> stateSpec =
-              StateSpecs.value(StringUtf8Coder.of());
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext context,
-              @TimerId(timerId) Timer timer,
-              @StateId(stateId) ValueState<String> state,
-              BoundedWindow window) {
-            timer.set(window.maxTimestamp());
-            state.write(context.element().getKey());
-            context.output(
-                KV.of(context.element().getKey(), context.element().getValue() + offset));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(@StateId(stateId) ValueState<String> state,
-                              OutputReceiver<KV<String, Integer>> r) {
-            r.output(KV.of(state.read(), timerOutput));
-          }
-        };
-
-    // Enough keys that we exercise interesting code paths
-    int numKeys = 50;
-    List<KV<String, Integer>> input = new ArrayList<>();
-    List<KV<String, Integer>> expectedOutput = new ArrayList<>();
-
-    for (Integer key = 0; key < numKeys; ++key) {
-      // Each key should have just one final output at GC time
-      expectedOutput.add(KV.of(key.toString(), timerOutput));
-
-      for (int i = 0; i < 15; ++i) {
-        // Each input should be output with the offset added
-        input.add(KV.of(key.toString(), i));
-        expectedOutput.add(KV.of(key.toString(), i + offset));
-      }
-    }
-
-    Collections.shuffle(input);
-
-    PCollection<KV<String, Integer>> output =
-        pipeline
-            .apply(
-                Create.of(input))
-            .apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(expectedOutput);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testAbsoluteProcessingTimeTimerRejected() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer) {
-            timer.set(new Instant(0));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer() {}
-        };
-
-    pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    thrown.expect(RuntimeException.class);
-    // Note that runners can reasonably vary their message - this matcher should be flexible
-    // and can be evolved.
-    thrown.expectMessage("relative timers");
-    thrown.expectMessage("processing time");
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testOutOfBoundsEventTimeTimer() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(
-              ProcessContext context, BoundedWindow window, @TimerId(timerId) Timer timer) {
-            timer.set(window.maxTimestamp().plus(1L));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer() {}
-        };
-
-    pipeline.apply(Create.of(KV.of("hello", 37))).apply(ParDo.of(fn));
-    thrown.expect(RuntimeException.class);
-    // Note that runners can reasonably vary their message - this matcher should be flexible
-    // and can be evolved.
-    thrown.expectMessage("event time timer");
-    thrown.expectMessage("expiration");
-    pipeline.run();
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testSimpleProcessingTimerTimer() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            r.output(3);
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(TimeDomain timeDomain, OutputReceiver<Integer> r) {
-            if (timeDomain.equals(TimeDomain.PROCESSING_TIME)) {
-              r.output(42);
-            }
-          }
-        };
-
-    TestStream<KV<String, Integer>> stream =
-        TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()))
-            .addElements(KV.of("hello", 37))
-            .advanceProcessingTime(Duration.standardSeconds(2))
-            .advanceWatermarkToInfinity();
-
-    PCollection<Integer> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(3, 42);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testEventTimeTimerUnbounded() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, Integer> fn =
-        new DoFn<KV<String, Integer>, Integer>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer, OutputReceiver<Integer> r) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            r.output(3);
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(OutputReceiver<Integer> r) {
-            r.output(42);
-          }
-        };
-
-    TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
-        .of(StringUtf8Coder.of(), VarIntCoder.of()))
-        .advanceWatermarkTo(new Instant(0))
-        .addElements(KV.of("hello", 37))
-        .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(1)))
-        .advanceWatermarkToInfinity();
-
-    PCollection<Integer> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(3, 42);
-    pipeline.run();
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testEventTimeTimerAlignUnbounded() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
-        new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(@TimerId(timerId) Timer timer,
-                                     @Timestamp Instant timestamp,
-                                     OutputReceiver<KV<Integer, Instant>> r) {
-            timer.align(Duration.standardSeconds(1)).offset(Duration.millis(1)).setRelative();
-            r.output(KV.of(3, timestamp));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(@Timestamp Instant timestamp,
-                              OutputReceiver<KV<Integer, Instant>> r) {
-            r.output(KV.of(42, timestamp));
-          }
-        };
-
-    TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
-        .of(StringUtf8Coder.of(), VarIntCoder.of()))
-        .advanceWatermarkTo(new Instant(5))
-        .addElements(KV.of("hello", 37))
-        .advanceWatermarkTo(new Instant(0).plus(Duration.standardSeconds(1).plus(1)))
-        .advanceWatermarkToInfinity();
-
-    PCollection<KV<Integer, Instant>> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(KV.of(3, new Instant(5)),
-        KV.of(42, new Instant(Duration.standardSeconds(1).minus(1).getMillis())));
-    pipeline.run();
-  }
-
-  @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testEventTimeTimerAlignAfterGcTimeUnbounded() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, Integer>, KV<Integer, Instant>> fn =
-        new DoFn<KV<String, Integer>, KV<Integer, Instant>>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
-            // This aligned time will exceed the END_OF_GLOBAL_WINDOW
-            timer.align(Duration.standardDays(1)).setRelative();
-            context.output(KV.of(3, context.timestamp()));
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(@Timestamp Instant timestamp,
-                              OutputReceiver<KV<Integer, Instant>> r) {
-            r.output(KV.of(42, timestamp));
-          }
-        };
-
-    TestStream<KV<String, Integer>> stream = TestStream.create(KvCoder
-        .of(StringUtf8Coder.of(), VarIntCoder.of()))
-        // See GlobalWindow,
-        // END_OF_GLOBAL_WINDOW is TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))
-        .advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1)))
-        .addElements(KV.of("hello", 37))
-        .advanceWatermarkToInfinity();
-
-    PCollection<KV<Integer, Instant>> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    PAssert.that(output).containsInAnyOrder(
-        KV.of(3, BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))),
-        KV.of(42, BoundedWindow.TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1))));
-    pipeline.run();
-  }
-
-  /**
-   * A test makes sure that a processing time timer should reset rather than creating duplicate
-   * timers when a "set" method is called on it before it goes off.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testProcessingTimeTimerCanBeReset() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, String>, String> fn =
-        new DoFn<KV<String, String>, String>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
-
-          @ProcessElement
-          public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            context.output(context.element().getValue());
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(OutputReceiver<String> r) {
-            r.output("timer_output");
-          }
-        };
-
-    TestStream<KV<String, String>> stream =
-        TestStream.create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
-            .addElements(KV.of("key", "input1"))
-            .addElements(KV.of("key", "input2"))
-            .advanceProcessingTime(Duration.standardSeconds(2))
-            .advanceWatermarkToInfinity();
-
-    PCollection<String> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    // Timer "foo" is set twice because input1 and input 2 are outputted. However, only one
-    // "timer_output" is outputted. Therefore, the timer is overwritten.
-    PAssert.that(output).containsInAnyOrder("input1", "input2", "timer_output");
-    pipeline.run();
-  }
-
-  /**
-   * A test makes sure that an event time timer should reset rather than creating duplicate
-   * timers when a "set" method is called on it before it goes off.
-   */
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class, UsesTestStream.class})
-  public void testEventTimeTimerCanBeReset() throws Exception {
-    final String timerId = "foo";
-
-    DoFn<KV<String, String>, String> fn =
-        new DoFn<KV<String, String>, String>() {
-
-          @TimerId(timerId)
-          private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-          @ProcessElement
-          public void processElement(ProcessContext context, @TimerId(timerId) Timer timer) {
-            timer.offset(Duration.standardSeconds(1)).setRelative();
-            context.output(context.element().getValue());
-          }
-
-          @OnTimer(timerId)
-          public void onTimer(OutputReceiver<String> r) {
-            r.output("timer_output");
-          }
-        };
-
-    TestStream<KV<String, String>> stream = TestStream.create(KvCoder
-        .of(StringUtf8Coder.of(), StringUtf8Coder.of()))
-        .advanceWatermarkTo(new Instant(0))
-        .addElements(KV.of("hello", "input1"))
-        .addElements(KV.of("hello", "input2"))
-        .advanceWatermarkToInfinity();
-
-    PCollection<String> output = pipeline.apply(stream).apply(ParDo.of(fn));
-    // Timer "foo" is set twice because input1 and input 2 are outputted. However, only one
-    // "timer_output" is outputted. Therefore, the timer is overwritten.
-    PAssert.that(output).containsInAnyOrder("input1", "input2", "timer_output");
-    pipeline.run();
-  }
-
-  @Test
-  public void testWithOutputTagsDisplayData() {
-    DoFn<String, String> fn = new DoFn<String, String>() {
-      @ProcessElement
-      public void proccessElement(ProcessContext c) {}
-
-      @Override
-      public void populateDisplayData(Builder builder) {
-        builder.add(DisplayData.item("fnMetadata", "foobar"));
-      }
-    };
-
-    ParDo.MultiOutput<String, String> parDo =
-        ParDo.of(fn).withOutputTags(new TupleTag<>(), TupleTagList.empty());
-
-    DisplayData displayData = DisplayData.from(parDo);
-    assertThat(displayData, includesDisplayDataFor("fn", fn));
-    assertThat(displayData, hasDisplayItem("fn", fn.getClass()));
-  }
-
-  @Test
-  public void testRejectsWrongWindowType() {
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage(GlobalWindow.class.getSimpleName());
-    thrown.expectMessage(IntervalWindow.class.getSimpleName());
-    thrown.expectMessage("window type");
-    thrown.expectMessage("not a supertype");
-
-    pipeline
-        .apply(Create.of(1, 2, 3))
-        .apply(
-            ParDo.of(
-                new DoFn<Integer, Integer>() {
-                  @ProcessElement
-                  public void process(ProcessContext c, IntervalWindow w) {}
-                }));
-  }
-
-  /**
-   * Tests that it is OK to use different window types in the parameter lists to different
-   * {@link DoFn} functions, as long as they are all subtypes of the actual window type
-   * of the input.
-   *
-   * <p>Today, the only method other than {@link ProcessElement @ProcessElement} that can accept
-   * extended parameters is {@link OnTimer @OnTimer}, which is rejected before it reaches window
-   * type validation. Rather than delay validation, this test is temporarily disabled.
-   */
-  @Ignore("ParDo rejects this on account of it using timers")
-  @Test
-  public void testMultipleWindowSubtypesOK() {
-    final String timerId = "gobbledegook";
-
-    pipeline
-        .apply(Create.of(1, 2, 3))
-        .apply(Window.into(FixedWindows.of(Duration.standardSeconds(10))))
-        .apply(
-            ParDo.of(
-                new DoFn<Integer, Integer>() {
-                  @TimerId(timerId)
-                  private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-                  @ProcessElement
-                  public void process(ProcessContext c, IntervalWindow w) {}
-
-                  @OnTimer(timerId)
-                  public void onTimer(BoundedWindow w) {}
-                }));
-
-    // If it doesn't crash, we made it!
-  }
-
   /** A {@link PipelineOptions} subclass for testing passing to a {@link DoFn}. */
   public interface MyOptions extends PipelineOptions {
     @Default.String("fake option")
     String getFakeOption();
     void setFakeOption(String value);
-  }
-
-  @Test
-  @Category(ValidatesRunner.class)
-  public void testPipelineOptionsParameter() {
-    PCollection<String> results = pipeline
-        .apply(Create.of(1))
-        .apply(
-            ParDo.of(
-                new DoFn<Integer, String>() {
-                  @ProcessElement
-                  public void process(OutputReceiver<String> r, PipelineOptions options) {
-                    r.output(options.as(MyOptions.class).getFakeOption());
-                  }
-                }));
-
-    String testOptionValue = "not fake anymore";
-    pipeline.getOptions().as(MyOptions.class).setFakeOption(testOptionValue);
-    PAssert.that(results).containsInAnyOrder("not fake anymore");
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTimersInParDo.class})
-  public void testPipelineOptionsParameterOnTimer() {
-    final String timerId = "thisTimer";
-
-    PCollection<String> results =
-        pipeline
-            .apply(Create.of(KV.of(0, 0)))
-            .apply(
-                ParDo.of(
-                    new DoFn<KV<Integer, Integer>, String>() {
-                      @TimerId(timerId)
-                      private final TimerSpec spec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
-
-                      @ProcessElement
-                      public void process(
-                          ProcessContext c, BoundedWindow w, @TimerId(timerId) Timer timer) {
-                        timer.set(w.maxTimestamp());
-                      }
-
-                      @OnTimer(timerId)
-                      public void onTimer(OutputReceiver<String> r, PipelineOptions options) {
-                        r.output(options.as(MyOptions.class).getFakeOption());
-                      }
-                    }));
-
-    String testOptionValue = "not fake anymore";
-    pipeline.getOptions().as(MyOptions.class).setFakeOption(testOptionValue);
-    PAssert.that(results).containsInAnyOrder("not fake anymore");
-
-    pipeline.run();
-  }
-
-  @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
-  public void duplicateTimerSetting() {
-    TestStream<KV<String, String>> stream = TestStream
-        .create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
-        .addElements(KV.of("key1", "v1"))
-        .advanceWatermarkToInfinity();
-
-    PCollection<String> result = pipeline
-        .apply(stream)
-        .apply(ParDo.of(new TwoTimerDoFn()));
-    PAssert.that(result).containsInAnyOrder("It works");
-
-    pipeline.run().waitUntilFinish();
   }
 
   private static class TwoTimerDoFn extends DoFn<KV<String, String>, String> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PartitionTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PartitionTest.java
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Partition.PartitionFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
@@ -66,7 +65,7 @@ public class PartitionTest implements Serializable {
 
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testEvenOddPartition() {
 
     PCollectionList<Integer> outputs = pipeline

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SampleTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/SampleTest.java
@@ -41,9 +41,9 @@ import org.apache.beam.sdk.TestUtils;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.CombineFnTester;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
@@ -172,7 +172,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testPickAny() {
       runPickAnyTest(lines, limit);
     }
@@ -256,7 +256,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleAny() {
       PCollection<Integer> input =
           pipeline
@@ -276,7 +276,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleAnyEmpty() {
       PCollection<Integer> input = pipeline.apply(Create.empty(BigEndianIntegerCoder.of()));
       PCollection<Integer> output =
@@ -289,7 +289,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleAnyZero() {
       PCollection<Integer> input =
           pipeline.apply(
@@ -310,7 +310,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleAnyInsufficientElements() {
       PCollection<Integer> input = pipeline.apply(Create.empty(BigEndianIntegerCoder.of()));
       PCollection<Integer> output =
@@ -331,7 +331,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSample() {
 
       PCollection<Integer> input =
@@ -345,7 +345,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleEmpty() {
 
       PCollection<Integer> input = pipeline.apply(Create.empty(BigEndianIntegerCoder.of()));
@@ -357,7 +357,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleZero() {
 
       PCollection<Integer> input = pipeline.apply(Create.of(ImmutableList.copyOf(DATA))
@@ -370,7 +370,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleInsufficientElements() {
 
       PCollection<Integer> input =
@@ -394,7 +394,7 @@ public class SampleTest {
     }
 
     @Test
-    @Category(ValidatesRunner.class)
+    @Category(NeedsRunner.class)
     public void testSampleMultiplicity() {
 
       PCollection<Integer> input =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ToStringTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ToStringTest.java
@@ -22,9 +22,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.Rule;
@@ -42,7 +42,7 @@ public class ToStringTest {
   public final TestPipeline p = TestPipeline.create();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testToStringOf() {
     Integer[] ints = {1, 2, 3, 4, 5};
     String[] strings = {"1", "2", "3", "4", "5"};
@@ -53,7 +53,7 @@ public class ToStringTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testToStringKV() {
     ArrayList<KV<String, Integer>> kvs = new ArrayList<>();
     kvs.add(KV.of("one", 1));
@@ -70,7 +70,7 @@ public class ToStringTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testToStringKVWithDelimiter() {
     ArrayList<KV<String, Integer>> kvs = new ArrayList<>();
     kvs.add(KV.of("one", 1));
@@ -87,7 +87,7 @@ public class ToStringTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testToStringIterable() {
     ArrayList<Iterable<String>> iterables = new ArrayList<>();
     iterables.add(Arrays.asList(new String[]{"one", "two", "three"}));
@@ -105,7 +105,7 @@ public class ToStringTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testToStringIterableWithDelimiter() {
     ArrayList<Iterable<String>> iterables = new ArrayList<>();
     iterables.add(Arrays.asList(new String[]{"one", "two", "three"}));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ValuesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ValuesTest.java
@@ -23,9 +23,9 @@ import java.util.Arrays;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.Rule;
@@ -56,7 +56,7 @@ public class ValuesTest {
   public final TestPipeline p = TestPipeline.create();
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testValues() {
 
     PCollection<KV<String, Integer>> input =
@@ -72,7 +72,7 @@ public class ValuesTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void testValuesEmpty() {
 
     PCollection<KV<String, Integer>> input =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WithKeysTest.java
@@ -25,7 +25,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -157,7 +156,7 @@ public class WithKeysTest {
   }
 
   @Test
-  @Category(ValidatesRunner.class)
+  @Category(NeedsRunner.class)
   public void withLambdaAndTypeDescriptorShouldSucceed() {
 
     PCollection<String> values = p.apply(Create.of("1234", "3210", "0", "-12"));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -69,11 +69,11 @@ import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.testing.ExpectedLogs;
+import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.testing.UsesTestStream;
-import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFnTester;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -361,7 +361,7 @@ public class BigQueryIOWriteTest implements Serializable {
   }
 
   @Test
-  @Category({ValidatesRunner.class, UsesTestStream.class})
+  @Category({NeedsRunner.class, UsesTestStream.class})
   public void testTriggeredFileLoads() throws Exception {
     List<TableRow> elements = Lists.newArrayList();
     for (int i = 0; i < 30; ++i) {


### PR DESCRIPTION
Dataflow ValidatesRunner test suite has gotten obscenely slow due to the number of ValidatesRunner tests. There are currently over 250, and each one takes at least 3 minutes to run on Dataflow. Many of them don't actually need to be run on every worker, and this test converts them to `@NeedsRunner` tests instead.

Gradle also parallelizes tests differently, parallelizing at the test class level rather than per test case. As a result, the largest test class will be a bottleneck for the overall execution. This PR splits up large `@ValidatesRunner` test classes into scenario-based subclasses.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

