### PR TITLE
Remove Gradle worker cap.

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -170,10 +170,6 @@ class common_job_properties {
     "--info",
     // Continue the build even if there is a failure to show as many potential failures as possible.
     '--continue',
-    // Limit background number of workers to prevent exhausting machine memory.
-    // Jenkins machines have 15GB memory, and run 2 jobs in parallel; workers are configured with
-    // JVM max heap size 3.5GB. So 2 jobs * 2 workers * 3.5GB heap = 14GB
-    '--max-workers=2',
   ]
 
   static void setGradleSwitches(context) {

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -179,8 +179,12 @@ class common_job_properties {
     context.switches("--max-workers=${maxWorkers}")
 
     // Ensure that parallel workers don't exceed total available memory.
-    def os = (com.sun.management.OperatingSystemMXBean)java.lang.management.ManagementFactory.getOperatingSystemMXBean()
-    def totalMemoryMb = os.getTotalPhysicalMemorySize() / (1024*1024)
+
+    // TODO(BEAM-4230): OperatingSystemMXBeam incorrectly reports total memory; hard-code for now
+    // Jenkins machines are GCE n1-highmem-16, with 104 GB of memory
+    // def os = (com.sun.management.OperatingSystemMXBean)java.lang.management.ManagementFactory.getOperatingSystemMXBean()
+    // def totalMemoryMb = os.getTotalPhysicalMemorySize() / (1024*1024)
+    def totalMemoryMb = 104 * 1024
     // Jenkins uses 2 executors to schedule concurrent jobs, so ensure that each executor uses only half the
     // machine memory.
     def totalExecutorMemoryMb = totalMemoryMb / 2

--- a/.test-infra/jenkins/job_beam_PostCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Go_GradleBuild.groovy
@@ -35,12 +35,10 @@ job('beam_PostCommit_Go_GradleBuild') {
   // Sets that this is a PostCommit job.
   common_job_properties.setPostCommit(delegate, '15 */6 * * *', false)
 
-  def gradle_command_line = './gradlew ' + common_job_properties.gradle_switches.join(' ') + ' :goPostCommit'
-
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(
       delegate,
-      gradle_command_line,
+      './gradlew :goPostCommit',
       'Run Go PostCommit')
 
   steps {

--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -47,13 +47,12 @@ job('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle') {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':beam-runners-google-cloud-dataflow-java:validatesRunner')
-      common_job_properties.setGradleSwitches(delegate)
       // Increase parallel worker threads above processor limit since most time is
       // spent waiting on Dataflow jobs. ValidatesRunner tests on Dataflow are slow
       // because each one launches a Dataflow job with about 3 mins of overhead.
       // 3 x num_cores strikes a good balance between maxing out parallelism without
       // overloading the machines.
-      switches("--max-workers=${3 * Runtime.runtime.availableProcessors()}")
+      common_job_properties.setGradleSwitches(delegate, 3 * Runtime.runtime.availableProcessors())
     }
   }
 }

--- a/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Java_ValidatesRunner_Dataflow.groovy
@@ -48,6 +48,12 @@ job('beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle') {
       rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':beam-runners-google-cloud-dataflow-java:validatesRunner')
       common_job_properties.setGradleSwitches(delegate)
+      // Increase parallel worker threads above processor limit since most time is
+      // spent waiting on Dataflow jobs. ValidatesRunner tests on Dataflow are slow
+      // because each one launches a Dataflow job with about 3 mins of overhead.
+      // 3 x num_cores strikes a good balance between maxing out parallelism without
+      // overloading the machines.
+      switches("--max-workers=${3 * Runtime.runtime.availableProcessors()}")
     }
   }
 }

--- a/.test-infra/jenkins/job_beam_PreCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_beam_PreCommit_Go_GradleBuild.groovy
@@ -32,9 +32,8 @@ job('beam_PreCommit_Go_GradleBuild') {
     'master',
     150)
 
-  def gradle_command_line = './gradlew ' + common_job_properties.gradle_switches.join(' ') + ' :goPreCommit'
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, gradle_command_line, 'Run Go PreCommit')
+  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit')
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_beam_PreCommit_Python_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_beam_PreCommit_Python_GradleBuild.groovy
@@ -38,9 +38,8 @@ job('beam_PreCommit_Python_GradleBuild') {
     archiveJunit('**/nosetests.xml')
   }
 
-  def gradle_command_line = './gradlew ' + common_job_properties.gradle_switches.join(' ') + ' :pythonPreCommit'
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, gradle_command_line, 'Run Python PreCommit')
+  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit')
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_beam_Release_Gradle_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_beam_Release_Gradle_NightlySnapshot.groovy
@@ -37,9 +37,6 @@ job('beam_Release_Gradle_NightlySnapshot') {
       'dev@beam.apache.org')
 
 
-  def gradle_switches = [
-  ]
-
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(
       delegate,


### PR DESCRIPTION
This was added because our previous machines could not handle the memory
load. We now have much larger machines, so we can remove this cap and
achieve much better performance.