### PR TITLE
Mark some ReduceFnRunner arguments Nullable

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnContextFactory.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnContextFactory.java
@@ -53,8 +53,8 @@ class ReduceFnContextFactory<K, InputT, OutputT, W extends BoundedWindow> {
   private final StateInternals stateInternals;
   private final ActiveWindowSet<W> activeWindows;
   private final TimerInternals timerInternals;
-  private final SideInputReader sideInputReader;
-  private final PipelineOptions options;
+  @Nullable private final SideInputReader sideInputReader;
+  @Nullable private final PipelineOptions options;
 
   ReduceFnContextFactory(
       K key,
@@ -63,8 +63,8 @@ class ReduceFnContextFactory<K, InputT, OutputT, W extends BoundedWindow> {
       StateInternals stateInternals,
       ActiveWindowSet<W> activeWindows,
       TimerInternals timerInternals,
-      SideInputReader sideInputReader,
-      PipelineOptions options) {
+      @Nullable SideInputReader sideInputReader,
+      @Nullable PipelineOptions options) {
     this.key = key;
     this.reduceFn = reduceFn;
     this.windowingStrategy = windowingStrategy;
@@ -513,9 +513,9 @@ class ReduceFnContextFactory<K, InputT, OutputT, W extends BoundedWindow> {
 
   private static <W extends BoundedWindow> StateContext<W> stateContextFromComponents(
       @Nullable final PipelineOptions options,
-      final SideInputReader sideInputReader,
+      @Nullable final SideInputReader sideInputReader,
       final W mainInputWindow) {
-    if (options == null) {
+    if (options == null || sideInputReader == null) {
       return StateContexts.nullContext();
     } else {
       return new StateContext<W>() {
@@ -528,9 +528,7 @@ class ReduceFnContextFactory<K, InputT, OutputT, W extends BoundedWindow> {
         @Override
         public <T> T sideInput(PCollectionView<T> view) {
           return sideInputReader.get(
-              view,
-              view.getWindowMappingFn()
-                  .getSideInputWindow(mainInputWindow));
+              view, view.getWindowMappingFn().getSideInputWindow(mainInputWindow));
         }
 
         @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/ReduceFnRunner.java
@@ -212,9 +212,9 @@ public class ReduceFnRunner<K, InputT, OutputT, W extends BoundedWindow> {
       StateInternals stateInternals,
       TimerInternals timerInternals,
       OutputWindowedValue<KV<K, OutputT>> outputter,
-      SideInputReader sideInputReader,
+      @Nullable SideInputReader sideInputReader,
       ReduceFn<K, InputT, OutputT, W> reduceFn,
-      PipelineOptions options) {
+      @Nullable PipelineOptions options) {
     this.key = key;
     this.timerInternals = timerInternals;
     this.paneInfoTracker = new PaneInfoTracker(timerInternals);
@@ -235,8 +235,15 @@ public class ReduceFnRunner<K, InputT, OutputT, W extends BoundedWindow> {
     this.activeWindows = createActiveWindowSet();
 
     this.contextFactory =
-        new ReduceFnContextFactory<>(key, reduceFn, this.windowingStrategy,
-            stateInternals, this.activeWindows, timerInternals, sideInputReader, options);
+        new ReduceFnContextFactory<>(
+            key,
+            reduceFn,
+            this.windowingStrategy,
+            stateInternals,
+            this.activeWindows,
+            timerInternals,
+            sideInputReader,
+            options);
 
     this.watermarkHold = new WatermarkHold<>(timerInternals, windowingStrategy);
     this.triggerRunner =


### PR DESCRIPTION
Options and SideInputReader are only required when executing a Combine
with Context within the ReduceFnRunner. Within Portability, that
behavior isn't modelled within the ReduceFnRunner, so mark the arguments
as not required.

Update ReduceFnContextFactory to take the same Nullability of arguments.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

