### PR TITLE
[BEAM-4337] Enforce ErrorProne analysis in cassandra IO

### DIFF
--- a/sdks/java/io/cassandra/build.gradle
+++ b/sdks/java/io/cassandra/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 
@@ -31,6 +31,7 @@ dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
   shadow library.java.findbugs_jsr305
+  compileOnly library.java.findbugs_annotations
   shadow "com.datastax.cassandra:cassandra-driver-core:$cassandra_version"
   shadow "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_version"
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
@@ -39,4 +40,5 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.slf4j_jdk14
   testCompile library.java.mockito_core
+  testCompileOnly library.java.findbugs_annotations
 }


### PR DESCRIPTION
Enforces a fail of the build on error prone warnings for cassandra IO.

@iemejia - you have already fixed the warnings - can you review please?



------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
