### PR TITLE
Improve the TaggedOutput error when a tuple is passed as a tag.

### DIFF
--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -263,7 +263,7 @@ class TaggedOutput(object):
   def __init__(self, tag, value):
     if not isinstance(tag, string_types):
       raise TypeError(
-          'Attempting to create a TaggedOutput with non-string tag %s' % tag)
+          'Attempting to create a TaggedOutput with non-string tag %s' % (tag,))
     self.tag = tag
     self.value = value
 

--- a/sdks/python/apache_beam/pvalue_test.py
+++ b/sdks/python/apache_beam/pvalue_test.py
@@ -21,6 +21,7 @@ import unittest
 
 from apache_beam.pvalue import AsSingleton
 from apache_beam.pvalue import PValue
+from apache_beam.pvalue import TaggedOutput
 from apache_beam.testing.test_pipeline import TestPipeline
 
 
@@ -37,6 +38,15 @@ class PValueTest(unittest.TestCase):
         'PCollection of size 2 with more than one element accessed as a '
         'singleton view. First two elements encountered are \"1\", \"2\".'):
       AsSingleton._from_runtime_iterable([1, 2], {})
+
+
+class TaggedValueTest(unittest.TestCase):
+
+  def test_passed_tuple_as_tag(self):
+    with self.assertRaisesRegexp(
+        TypeError,
+        r'Attempting to create a TaggedOutput with non-string tag \(1, 2, 3\)'):
+      TaggedOutput((1, 2, 3), 'value')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This can easily happen when attempting to emit a key-value pair, and
switching the tag and value.

DESCRIPTION HERE

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [N/A] Make sure there is a [JIRA issue](https://issues.apache.org/jira/projects/BEAM/issues/) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [N/A] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue.
 - [*] Write a pull request description that is detailed enough to understand:
   - [ ] What the pull request does
   - [ ] Why it does it
   - [ ] How it does it
   - [ ] Why this approach
 - [*] Each commit in the pull request should have a meaningful subject line and body.
 - [*] Run `./gradlew build` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [N/A] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

