### PR TITLE
Make experiments as static set attr of RuntimeValueProvider

### DIFF
--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -69,6 +69,7 @@ class StaticValueProvider(ValueProvider):
 
 class RuntimeValueProvider(ValueProvider):
   runtime_options = None
+  experiments = None
 
   def __init__(self, option_name, value_type, default_value):
     self.option_name = option_name
@@ -101,6 +102,8 @@ class RuntimeValueProvider(ValueProvider):
   @classmethod
   def set_runtime_options(cls, pipeline_options):
     RuntimeValueProvider.runtime_options = pipeline_options
+    RuntimeValueProvider.experiments = RuntimeValueProvider.get_value(
+        'experiments', set, set())
 
   def __str__(self):
     return '%s(option: %s, type: %s, default_value: %s)' % (

--- a/sdks/python/apache_beam/options/value_provider_test.py
+++ b/sdks/python/apache_beam/options/value_provider_test.py
@@ -183,6 +183,17 @@ class ValueProviderTests(unittest.TestCase):
     self.assertEqual(options.vpt_vp_arg13.get(), 'a')
     self.assertEqual(options.vpt_vp_arg14.get(), 2)
 
+  def test_experiments_setup(self):
+    RuntimeValueProvider.set_runtime_options(
+        {'experiments': ['feature_1', 'feature_2']}
+    )
+    self.assertTrue(isinstance(RuntimeValueProvider.experiments, set))
+    self.assertTrue('feature_1' in RuntimeValueProvider.experiments)
+    self.assertTrue('feature_2' in RuntimeValueProvider.experiments)
+    # Clean up runtime_options after this test case finish, otherwise, it'll
+    # affect other cases since runtime_options is static attr
+    RuntimeValueProvider.set_runtime_options(None)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Reason to do this change:
it's possible to add more experiments option in the future. maybe better to make check experiment option in O(1) time complexity.

Usage:
if 'feature_1' in RuntimeValueProvider.experiments:
  perform feature_1

r: @aaltay 
cc: @pabloem 
