### PR TITLE
Allow request hooks to update the context.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/session.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/session.go
@@ -203,12 +203,12 @@ var captureHookRegistry = make(map[string]CaptureHookFactory)
 func init() {
 	hf := func(opts []string) hooks.Hook {
 		return hooks.Hook{
-			Init: func(_ context.Context) error {
+			Init: func(ctx context.Context) (context.Context, error) {
 				if len(opts) > 0 {
 					name, opts := hooks.Decode(opts[0])
 					capture = captureHookRegistry[name](opts)
 				}
-				return nil
+				return ctx, nil
 			},
 		}
 	}

--- a/sdks/go/pkg/beam/core/util/hooks/hooks_test.go
+++ b/sdks/go/pkg/beam/core/util/hooks/hooks_test.go
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hooks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
+)
+
+type contextKey string
+
+func initializeHooks() {
+	activeHooks["test"] = Hook{
+		Init: func(ctx context.Context) (context.Context, error) {
+			return context.WithValue(ctx, contextKey("init_key"), "value"), nil
+		},
+		Req: func(ctx context.Context, req *fnpb.InstructionRequest) (context.Context, error) {
+			return context.WithValue(ctx, contextKey("req_key"), "value"), nil
+		},
+	}
+}
+
+func TestInitContextPropagation(t *testing.T) {
+	initializeHooks()
+	ctx := context.Background()
+	var err error
+
+	expected := `context.Background.WithValue("init_key", "value")`
+	ctx, err = RunInitHooks(ctx)
+	if err != nil {
+		t.Errorf("got %v error, wanted no error", err)
+	}
+	actual := ctx.(fmt.Stringer).String()
+	if actual != expected {
+		t.Errorf("Got %s, wanted %s", actual, expected)
+	}
+}
+
+func TestRequestContextPropagation(t *testing.T) {
+	initializeHooks()
+	ctx := context.Background()
+
+	expected := `context.Background.WithValue("req_key", "value")`
+	ctx = RunRequestHooks(ctx, nil)
+	actual := ctx.(fmt.Stringer).String()
+	if actual != expected {
+		t.Errorf("Got %s, wanted %s", actual, expected)
+	}
+}

--- a/sdks/go/pkg/beam/util/grpcx/hook.go
+++ b/sdks/go/pkg/beam/util/grpcx/hook.go
@@ -34,6 +34,7 @@ type Hook struct {
 	// TODO(wcn): expose other hooks here.
 }
 
+// HookFactory is a function that creates hooks from supplied arguments.
 type HookFactory func([]string) Hook
 
 var hookRegistry = make(map[string]HookFactory)
@@ -49,9 +50,9 @@ func RegisterHook(name string, c HookFactory) {
 
 	hf := func(opts []string) hooks.Hook {
 		return hooks.Hook{
-			Init: func(_ context.Context) error {
+			Init: func(ctx context.Context) (context.Context, error) {
 				if len(opts) == 0 {
-					return nil
+					return ctx, nil
 				}
 
 				name, opts := hooks.Decode(opts[0])
@@ -59,7 +60,7 @@ func RegisterHook(name string, c HookFactory) {
 				if grpcHook.Dialer != nil {
 					Dial = grpcHook.Dialer
 				}
-				return nil
+				return ctx, nil
 			},
 		}
 	}

--- a/sdks/go/pkg/beam/x/hooks/perf/perf.go
+++ b/sdks/go/pkg/beam/x/hooks/perf/perf.go
@@ -49,12 +49,12 @@ func init() {
 		enabled := len(enabledProfCaptureHooks) > 0
 		var cpuProfBuf bytes.Buffer
 		return hooks.Hook{
-			Req: func(_ context.Context, _ *fnpb.InstructionRequest) error {
+			Req: func(ctx context.Context, _ *fnpb.InstructionRequest) (context.Context, error) {
 				if !enabled {
-					return nil
+					return ctx, nil
 				}
 				cpuProfBuf.Reset()
-				return pprof.StartCPUProfile(&cpuProfBuf)
+				return ctx, pprof.StartCPUProfile(&cpuProfBuf)
 			},
 			Resp: func(ctx context.Context, req *fnpb.InstructionRequest, _ *fnpb.InstructionResponse) error {
 				if !enabled {
@@ -78,12 +78,12 @@ func init() {
 		enabledTraceCaptureHooks = opts
 		enabled := len(enabledTraceCaptureHooks) > 0
 		return hooks.Hook{
-			Req: func(_ context.Context, _ *fnpb.InstructionRequest) error {
+			Req: func(ctx context.Context, _ *fnpb.InstructionRequest) (context.Context, error) {
 				if !enabled {
-					return nil
+					return ctx, nil
 				}
 				traceProfBuf.Reset()
-				return trace.Start(&traceProfBuf)
+				return ctx, trace.Start(&traceProfBuf)
 			},
 			Resp: func(ctx context.Context, req *fnpb.InstructionRequest, _ *fnpb.InstructionResponse) error {
 				if !enabled {


### PR DESCRIPTION
It's useful for a request hook to enrich the context with information,
so it can pass values to downstream processing. The hook should return the
originally provided context if no modifications are made.
