### PR TITLE
[BEAM-4166] Invoke @Setup in FnApiDoFnRunner

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -384,6 +384,7 @@ public class FnApiDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Outp
     this.windowingStrategy = windowingStrategy;
     this.doFnSignature = DoFnSignatures.signatureForDoFn(doFn);
     this.doFnInvoker = DoFnInvokers.invokerFor(doFn);
+    this.doFnInvoker.invokeSetup();
     this.stateBinder = new BeamFnStateBinder();
     this.startBundleContext = new StartBundleContext();
     this.processBundleContext = new ProcessBundleContext();

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.fn.harness;
 
+import static com.google.common.base.Preconditions.checkState;
 import static org.apache.beam.sdk.util.WindowedValue.timestampedValueInGlobalWindow;
 import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
 import static org.hamcrest.Matchers.contains;
@@ -97,10 +98,33 @@ public class FnApiDoFnRunnerTest {
     private static final TupleTag<String> mainOutput = new TupleTag<>("mainOutput");
     private static final TupleTag<String> additionalOutput = new TupleTag<>("output");
 
+    private enum State {
+      NOT_SET_UP,
+      OUTSIDE_BUNDLE,
+      INSIDE_BUNDLE,
+    }
+
+    private State state = State.NOT_SET_UP;
+
     private BoundedWindow window;
+
+    @Setup
+    public void setUp() {
+      checkState(State.NOT_SET_UP.equals(state), "Unexpected state: %s", state);
+      state = State.OUTSIDE_BUNDLE;
+    }
+
+    // No testing for TearDown - it's currently not supported by FnHarness.
+
+    @StartBundle
+    public void startBundle() {
+      checkState(State.OUTSIDE_BUNDLE.equals(state), "Unexpected state: %s", state);
+      state = State.INSIDE_BUNDLE;
+    }
 
     @ProcessElement
     public void processElement(ProcessContext context, BoundedWindow window) {
+      checkState(State.INSIDE_BUNDLE.equals(state), "Unexpected state: %s", state);
       context.output("MainOutput" + context.element());
       context.output(additionalOutput, "AdditionalOutput" + context.element());
       this.window = window;
@@ -108,6 +132,8 @@ public class FnApiDoFnRunnerTest {
 
     @FinishBundle
     public void finishBundle(FinishBundleContext context) {
+      checkState(State.INSIDE_BUNDLE.equals(state), "Unexpected state: %s", state);
+      state = State.OUTSIDE_BUNDLE;
       if (window != null) {
         context.output("FinishBundle", window.maxTimestamp(), window);
         window = null;


### PR DESCRIPTION
Don't invoke Teardown because there seems to be no appropriate or necessary place to invoke it all the way up to the main() of FnHarness.

R: @bsidhom 
CC: @tgroh @angoenka 