### PR TITLE
Simplify single-line lambdas

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -103,17 +103,14 @@ public class SplittableDoFnOperator<
 
     checkState(doFn instanceof ProcessFn);
 
+    // this will implicitly be keyed by the key of the incoming
+    // element or by the key of a firing timer
     StateInternalsFactory<String> stateInternalsFactory =
-        key -> {
-          // this will implicitly be keyed by the key of the incoming
-          // element or by the key of a firing timer
-          return (StateInternals) keyedStateInternals;
-        };
+        key -> (StateInternals) keyedStateInternals;
+
+    // this will implicitly be keyed like the StateInternalsFactory
     TimerInternalsFactory<String> timerInternalsFactory =
-        key -> {
-          // this will implicitly be keyed like the StateInternalsFactory
-          return timerInternals;
-        };
+        key -> timerInternals;
 
     executorService = Executors.newSingleThreadScheduledExecutor(Executors.defaultThreadFactory());
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -98,17 +98,14 @@ public class WindowDoFnOperator<K, InputT, OutputT>
 
   @Override
   protected DoFn<KeyedWorkItem<K, InputT>, KV<K, OutputT>> getDoFn() {
+    // this will implicitly be keyed by the key of the incoming
+    // element or by the key of a firing timer
     StateInternalsFactory<K> stateInternalsFactory =
-        key -> {
-          // this will implicitly be keyed by the key of the incoming
-          // element or by the key of a firing timer
-          return (StateInternals) keyedStateInternals;
-        };
+        key -> (StateInternals) keyedStateInternals;
+
+    // this will implicitly be keyed like the StateInternalsFactory
     TimerInternalsFactory<K> timerInternalsFactory =
-        key -> {
-          // this will implicitly be keyed like the StateInternalsFactory
-          return timerInternals;
-        };
+        key -> timerInternals;
 
     // we have to do the unchecked cast because GroupAlsoByWindowViaWindowSetDoFn.create
     // has the window type as generic parameter while WindowingStrategy is almost always

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
@@ -507,10 +507,9 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
             JavaSparkContext$.MODULE$.fakeClassTag(),
             JavaSparkContext$.MODULE$.fakeClassTag())
         .filter(
-            t2 -> {
-              // filter output if defined.
-              return !t2._2()._2().isEmpty();
-            })
+            // filter output if defined.
+            t2 -> !t2._2()._2().isEmpty()
+            )
         .flatMap(
             new FlatMapFunction<
                 Tuple2</*K*/ ByteArray, Tuple2<StateAndTimers, /*WV<KV<K, Itr<I>>>*/ List<byte[]>>>,
@@ -564,10 +563,9 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
                             true)
                         .mapPartitionsToPair(TranslationUtils.toPairFlatMapFunction(), true)
                         .mapValues(
-                            values -> {
-                              // add the batch timestamp for visibility (e.g., debugging)
-                              return KV.of(time.milliseconds(), values);
-                            })
+                            // add the batch timestamp for visibility (e.g., debugging)
+                            values -> KV.of(time.milliseconds(), values)
+                            )
                         // move to bytes representation and use coders for deserialization
                         // because of checkpointing.
                         .mapPartitionsToPair(

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/util/GcsUtil.java
@@ -589,9 +589,7 @@ public class GcsUtil {
     List<CompletionStage<Void>> futures = new LinkedList<>();
     for (final BatchRequest batch : batches) {
       futures.add(MoreFutures.runAsync(
-          () -> {
-            batch.execute();
-          },
+          () -> batch.execute(),
           executor));
     }
 


### PR DESCRIPTION
We can simplify single-line lambda expressions by removing the curly brackets and return statements.