### PR TITLE
[BEAM-4073] Migrate DirectRunner Evaluators to use Portable Graph Components

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoders.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ModelCoders.java
@@ -40,19 +40,16 @@ public class ModelCoders {
 
   public static final String ITERABLE_CODER_URN = getUrn(StandardCoders.Enum.ITERABLE);
   public static final String KV_CODER_URN = getUrn(StandardCoders.Enum.KV);
-  public static final String LENGTH_PREFIX_CODER_URN =
-      getUrn(StandardCoders.Enum.LENGTH_PREFIX);
+  public static final String LENGTH_PREFIX_CODER_URN = getUrn(StandardCoders.Enum.LENGTH_PREFIX);
 
-  public static final String GLOBAL_WINDOW_CODER_URN =
-      getUrn(StandardCoders.Enum.GLOBAL_WINDOW);
+  public static final String GLOBAL_WINDOW_CODER_URN = getUrn(StandardCoders.Enum.GLOBAL_WINDOW);
   // This isn't strictly required once there's a way to represent an 'unknown window' (i.e. the
   // custom window encoding + the maximum timestamp of the window, this can be used for interval
   // windows.
   public static final String INTERVAL_WINDOW_CODER_URN =
       getUrn(StandardCoders.Enum.INTERVAL_WINDOW);
 
-  public static final String WINDOWED_VALUE_CODER_URN =
-      getUrn(StandardCoders.Enum.WINDOWED_VALUE);
+  public static final String WINDOWED_VALUE_CODER_URN = getUrn(StandardCoders.Enum.WINDOWED_VALUE);
 
   private static final Set<String> MODEL_CODER_URNS =
       ImmutableSet.of(

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   compile project(path: ":beam-runners-core-construction-java", configuration: "shadow")
   compile project(path: ":beam-runners-core-java", configuration: "shadow")
   compile project(path: ":beam-runners-local-java-core", configuration: "shadow")
+  compile project(path: ":beam-runners-java-fn-execution", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.joda_time
   shadow library.java.findbugs_jsr305

--- a/runners/direct-java/pom.xml
+++ b/runners/direct-java/pom.xml
@@ -205,6 +205,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-java-fn-execution</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/GroupByKeyOnlyEvaluatorFactory.java
@@ -17,41 +17,56 @@
  */
 package org.apache.beam.runners.direct.portable;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.Iterables.getOnlyElement;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
 import org.apache.beam.runners.core.GroupByKeyViaGroupByKeyOnly;
 import org.apache.beam.runners.core.GroupByKeyViaGroupByKeyOnly.GroupByKeyOnly;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.KeyedWorkItems;
+import org.apache.beam.runners.core.construction.CoderTranslation;
+import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
-import org.apache.beam.runners.direct.portable.StepTransformResult.Builder;
+import org.apache.beam.runners.direct.ExecutableGraph;
+import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.runners.local.StructuralKey;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.KV;
 
 /**
- * The {@link DirectRunner} {@link TransformEvaluatorFactory} for the
- * {@link GroupByKeyOnly} {@link PTransform}.
+ * The {@code DirectRunner} {@link TransformEvaluatorFactory} for the {@link GroupByKeyOnly} {@link
+ * PTransform}.
  */
 class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
-  private final EvaluationContext evaluationContext;
+  private final Components components;
 
-  GroupByKeyOnlyEvaluatorFactory(EvaluationContext evaluationContext) {
-    this.evaluationContext = evaluationContext;
+  private final BundleFactory bundleFactory;
+  private final ExecutableGraph<PTransformNode, PCollectionNode> graph;
+
+  GroupByKeyOnlyEvaluatorFactory(
+      Components components,
+      BundleFactory bundleFactory,
+      ExecutableGraph<PTransformNode, PCollectionNode> graph) {
+    this.components = components;
+    this.bundleFactory = bundleFactory;
+    this.graph = graph;
   }
 
   @Override
   public <InputT> TransformEvaluator<InputT> forApplication(
-      PTransformNode application,
-      CommittedBundle<?> inputBundle) {
+      PTransformNode application, CommittedBundle<?> inputBundle) {
     @SuppressWarnings({"cast", "unchecked", "rawtypes"})
     TransformEvaluator<InputT> evaluator = (TransformEvaluator) createEvaluator(application);
     return evaluator;
@@ -61,7 +76,7 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
   public void cleanup() {}
 
   private <K, V> TransformEvaluator<KV<K, V>> createEvaluator(final PTransformNode application) {
-    return new GroupByKeyOnlyEvaluator<>(evaluationContext, application);
+    return new GroupByKeyOnlyEvaluator<>(application);
   }
 
   /**
@@ -70,35 +85,52 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
    *
    * @see GroupByKeyViaGroupByKeyOnly
    */
-  private static class GroupByKeyOnlyEvaluator<K, V>
-      implements TransformEvaluator<KV<K, V>> {
-    private final EvaluationContext evaluationContext;
-
-    private final PTransformNode application;
+  private class GroupByKeyOnlyEvaluator<K, V> implements TransformEvaluator<KV<K, V>> {
     private final Coder<K> keyCoder;
-    private Map<StructuralKey<K>, List<WindowedValue<V>>> groupingMap;
+    private final Map<StructuralKey<K>, List<WindowedValue<V>>> groupingMap;
 
-    public GroupByKeyOnlyEvaluator(
-        EvaluationContext evaluationContext,
-        PTransformNode application) {
-      this.evaluationContext = evaluationContext;
-      this.application = application;
-      this.keyCoder = null;
-      this.groupingMap = new HashMap<>();
-      throw new UnsupportedOperationException("Not yet migrated");
+    private final PCollectionNode outputPCollection;
+    private final StepTransformResult.Builder<KV<K, V>> resultBuilder;
+
+    private GroupByKeyOnlyEvaluator(PTransformNode application) {
+      keyCoder = getKeyCoder(application);
+      groupingMap = new HashMap<>();
+      outputPCollection = getOnlyElement(graph.getProduced(application));
+      resultBuilder = StepTransformResult.withoutHold(application);
     }
 
-    private Coder<K> getKeyCoder(Coder<KV<K, V>> coder) {
-      checkState(
-          coder instanceof KvCoder,
-          "%s requires a coder of class %s."
-              + " This is an internal error; this is checked during pipeline construction"
-              + " but became corrupted.",
-          getClass().getSimpleName(),
-          KvCoder.class.getSimpleName());
-      @SuppressWarnings("unchecked")
-      Coder<K> keyCoder = ((KvCoder<K, V>) coder).getKeyCoder();
-      return keyCoder;
+    private Coder<K> getKeyCoder(PTransformNode application) {
+      PCollectionNode inputPCollection = getOnlyElement(graph.getPerElementInputs(application));
+      try {
+        // We know the type restrictions on the input PCollection, and the restrictions on the
+        // Wire coder
+        MessageWithComponents wireCoderProto =
+            WireCoders.createRunnerWireCoder(
+                inputPCollection, components, components::containsCoders);
+        Coder<WindowedValue<KV<K, V>>> wireCoder =
+            (Coder<WindowedValue<KV<K, V>>>)
+                CoderTranslation.fromProto(
+                    wireCoderProto.getCoder(),
+                    RehydratedComponents.forComponents(wireCoderProto.getComponents()));
+
+        checkArgument(
+            wireCoder instanceof WindowedValue.WindowedValueCoder,
+            "Wire %s must be a %s",
+            Coder.class.getSimpleName(),
+            WindowedValueCoder.class.getSimpleName());
+        WindowedValueCoder<KV<K, V>> windowedValueCoder = (WindowedValueCoder<KV<K, V>>) wireCoder;
+
+        checkArgument(
+            windowedValueCoder.getValueCoder() instanceof KvCoder,
+            "Input elements to %s must be encoded with a %s",
+            DirectGroupByKey.DirectGroupByKeyOnly.class.getSimpleName(),
+            KvCoder.class.getSimpleName());
+        KvCoder<K, V> kvCoder = (KvCoder<K, V>) windowedValueCoder.getValueCoder();
+
+        return kvCoder.getKeyCoder();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
     }
 
     @Override
@@ -113,19 +145,17 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
 
     @Override
     public TransformResult<KV<K, V>> finishBundle() {
-      Builder resultBuilder = StepTransformResult.withoutHold(application);
       for (Map.Entry<StructuralKey<K>, List<WindowedValue<V>>> groupedEntry :
           groupingMap.entrySet()) {
         K key = groupedEntry.getKey().getKey();
         KeyedWorkItem<K, V> groupedKv =
             KeyedWorkItems.elementsWorkItem(key, groupedEntry.getValue());
-        PCollectionNode outputNode = null;
         UncommittedBundle<KeyedWorkItem<K, V>> bundle =
-            evaluationContext.createKeyedBundle(StructuralKey.of(key, keyCoder), outputNode);
+            bundleFactory.createKeyedBundle(StructuralKey.of(key, keyCoder), outputPCollection);
         bundle.add(WindowedValue.valueInGlobalWindow(groupedKv));
         resultBuilder.addOutput(bundle);
       }
-      throw new UnsupportedOperationException("Not yet migrated");
+      return resultBuilder.build();
     }
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/RootProviderRegistry.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/RootProviderRegistry.java
@@ -34,10 +34,12 @@ import org.apache.beam.sdk.transforms.PTransform;
  */
 class RootProviderRegistry {
   /** Returns a {@link RootProviderRegistry} that only supports the {@link Impulse} primitive. */
-  public static RootProviderRegistry impulseRegistry(EvaluationContext context) {
+  public static RootProviderRegistry impulseRegistry(BundleFactory bundleFactory) {
     return new RootProviderRegistry(
         ImmutableMap.<String, RootInputProvider<?>>builder()
-            .put(IMPULSE_TRANSFORM_URN, new ImpulseEvaluatorFactory.ImpulseRootProvider(context))
+            .put(
+                IMPULSE_TRANSFORM_URN,
+                new ImpulseEvaluatorFactory.ImpulseRootProvider(bundleFactory))
             .build());
   }
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/ImpulseEvaluatorFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/ImpulseEvaluatorFactoryTest.java
@@ -23,17 +23,18 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Iterables;
 import java.util.Collection;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
+import org.apache.beam.runners.direct.ExecutableGraph;
 import org.apache.beam.runners.direct.portable.ImpulseEvaluatorFactory.ImpulseRootProvider;
 import org.apache.beam.runners.direct.portable.ImpulseEvaluatorFactory.ImpulseShard;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -41,16 +42,13 @@ import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.joda.time.Instant;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link ImpulseEvaluatorFactory}. */
 @RunWith(JUnit4.class)
-@Ignore("Not yet migrated")
 public class ImpulseEvaluatorFactoryTest {
   private BundleFactory bundleFactory = ImmutableListBundleFactory.create();
 
@@ -62,9 +60,20 @@ public class ImpulseEvaluatorFactoryTest {
                   FunctionSpec.newBuilder()
                       .setUrn(PTransformTranslation.IMPULSE_TRANSFORM_URN)
                       .build())
+              .putOutputs("output", "impulse.out")
               .build());
-
-  @Mock private EvaluationContext context;
+  private PCollectionNode impulseOut =
+      PipelineNode.pCollection(
+          "impulse.out", RunnerApi.PCollection.newBuilder().setUniqueName("impulse.out").build());
+  private ExecutableGraph<PTransformNode, PCollectionNode> graph =
+      PortableGraph.forPipeline(
+          RunnerApi.Pipeline.newBuilder()
+              .addRootTransformIds("impulse")
+              .setComponents(
+                  Components.newBuilder()
+                      .putTransforms("impulse", impulseApplication.getTransform())
+                      .putPcollections("impulse.out", impulseOut.getPCollection()))
+              .build());
 
   @Before
   public void setup() {
@@ -73,17 +82,13 @@ public class ImpulseEvaluatorFactoryTest {
 
   @Test
   public void testImpulse() throws Exception {
-    PCollectionNode impulseOut =
-        PipelineNode.pCollection(
-            "impulse.out", RunnerApi.PCollection.newBuilder().setUniqueName("impulse.out").build());
 
-    ImpulseEvaluatorFactory factory = new ImpulseEvaluatorFactory(context);
+    ImpulseEvaluatorFactory factory = new ImpulseEvaluatorFactory(bundleFactory, graph);
 
     WindowedValue<ImpulseShard> inputShard = WindowedValue.valueInGlobalWindow(new ImpulseShard());
     CommittedBundle<ImpulseShard> inputShardBundle =
         bundleFactory.<ImpulseShard>createRootBundle().add(inputShard).commit(Instant.now());
 
-    when(context.createBundle(impulseOut)).thenReturn(bundleFactory.createBundle(impulseOut));
     TransformEvaluator<ImpulseShard> evaluator =
         factory.forApplication(impulseApplication, inputShardBundle);
     evaluator.processElement(inputShard);
@@ -112,8 +117,7 @@ public class ImpulseEvaluatorFactoryTest {
 
   @Test
   public void testRootProvider() {
-    ImpulseRootProvider rootProvider = new ImpulseRootProvider(context);
-    when(context.createRootBundle()).thenReturn(bundleFactory.createRootBundle());
+    ImpulseRootProvider rootProvider = new ImpulseRootProvider(bundleFactory);
 
     Collection<? extends CommittedBundle<?>> inputs =
         rootProvider.getInitialInputs(impulseApplication, 100);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCoders.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCoders.java
@@ -16,15 +16,12 @@
 
 package org.apache.beam.runners.fnexecution.wire;
 
-import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
-
 import com.google.common.collect.Sets;
 import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
-import org.apache.beam.model.pipeline.v1.RunnerApi.StandardCoders;
 import org.apache.beam.runners.core.construction.ModelCoders;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.LengthPrefixCoder;
@@ -33,9 +30,6 @@ import org.apache.beam.sdk.coders.LengthPrefixCoder;
  * Utilities for replacing or wrapping unknown coders with {@link LengthPrefixCoder}.
  */
 public class LengthPrefixUnknownCoders {
-  private static final String BYTES_CODER_TYPE = ModelCoders.BYTES_CODER_URN;
-  private static final String LENGTH_PREFIX_CODER_TYPE = ModelCoders.LENGTH_PREFIX_CODER_URN;
-
   /**
    * Recursively traverse the coder tree and wrap the first unknown coder in every branch with a
    * {@link LengthPrefixCoder} unless an ancestor coder is itself a {@link LengthPrefixCoder}. If
@@ -67,8 +61,7 @@ public class LengthPrefixUnknownCoders {
     //     rebuild the coder by recursively length prefixing any unknown component coders.
     //  3) the requested coder is an unknown coder. In this case we either wrap the requested coder
     //     with a length prefix coder or replace it with a length prefix byte array coder.
-    if (getUrn(StandardCoders.Enum.LENGTH_PREFIX)
-        .equals(currentCoder.getSpec().getSpec().getUrn())) {
+    if (ModelCoders.LENGTH_PREFIX_CODER_URN.equals(currentCoder.getSpec().getSpec().getUrn())) {
       if (replaceWithByteArrayCoder) {
         return createLengthPrefixByteArrayCoder(coderId, components);
       }
@@ -132,11 +125,12 @@ public class LengthPrefixUnknownCoders {
       rvalBuilder.getComponentsBuilder().putCoders(coderId, currentCoder);
     }
 
-    rvalBuilder.getCoderBuilder()
+    rvalBuilder
+        .getCoderBuilder()
         .addComponentCoderIds(lengthPrefixComponentCoderId)
         .getSpecBuilder()
         .getSpecBuilder()
-        .setUrn(getUrn(StandardCoders.Enum.LENGTH_PREFIX));
+        .setUrn(ModelCoders.LENGTH_PREFIX_CODER_URN);
     return rvalBuilder.build();
   }
 
@@ -153,14 +147,14 @@ public class LengthPrefixUnknownCoders {
     byteArrayCoder
         .getSpecBuilder()
         .getSpecBuilder()
-        .setUrn(getUrn(StandardCoders.Enum.BYTES));
+        .setUrn(ModelCoders.BYTES_CODER_URN);
     rvalBuilder.getComponentsBuilder().putCoders(byteArrayCoderId,
         byteArrayCoder.build());
     rvalBuilder.getCoderBuilder()
         .addComponentCoderIds(byteArrayCoderId)
         .getSpecBuilder()
         .getSpecBuilder()
-        .setUrn(getUrn(StandardCoders.Enum.LENGTH_PREFIX));
+        .setUrn(ModelCoders.LENGTH_PREFIX_CODER_URN);
 
     return rvalBuilder.build();
   }


### PR DESCRIPTION
This migrates the Impulse, Flatten, and GroupByKeyOnly evaluators to use information
extracted from the portable graph.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

