### PR TITLE
Fix warning on repeated core-construction-java dependency on runners/reference/java

### DIFF
--- a/runners/reference/java/pom.xml
+++ b/runners/reference/java/pom.xml
@@ -62,11 +62,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.beam</groupId>
-      <artifactId>beam-runners-core-construction-java</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>


### PR DESCRIPTION
Just to avoid the annoying warning.