### PR TITLE
[BEAM-4347] Enforce ErrorProne analysis in kafka IO

### DIFF
--- a/sdks/java/io/kafka/build.gradle
+++ b/sdks/java/io/kafka/build.gradle
@@ -17,13 +17,14 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableFindbugs: false)
+applyJavaNature(failOnWarning: true, enableFindbugs: false)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Kafka"
 ext.summary = "Library to read Kafka topics."
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.kafka_clients
   shadow library.java.slf4j_api
@@ -37,4 +38,5 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.junit
   testCompile library.java.slf4j_jdk14
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -433,6 +433,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         ProducerSpEL.beginTransaction(producer);
       }
 
+      @SuppressWarnings("FutureReturnValueIgnored")
       void sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
         try {
           Long timestampMillis = spec.getPublishTimestampFunction() != null
@@ -563,6 +564,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
      * closed if it is stays in cache for more than 1 minute, i.e. not used inside
      * KafkaExactlyOnceSink DoFn for a minute.
      */
+    @SuppressWarnings("FutureReturnValueIgnored")
     private static class ShardWriterCache<K, V> {
 
       static final ScheduledExecutorService SCHEDULED_CLEAN_UP_THREAD =

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -73,6 +74,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
@@ -262,6 +264,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
       KafkaExactlyOnceSink.ensureEOSSupport();
     }
 
+    // Note: Futures ignored as exceptions will be flushed out in the commitTxn
+    @SuppressWarnings("FutureReturnValueIgnored")
     @ProcessElement
     public void processElement(@StateId(NEXT_ID) ValueState<Long> nextIdState,
                                @StateId(MIN_BUFFERED_ID) ValueState<Long> minBufferedIdState,
@@ -433,19 +437,20 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         ProducerSpEL.beginTransaction(producer);
       }
 
-      @SuppressWarnings("FutureReturnValueIgnored")
-      void sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
+
+      Future<RecordMetadata> sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
         try {
           Long timestampMillis = spec.getPublishTimestampFunction() != null
             ? spec.getPublishTimestampFunction().getTimestamp(record.getValue(),
                                                               record.getTimestamp()).getMillis()
             : null;
 
-          producer.send(
+          Future<RecordMetadata> result = producer.send(
               new ProducerRecord<>(
                   spec.getTopic(), null, timestampMillis,
                   record.getValue().getKey(), record.getValue().getValue()));
           sendCounter.inc();
+          return result;
         } catch (KafkaException e) {
           ProducerSpEL.abortTransaction(producer);
           throw e;
@@ -564,7 +569,6 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
      * closed if it is stays in cache for more than 1 minute, i.e. not used inside
      * KafkaExactlyOnceSink DoFn for a minute.
      */
-    @SuppressWarnings("FutureReturnValueIgnored")
     private static class ShardWriterCache<K, V> {
 
       static final ScheduledExecutorService SCHEDULED_CLEAN_UP_THREAD =
@@ -575,6 +579,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
       private final Cache<Integer, ShardWriter<K, V>> cache;
 
+      // Note: Exceptions arising from the cache cleanup are ignored
+      @SuppressWarnings("FutureReturnValueIgnored")
       ShardWriterCache() {
         this.cache =
           CacheBuilder.newBuilder()

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -264,7 +264,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
       KafkaExactlyOnceSink.ensureEOSSupport();
     }
 
-    // Note: Futures ignored as exceptions will be flushed out in the commitTxn
+    // Futures ignored as exceptions will be flushed out in the commitTxn
     @SuppressWarnings("FutureReturnValueIgnored")
     @ProcessElement
     public void processElement(@StateId(NEXT_ID) ValueState<Long> nextIdState,
@@ -579,7 +579,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
       private final Cache<Integer, ShardWriter<K, V>> cache;
 
-      // Note: Exceptions arising from the cache cleanup are ignored
+      // Exceptions arising from the cache cleanup are ignored
       @SuppressWarnings("FutureReturnValueIgnored")
       ShardWriterCache() {
         this.cache =

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1038,6 +1038,7 @@ public class KafkaIO {
       return PDone.in(input.getPipeline());
     }
 
+    @Override
     public void validate(PipelineOptions options) {
       if (isEOS()) {
         String runner = options.getRunner().getName();

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -620,7 +619,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     partitionStates.forEach(p -> p.recordIter = records.records(p.topicPartition).iterator());
 
     // cycle through the partitions in order to interleave records from each.
-    curBatch = Iterators.cycle(new ArrayDeque<>(partitionStates));
+    curBatch = Iterators.cycle(new ArrayList<>(partitionStates));
   }
 
   private void setupInitialOffset(PartitionState pState) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.io.Closeables;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -619,7 +620,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     partitionStates.forEach(p -> p.recordIter = records.records(p.topicPartition).iterator());
 
     // cycle through the partitions in order to interleave records from each.
-    curBatch = Iterators.cycle(new ArrayList<>(partitionStates));
+    curBatch = Iterators.cycle(new ArrayDeque<>(partitionStates));
   }
 
   private void setupInitialOffset(PartitionState pState) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -49,6 +49,7 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
     }
   }
 
+  // Note: Suppression since rrrors are tracked in SendCallback(), and checked on finishBundle()
   @ProcessElement
   @SuppressWarnings("FutureReturnValueIgnored")
   public void processElement(ProcessContext ctx) throws Exception {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -50,6 +50,7 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
   }
 
   @ProcessElement
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void processElement(ProcessContext ctx) throws Exception {
     checkForFailures();
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -49,7 +49,7 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
     }
   }
 
-  // Note: Suppression since rrrors are tracked in SendCallback(), and checked on finishBundle()
+  // Suppression since rrrors are tracked in SendCallback(), and checked on finishBundle()
   @ProcessElement
   @SuppressWarnings("FutureReturnValueIgnored")
   public void processElement(ProcessContext ctx) throws Exception {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriter.java
@@ -49,7 +49,7 @@ class KafkaWriter<K, V> extends DoFn<KV<K, V>, Void> {
     }
   }
 
-  // Suppression since rrrors are tracked in SendCallback(), and checked on finishBundle()
+  // Suppression since errors are tracked in SendCallback(), and checked in finishBundle()
   @ProcessElement
   @SuppressWarnings("FutureReturnValueIgnored")
   public void processElement(ProcessContext ctx) throws Exception {

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/CustomTimestampPolicyWithLimitedDelayTest.java
@@ -108,7 +108,7 @@ public class CustomTimestampPolicyWithLimitedDelayTest {
     // (3) Verify that Watermark advances when there is no backlog
 
     // advance current time by 5 minutes
-    now = now.plus(Duration.standardSeconds(300));
+    now = now.plus(Duration.standardMinutes(5));
     Instant backlogCheckTime = now.minus(Duration.standardSeconds(10));
 
     when(ctx.getMessageBacklog()).thenReturn(0L);

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -209,7 +209,7 @@ public class KafkaIOTest {
     final MockConsumer<byte[], byte[]> consumer =
         new MockConsumer<byte[], byte[]>(offsetResetStrategy) {
           @Override
-          public void assign(final Collection<TopicPartition> assigned) {
+          public synchronized void assign(final Collection<TopicPartition> assigned) {
             super.assign(assigned);
             assignedPartitions.set(ImmutableList.copyOf(assigned));
             for (TopicPartition tp : assigned) {
@@ -219,7 +219,7 @@ public class KafkaIOTest {
           }
           // Override offsetsForTimes() in order to look up the offsets by timestamp.
           @Override
-          public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(
+          public synchronized Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(
             Map<TopicPartition, Long> timestampsToSearch) {
             return timestampsToSearch
               .entrySet()
@@ -529,7 +529,7 @@ public class KafkaIOTest {
                   (tp, prevWatermark) -> new CustomTimestampPolicyWithLimitedDelay<Integer, Long>(
                     (record -> new Instant(TimeUnit.SECONDS.toMillis(record.getKV().getValue())
                                              + customTimestampStartMillis)),
-                   Duration.millis(0),
+                   Duration.ZERO,
                    prevWatermark))
                 .withoutMetadata())
         .apply(Values.create());
@@ -558,7 +558,7 @@ public class KafkaIOTest {
 
     PCollection<Long> input =
       p.apply(mkKafkaReadTransform(numElements, null)
-                .withCreateTime(Duration.millis(0))
+                .withCreateTime(Duration.ZERO)
                 .updateConsumerProperties(ImmutableMap.of(
                   TIMESTAMP_TYPE_CONFIG, "CreateTime",
                   TIMESTAMP_START_MILLIS_CONFIG, createTimestampStartMillis))
@@ -1345,7 +1345,7 @@ public class KafkaIOTest {
         // ProducerCompletionThread to inject errors.
 
         @Override
-        public void flush() {
+        public synchronized void flush() {
           while (completeNext()) {
             // there are some uncompleted records. let the completion thread handle them.
             try {
@@ -1361,6 +1361,7 @@ public class KafkaIOTest {
       assertNull(MOCK_PRODUCER_MAP.putIfAbsent(producerKey, mockProducer));
     }
 
+    @Override
     public void close() {
       MOCK_PRODUCER_MAP.remove(producerKey);
       try {
@@ -1445,6 +1446,7 @@ public class KafkaIOTest {
       injectorThread = Executors.newSingleThreadExecutor();
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored")
     ProducerSendCompletionThread start() {
       injectorThread.submit(
           () -> {

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaRecordCoderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaRecordCoderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -44,7 +45,7 @@ public class KafkaRecordCoderTest {
   @Test
   public void testKafkaRecordSerializableWithHeaders() throws IOException {
     RecordHeaders headers = new RecordHeaders();
-    headers.add("headerKey", "headerVal".getBytes());
+    headers.add("headerKey", "headerVal".getBytes(StandardCharsets.UTF_8));
     verifySerialization(headers);
   }
 


### PR DESCRIPTION
A simple PR to enforce error prone and fail the build on warnings raised. Current `errorprone` warnings are fixed (but I did not do an IDEA code analysis in this editing round).

CC @iemejia @swegner - could you please assign a reviewer?

