### PR TITLE
Fix error-prone warnings and multiple cleanups based on static analysis for CassandraIO

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraService.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/CassandraService.java
@@ -22,45 +22,30 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.apache.beam.sdk.io.BoundedSource;
 
-/**
- * An interface for real or fake implementations of Cassandra.
- */
+/** An interface for real or fake implementations of Cassandra. */
 public interface CassandraService<T> extends Serializable {
-
   /**
    * Returns a {@link org.apache.beam.sdk.io.BoundedSource.BoundedReader} that will read from
-   * Cassandra using the spec from
-   * {@link org.apache.beam.sdk.io.cassandra.CassandraIO.CassandraSource}.
+   * Cassandra using the spec from {@link
+   * org.apache.beam.sdk.io.cassandra.CassandraIO.CassandraSource}.
    */
   BoundedSource.BoundedReader<T> createReader(CassandraIO.CassandraSource<T> source);
 
-  /**
-   * Returns an estimation of the size that could be read.
-   */
+  /** Returns an estimation of the size that could be read. */
   long getEstimatedSizeBytes(CassandraIO.Read<T> spec);
 
-  /**
-   * Split a table read into several sources.
-   */
-  List<BoundedSource<T>> split(CassandraIO.Read<T> spec,
-                                          long desiredBundleSizeBytes);
+  /** Split a table read into several sources. */
+  List<BoundedSource<T>> split(CassandraIO.Read<T> spec, long desiredBundleSizeBytes);
 
-  /**
-   * Create a {@link Writer} that writes entities into the Cassandra instance.
-   */
-  Writer createWriter(CassandraIO.Write<T> spec) throws Exception;
+  /** Create a {@link Writer} that writes entities into the Cassandra instance. */
+  Writer createWriter(CassandraIO.Write<T> spec);
 
-  /**
-   * Writer for an entity.
-   */
+  /** Writer for an entity. */
   interface Writer<T> extends AutoCloseable {
-
     /**
      * This method should be synchronous. It means you have to be sure that the entity is fully
      * stored (and committed) into the Cassandra instance when you exit from this method.
      */
     void write(T entity) throws ExecutionException, InterruptedException;
-
   }
-
 }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/RingRange.java
@@ -43,11 +43,7 @@ final class RingRange {
    * @return size of the range, max - range, in case of wrap
    */
   BigInteger span(BigInteger ringSize) {
-    if (start.compareTo(end) >= 0) {
-      return end.subtract(start).add(ringSize);
-    } else {
-      return end.subtract(start);
-    }
+    return (start.compareTo(end) >= 0) ? end.subtract(start).add(ringSize) : end.subtract(start);
   }
 
   /**

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/package-info.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/package-info.java
@@ -17,6 +17,8 @@
  */
 
 /**
- * Transforms for reading and writing from Apache Cassandra database.
+ * Transforms for reading and writing from/to Apache Cassandra.
+ *
+ * @see org.apache.beam.sdk.io.cassandra.CassandraIO
  */
 package org.apache.beam.sdk.io.cassandra;

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOIT.java
@@ -75,7 +75,7 @@ public class CassandraIOIT implements Serializable {
   @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
-  public static void setup() throws Exception {
+  public static void setup() {
     PipelineOptionsFactory.register(IOTestPipelineOptions.class);
     options = TestPipeline.testingPipelineOptions()
         .as(IOTestPipelineOptions.class);
@@ -88,7 +88,7 @@ public class CassandraIOIT implements Serializable {
   }
 
   @Test
-  public void testRead() throws Exception {
+  public void testRead() {
     PCollection<Scientist> output = pipeline.apply(CassandraIO.<Scientist>read()
         .withHosts(Collections.singletonList(options.getCassandraHost()))
         .withPort(options.getCassandraPort())
@@ -104,9 +104,9 @@ public class CassandraIOIT implements Serializable {
         output.apply(
             MapElements.via(
                 new SimpleFunction<Scientist, KV<String, Integer>>() {
+                  @Override
                   public KV<String, Integer> apply(Scientist scientist) {
-                    KV<String, Integer> kv = KV.of(scientist.name, scientist.id);
-                    return kv;
+                    return KV.of(scientist.name, scientist.id);
                   }
                 }
             )
@@ -124,7 +124,7 @@ public class CassandraIOIT implements Serializable {
   }
 
   @Test
-  public void testWrite() throws Exception {
+  public void testWrite() {
     IOTestPipelineOptions options =
         TestPipeline.testingPipelineOptions().as(IOTestPipelineOptions.class);
 
@@ -155,13 +155,13 @@ public class CassandraIOIT implements Serializable {
   /**
    * Simple matcher.
    */
-  public class CassandraMatcher extends TypeSafeMatcher<PipelineResult>
+  static class CassandraMatcher extends TypeSafeMatcher<PipelineResult>
       implements SerializableMatcher<PipelineResult> {
 
-    private String tableName;
-    private Cluster cluster;
+    private final String tableName;
+    private final Cluster cluster;
 
-    public CassandraMatcher(Cluster cluster, String tableName) {
+    CassandraMatcher(Cluster cluster, String tableName) {
       this.cluster = cluster;
       this.tableName = tableName;
     }
@@ -194,34 +194,17 @@ public class CassandraIOIT implements Serializable {
    * Simple Cassandra entity representing a scientist. Used for read test.
    */
   @Table(name = CassandraTestDataSet.TABLE_READ_NAME, keyspace = CassandraTestDataSet.KEYSPACE)
-  public static class Scientist implements Serializable {
-
+  static class Scientist implements Serializable {
     @PartitionKey
     @Column(name = "id")
-    private final int id;
+    final int id;
 
     @Column(name = "name")
-    private final String name;
+    final String name;
 
-    public Scientist() {
-      this(0, "");
-    }
-
-    public Scientist(int id) {
-      this(id, "");
-    }
-
-    public Scientist(int id, String name) {
+    Scientist(int id, String name) {
       this.id = id;
       this.name = name;
-    }
-
-    public int getId() {
-      return id;
-    }
-
-    public String getName() {
-      return name;
     }
   }
 
@@ -229,19 +212,17 @@ public class CassandraIOIT implements Serializable {
    * Simple Cassandra entity representing a scientist, used for write test.
    */
   @Table(name = CassandraTestDataSet.TABLE_WRITE_NAME, keyspace = CassandraTestDataSet.KEYSPACE)
-  public class ScientistForWrite implements Serializable {
-
+  static class ScientistForWrite implements Serializable {
     @PartitionKey
     @Column(name = "id")
-    public Integer id;
+    Integer id;
 
     @Column(name = "name")
-    public String name;
+    String name;
 
+    @Override
     public String toString() {
       return id + ":" + name;
     }
-
   }
-
 }

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -23,8 +23,8 @@ import static org.junit.Assert.assertEquals;
 import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.Table;
 import com.google.common.base.Objects;
-import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -33,6 +33,7 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.BoundedSource.BoundedReader;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
@@ -52,7 +53,7 @@ public class CassandraIOTest implements Serializable {
   @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
   @Test
-  public void testEstimatedSizeBytes() throws Exception {
+  public void testEstimatedSizeBytes() {
     final FakeCassandraService service = new FakeCassandraService();
     service.load();
 
@@ -67,7 +68,7 @@ public class CassandraIOTest implements Serializable {
   }
 
   @Test
-  public void testRead() throws Exception {
+  public void testRead() {
     FakeCassandraService service = new FakeCassandraService();
     service.load();
 
@@ -86,6 +87,7 @@ public class CassandraIOTest implements Serializable {
         output.apply(
             MapElements.via(
                 new SimpleFunction<Scientist, KV<String, Integer>>() {
+                  @Override
                   public KV<String, Integer> apply(Scientist scientist) {
                     return KV.of(scientist.name, scientist.id);
                   }
@@ -103,7 +105,7 @@ public class CassandraIOTest implements Serializable {
   }
 
   @Test
-  public void testWrite() throws  Exception {
+  public void testWrite() {
     FakeCassandraService service = new FakeCassandraService();
 
     ArrayList<Scientist> data = new ArrayList<>();
@@ -121,7 +123,7 @@ public class CassandraIOTest implements Serializable {
             .withEntity(Scientist.class));
     pipeline.run();
 
-    assertEquals(service.getTable().size(), 1000);
+    assertEquals(1000, service.getTable().size());
     for (Scientist scientist : service.getTable().values()) {
       assertTrue(scientist.name.matches("Name (\\d*)"));
     }
@@ -131,10 +133,9 @@ public class CassandraIOTest implements Serializable {
    * A {@link CassandraService} implementation that stores the entity in memory.
    */
   private static class FakeCassandraService implements CassandraService<Scientist> {
-
     private static final Map<Integer, Scientist> table = new ConcurrentHashMap<>();
 
-    public void load() {
+    void load() {
       table.clear();
       String[] scientists = {
           "Lovelace",
@@ -157,34 +158,33 @@ public class CassandraIOTest implements Serializable {
       }
     }
 
-    public Map<Integer, Scientist> getTable() {
+    Map<Integer, Scientist> getTable() {
       return table;
     }
 
     @Override
-    public FakeCassandraReader createReader(CassandraIO.CassandraSource source) {
+    public BoundedReader<Scientist> createReader(CassandraIO.CassandraSource source) {
       return new FakeCassandraReader(source);
     }
 
-    static class FakeCassandraReader extends BoundedSource.BoundedReader {
-
+    private static class FakeCassandraReader extends BoundedSource.BoundedReader {
       private final CassandraIO.CassandraSource source;
 
       private Iterator<Scientist> iterator;
       private Scientist current;
 
-      public FakeCassandraReader(CassandraIO.CassandraSource source) {
+      FakeCassandraReader(CassandraIO.CassandraSource source) {
         this.source = source;
       }
 
       @Override
-      public boolean start() throws IOException {
+      public boolean start() {
         iterator = table.values().iterator();
         return advance();
       }
 
       @Override
-      public boolean advance() throws IOException {
+      public boolean advance() {
         if (iterator.hasNext()) {
           current = iterator.next();
           return true;
@@ -211,28 +211,26 @@ public class CassandraIOTest implements Serializable {
       public CassandraIO.CassandraSource getCurrentSource() {
         return this.source;
       }
-
     }
 
     @Override
     public long getEstimatedSizeBytes(CassandraIO.Read spec) {
       long size = 0L;
       for (Scientist scientist : table.values()) {
-        size = size + scientist.toString().getBytes().length;
+        size = size + scientist.toString().getBytes(StandardCharsets.UTF_8).length;
       }
       return size;
     }
 
     @Override
-    public List<BoundedSource<Scientist>> split(CassandraIO.Read spec,
-                                                           long desiredBundleSizeBytes) {
+    public List<BoundedSource<Scientist>> split(
+        CassandraIO.Read spec, long desiredBundleSizeBytes) {
       List<BoundedSource<Scientist>> sources = new ArrayList<>();
       sources.add(new CassandraIO.CassandraSource<Scientist>(spec, null));
       return sources;
     }
 
-    static class FakeCassandraWriter implements Writer<Scientist> {
-
+    private static class FakeCassandraWriter implements Writer<Scientist> {
       @Override
       public void write(Scientist scientist) {
         table.put(scientist.id, scientist);
@@ -242,26 +240,24 @@ public class CassandraIOTest implements Serializable {
       public void close() {
         // nothing to do
       }
-
     }
 
     @Override
     public FakeCassandraWriter createWriter(CassandraIO.Write<Scientist> spec) {
       return new FakeCassandraWriter();
     }
-
   }
 
   /** Simple Cassandra entity used in test. */
   @Table(name = "scientist", keyspace = "beam")
-  public static class Scientist implements Serializable {
-
+  static class Scientist implements Serializable {
     @Column(name = "person_name")
-    public String name;
+    String name;
 
     @Column(name = "person_id")
-    public int id;
+    int id;
 
+    @Override
     public String toString() {
       return id + ":" + name;
     }

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraTestDataSet.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraTestDataSet.java
@@ -58,7 +58,7 @@ public class CassandraTestDataSet {
   public static final String TABLE_READ_NAME = "BEAM_READ_TEST";
   public static final String TABLE_WRITE_NAME = "BEAM_WRITE_TEST";
 
-  public static void createDataTable(IOTestPipelineOptions options) {
+  private static void createDataTable(IOTestPipelineOptions options) {
     createTable(options, TABLE_READ_NAME);
     insertTestData(options, TABLE_READ_NAME);
     createTable(options, TABLE_WRITE_NAME);
@@ -72,80 +72,45 @@ public class CassandraTestDataSet {
   }
 
   private static void createTable(IOTestPipelineOptions options, String tableName) {
-    Cluster cluster = null;
-    Session session = null;
-    try {
-      cluster = getCluster(options);
-      session = cluster.connect();
-
+    try (Cluster cluster = getCluster(options); Session session = cluster.connect()) {
       LOG.info("Create {} keyspace if not exists", KEYSPACE);
       session.execute("CREATE KEYSPACE IF NOT EXISTS " + KEYSPACE + " WITH REPLICATION = "
-          + "{'class':'SimpleStrategy', 'replication_factor':3};");
+              + "{'class':'SimpleStrategy', 'replication_factor':3};");
 
       session.execute("USE " + KEYSPACE);
 
       LOG.info("Create {} table if not exists", tableName);
       session.execute("CREATE TABLE IF NOT EXISTS " + tableName + "(id int, name text, PRIMARY "
-          + "KEY(id))");
-    } finally {
-      if (session != null) {
-        session.close();
-      }
-      if (cluster != null) {
-        cluster.close();
-      }
+              + "KEY(id))");
     }
   }
 
   private static void insertTestData(IOTestPipelineOptions options, String tableName) {
-    Cluster cluster = null;
-    Session session = null;
-    try {
-      cluster = getCluster(options);
-      session = cluster.connect();
-
+    try (Cluster cluster = getCluster(options); Session session = cluster.connect()) {
       LOG.info("Insert test dataset");
       String[] scientists = {
-          "Lovelace",
-          "Franklin",
-          "Meitner",
-          "Hopper",
-          "Curie",
-          "Faraday",
-          "Newton",
-          "Bohr",
-          "Galilei",
-          "Maxwell"
+        "Lovelace",
+        "Franklin",
+        "Meitner",
+        "Hopper",
+        "Curie",
+        "Faraday",
+        "Newton",
+        "Bohr",
+        "Galilei",
+        "Maxwell"
       };
       for (int i = 0; i < 1000; i++) {
         int index = i % scientists.length;
         session.execute("INSERT INTO " + KEYSPACE + "." + tableName + "(id, name) values("
-            + i + ",'" + scientists[index] + "');");
-      }
-    } finally {
-      if (session != null) {
-        session.close();
-      }
-      if (cluster != null) {
-        cluster.close();
+                + i + ",'" + scientists[index] + "');");
       }
     }
   }
 
   public static void cleanUpDataTable(IOTestPipelineOptions options) {
-      Cluster cluster = null;
-      Session session = null;
-      try {
-        cluster = getCluster(options);
-        session = cluster.connect();
-        session.execute("TRUNCATE TABLE " + KEYSPACE + "." + TABLE_WRITE_NAME);
-      } finally {
-        if (session != null) {
-          session.close();
-        }
-        if (cluster != null) {
-          cluster.close();
-        }
+    try (Cluster cluster = getCluster(options); Session session = cluster.connect()) {
+      session.execute("TRUNCATE TABLE " + KEYSPACE + "." + TABLE_WRITE_NAME);
     }
   }
 

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/SplitGeneratorTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/SplitGeneratorTest.java
@@ -19,6 +19,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.junit.Test;
 
 /** Tests on {@link SplitGenerator}. */
@@ -27,15 +28,14 @@ public final class SplitGeneratorTest {
   @Test
   public void testGenerateSegments() {
     List<BigInteger> tokens =
-        Arrays.asList(
+        Stream.of(
                 "0",
                 "1",
                 "56713727820156410577229101238628035242",
                 "56713727820156410577229101238628035243",
                 "113427455640312821154458202477256070484",
                 "113427455640312821154458202477256070485")
-            .stream()
-            .map(s -> new BigInteger(s))
+            .map(BigInteger::new)
             .collect(Collectors.toList());
 
     SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
@@ -51,15 +51,14 @@ public final class SplitGeneratorTest {
         segments.get(5).toString());
 
     tokens =
-        Arrays.asList(
+        Stream.of(
                 "5",
                 "6",
                 "56713727820156410577229101238628035242",
                 "56713727820156410577229101238628035243",
                 "113427455640312821154458202477256070484",
                 "113427455640312821154458202477256070485")
-            .stream()
-            .map(s -> new BigInteger(s))
+            .map(BigInteger::new)
             .collect(Collectors.toList());
 
     segments = generator.generateSplits(10, tokens);
@@ -86,7 +85,7 @@ public final class SplitGeneratorTest {
             "113427455640312821154458202477256070485");
 
     List<BigInteger> tokens =
-        tokenStrings.stream().map(s -> new BigInteger(s)).collect(Collectors.toList());
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
 
     SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
     generator.generateSplits(10, tokens);
@@ -104,7 +103,7 @@ public final class SplitGeneratorTest {
             "56713727820156410577229101238628035242");
 
     List<BigInteger> tokens =
-        tokenStrings.stream().map(s -> new BigInteger(s)).collect(Collectors.toList());
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
 
     SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
     List<List<RingRange>> segments = generator.generateSplits(5, tokens);
@@ -132,7 +131,7 @@ public final class SplitGeneratorTest {
             "113427455640312821154458202477256070484");
 
     List<BigInteger> tokens =
-        tokenStrings.stream().map(s -> new BigInteger(s)).collect(Collectors.toList());
+        tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
 
     SplitGenerator generator = new SplitGenerator("foo.bar.RandomPartitioner");
     generator.generateSplits(10, tokens);


### PR DESCRIPTION
Simple PR to fix a good chunk of warnings of error-prone and IntelliJ's static analysis.
Apart of these there are two minor method refactorings.