### PR TITLE
Templatize host name in SpannerIO

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerConfig.java
@@ -52,7 +52,7 @@ public abstract class SpannerConfig implements Serializable {
   public abstract ValueProvider<String> getDatabaseId();
 
   @Nullable
-  public abstract String getHost();
+  public abstract ValueProvider<String> getHost();
 
   @Nullable
   @VisibleForTesting
@@ -61,7 +61,7 @@ public abstract class SpannerConfig implements Serializable {
   abstract Builder toBuilder();
 
   public static SpannerConfig create() {
-    return builder().setHost(DEFAULT_HOST).build();
+    return builder().setHost(ValueProvider.StaticValueProvider.of(DEFAULT_HOST)).build();
   }
 
   static Builder builder() {
@@ -100,7 +100,7 @@ public abstract class SpannerConfig implements Serializable {
 
     abstract Builder setDatabaseId(ValueProvider<String> databaseId);
 
-    abstract Builder setHost(String host);
+    abstract Builder setHost(ValueProvider<String> host);
 
     abstract Builder setServiceFactory(ServiceFactory<Spanner, SpannerOptions> serviceFactory);
 
@@ -131,7 +131,7 @@ public abstract class SpannerConfig implements Serializable {
     return withDatabaseId(ValueProvider.StaticValueProvider.of(databaseId));
   }
 
-  public SpannerConfig withHost(String host) {
+  public SpannerConfig withHost(ValueProvider<String> host) {
     return toBuilder().setHost(host).build();
   }
 
@@ -149,7 +149,7 @@ public abstract class SpannerConfig implements Serializable {
       builder.setServiceFactory(this.getServiceFactory());
     }
     if (getHost() != null) {
-      builder.setHost(getHost());
+      builder.setHost(getHost().get());
     }
     ReleaseInfo releaseInfo = ReleaseInfo.getReleaseInfo();
     builder.setUserAgentPrefix(USER_AGENT_PREFIX + "/" + releaseInfo.getVersion());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -305,9 +305,13 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public ReadAll withHost(String host) {
+    public ReadAll withHost(ValueProvider<String> host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
+    }
+
+    public ReadAll withHost(String host) {
+      return withHost(ValueProvider.StaticValueProvider.of(host));
     }
 
     /** Specifies the Cloud Spanner database. */
@@ -439,9 +443,13 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public Read withHost(String host) {
+    public Read withHost(ValueProvider<String> host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
+    }
+
+    public Read withHost(String host) {
+      return withHost(ValueProvider.StaticValueProvider.of(host));
     }
 
     /** If true the uses Cloud Spanner batch API. */
@@ -604,9 +612,13 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public CreateTransaction withHost(String host) {
+    public CreateTransaction withHost(ValueProvider<String> host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
+    }
+
+    public CreateTransaction withHost(String host) {
+      return withHost(ValueProvider.StaticValueProvider.of(host));
     }
 
     @VisibleForTesting
@@ -708,9 +720,14 @@ public class SpannerIO {
     }
 
     /** Specifies the Cloud Spanner host. */
-    public Write withHost(String host) {
+    public Write withHost(ValueProvider<String> host) {
       SpannerConfig config = getSpannerConfig();
       return withSpannerConfig(config.withHost(host));
+    }
+
+    /** Specifies the Cloud Spanner host. */
+    public Write withHost(String host) {
+      return withHost(ValueProvider.StaticValueProvider.of(host));
     }
 
     @VisibleForTesting


### PR DESCRIPTION
R: @jkff This allows to build a test infrastructure for Dataflow templates that use `SpannerIO`.