### PR TITLE
[BEAM-4236, BEAM-2927] Make Python SDK side inputs work with non well known coders and also work with Dataflow

### DIFF
--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -307,8 +307,7 @@ class AsSideInput(object):
     return SideInputData(
         common_urns.side_inputs.ITERABLE.urn,
         self._window_mapping_fn,
-        lambda iterable: from_runtime_iterable(iterable, view_options),
-        self._input_element_coder())
+        lambda iterable: from_runtime_iterable(iterable, view_options))
 
   def _input_element_coder(self):
     return coders.WindowedValueCoder(
@@ -346,11 +345,10 @@ class _UnpickledSideInput(AsSideInput):
 
 class SideInputData(object):
   """All of the data about a side input except for the bound PCollection."""
-  def __init__(self, access_pattern, window_mapping_fn, view_fn, coder):
+  def __init__(self, access_pattern, window_mapping_fn, view_fn):
     self.access_pattern = access_pattern
     self.window_mapping_fn = window_mapping_fn
     self.view_fn = view_fn
-    self.coder = coder
 
   def to_runner_api(self, context):
     return beam_runner_api_pb2.SideInput(
@@ -360,7 +358,7 @@ class SideInputData(object):
             environment_id=context.default_environment_id(),
             spec=beam_runner_api_pb2.FunctionSpec(
                 urn=python_urns.PICKLED_VIEWFN,
-                payload=pickler.dumps((self.view_fn, self.coder)))),
+                payload=pickler.dumps(self.view_fn))),
         window_mapping_fn=beam_runner_api_pb2.SdkFunctionSpec(
             environment_id=context.default_environment_id(),
             spec=beam_runner_api_pb2.FunctionSpec(
@@ -375,7 +373,7 @@ class SideInputData(object):
     return SideInputData(
         proto.access_pattern.urn,
         pickler.loads(proto.window_mapping_fn.spec.payload),
-        *pickler.loads(proto.view_fn.spec.payload))
+        pickler.loads(proto.view_fn.spec.payload))
 
 
 class AsSingleton(AsSideInput):
@@ -451,8 +449,7 @@ class AsIter(AsSideInput):
     return SideInputData(
         common_urns.side_inputs.ITERABLE.urn,
         self._window_mapping_fn,
-        lambda iterable: iterable,
-        self._input_element_coder())
+        lambda iterable: iterable)
 
   @property
   def element_type(self):
@@ -482,8 +479,7 @@ class AsList(AsSideInput):
     return SideInputData(
         common_urns.side_inputs.ITERABLE.urn,
         self._window_mapping_fn,
-        list,
-        self._input_element_coder())
+        list)
 
 
 class AsDict(AsSideInput):
@@ -510,8 +506,7 @@ class AsDict(AsSideInput):
     return SideInputData(
         common_urns.side_inputs.ITERABLE.urn,
         self._window_mapping_fn,
-        dict,
-        self._input_element_coder())
+        dict)
 
 
 class AsMultiMap(AsSideInput):
@@ -537,8 +532,7 @@ class AsMultiMap(AsSideInput):
     return SideInputData(
         common_urns.side_inputs.MULTIMAP.urn,
         self._window_mapping_fn,
-        lambda x: x,
-        self._input_element_coder())
+        lambda x: x)
 
 
 class EmptySideInput(object):

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -72,6 +72,7 @@ cdef class PerWindowInvoker(DoFnInvoker):
   cdef dict kwargs_for_process
   cdef list placeholders
   cdef bint has_windowed_inputs
+  cdef bint cache_globally_windowed_args
   cdef object process_method
 
 

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -88,3 +88,4 @@ class PropertyNames(object):
   VALIDATE_SINK = 'validate_sink'
   VALIDATE_SOURCE = 'validate_source'
   VALUE = 'value'
+  WINDOWING_STRATEGY = 'windowing_strategy'

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -277,21 +277,13 @@ class PValueCache(object):
     else:
       tag = tag_or_value
     self._cache[
-        self.to_cache_key(transform, tag)] = [value, transform.refcounts[tag]]
+        self.to_cache_key(transform, tag)] = value
 
-  def get_pvalue(self, pvalue, decref=True):
+  def get_pvalue(self, pvalue):
     """Gets the value associated with a PValue from the cache."""
     self._ensure_pvalue_has_real_producer(pvalue)
     try:
-      value_with_refcount = self._cache[self.key(pvalue)]
-      if decref:
-        value_with_refcount[1] -= 1
-        logging.debug('PValue computed by %s (tag %s): refcount: %d => %d',
-                      pvalue.real_producer.full_label, self.key(pvalue)[1],
-                      value_with_refcount[1] + 1, value_with_refcount[1])
-        if value_with_refcount[1] <= 0:
-          self.clear_pvalue(pvalue)
-      return value_with_refcount[0]
+      return self._cache[self.key(pvalue)]
     except KeyError:
       if (pvalue.tag is not None
           and self.to_cache_key(pvalue.real_producer, None) in self._cache):
@@ -301,8 +293,8 @@ class PValueCache(object):
       else:
         raise
 
-  def get_unwindowed_pvalue(self, pvalue, decref=True):
-    return [v.value for v in self.get_pvalue(pvalue, decref)]
+  def get_unwindowed_pvalue(self, pvalue):
+    return [v.value for v in self.get_pvalue(pvalue)]
 
   def clear_pvalue(self, pvalue):
     """Removes a PValue from the cache."""

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -655,3 +655,18 @@ def create(factory, transform_id, transform_proto, unused_parameter, consumers):
           factory.state_sampler),
       transform_proto.unique_name,
       consumers)
+
+
+@BeamTransformFactory.register_urn(
+    common_urns.primitives.MAP_WINDOWS.urn,
+    beam_runner_api_pb2.SdkFunctionSpec)
+def create(factory, transform_id, transform_proto, mapping_fn_spec, consumers):
+  assert mapping_fn_spec.urn == python_urns.PICKLED_WINDOW_MAPPING_FN
+  window_mapping_fn = pickler.loads(mapping_fn_spec.payload)
+  class MapWindows(beam.DoFn):
+    def process(self, element):
+      key, window = element
+      return [(key, window_mapping_fn(window))]
+  return _create_simple_pardo_operation(
+      factory, transform_id, transform_proto, consumers,
+      MapWindows())


### PR DESCRIPTION
Several issues addressed:
* Lack of support for mapping windows
* relying on reading the side input specification that was being serialized within the DoFn and not read from the pipeline description when using the Fn API
* eagerly pre-fetching the side input when the process bundle had zero elements which lead to a state request for a bundle containing zero elements

Streaming Dataflow job w/ Fn API side inputs: 2018-05-09_14_40_12-2860575533296523734 (note SIDE_INPUT being logged)
Batch Dataflow job w/ legacy side inputs: 2018-05-09_14_30_24-10730914164827927481

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

