### PR TITLE
[BEAM-4009] Futurize unpackaged files

### DIFF
--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -72,6 +72,8 @@ has some examples.
 """
 
 
+from __future__ import absolute_import
+
 import sys
 
 

--- a/sdks/python/apache_beam/error.py
+++ b/sdks/python/apache_beam/error.py
@@ -17,6 +17,8 @@
 
 """Python Dataflow error classes."""
 
+from __future__ import absolute_import
+
 
 class BeamError(Exception):
   """Base class for all Beam errors."""

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -52,6 +52,10 @@ import logging
 import os
 import shutil
 import tempfile
+from builtins import object
+from builtins import zip
+
+from future.utils import with_metaclass
 
 from apache_beam import pvalue
 from apache_beam.internal import pickler
@@ -880,7 +884,7 @@ class AppliedPTransform(object):
     return result
 
 
-class PTransformOverride(object):
+class PTransformOverride(with_metaclass(abc.ABCMeta, object)):
   """For internal use only; no backwards-compatibility guarantees.
 
   Gives a matcher and replacements for matching PTransforms.
@@ -888,7 +892,6 @@ class PTransformOverride(object):
   TODO: Update this to support cases where input and/our output types are
   different.
   """
-  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def matches(self, applied_ptransform):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -17,10 +17,14 @@
 
 """Unit tests for the Pipeline class."""
 
+from __future__ import absolute_import
+
 import copy
 import logging
 import platform
 import unittest
+from builtins import object
+from builtins import range
 from collections import defaultdict
 
 import mock

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -266,7 +266,7 @@ class TaggedOutput(object):
   """
 
   def __init__(self, tag, value):
-    if not isinstance(tag, (bytes, unicode)):
+    if not isinstance(tag, (str, unicode)):
       raise TypeError(
           'Attempting to create a TaggedOutput with non-string tag %s' % tag)
     self.tag = tag

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -28,8 +28,8 @@ from __future__ import absolute_import
 
 import collections
 import itertools
-
-from six import string_types
+from builtins import hex
+from builtins import object
 
 from apache_beam import coders
 from apache_beam import typehints
@@ -37,6 +37,11 @@ from apache_beam.internal import pickler
 from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 __all__ = [
     'PCollection',
@@ -261,7 +266,7 @@ class TaggedOutput(object):
   """
 
   def __init__(self, tag, value):
-    if not isinstance(tag, string_types):
+    if not isinstance(tag, (bytes, unicode)):
       raise TypeError(
           'Attempting to create a TaggedOutput with non-string tag %s' % tag)
     self.tag = tag

--- a/sdks/python/apache_beam/pvalue_test.py
+++ b/sdks/python/apache_beam/pvalue_test.py
@@ -17,6 +17,8 @@
 
 """Unit tests for the PValue and PCollection classes."""
 
+from __future__ import absolute_import
+
 import unittest
 
 from apache_beam.pvalue import AsSingleton

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -99,6 +99,11 @@ deps =
   flake8==3.5.0
 modules =
   apache_beam/coders
+  apache_beam/error
+  apache_beam/pipeline
+  apache_beam/pipeline_test
+  apache_beam/pvalue
+  apache_beam/pvalue_test
 commands =
   python --version
   pip --version


### PR DESCRIPTION
This pull request prepares the unpackaged files for Python 3 support. This PR is part of a series in which all subpackages will be updated using the same approach.
This approach has been documented [here](https://s.apache.org/beam-python-3) and the first pull request in the series (Futurize coders subpackage) demonstrating this approach can be found at #5053.

R: @aaltay @tvalentyn @RobbeSneyders