### PR TITLE
[BEAM-4041] Increase timeout for getting K8s LoadBalancer external IP

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -260,7 +260,7 @@ class common_job_properties {
       dpb_log_level: 'INFO',
       maven_binary: '/home/jenkins/tools/maven/latest/bin/mvn',
       bigquery_table: 'beam_performance.pkb_results',
-      k8s_get_retry_count: 36, // wait up tp 6 minutes for K8s LoadBalancer
+      k8s_get_retry_count: 36, // wait up to 6 minutes for K8s LoadBalancer
       k8s_get_wait_interval: 10,
       temp_dir: '$WORKSPACE',
       // Use source cloned by Jenkins and not clone it second time (redundantly).

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -260,6 +260,8 @@ class common_job_properties {
       dpb_log_level: 'INFO',
       maven_binary: '/home/jenkins/tools/maven/latest/bin/mvn',
       bigquery_table: 'beam_performance.pkb_results',
+      k8s_get_retry_count: 36, // wait up tp 6 minutes for K8s LoadBalancer
+      k8s_get_wait_interval: 10,
       temp_dir: '$WORKSPACE',
       // Use source cloned by Jenkins and not clone it second time (redundantly).
       beam_location: '$WORKSPACE/src',


### PR DESCRIPTION
From some time we're observing that obtaining K8s LoadBalancer IP fails, even with 3 minutes timeout. This came less often but still in this week (at least) two jobs suffered this problem:

- `beam_PerformanceTests_MongoDBIO_IT` [build 168](https://builds.apache.org/view/A-D/view/Beam/job/beam_PerformanceTests_MongoDBIO_IT/168/console)
- `beam_PerformanceTests_HadoopInputFormat` [build 256](https://builds.apache.org/view/A-D/view/Beam/job/beam_PerformanceTests_HadoopInputFormat/256/console) and [build 257](https://builds.apache.org/view/A-D/view/Beam/job/beam_PerformanceTests_HadoopInputFormat/257/console)

Since [PR 1641 to PerfkiBenchmarker](https://github.com/GoogleCloudPlatform/PerfKitBenchmarker/pull/1641) it's now possible to configure retry-mechanism policy. 
This PR increases overall timeout from 3 minutes to 6 minutes.

----------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
