### PR TITLE
[BEAM-2732] StateSampler knows the execution thread it tracks.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/statesampler.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler.py
@@ -47,7 +47,10 @@ def get_current_tracker():
 
 StateSamplerInfo = namedtuple(
     'StateSamplerInfo',
-    ['state_name', 'transition_count', 'time_since_transition'])
+    ['state_name',
+     'transition_count',
+     'time_since_transition',
+     'tracked_thread'])
 
 
 # Default period for sampling current state of pipeline execution.
@@ -63,6 +66,7 @@ class StateSampler(statesampler_impl.StateSampler):
     self._counter_factory = counter_factory
     self._states_by_name = {}
     self.sampling_period_ms = sampling_period_ms
+    self.tracked_thread = None
     super(StateSampler, self).__init__(sampling_period_ms)
 
   def stop_if_still_running(self):
@@ -70,6 +74,7 @@ class StateSampler(statesampler_impl.StateSampler):
       self.stop()
 
   def start(self):
+    self.tracked_thread = threading.current_thread()
     set_current_tracker(self)
     execution.metrics_startup()
     super(StateSampler, self).start()
@@ -80,7 +85,8 @@ class StateSampler(statesampler_impl.StateSampler):
     return StateSamplerInfo(
         self.current_state().name,
         self.state_transition_count,
-        self.time_since_transition)
+        self.time_since_transition,
+        self.tracked_thread)
 
   def scoped_state(self,
                    step_name,


### PR DESCRIPTION
This will enable features such as logging a stack trace when the execution thread is stuck in a specific execution state