### PR TITLE
Fix error-prone warnings for io/hadoop-common

### DIFF
--- a/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
+++ b/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/SerializableConfiguration.java
@@ -21,6 +21,7 @@ import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
@@ -60,9 +61,12 @@ public class SerializableConfiguration implements Externalizable {
   public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
     String className = in.readUTF();
     try {
-      conf = (Configuration) Class.forName(className).newInstance();
+      conf = (Configuration) Class.forName(className).getDeclaredConstructor().newInstance();
       conf.readFields(in);
-    } catch (InstantiationException | IllegalAccessException e) {
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
       throw new IOException("Unable to create configuration: " + e);
     }
   }

--- a/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/WritableCoder.java
+++ b/sdks/java/io/hadoop-common/src/main/java/org/apache/beam/sdk/io/hadoop/WritableCoder.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -63,6 +64,7 @@ public class WritableCoder<T extends Writable> extends CustomCoder<T> {
 
   private final Class<T> type;
 
+  @SuppressWarnings("WeakerAccess")
   public WritableCoder(Class<T> type) {
     this.type = type;
   }
@@ -80,10 +82,13 @@ public class WritableCoder<T extends Writable> extends CustomCoder<T> {
         // NullWritable has no default constructor
         return (T) NullWritable.get();
       }
-      T t = type.newInstance();
+      T t = type.getDeclaredConstructor().newInstance();
       t.readFields(new DataInputStream(inStream));
       return t;
-    } catch (InstantiationException | IllegalAccessException e) {
+    } catch (InstantiationException
+        | IllegalAccessException
+        | NoSuchMethodException
+        | InvocationTargetException e) {
       throw new CoderException("unable to deserialize record", e);
     }
   }
@@ -122,6 +127,7 @@ public class WritableCoder<T extends Writable> extends CustomCoder<T> {
    *
    * <p>This method is invoked reflectively from {@link DefaultCoder}.
    */
+  @SuppressWarnings("WeakerAccess")
   public static CoderProvider getCoderProvider() {
     return new WritableCoderProvider();
   }

--- a/sdks/java/io/hadoop-common/src/test/java/org/apache/beam/sdk/io/hadoop/SerializableConfigurationTest.java
+++ b/sdks/java/io/hadoop-common/src/test/java/org/apache/beam/sdk/io/hadoop/SerializableConfigurationTest.java
@@ -39,13 +39,13 @@ public class SerializableConfigurationTest {
           new SerializableConfiguration(new Configuration());
 
   @Test
-  public void testSerializationDeserialization() throws Exception {
+  public void testSerializationDeserialization() {
     Configuration conf = new Configuration();
     conf.set("hadoop.silly.test", "test-value");
     byte[] object = SerializationUtils.serialize(new SerializableConfiguration(conf));
     SerializableConfiguration serConf = SerializationUtils.deserialize(object);
     assertNotNull(serConf);
-    assertEquals(serConf.get().get("hadoop.silly.test"), "test-value");
+    assertEquals("test-value", serConf.get().get("hadoop.silly.test"));
   }
 
   @Test
@@ -57,7 +57,7 @@ public class SerializableConfigurationTest {
   }
 
   @Test
-  public void testCreateNewConfiguration() throws Exception {
+  public void testCreateNewConfiguration() {
     Configuration confFromNull = SerializableConfiguration.newConfiguration(null);
     assertNotNull(confFromNull);
     Configuration conf =


### PR DESCRIPTION
Really simple PR to fix error-prone and some static analysis warnings in io/hadoop-common

CC @iemejia 