### PR TITLE
Fix error-prone warnings for file-based-io-tests

### DIFF
--- a/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/TestRow.java
+++ b/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/TestRow.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.transforms.DoFn;
 
 /**
@@ -42,6 +41,7 @@ public abstract class TestRow implements Serializable, Comparable<TestRow> {
   public abstract Integer id();
   public abstract String name();
 
+  @Override
   public int compareTo(TestRow other) {
     return id().compareTo(other.id());
   }
@@ -96,7 +96,7 @@ public abstract class TestRow implements Serializable, Comparable<TestRow> {
    * Precalculated hashes - you can calculate an entry by running HashingFn on
    * the name() for the rows generated from seeds in [0, n).
    */
-  private static final Map<Integer, String> EXPECTED_HASHES = ImmutableMap.of(
+  private static final ImmutableMap<Integer, String> EXPECTED_HASHES = ImmutableMap.of(
       1000, "7d94d63a41164be058a9680002914358",
       100_000, "c7cbddb319209e200f1c5eebef8fe960",
       600_000, "e2add2f680de9024e9bc46cd3912545e",

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/tfrecord/TFRecordIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/tfrecord/TFRecordIOIT.java
@@ -23,6 +23,7 @@ import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.appendTimestampS
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.getExpectedHashForLineCount;
 import static org.apache.beam.sdk.io.common.FileBasedIOITHelper.readTestPipelineOptions;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.io.Compression;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TFRecordIO;
@@ -45,6 +46,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 
 /**
  * Integration tests for {@link org.apache.beam.sdk.io.TFRecordIO}.
@@ -132,14 +134,14 @@ public class TFRecordIOIT {
   static class StringToByteArray extends SimpleFunction<String, byte[]> {
     @Override
     public byte[] apply(String input) {
-      return input.getBytes();
+      return input.getBytes(StandardCharsets.UTF_8);
     }
   }
 
   static class ByteArrayToString extends SimpleFunction<byte[], String> {
     @Override
     public String apply(byte[] input) {
-      return new String(input);
+      return new String(input, StandardCharsets.UTF_8);
     }
   }
 }

--- a/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/xml/XmlIOIT.java
+++ b/sdks/java/io/file-based-io-tests/src/test/java/org/apache/beam/sdk/io/xml/XmlIOIT.java
@@ -23,7 +23,6 @@ import static org.apache.beam.sdk.io.common.IOITHelper.getHashForRecordCount;
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.nio.charset.Charset;
-import java.util.Map;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
@@ -70,7 +69,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class XmlIOIT {
 
-  private static final Map<Integer, String> EXPECTED_HASHES = ImmutableMap.of(
+  private static final ImmutableMap<Integer, String> EXPECTED_HASHES = ImmutableMap.of(
     1000, "7f51adaf701441ee83459a3f705c1b86",
     100_000, "af7775de90d0b0c8bbc36273fbca26fe",
     100_000_000, "bfee52b33aa1552b9c1bfa8bcc41ae80"

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
@@ -252,7 +252,7 @@ public class XmlIO {
       /** @see Compression#DEFLATE */
       DEFLATE(Compression.DEFLATE);
 
-      private Compression canonical;
+      private final Compression canonical;
 
       CompressionType(Compression canonical) {
         this.canonical = canonical;


### PR DESCRIPTION
Really simple PR to fix error-prone warnings in file-based-io-tests

( CC @iemejia )