### PR TITLE
[BEAM-4338] Enforce ErrorProne analysis in common IO

### DIFF
--- a/sdks/java/io/common/build.gradle
+++ b/sdks/java/io/common/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Common"
 ext.summary = "Code used by all Beam IOs"
@@ -27,4 +27,5 @@ dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   testCompile library.java.junit
   testCompile library.java.postgres
+  testCompileOnly library.java.findbugs_annotations
 }


### PR DESCRIPTION
Enforces ErrorProne analysis in common IO by breaking the build on warnings.
There are none. 

CC @swegner @iemejia 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
