### PR TITLE
[BEAM-3827] Invoke Go Dataflow integration tests from post-commit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -157,8 +157,18 @@ task goPreCommit() {
 }
 
 task goPostCommit() {
-  // Same currently as precommit, but duplicated to provide a clearer signal of reliability.
   dependsOn ":goPreCommit"
+  dependsOn ":goIntegrationTests"
+}
+
+task goIntegrationTests() {
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', './sdks/go/test/run_integration_tests.sh'
+    }
+  }
+  dependsOn ":beam-sdks-go-test:build"
 }
 
 task pythonPreCommit() {

--- a/sdks/go/build.gradle
+++ b/sdks/go/build.gradle
@@ -31,5 +31,8 @@ golang {
 
     // Build debugging utilities
     go 'build -o ./build/bin/beamctl github.com/apache/beam/sdks/go/cmd/beamctl'
+
+    // Build integration test driver
+    go 'build -o ./build/bin/integration github.com/apache/beam/sdks/go/test/integration'
   }
 }

--- a/sdks/go/test/build.gradle
+++ b/sdks/go/test/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply from: project(":").file("build_rules.gradle")
+applyGoNature()
+
+description = "Apache Beam :: SDKs :: Go :: Test"
+
+// Figure out why the golang plugin does not add a build dependency between projects.
+// Without the line below, we get spurious errors about not being able to resolve
+// "./github.com/apache/beam/sdks/go"
+resolveBuildDependencies.dependsOn ":beam-sdks-go:build"
+
+dependencies {
+  golang {
+    // TODO(herohde): use "./" prefix to prevent gogradle use base github path, for now.
+    // TODO(herohde): get the pkg subdirectory only, if possible. We spend mins pulling cmd/beamctl deps.
+    build name: './github.com/apache/beam/sdks/go', dir: project(':beam-sdks-go').projectDir
+    test name: './github.com/apache/beam/sdks/go', dir: project(':beam-sdks-go').projectDir
+  }
+}
+
+golang {
+  packagePath = 'github.com/apache/beam/sdks/go/test'
+  build {
+    // Build the linux-amd64 worker. The native version is built in the parent to
+    // have a fixed name, which is not possible with multiple target platforms. The
+    // script would otherwise have to figure out which arch/platform binary to invoke.
+
+    targetPlatform = ['linux-amd64']
+    go 'build -o ./build/bin/linux-amd64/worker github.com/apache/beam/sdks/go/test/integration'
+  }
+}

--- a/sdks/go/test/run_integration_tests.sh
+++ b/sdks/go/test/run_integration_tests.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This script will be run by Jenkins as a post commit test. In order to run
+# locally make the following changes:
+#
+# GCS_LOCATION     -> Temporary location to use for service tests.
+# PROJECT          -> Project name to use for docker images.
+# DATAFLOW_PROJECT -> Project name to use for dataflow.
+#
+# Execute from the root of the repository. It assumes binaries are built.
+
+set -e
+set -v
+
+# Where to store integration test outputs.
+GCS_LOCATION=gs://temp-storage-for-end-to-end-tests
+
+# Project for the container and integration test
+PROJECT=apache-beam-testing
+DATAFLOW_PROJECT=apache-beam-testing
+
+# Verify in the root of the repository
+test -d sdks/go/test
+
+# Verify docker and gcloud commands exist
+command -v docker
+command -v gcloud
+docker -v
+gcloud -v
+
+# ensure gcloud is version 186 or above
+TMPDIR=$(mktemp -d)
+gcloud_ver=$(gcloud -v | head -1 | awk '{print $4}')
+if [[ "$gcloud_ver" < "186" ]]
+then
+  pushd $TMPDIR
+  curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-186.0.0-linux-x86_64.tar.gz --output gcloud.tar.gz
+  tar xf gcloud.tar.gz
+  ./google-cloud-sdk/install.sh --quiet
+  . ./google-cloud-sdk/path.bash.inc
+  popd
+  gcloud components update --quiet || echo 'gcloud components update failed'
+  gcloud -v
+fi
+
+# Build the container
+TAG=$(date +%Y%m%d-%H%M%S)
+CONTAINER=us.gcr.io/$PROJECT/$USER/go
+echo "Using container $CONTAINER"
+./gradlew :beam-sdks-go-container:docker -Pdocker-repository-root=us.gcr.io/$PROJECT/$USER -Pdocker-tag=$TAG
+
+# Verify it exists
+docker images | grep $TAG
+
+# Push the container
+gcloud docker -- push $CONTAINER
+
+echo ">>> RUNNING DATAFLOW INTEGRATION TESTS"
+./sdks/go/build/bin/integration \
+    --runner=dataflow \
+    --project=$DATAFLOW_PROJECT \
+    --worker_harness_container_image=$CONTAINER:$TAG \
+    --staging_location=$GCS_LOCATION/staging-validatesrunner-test \
+    --temp_location=$GCS_LOCATION/temp-validatesrunner-test \
+    --worker_binary=./sdks/go/test/build/bin/linux-amd64/worker
+
+# TODO(herohde) 5/9/2018: run other runner tests here to reuse the container image?
+
+# Delete the container locally and remotely
+docker rmi $CONTAINER:$TAG || echo "Failed to remove container"
+gcloud --quiet container images delete $CONTAINER:$TAG || echo "Failed to delete container"
+
+# Clean up tempdir
+rm -rf $TMPDIR
+
+echo ">>> SUCCESS"

--- a/settings.gradle
+++ b/settings.gradle
@@ -66,6 +66,8 @@ include "beam-sdks-go-container"
 project(":beam-sdks-go-container").dir = file("sdks/go/container")
 include "beam-sdks-go-examples"
 project(":beam-sdks-go-examples").dir = file("sdks/go/examples")
+include "beam-sdks-go-test"
+project(":beam-sdks-go-test").dir = file("sdks/go/test")
 include "beam-sdks-java-build-tools"
 project(":beam-sdks-java-build-tools").dir = file("sdks/java/build-tools")
 include "beam-sdks-java-container"


### PR DESCRIPTION
 * Add a Python ValidatesContainer-style script to build the Go container around the integration tests. It uses the same bash logic for consistency, but ideally we'd have a better solution for building containers for integration tests shared across the SDKs.
 * Add another Gradle build file to build the linux_amd64 Go integration test worker with a fixed name. This separation makes it easier to invoke the correct test driver from the script, because we don't have to figure out what the host platform and architecture is. It didn't seem possible to do this from a single Gradle build file.

Design notes: https://docs.google.com/document/d/1jy6EE7D4RjgfNV0FhD3rMsT1YKhnUfcHRZMAlC6ygXw/edit?usp=sharing
