### PR TITLE
Enable Gradle daemon by default

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.configureondemand=true
+org.gradle.daemon=true
 offlineRepositoryRoot=offline-repository
 signing.gnupg.executable=gpg
 signing.gnupg.useLegacyGpg=true


### PR DESCRIPTION
This is a Gradle best-practice and should improve Jenkins build performance even further:

https://docs.gradle.org/current/userguide/gradle_daemon.html