### PR TITLE
[BEAM-3986] Enhance awsCredentialsProvider option description

### DIFF
--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
@@ -47,14 +47,28 @@ public interface AwsOptions extends PipelineOptions {
   void setAwsServiceEndpoint(String value);
 
   /**
-   * The credential instance that should be used to authenticate against AWS services. Refer to
-   * {@link DefaultAWSCredentialsProviderChain} Javadoc for usage help.
+   * The credential instance that should be used to authenticate against AWS services.
+   * The option value must contain a "@type" field and an AWS Credentials Provider class
+   * as the field value. Refer to {@link DefaultAWSCredentialsProviderChain} Javadoc for
+   * usage help.
+   * <p>
+   * For example, to specify the AWS key ID and secret, specify the following:
+   * <code>
+   * {"@type" : "AWSStaticCredentialsProvider", "awsAccessKeyId" : "key_id_value",
+   * "awsSecretKey" : "secret_value"}
+   * </code>
+   * </p>
    */
-  @Description("The credential instance that should be used to authenticate against AWS services. "
-      + "Refer to DefaultAWSCredentialsProviderChain Javadoc for usage help.")
-  @Default.InstanceFactory(AwsUserCredentialsFactory.class)
-  AWSCredentialsProvider getAwsCredentialsProvider();
-  void setAwsCredentialsProvider(AWSCredentialsProvider value);
+   @Description("The credential instance that should be used to authenticate "
+           + "against AWS services. The option value must contain \"@type\" field "
+           + "and an AWS Credentials Provider class name as the field value. "
+           + "Refer to DefaultAWSCredentialsProviderChain Javadoc for usage help. "
+           + "For example, to specify the AWS key ID and secret, specify the following: "
+           + "{\"@type\": \"AWSStaticCredentialsProvider\", "
+           + "\"awsAccessKeyId\":\"<key_id>\", \"awsSecretKey\":\"<secret_key>\"}")
+   @Default.InstanceFactory(AwsUserCredentialsFactory.class)
+   AWSCredentialsProvider getAwsCredentialsProvider();
+   void setAwsCredentialsProvider(AWSCredentialsProvider value);
 
   /**
    * Attempts to load AWS credentials.


### PR DESCRIPTION
Improves `--awsCredentialsProvider` description and javadoc by including required field `@type` and providing an example since previously there was no indication that the field was required.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand:
   - [x] What the pull request does
   - [x] Why it does it
   - [x] How it does it
   - [x] Why this approach
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

