### PR TITLE
[BEAM-4355] Enforce ErrorProne analysis in XML IO

### DIFF
--- a/sdks/java/io/xml/build.gradle
+++ b/sdks/java/io/xml/build.gradle
@@ -24,7 +24,7 @@ ext.summary = "IO to read and write XML files."
 
 dependencies {
   compile library.java.guava
-  compile library.java.findbugs_annotations
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.stax2_api
   shadow library.java.findbugs_jsr305

--- a/sdks/java/io/xml/build.gradle
+++ b/sdks/java/io/xml/build.gradle
@@ -17,13 +17,14 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: XML"
 ext.summary = "IO to read and write XML files."
 
 dependencies {
   compile library.java.guava
+  compile library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.stax2_api
   shadow library.java.findbugs_jsr305
@@ -34,4 +35,5 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.slf4j_jdk14
   testCompile library.java.hamcrest_core
+  testCompileOnly library.java.findbugs_annotations
 }


### PR DESCRIPTION
This enforces error prone by failing the build on warnings for xml IO.

Note that [I had already addressed the errorprone and IDEA analysis warnings](https://github.com/apache/beam/pull/5365) and @kennknowles has reviewed and committed them.

Suggest @kennknowles to review (CC @iemejia @swegner)

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
