### PR TITLE
BEAM-4182 fix to allow JMSMessageId to be null

### DIFF
--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsRecord.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsRecord.java
@@ -29,7 +29,7 @@ import javax.jms.Destination;
  */
 public class JmsRecord implements Serializable {
 
-  private final String jmsMessageID;
+  @Nullable private final String jmsMessageID;
   private final long jmsTimestamp;
   private final String jmsCorrelationID;
   @Nullable private final Destination jmsReplyTo;
@@ -43,7 +43,7 @@ public class JmsRecord implements Serializable {
   private final String text;
 
   public JmsRecord(
-      String jmsMessageID,
+      @Nullable String jmsMessageID,
       long jmsTimestamp,
       String jmsCorrelationID,
       @Nullable Destination jmsReplyTo,
@@ -137,8 +137,7 @@ public class JmsRecord implements Serializable {
   public boolean equals(Object obj) {
     if (obj instanceof JmsRecord) {
       JmsRecord other = (JmsRecord) obj;
-      return jmsMessageID.equals(other.jmsMessageID)
-          && jmsDestination.equals(other.jmsDestination)
+      return jmsDestination.equals(other.jmsDestination)
           && jmsDeliveryMode == other.jmsDeliveryMode
           && jmsRedelivered == other.jmsRedelivered
           && jmsExpiration == other.jmsExpiration


### PR DESCRIPTION
the `equals` assumes that JMSMessageID is always present, but the spec if fine to have this being null:

>Message header field references are restricted to JMSDeliveryMode,
JMSPriority, JMSMessageID, JMSTimestamp, JMSCorrelationID, and
JMSType. JMSMessageID, JMSCorrelationID, and JMSType values may be
null and if so are treated as a NULL value.


------------------------

This PR removes the `jmsmessageID` from the `equals` since it can be actually null, see quoted SPEC text.


