### PR TITLE
Fix error-prone warnings for ElasticsearchIO

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/src/test/java/org/elasticsearch/bootstrap/JarHell.java
@@ -17,9 +17,6 @@
  */
 package org.elasticsearch.bootstrap;
 
-import java.io.IOException;
-import java.net.URISyntaxException;
-
 /**
  * We need a real Elasticsearch instance to properly test the IO
  * (split, slice API, scroll API, ...). Starting at ES 5, to have Elasticsearch embedded,
@@ -34,6 +31,7 @@ import java.net.URISyntaxException;
 class JarHell {
 
 
-  public static void checkJarHell() throws IOException, URISyntaxException {
+  @SuppressWarnings("EmptyMethod")
+  public static void checkJarHell() {
   }
 }

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOITCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOITCommon.java
@@ -73,7 +73,7 @@ public class ElasticsearchIOITCommon {
 
   static ConnectionConfiguration getConnectionConfiguration(IOTestPipelineOptions options,
       ReadOrWrite rOw) {
-    ConnectionConfiguration connectionConfiguration = ConnectionConfiguration.create(
+    return ConnectionConfiguration.create(
             new String[] {
               "http://"
                   + options.getElasticsearchServer()
@@ -82,7 +82,6 @@ public class ElasticsearchIOITCommon {
             },
             (rOw == ReadOrWrite.READ) ? ES_INDEX : writeIndex,
             ES_TYPE);
-    return connectionConfiguration;
   }
 
   /** Enum that tells whether we use the index for reading or for writing. */

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertThat;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -64,10 +65,10 @@ class ElasticsearchIOTestCommon implements Serializable {
   private static final long BATCH_SIZE = 200L;
   private static final long BATCH_SIZE_BYTES = 2048L;
 
-  private long numDocs;
-  private ConnectionConfiguration connectionConfiguration;
-  private RestClient restClient;
-  private boolean useAsITests;
+  private final long numDocs;
+  private final ConnectionConfiguration connectionConfiguration;
+  private final RestClient restClient;
+  private final boolean useAsITests;
 
   private TestPipeline pipeline;
   private ExpectedException expectedException;
@@ -261,7 +262,7 @@ class ElasticsearchIOTestCommon implements Serializable {
       for (String document : input) {
         fnTester.processElement(document);
         numDocsProcessed++;
-        sizeProcessed += document.getBytes().length;
+        sizeProcessed += document.getBytes(StandardCharsets.UTF_8).length;
         // test every 40 docs to avoid overloading ES
         if ((numDocsProcessed % 40) == 0) {
           // force the index to upgrade after inserting for the inserted docs

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -423,7 +423,7 @@ public class ElasticsearchIO {
     public Read withBatchSize(long batchSize) {
       checkArgument(
           batchSize > 0 && batchSize <= MAX_BATCH_SIZE,
-          "batchSize must be > 0 and <= %d, but was: %d",
+          "batchSize must be > 0 and <= %s, but was: %s",
           MAX_BATCH_SIZE,
           batchSize);
       return builder().setBatchSize(batchSize).build();
@@ -567,7 +567,7 @@ public class ElasticsearchIO {
     }
 
     @Override
-    public BoundedReader<String> createReader(PipelineOptions options) throws IOException {
+    public BoundedReader<String> createReader(PipelineOptions options) {
       return new BoundedElasticsearchReader(this);
     }
 
@@ -787,7 +787,7 @@ public class ElasticsearchIO {
      * @return the {@link Write} with connection batch size set
      */
     public Write withMaxBatchSize(long batchSize) {
-      checkArgument(batchSize > 0, "batchSize must be > 0, but was %d", batchSize);
+      checkArgument(batchSize > 0, "batchSize must be > 0, but was %s", batchSize);
       return builder().setMaxBatchSize(batchSize).build();
     }
 
@@ -803,7 +803,7 @@ public class ElasticsearchIO {
      * @return the {@link Write} with connection batch size in bytes set
      */
     public Write withMaxBatchSizeBytes(long batchSizeBytes) {
-      checkArgument(batchSizeBytes > 0, "batchSizeBytes must be > 0, but was %d", batchSizeBytes);
+      checkArgument(batchSizeBytes > 0, "batchSizeBytes must be > 0, but was %s", batchSizeBytes);
       return builder().setMaxBatchSizeBytes(batchSizeBytes).build();
     }
 
@@ -875,13 +875,13 @@ public class ElasticsearchIO {
       @JsonInclude(JsonInclude.Include.NON_NULL)
       private static class DocumentAddress implements Serializable {
         @JsonProperty("_index")
-        String index;
+        final String index;
 
         @JsonProperty("_type")
-        String type;
+        final String type;
 
         @JsonProperty("_id")
-        String id;
+        final String id;
 
         DocumentAddress(String index, String type, String id) {
           this.index = index;
@@ -903,7 +903,7 @@ public class ElasticsearchIO {
       }
 
       @StartBundle
-      public void startBundle(StartBundleContext context) throws Exception {
+      public void startBundle(StartBundleContext context) {
         batch = new ArrayList<>();
         currentBatchSizeBytes = 0;
       }


### PR DESCRIPTION
Really simple PR to fix error-prone and some static analysis warnings in ElasticsearchIO

[ CC @iemejia ]