### PR TITLE
[BEAM-3042] Adding time tracking of batch side inputs [low priority]

### DIFF
--- a/sdks/python/apache_beam/runners/worker/opcounters.pxd
+++ b/sdks/python/apache_beam/runners/worker/opcounters.pxd
@@ -19,13 +19,14 @@ cimport cython
 cimport libc.stdint
 
 from apache_beam.utils.counters cimport Counter
+from apache_beam.runners.worker cimport statesampler_fast
 
 
 cdef class TransformIOCounter(object):
   cdef readonly object _counter_factory
   cdef readonly object _state_sampler
   cdef Counter bytes_read_counter
-  cdef object scoped_state
+  cdef statesampler_fast.ScopedState scoped_state
   cdef object _latest_step
 
   cpdef update_current_step(self)

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -325,7 +325,7 @@ class DoOperation(Operation):
         sources.append(si.source)
         # The tracking of time spend reading and bytes read from side inputs is
         # behind an experiment flag to test its performance impact.
-        if 'sideinput_io_metrics' in RuntimeValueProvider.experiments:
+        if 'sideinput_io_metrics_v2' in RuntimeValueProvider.experiments:
           si_counter = opcounters.SideInputReadCounter(
               self.counter_factory,
               self.state_sampler,

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -80,7 +80,7 @@ class PrefetchingSourceSetIterable(object):
   def add_byte_counter(self, reader):
     """Adds byte counter observer to a side input reader.
 
-    If the 'sideinput_io_metrics' experiment flag is not passed in, then
+    If the 'sideinput_io_metrics_v2' experiment flag is not passed in, then
     nothing is attached to the reader.
 
     Args:
@@ -123,7 +123,7 @@ class PrefetchingSourceSetIterable(object):
               # The tracking of time spend reading and bytes read from side
               # inputs is kept behind an experiment flag to test performance
               # impact.
-              if 'sideinput_io_metrics' in RuntimeValueProvider.experiments:
+              if 'sideinput_io_metrics_v2' in RuntimeValueProvider.experiments:
                 self.add_byte_counter(reader)
               returns_windowed_values = reader.returns_windowed_values
               for value in reader:

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -159,7 +159,8 @@ class PrefetchingSourceSetIterable(object):
     try:
       while True:
         try:
-          element = self.element_queue.get()
+          with self.read_counter:
+            element = self.element_queue.get()
           if element is READER_THREAD_IS_DONE_SENTINEL:
             num_readers_finished += 1
             if num_readers_finished == self.num_reader_threads:

--- a/sdks/python/apache_beam/runners/worker/sideinputs_test.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs_test.py
@@ -92,7 +92,7 @@ class PrefetchingSourceIteratorTest(unittest.TestCase):
 
   def test_bytes_read_are_reported(self):
     RuntimeValueProvider.set_runtime_options(
-        {'experiments': ['sideinput_io_metrics', 'other']})
+        {'experiments': ['sideinput_io_metrics_v2', 'other']})
     mock_read_counter = mock.MagicMock()
     source_records = ['a', 'b', 'c', 'd']
     sources = [

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pxd
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pxd
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+cimport cython
+
+from apache_beam.metrics.execution cimport MetricsContainer
+
+from cpython cimport pythread
+from libc.stdint cimport int32_t, int64_t
+
+cdef class StateSampler(object):
+  """Tracks time spent in states during pipeline execution."""
+  cdef int _sampling_period_ms
+
+  cdef list scoped_states_by_index
+
+  cdef public bint started
+  cdef public bint finished
+  cdef object sampling_thread
+
+  # This lock guards members that are shared between threads, specificaly
+  # finished, scoped_states_by_index, and the nsecs field of each state therein.
+  cdef pythread.PyThread_type_lock lock
+
+  cdef public int64_t state_transition_count
+  cdef public int64_t time_since_transition
+
+  cdef int32_t current_state_index
+
+  cpdef _scoped_state(self, counter_name, output_counter, metrics_container)
+
+cdef class ScopedState(object):
+  """Context manager class managing transitions for a given sampler state."""
+
+  cdef readonly StateSampler sampler
+  cdef readonly int32_t state_index
+  cdef readonly object counter
+  cdef readonly object name
+  cdef readonly int64_t _nsecs
+  cdef int32_t old_state_index
+  cdef readonly MetricsContainer _metrics_container
+
+  cpdef __enter__(self)
+
+  cpdef __exit__(self, unused_exc_type, unused_exc_value, unused_traceback)

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pxd
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pxd
@@ -25,6 +25,8 @@ from libc.stdint cimport int32_t, int64_t
 cdef class StateSampler(object):
   """Tracks time spent in states during pipeline execution."""
   cdef int _sampling_period_ms
+  cdef int _sampling_period_ms_start
+  cdef double _sampling_period_ratio
 
   cdef list scoped_states_by_index
 

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -172,7 +172,7 @@ cdef class StateSampler(object):
     return self.scoped_states_by_index[self.current_state_index]
 
   cpdef _scoped_state(self, counter_name, output_counter,
-                      metrics_container=None):
+                      metrics_container):
     """Returns a context manager managing transitions for a given state.
     Args:
      counter_name: A CounterName object with information about the execution
@@ -200,14 +200,6 @@ cdef class StateSampler(object):
 
 cdef class ScopedState(object):
   """Context manager class managing transitions for a given sampler state."""
-
-  cdef readonly StateSampler sampler
-  cdef readonly int32_t state_index
-  cdef readonly object counter
-  cdef readonly object name
-  cdef readonly int64_t _nsecs
-  cdef int32_t old_state_index
-  cdef readonly MetricsContainer _metrics_container
 
   def __init__(
       self, sampler, name, state_index, counter=None, metrics_container=None):

--- a/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
+++ b/sdks/python/apache_beam/runners/worker/statesampler_fast.pyx
@@ -71,24 +71,6 @@ cdef inline int64_t get_nsec_time() nogil:
 
 cdef class StateSampler(object):
   """Tracks time spent in states during pipeline execution."""
-  cdef int _sampling_period_ms
-  cdef int _sampling_period_ms_start
-  cdef double _sampling_period_ratio
-
-  cdef list scoped_states_by_index
-
-  cdef public bint started
-  cdef public bint finished
-  cdef object sampling_thread
-
-  # This lock guards members that are shared between threads, specificaly
-  # finished, scoped_states_by_index, and the nsecs field of each state therein.
-  cdef pythread.PyThread_type_lock lock
-
-  cdef public int64_t state_transition_count
-  cdef public int64_t time_since_transition
-
-  cdef int32_t current_state_index
 
   def __init__(self,
                sampling_period_ms,

--- a/sdks/python/apache_beam/tools/sideinput_microbenchmark.py
+++ b/sdks/python/apache_beam/tools/sideinput_microbenchmark.py
@@ -48,6 +48,7 @@ def run_benchmark(num_runs=50, input_per_source=4000, num_sources=4):
   for i in range(num_runs):
     counter_factory = CounterFactory()
     state_sampler = statesampler.StateSampler('basic', counter_factory)
+    state_sampler.start()
     with state_sampler.scoped_state('step1', 'state'):
       si_counter = opcounters.SideInputReadCounter(
           counter_factory, state_sampler, 'step1', 1)
@@ -61,6 +62,7 @@ def run_benchmark(num_runs=50, input_per_source=4000, num_sources=4):
       list(iterator_fn())
       time_cost = time.time() - start
       times.append(time_cost)
+    state_sampler.stop()
 
   print("Runtimes:", times)
 


### PR DESCRIPTION
This PR improves Cython tags for some classes, and uses them for tracking of time spent reading side inputs.

It also adds a state sampler thread to make the side input microbenchmark a more realistic representation of the worker environment (as there may be contention due to the state switching).

NOTE: This PR should add flag versioning before merging in any case.

Current performance with 500 runs:
- Average runtime: 0.604471780777
- Time per element: 3.77794862986e-05
- Regression: 0% (it's the baseline)

With change and flag deactivated:
- Average runtime: 0.614184889793
- Time per element: 3.83865556121e-05
- Regression: 1.6%

With change and flag activated:
- Average runtime: 0.611651549339
- Time per element: 3.82282218337e-05
- Regression: 1.187%

This represents a really small regression in a microbenchmark that specifically exercises this feature.