### PR TITLE
Consistently handle EmptyMatchTreatment

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -161,15 +161,16 @@ public class FileSystems {
   private static MatchResult maybeAdjustEmptyMatchResult(
       String spec, MatchResult res, EmptyMatchTreatment emptyMatchTreatment)
       throws IOException {
-    if (res.status() != Status.NOT_FOUND) {
-      return res;
-    }
-    boolean notFoundAllowed =
-        emptyMatchTreatment == EmptyMatchTreatment.ALLOW
-            || (FileSystems.hasGlobWildcard(spec)
-                && emptyMatchTreatment == EmptyMatchTreatment.ALLOW_IF_WILDCARD);
-    if (notFoundAllowed) {
-      return MatchResult.create(Status.OK, Collections.emptyList());
+    if (res.status() == Status.NOT_FOUND
+        || (res.status() == Status.OK && res.metadata().isEmpty())) {
+      boolean notFoundAllowed =
+          emptyMatchTreatment == EmptyMatchTreatment.ALLOW
+              || (hasGlobWildcard(spec)
+                  && emptyMatchTreatment == EmptyMatchTreatment.ALLOW_IF_WILDCARD);
+      return notFoundAllowed
+          ? MatchResult.create(Status.OK, Collections.emptyList())
+          : MatchResult.create(
+              Status.NOT_FOUND, new FileNotFoundException("No files matched spec: " + spec));
     }
     return res;
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileBasedSourceTest.java
@@ -450,7 +450,7 @@ public class FileBasedSourceTest {
     String missingFilePath = tempFolder.newFolder().getAbsolutePath() + "/missing.txt";
     TestFileBasedSource source = new TestFileBasedSource(missingFilePath, Long.MAX_VALUE, null);
     thrown.expect(FileNotFoundException.class);
-    thrown.expectMessage(String.format("No files found for spec: %s", missingFilePath));
+    thrown.expectMessage(missingFilePath);
     source.split(1234, options);
   }
 


### PR DESCRIPTION
Some FileSystem implementations (e.g. GCS for globs) don't return NOT_FOUND for empty matches.
It's better to handle this consistently in FileSystems, rather than add the same code to every FileSystem.

R: @chamikaramj 