### PR TITLE
[BEAM-2163] Remove the dependency on examples from ptransform_test

### DIFF
--- a/sdks/python/apache_beam/io/utils.py
+++ b/sdks/python/apache_beam/io/utils.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Utils for the io library.
+* CountingSource: Subclass of iobase.BoundedSource. Used
+on transforms.ptransform_test.test_read_metrics.
+"""
+
+from apache_beam.io import iobase
+from apache_beam.io.range_trackers import OffsetRangeTracker
+from apache_beam.metrics import Metrics
+
+
+class CountingSource(iobase.BoundedSource):
+
+  def __init__(self, count):
+    self.records_read = Metrics.counter(self.__class__, 'recordsRead')
+    self._count = count
+
+  def estimate_size(self):
+    return self._count
+
+  def get_range_tracker(self, start_position, stop_position):
+    if start_position is None:
+      start_position = 0
+    if stop_position is None:
+      stop_position = self._count
+
+    return OffsetRangeTracker(start_position, stop_position)
+
+  def read(self, range_tracker):
+    for i in range(self._count):
+      if not range_tracker.try_claim(i):
+        return
+      self.records_read.inc()
+      yield i
+
+  def split(self, desired_bundle_size, start_position=None,
+            stop_position=None):
+    if start_position is None:
+      start_position = 0
+    if stop_position is None:
+      stop_position = self._count
+
+    bundle_start = start_position
+    while bundle_start < self._count:
+      bundle_stop = max(self._count, bundle_start + desired_bundle_size)
+      yield iobase.SourceBundle(weight=(bundle_stop - bundle_start),
+                                source=self,
+                                start_position=bundle_start,
+                                stop_position=bundle_stop)
+      bundle_start = bundle_stop

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -182,7 +182,7 @@ class PTransformTest(unittest.TestCase):
 
   @attr('ValidatesRunner')
   def test_read_metrics(self):
-    from apache_beam.examples.snippets.snippets import CountingSource
+    from apache_beam.io.utils import CountingSource
 
     class CounterDoFn(beam.DoFn):
       def __init__(self):
@@ -197,7 +197,7 @@ class PTransformTest(unittest.TestCase):
     (pipeline | Read(CountingSource(100)) | beam.ParDo(CounterDoFn()))
     res = pipeline.run()
     res.wait_until_finish()
-    # This counter is defined in snippets.CountingSource.
+    # This counter is defined in utils.CountingSource.
     metric_results = res.metrics().query(MetricsFilter()
                                          .with_name('recordsRead'))
     outputs_counter = metric_results['counters'][0]


### PR DESCRIPTION
 The test_read_metrics function no longer depends on the snippets file. The CountingSource class is contained in io.utils which forms part of the library.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

