### PR TITLE
[BEAM-4162][SQL] Wire up PubsubIO to SQL

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -505,6 +505,13 @@ public class Schema implements Serializable {
   }
 
   /**
+   * Returns true if {@code fieldName} exists in the schema, false otherwise.
+   */
+  public boolean hasField(String fieldName) {
+    return fieldIndices.containsKey(fieldName);
+  }
+
+  /**
    * Return the name of field by index.
    */
   public String nameOf(int fieldIndex) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/JsonToRowUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/JsonToRowUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * JsonToRowUtils.
+ */
+@Internal
+public class JsonToRowUtils {
+
+  public static ObjectMapper newObjectMapperWith(RowJsonDeserializer deserializer) {
+    SimpleModule module = new SimpleModule("rowDeserializationModule");
+    module.addDeserializer(Row.class, deserializer);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(module);
+
+    return objectMapper;
+  }
+
+  public static Row jsonToRow(ObjectMapper objectMapper, String jsonString) {
+    try {
+      return objectMapper.readValue(jsonString, Row.class);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Unable to parse json object: " + jsonString, e);
+    }
+  }
+}

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -64,6 +64,7 @@ dependencies {
   shadow library.java.joda_time
   shadow project(path: ":beam-runners-direct-java", configuration: "shadow")
   provided project(path: ":beam-sdks-java-io-kafka", configuration: "shadow")
+  provided project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
   provided library.java.kafka_clients
   testCompile library.java.slf4j_jdk14
   testCompile library.java.junit

--- a/sdks/java/extensions/sql/pom.xml
+++ b/sdks/java/extensions/sql/pom.xml
@@ -391,6 +391,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-sdks-java-io-google-cloud-platform</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <scope>provided</scope>

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
@@ -40,6 +40,8 @@ public abstract class Table implements Serializable {
   @Nullable
   public abstract JSONObject getProperties();
 
+  public abstract Builder toBuilder();
+
   public static Builder builder() {
     return new org.apache.beam.sdk.extensions.sql.meta.AutoValue_Table.Builder();
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static com.google.api.client.util.DateTime.parseRfc3339;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.DATETIME;
+import static org.apache.beam.sdk.util.JsonToRowUtils.newObjectMapperWith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.impl.schema.BeamIOType;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.util.JsonToRowUtils;
+import org.apache.beam.sdk.util.RowJsonDeserializer;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.DateTime;
+
+/**
+ * <i>Experimental</i>
+ *
+ * <p>Wraps the {@link PubsubIO} with JSON messages into {@link BeamSqlTable}.
+ *
+ * <p>This enables {@link PubsubIO} registration in Beam SQL environment as a table, including DDL
+ * support.
+ *
+ * <p>For example:
+ * <pre>
+ *
+ *  CREATE TABLE topic (name VARCHAR, age INTEGER)
+ *     TYPE 'pubsub'
+ *     LOCATION projects/&lt;GCP project id&gt;/topics/&lt;topic name&gt;
+ *     TBLPROPERTIES '{ \"timestampAttributeKey\" : &lt;timestamp attribute&gt; }';
+ *
+ *   SELECT name, age FROM topic;
+ *
+ * </pre>
+ */
+@AutoValue
+@Internal
+@Experimental
+abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
+
+  /**
+   * Schema of the pubsubs message payload.
+   *
+   * <p>Only UTF-8 flat JSON objects are supported at the moment.
+   */
+  abstract Schema getPayloadSchema();
+
+  /**
+   * Attribute key of the Pubsub message from which to extract the event timestamp.
+   *
+   * <p>This attribute has to conform to the same requirements as in {@link
+   * PubsubIO.Read.Builder#withTimestampAttribute}.
+   *
+   * <p>Short version: it has to be either millis since epoch or string in RFC 3339 format.
+   */
+  abstract String getTimestampAttribute();
+
+  /**
+   * Pubsub topic name.
+   *
+   * <p>Topic is the only way to specify the Pubsub source. Explicitly specifying the subscription
+   * is not supported at the moment. Subscriptions are automatically created an managed.
+   */
+  abstract String getTopic();
+
+  static Builder builder() {
+    return new AutoValue_PubsubIOJsonTable.Builder();
+  }
+
+  /**
+   * Table schema.
+   *
+   * <p>Inherited from {@link BeamSqlTable}. Different from {@link #getPayloadSchema()},
+   * includes timestamp attribute.
+   */
+   public abstract Schema getSchema();
+
+  @Override
+  public BeamIOType getSourceType() {
+    return BeamIOType.UNBOUNDED;
+  }
+
+  @Override
+  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+    return
+        PBegin
+            .in(pipeline)
+            .apply("readFromPubsub", readMessagesWithAttributes())
+            .apply("parseTimestampAttribute", parseTimestampAttribute())
+            .apply("parseJsonPayload", parseJsonPayload())
+            .setCoder(getSchema().getRowCoder());
+  }
+
+  private PubsubIO.Read<PubsubMessage> readMessagesWithAttributes() {
+    return
+        PubsubIO
+            .readMessagesWithAttributes()
+            .fromTopic(getTopic())
+            .withTimestampAttribute(getTimestampAttribute());
+  }
+
+  private ParDo.SingleOutput<PubsubMessage, KV<DateTime, PubsubMessage>> parseTimestampAttribute() {
+    return
+        ParDo.of(new DoFn<PubsubMessage, KV<DateTime, PubsubMessage>>() {
+          @ProcessElement
+          public void processElement(ProcessContext context) {
+            PubsubMessage pubsubMessage = context.element();
+            long msSinceEpoch = asMsSinceEpoch(pubsubMessage.getAttribute(getTimestampAttribute()));
+            context.output(KV.of(new DateTime(msSinceEpoch), pubsubMessage));
+          }
+        });
+  }
+
+  private static long asMsSinceEpoch(String timestamp) {
+    try {
+      return Long.parseLong(timestamp);
+    } catch (IllegalArgumentException e1) {
+      return parseRfc3339(timestamp).getValue();
+    }
+  }
+
+  private ParDo.SingleOutput<KV<DateTime, PubsubMessage>, Row> parseJsonPayload() {
+    return ParDo.of(
+        new DoFn<KV<DateTime, PubsubMessage>, Row>() {
+          private transient volatile @Nullable ObjectMapper objectMapper;
+
+          @ProcessElement
+          public void processElement(ProcessContext context) {
+            DateTime timestamp = context.element().getKey();
+            byte[] payloadBytes = context.element().getValue().getPayload();
+            String payloadJson = new String(payloadBytes, StandardCharsets.UTF_8);
+            Row payloadRow = parseRow(payloadJson);
+
+            context.output(
+                Row
+                    .withSchema(getSchema())
+                    .addValues(payloadRow.getValues())
+                    .addValue(timestamp)
+                    .build());
+          }
+
+          private Row parseRow(String json) {
+            if (objectMapper == null) {
+              objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(getPayloadSchema()));
+            }
+
+            return JsonToRowUtils.jsonToRow(objectMapper, json);
+          }
+        });
+  }
+
+  @Override
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+    throw new UnsupportedOperationException("Writing to a Pubsub topic is not supported");
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setPayloadSchema(Schema payloadSchema);
+    abstract Builder setSchema(Schema schema);
+    abstract Builder setTimestampAttribute(String timestampAttribute);
+    abstract Builder setTopic(String topic);
+
+    abstract PubsubIOJsonTable autoBuild();
+
+    abstract Schema getPayloadSchema();
+    abstract String getTimestampAttribute();
+
+    public PubsubIOJsonTable build() {
+      return
+          this
+              .setSchema(addTimestampField(getPayloadSchema(), getTimestampAttribute()))
+              .autoBuild();
+    }
+
+    private Schema addTimestampField(Schema schema, String timestampField) {
+      return
+          Schema
+              .builder()
+              .addFields(schema.getFields())
+              .addField(Schema.Field.of(timestampField, DATETIME.type()))
+              .build();
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import com.alibaba.fastjson.JSONObject;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.meta.Table;
+import org.apache.beam.sdk.extensions.sql.meta.provider.InMemoryMetaTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
+import org.apache.beam.sdk.schemas.Schema;
+
+/**
+ * {@link TableProvider} for {@link PubsubIOJsonTable} which wraps {@link PubsubIO} for Beam SQL.
+ */
+@Internal
+@Experimental
+public class PubsubJsonTableProvider extends InMemoryMetaTableProvider {
+
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
+    Schema tableSchema = table.getSchema();
+
+    JSONObject tableProperties = table.getProperties();
+    String timestampAttributeKey = tableProperties.getString("timestampAttributeKey");
+
+    if (timestampAttributeKey == null) {
+      throw new IllegalArgumentException(
+          "Unable to find 'timestampAttributeKey' property "
+          + "in TBLPROPERTIES JSON. At the moment Pubsub table "
+          + "have to explicitly declare the 'timestampAttributeKey', "
+          + "so that event time can be determined. Publish time "
+          + "or other timestamp sources are not supported at this time.");
+    }
+
+    if (tableSchema.hasField(timestampAttributeKey)) {
+      throw new IllegalArgumentException(
+          "Conflicting field '" + timestampAttributeKey + "'. "
+          + "It is declared both in the table schema and as a timestamp attribute "
+          + "at the same time. This is not supported. Either remove field from table schema "
+          + "or choose a different timestamp attribute.");
+    }
+
+    return
+        PubsubIOJsonTable
+            .builder()
+            .setPayloadSchema(tableSchema)
+            .setTimestampAttribute(timestampAttributeKey)
+            .setTopic(table.getLocation())
+            .build();
+  }
+
+  @Override
+  public String getTableType() {
+    return "pubsub";
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.beam.sdk.util.JsonToRowUtils.newObjectMapperWith;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.extensions.sql.RowSqlTypes;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.util.JsonToRowUtils;
+import org.apache.beam.sdk.util.RowJsonDeserializer;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.Instant;
+
+/**
+ * A {@link DoFn} to convert {@link PubsubMessage} with JSON payload to {@link Row}.
+ */
+@Internal
+@Experimental
+public class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
+  static final String TIMESTAMP_FIELD = "event_timestamp";
+  static final String ATTRIBUTES_FIELD = "attributes";
+  static final String PAYLOAD_FIELD = "payload";
+
+  private transient volatile @Nullable ObjectMapper objectMapper;
+  private Schema messageSchema;
+
+  /**
+   * Schema of the Pubsub message.
+   *
+   * <p>Required to have exactly 3 top level fields at the moment:
+   * <ul>
+   *   <li>'event_timestamp' of type {@link RowSqlTypes#TIMESTAMP}</li>
+   *   <li>'attributes' of type {@link TypeName#MAP MAP&lt;VARCHAR,VARCHAR&gt;}</li>
+   *   <li>'payload' of type {@link TypeName#ROW ROW&lt;...&gt;}</li>
+   * </ul>
+   *
+   * <p>Only UTF-8 JSON objects are supported.
+   */
+  public Schema getMessageSchema() {
+    return messageSchema;
+  }
+
+  public static ParDo.SingleOutput<PubsubMessage, Row> forSchema(Schema messageSchema) {
+    return ParDo.of(new PubsubMessageToRow(messageSchema));
+  }
+
+  private PubsubMessageToRow(Schema messageSchema) {
+    this.messageSchema = messageSchema;
+  }
+
+  @DoFn.ProcessElement
+  public void processElement(ProcessContext context) {
+    // get values for fields
+    // in the same order they're specified in schema
+    List<Object> values = getMessageSchema()
+        .getFields()
+        .stream()
+        .map(field ->
+                 getValueForField(
+                     field,
+                     context.timestamp(),
+                     context.element()))
+        .collect(toList());
+
+    context.output(
+        Row.withSchema(getMessageSchema()).addValues(values).build());
+  }
+
+  private Object getValueForField(
+      Schema.Field field,
+      Instant timestamp,
+      PubsubMessage pubsubMessage) {
+
+    switch (field.getName()) {
+      case TIMESTAMP_FIELD:
+        return timestamp;
+      case ATTRIBUTES_FIELD:
+        return pubsubMessage.getAttributeMap();
+      case PAYLOAD_FIELD:
+        return parsePayloadJsonRow(pubsubMessage);
+      default:
+        throw new IllegalArgumentException(
+            "Unexpected field '" + field.getName() + "' in top level schema"
+            + " for Pubsub message. Top level schema should only contain "
+            + "'timestamp', 'attributes', and 'payload' fields");
+    }
+  }
+
+  private Row parsePayloadJsonRow(PubsubMessage pubsubMessage) {
+    String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
+
+    if (objectMapper == null) {
+      objectMapper =
+          newObjectMapperWith(RowJsonDeserializer.forSchema(getPayloadSchema()));
+    }
+
+    return JsonToRowUtils.jsonToRow(objectMapper, payloadJson);
+  }
+
+  private Schema getPayloadSchema() {
+    return getMessageSchema().getField(PAYLOAD_FIELD).getType().getRowSchema();
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Table schema for {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubIO}.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
@@ -19,4 +19,8 @@
 /**
  * Table schema for {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubIO}.
  */
+@DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql;
+
+import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubJsonTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link BeamSqlCli} Pubsub functionality.
+ */
+public class BeamSqlCliPubsubTest {
+
+  @Test
+  @Ignore("Something like this needs an emulator. TODO(akedin): BEAM-4195")
+  public void testPubsubTable() throws Exception {
+    String pubsubTopic = "projects/<probject>/topics/<topic>";
+    InMemoryMetaStore metaStore = new InMemoryMetaStore();
+    metaStore.registerProvider(new PubsubJsonTableProvider());
+
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
+
+    cli.execute(
+        "CREATE TABLE topic (\n"
+        + "name VARCHAR, \n"
+        + "age INTEGER) \n"
+        + "TYPE 'pubsub' \n"
+        + "LOCATION '" + pubsubTopic + "' \n"
+        + "TBLPROPERTIES '{ \"timestampAttributeKey\" : \"ts\" }'");
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 public class BeamSqlCliPubsubTest {
 
   @Test
-  @Ignore("Something like this needs an emulator. TODO(akedin): BEAM-4195")
+  @Ignore("Something like this needs an emulator. TODO: BEAM-4195")
   public void testPubsubTable() throws Exception {
     String pubsubTopic = "projects/<probject>/topics/<topic>";
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
@@ -38,10 +38,17 @@ public class BeamSqlCliPubsubTest {
 
     cli.execute(
         "CREATE TABLE topic (\n"
-        + "name VARCHAR, \n"
-        + "age INTEGER) \n"
+        + "event_timestamp TIMESTAMP, \n"
+        + "attributes MAP<VARCHAR, VARCHAR>, \n"
+        + "payload ROW< \n"
+        + "             `id` INTEGER, \n"
+        + "             `name` VARCHAR \n"
+        + "           > \n"
+        + ") \n"
         + "TYPE 'pubsub' \n"
         + "LOCATION '" + pubsubTopic + "' \n"
         + "TBLPROPERTIES '{ \"timestampAttributeKey\" : \"ts\" }'");
+
+    cli.execute("SELECT topic.payload.name from topic");
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.apache.beam.sdk.extensions.sql.RowSqlTypes.INTEGER;
+import static org.apache.beam.sdk.extensions.sql.RowSqlTypes.VARCHAR;
+import static org.apache.beam.sdk.schemas.Schema.toSchema;
+import static org.junit.Assert.assertEquals;
+
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.meta.Table;
+import org.apache.beam.sdk.schemas.Schema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Unit tests for {@link PubsubJsonTableProvider}.
+ */
+public class PubsubJsonTableProviderTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testTableTypePubsub() {
+    PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
+    assertEquals("pubsub", provider.getTableType());
+  }
+
+  @Test
+  public void testCreatesTable() {
+    PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
+
+    BeamSqlTable pubsubTable = provider.buildBeamSqlTable(fakeTable());
+    assertNotNull(pubsubTable);
+  }
+
+
+  @Test
+  public void testThrowsIfTimestampAttributeNotProvided() {
+    PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
+
+    Table table = fakeTable().toBuilder().properties(new JSONObject()).build();
+
+    thrown.expectMessage("timestampAttributeKey");
+    provider.buildBeamSqlTable(table);
+  }
+
+  @Test
+  public void testThrowsIfTimestampFieldExistsInSchema() {
+    PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
+
+    Table table =
+        fakeTable()
+            .toBuilder()
+            .schema(
+                Stream
+                    .of(Schema.Field.of("ts_field", VARCHAR).withNullable(true))
+                    .collect(toSchema()))
+            .build();
+
+    thrown.expectMessage("ts_field");
+    provider.buildBeamSqlTable(table);
+  }
+
+  private static Table fakeTable() {
+    return
+        Table
+            .builder()
+            .name("FakeTable")
+            .comment("fake table")
+            .location("projects/project/topics/topic")
+            .schema(
+                Stream.of(
+                    Schema.Field.of("id", INTEGER).withNullable(true),
+                    Schema.Field.of("id", VARCHAR).withNullable(true)
+                ).collect(toSchema()))
+            .type("pubsub")
+            .properties(JSON.parseObject("{ \"timestampAttributeKey\" : \"ts_field\" }"))
+            .build();
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
+
+import static org.apache.calcite.sql.type.SqlTypeName.VARCHAR;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.beam.sdk.extensions.sql.RowSqlTypes;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.DateTime;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link PubsubMessageToRow}.
+ */
+public class PubsubMessageToRowTest implements Serializable {
+
+  @Rule
+  public transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testConvertsMessages() {
+    Schema payloadSchema =
+        RowSqlTypes
+            .builder()
+            .withIntegerField("id")
+            .withVarcharField("name")
+            .build();
+
+    Schema messageSchema =
+        RowSqlTypes
+            .builder()
+            .withTimestampField("event_timestamp")
+            .withMapField("attributes", VARCHAR, VARCHAR)
+            .withRowField("payload", payloadSchema)
+            .build();
+
+    PCollection<Row> rows = pipeline
+        .apply("create",
+               Create.timestamped(
+                   message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                   message(2, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }"),
+                   message(3, map("cttr", "vcl"), "{ \"id\" : 7, \"name\" : \"bar\" }"),
+                   message(4, map("dttr", "vdl"), "{ \"name\" : \"qaz\", \"id\" : 8 }")))
+        .apply("convert", PubsubMessageToRow.forSchema(messageSchema));
+
+    PAssert
+        .that(rows)
+        .containsInAnyOrder(
+            Row.withSchema(messageSchema)
+               .addValues(ts(1), map("attr", "val"), row(payloadSchema, 3, "foo"))
+               .build(),
+            Row.withSchema(messageSchema)
+               .addValues(ts(2), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
+               .build(),
+            Row.withSchema(messageSchema)
+               .addValues(ts(3), map("cttr", "vcl"), row(payloadSchema, 7, "bar"))
+               .build(),
+            Row.withSchema(messageSchema)
+               .addValues(ts(4), map("dttr", "vdl"), row(payloadSchema, 8, "qaz"))
+               .build()
+        );
+
+    pipeline.run();
+  }
+
+  private Row row(Schema schema, int id, String name) {
+    return Row.withSchema(schema).addValues(id, name).build();
+  }
+
+  private Map<String, String> map(String attr, String val) {
+    return ImmutableMap.of(attr, val);
+  }
+
+  private TimestampedValue<PubsubMessage> message(
+      int timestamp,
+      Map<String, String> attributes,
+      String payload) {
+
+    return TimestampedValue.of(
+        new PubsubMessage(payload.getBytes(StandardCharsets.UTF_8), attributes),
+        ts(timestamp));
+  }
+
+  private Instant ts(long timestamp) {
+    return new DateTime(timestamp).toInstant();
+  }
+}


### PR DESCRIPTION
Implement a simple PubsubJsonTable which reads JSON objects with DDL-defined schema from a Pubsub topic and converts them to Rows, allowing querying the input with Beam SQL

This is a first step of integrating Pubsub with Beam SQL. This is not a full feature yet, and will evolve a lot. Follow up tasks, for example:
 - supporting complex types in DDL: [BEAM-4196](https://issues.apache.org/jira/browse/BEAM-4196);
 - supporting trigger definitions: [BEAM-4193](https://issues.apache.org/jira/browse/BEAM-4193);
 - support of Pubsub emulator for tests: [BEAM-4195](https://issues.apache.org/jira/browse/BEAM-4195);


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

