### PR TITLE
[BEAM-4345] Enforce ErrorProne analysis in JDBC IO

### DIFF
--- a/sdks/java/io/jdbc/build.gradle
+++ b/sdks/java/io/jdbc/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false)
+applyJavaNature(failOnWarning: true, enableFindbugs: false)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 
@@ -26,6 +26,7 @@ ext.summary = "IO to read and write on JDBC datasource."
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.findbugs_jsr305
   shadow "org.apache.commons:commons-dbcp2:2.1.1"
@@ -41,4 +42,5 @@ dependencies {
   testCompile group: "org.apache.derby", name: "derby", version:"10.12.1.1"
   testCompile group: "org.apache.derby", name: "derbyclient", version:"10.12.1.1"
   testCompile group: "org.apache.derby", name: "derbynet", version:"10.12.1.1"
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -672,7 +672,7 @@ public class JdbcIO {
      * @param batchSize maximum batch size in number of statements
      */
     public Write<T> withBatchSize(long batchSize) {
-      checkArgument(batchSize > 0, "batchSize must be > 0, but was %d", batchSize);
+      checkArgument(batchSize > 0, "batchSize must be > 0, but was %s", batchSize);
       return toBuilder().setBatchSize(batchSize).build();
     }
 


### PR DESCRIPTION
Fixes the last warning and enforces a build failure on warnings for JDBC IO.

CC @swegner @iemejia 