### PR TITLE
Enable githubCommitNotifier for post commits

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -238,6 +238,7 @@ class common_job_properties {
     }
 
     context.publishers {
+      githubCommitNotifier()
       // Notify an email address for each failed build (defaults to commits@).
       mailer(notifyAddress, false, emailIndividuals)
     }


### PR DESCRIPTION
This should enable status for post commits run on master.