### PR TITLE
[BEAM-4229] Downgrade BigQuery to fix Spanner

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -234,7 +234,7 @@ ext.library = [
     google_api_services_storage: "com.google.apis:google-api-services-storage:v1-rev124-$google_clients_version",
     google_auth_library_credentials: "com.google.auth:google-auth-library-credentials:$google_auth_version",
     google_auth_library_oauth2_http: "com.google.auth:google-auth-library-oauth2-http:$google_auth_version",
-    google_cloud_bigquery: "com.google.cloud:google-cloud-bigquery:$google_clients_version",
+    google_cloud_bigquery: "com.google.cloud:google-cloud-bigquery:0.20.0-beta",
     google_cloud_core: "com.google.cloud:google-cloud-core:1.0.2",
     google_cloud_core_grpc: "com.google.cloud:google-cloud-core-grpc:$grpc_version",
     google_cloud_dataflow_java_proto_library_all: "com.google.cloud.dataflow:google-cloud-dataflow-java-proto-library-all:0.5.160304",

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,7 @@
     <protobuf.version>3.2.0</protobuf.version>
     <pubsub.version>v1-rev382-1.23.0</pubsub.version>
     <slf4j.version>1.7.25</slf4j.version>
+    <bigquery.version>0.20.0-beta</bigquery.version>
     <spanner.version>0.20.0b-beta</spanner.version>
     <spark.version>2.3.0</spark.version>
     <spring.version>4.3.5.RELEASE</spring.version>
@@ -1123,7 +1124,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-bigquery</artifactId>
-        <version>${google-clients.version}</version>
+        <version>${bigquery.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Both Spanner and BigQuery depend on google-cloud-core. The spanner library requires 1.2.0, the BigQuery library requires 1.27.0, and we include 1.0.2 in our build_rules.gradle. Downgrading the BigQuery library fixes the issue. We can't upgrade spanner because of a conflict with gRPC and Protobuf. This shouldn't be a problem as we are only using this BigQuery library for schema conversion, our actual IO uses an even older library.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

