### PR TITLE
Revert "Enable githubCommitNotifier for post commits"

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -238,7 +238,6 @@ class common_job_properties {
     }
 
     context.publishers {
-      githubCommitNotifier()
       // Notify an email address for each failed build (defaults to commits@).
       mailer(notifyAddress, false, emailIndividuals)
     }


### PR DESCRIPTION
Reverts apache/beam#5305

Credentials aren't plumbed through, so this won't work.