### PR TITLE
[BEAM-3979] Reintroduce usage from pr/4989

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -106,7 +106,7 @@ public class WindowedWordCount {
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c) {
+    public void processElement(@Element String element, OutputReceiver<String> receiver) {
       Instant randomTimestamp =
           new Instant(
               ThreadLocalRandom.current()
@@ -115,7 +115,7 @@ public class WindowedWordCount {
       /**
        * Concept #2: Set the data element with that timestamp.
        */
-      c.outputWithTimestamp(c.element(), new Instant(randomTimestamp));
+      receiver.outputWithTimestamp(element, new Instant(randomTimestamp));
     }
   }
 

--- a/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WordCount.java
@@ -93,19 +93,19 @@ public class WordCount {
         ExtractWordsFn.class, "lineLenDistro");
 
     @ProcessElement
-    public void processElement(ProcessContext c) {
-      lineLenDist.update(c.element().length());
-      if (c.element().trim().isEmpty()) {
+    public void processElement(@Element String element, OutputReceiver<String> receiver) {
+      lineLenDist.update(element.length());
+      if (element.trim().isEmpty()) {
         emptyLines.inc();
       }
 
       // Split the line into words.
-      String[] words = c.element().split(ExampleUtils.TOKENIZER_PATTERN);
+      String[] words = element.split(ExampleUtils.TOKENIZER_PATTERN);
 
       // Output each word encountered into the output PCollection.
       for (String word : words) {
         if (!word.isEmpty()) {
-          c.output(word);
+          receiver.output(word);
         }
       }
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -1859,14 +1859,14 @@ public class Combine {
             }
 
             @ProcessElement
-            public void processElement(ProcessContext c) {
-              KV<K, InputT> kv = c.element();
+            public void processElement(@Element KV<K, InputT> kv,
+                                       MultiOutputReceiver receiver) {
               int spread = Math.max(1, hotKeyFanout.apply(kv.getKey()));
               if (spread <= 1) {
-                c.output(kv);
+                receiver.get(cold).output(kv);
               } else {
                 int nonce = counter++ % spread;
-                c.output(hot, KV.of(KV.of(kv.getKey(), nonce), kv.getValue()));
+                receiver.get(hot).output(KV.of(KV.of(kv.getKey(), nonce), kv.getValue()));
               }
             }
           })

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/CombineFns.java
@@ -81,12 +81,12 @@ public class CombineFns {
    *     .apply(ParDo.of(
    *         new DoFn<CoCombineResult, T>() {
    *          {@literal @}ProcessElement
-   *           public void processElement(ProcessContext c) throws Exception {
-   *             CoCombineResult e = c.element();
+   *           public void processElement(
+   *            {@literal @}Element CoCombineResult e, OutputReceiver<T> r) throws Exception {
    *             Integer maxLatency = e.get(maxLatencyTag);
    *             Double meanLatency = e.get(meanLatencyTag);
    *             .... Do Something ....
-   *             c.output(...some T...);
+   *             r.output(...some T...);
    *           }
    *         }));
    * }</pre>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Create.java
@@ -603,8 +603,8 @@ public class Create<T> {
 
     private static class ConvertTimestamps<T> extends DoFn<TimestampedValue<T>, T> {
       @ProcessElement
-      public void processElement(ProcessContext c) {
-        c.outputWithTimestamp(c.element().getValue(), c.element().getTimestamp());
+      public void processElement(@Element TimestampedValue<T> element, OutputReceiver<T> r) {
+        r.outputWithTimestamp(element.getValue(), element.getTimestamp());
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Distinct.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Distinct.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.DefaultTrigger;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -124,10 +125,11 @@ public class Distinct<T> extends PTransform<PCollection<T>, PCollection<T>> {
         ParDo.of(
             new DoFn<KV<T, Void>, T>() {
               @ProcessElement
-              public void processElement(ProcessContext c) {
-                if (c.pane().isFirst()) {
+              public void processElement(@Element KV<T, Void> element, PaneInfo pane,
+                                         OutputReceiver<T> receiver) {
+                if (pane.isFirst()) {
                   // Only output the key if it's the first time it's been seen.
-                  c.output(c.element().getKey());
+                  receiver.output(element.getKey());
                 }
               }
             }));
@@ -187,10 +189,11 @@ public class Distinct<T> extends PTransform<PCollection<T>, PCollection<T>> {
           ParDo.of(
               new DoFn<KV<IdT, T>, T>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) {
+                public void processElement(@Element KV<IdT, T> element, PaneInfo pane,
+                                           OutputReceiver<T> receiver) {
                   // Only output the value if it's the first time it's been seen.
-                  if (c.pane().isFirst()) {
-                    c.output(c.element().getValue());
+                  if (pane.isFirst()) {
+                    receiver.output(element.getValue());
                   }
                 }
               }));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
@@ -212,9 +212,9 @@ public class Filter<T> extends PTransform<PCollection<T>, PCollection<T>> {
             ParDo.of(
                 new DoFn<T, T>() {
                   @ProcessElement
-                  public void processElement(ProcessContext c) {
-                    if (predicate.apply(c.element())) {
-                      c.output(c.element());
+                  public void processElement(@Element T element, OutputReceiver<T> r) {
+                    if (predicate.apply(element)) {
+                      r.output(element);
                     }
                   }
                 }))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Latest.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Latest.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.coders.NullableCoder;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Instant;
 
 /**
  * {@link PTransform} and {@link Combine.CombineFn} for computing the latest element
@@ -167,8 +168,9 @@ public class Latest {
               ParDo.of(
                   new DoFn<T, TimestampedValue<T>>() {
                     @ProcessElement
-                    public void processElement(ProcessContext c) {
-                      c.output(TimestampedValue.of(c.element(), c.timestamp()));
+                    public void processElement(@Element T element, @Timestamp Instant timestamp,
+                                               OutputReceiver<TimestampedValue<T>> r) {
+                      r.output(TimestampedValue.of(element, timestamp));
                     }
                   }))
           .setCoder(TimestampedValue.TimestampedValueCoder.of(inputCoder))
@@ -194,11 +196,13 @@ public class Latest {
               ParDo.of(
                   new DoFn<KV<K, V>, KV<K, TimestampedValue<V>>>() {
                     @ProcessElement
-                    public void processElement(ProcessContext c) {
-                      c.output(
+                    public void processElement(@Element KV<K, V> element,
+                                               @Timestamp Instant timestamp,
+                                               OutputReceiver<KV<K, TimestampedValue<V>>> r) {
+                      r.output(
                           KV.of(
-                              c.element().getKey(),
-                              TimestampedValue.of(c.element().getValue(), c.timestamp())));
+                              element.getKey(),
+                              TimestampedValue.of(element.getValue(), timestamp)));
                     }
                   }))
           .setCoder(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -125,8 +125,10 @@ extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
         ParDo.of(
             new DoFn<InputT, OutputT>() {
               @ProcessElement
-              public void processElement(ProcessContext c) throws Exception {
-                c.output(fn.getClosure().apply(c.element(), Fn.Context.wrapProcessContext(c)));
+              public void processElement(@Element InputT element,
+                                         OutputReceiver<OutputT> receiver,
+                                         ProcessContext c) throws Exception {
+                receiver.output(fn.getClosure().apply(element, Fn.Context.wrapProcessContext(c)));
               }
 
               @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Partition.java
@@ -163,13 +163,12 @@ public class Partition<T> extends PTransform<PCollection<T>, PCollectionList<T>>
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c) {
-      X input = c.element();
+    public void processElement(@Element X input, MultiOutputReceiver r) {
       int partition = partitionFn.partitionFor(input, numPartitions);
       if (0 <= partition && partition < numPartitions) {
         @SuppressWarnings("unchecked")
         TupleTag<X> typedTag = (TupleTag<X>) outputTags.get(partition);
-        c.output(typedTag, input);
+        r.get(typedTag).output(input);
       } else {
         throw new IndexOutOfBoundsException(
             "Partition function returned out of bounds index: "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Regex.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Regex.java
@@ -430,11 +430,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.matches()) {
-                    c.output(m.group(group));
+                    r.output(m.group(group));
                   }
                 }
               }));
@@ -472,11 +473,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.matches()) {
-                    c.output(m.group(groupName));
+                    r.output(m.group(groupName));
                   }
                 }
               }));
@@ -514,8 +516,9 @@ public class Regex {
           ParDo.of(
               new DoFn<String, List<String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<List<String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.matches()) {
                     ArrayList list = new ArrayList(m.groupCount());
@@ -525,7 +528,7 @@ public class Regex {
                       list.add(m.group(i));
                     }
 
-                    c.output(list);
+                    r.output(list);
                   }
                 }
               }));
@@ -566,11 +569,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, KV<String, String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<KV<String, String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(KV.of(m.group(keyGroup), m.group(valueGroup)));
+                    r.output(KV.of(m.group(keyGroup), m.group(valueGroup)));
                   }
                 }
               }));
@@ -612,11 +616,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, KV<String, String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<KV<String, String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(KV.of(m.group(keyGroupName), m.group(valueGroupName)));
+                    r.output(KV.of(m.group(keyGroupName), m.group(valueGroupName)));
                   }
                 }
               }));
@@ -654,11 +659,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(m.group(group));
+                    r.output(m.group(group));
                   }
                 }
               }));
@@ -696,11 +702,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(m.group(groupName));
+                    r.output(m.group(groupName));
                   }
                 }
               }));
@@ -737,8 +744,9 @@ public class Regex {
           ParDo.of(
               new DoFn<String, List<String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<List<String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
                     ArrayList list = new ArrayList(m.groupCount());
@@ -748,7 +756,7 @@ public class Regex {
                       list.add(m.group(i));
                     }
 
-                    c.output(list);
+                    r.output(list);
                   }
                 }
               }));
@@ -790,11 +798,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, KV<String, String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<KV<String, String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(KV.of(m.group(keyGroup), m.group(valueGroup)));
+                    r.output(KV.of(m.group(keyGroup), m.group(valueGroup)));
                   }
                 }
               }));
@@ -837,11 +846,12 @@ public class Regex {
           ParDo.of(
               new DoFn<String, KV<String, String>>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<KV<String, String>> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
 
                   if (m.find()) {
-                    c.output(KV.of(m.group(keyGroupName), m.group(valueGroupName)));
+                    r.output(KV.of(m.group(keyGroupName), m.group(valueGroupName)));
                   }
                 }
               }));
@@ -879,9 +889,10 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
-                  c.output(m.replaceAll(replacement));
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
+                  r.output(m.replaceAll(replacement));
                 }
               }));
     }
@@ -918,9 +929,10 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  Matcher m = pattern.matcher(c.element());
-                  c.output(m.replaceFirst(replacement));
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  Matcher m = pattern.matcher(element);
+                  r.output(m.replaceFirst(replacement));
                 }
               }));
     }
@@ -959,12 +971,13 @@ public class Regex {
           ParDo.of(
               new DoFn<String, String>() {
                 @ProcessElement
-                public void processElement(ProcessContext c) throws Exception {
-                  String[] items = pattern.split(c.element());
+                public void processElement(@Element String element,
+                                           OutputReceiver<String> r) throws Exception {
+                  String[] items = pattern.split(element);
 
                   for (String item : items) {
                     if (outputEmpty || !item.isEmpty()) {
-                      c.output(item);
+                      r.output(item);
                     }
                   }
                 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ReifyTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ReifyTimestamps.java
@@ -67,8 +67,8 @@ class ReifyTimestamps {
           ParDo.of(
               new DoFn<T, T>() {
                 @ProcessElement
-                public void process(ProcessContext c) {
-                  c.output(c.element());
+                public void process(@Element T element, OutputReceiver<T> r) {
+                  r.output(element);
                 }
               }));
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -499,8 +499,8 @@ public class View {
 
     private static class VoidKeyToMultimapMaterializationDoFn<T> extends DoFn<T, KV<Void, T>> {
       @ProcessElement
-      public void processElement(ProcessContext ctxt) {
-        ctxt.output(KV.of((Void) null, ctxt.element()));
+      public void processElement(@Element T element, OutputReceiver<KV<Void, T>> r) {
+        r.output(KV.of((Void) null, element));
       }
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -131,11 +131,11 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
     }
 
     @ProcessElement
-    public void processElement(ProcessContext c) {
-      Instant timestamp = fn.apply(c.element());
+    public void processElement(@Element T element, OutputReceiver<T> r) {
+      Instant timestamp = fn.apply(element);
       checkNotNull(
           timestamp, "Timestamps for WithTimestamps cannot be null. Timestamp provided by %s.", fn);
-      c.outputWithTimestamp(c.element(), timestamp);
+      r.outputWithTimestamp(element, timestamp);
     }
 
     @Override


### PR DESCRIPTION
Usage components from pr/4989 were reverted from that PR due to compatibility issues with the Dataflow runner. Now that Dataflow is updated, reintroduce those files.