### PR TITLE
[BEAM-4002] Futurize options subpackage

### DIFF
--- a/sdks/python/apache_beam/options/__init__.py
+++ b/sdks/python/apache_beam/options/__init__.py
@@ -14,3 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -17,7 +17,10 @@
 
 """Pipeline options obtained from command line parsing."""
 
+from __future__ import absolute_import
+
 import argparse
+from builtins import object
 
 from apache_beam.options.value_provider import RuntimeValueProvider
 from apache_beam.options.value_provider import StaticValueProvider
@@ -175,7 +178,7 @@ class PipelineOptions(HasDisplayData):
       A PipelineOptions object representing the given arguments.
     """
     flags = []
-    for k, v in options.iteritems():
+    for k, v in options.items():
       if isinstance(v, bool):
         if v:
           flags.append('--%s' % k)
@@ -233,7 +236,7 @@ class PipelineOptions(HasDisplayData):
                   for option in dir(self._visible_options) if option[0] != '_')
 
   def __dir__(self):
-    return sorted(dir(type(self)) + self.__dict__.keys() +
+    return sorted(dir(type(self)) + list(self.__dict__.keys()) +
                   self._visible_option_list())
 
   def __getattr__(self, name):

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -17,6 +17,8 @@
 
 """Unit tests for the pipeline options module."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/options/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator.py
@@ -19,7 +19,10 @@
 
 For internal use only; no backwards-compatibility guarantees.
 """
+from __future__ import absolute_import
+
 import re
+from builtins import object
 
 from apache_beam.internal import pickler
 from apache_beam.options.pipeline_options import DebugOptions

--- a/sdks/python/apache_beam/options/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator_test.py
@@ -17,8 +17,11 @@
 
 """Unit tests for the pipeline options validator module."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
+from builtins import object
 
 from hamcrest.core.base_matcher import BaseMatcher
 

--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -19,6 +19,9 @@
 and dynamically provided values.
 """
 
+from __future__ import absolute_import
+
+from builtins import object
 from functools import wraps
 
 from apache_beam import error
@@ -65,6 +68,9 @@ class StaticValueProvider(ValueProvider):
           self.value == other.value):
         return True
     return False
+
+  def __hash__(self):
+    return hash((type(self), self.value_type, self.value))
 
 
 class RuntimeValueProvider(ValueProvider):

--- a/sdks/python/apache_beam/options/value_provider_test.py
+++ b/sdks/python/apache_beam/options/value_provider_test.py
@@ -16,6 +16,9 @@
 #
 
 """Unit tests for the ValueProvider class."""
+
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -100,6 +100,7 @@ deps =
 modules =
   apache_beam/coders
   apache_beam/metrics
+  apache_beam/options
 commands =
   python --version
   pip --version


### PR DESCRIPTION
This pull request prepares the options subpackage for Python 3 support. This PR is part of a series in which all subpackages will be updated using the same approach.
This approach has been documented [here](https://docs.google.com/document/d/1xDG0MWVlDKDPu_IW9gtMvxi2S9I0GB0VDTkPhjXT0nE/edit#) and the first pull request in the series (Futurize coders subpackage) demonstrating this approach can be found at #5053.

R: @aaltay @tvalentyn