### PR TITLE
[BEAM-4352] Enforce ErrorProne analysis in Redis IO

### DIFF
--- a/sdks/java/io/redis/build.gradle
+++ b/sdks/java/io/redis/build.gradle
@@ -17,13 +17,14 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Redis"
 ext.summary ="IO to read and write on a Redis keystore."
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.findbugs_jsr305
   shadow "redis.clients:jedis:2.9.0"
@@ -32,4 +33,5 @@ dependencies {
   testCompile library.java.slf4j_jdk14
   testCompile library.java.hamcrest_core
   testCompile "com.github.kstyrc:embedded-redis:0.6"
+  testCompileOnly library.java.findbugs_annotations
 }


### PR DESCRIPTION
Enforces builds failures on any warnings surfaced in the Redis IO build
There are no warnings currently.

CC @iemejia 