### PR TITLE
Resolve errors blocking `python3 setup.py nosetests`

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -28,8 +28,6 @@ For internal use only; no backwards-compatibility guarantees.
 """
 from __future__ import absolute_import
 
-from types import NoneType
-
 import six
 
 from apache_beam.coders import observable
@@ -279,7 +277,7 @@ class FastPrimitivesCoderImpl(StreamCoderImpl):
 
   def encode_to_stream(self, value, stream, nested):
     t = type(value)
-    if t is NoneType:
+    if value is None:
       stream.write_byte(NONE_TYPE)
     elif t is int:
       stream.write_byte(INT_TYPE)

--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -42,7 +42,10 @@ that can be used to write a given ``PCollection`` of Python objects to an
 Avro file.
 """
 
-import cStringIO
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 import os
 import zlib
 from functools import partial

--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -42,10 +42,6 @@ that can be used to write a given ``PCollection`` of Python objects to an
 Avro file.
 """
 
-try:
-  import cStringIO
-except ImportError:
-  from io import BytesIO as cStringIO
 import os
 import zlib
 from functools import partial
@@ -62,6 +58,11 @@ from apache_beam.io import iobase
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.iobase import Read
 from apache_beam.transforms import PTransform
+
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 
 __all__ = ['ReadFromAvro', 'ReadAllFromAvro', 'WriteToAvro']
 

--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -60,9 +60,9 @@ from apache_beam.io.iobase import Read
 from apache_beam.transforms import PTransform
 
 try:
-  import cStringIO
+  from cStringIO import StringIO as BytesIO
 except ImportError:
-  from io import BytesIO as cStringIO
+  from io import BytesIO
 
 __all__ = ['ReadFromAvro', 'ReadAllFromAvro', 'WriteToAvro']
 
@@ -315,7 +315,7 @@ class _AvroBlock(object):
       # We take care to avoid extra copies of data while slicing large objects
       # by use of a buffer.
       result = snappy.decompress(buffer(data)[:-4])
-      avroio.BinaryDecoder(cStringIO.StringIO(data[-4:])).check_crc32(result)
+      avroio.BinaryDecoder(BytesIO(data[-4:])).check_crc32(result)
       return result
     else:
       raise ValueError('Unknown codec: %r', codec)
@@ -324,8 +324,7 @@ class _AvroBlock(object):
     return self._num_records
 
   def records(self):
-    decoder = avroio.BinaryDecoder(
-        cStringIO.StringIO(self._decompressed_block_bytes))
+    decoder = avroio.BinaryDecoder(BytesIO(self._decompressed_block_bytes))
     reader = avroio.DatumReader(
         writers_schema=self._schema, readers_schema=self._schema)
 

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -16,10 +16,6 @@
 #
 
 import bz2
-try:
-  import cStringIO
-except ImportError:
-  from io import BytesIO as cStringIO
 import gzip
 import logging
 import math
@@ -46,6 +42,11 @@ from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
+
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 
 
 class LineSource(FileBasedSource):

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -44,9 +44,9 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 
 try:
-  import cStringIO
+  from cStringIO import StringIO as BytesIO
 except ImportError:
-  from io import BytesIO as cStringIO
+  from io import BytesIO
 
 
 class LineSource(FileBasedSource):
@@ -477,7 +477,7 @@ class TestFileBasedSource(unittest.TestCase):
     chunks = [lines[splits[i-1]:splits[i]] for i in range(1, len(splits))]
     compressed_chunks = []
     for c in chunks:
-      out = cStringIO.StringIO()
+      out = BytesIO()
       with gzip.GzipFile(fileobj=out, mode="w") as f:
         f.write('\n'.join(c))
       compressed_chunks.append(out.getvalue())
@@ -524,7 +524,7 @@ class TestFileBasedSource(unittest.TestCase):
     chunks = [lines[splits[i - 1]:splits[i]] for i in range(1, len(splits))]
     compressed_chunks = []
     for c in chunks:
-      out = cStringIO.StringIO()
+      out = BytesIO()
       with gzip.GzipFile(fileobj=out, mode="w") as f:
         f.write('\n'.join(c))
       compressed_chunks.append(out.getvalue())
@@ -544,7 +544,7 @@ class TestFileBasedSource(unittest.TestCase):
     chunks_to_write = []
     for i, c in enumerate(chunks):
       if i%2 == 0:
-        out = cStringIO.StringIO()
+        out = BytesIO()
         with gzip.GzipFile(fileobj=out, mode="w") as f:
           f.write('\n'.join(c))
         chunks_to_write.append(out.getvalue())

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -16,7 +16,10 @@
 #
 
 import bz2
-import cStringIO
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 import gzip
 import logging
 import math

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -34,9 +34,9 @@ from six import string_types
 from apache_beam.utils.plugin import BeamPlugin
 
 try:
-  import cStringIO
+  from cStringIO import StringIO as BytesIO
 except ImportError:
-  from io import BytesIO as cStringIO
+  from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ class CompressedFile(object):
 
     if self.readable():
       self._read_size = read_size
-      self._read_buffer = cStringIO.StringIO()
+      self._read_buffer = BytesIO()
       self._read_position = 0
       self._read_eof = False
 
@@ -245,7 +245,7 @@ class CompressedFile(object):
     if not self._decompressor:
       raise ValueError('decompressor not initialized')
 
-    io = cStringIO.StringIO()
+    io = BytesIO()
     while True:
       # Ensure that the internal buffer has at least half the read_size. Going
       # with half the _read_size (as opposed to a full _read_size) to ensure

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -20,10 +20,6 @@ from __future__ import absolute_import
 
 import abc
 import bz2
-try:
-  import cStringIO
-except ImportError:
-  from io import BytesIO as cStringIO
 import fnmatch
 import logging
 import os
@@ -36,6 +32,11 @@ from six import integer_types
 from six import string_types
 
 from apache_beam.utils.plugin import BeamPlugin
+
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 
 logger = logging.getLogger(__name__)
 

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -20,7 +20,10 @@ from __future__ import absolute_import
 
 import abc
 import bz2
-import cStringIO
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 import fnmatch
 import logging
 import os

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -20,10 +20,6 @@ This library evolved from the Google App Engine GCS client available at
 https://github.com/GoogleCloudPlatform/appengine-gcs-client.
 """
 
-try:
-  import cStringIO
-except ImportError:
-  from io import BytesIO as cStringIO
 import errno
 import io
 import logging
@@ -42,6 +38,11 @@ from apache_beam.io.filesystemio import PipeStream
 from apache_beam.io.filesystemio import Uploader
 from apache_beam.io.filesystemio import UploaderStream
 from apache_beam.utils import retry
+
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO  # pylint: disable=ungrouped-imports
 
 __all__ = ['GcsIO']
 

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -40,9 +40,9 @@ from apache_beam.io.filesystemio import UploaderStream
 from apache_beam.utils import retry
 
 try:
-  import cStringIO
+  from cStringIO import StringIO as BytesIO
 except ImportError:
-  from io import BytesIO as cStringIO  # pylint: disable=ungrouped-imports
+  from io import BytesIO  # pylint: disable=ungrouped-imports
 
 __all__ = ['GcsIO']
 
@@ -472,7 +472,7 @@ class GcsDownloader(Downloader):
     self._get_request.generation = metadata.generation
 
     # Initialize read buffer state.
-    self._download_stream = cStringIO.StringIO()
+    self._download_stream = BytesIO()
     self._downloader = transfer.Download(
         self._download_stream, auto_transfer=False, chunksize=self._buffer_size)
     self._client.objects.Get(self._get_request, download=self._downloader)

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -20,7 +20,10 @@ This library evolved from the Google App Engine GCS client available at
 https://github.com/GoogleCloudPlatform/appengine-gcs-client.
 """
 
-import cStringIO
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 import errno
 import io
 import logging

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -42,9 +42,9 @@ from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
 try:
-  import cStringIO
+  from cStringIO import StringIO as BytesIO
 except ImportError:
-  from io import BytesIO as cStringIO
+  from io import BytesIO
 
 try:
   import tensorflow as tf  # pylint: disable=import-error
@@ -85,7 +85,7 @@ class TestTFRecordUtil(unittest.TestCase):
     self.record = binascii.a2b_base64(FOO_RECORD_BASE64)
 
   def _as_file_handle(self, contents):
-    result = cStringIO.StringIO()
+    result = BytesIO()
     result.write(contents)
     result.reset()
     return result
@@ -126,7 +126,7 @@ class TestTFRecordUtil(unittest.TestCase):
             '\x03\x00\x00\x00\x00\x00\x00\x00', crc32c_fn=crc32c_fn))
 
   def test_write_record(self):
-    file_handle = cStringIO.StringIO()
+    file_handle = BytesIO()
     _TFRecordUtil.write_record(file_handle, 'foo')
     self.assertEqual(self.record, file_handle.getvalue())
 
@@ -147,7 +147,7 @@ class TestTFRecordUtil(unittest.TestCase):
 
   def test_compatibility_read_write(self):
     for record in ['', 'blah', 'another blah']:
-      file_handle = cStringIO.StringIO()
+      file_handle = BytesIO()
       _TFRecordUtil.write_record(file_handle, record)
       file_handle.reset()
       actual = _TFRecordUtil.read_record(file_handle)
@@ -395,7 +395,7 @@ class TestEnd2EndWriteAndRead(unittest.TestCase):
   def create_inputs(self):
     input_array = [[random.random() - 0.5 for _ in range(15)]
                    for _ in range(12)]
-    memfile = cStringIO.StringIO()
+    memfile = BytesIO()
     pickle.dump(input_array, memfile)
     return memfile.getvalue()
 

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -16,7 +16,10 @@
 #
 
 import binascii
-import cStringIO
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 import glob
 import gzip
 import logging

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -16,10 +16,6 @@
 #
 
 import binascii
-try:
-  import cStringIO
-except ImportError:
-  from io import BytesIO as cStringIO
 import glob
 import gzip
 import logging
@@ -44,6 +40,11 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_utils import TempDir
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+
+try:
+  import cStringIO
+except ImportError:
+  from io import BytesIO as cStringIO
 
 try:
   import tensorflow as tf  # pylint: disable=import-error

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -408,6 +408,10 @@ class AnyTypeConstraint(TypeConstraint):
   def __eq__(self, other):
     return type(self) == type(other)
 
+  def __hash__(self):
+    # TODO(BEAM-3730): TypeVariable incorrect functionality with valid hash fn
+    return id(self)
+
   def __repr__(self):
     return 'Any'
 


### PR DESCRIPTION
DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

This removes the errors which prevent the project from running nosetests in Python 3 while not
changing the functionality of the Python 2 version.

Not being able to run `setup.py` means that the majority of the tests in the suite cannot
be run, slowing down the porting process. This PR along with #5230 aim to speed up the
process.

If the PR is merged, the scope of Python 3 issues that can be worked on concurrently will increase.

See
[this Google Doc](https://docs.google.com/document/d/1vIZM7-XsISqBZIODLY7PKlvWneWCzBSpw1Ai158Fds8/edit
) for the instructions on how to get most of the test suite to run in Python 3.
