### PR TITLE
[BEAM-4353] Enforce ErrorProne analysis in solr IO

### DIFF
--- a/sdks/java/io/solr/build.gradle
+++ b/sdks/java/io/solr/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Solr"
 ext.summary = "IO to read and write from/to Solr."
@@ -29,6 +29,7 @@ dependencies {
   shadow library.java.commons_compress
   shadow "org.apache.solr:solr-solrj:5.5.4"
   compileOnly "org.apache.httpcomponents:httpclient:4.4.1"
+  compileOnly library.java.findbugs_annotations
   testCompile project(path: ":beam-sdks-java-core", configuration: "shadowTest")
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadow")
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
@@ -38,5 +39,6 @@ dependencies {
   testCompile "org.apache.solr:solr-test-framework:5.5.4"
   testCompile "org.apache.solr:solr-core:5.5.4"
   testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.3.2"
+  testCompileOnly library.java.findbugs_annotations
   shadowTest library.java.slf4j_jdk14
 }


### PR DESCRIPTION
This enables the fail on warning for errorprone and findbugs.

I fixed the warnings [in a previous PR](https://github.com/apache/beam/pull/5361) applied already by @iemejia 

@iemejia can you please review this (CC @swegner ) ?

Note: I've opted to add the required `findbugs-annotation` on a case by case basis in all the IO and scoped appropriately (equivalent of `mvn provided`). No one voiced a preference on slack and we already expect find-bugs will be removed before long.
