### PR TITLE
Moving Python PostCommit into a Gradle task.

### DIFF
--- a/.test-infra/jenkins/job_beam_PostCommit_Python_Verify.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Python_Verify.groovy
@@ -39,6 +39,7 @@ job('beam_PostCommit_Python_Verify') {
   // Execute shell command to test Python SDK.
   steps {
     gradle {
+      rootBuildScriptDir(common_job_properties.checkoutDir)
       tasks(':pythonPostCommit')
       common_job_properties.setGradleSwitches(delegate)
     }

--- a/.test-infra/jenkins/job_beam_PostCommit_Python_Verify.groovy
+++ b/.test-infra/jenkins/job_beam_PostCommit_Python_Verify.groovy
@@ -38,6 +38,9 @@ job('beam_PostCommit_Python_Verify') {
 
   // Execute shell command to test Python SDK.
   steps {
-    shell('cd ' + common_job_properties.checkoutDir + ' && bash sdks/python/run_postcommit.sh')
+    gradle {
+      tasks(':pythonPostCommit')
+      common_job_properties.setGradleSwitches(delegate)
+    }
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,12 @@ task pythonPreCommit() {
 }
 
 task pythonPostCommit() {
-  dependsOn ":beam-sdks-python:postCommit"
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', './sdks/python/run_postcommit.sh'
+    }
+  }
 }
 
 apply plugin: 'net.researchgate.release'

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,10 @@ task pythonPreCommit() {
   dependsOn ":beam-sdks-python:check"
 }
 
+task pythonPostCommit() {
+  dependsOn ":beam-sdks-python:postCommit"
+}
+
 apply plugin: 'net.researchgate.release'
 release {
   revertOnFail = true

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -159,3 +159,12 @@ task cover(dependsOn: 'setupVirtualenv') {
     }
   }
 }
+
+task postCommit() {
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', './run_postcommit.sh'
+    }
+  }
+}

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -160,11 +160,3 @@ task cover(dependsOn: 'setupVirtualenv') {
   }
 }
 
-task postCommit() {
-  doLast {
-    exec {
-      executable 'sh'
-      args '-c', './run_postcommit.sh'
-    }
-  }
-}


### PR DESCRIPTION
This is the first step to migrate python PostCommit tests to run fully, and as much as possible in Gradle.