### PR TITLE
[BEAM-4335] Enforce ErrorProne analysis in amazon-web-services IO

### DIFF
--- a/sdks/java/io/amazon-web-services/build.gradle
+++ b/sdks/java/io/amazon-web-services/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Amazon Web Services"
 ext.summary = "IO library to read and write Amazon Web Services services from Beam."
@@ -26,6 +26,7 @@ def aws_java_sdk_version = "1.11.319"
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow "com.amazonaws:aws-java-sdk-core:$aws_java_sdk_version"
   shadow "com.amazonaws:aws-java-sdk-s3:$aws_java_sdk_version"
@@ -37,6 +38,7 @@ dependencies {
   runtime 'commons-codec:commons-codec:1.9'
   runtime "org.apache.httpcomponents:httpclient:4.5.2"
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
+  testCompileOnly library.java.findbugs_annotations
   shadowTest library.java.guava_testlib
   shadowTest library.java.hamcrest_core
   shadowTest library.java.mockito_core


### PR DESCRIPTION
Enforces ErrorProne analysis in file-based-io-tests 
No warnings exist.

CC @iemejia @swegner 
