### PR TITLE
[BEAM-4255] Set singleton view writers' accumulation mode to discarding

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -1283,6 +1283,10 @@ public class Combine {
               insertDefault,
               insertDefault ? fn.defaultValue() : null,
           combined.getCoder());
+
+      // GBK's inside view writers for singleton view should discard previous values.
+      materializationInput.setWindowingStrategyInternal(materializationInput.getWindowingStrategy()
+          .withMode(WindowingStrategy.AccumulationMode.DISCARDING_FIRED_PANES));
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
     }


### PR DESCRIPTION
The code snippet below was writing multiple values to the sideInput, resulting in exception: "PCollection with more than one element accessed as a singleton view."

PCollectionView<Integer> globalView = input
.apply(Window.<Integer>into(new GlobalWindows())
    .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
    .accumulatingFiredPanes())
.apply(Sum.integersGlobally().asSingletonView())

This PR sets the accumulation mode to discarding for singleton view writer, so that the GBK's used by view writers do not accumulate combine results.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

