### PR TITLE
[BEAM-4346] Enforce ErrorProne analysis in JMS IO

### DIFF
--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: JMS"
 ext.summary = """IO to read and write to JMS (Java Messaging Service)
@@ -25,6 +25,7 @@ destinations (queues and topics)."""
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
   shadow library.java.joda_time
@@ -38,4 +39,5 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.hamcrest_core
   testCompile library.java.slf4j_jdk14
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -297,7 +297,7 @@ public class JmsIO {
      * @return The corresponding {@link JmsIO.Read}.
      */
     public Read<T> withMaxNumRecords(long maxNumRecords) {
-      checkArgument(maxNumRecords >= 0, "maxNumRecords must be > 0, but was: %d", maxNumRecords);
+      checkArgument(maxNumRecords >= 0, "maxNumRecords must be > 0, but was: %s", maxNumRecords);
       return builder().setMaxNumRecords(maxNumRecords).build();
     }
 

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.base.Throwables;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -187,7 +188,7 @@ public class JmsIOTest {
     Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
     MessageProducer producer = session.createProducer(session.createQueue(QUEUE));
     BytesMessage message = session.createBytesMessage();
-    message.writeBytes("This Is A Test".getBytes());
+    message.writeBytes("This Is A Test".getBytes(StandardCharsets.UTF_8));
     producer.send(message);
     producer.close();
     session.close();
@@ -354,7 +355,7 @@ public class JmsIOTest {
 
       byte[] bytes = new byte[(int) bytesMessage.getBodyLength()];
 
-      return new String(bytes);
+      return new String(bytes, StandardCharsets.UTF_8);
     }
   }
 


### PR DESCRIPTION
Simple PR to enforce a build failure on error prone warnings, and addresses current warnings

CC @iemejia for a review (super simple one)

