### PR TITLE
Improving metrics api - execution separation.

### DIFF
--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -36,6 +36,7 @@ from apache_beam.metrics.cells import CounterCell
 from apache_beam.metrics.cells import DistributionCell
 from apache_beam.metrics.cells import GaugeCell
 from apache_beam.portability.api import beam_fn_api_pb2
+from apache_beam.runners.worker import statesampler
 
 
 class MetricKey(object):
@@ -147,12 +148,6 @@ class _MetricsEnvironment(object):
 
 
 MetricsEnvironment = _MetricsEnvironment()
-
-
-def metrics_startup():
-  """Initialize metrics context to run."""
-  global statesampler  # pylint: disable=global-variable-not-assigned
-  from apache_beam.runners.worker import statesampler
 
 
 class MetricsContainer(object):

--- a/sdks/python/apache_beam/metrics/metric.py
+++ b/sdks/python/apache_beam/metrics/metric.py
@@ -35,6 +35,7 @@ __all__ = ['Metrics', 'MetricsFilter']
 
 
 class _DelegatingMetric(object):
+  """Initializes metrics execution upon creation."""
   def __init__(self):
     global MetricsEnvironment  # pylint: disable=global-variable-not-assigned
     from apache_beam.metrics.execution import MetricsEnvironment
@@ -121,7 +122,7 @@ class Metrics(object):
       if container is not None:
         container.get_distribution(self.metric_name).update(value)
 
-  class DelegatingGauge(_DelegatingMetric, Gauge):
+  class DelegatingGauge(Gauge, _DelegatingMetric):
     """Metrics Gauge that Delegates functionality to MetricsEnvironment."""
 
     def __init__(self, metric_name):

--- a/sdks/python/apache_beam/metrics/metric_test.py
+++ b/sdks/python/apache_beam/metrics/metric_test.py
@@ -121,6 +121,7 @@ class MetricsTest(unittest.TestCase):
     statesampler.set_current_tracker(sampler)
     state1 = sampler.scoped_state('mystep', 'myState',
                                   metrics_container=MetricsContainer('mystep'))
+    sampler.start()
     with state1:
       counter_ns = 'aCounterNamespace'
       distro_ns = 'aDistributionNamespace'
@@ -144,6 +145,7 @@ class MetricsTest(unittest.TestCase):
       self.assertEqual(
           container.distributions[MetricName(distro_ns, name)].get_cumulative(),
           DistributionData(12, 2, 2, 10))
+    sampler.stop()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/worker/statesampler.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler.py
@@ -19,7 +19,6 @@
 import threading
 from collections import namedtuple
 
-from apache_beam.metrics import execution
 from apache_beam.utils.counters import Counter
 from apache_beam.utils.counters import CounterName
 
@@ -71,7 +70,6 @@ class StateSampler(statesampler_impl.StateSampler):
 
   def start(self):
     set_current_tracker(self)
-    execution.metrics_startup()
     super(StateSampler, self).start()
     self.started = True
 

--- a/sdks/python/generate_pydoc.sh
+++ b/sdks/python/generate_pydoc.sh
@@ -132,6 +132,7 @@ ignore_identifiers = [
   'apache_beam.io.iobase.SourceBase',
   'apache_beam.io.source_test_utils.ExpectedSplitOutcome',
   'apache_beam.metrics.metric.MetricResults',
+  'apache_beam.metrics.metric._DelegatingMetric',
   'apache_beam.pipeline.PipelineVisitor',
   'apache_beam.pipeline.PTransformOverride',
   'apache_beam.pvalue.AsSideInput',


### PR DESCRIPTION
This issue has caused trouble in the current Apache Beam import process.

This PR gives Metrics the responsibility of attaching itself to statesampler for state tracking, instead of statesampler initializing metrics, which is somewhat awkward.

Metrics execution infrastructure is initialized only when metrics are to be used, and not when the metrics api is imported.

- Changing reviewer as Robert is OOO
r: @aaltay 