### PR TITLE
Run python-modernize fixer "libmodernize.fixes.fix_imports_six"

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -22,7 +22,7 @@ Only those coders listed in __all__ are part of the public API of this module.
 from __future__ import absolute_import
 
 import base64
-import cPickle as pickle
+import six.moves.cPickle as pickle
 
 import google.protobuf
 from google.protobuf import wrappers_pb2

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -22,11 +22,11 @@ Only those coders listed in __all__ are part of the public API of this module.
 from __future__ import absolute_import
 
 import base64
-import six.moves.cPickle as pickle
 
 import google.protobuf
 from google.protobuf import wrappers_pb2
 
+import six.moves.cPickle as pickle  # pylint: disable=wrong-import-order
 from apache_beam.coders import coder_impl
 from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import collections
 import itertools
 import logging
-import Queue
+import six.moves.queue
 import sys
 import threading
 import traceback
@@ -80,7 +80,7 @@ class _ExecutorService(object):
         # shutdown.
         return self.queue.get(
             timeout=_ExecutorService._ExecutorServiceWorker.TIMEOUT)
-      except Queue.Empty:
+      except six.moves.queue.Empty:
         return None
 
     def run(self):
@@ -101,7 +101,7 @@ class _ExecutorService(object):
       self.shutdown_requested = True
 
   def __init__(self, num_workers):
-    self.queue = Queue.Queue()
+    self.queue = six.moves.queue.Queue()
     self.workers = [_ExecutorService._ExecutorServiceWorker(
         self.queue, i) for i in range(num_workers)]
     self.shutdown_requested = False
@@ -126,7 +126,7 @@ class _ExecutorService(object):
       try:
         self.queue.get_nowait()
         self.queue.task_done()
-      except Queue.Empty:
+      except six.moves.queue.Empty:
         continue
     # All existing threads will eventually terminate (after they complete their
     # last task).
@@ -481,14 +481,14 @@ class _ExecutorServiceParallelExecutor(object):
 
     def __init__(self, item_type):
       self._item_type = item_type
-      self._queue = Queue.Queue()
+      self._queue = six.moves.queue.Queue()
 
     def poll(self):
       try:
         item = self._queue.get_nowait()
         self._queue.task_done()
         return  item
-      except Queue.Empty:
+      except six.moves.queue.Empty:
         return None
 
     def take(self):
@@ -501,7 +501,7 @@ class _ExecutorServiceParallelExecutor(object):
           item = self._queue.get(timeout=1)
           self._queue.task_done()
           return item
-        except Queue.Empty:
+        except six.moves.queue.Empty:
           pass
 
     def offer(self, item):

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 import collections
 import itertools
 import logging
-import six.moves.queue
 import sys
 import threading
 import traceback
@@ -30,6 +29,7 @@ from weakref import WeakValueDictionary
 
 import six
 
+import six.moves.queue  # pylint: disable=wrong-import-order
 from apache_beam.metrics.execution import MetricsContainer
 from apache_beam.runners.worker import statesampler
 from apache_beam.transforms import sideinputs

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -21,7 +21,6 @@ import collections
 import contextlib
 import copy
 import logging
-import six.moves.queue as queue
 import threading
 import time
 from concurrent import futures
@@ -29,6 +28,7 @@ from concurrent import futures
 import grpc
 
 import apache_beam as beam  # pylint: disable=ungrouped-imports
+import six.moves.queue as queue  # pylint: disable=wrong-import-order
 from apache_beam import coders
 from apache_beam import metrics
 from apache_beam.coders import WindowedValueCoder

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -21,7 +21,7 @@ import collections
 import contextlib
 import copy
 import logging
-import Queue as queue
+import six.moves.queue as queue
 import threading
 import time
 from concurrent import futures

--- a/sdks/python/apache_beam/runners/portability/universal_local_runner.py
+++ b/sdks/python/apache_beam/runners/portability/universal_local_runner.py
@@ -18,7 +18,7 @@
 import functools
 import logging
 import os
-import Queue as queue
+import six.moves.queue as queue
 import socket
 import subprocess
 import sys

--- a/sdks/python/apache_beam/runners/portability/universal_local_runner.py
+++ b/sdks/python/apache_beam/runners/portability/universal_local_runner.py
@@ -18,7 +18,6 @@
 import functools
 import logging
 import os
-import six.moves.queue as queue
 import socket
 import subprocess
 import sys
@@ -31,6 +30,7 @@ from concurrent import futures
 import grpc
 from google.protobuf import text_format
 
+import six.moves.queue as queue  # pylint: disable=wrong-import-order
 from apache_beam import coders
 from apache_beam.internal import pickler
 from apache_beam.portability.api import beam_fn_api_pb2_grpc

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -24,13 +24,13 @@ from __future__ import print_function
 import abc
 import collections
 import logging
-import six.moves.queue as queue
 import sys
 import threading
 
 import grpc
 import six
 
+import six.moves.queue as queue  # pylint: disable=wrong-import-order
 from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -24,7 +24,7 @@ from __future__ import print_function
 import abc
 import collections
 import logging
-import Queue as queue
+import six.moves.queue as queue
 import sys
 import threading
 

--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -18,7 +18,7 @@
 
 import logging
 import math
-import Queue as queue
+import six.moves.queue as queue
 import threading
 
 import grpc

--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -18,11 +18,11 @@
 
 import logging
 import math
-import six.moves.queue as queue
 import threading
 
 import grpc
 
+import six.moves.queue as queue  # pylint: disable=wrong-import-order
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -23,7 +23,7 @@ from __future__ import print_function
 import abc
 import contextlib
 import logging
-import Queue as queue
+import six.moves.queue as queue
 import sys
 import threading
 import traceback

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -23,7 +23,6 @@ from __future__ import print_function
 import abc
 import contextlib
 import logging
-import six.moves.queue as queue
 import sys
 import threading
 import traceback
@@ -32,6 +31,7 @@ from concurrent import futures
 import grpc
 import six
 
+import six.moves.queue as queue  # pylint: disable=wrong-import-order
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker import bundle_processor

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -16,7 +16,6 @@
 #
 """SDK Fn Harness entry point."""
 
-import six.moves.BaseHTTPServer
 import json
 import logging
 import os
@@ -27,6 +26,7 @@ import traceback
 
 from google.protobuf import text_format
 
+import six.moves.BaseHTTPServer  # pylint: disable=wrong-import-order
 from apache_beam.internal import pickler
 from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.dataflow.internal import names

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -16,7 +16,7 @@
 #
 """SDK Fn Harness entry point."""
 
-import BaseHTTPServer
+import six.moves.BaseHTTPServer
 import json
 import logging
 import os
@@ -57,7 +57,7 @@ class StatusServer(object):
         Default is 0 which means any free unsecured port
     """
 
-    class StatusHttpHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+    class StatusHttpHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
       """HTTP handler for serving stacktraces of all threads."""
 
       def do_GET(self):  # pylint: disable=invalid-name
@@ -73,7 +73,7 @@ class StatusServer(object):
         """Do not log any messages."""
         pass
 
-    self.httpd = httpd = BaseHTTPServer.HTTPServer(
+    self.httpd = httpd = six.moves.BaseHTTPServer.HTTPServer(
         ('localhost', status_http_port), StatusHttpHandler)
     logging.info('Status HTTP server running at %s:%s', httpd.server_name,
                  httpd.server_port)

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -19,10 +19,10 @@
 
 import collections
 import logging
-import six.moves.queue
 import threading
 import traceback
 
+import six.moves.queue  # pylint: disable=wrong-import-order
 from apache_beam.coders import observable
 from apache_beam.io import iobase
 from apache_beam.options.value_provider import RuntimeValueProvider

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -19,7 +19,7 @@
 
 import collections
 import logging
-import Queue
+import six.moves.queue
 import threading
 import traceback
 
@@ -61,13 +61,13 @@ class PrefetchingSourceSetIterable(object):
     self.num_reader_threads = min(max_reader_threads, len(self.sources))
 
     # Queue for sources that are to be read.
-    self.sources_queue = Queue.Queue()
+    self.sources_queue = six.moves.queue.Queue()
     for source in sources:
       self.sources_queue.put(source)
     # Queue for elements that have been read.
-    self.element_queue = Queue.Queue(ELEMENT_QUEUE_SIZE)
+    self.element_queue = six.moves.queue.Queue(ELEMENT_QUEUE_SIZE)
     # Queue for exceptions encountered in reader threads; to be rethrown.
-    self.reader_exceptions = Queue.Queue()
+    self.reader_exceptions = six.moves.queue.Queue()
     # Whether we have already iterated; this iterable can only be used once.
     self.already_iterated = False
     # Whether an error was encountered in any source reader.
@@ -136,7 +136,7 @@ class PrefetchingSourceSetIterable(object):
                   self.element_queue.put(value)
                 else:
                   self.element_queue.put(_globally_windowed(value))
-        except Queue.Empty:
+        except six.moves.queue.Empty:
           return
     except Exception as e:  # pylint: disable=broad-except
       logging.error('Encountered exception in PrefetchingSourceSetIterable '


### PR DESCRIPTION
Use automated fixer to speed up the porting to Python 3 process

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

This PR resolves import errors due to
`Queue`, `cPickle`, and `BaseHTTPServer` being moved to different places in python 3
by using the automated tool `python-modernize`.

python-modernize fixes the issue with `six`. This is not completely desirable, but `six` is
already a dependency. We could replace this with `try-except` blocks now, but it may be
better to fix this later in bulk to reduce the chance of bugs appearing.

'isort' and 'pylint' conflict when it comes to `six.moves` imports. `isort:skip` is buggy so
we disable the pylint error (wrong-import-order) instead.

### Why is this important (to the Python 3 porting process)?

Most of the tests in the package cannot be run in Python 3 because of syntax and import errors.
Running tests in Python 3 at the moment requires commenting out more lines than just the
statement in `apache_beam/__init__.py`. This slows down our ability to port to Python 3.

After resolving these errors, it would be possible to create a guide for contributing to Python 3.

### Why this approach?

#### Why not `futurize`?
Futurize requires us to use

```
from future import standard_library
standard_library.install_aliases()
```

which requires adding `future` as a dependency. I believe that this issue was discussed in the past.

It may also be important to note that future aliases do not work well with type inference.

#### How does this relate to other Python3 issues ([BEAM-3981], [BEAM-3761], etc.)?
Using mainly automated conversion tools should reduce the likelihood of conflicts.
Resolving syntax and import errors should speed up the module-based process as
circular dependencies will no longer hinder the process. In addition, if the Pipeline
tests can run, bugs which affect Python 3 can be caught earlier on.

@RobbeSneyders
@holdenk 

python3


