### PR TITLE
[BEAM-4340] Enforce ErrorProne analysis in file-based-io-tests

### DIFF
--- a/sdks/java/io/file-based-io-tests/build.gradle
+++ b/sdks/java/io/file-based-io-tests/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 
@@ -25,6 +25,7 @@ description = "Apache Beam :: SDKs :: Java :: File-based-io-tests"
 ext.summary = "Integration tests for reading/writing using file-based sources/sinks."
 
 dependencies {
+  compileOnly library.java.findbugs_annotations
   shadowTest project(":beam-sdks-java-core")
   shadowTest project(":beam-sdks-java-io-common")
   shadowTest project(path: ":beam-sdks-java-io-common", configuration: "shadowTest")
@@ -33,4 +34,5 @@ dependencies {
   shadowTest library.java.junit
   shadowTest library.java.hamcrest_core
   shadowTest library.java.jaxb_api
+  testCompileOnly library.java.findbugs_annotations
 }


### PR DESCRIPTION
Enforce ErrorProne analysis in file-based-io-tests

Note: [I provided the fixes already](https://github.com/apache/beam/pull/5363) which are already merged by @pabloem but this enforces the build failure.

CC @swegner 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
