### PR TITLE
[BEAM-4282] Fix python docker build by changing cython version to 28.1

### DIFF
--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -64,7 +64,7 @@ RUN \
     pip install "google-cloud-pubsub == 0.26.0" && \
     pip install "google-cloud-bigquery == 0.25.0" && \
     # Optional packages
-    pip install "cython == 0.27.2" && \
+    pip install "cython == 0.28.1" && \
     pip install "guppy == 0.1.10" && \
     pip install "python-snappy == 0.5.1" && \
     # These are additional packages likely to be used by customers.


### PR DESCRIPTION
Fix python docker build by changing cython version to 28.1

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

