### PR TITLE
Count compressed records with a long to avoid overflow

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CompressedSource.java
@@ -305,7 +305,7 @@ public class CompressedSource<T> extends FileBasedSource<T> {
     private final FileBasedReader<T> readerDelegate;
     private final Object progressLock = new Object();
     @GuardedBy("progressLock")
-    private int numRecordsRead;
+    private long numRecordsRead;
 
     @Nullable // Initialized in startReading
     @GuardedBy("progressLock")


### PR DESCRIPTION
Very large compressed files will fail with:
java.io.IOException: Failed to advance reader of source
due to overflow of this value. Changing it to a long prevents this.