### PR TITLE
[BEAM-4263] Bugfix: Read BQ bytes processed from correct field.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -102,7 +102,7 @@ class BigQueryQuerySource<T> extends BigQuerySourceBase<T> {
   @Override
   public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
     BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
-    return dryRunQueryIfNeeded(bqOptions).getTotalBytesProcessed();
+    return dryRunQueryIfNeeded(bqOptions).getQuery().getTotalBytesProcessed();
   }
 
   @Override


### PR DESCRIPTION
The totalBytesProcessed field in the BigQuery job statistics is
deprecated:

  https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs

This change modifies the code to read the bytes processed value
from the correct field in the query statistics and adds a test to
cover the getEstimatedSizeBytes code path in the BigQuery query
source.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

