### PR TITLE
Fix error-prone warnings for io/hadoop-file-system

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -210,7 +210,7 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
     }
 
     @Override
-    public int write(ByteBuffer src) throws IOException {
+    public int write(ByteBuffer src) {
       throw new UnsupportedOperationException();
     }
 
@@ -240,7 +240,7 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
     }
 
     @Override
-    public SeekableByteChannel truncate(long size) throws IOException {
+    public SeekableByteChannel truncate(long size) {
       throw new UnsupportedOperationException();
     }
 

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModule.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModule.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io.hdfs;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
@@ -55,10 +54,10 @@ public class HadoopFileSystemModule extends SimpleModule {
   private static class ConfigurationMixin {}
 
   /** A Jackson {@link JsonDeserializer} for Hadoop {@link Configuration} objects. */
-  static class ConfigurationDeserializer extends JsonDeserializer<Configuration> {
+  private static class ConfigurationDeserializer extends JsonDeserializer<Configuration> {
     @Override
     public Configuration deserialize(JsonParser jsonParser,
-        DeserializationContext deserializationContext) throws IOException, JsonProcessingException {
+        DeserializationContext deserializationContext) throws IOException {
       Map<String, String> rawConfiguration =
           jsonParser.readValueAs(new TypeReference<Map<String, String>>() {});
       Configuration configuration = new Configuration(false);
@@ -70,10 +69,10 @@ public class HadoopFileSystemModule extends SimpleModule {
   }
 
   /** A Jackson {@link JsonSerializer} for Hadoop {@link Configuration} objects. */
-  static class ConfigurationSerializer extends JsonSerializer<Configuration> {
+  private static class ConfigurationSerializer extends JsonSerializer<Configuration> {
     @Override
     public void serialize(Configuration configuration, JsonGenerator jsonGenerator,
-        SerializerProvider serializerProvider) throws IOException, JsonProcessingException {
+        SerializerProvider serializerProvider) throws IOException {
       Map<String, String> map = new TreeMap<>();
       for (Map.Entry<String, String> entry : configuration) {
         map.put(entry.getKey(), entry.getValue());

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptions.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * {@link PipelineOptions} which encapsulate {@link Configuration Hadoop Configuration}
  * for the {@link HadoopFileSystem}.
  */
+@SuppressWarnings("WeakerAccess")
 @Experimental(Kind.FILESYSTEM)
 public interface HadoopFileSystemOptions extends PipelineOptions {
   @Description("A list of Hadoop configurations used to configure zero or more Hadoop filesystems. "

--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopResourceId.java
@@ -57,6 +57,7 @@ class HadoopResourceId implements ResourceId {
     return new HadoopResourceId(uri.getPath().endsWith("/") ? uri : uri.resolve("."));
   }
 
+  @Override
   public boolean isDirectory() {
     return uri.getPath().endsWith("/");
   }

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModuleTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemModuleTest.java
@@ -38,11 +38,12 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class HadoopFileSystemModuleTest {
   @Test
-  public void testObjectMapperIsAbleToFindModule() throws Exception {
+  public void testObjectMapperIsAbleToFindModule() {
     List<Module> modules = ObjectMapper.findModules(ReflectHelpers.findClassLoader());
     assertThat(modules, hasItem(Matchers.<Module>instanceOf(HadoopFileSystemModule.class)));
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testConfigurationSerializationDeserialization() throws Exception {
     Configuration baseConfiguration = new Configuration(false);

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemOptionsTest.java
@@ -48,6 +48,7 @@ import org.junit.runners.JUnit4;
 public class HadoopFileSystemOptionsTest {
   @Rule public TemporaryFolder tmpFolder = new TemporaryFolder();
 
+  @SuppressWarnings("unchecked")
   @Test
   public void testParsingHdfsConfiguration() {
     HadoopFileSystemOptions options = PipelineOptionsFactory.fromArgs(

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemRegistrarTest.java
@@ -59,7 +59,7 @@ public class HadoopFileSystemRegistrarTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     hdfsCluster.shutdown();
   }
 

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.io.FileSystems;
@@ -82,20 +83,20 @@ public class HadoopFileSystemTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     hdfsCluster.shutdown();
   }
 
   @Test
   public void testCreateAndReadFile() throws Exception {
-    byte[] bytes = "testData".getBytes();
+    byte[] bytes = "testData".getBytes(StandardCharsets.UTF_8);
     create("testFile", bytes);
     assertArrayEquals(bytes, read("testFile", 0));
   }
 
   @Test
   public void testCreateAndReadFileWithShift() throws Exception {
-    byte[] bytes = "testData".getBytes();
+    byte[] bytes = "testData".getBytes(StandardCharsets.UTF_8);
     create("testFile", bytes);
     int bytesToSkip = 3;
     byte[] expected = Arrays.copyOfRange(bytes, bytesToSkip, bytes.length);
@@ -105,7 +106,7 @@ public class HadoopFileSystemTest {
 
   @Test
   public void testCreateAndReadFileWithShiftToEnd() throws Exception {
-    byte[] bytes = "testData".getBytes();
+    byte[] bytes = "testData".getBytes(StandardCharsets.UTF_8);
     create("testFile", bytes);
     int bytesToSkip = bytes.length;
     byte[] expected = Arrays.copyOfRange(bytes, bytesToSkip, bytes.length);
@@ -114,8 +115,8 @@ public class HadoopFileSystemTest {
 
   @Test
   public void testCopy() throws Exception {
-    create("testFileA", "testDataA".getBytes());
-    create("testFileB", "testDataB".getBytes());
+    create("testFileA", "testDataA".getBytes(StandardCharsets.UTF_8));
+    create("testFileB", "testDataB".getBytes(StandardCharsets.UTF_8));
     fileSystem.copy(
         ImmutableList.of(
             testPath("testFileA"),
@@ -123,22 +124,22 @@ public class HadoopFileSystemTest {
         ImmutableList.of(
             testPath("copyTestFileA"),
             testPath("copyTestFileB")));
-    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
-    assertArrayEquals("testDataA".getBytes(), read("copyTestFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("copyTestFileB", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("testFileB", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("copyTestFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("copyTestFileB", 0));
   }
 
   @Test
   public void testDelete() throws Exception {
-    create("testFileA", "testDataA".getBytes());
-    create("testFileB", "testDataB".getBytes());
-    create("testFileC", "testDataC".getBytes());
+    create("testFileA", "testDataA".getBytes(StandardCharsets.UTF_8));
+    create("testFileB", "testDataB".getBytes(StandardCharsets.UTF_8));
+    create("testFileC", "testDataC".getBytes(StandardCharsets.UTF_8));
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
-    assertArrayEquals("testDataC".getBytes(), read("testFileC", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("testFileB", 0));
+    assertArrayEquals("testDataC".getBytes(StandardCharsets.UTF_8), read("testFileC", 0));
 
     fileSystem.delete(ImmutableList.of(
         testPath("testFileA"),
@@ -150,20 +151,20 @@ public class HadoopFileSystemTest {
         Metadata.builder()
             .setResourceId(testPath("testFileB"))
             .setIsReadSeekEfficient(true)
-            .setSizeBytes("testDataB".getBytes().length)
+            .setSizeBytes("testDataB".getBytes(StandardCharsets.UTF_8).length)
             .build()))));
   }
 
   @Test
   public void testMatch() throws Exception {
-    create("testFileAA", "testDataAA".getBytes());
-    create("testFileA", "testDataA".getBytes());
-    create("testFileB", "testDataB".getBytes());
+    create("testFileAA", "testDataAA".getBytes(StandardCharsets.UTF_8));
+    create("testFileA", "testDataA".getBytes(StandardCharsets.UTF_8));
+    create("testFileB", "testDataB".getBytes(StandardCharsets.UTF_8));
 
     // ensure files exist
-    assertArrayEquals("testDataAA".getBytes(), read("testFileAA", 0));
-    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
+    assertArrayEquals("testDataAA".getBytes(StandardCharsets.UTF_8), read("testFileAA", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("testFileB", 0));
 
     List<MatchResult> results =
         fileSystem.match(ImmutableList.of(testPath("testFileA*").toString()));
@@ -172,23 +173,23 @@ public class HadoopFileSystemTest {
         Metadata.builder()
             .setResourceId(testPath("testFileAA"))
             .setIsReadSeekEfficient(true)
-            .setSizeBytes("testDataAA".getBytes().length)
+            .setSizeBytes("testDataAA".getBytes(StandardCharsets.UTF_8).length)
             .build(),
         Metadata.builder()
             .setResourceId(testPath("testFileA"))
             .setIsReadSeekEfficient(true)
-            .setSizeBytes("testDataA".getBytes().length)
+            .setSizeBytes("testDataA".getBytes(StandardCharsets.UTF_8).length)
             .build()));
   }
 
   @Test
   public void testMatchForNonExistentFile() throws Exception {
-    create("testFileAA", "testDataAA".getBytes());
-    create("testFileBB", "testDataBB".getBytes());
+    create("testFileAA", "testDataAA".getBytes(StandardCharsets.UTF_8));
+    create("testFileBB", "testDataBB".getBytes(StandardCharsets.UTF_8));
 
     // ensure files exist
-    assertArrayEquals("testDataAA".getBytes(), read("testFileAA", 0));
-    assertArrayEquals("testDataBB".getBytes(), read("testFileBB", 0));
+    assertArrayEquals("testDataAA".getBytes(StandardCharsets.UTF_8), read("testFileAA", 0));
+    assertArrayEquals("testDataBB".getBytes(StandardCharsets.UTF_8), read("testFileBB", 0));
 
     List<MatchResult> matchResults = fileSystem.match(ImmutableList.of(
         testPath("testFileAA").toString(),
@@ -205,7 +206,7 @@ public class HadoopFileSystemTest {
                     Metadata.builder()
                         .setResourceId(testPath("testFileAA"))
                         .setIsReadSeekEfficient(true)
-                        .setSizeBytes("testDataAA".getBytes().length)
+                        .setSizeBytes("testDataAA".getBytes(StandardCharsets.UTF_8).length)
                         .build())),
             MatchResult.create(Status.NOT_FOUND, ImmutableList.of()),
             MatchResult.create(
@@ -214,19 +215,19 @@ public class HadoopFileSystemTest {
                     Metadata.builder()
                         .setResourceId(testPath("testFileBB"))
                         .setIsReadSeekEfficient(true)
-                        .setSizeBytes("testDataBB".getBytes().length)
+                        .setSizeBytes("testDataBB".getBytes(StandardCharsets.UTF_8).length)
                         .build())));
     assertThat(matchResults, equalTo(expected));
   }
 
   @Test
   public void testRename() throws Exception {
-    create("testFileA", "testDataA".getBytes());
-    create("testFileB", "testDataB".getBytes());
+    create("testFileA", "testDataA".getBytes(StandardCharsets.UTF_8));
+    create("testFileB", "testDataB".getBytes(StandardCharsets.UTF_8));
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("testFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("testFileB", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("testFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("testFileB", 0));
 
     fileSystem.rename(
         ImmutableList.of(
@@ -241,21 +242,21 @@ public class HadoopFileSystemTest {
         Metadata.builder()
             .setResourceId(testPath("renameFileA"))
             .setIsReadSeekEfficient(true)
-            .setSizeBytes("testDataA".getBytes().length)
+            .setSizeBytes("testDataA".getBytes(StandardCharsets.UTF_8).length)
             .build(),
         Metadata.builder()
             .setResourceId(testPath("renameFileB"))
             .setIsReadSeekEfficient(true)
-            .setSizeBytes("testDataB".getBytes().length)
+            .setSizeBytes("testDataB".getBytes(StandardCharsets.UTF_8).length)
             .build()));
 
     // ensure files exist
-    assertArrayEquals("testDataA".getBytes(), read("renameFileA", 0));
-    assertArrayEquals("testDataB".getBytes(), read("renameFileB", 0));
+    assertArrayEquals("testDataA".getBytes(StandardCharsets.UTF_8), read("renameFileA", 0));
+    assertArrayEquals("testDataB".getBytes(StandardCharsets.UTF_8), read("renameFileB", 0));
   }
 
   @Test
-  public void testMatchNewResource() throws Exception {
+  public void testMatchNewResource() {
     // match file spec
     assertEquals(testPath("file"),
         fileSystem.matchNewResource(testPath("file").toString(), false));
@@ -274,9 +275,9 @@ public class HadoopFileSystemTest {
   @Test
   @Ignore("TestPipeline needs a way to take in HadoopFileSystemOptions")
   public void testReadPipeline() throws Exception {
-    create("testFileA", "testDataA".getBytes());
-    create("testFileB", "testDataB".getBytes());
-    create("testFileC", "testDataC".getBytes());
+    create("testFileA", "testDataA".getBytes(StandardCharsets.UTF_8));
+    create("testFileB", "testDataB".getBytes(StandardCharsets.UTF_8));
+    create("testFileC", "testDataC".getBytes(StandardCharsets.UTF_8));
 
     HadoopFileSystemOptions options = TestPipeline.testingPipelineOptions()
         .as(HadoopFileSystemOptions.class);

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopResourceIdTest.java
@@ -58,13 +58,13 @@ public class HadoopResourceIdTest {
   }
 
   @After
-  public void tearDown() throws Exception {
+  public void tearDown() {
     hdfsCluster.shutdown();
   }
 
   @Test
   @Ignore("https://issues.apache.org/jira/browse/BEAM-4142")
-  public void testResourceIdTester() throws Exception {
+  public void testResourceIdTester() {
     ResourceId baseDirectory =
         FileSystems.matchNewResource(
             "hdfs://" + hdfsClusterBaseUri.getPath(), true /* isDirectory */);


### PR DESCRIPTION
Really simple PR to fix error-prone and some static analysis warnings in io/hadoop-file-system

CC @iemejia