### PR TITLE
Add py27-lint3 test to gradle.build

### DIFF
--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -97,6 +97,16 @@ task lintPy27(dependsOn: 'setupVirtualenv') {
 }
 lint.dependsOn lintPy27
 
+task lintPy27_3(dependsOn: 'setupVirtualenv') {
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', ". ${envdir}/bin/activate && tox ${tox_opts} -e py27-lint3"
+    }
+  }
+}
+lint.dependsOn lintPy27_3
+
 task lintPy3(dependsOn: 'setupVirtualenv') {
   doLast {
     exec {


### PR DESCRIPTION
This PR adds the py27-lint3 check to the gradle build.
The check was introduced in #5053 to test for Python 2 / Python 3 compatibility.

@aaltay @tvalentyn 