### PR TITLE
[BEAM-3515] Portable translation of SplittableProcessKeyed

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -69,6 +69,7 @@ message MessageWithComponents {
     CombinePayload combine_payload = 3;
     SdkFunctionSpec sdk_function_spec = 4;
     ParDoPayload par_do_payload = 6;
+    SplittableProcessKeyedPayload splittable_process_keyed_payload = 15;
     PTransform ptransform = 7;
     PCollection pcollection = 8;
     ReadPayload read_payload = 9;
@@ -245,6 +246,9 @@ message StandardPTransforms {
     COMBINE_MERGE_ACCUMULATORS = 1 [(beam_urn) = "beam:transform:combine_merge_accumulators:v1"];
     COMBINE_EXTRACT_OUTPUTS = 2 [(beam_urn) = "beam:transform:combine_extract_outputs:v1"];
   }
+  enum SplittableParDoComponents {
+    SPLITTABLE_PROCESS_KEYED = 0 [(beam_urn) = "beam:transform:splittable_process_keyed_elements:v1"];
+  }
 
   // This field is needed only as a work-around for a proto compiler bug.
   // See https://github.com/google/protobuf/issues/4514
@@ -350,6 +354,20 @@ message ParDoPayload {
 
   // Whether the DoFn is splittable
   bool splittable = 6;
+}
+
+// The payload for the primitive SplittableProcessKeyed transform.
+message SplittableProcessKeyedPayload {
+
+  // (Required) The SdkFunctionSpec of the splittable DoFn.
+  SdkFunctionSpec do_fn = 1;
+
+  // (Optional) A mapping of local input names to side inputs, describing
+  // the expected access pattern.
+  map<string, SideInput> side_inputs = 3;
+
+  // (Required) Id of the restriction coder.
+  string restriction_coder_id = 4;
 }
 
 // Parameters that a UDF might require.

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms;
+import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.SplittableParDoComponents;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -82,6 +83,8 @@ public class PTransformTranslation {
       StandardPTransforms.Composites.RESHUFFLE);
   public static final String WRITE_FILES_TRANSFORM_URN =
       getUrn(StandardPTransforms.Composites.WRITE_FILES);
+  public static final String SPLITTABLE_PROCESS_KEYED_URN =
+      getUrn(SplittableParDoComponents.SPLITTABLE_PROCESS_KEYED);
 
   private static final Map<Class<? extends PTransform>, TransformPayloadTranslator>
       KNOWN_PAYLOAD_TRANSLATORS = loadTransformPayloadTranslators();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -442,8 +442,7 @@ public class ParDoTranslation {
         .build();
   }
 
-  private static DoFnAndMainOutput doFnAndMainOutputTagFromProto(SdkFunctionSpec fnSpec)
-      throws InvalidProtocolBufferException {
+  public static DoFnAndMainOutput doFnAndMainOutputTagFromProto(SdkFunctionSpec fnSpec) {
     checkArgument(
         fnSpec.getSpec().getUrn().equals(CUSTOM_JAVA_DO_FN_URN),
         "Expected %s to be %s with URN %s, but URN was %s",

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -267,7 +267,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
             .add(
                 PTransformOverride.of(
                     PTransformMatchers.urnEqualTo(
-                        SplittableParDo.SPLITTABLE_PROCESS_KEYED_ELEMENTS_URN),
+                        PTransformTranslation.SPLITTABLE_PROCESS_KEYED_URN),
                     new SplittableParDoViaKeyedWorkItems.OverrideFactory()))
             .add(
                 PTransformOverride.of(

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -47,6 +47,11 @@ public interface TransformTranslator<TransformT extends PTransform> {
    * including reading and writing the values of {@link PCollection}s and side inputs.
    */
   interface TranslationContext {
+    default boolean isFnApi() {
+      List<String> experiments = getPipelineOptions().getExperiments();
+      return (experiments != null && experiments.contains("beam_fn_api"));
+    }
+
     /** Returns the configured pipeline options. */
     DataflowPipelineOptions getPipelineOptions();
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -45,6 +45,7 @@ import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -52,12 +53,17 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.SplittableProcessKeyedPayload;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.core.construction.ParDoTranslation;
+import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.dataflow.DataflowPipelineTranslator.JobSpecification;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions;
 import org.apache.beam.runners.dataflow.util.CloudObject;
 import org.apache.beam.runners.dataflow.util.CloudObjects;
-import org.apache.beam.runners.dataflow.util.OutputReference;
 import org.apache.beam.runners.dataflow.util.PropertyNames;
 import org.apache.beam.runners.dataflow.util.Structs;
 import org.apache.beam.sdk.Pipeline;
@@ -137,9 +143,6 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     options.setRunner(DataflowRunner.class);
     Pipeline p = Pipeline.create(options);
 
-    // Enable the FileSystems API to know about gs:// URIs in this test.
-    FileSystems.setDefaultPipelineOptions(options);
-
     p.apply("ReadMyFile", TextIO.read().from("gs://bucket/object"))
         .apply("WriteMyFile", TextIO.write().to("gs://bucket/object"));
     DataflowRunner runner = DataflowRunner.fromOptions(options);
@@ -183,6 +186,10 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     options.setFilesToStage(new LinkedList<>());
     options.setDataflowClient(buildMockDataflow(new IsValidCreateRequest()));
     options.setGcsUtil(mockGcsUtil);
+
+    // Enable the FileSystems API to know about gs:// URIs in this test.
+    FileSystems.setDefaultPipelineOptions(options);
+
     return options;
   }
 
@@ -409,47 +416,6 @@ public class DataflowPipelineTranslatorTest implements Serializable {
     assertEquals(1, job.getEnvironment().getWorkerPools().size());
     assertEquals(diskSizeGb,
         job.getEnvironment().getWorkerPools().get(0).getDiskSizeGb());
-  }
-
-  /**
-   * Construct a OutputReference for the output of the step.
-   */
-  private static OutputReference getOutputPortReference(Step step) throws Exception {
-    // TODO: This should be done via a Structs accessor.
-    @SuppressWarnings("unchecked")
-    List<Map<String, Object>> output =
-        (List<Map<String, Object>>) step.getProperties().get(PropertyNames.OUTPUT_INFO);
-    String outputTagId = getString(Iterables.getOnlyElement(output), PropertyNames.OUTPUT_NAME);
-    return new OutputReference(step.getName(), outputTagId);
-  }
-
-  /**
-   * Returns a Step for a {@link DoFn} by creating and translating a pipeline.
-   */
-  private static Step createPredefinedStep() throws Exception {
-    DataflowPipelineOptions options = buildPipelineOptions();
-    DataflowPipelineTranslator translator = DataflowPipelineTranslator.fromOptions(options);
-    Pipeline pipeline = Pipeline.create(options);
-    String stepName = "DoFn1";
-    pipeline.apply("ReadMyFile", TextIO.read().from("gs://bucket/in"))
-        .apply(stepName, ParDo.of(new NoOpFn()))
-        .apply("WriteMyFile", TextIO.write().to("gs://bucket/out"));
-    DataflowRunner runner = DataflowRunner.fromOptions(options);
-    runner.replaceTransforms(pipeline);
-    Job job = translator.translate(pipeline, runner, Collections.emptyList()).getJob();
-
-    assertEquals(8, job.getSteps().size());
-    Step step = job.getSteps().get(1);
-    assertEquals(stepName, getString(step.getProperties(), PropertyNames.USER_NAME));
-    assertAllStepOutputsHaveUniqueIds(job);
-    return step;
-  }
-
-  private static class NoOpFn extends DoFn<String, String> {
-    @ProcessElement
-    public void processElement(ProcessContext c) throws Exception {
-      c.output(c.element());
-    }
   }
 
   /**
@@ -806,6 +772,65 @@ public class DataflowPipelineTranslatorTest implements Serializable {
                     processKeyedStep.getProperties(), PropertyNames.RESTRICTION_CODER));
 
     assertEquals(SerializableCoder.of(OffsetRange.class), restrictionCoder);
+  }
+
+  /**
+   * Smoke test to fail fast if translation of a splittable ParDo
+   * in streaming breaks.
+   */
+  @Test
+  public void testStreamingSplittableParDoTranslationFnApi() throws Exception {
+    DataflowPipelineOptions options = buildPipelineOptions();
+    DataflowRunner runner = DataflowRunner.fromOptions(options);
+    options.setStreaming(true);
+    options.setExperiments(Arrays.asList("beam_fn_api"));
+    DataflowPipelineTranslator translator = DataflowPipelineTranslator.fromOptions(options);
+
+    Pipeline pipeline = Pipeline.create(options);
+
+    PCollection<String> windowedInput =
+        pipeline
+            .apply(Create.of("a"))
+            .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))));
+    windowedInput.apply(ParDo.of(new TestSplittableFn()));
+
+    runner.replaceTransforms(pipeline);
+
+    JobSpecification result = translator.translate(pipeline, runner, Collections.emptyList());
+
+    Job job = result.getJob();
+
+    // The job should contain a SplittableParDo.ProcessKeyedElements step, translated as
+    // "SplittableProcessKeyed".
+
+    List<Step> steps = job.getSteps();
+    Step processKeyedStep = null;
+    for (Step step : steps) {
+      if ("SplittableProcessKeyed".equals(step.getKind())) {
+        assertNull(processKeyedStep);
+        processKeyedStep = step;
+      }
+    }
+    assertNotNull(processKeyedStep);
+
+    String fn = Structs.getString(processKeyedStep.getProperties(), PropertyNames.SERIALIZED_FN);
+    String restrictionCoder = Structs.getString(
+        processKeyedStep.getProperties(), PropertyNames.RESTRICTION_CODER);
+
+    Components componentsProto = result.getPipelineProto().getComponents();
+    RehydratedComponents components = RehydratedComponents
+        .forComponents(componentsProto);
+    RunnerApi.PTransform spkTransform = componentsProto
+        .getTransformsOrThrow(fn);
+    assertEquals(PTransformTranslation.SPLITTABLE_PROCESS_KEYED_URN,
+        spkTransform.getSpec().getUrn());
+    SplittableProcessKeyedPayload payload = SplittableProcessKeyedPayload
+        .parseFrom(spkTransform.getSpec().getPayload());
+    assertThat(
+        ParDoTranslation.doFnAndMainOutputTagFromProto(payload.getDoFn()).getDoFn(),
+        instanceOf(TestSplittableFn.class));
+    assertEquals(restrictionCoder, payload.getRestrictionCoderId());
+    assertThat(components.getCoder(restrictionCoder), instanceOf(SerializableCoder.class));
   }
 
   @Test


### PR DESCRIPTION
Introduces a new Payload for this primitive transform, consisting of the DoFn and restriction coder id.
Expansion on the Dataflow backend side will proceed as usual. Next steps will be mostly in the worker, which will get a ParDo instruction now properly referencing the DoFn and coder in the portable pipeline proto.