### PR TITLE
Undefined names: import MetricKey, MetricName

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -25,7 +25,9 @@ import traceback
 import unittest
 
 import apache_beam as beam
+from apache_beam.metrics.execution import MetricKey
 from apache_beam.metrics.execution import MetricsEnvironment
+from apache_beam.metrics.metricbase import MetricName
 from apache_beam.runners.portability import fn_api_runner
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statesampler


### PR DESCRIPTION
As mentioned at https://github.com/apache/beam/commit/582fcea913b2fe84d771df4a4467fff887af9842#r28136702 these two variables are undefined names in this context.  This PR imports them to resolve the undefined names.

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

