### PR TITLE
Use Collections.emptyList() instead of Collections.EMPTY_LIST

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/Trigger.java
@@ -79,7 +79,7 @@ public abstract class Trigger implements Serializable {
   }
 
   protected Trigger() {
-    this(Collections.EMPTY_LIST);
+    this(Collections.emptyList());
   }
 
   public List<Trigger> subTriggers() {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CreateTest.java
@@ -385,7 +385,7 @@ public class CreateTest {
   @Test
   public void testCreateGetName() {
     assertEquals("Create.Values", Create.of(1, 2, 3).getName());
-    assertEquals("Create.TimestampedValues", Create.timestamped(Collections.EMPTY_LIST).getName());
+    assertEquals("Create.TimestampedValues", Create.timestamped(Collections.emptyList()).getName());
   }
 
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/GcsUtilTest.java
@@ -335,7 +335,7 @@ public class GcsUtilTest {
         mockStorageGet);
     when(mockStorageGet.execute()).thenThrow(expectedException);
 
-    assertEquals(Collections.EMPTY_LIST, gcsUtil.expand(pattern));
+    assertEquals(Collections.emptyList(), gcsUtil.expand(pattern));
   }
 
   // GCSUtil.expand() should fail for other errors such as access denied.


### PR DESCRIPTION
A fairly trivial patch....use Collections.emptyList() instead of Collections.EMPTY_LIST in a few places to remove warnings in eclipse