### PR TITLE
[BEAM-4342] Enforce ErrorProne analysis in hadoop IO

### DIFF
--- a/sdks/java/io/hadoop-common/build.gradle
+++ b/sdks/java/io/hadoop-common/build.gradle
@@ -17,12 +17,13 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Hadoop Common"
 ext.summary = "Library to add shared Hadoop classes among Beam IOs."
 
 dependencies {
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.findbugs_jsr305
   provided library.java.hadoop_client
@@ -31,4 +32,5 @@ dependencies {
   testCompile library.java.commons_lang3
   testCompile library.java.hamcrest_core
   testCompile library.java.junit
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/hadoop-file-system/build.gradle
+++ b/sdks/java/io/hadoop-file-system/build.gradle
@@ -17,13 +17,14 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Hadoop File System"
 ext.summary = "Library to read and write Hadoop/HDFS file formats from Beam."
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.jackson_core
   shadow library.java.jackson_databind
@@ -40,4 +41,5 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.hadoop_minicluster
   testCompile library.java.hadoop_hdfs_tests
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/hadoop-input-format/build.gradle
+++ b/sdks/java/io/hadoop-input-format/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 
@@ -41,6 +41,7 @@ configurations.testRuntimeClasspath {
 dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow library.java.slf4j_api
   shadow library.java.findbugs_jsr305
   shadow project(path: ":beam-sdks-java-io-hadoop-common", configuration: "shadow")
@@ -74,6 +75,7 @@ dependencies {
   testCompile "org.apache.logging.log4j:log4j-core:$log4j_version"
   testCompile library.java.junit
   shadow library.java.commons_io_2x
+  testCompileOnly library.java.findbugs_annotations
 }
 
 // The cassandra.yaml file currently assumes "target/..." exists.

--- a/sdks/java/io/hadoop-input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
+++ b/sdks/java/io/hadoop-input-format/src/main/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIO.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -234,6 +235,7 @@ public class HadoopInputFormatIO {
     }
 
     /** Reads from the source using the options provided by the given configuration. */
+    @SuppressWarnings("unchecked")
     public Read<K, V> withConfiguration(Configuration configuration) {
       validateConfiguration(configuration);
       TypeDescriptor<?> inputFormatClass =
@@ -352,6 +354,7 @@ public class HadoopInputFormatIO {
      * coder, if not found in Coder Registry, then check if the type descriptor provided is of type
      * Writable, then WritableCoder is returned, else exception is thrown "Cannot find coder".
      */
+    @SuppressWarnings({"unchecked", "WeakerAccess"})
     public <T> Coder<T> getDefaultCoder(TypeDescriptor<?> typeDesc, CoderRegistry coderRegistry) {
       Class classType = typeDesc.getRawType();
       try {
@@ -411,6 +414,7 @@ public class HadoopInputFormatIO {
           null);
     }
 
+    @SuppressWarnings("WeakerAccess")
     protected HadoopInputFormatBoundedSource(
         SerializableConfiguration conf,
         Coder<K> keyCoder,
@@ -426,6 +430,7 @@ public class HadoopInputFormatIO {
       this.valueTranslationFunction = valueTranslationFunction;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public SerializableConfiguration getConfiguration() {
       return conf;
     }
@@ -472,15 +477,13 @@ public class HadoopInputFormatIO {
           .stream()
           .map(
               serializableInputSplit -> {
-                HadoopInputFormatBoundedSource<K, V> hifBoundedSource =
-                    new HadoopInputFormatBoundedSource<>(
-                        conf,
-                        keyCoder,
-                        valueCoder,
-                        keyTranslationFunction,
-                        valueTranslationFunction,
-                        serializableInputSplit);
-                return hifBoundedSource;
+                return new HadoopInputFormatBoundedSource<>(
+                    conf,
+                    keyCoder,
+                    valueCoder,
+                    keyTranslationFunction,
+                    valueTranslationFunction,
+                    serializableInputSplit);
               })
           .collect(Collectors.toList());
     }
@@ -531,6 +534,7 @@ public class HadoopInputFormatIO {
      * Creates instance of InputFormat class. The InputFormat class name is specified in the Hadoop
      * configuration.
      */
+    @SuppressWarnings("WeakerAccess")
     protected void createInputFormatInstance() throws IOException {
       if (inputFormatObj == null) {
         try {
@@ -541,6 +545,7 @@ public class HadoopInputFormatIO {
                   .get()
                   .getClassByName(
                       conf.get().get("mapreduce.job.inputformat.class"))
+                  .getConstructor()
                   .newInstance();
           /*
            * If InputFormat explicitly implements interface {@link Configurable}, then setConf()
@@ -552,7 +557,11 @@ public class HadoopInputFormatIO {
           if (Configurable.class.isAssignableFrom(inputFormatObj.getClass())) {
             ((Configurable) inputFormatObj).setConf(conf.get());
           }
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+        } catch (InstantiationException
+            | IllegalAccessException
+            | ClassNotFoundException
+            | NoSuchMethodException
+            | InvocationTargetException e) {
           throw new IOException("Unable to create InputFormat object: ", e);
         }
       }
@@ -604,13 +613,15 @@ public class HadoopInputFormatIO {
       private final SerializableSplit split;
       private RecordReader<T1, T2> recordReader;
       private volatile boolean doneReading = false;
-      private AtomicLong recordsReturned = new AtomicLong();
+      private final AtomicLong recordsReturned = new AtomicLong();
       // Tracks the progress of the RecordReader.
-      private AtomicDouble progressValue = new AtomicDouble();
-      private transient InputFormat<T1, T2> inputFormatObj;
-      private transient TaskAttemptContext taskAttemptContext;
+      private final AtomicDouble progressValue = new AtomicDouble();
+      private final transient InputFormat<T1, T2> inputFormatObj;
+      private final transient TaskAttemptContext taskAttemptContext;
 
-      private HadoopInputFormatReader(HadoopInputFormatBoundedSource<K, V> source,
+      @SuppressWarnings("unchecked")
+      private HadoopInputFormatReader(
+          HadoopInputFormatBoundedSource<K, V> source,
           @Nullable SimpleFunction keyTranslationFunction,
           @Nullable SimpleFunction valueTranslationFunction,
           SerializableSplit split,
@@ -696,12 +707,14 @@ public class HadoopInputFormatIO {
 
       /**
        * Returns the serialized output of transformed key or value object.
+       *
        * @throws ClassCastException
        * @throws CoderException
        */
-      private <T, T3> T3 transformKeyOrValue(T input,
-          @Nullable SimpleFunction<T, T3> simpleFunction, Coder<T3> coder) throws CoderException,
-          ClassCastException {
+      @SuppressWarnings("unchecked")
+      private <T, T3> T3 transformKeyOrValue(
+          T input, @Nullable SimpleFunction<T, T3> simpleFunction, Coder<T3> coder)
+          throws CoderException, ClassCastException {
         T3 output;
         if (null != simpleFunction) {
           output = simpleFunction.apply(input);
@@ -777,9 +790,9 @@ public class HadoopInputFormatIO {
         if (doneReading) {
           return 0;
         }
-        /**
-         * This source does not currently support dynamic work rebalancing, so remaining parallelism
-         * is always 1.
+        /*
+          This source does not currently support dynamic work rebalancing, so remaining parallelism
+          is always 1.
          */
         return 1;
       }
@@ -802,11 +815,12 @@ public class HadoopInputFormatIO {
       this.inputSplit = split;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public InputSplit getSplit() {
       return inputSplit;
     }
 
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+    private void readObject(ObjectInputStream in) throws IOException {
       ObjectWritable ow = new ObjectWritable();
       ow.setConf(new Configuration(false));
       ow.readFields(in);

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/ConfigurableEmployeeInputFormat.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/ConfigurableEmployeeInputFormat.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
  * Configurable. This validates if setConf() method is called before getSplits(). Known InputFormats
  * which implement Configurable are DBInputFormat, TableInputFormat etc.
  */
-public class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee> implements
+class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee> implements
     Configurable {
   public boolean isConfSet = false;
 
@@ -55,7 +55,7 @@ public class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee>
 
   @Override
   public RecordReader<Text, Employee> createRecordReader(InputSplit split,
-      TaskAttemptContext context) throws IOException, InterruptedException {
+      TaskAttemptContext context) {
     return new ConfigurableEmployeeRecordReader();
   }
 
@@ -64,7 +64,7 @@ public class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee>
    * {@link #setConf()} is not called.
    */
   @Override
-  public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+  public List<InputSplit> getSplits(JobContext context) throws IOException {
     if (!isConfSet) {
       throw new IOException("Configuration is not set.");
     }
@@ -76,21 +76,21 @@ public class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee>
   /**
    * InputSplit implementation for ConfigurableEmployeeInputFormat.
    */
-  public class ConfigurableEmployeeInputSplit extends InputSplit implements Writable {
+  static class ConfigurableEmployeeInputSplit extends InputSplit implements Writable {
 
     @Override
-    public void readFields(DataInput arg0) throws IOException {}
+    public void readFields(DataInput arg0) {}
 
     @Override
-    public void write(DataOutput arg0) throws IOException {}
+    public void write(DataOutput arg0) {}
 
     @Override
-    public long getLength() throws IOException, InterruptedException {
+    public long getLength() {
       return 0;
     }
 
     @Override
-    public String[] getLocations() throws IOException, InterruptedException {
+    public String[] getLocations() {
       return null;
     }
   }
@@ -98,33 +98,33 @@ public class ConfigurableEmployeeInputFormat extends InputFormat<Text, Employee>
   /**
    * RecordReader for ConfigurableEmployeeInputFormat.
    */
-  public class ConfigurableEmployeeRecordReader extends RecordReader<Text, Employee> {
+  static class ConfigurableEmployeeRecordReader extends RecordReader<Text, Employee> {
 
     @Override
-    public void initialize(InputSplit paramInputSplit, TaskAttemptContext paramTaskAttemptContext)
-        throws IOException, InterruptedException {}
+    public void initialize(
+        InputSplit paramInputSplit, TaskAttemptContext paramTaskAttemptContext) {}
 
     @Override
-    public boolean nextKeyValue() throws IOException, InterruptedException {
+    public boolean nextKeyValue() {
       return false;
     }
 
     @Override
-    public Text getCurrentKey() throws IOException, InterruptedException {
+    public Text getCurrentKey() {
       return null;
     }
 
     @Override
-    public Employee getCurrentValue() throws IOException, InterruptedException {
+    public Employee getCurrentValue() {
       return null;
     }
 
     @Override
-    public float getProgress() throws IOException, InterruptedException {
+    public float getProgress() {
       return 0;
     }
 
     @Override
-    public void close() throws IOException {}
+    public void close() {}
   }
 }

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOCassandraIT.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOCassandraIT.java
@@ -109,7 +109,7 @@ public class HIFIOCassandraIT implements Serializable {
     pipeline.run().waitUntilFinish();
   }
 
-  SimpleFunction<Row, String> myValueTranslate = new SimpleFunction<Row, String>() {
+  private final SimpleFunction<Row, String> myValueTranslate = new SimpleFunction<Row, String>() {
     @Override
     public String apply(Row input) {
       return input.getString("y_id") + "|" + input.getString("field0") + "|"

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOElasticIT.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOElasticIT.java
@@ -14,7 +14,6 @@
  */
 package org.apache.beam.sdk.io.hadoop.inputformat;
 
-import java.io.IOException;
 import java.io.Serializable;
 import org.apache.beam.sdk.io.common.HashingFn;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -87,7 +86,7 @@ public class HIFIOElasticIT implements Serializable {
    * successfully.
    */
   @Test
-  public void testHifIOWithElastic() throws SecurityException, IOException {
+  public void testHifIOWithElastic() throws SecurityException {
     // Expected hashcode is evaluated during insertion time one time and hardcoded here.
     final long expectedRowCount = 1000L;
     String expectedHashCode = "42e254c8689050ed0a617ff5e80ea392";
@@ -106,7 +105,7 @@ public class HIFIOElasticIT implements Serializable {
     pipeline.run().waitUntilFinish();
   }
 
-  MapElements<LinkedMapWritable, String> transformFunc =
+  private final MapElements<LinkedMapWritable, String> transformFunc =
       MapElements.via(
           new SimpleFunction<LinkedMapWritable, String>() {
             @Override
@@ -145,7 +144,7 @@ public class HIFIOElasticIT implements Serializable {
    * separator.
    */
   private String addFieldValuesToRow(String row, MapWritable mapw, String columnName) {
-    Object valueObj = (Object) mapw.get(new Text(columnName));
+    Object valueObj = mapw.get(new Text(columnName));
     row += valueObj.toString() + "|";
     return row;
   }

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithEmbeddedCassandraTest.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFIOWithEmbeddedCassandraTest.java
@@ -63,7 +63,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
   private static transient Cluster cluster;
   private static transient Session session;
   private static final long TEST_DATA_ROW_COUNT = 10L;
-  private static EmbeddedCassandraService cassandra = new EmbeddedCassandraService();
+  private static final EmbeddedCassandraService cassandra = new EmbeddedCassandraService();
 
   @Rule
   public final transient TestPipeline p = TestPipeline.create();
@@ -74,7 +74,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
    * @throws Exception
    */
   @Test
-  public void testHIFReadForCassandra() throws Exception {
+  public void testHIFReadForCassandra() {
     // Expected hashcode is evaluated during insertion time one time and hardcoded here.
     String expectedHashCode = "1b9780833cce000138b9afa25ba63486";
     Configuration conf = getConfiguration();
@@ -92,20 +92,20 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
     p.run().waitUntilFinish();
   }
 
-  SimpleFunction<Row, String> myValueTranslate = new SimpleFunction<Row, String>() {
-    @Override
-    public String apply(Row input) {
-      String scientistRecord = input.getInt("id") + "|" + input.getString("scientist");
-      return scientistRecord;
-    }
-  };
+  private final SimpleFunction<Row, String> myValueTranslate =
+      new SimpleFunction<Row, String>() {
+        @Override
+        public String apply(Row input) {
+          return input.getInt("id") + "|" + input.getString("scientist");
+        }
+      };
 
   /**
    * Test to read data from embedded Cassandra instance based on query and verify whether data is
    * read successfully.
    */
   @Test
-  public void testHIFReadForCassandraQuery() throws Exception {
+  public void testHIFReadForCassandraQuery() {
     Long expectedCount = 1L;
     String expectedChecksum = "f11caabc7a9fc170e22b41218749166c";
     Configuration conf = getConfiguration();
@@ -129,7 +129,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
    * class name, key class, value class are thrift port, thrift address, partitioner class, keyspace
    * and columnfamily name
    */
-  public Configuration getConfiguration() {
+  private Configuration getConfiguration() {
     Configuration conf = new Configuration();
     conf.set(CASSANDRA_THRIFT_PORT_PROPERTY, CASSANDRA_PORT);
     conf.set(CASSANDRA_THRIFT_ADDRESS_PROPERTY, CASSANDRA_HOST);
@@ -143,7 +143,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
     return conf;
   }
 
-  public static void createCassandraData() throws Exception {
+  private static void createCassandraData() {
     session.execute("DROP KEYSPACE IF EXISTS " + CASSANDRA_KEYSPACE);
     session.execute("CREATE KEYSPACE " + CASSANDRA_KEYSPACE
         + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};");
@@ -173,7 +173,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
   }
 
   @AfterClass
-  public static void stopEmbeddedCassandra() throws Exception {
+  public static void stopEmbeddedCassandra() {
     session.close();
     cluster.close();
   }
@@ -205,6 +205,7 @@ public class HIFIOWithEmbeddedCassandraTest implements Serializable {
       this.id = id;
     }
 
+    @Override
     public String toString() {
       return id + ":" + name;
     }

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFITestOptions.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFITestOptions.java
@@ -24,7 +24,7 @@ import org.apache.beam.sdk.testing.TestPipelineOptions;
 /**
  * Properties needed when using HadoopInputFormatIO with the Beam SDK.
  */
-public interface HIFITestOptions extends TestPipelineOptions {
+interface HIFITestOptions extends TestPipelineOptions {
 
   //Cassandra test options
   @Description("Cassandra Server IP")

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HadoopInputFormatIOTest.java
@@ -63,9 +63,9 @@ import org.mockito.Mockito;
  */
 @RunWith(JUnit4.class)
 public class HadoopInputFormatIOTest {
-  static SerializableConfiguration serConf;
-  static SimpleFunction<Text, String> myKeyTranslate;
-  static SimpleFunction<Employee, String> myValueTranslate;
+  private static SerializableConfiguration serConf;
+  private static SimpleFunction<Text, String> myKeyTranslate;
+  private static SimpleFunction<Employee, String> myValueTranslate;
 
   @Rule public final transient TestPipeline p = TestPipeline.create();
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -73,7 +73,7 @@ public class HadoopInputFormatIOTest {
   private PBegin input = PBegin.in(p);
 
   @BeforeClass
-  public static void setUp() throws IOException, InterruptedException {
+  public static void setUp() {
     serConf = loadTestConfiguration(
                   EmployeeInputFormat.class,
                   Text.class,
@@ -135,8 +135,7 @@ public class HadoopInputFormatIOTest {
    * @throws IOException
    */
   @Test
-  public void testReadBuildsCorrectlyIfWithConfigurationIsCalledMoreThanOneTime()
-      throws IOException, InterruptedException {
+  public void testReadBuildsCorrectlyIfWithConfigurationIsCalledMoreThanOneTime() {
     SerializableConfiguration diffConf =
         loadTestConfiguration(
             EmployeeInputFormat.class,
@@ -386,7 +385,7 @@ public class HadoopInputFormatIOTest {
   }
 
   @Test
-  public void testReadingData() throws Exception {
+  public void testReadingData() {
     HadoopInputFormatIO.Read<Text, Employee> read = HadoopInputFormatIO.<Text, Employee>read()
         .withConfiguration(serConf.get());
     List<KV<Text, Employee>> expected = TestEmployeeDataSet.getEmployeeData();

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/TestEmployeeDataSet.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/TestEmployeeDataSet.java
@@ -14,6 +14,7 @@
  */
 package org.apache.beam.sdk.io.hadoop.inputformat;
 
+import com.google.common.base.Splitter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,7 +25,7 @@ import org.apache.hadoop.io.Text;
  * Test Utils used in {@link EmployeeInputFormat} and {@link ReuseObjectsEmployeeInputFormat} for
  * computing splits.
  */
-public class TestEmployeeDataSet {
+class TestEmployeeDataSet {
   public static final long NUMBER_OF_RECORDS_IN_EACH_SPLIT = 5L;
   public static final long NUMBER_OF_SPLITS = 3L;
   private static final List<KV<String, String>> data = new ArrayList<>();
@@ -66,8 +67,8 @@ public class TestEmployeeDataSet {
         .stream()
         .map(
             input -> {
-              String[] empData = input.getValue().split("_");
-              return KV.of(new Text(input.getKey()), new Employee(empData[0], empData[1]));
+              List<String> empData = Splitter.on('_').splitToList(input.getValue());
+              return KV.of(new Text(input.getKey()), new Employee(empData.get(0), empData.get(1)));
             })
         .collect(Collectors.toList());
   }

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/TestRowDBWritable.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/TestRowDBWritable.java
@@ -35,15 +35,17 @@ import org.apache.hadoop.mapreduce.lib.db.DBWritable;
  * {@link org.apache.hadoop.mapreduce.lib.db.DBInputFormat}.
  */
 @DefaultCoder(AvroCoder.class)
-public class TestRowDBWritable extends TestRow implements DBWritable, Writable {
+class TestRowDBWritable extends TestRow implements DBWritable, Writable {
 
   private Integer id;
   private String name;
 
-  @Override public Integer id() {
+  @Override
+  public Integer id() {
     return id;
   }
 
+  @Override
   public String name() {
     return name;
   }


### PR DESCRIPTION
This enables the `failOnWarning` for all hadoop io related modules, fixes outstanding error prone issues and also addresses simple static analysis issues identified by IDEA.

Please note, this is a replacement for a [previous PR](https://github.com/apache/beam/pull/5382) which had 3 outstanding discussion points raised by @jasonkuster and with responses for his consideration.

@iemejia can you please assign @jasonkuster as reviewer? (sorry again @jasonkuster for the rebase on the previous one)
