### PR TITLE
Upgrade Tika due to multiple CVEs

### DIFF
--- a/sdks/java/io/tika/build.gradle
+++ b/sdks/java/io/tika/build.gradle
@@ -22,7 +22,7 @@ applyJavaNature()
 description = "Apache Beam :: SDKs :: Java :: IO :: Tika"
 ext.summary = "Tika Input to parse files."
 
-def tika_version = "1.16"
+def tika_version = "1.18"
 
 dependencies {
   compile library.java.guava

--- a/sdks/java/io/tika/pom.xml
+++ b/sdks/java/io/tika/pom.xml
@@ -29,7 +29,7 @@
  
 
     <properties>
-        <tika.version>1.16</tika.version>
+        <tika.version>1.18</tika.version>
     </properties>
     
     <dependencies>


### PR DESCRIPTION
There are a number of CVEs released fixed in the recent Tika 1.18 release - we should upgrade.