### PR TITLE
[BEAM-4233] [SQL] Use the same javacc and fmpp as calcite

### DIFF
--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -48,7 +48,8 @@ def calcite_version = "1.16.0"
 def avatica_version = "1.11.0"
 
 dependencies {
-  fmppTask "net.sourceforge.fmpp:fmpp:0.9.15"
+  javacc "net.java.dev.javacc:javacc:4.0"
+  fmppTask "com.googlecode.fmpp-maven-plugin:fmpp-maven-plugin:1.0"
   fmppTask "org.freemarker:freemarker:2.3.25-incubating"
   fmppTemplates "org.apache.calcite:calcite-core:$calcite_version"
   compile library.java.guava

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.parser.impl.BeamSqlParserImpl;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamLogicalConvention;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode;
 import org.apache.beam.sdk.values.PCollection;
@@ -91,7 +92,10 @@ public class BeamQueryPlanner {
 
     FrameworkConfig config =
         Frameworks.newConfigBuilder()
-            .parserConfig(SqlParser.configBuilder().setLex(Lex.MYSQL).build())
+            .parserConfig(SqlParser.configBuilder()
+                .setLex(Lex.MYSQL)
+                .setParserFactory(BeamSqlParserImpl.FACTORY)
+                .build())
             .defaultSchema(schema)
             .traitDefs(traitDefs)
             .context(Contexts.EMPTY_CONTEXT)


### PR DESCRIPTION
Calcite uses very specific versions of javacc and fmpp. We should use those so we don't hit bugs caused by incompatibilities.