### PR TITLE
Make Cloud Spanner transaction id public.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/Transaction.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/Transaction.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 public abstract class Transaction implements Serializable {
 
   @Nullable
-  abstract BatchTransactionId transactionId();
+  public abstract BatchTransactionId transactionId();
 
   public static Transaction create(BatchTransactionId txId) {
     return new AutoValue_Transaction(txId);


### PR DESCRIPTION
Allows to build non-library transforms that run in the same transaction with library ones.

