### PR TITLE
Upgrade Gradle to 4.7

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip


### PR DESCRIPTION
https://docs.gradle.org/4.7/release-notes.html

Notable differences:
* Support for resources and test resources in the IDEA plugin
* Rerun failed tests first
* Make CheckStyle plugin work by default for multi-project builds