### PR TITLE
[BEAM-3733] [SQL] Use saffron.properties for charset

### DIFF
--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -25,16 +25,6 @@ apply plugin: 'ca.coglinc.javacc'
 description = "Apache Beam :: SDKs :: Java :: Extensions :: SQL"
 ext.summary = "Beam SQL provides a new interface to generate a Beam pipeline from SQL statement"
 
-test {
-  // charset that calcite will use for the tables in the tests
-  // need to setup as system property prior to running any tests
-  // or some of the tests may fail as calcite will init itself
-  // with it's default of ISO-8859-1
-  systemProperty 'saffron.default.charset', 'UTF-16LE'
-  systemProperty 'saffron.default.nationalcharset', 'UTF-16LE'
-  systemProperty 'saffron.default.collation.name', 'UTF-16LE$en_US'
-}
-
 configurations {
   // Create an fmppTask configuration representing the dependencies
   // required to define and execute the Ant FMPP task.
@@ -42,7 +32,6 @@ configurations {
   fmppTask
   fmppTemplates
 }
-
 
 def calcite_version = "1.16.0"
 def avatica_version = "1.11.0"

--- a/sdks/java/extensions/sql/pom.xml
+++ b/sdks/java/extensions/sql/pom.xml
@@ -39,12 +39,6 @@
     <avatica.version>1.11.0</avatica.version>
     <mockito.version>1.9.5</mockito.version>
     <quickcheck.version>0.8</quickcheck.version>
-    
-    <!-- charset that calcite will use for the tables in the tests -->
-    <!-- need to setup as system property prior to running any tests
-         or some of the tests may fail as calcite will init itself
-         with it's default of ISO-8859-1 -->
-    <calcite.charset>UTF-16LE</calcite.charset>
   </properties>
 
   <profiles>
@@ -209,13 +203,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <systemPropertyVariables>
-            <saffron.default.charset>${calcite.charset}</saffron.default.charset>
-            <saffron.default.nationalcharset>${calcite.charset}</saffron.default.nationalcharset>
-            <saffron.default.collation.name>${calcite.charset}$en_US</saffron.default.collation.name>
-          </systemPropertyVariables>
-        </configuration>
       </plugin>
 
       <plugin>

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
@@ -52,7 +52,6 @@ import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.Planner;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
-import org.apache.calcite.util.ConversionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,15 +69,6 @@ public class BeamQueryPlanner {
       RelDataTypeSystem.DEFAULT);
 
   public BeamQueryPlanner(SchemaPlus schema) {
-    String defaultCharsetKey = "saffron.default.charset";
-    if (System.getProperty(defaultCharsetKey) == null) {
-      System.setProperty(defaultCharsetKey, ConversionUtil.NATIVE_UTF16_CHARSET_NAME);
-      System.setProperty("saffron.default.nationalcharset",
-        ConversionUtil.NATIVE_UTF16_CHARSET_NAME);
-      System.setProperty("saffron.default.collation.name",
-        String.format("%s$%s", ConversionUtil.NATIVE_UTF16_CHARSET_NAME, "en_US"));
-    }
-
     final List<RelTraitDef> traitDefs = new ArrayList<>();
     traitDefs.add(ConventionTraitDef.INSTANCE);
     traitDefs.add(RelCollationTraitDef.INSTANCE);

--- a/sdks/java/extensions/sql/src/main/resources/saffron.properties
+++ b/sdks/java/extensions/sql/src/main/resources/saffron.properties
@@ -1,0 +1,21 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+saffron.default.charset=UTF-16LE
+saffron.default.nationalcharset=UTF-16LE
+saffron.default.collation.name=UTF-16LE$en_US


### PR DESCRIPTION
Hit the charset issues again for things that load calcite not via maven or gradle. This should fix it once and for all by adding the config file to the jar.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand:
   - [X] What the pull request does
   - [X] Why it does it
   - [X] How it does it
   - [X] Why this approach
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [X] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

