### PR TITLE
[BEAM-4224] Update perf.go: only trigger on processing bundles

### DIFF
--- a/sdks/go/pkg/beam/x/hooks/perf/perf.go
+++ b/sdks/go/pkg/beam/x/hooks/perf/perf.go
@@ -49,15 +49,15 @@ func init() {
 		enabled := len(enabledProfCaptureHooks) > 0
 		var cpuProfBuf bytes.Buffer
 		return hooks.Hook{
-			Req: func(ctx context.Context, _ *fnpb.InstructionRequest) (context.Context, error) {
-				if !enabled {
+			Req: func(ctx context.Context,  req *fnpb.InstructionRequest) (context.Context, error) {
+				if !enabled || req.GetProcessBundle() == nil {
 					return ctx, nil
 				}
 				cpuProfBuf.Reset()
 				return ctx, pprof.StartCPUProfile(&cpuProfBuf)
 			},
 			Resp: func(ctx context.Context, req *fnpb.InstructionRequest, _ *fnpb.InstructionResponse) error {
-				if !enabled {
+				if !enabled || req.GetProcessBundle() == nil {
 					return nil
 				}
 				pprof.StopCPUProfile()


### PR DESCRIPTION
Fix profiling of user code in Beam Go to only trigger at the beginning in and end of ProcessBundle requests, since that's where all user code executes.
Otherwise the profiling toggles on every ProcessBundleProgress request as well, which leads to meaningless or corrupt profiles.