### PR TITLE
[BEAM-4167] Implement UNNEST

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlExpressionExecutor.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlExpressionExecutor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -32,7 +33,8 @@ public interface BeamSqlExpressionExecutor extends Serializable {
   void prepare();
 
   /** apply transformation to input record {@link Row} with {@link BoundedWindow}. */
-  List<Object> execute(Row inputRow, BoundedWindow window);
+  List<Object> execute(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv);
 
   void close();
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
@@ -49,13 +50,16 @@ public class BeamSqlCaseExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     for (int i = 0; i < operands.size() - 1; i += 2) {
-      Boolean wasOpEvaluated = opValueEvaluated(i, inputRow, window);
+      Boolean wasOpEvaluated = opValueEvaluated(i, inputRow, window, correlateEnv);
       if (wasOpEvaluated != null && wasOpEvaluated) {
-        return BeamSqlPrimitive.of(outputType, opValueEvaluated(i + 1, inputRow, window));
+        return BeamSqlPrimitive.of(
+            outputType, opValueEvaluated(i + 1, inputRow, window, correlateEnv));
       }
     }
-    return BeamSqlPrimitive.of(outputType, opValueEvaluated(operands.size() - 1, inputRow, window));
+    return BeamSqlPrimitive.of(
+        outputType, opValueEvaluated(operands.size() - 1, inputRow, window, correlateEnv));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
@@ -72,46 +73,52 @@ public class BeamSqlCastExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     SqlTypeName castOutputType = getOutputType();
     switch (castOutputType) {
       case INTEGER:
         return BeamSqlPrimitive.of(
             SqlTypeName.INTEGER,
-            SqlFunctions.toInt((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toInt((Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case DOUBLE:
         return BeamSqlPrimitive.of(
             SqlTypeName.DOUBLE,
-            SqlFunctions.toDouble((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toDouble(
+                (Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case SMALLINT:
         return BeamSqlPrimitive.of(
             SqlTypeName.SMALLINT,
-            SqlFunctions.toShort((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toShort((Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case TINYINT:
         return BeamSqlPrimitive.of(
-            SqlTypeName.TINYINT, SqlFunctions.toByte(opValueEvaluated(index, inputRow, window)));
+            SqlTypeName.TINYINT,
+            SqlFunctions.toByte(opValueEvaluated(index, inputRow, window, correlateEnv)));
       case BIGINT:
         return BeamSqlPrimitive.of(
             SqlTypeName.BIGINT,
-            SqlFunctions.toLong((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toLong((Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case DECIMAL:
         return BeamSqlPrimitive.of(
             SqlTypeName.DECIMAL,
-            SqlFunctions.toBigDecimal((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toBigDecimal(
+                (Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case FLOAT:
         return BeamSqlPrimitive.of(
             SqlTypeName.FLOAT,
-            SqlFunctions.toFloat((Object) opValueEvaluated(index, inputRow, window)));
+            SqlFunctions.toFloat((Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case CHAR:
       case VARCHAR:
         return BeamSqlPrimitive.of(
-            SqlTypeName.VARCHAR, opValueEvaluated(index, inputRow, window).toString());
+            SqlTypeName.VARCHAR,
+            opValueEvaluated(index, inputRow, window, correlateEnv).toString());
       case DATE:
         return BeamSqlPrimitive.of(
-            SqlTypeName.DATE, toDate(opValueEvaluated(index, inputRow, window)));
+            SqlTypeName.DATE, toDate(opValueEvaluated(index, inputRow, window, correlateEnv)));
       case TIMESTAMP:
         return BeamSqlPrimitive.of(
-            SqlTypeName.TIMESTAMP, toTimeStamp(opValueEvaluated(index, inputRow, window)));
+            SqlTypeName.TIMESTAMP,
+            toTimeStamp(opValueEvaluated(index, inputRow, window, correlateEnv)));
     }
     throw new UnsupportedOperationException(
         String.format("Cast to type %s not supported", castOutputType));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDefaultExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDefaultExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -30,7 +31,8 @@ public class BeamSqlDefaultExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(SqlTypeName.ANY, null);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -49,8 +50,9 @@ public abstract class BeamSqlExpression implements Serializable {
     return op(idx).getOutputType();
   }
 
-  public <T> T opValueEvaluated(int idx, Row row, BoundedWindow window) {
-    return (T) op(idx).evaluate(row, window).getValue();
+  public <T> T opValueEvaluated(
+      int idx, Row row, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    return (T) op(idx).evaluate(row, window, correlateEnv).getValue();
   }
 
   /** assertion to make sure the input and output are supported in this expression. */
@@ -60,7 +62,8 @@ public abstract class BeamSqlExpression implements Serializable {
    * Apply input record {@link Row} with {@link BoundedWindow} to this expression, the output value
    * is wrapped with {@link BeamSqlPrimitive}.
    */
-  public abstract BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window);
+  public abstract BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv);
 
   public List<BeamSqlExpression> getOperands() {
     return operands;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -36,7 +37,8 @@ public class BeamSqlInputRefExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(outputType, inputRow.getValue(inputRef));
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,8 @@ import org.joda.time.ReadableInstant;
 
 /**
  * {@link BeamSqlPrimitive} is a special, self-reference {@link BeamSqlExpression}. It holds the
- * value, and return it directly during {@link #evaluate(Row, BoundedWindow)}.
+ * value, and return it directly during {@link BeamSqlExpression#evaluate(Row, BoundedWindow,
+ * ImmutableMap)}.
  */
 public class BeamSqlPrimitive<T> extends BeamSqlExpression {
   private T value;
@@ -148,6 +150,8 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
         return value instanceof Map;
       case ROW:
         return value instanceof Row;
+      case MULTISET:
+        return value instanceof Iterable;
       default:
         throw new UnsupportedOperationException(
             "Unsupported Beam SQL type in expression: " + outputType.name());
@@ -155,7 +159,8 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<T> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<T> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return this;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -52,14 +53,15 @@ public class BeamSqlUdfExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (method == null) {
       reConstructMethod();
     }
     try {
       List<Object> paras = new ArrayList<>();
       for (BeamSqlExpression e : getOperands()) {
-        paras.add(e.evaluate(inputRow, window).getValue());
+        paras.add(e.evaluate(inputRow, window, correlateEnv).getValue());
       }
 
       return BeamSqlPrimitive.of(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowEndExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowEndExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.Row;
@@ -36,7 +37,8 @@ public class BeamSqlWindowEndExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<DateTime> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<DateTime> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (window instanceof IntervalWindow) {
       return BeamSqlPrimitive.of(
           SqlTypeName.TIMESTAMP, new DateTime(((IntervalWindow) window).end()));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
@@ -43,9 +44,10 @@ public class BeamSqlWindowExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<ReadableInstant> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<ReadableInstant> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(
         SqlTypeName.TIMESTAMP,
-        (ReadableInstant) operands.get(0).evaluate(inputRow, window).getValue());
+        (ReadableInstant) operands.get(0).evaluate(inputRow, window, correlateEnv).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowStartExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowStartExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.values.Row;
@@ -37,7 +38,8 @@ public class BeamSqlWindowStartExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<DateTime> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<DateTime> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (window instanceof IntervalWindow) {
       return BeamSqlPrimitive.of(
           SqlTypeName.TIMESTAMP, new DateTime(((IntervalWindow) window).start()));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.arithmetic;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,9 +54,12 @@ public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
-    BigDecimal left = SqlFunctions.toBigDecimal((Object) opValueEvaluated(0, inputRow, window));
-    BigDecimal right = SqlFunctions.toBigDecimal((Object) opValueEvaluated(1, inputRow, window));
+  public BeamSqlPrimitive<? extends Number> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    BigDecimal left =
+        SqlFunctions.toBigDecimal((Object) opValueEvaluated(0, inputRow, window, correlateEnv));
+    BigDecimal right =
+        SqlFunctions.toBigDecimal((Object) opValueEvaluated(1, inputRow, window, correlateEnv));
 
     BigDecimal result = calc(left, right);
     return getCorrectlyTypedResult(result);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.array;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -38,11 +39,12 @@ public class BeamSqlArrayExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     List<Object> elements =
         operands
             .stream()
-            .map(op -> op.evaluate(inputRow, window).getValue())
+            .map(op -> op.evaluate(inputRow, window, correlateEnv).getValue())
             .collect(Collectors.toList());
 
     return BeamSqlPrimitive.of(outputType, elements);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.array;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -38,9 +39,10 @@ public class BeamSqlArrayItemExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    List<Object> array = opValueEvaluated(0, inputRow, window);
-    Integer index = opValueEvaluated(1, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    List<Object> array = opValueEvaluated(0, inputRow, window, correlateEnv);
+    Integer index = opValueEvaluated(1, inputRow, window, correlateEnv);
 
     return BeamSqlPrimitive.of(outputType, array.get(index));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.collection;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -32,7 +33,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 public class BeamSqlCardinalityExpression extends BeamSqlExpression {
 
   public BeamSqlCardinalityExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
-
     super(operands, sqlTypeName);
   }
 
@@ -42,9 +42,9 @@ public class BeamSqlCardinalityExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    Collection<Object> collection = opValueEvaluated(0, inputRow, window);
-
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Collection<Object> collection = opValueEvaluated(0, inputRow, window, correlateEnv);
     return BeamSqlPrimitive.of(outputType, collection.size());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.collection;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -43,8 +44,9 @@ public class BeamSqlSingleElementExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    Collection<Object> collection = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Collection<Object> collection = opValueEvaluated(0, inputRow, window, correlateEnv);
 
     if (collection.size() <= 1) {
       return (collection.size() == 0)

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -48,9 +49,10 @@ public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<Boolean> evaluate(Row inputRow, BoundedWindow window) {
-    Object leftValue = operands.get(0).evaluate(inputRow, window).getValue();
-    Object rightValue = operands.get(1).evaluate(inputRow, window).getValue();
+  public BeamSqlPrimitive<Boolean> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Object leftValue = operands.get(0).evaluate(inputRow, window, correlateEnv).getValue();
+    Object rightValue = operands.get(1).evaluate(inputRow, window, correlateEnv).getValue();
     switch (operands.get(0).getOutputType()) {
       case BIGINT:
       case DECIMAL:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNotNullExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNotNullExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -43,8 +44,9 @@ public class BeamSqlIsNotNullExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<Boolean> evaluate(Row inputRow, BoundedWindow window) {
-    Object leftValue = operands.get(0).evaluate(inputRow, window).getValue();
+  public BeamSqlPrimitive<Boolean> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Object leftValue = operands.get(0).evaluate(inputRow, window, correlateEnv).getValue();
     return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, leftValue != null);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNullExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNullExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -43,8 +44,9 @@ public class BeamSqlIsNullExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<Boolean> evaluate(Row inputRow, BoundedWindow window) {
-    Object leftValue = operands.get(0).evaluate(inputRow, window).getValue();
+  public BeamSqlPrimitive<Boolean> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Object leftValue = operands.get(0).evaluate(inputRow, window, correlateEnv).getValue();
     return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, leftValue == null);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -42,7 +43,8 @@ public class BeamSqlCurrentDateExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -46,7 +47,8 @@ public class BeamSqlCurrentTimeExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -46,7 +47,8 @@ public class BeamSqlCurrentTimestampExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -45,8 +46,9 @@ public class BeamSqlDateCeilExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    ReadableInstant date = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    ReadableInstant date = opValueEvaluated(0, inputRow, window, correlateEnv);
     long time = date.getMillis();
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(1)).getValue();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -45,8 +46,9 @@ public class BeamSqlDateFloorExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    ReadableInstant date = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    ReadableInstant date = opValueEvaluated(0, inputRow, window, correlateEnv);
     long time = date.getMillis();
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(1)).getValue();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
@@ -94,11 +94,12 @@ public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (delegateExpression == null) {
       throw new IllegalStateException("Unable to execute unsupported 'datetime minus' expression");
     }
 
-    return delegateExpression.evaluate(inputRow, window);
+    return delegateExpression.evaluate(inputRow, window, correlateEnv);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.TimeUnitUtils.timeUnitInternalMultiplier;
 import static org.apache.beam.sdk.extensions.sql.impl.utils.SqlTypeUtils.findExpressionOfType;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.math.BigDecimal;
 import java.util.List;
@@ -72,9 +73,10 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
    * way.
    */
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    DateTime timestamp = getTimestampOperand(inputRow, window);
-    BeamSqlPrimitive intervalOperandPrimitive = getIntervalOperand(inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    DateTime timestamp = getTimestampOperand(inputRow, window, correlateEnv);
+    BeamSqlPrimitive intervalOperandPrimitive = getIntervalOperand(inputRow, window, correlateEnv);
     SqlTypeName intervalOperandType = intervalOperandPrimitive.getOutputType();
     int intervalMultiplier = getIntervalMultiplier(intervalOperandPrimitive);
 
@@ -91,15 +93,19 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
     return multiplier.intValueExact();
   }
 
-  private BeamSqlPrimitive getIntervalOperand(Row inputRow, BoundedWindow window) {
+  private BeamSqlPrimitive getIntervalOperand(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return findExpressionOfType(operands, SUPPORTED_INTERVAL_TYPES)
         .get()
-        .evaluate(inputRow, window);
+        .evaluate(inputRow, window, correlateEnv);
   }
 
-  private DateTime getTimestampOperand(Row inputRow, BoundedWindow window) {
+  private DateTime getTimestampOperand(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     BeamSqlPrimitive timestampOperandPrimitive =
-        findExpressionOfType(operands, SqlTypeName.TIMESTAMP).get().evaluate(inputRow, window);
+        findExpressionOfType(operands, SqlTypeName.TIMESTAMP)
+            .get()
+            .evaluate(inputRow, window, correlateEnv);
     return new DateTime(timestampOperandPrimitive.getDate());
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -58,8 +59,9 @@ public class BeamSqlExtractExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    ReadableInstant time = opValueEvaluated(1, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    ReadableInstant time = opValueEvaluated(1, inputRow, window, correlateEnv);
 
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(0)).getValue();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpression.java
@@ -22,6 +22,7 @@ import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.
 import static org.apache.beam.sdk.extensions.sql.impl.utils.SqlTypeUtils.findExpressionOfType;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -75,13 +76,18 @@ public class BeamSqlIntervalMultiplyExpression extends BeamSqlExpression {
    * YEAR" is equivalent tot this: "TIMESTAMPADD(YEAR, 2, TIMESTAMP '1984-04-19 01:02:03')"
    */
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     BeamSqlPrimitive intervalOperandPrimitive =
-        findExpressionOfType(operands, SqlTypeName.INTERVAL_TYPES).get().evaluate(inputRow, window);
+        findExpressionOfType(operands, SqlTypeName.INTERVAL_TYPES)
+            .get()
+            .evaluate(inputRow, window, correlateEnv);
     SqlTypeName intervalOperandType = intervalOperandPrimitive.getOutputType();
 
     BeamSqlPrimitive integerOperandPrimitive =
-        findExpressionOfType(operands, SqlTypeName.INTEGER).get().evaluate(inputRow, window);
+        findExpressionOfType(operands, SqlTypeName.INTEGER)
+            .get()
+            .evaluate(inputRow, window, correlateEnv);
     BigDecimal integerOperandValue = new BigDecimal(integerOperandPrimitive.getInteger());
 
     BigDecimal multiplicationResult =

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlDatetimeMinusExpression.INTERVALS_DURATIONS_TYPES;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -56,9 +57,10 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row row, BoundedWindow window) {
-    DateTime date = new DateTime((Object) opValueEvaluated(0, row, window));
-    Period period = intervalToPeriod(op(1).evaluate(row, window));
+  public BeamSqlPrimitive evaluate(
+      Row row, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    DateTime date = new DateTime((Object) opValueEvaluated(0, row, window, correlateEnv));
+    Period period = intervalToPeriod(op(1).evaluate(row, window, correlateEnv));
 
     return BeamSqlPrimitive.of(outputType, date.minus(period));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlDatetimeMinusExpression.INTERVALS_DURATIONS_TYPES;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -67,9 +68,12 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
    * Calcite deals with all intervals this way. Whenever there is an interval, its value is always
    * multiplied by the corresponding TimeUnit.multiplier
    */
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    DateTime timestampStart = new DateTime((Object) opValueEvaluated(1, inputRow, window));
-    DateTime timestampEnd = new DateTime((Object) opValueEvaluated(0, inputRow, window));
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    DateTime timestampStart =
+        new DateTime((Object) opValueEvaluated(1, inputRow, window, correlateEnv));
+    DateTime timestampEnd =
+        new DateTime((Object) opValueEvaluated(0, inputRow, window, correlateEnv));
 
     long numberOfIntervals = numberOfIntervalsBetweenDates(timestampStart, timestampEnd);
     long multiplier = TimeUnitUtils.timeUnitInternalMultiplier(intervalType).longValue();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.logical;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -31,10 +32,11 @@ public class BeamSqlAndExpression extends BeamSqlLogicalExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<Boolean> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<Boolean> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     boolean result = true;
     for (BeamSqlExpression exp : operands) {
-      BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window);
+      BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window, correlateEnv);
       if (!expOut.getValue()) {
         result = false;
         break;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.logical;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -36,8 +37,9 @@ public class BeamSqlNotExpression extends BeamSqlLogicalExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    Boolean value = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Boolean value = opValueEvaluated(0, inputRow, window, correlateEnv);
     if (value == null) {
       return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, window);
     } else {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.logical;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -31,10 +32,11 @@ public class BeamSqlOrExpression extends BeamSqlLogicalExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<Boolean> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<Boolean> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     boolean result = false;
     for (BeamSqlExpression exp : operands) {
-      BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window);
+      BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window, correlateEnv);
       result = expOut.getValue();
       if (result) {
         break;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.map;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,12 +40,13 @@ public class BeamSqlMapExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     Map<Object, Object> elements = new HashMap<>();
     for (int idx = 0; idx < operands.size() / 2; ++idx) {
       elements.put(
-          operands.get(idx * 2).evaluate(inputRow, window).getValue(),
-          operands.get(idx * 2 + 1).evaluate(inputRow, window).getValue());
+          operands.get(idx * 2).evaluate(inputRow, window, correlateEnv).getValue(),
+          operands.get(idx * 2 + 1).evaluate(inputRow, window, correlateEnv).getValue());
     }
     return BeamSqlPrimitive.of(outputType, elements);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.map;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -39,10 +40,10 @@ public class BeamSqlMapItemExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    Map<Object, Object> map = opValueEvaluated(0, inputRow, window);
-    Object key = opValueEvaluated(1, inputRow, window);
-
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    Map<Object, Object> map = opValueEvaluated(0, inputRow, window, correlateEnv);
+    Object key = opValueEvaluated(1, inputRow, window, correlateEnv);
     return BeamSqlPrimitive.of(outputType, map.get(key));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -38,10 +39,13 @@ public abstract class BeamSqlMathBinaryExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<? extends Number> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     BeamSqlExpression leftOp = op(0);
     BeamSqlExpression rightOp = op(1);
-    return calculate(leftOp.evaluate(inputRow, window), rightOp.evaluate(inputRow, window));
+    return calculate(
+        leftOp.evaluate(inputRow, window, correlateEnv),
+        rightOp.evaluate(inputRow, window, correlateEnv));
   }
 
   /**

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -46,9 +47,10 @@ public abstract class BeamSqlMathUnaryExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive<? extends Number> evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     BeamSqlExpression operand = op(0);
-    return calculate(operand.evaluate(inputRow, window));
+    return calculate(operand.evaluate(inputRow, window, correlateEnv));
   }
 
   /** For the operands of other type {@link SqlTypeName#NUMERIC_TYPES}. */

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPiExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPiExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -37,7 +38,8 @@ public class BeamSqlPiExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     return BeamSqlPrimitive.of(SqlTypeName.DOUBLE, Math.PI);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Random;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -41,9 +42,10 @@ public class BeamSqlRandExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (operands.size() == 1) {
-      int rowSeed = opValueEvaluated(0, inputRow, window);
+      int rowSeed = opValueEvaluated(0, inputRow, window, correlateEnv);
       if (seed == null || seed != rowSeed) {
         rand.setSeed(rowSeed);
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Random;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -41,16 +42,18 @@ public class BeamSqlRandIntegerExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     int numericIdx = 0;
     if (operands.size() == 2) {
-      int rowSeed = opValueEvaluated(0, inputRow, window);
+      int rowSeed = opValueEvaluated(0, inputRow, window, correlateEnv);
       if (seed == null || seed != rowSeed) {
         rand.setSeed(rowSeed);
       }
       numericIdx = 1;
     }
     return BeamSqlPrimitive.of(
-        SqlTypeName.INTEGER, rand.nextInt((int) opValueEvaluated(numericIdx, inputRow, window)));
+        SqlTypeName.INTEGER,
+        rand.nextInt((int) opValueEvaluated(numericIdx, inputRow, window, correlateEnv)));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/BeamSqlReinterpretExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/BeamSqlReinterpretExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.reinterpret;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -50,7 +51,9 @@ public class BeamSqlReinterpretExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    return REINTERPRETER.convert(SqlTypeName.BIGINT, operands.get(0).evaluate(inputRow, window));
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    return REINTERPRETER.convert(
+        SqlTypeName.BIGINT, operands.get(0).evaluate(inputRow, window, correlateEnv));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.row;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -46,8 +47,9 @@ public class BeamSqlFieldAccessExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    BeamSqlPrimitive targetObject = referenceExpression.evaluate(inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    BeamSqlPrimitive targetObject = referenceExpression.evaluate(inputRow, window, correlateEnv);
     SqlTypeName targetFieldType = targetObject.getOutputType();
 
     Object targetFieldValue;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -32,8 +33,9 @@ public class BeamSqlCharLengthExpression extends BeamSqlStringUnaryExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
     return BeamSqlPrimitive.of(SqlTypeName.INTEGER, str.length());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -52,9 +53,10 @@ public class BeamSqlConcatExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String left = opValueEvaluated(0, inputRow, window);
-    String right = opValueEvaluated(1, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String left = opValueEvaluated(0, inputRow, window, correlateEnv);
+    String right = opValueEvaluated(1, inputRow, window, correlateEnv);
 
     return BeamSqlPrimitive.of(
         SqlTypeName.VARCHAR,

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -32,8 +33,9 @@ public class BeamSqlInitCapExpression extends BeamSqlStringUnaryExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
 
     StringBuilder ret = new StringBuilder(str);
     boolean isInit = true;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -32,8 +33,9 @@ public class BeamSqlLowerExpression extends BeamSqlStringUnaryExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
     return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, str.toLowerCase());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -55,15 +56,16 @@ public class BeamSqlOverlayExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
-    String replaceStr = opValueEvaluated(1, inputRow, window);
-    int idx = opValueEvaluated(2, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
+    String replaceStr = opValueEvaluated(1, inputRow, window, correlateEnv);
+    int idx = opValueEvaluated(2, inputRow, window, correlateEnv);
     // the index is 1 based.
     idx -= 1;
     int length = replaceStr.length();
     if (operands.size() == 4) {
-      length = opValueEvaluated(3, inputRow, window);
+      length = opValueEvaluated(3, inputRow, window, correlateEnv);
     }
 
     StringBuilder result = new StringBuilder(str.length() + replaceStr.length() - length);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -28,12 +29,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * String position operator.
  *
- * <p>example:
- *
- * <ul>
- *   <li>{@code POSITION(string1 IN string2)}
- *   <li>{@code POSITION(string1 IN string2 FROM integer)}
- * </ul>
+ * <p>example: POSITION(string1 IN string2) POSITION(string1 IN string2 FROM integer)
  */
 public class BeamSqlPositionExpression extends BeamSqlExpression {
   public BeamSqlPositionExpression(List<BeamSqlExpression> operands) {
@@ -59,12 +55,13 @@ public class BeamSqlPositionExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String targetStr = opValueEvaluated(0, inputRow, window);
-    String containingStr = opValueEvaluated(1, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String targetStr = opValueEvaluated(0, inputRow, window, correlateEnv);
+    String containingStr = opValueEvaluated(1, inputRow, window, correlateEnv);
     int from = -1;
     if (operands.size() == 3) {
-      Number tmp = opValueEvaluated(2, inputRow, window);
+      Number tmp = opValueEvaluated(2, inputRow, window, correlateEnv);
       from = tmp.intValue();
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -28,12 +29,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * 'SUBSTRING' operator.
  *
- * <p>Examples usage:
- *
- * <ul>
- *   <li>{@code SUBSTRING(string FROM integer)}
- *   <li>{@code SUBSTRING(string FROM integer FOR integer)}
- * </ul>
+ * <p>SUBSTRING(string FROM integer) SUBSTRING(string FROM integer FOR integer)
  */
 public class BeamSqlSubstringExpression extends BeamSqlExpression {
   public BeamSqlSubstringExpression(List<BeamSqlExpression> operands) {
@@ -58,9 +54,10 @@ public class BeamSqlSubstringExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
-    int idx = opValueEvaluated(1, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
+    int idx = opValueEvaluated(1, inputRow, window, correlateEnv);
     int startIdx = idx;
     if (startIdx > 0) {
       // NOTE: SQL substring is 1 based(rather than 0 based)
@@ -73,7 +70,7 @@ public class BeamSqlSubstringExpression extends BeamSqlExpression {
     }
 
     if (operands.size() == 3) {
-      int length = opValueEvaluated(2, inputRow, window);
+      int length = opValueEvaluated(2, inputRow, window, correlateEnv);
       if (length < 0) {
         length = 0;
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -57,14 +58,16 @@ public class BeamSqlTrimExpression extends BeamSqlExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     if (operands.size() == 1) {
       return BeamSqlPrimitive.of(
-          SqlTypeName.VARCHAR, opValueEvaluated(0, inputRow, window).toString().trim());
+          SqlTypeName.VARCHAR,
+          opValueEvaluated(0, inputRow, window, correlateEnv).toString().trim());
     } else {
-      SqlTrimFunction.Flag type = opValueEvaluated(0, inputRow, window);
-      String targetStr = opValueEvaluated(1, inputRow, window);
-      String containingStr = opValueEvaluated(2, inputRow, window);
+      SqlTrimFunction.Flag type = opValueEvaluated(0, inputRow, window, correlateEnv);
+      String targetStr = opValueEvaluated(1, inputRow, window, correlateEnv);
+      String containingStr = opValueEvaluated(2, inputRow, window, correlateEnv);
 
       switch (type) {
         case LEADING:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpression.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -32,8 +33,9 @@ public class BeamSqlUpperExpression extends BeamSqlStringUnaryExpression {
   }
 
   @Override
-  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    String str = opValueEvaluated(0, inputRow, window);
+  public BeamSqlPrimitive evaluate(
+      Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
+    String str = opValueEvaluated(0, inputRow, window, correlateEnv);
     return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, str.toUpperCase());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
@@ -149,6 +149,7 @@ public class BeamQueryPlanner {
               .replace(root.collation)
               .simplify();
       beamRelNode = (BeamRelNode) planner.transform(0, desiredTraits, root.rel);
+      LOG.info("BeamSQL>\n" + RelOptUtil.toString(beamRelNode));
     } finally {
       planner.close();
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamRuleSets.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamRuleSets.java
@@ -26,7 +26,9 @@ import org.apache.beam.sdk.extensions.sql.impl.rule.BeamJoinRule;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamMinusRule;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamProjectRule;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamSortRule;
+import org.apache.beam.sdk.extensions.sql.impl.rule.BeamUncollectRule;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamUnionRule;
+import org.apache.beam.sdk.extensions.sql.impl.rule.BeamUnnestRule;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamValuesRule;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.tools.RuleSet;
@@ -49,6 +51,8 @@ public class BeamRuleSets {
           BeamIntersectRule.INSTANCE,
           BeamMinusRule.INSTANCE,
           BeamUnionRule.INSTANCE,
+          BeamUncollectRule.INSTANCE,
+          BeamUnnestRule.INSTANCE,
           BeamJoinRule.INSTANCE,
           BeamEnumerableConverterRule.INSTANCE)
     };

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.rel;
+
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Uncollect;
+
+/** {@link BeamRelNode} to implement an uncorrelated {@link Uncollect}, aka UNNEST. */
+public class BeamUncollectRel extends Uncollect implements BeamRelNode {
+
+  public BeamUncollectRel(
+      RelOptCluster cluster, RelTraitSet traitSet, RelNode input, boolean withOrdinality) {
+    super(cluster, traitSet, input, withOrdinality);
+  }
+
+  @Override
+  public RelNode copy(RelTraitSet traitSet, RelNode input) {
+    return new BeamUncollectRel(getCluster(), traitSet, input, withOrdinality);
+  }
+
+  @Override
+  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+    return new Transform();
+  }
+
+  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+    @Override
+    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
+      RelNode input = getInput();
+      String stageName = BeamSqlRelUtils.getStageName(BeamUncollectRel.this);
+
+      PCollection<Row> upstream =
+          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+
+      // Each row of the input contains a single array of things to be emitted; Calcite knows
+      // what the row looks like
+      Schema outputSchema = CalciteUtils.toBeamSchema(getRowType());
+
+      PCollection<Row> uncollected =
+          upstream
+              .apply(stageName, ParDo.of(new UncollectDoFn(outputSchema)))
+              .setCoder(outputSchema.getRowCoder());
+
+      return uncollected;
+    }
+  }
+
+  private static class UncollectDoFn extends DoFn<Row, Row> {
+
+    private final Schema schema;
+
+    private UncollectDoFn(Schema schema) {
+      this.schema = schema;
+    }
+
+    @ProcessElement
+    public void process(@Element Row inputRow, OutputReceiver<Row> output) {
+      for (Object element : inputRow.getArray(0)) {
+        output.output(Row.withSchema(schema).addValue(element).build());
+      }
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.rel;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionExecutor;
+import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutor;
+import org.apache.beam.sdk.extensions.sql.impl.schema.BeamTableUtils;
+import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Correlate;
+import org.apache.calcite.rel.core.CorrelationId;
+import org.apache.calcite.rel.core.Uncollect;
+import org.apache.calcite.sql.SemiJoinType;
+import org.apache.calcite.util.ImmutableBitSet;
+
+/**
+ * {@link BeamRelNode} to implement UNNEST, supporting specifically only {@link Correlate} with
+ * {@link Uncollect}.
+ */
+public class BeamUnnestRel extends Correlate implements BeamRelNode {
+
+  public BeamUnnestRel(
+      RelOptCluster cluster,
+      RelTraitSet traits,
+      RelNode left,
+      RelNode right,
+      CorrelationId correlationId,
+      ImmutableBitSet requiredColumns,
+      SemiJoinType joinType) {
+    super(cluster, traits, left, right, correlationId, requiredColumns, joinType);
+  }
+
+  @Override
+  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+    return new Transform();
+  }
+
+  @Override
+  public Correlate copy(
+      RelTraitSet relTraitSet,
+      RelNode left,
+      RelNode right,
+      CorrelationId correlationId,
+      ImmutableBitSet requireColumns,
+      SemiJoinType joinType) {
+    return new BeamUnnestRel(
+        getCluster(), relTraitSet, left, right, correlationId, requiredColumns, joinType);
+  }
+
+  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+    @Override
+    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
+      String stageName = BeamSqlRelUtils.getStageName(BeamUnnestRel.this);
+
+      // The set of rows where we run the correlated unnest for each row
+      PCollection<Row> outer =
+          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(left).toPTransform());
+
+      // The correlated subquery
+      BeamUncollectRel uncollect = (BeamUncollectRel) BeamSqlRelUtils.getBeamRelInput(right);
+      Schema innerSchema = CalciteUtils.toBeamSchema(uncollect.getRowType());
+      checkArgument(
+          innerSchema.getFieldCount() == 1, "Can only UNNEST a single column", getClass());
+
+      BeamSqlExpressionExecutor expr =
+          new BeamSqlFnExecutor(BeamSqlRelUtils.getBeamRelInput(uncollect.getInput()));
+
+      Schema joinedSchema = CalciteUtils.toBeamSchema(rowType);
+
+      return outer
+          .apply(
+              stageName,
+              ParDo.of(
+                  new UnnestFn(correlationId.getId(), expr, joinedSchema, innerSchema.getField(0))))
+          .setCoder(joinedSchema.getRowCoder());
+    }
+  }
+
+  private static class UnnestFn extends DoFn<Row, Row> {
+
+    /** The expression that should return an iterable to be uncollected. */
+    private final BeamSqlExpressionExecutor expr;
+
+    private final int correlationId;
+    private final Schema outputSchema;
+    private final Schema.Field innerField;
+
+    private UnnestFn(
+        int correlationId,
+        BeamSqlExpressionExecutor expr,
+        Schema outputSchema,
+        Schema.Field innerField) {
+      this.correlationId = correlationId;
+      this.expr = expr;
+      this.outputSchema = outputSchema;
+      this.innerField = innerField;
+    }
+
+    @ProcessElement
+    public void process(@Element Row row, BoundedWindow window, OutputReceiver<Row> out) {
+
+      List<Object> rawValues = expr.execute(row, window, ImmutableMap.of(correlationId, row));
+
+      checkState(
+          rawValues.size() == 1,
+          "%s expression to unnest %s resulted in more than one column",
+          getClass(),
+          expr);
+
+      checkState(
+          rawValues.get(0) instanceof Iterable,
+          "%s expression to unnest %s not iterable",
+          getClass(),
+          expr);
+
+      for (Object uncollectedValue : (Iterable) rawValues.get(0)) {
+        Object coercedValue = BeamTableUtils.autoCastField(innerField, uncollectedValue);
+        out.output(
+            Row.withSchema(outputSchema).addValues(row.getValues()).addValue(coercedValue).build());
+      }
+    }
+
+    @Teardown
+    public void close() {
+      expr.close();
+    }
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUncollectRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUncollectRule.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.sql.impl.rule;
+
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamLogicalConvention;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamUncollectRel;
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.convert.ConverterRule;
+import org.apache.calcite.rel.core.Uncollect;
+import org.apache.calcite.rel.core.Union;
+
+/** A {@code ConverterRule} to replace {@link Union} with {@link BeamUncollectRule}. */
+public class BeamUncollectRule extends ConverterRule {
+  public static final BeamUncollectRule INSTANCE = new BeamUncollectRule();
+
+  private BeamUncollectRule() {
+    super(Uncollect.class, Convention.NONE, BeamLogicalConvention.INSTANCE, "BeamUncollectRule");
+  }
+
+  @Override
+  public RelNode convert(RelNode rel) {
+    Uncollect uncollect = (Uncollect) rel;
+
+    return new BeamUncollectRel(
+        uncollect.getCluster(),
+        uncollect.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
+        convert(
+            uncollect.getInput(),
+            uncollect.getInput().getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
+        uncollect.withOrdinality);
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUnnestRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUnnestRule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.sql.impl.rule;
+
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamLogicalConvention;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamUnnestRel;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Uncollect;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.logical.LogicalCorrelate;
+
+/** A {@code ConverterRule} to replace {@link Union} with {@link BeamUnnestRule}. */
+public class BeamUnnestRule extends RelOptRule {
+  public static final BeamUnnestRule INSTANCE = new BeamUnnestRule();
+
+  // TODO: more general Correlate
+  private BeamUnnestRule() {
+    super(
+        operand(
+            LogicalCorrelate.class, operand(RelNode.class, any()), operand(Uncollect.class, any())),
+        "BeamUnnestRule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    LogicalCorrelate correlate = call.rel(0);
+    RelNode outer = call.rel(1);
+    RelNode uncollect = call.rel(2);
+
+    call.transformTo(
+        new BeamUnnestRel(
+            correlate.getCluster(),
+            correlate.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
+            outer,
+            convert(uncollect, uncollect.getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
+            correlate.getCorrelationId(),
+            correlate.getRequiredColumns(),
+            correlate.getJoinType()));
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.schemas.Schema.toSchema;
 import static org.apache.beam.sdk.values.Row.toRow;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.io.InputStream;
@@ -250,7 +251,7 @@ public class BeamAggregationTransforms implements Serializable {
                   .get(idx)
                   .addInput(
                       accumulator.accumulatorElements.get(idx),
-                      exp.evaluate(input, null).getValue()));
+                      exp.evaluate(input, null, ImmutableMap.of()).getValue()));
         } else if (sourceFieldExps.get(idx) instanceof KV) {
           /**
            * If source expression is type of KV pair, we bundle the value of two expressions into KV
@@ -264,8 +265,8 @@ public class BeamAggregationTransforms implements Serializable {
                   .addInput(
                       accumulator.accumulatorElements.get(idx),
                       KV.of(
-                          exp.getKey().evaluate(input, null).getValue(),
-                          exp.getValue().evaluate(input, null).getValue())));
+                          exp.getKey().evaluate(input, null, ImmutableMap.of()).getValue(),
+                          exp.getValue().evaluate(input, null, ImmutableMap.of()).getValue())));
         }
       }
       return deltaAcc;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlFilterFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlFilterFn.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.transform;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionExecutor;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamFilterRel;
@@ -45,7 +46,7 @@ public class BeamSqlFilterFn extends DoFn<Row, Row> {
   public void processElement(ProcessContext c, BoundedWindow window) {
     Row in = c.element();
 
-    List<Object> result = executor.execute(in, window);
+    List<Object> result = executor.execute(in, window, ImmutableMap.of());
 
     if ((Boolean) result.get(0)) {
       c.output(in);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlProjectFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlProjectFn.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.transform;
 
 import static java.util.stream.Collectors.toList;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionExecutor;
@@ -51,7 +52,7 @@ public class BeamSqlProjectFn extends DoFn<Row, Row> {
   @ProcessElement
   public void processElement(ProcessContext c, BoundedWindow window) {
     Row inputRow = c.element();
-    List<Object> rawResultValues = executor.execute(inputRow, window);
+    List<Object> rawResultValues = executor.execute(inputRow, window, ImmutableMap.of());
 
     List<Object> castResultValues =
         IntStream.range(0, outputSchema.getFieldCount())

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamNullExperssionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamNullExperssionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlIsNotNullExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlIsNullExpression;
@@ -31,21 +32,21 @@ public class BeamNullExperssionTest extends BeamSqlFnExecutorTestBase {
   public void testIsNull() {
     BeamSqlIsNullExpression exp1 =
         new BeamSqlIsNullExpression(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
-    Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlIsNullExpression exp2 =
         new BeamSqlIsNullExpression(BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
-    Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
   public void testIsNotNull() {
     BeamSqlIsNotNullExpression exp1 =
         new BeamSqlIsNotNullExpression(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
-    Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlIsNotNullExpression exp2 =
         new BeamSqlIsNotNullExpression(BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
-    Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlAndOrExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlAndOrExpressionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -35,11 +36,13 @@ public class BeamSqlAndOrExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
 
-    Assert.assertTrue(new BeamSqlAndExpression(operands).evaluate(row, null).getValue());
+    Assert.assertTrue(
+        new BeamSqlAndExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
 
-    Assert.assertFalse(new BeamSqlAndExpression(operands).evaluate(row, null).getValue());
+    Assert.assertFalse(
+        new BeamSqlAndExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -48,10 +51,12 @@ public class BeamSqlAndOrExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
 
-    Assert.assertFalse(new BeamSqlOrExpression(operands).evaluate(row, null).getValue());
+    Assert.assertFalse(
+        new BeamSqlOrExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
 
-    Assert.assertTrue(new BeamSqlOrExpression(operands).evaluate(row, null).getValue());
+    Assert.assertTrue(
+        new BeamSqlOrExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -70,13 +71,17 @@ public class BeamSqlCaseExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("hello", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello",
+        new BeamSqlCaseExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("world", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "world",
+        new BeamSqlCaseExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
@@ -84,6 +89,8 @@ public class BeamSqlCaseExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello1"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("hello1", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello1",
+        new BeamSqlCaseExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -50,14 +51,20 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
   public void testForIntegerToBigintTypeCasting() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
     Assert.assertEquals(
-        5L, new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
+        5L,
+        new BeamSqlCastExpression(operands, SqlTypeName.BIGINT)
+            .evaluate(row, null, ImmutableMap.of())
+            .getLong());
   }
 
   @Test
   public void testForDoubleToBigIntCasting() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 5.45));
     Assert.assertEquals(
-        5L, new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
+        5L,
+        new BeamSqlCastExpression(operands, SqlTypeName.BIGINT)
+            .evaluate(row, null, ImmutableMap.of())
+            .getLong());
   }
 
   @Test
@@ -66,7 +73,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 20170521));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
-        new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.DATE)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test
@@ -75,7 +84,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21"));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
-        new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.DATE)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test
@@ -84,7 +95,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "17.05.21"));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
-        new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.DATE)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test
@@ -93,7 +106,7 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     Assert.assertEquals(
         SqlTypeName.TIMESTAMP,
         new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
-            .evaluate(row, null)
+            .evaluate(row, null, ImmutableMap.of())
             .getOutputType());
   }
 
@@ -102,7 +115,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21 23:59:59.989"));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 22).withTime(0, 0, 0, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test
@@ -115,7 +130,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
             .withTime(0, 0, 0, 0);
     Assert.assertEquals(
         expected,
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test
@@ -123,7 +140,9 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21 23:59:59"));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 21).withTime(23, 59, 59, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 
   @Test(expected = RuntimeException.class)
@@ -131,6 +150,8 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.TIME, DateTime.now()));
     Assert.assertEquals(
         new DateTime().withDate(2017, 05, 22).withTime(0, 0, 0, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlCompareExpression;
@@ -40,14 +41,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 100L)));
-    Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlEqualsExpression exp2 =
         new BeamSqlEqualsExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
-    Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -57,14 +58,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
-    Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlGreaterThanExpression exp2 =
         new BeamSqlGreaterThanExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234566L)));
-    Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -74,14 +75,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
-    Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlGreaterThanOrEqualsExpression exp2 =
         new BeamSqlGreaterThanOrEqualsExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234568L)));
-    Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -91,14 +92,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
                 BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1)));
-    Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlLessThanExpression exp2 =
         new BeamSqlLessThanExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
                 BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1)));
-    Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -108,14 +109,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
                 BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.9)));
-    Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlLessThanOrEqualsExpression exp2 =
         new BeamSqlLessThanOrEqualsExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
                 BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.0)));
-    Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -125,13 +126,13 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
-    Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
+    Assert.assertEquals(false, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlNotEqualsExpression exp2 =
         new BeamSqlNotEqualsExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 0L)));
-    Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
+    Assert.assertEquals(true, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.RowSqlTypes;
 import org.apache.beam.sdk.schemas.Schema;
@@ -51,7 +52,8 @@ public class BeamSqlDotExpressionTest {
 
     BeamSqlDotExpression arrayExpression = new BeamSqlDotExpression(elements, SqlTypeName.VARCHAR);
 
-    assertEquals("aaa", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals(
+        "aaa", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -68,6 +70,7 @@ public class BeamSqlDotExpressionTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Cannot find field");
 
-    new BeamSqlDotExpression(elements, SqlTypeName.VARCHAR).evaluate(NULL_ROW, NULL_WINDOW);
+    new BeamSqlDotExpression(elements, SqlTypeName.VARCHAR)
+        .evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
@@ -28,27 +29,27 @@ public class BeamSqlInputRefExpressionTest extends BeamSqlFnExecutorTestBase {
   @Test
   public void testRefInRange() {
     BeamSqlInputRefExpression ref0 = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0);
-    Assert.assertEquals(row.getInt64(0), ref0.evaluate(row, null).getValue());
+    Assert.assertEquals(row.getInt64(0), ref0.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlInputRefExpression ref1 = new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1);
-    Assert.assertEquals(row.getInt32(1), ref1.evaluate(row, null).getValue());
+    Assert.assertEquals(row.getInt32(1), ref1.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlInputRefExpression ref2 = new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2);
-    Assert.assertEquals(row.getDouble(2), ref2.evaluate(row, null).getValue());
+    Assert.assertEquals(row.getDouble(2), ref2.evaluate(row, null, ImmutableMap.of()).getValue());
 
     BeamSqlInputRefExpression ref3 = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3);
-    Assert.assertEquals(row.getInt64(3), ref3.evaluate(row, null).getValue());
+    Assert.assertEquals(row.getInt64(3), ref3.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void testRefOutOfRange() {
     BeamSqlInputRefExpression ref = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 4);
-    ref.evaluate(row, null).getValue();
+    ref.evaluate(row, null, ImmutableMap.of()).getValue();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testTypeUnMatch() {
     BeamSqlInputRefExpression ref = new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 0);
-    ref.evaluate(row, null).getValue();
+    ref.evaluate(row, null, ImmutableMap.of()).getValue();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
@@ -28,30 +29,35 @@ public class BeamSqlPrimitiveTest extends BeamSqlFnExecutorTestBase {
   @Test
   public void testPrimitiveInt() {
     BeamSqlPrimitive<Integer> expInt = BeamSqlPrimitive.of(SqlTypeName.INTEGER, 100);
-    Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
+    Assert.assertEquals(
+        expInt.getValue(), expInt.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch1() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.INTEGER, 100L);
-    Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
+    Assert.assertEquals(
+        expInt.getValue(), expInt.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch2() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.DECIMAL, 100L);
-    Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
+    Assert.assertEquals(
+        expInt.getValue(), expInt.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch3() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.FLOAT, 100L);
-    Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
+    Assert.assertEquals(
+        expInt.getValue(), expInt.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch4() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 100L);
-    Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
+    Assert.assertEquals(
+        expInt.getValue(), expInt.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlReinterpretExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlReinterpretExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.reinterpret.BeamSqlReinterpretExpression;
@@ -119,7 +120,9 @@ public class BeamSqlReinterpretExpressionTest extends BeamSqlFnExecutorTestBase 
   }
 
   private static long evaluateReinterpretExpression(BeamSqlExpression operand) {
-    return reinterpretExpression(operand).evaluate(NULL_ROW, NULL_WINDOW).getLong();
+    return reinterpretExpression(operand)
+        .evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of())
+        .getLong();
   }
 
   private static BeamSqlReinterpretExpression reinterpretExpression(BeamSqlExpression... operands) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpressionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -36,7 +37,7 @@ public class BeamSqlUdfExpressionTest extends BeamSqlFnExecutorTestBase {
         new BeamSqlUdfExpression(
             UdfFn.class.getMethod("negative", Integer.class), operands, SqlTypeName.INTEGER);
 
-    Assert.assertEquals(-10, exp.evaluate(row, null).getValue());
+    Assert.assertEquals(-10, exp.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   /** UDF example. */

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -85,31 +86,37 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     // integer + integer => integer
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(2, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2, new BeamSqlPlusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // integer + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L, new BeamSqlPlusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // long + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L, new BeamSqlPlusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // float + long => float
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 1.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(1.1F + 1, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1.1F + 1,
+        new BeamSqlPlusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // double + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2.1, new BeamSqlPlusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -119,19 +126,22 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     // integer + integer => long
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(1, new BeamSqlMinusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1, new BeamSqlMinusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // integer + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(1L, new BeamSqlMinusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1L, new BeamSqlMinusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // long + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(1L, new BeamSqlMinusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1L, new BeamSqlMinusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // float + long => double
     operands.clear();
@@ -139,14 +149,19 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
     assertEquals(
         2.1F - 1L,
-        new BeamSqlMinusExpression(operands).evaluate(row, null).getValue().floatValue(),
+        new BeamSqlMinusExpression(operands)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue()
+            .floatValue(),
         0.1);
 
     // double + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(1.1, new BeamSqlMinusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1.1,
+        new BeamSqlMinusExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -156,31 +171,41 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     // integer + integer => integer
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(2, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2,
+        new BeamSqlMultiplyExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // integer + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L,
+        new BeamSqlMultiplyExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // long + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L,
+        new BeamSqlMultiplyExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // float + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 2.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1F * 1L, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2.1F * 1L,
+        new BeamSqlMultiplyExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // double + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2.1,
+        new BeamSqlMultiplyExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -190,31 +215,40 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     // integer + integer => integer
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(2, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2, new BeamSqlDivideExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // integer + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L,
+        new BeamSqlDivideExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // long + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2L, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2L,
+        new BeamSqlDivideExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // float + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 2.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1F / 1, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2.1F / 1,
+        new BeamSqlDivideExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // double + long => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        2.1,
+        new BeamSqlDivideExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -224,18 +258,21 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     // integer + integer => long
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    assertEquals(1, new BeamSqlModExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1, new BeamSqlModExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // integer + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
-    assertEquals(1L, new BeamSqlModExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1L, new BeamSqlModExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // long + long => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 3L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
-    assertEquals(1L, new BeamSqlModExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        1L, new BeamSqlModExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -47,7 +48,8 @@ public class BeamSqlArrayExpressionTest {
     BeamSqlArrayExpression arrayExpression = new BeamSqlArrayExpression(elements);
 
     assertEquals(
-        Arrays.asList("aaa", "bbb"), arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+        Arrays.asList("aaa", "bbb"),
+        arrayExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -47,7 +48,7 @@ public class BeamSqlArrayItemExpressionTest {
     BeamSqlArrayItemExpression expression =
         new BeamSqlArrayItemExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -60,7 +61,7 @@ public class BeamSqlArrayItemExpressionTest {
     BeamSqlArrayItemExpression expression =
         new BeamSqlArrayItemExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals("bbb", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("bbb", expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -45,7 +46,7 @@ public class BeamSqlCardinalityExpressionTest {
     BeamSqlCardinalityExpression expression =
         new BeamSqlCardinalityExpression(inputWith2Elements, SqlTypeName.INTEGER);
 
-    assertEquals(2, expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals(2, expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -56,7 +57,7 @@ public class BeamSqlCardinalityExpressionTest {
     BeamSqlCardinalityExpression expression =
         new BeamSqlCardinalityExpression(emptyInput, SqlTypeName.INTEGER);
 
-    assertEquals(0, expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals(0, expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpressionTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -46,7 +47,7 @@ public class BeamSqlSingleElementExpressionTest {
     BeamSqlSingleElementExpression expression =
         new BeamSqlSingleElementExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -57,7 +58,7 @@ public class BeamSqlSingleElementExpressionTest {
     BeamSqlSingleElementExpression expression =
         new BeamSqlSingleElementExpression(input, SqlTypeName.VARCHAR);
 
-    assertNull(expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertNull(expression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
@@ -30,7 +31,7 @@ public class BeamSqlCurrentDateExpressionTest extends BeamSqlDateExpressionTestB
     Assert.assertEquals(
         SqlTypeName.DATE,
         new BeamSqlCurrentDateExpression()
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -33,6 +34,8 @@ public class BeamSqlCurrentTimeExpressionTest extends BeamSqlDateExpressionTestB
     List<BeamSqlExpression> operands = new ArrayList<>();
     assertEquals(
         SqlTypeName.TIME,
-        new BeamSqlCurrentTimeExpression(operands).evaluate(row, null).getOutputType());
+        new BeamSqlCurrentTimeExpression(operands)
+            .evaluate(row, null, ImmutableMap.of())
+            .getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -33,6 +34,8 @@ public class BeamSqlCurrentTimestampExpressionTest extends BeamSqlDateExpression
     List<BeamSqlExpression> operands = new ArrayList<>();
     assertEquals(
         SqlTypeName.TIMESTAMP,
-        new BeamSqlCurrentTimestampExpression(operands).evaluate(row, null).getOutputType());
+        new BeamSqlCurrentTimestampExpression(operands)
+            .evaluate(row, null, ImmutableMap.of())
+            .getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -39,14 +40,14 @@ public class BeamSqlDateCeilExpressionTest extends BeamSqlDateExpressionTestBase
     Assert.assertEquals(
         str2DateTime("2018-01-01 00:00:00"),
         new BeamSqlDateCeilExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getDate());
 
     operands.set(1, BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.MONTH));
     Assert.assertEquals(
         str2DateTime("2017-06-01 00:00:00"),
         new BeamSqlDateCeilExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getDate());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -38,11 +39,11 @@ public class BeamSqlDateFloorExpressionTest extends BeamSqlDateExpressionTestBas
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.YEAR));
     assertEquals(
         str2DateTime("2017-01-01 00:00:00"),
-        new BeamSqlDateFloorExpression(operands).evaluate(row, null).getDate());
+        new BeamSqlDateFloorExpression(operands).evaluate(row, null, ImmutableMap.of()).getDate());
     // MONTH
     operands.set(1, BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.MONTH));
     assertEquals(
         str2DateTime("2017-05-01 00:00:00"),
-        new BeamSqlDateFloorExpression(operands).evaluate(row, null).getDate());
+        new BeamSqlDateFloorExpression(operands).evaluate(row, null, ImmutableMap.of()).getDate());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -110,7 +111,8 @@ public class BeamSqlDatetimeMinusExpressionTest {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_SECOND, TIMESTAMP, TIMESTAMP_MINUS_2_SEC);
 
-    BeamSqlPrimitive subtractionResult = minusExpression.evaluate(NULL_ROW, NULL_WINDOW);
+    BeamSqlPrimitive subtractionResult =
+        minusExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of());
 
     assertEquals(SqlTypeName.BIGINT, subtractionResult.getOutputType());
     assertEquals(2L * TimeUnit.SECOND.multiplier.longValue(), subtractionResult.getLong());
@@ -121,7 +123,8 @@ public class BeamSqlDatetimeMinusExpressionTest {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 
-    BeamSqlPrimitive subtractionResult = minusExpression.evaluate(NULL_ROW, NULL_WINDOW);
+    BeamSqlPrimitive subtractionResult =
+        minusExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of());
 
     assertEquals(SqlTypeName.TIMESTAMP, subtractionResult.getOutputType());
     assertEquals(DATE_MINUS_2_SEC, subtractionResult.getDate());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -123,7 +124,9 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
 
   private static ReadableInstant evalDatetimePlus(
       BeamSqlExpression date, BeamSqlExpression interval) {
-    return dateTimePlus(date, interval).evaluate(NULL_INPUT_ROW, NULL_WINDOW).getDate();
+    return dateTimePlus(date, interval)
+        .evaluate(NULL_INPUT_ROW, NULL_WINDOW, ImmutableMap.of())
+        .getDate();
   }
 
   private static BeamSqlDatetimePlusExpression dateTimePlus(BeamSqlExpression... operands) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -43,7 +44,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         2017L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // MONTH
@@ -53,7 +54,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         5L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // DAY
@@ -63,7 +64,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         22L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // DAY_OF_WEEK
@@ -73,7 +74,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         2L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // DAY_OF_YEAR
@@ -83,7 +84,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         142L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // WEEK
@@ -93,7 +94,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         21L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
 
     // QUARTER
@@ -103,7 +104,7 @@ public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase 
     assertEquals(
         2L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .evaluate(BeamSqlFnExecutorTestBase.row, null, ImmutableMap.of())
             .getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpressionTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -94,7 +95,7 @@ public class BeamSqlIntervalMultiplyExpressionTest {
         newMultiplyExpression(SQL_INTERVAL_DAY, SQL_INTEGER_FOUR);
 
     BeamSqlPrimitive multiplicationResult =
-        multiplyExpression.evaluate(NULL_INPUT_ROW, NULL_WINDOW);
+        multiplyExpression.evaluate(NULL_INPUT_ROW, NULL_WINDOW, ImmutableMap.of());
 
     BigDecimal expectedResult =
         DECIMAL_FOUR.multiply(timeUnitInternalMultiplier(SqlTypeName.INTERVAL_DAY));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -157,7 +158,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 
-    BeamSqlPrimitive subtractionResult = minusExpression.evaluate(NULL_ROW, NULL_WINDOW);
+    BeamSqlPrimitive subtractionResult =
+        minusExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of());
 
     assertEquals(SqlTypeName.TIMESTAMP, subtractionResult.getOutputType());
     assertEquals(DATE_MINUS_2_SEC, subtractionResult.getDate());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -199,7 +200,7 @@ public class BeamSqlTimestampMinusTimestampExpressionTest {
   }
 
   private long eval(BeamSqlTimestampMinusTimestampExpression minusExpression) {
-    return minusExpression.evaluate(NULL_ROW, NULL_WINDOW).getLong();
+    return minusExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getLong();
   }
 
   private long applyMultiplier(long value, TimeUnit timeUnit) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.logical;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -33,14 +34,17 @@ public class BeamSqlNotExpressionTest extends BeamSqlFnExecutorTestBase {
   public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
-    Assert.assertTrue(new BeamSqlNotExpression(operands).evaluate(row, null).getBoolean());
+    Assert.assertTrue(
+        new BeamSqlNotExpression(operands).evaluate(row, null, ImmutableMap.of()).getBoolean());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
-    Assert.assertFalse(new BeamSqlNotExpression(operands).evaluate(row, null).getBoolean());
+    Assert.assertFalse(
+        new BeamSqlNotExpression(operands).evaluate(row, null, ImmutableMap.of()).getBoolean());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, null));
-    Assert.assertNull(new BeamSqlNotExpression(operands).evaluate(row, null).getValue());
+    Assert.assertNull(
+        new BeamSqlNotExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -69,61 +70,77 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // round(double, double) => double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
-    Assert.assertEquals(2.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2.0,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // round(integer,integer) => integer
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    Assert.assertEquals(2, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2, new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // round(long,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 5L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 3L));
-    Assert.assertEquals(5L, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        5L, new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // round(short) => short
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, new Short("4")));
     Assert.assertEquals(
         SqlFunctions.toShort(4),
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // round(long,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
-    Assert.assertEquals(2L, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2L, new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // round(double, long) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    Assert.assertEquals(1.1, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.1,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.368768));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    Assert.assertEquals(2.37, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2.37,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 3.78683686458));
-    Assert.assertEquals(4.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        4.0,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 378.683686458));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -2));
-    Assert.assertEquals(400.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        400.0,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 378.683686458));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    Assert.assertEquals(380.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        380.0,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // round(integer, double) => integer
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.2));
-    Assert.assertEquals(2, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2, new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // operand with a BeamSqlInputRefExpression
     // to select a column value from row of a row
@@ -133,7 +150,8 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
 
     Assert.assertEquals(
-        1234567L, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+        1234567L,
+        new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -144,42 +162,55 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
-    Assert.assertEquals(16.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        16.0,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // power(integer,integer) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    Assert.assertEquals(4.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        4.0,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // power(integer,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 3L));
-    Assert.assertEquals(8.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        8.0,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // power(long,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
-    Assert.assertEquals(4.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        4.0,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // power(double, int) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    Assert.assertEquals(1.1, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.1,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // power(double, long) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    Assert.assertEquals(1.1, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.1,
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // power(integer, double) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.2));
     Assert.assertEquals(
-        Math.pow(2, 2.2), new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+        Math.pow(2, 2.2),
+        new BeamSqlPowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -188,13 +219,15 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
     Assert.assertEquals(
-        2.0, new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
+        2.0,
+        new BeamSqlTruncateExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // truncate(double, integer) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.80685));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 4));
     Assert.assertEquals(
-        2.8068, new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
+        2.8068,
+        new BeamSqlTruncateExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -204,6 +237,6 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.56));
     Assert.assertEquals(
         Math.atan2(0.875, 0.56),
-        new BeamSqlAtan2Expression(operands).evaluate(row, null).getValue());
+        new BeamSqlAtan2Expression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpressionTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -61,7 +62,8 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, -28965734597L));
     Assert.assertEquals(
-        28965734597L, new BeamSqlAbsExpression(operands).evaluate(row, null).getValue());
+        28965734597L,
+        new BeamSqlAbsExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -71,18 +73,21 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for LN function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.log(2), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+        Math.log(2),
+        new BeamSqlLnExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     // test for LN function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.log(2.4), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+        Math.log(2.4),
+        new BeamSqlLnExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for LN function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        Math.log(2.56), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+        Math.log(2.56),
+        new BeamSqlLnExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -92,17 +97,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for log10 function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.log10(2), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+        Math.log10(2),
+        new BeamSqlLogExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for log10 function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.log10(2.4), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+        Math.log10(2.4),
+        new BeamSqlLogExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for log10 function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        Math.log10(2.56), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+        Math.log10(2.56),
+        new BeamSqlLogExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -112,17 +120,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.exp(2), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+        Math.exp(2),
+        new BeamSqlExpExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.exp(2.4), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+        Math.exp(2.4),
+        new BeamSqlExpExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        Math.exp(2.56), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+        Math.exp(2.56),
+        new BeamSqlExpExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -132,17 +143,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Double.NaN, new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+        Double.NaN,
+        new BeamSqlAcosExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
     Assert.assertEquals(
-        Math.acos(0.45), new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+        Math.acos(0.45),
+        new BeamSqlAcosExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
     Assert.assertEquals(
-        Math.acos(-0.367), new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+        Math.acos(-0.367),
+        new BeamSqlAcosExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -152,12 +166,14 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
     Assert.assertEquals(
-        Math.asin(0.45), new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
+        Math.asin(0.45),
+        new BeamSqlAsinExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
     Assert.assertEquals(
-        Math.asin(-0.367), new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
+        Math.asin(-0.367),
+        new BeamSqlAsinExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -167,12 +183,14 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
     Assert.assertEquals(
-        Math.atan(0.45), new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
+        Math.atan(0.45),
+        new BeamSqlAtanExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
     Assert.assertEquals(
-        Math.atan(-0.367), new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
+        Math.atan(-0.367),
+        new BeamSqlAtanExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -182,12 +200,14 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
     Assert.assertEquals(
-        Math.cos(0.45), new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
+        Math.cos(0.45),
+        new BeamSqlCosExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
     Assert.assertEquals(
-        Math.cos(-0.367), new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
+        Math.cos(-0.367),
+        new BeamSqlCosExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -197,12 +217,14 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, .45));
     Assert.assertEquals(
-        1.0d / Math.tan(0.45), new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
+        1.0d / Math.tan(0.45),
+        new BeamSqlCotExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-.367)));
     Assert.assertEquals(
-        1.0d / Math.tan(-0.367), new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
+        1.0d / Math.tan(-0.367),
+        new BeamSqlCotExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -212,18 +234,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.toDegrees(2), new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
+        Math.toDegrees(2),
+        new BeamSqlDegreesExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.toDegrees(2.4), new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
+        Math.toDegrees(2.4),
+        new BeamSqlDegreesExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
         Math.toDegrees(2.56),
-        new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
+        new BeamSqlDegreesExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -233,18 +257,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.toRadians(2), new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
+        Math.toRadians(2),
+        new BeamSqlRadiansExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.toRadians(2.4), new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
+        Math.toRadians(2.4),
+        new BeamSqlRadiansExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
         Math.toRadians(2.56),
-        new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
+        new BeamSqlRadiansExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -254,17 +280,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.sin(2), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+        Math.sin(2),
+        new BeamSqlSinExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.sin(2.4), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+        Math.sin(2.4),
+        new BeamSqlSinExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        Math.sin(2.56), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+        Math.sin(2.56),
+        new BeamSqlSinExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -274,17 +303,20 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        Math.tan(2), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+        Math.tan(2),
+        new BeamSqlTanExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
     Assert.assertEquals(
-        Math.tan(2.4), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+        Math.tan(2.4),
+        new BeamSqlTanExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        Math.tan(2.56), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+        Math.tan(2.56),
+        new BeamSqlTanExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -294,21 +326,25 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
     Assert.assertEquals(
-        (short) 1, new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
+        (short) 1,
+        new BeamSqlSignExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(1.0, new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.0, new BeamSqlSignExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
     Assert.assertEquals(
-        BigDecimal.ONE, new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
+        BigDecimal.ONE,
+        new BeamSqlSignExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
   public void testForPi() {
-    Assert.assertEquals(Math.PI, new BeamSqlPiExpression().evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.PI, new BeamSqlPiExpression().evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -316,7 +352,8 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.68687979));
     Assert.assertEquals(
-        Math.ceil(2.68687979), new BeamSqlCeilExpression(operands).evaluate(row, null).getValue());
+        Math.ceil(2.68687979),
+        new BeamSqlCeilExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -325,6 +362,6 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.68687979));
     Assert.assertEquals(
         Math.floor(2.68687979),
-        new BeamSqlFloorExpression(operands).evaluate(row, null).getValue());
+        new BeamSqlFloorExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpressionTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.row;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.RowSqlTypes;
@@ -47,7 +48,8 @@ public class BeamSqlFieldAccessExpressionTest {
     BeamSqlFieldAccessExpression arrayExpression =
         new BeamSqlFieldAccessExpression(targetArray, 1, SqlTypeName.VARCHAR);
 
-    assertEquals("bbb", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals(
+        "bbb", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -66,7 +68,8 @@ public class BeamSqlFieldAccessExpressionTest {
     BeamSqlFieldAccessExpression arrayExpression =
         new BeamSqlFieldAccessExpression(targetRow, 1, SqlTypeName.VARCHAR);
 
-    assertEquals("bb", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals(
+        "bb", arrayExpression.evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of()).getValue());
   }
 
   @Test
@@ -77,7 +80,7 @@ public class BeamSqlFieldAccessExpressionTest {
     thrown.expectMessage("unsupported type");
 
     new BeamSqlFieldAccessExpression(targetRow, 1, SqlTypeName.VARCHAR)
-        .evaluate(NULL_ROW, NULL_WINDOW)
+        .evaluate(NULL_ROW, NULL_WINDOW, ImmutableMap.of())
         .getValue();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -36,6 +37,10 @@ public class BeamSqlCharLengthExpressionTest extends BeamSqlFnExecutorTestBase {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
-    assertEquals(5, new BeamSqlCharLengthExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        5,
+        new BeamSqlCharLengthExpression(operands)
+            .evaluate(row, null, ImmutableMap.of())
+            .getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpressionTest.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -60,6 +61,7 @@ public class BeamSqlConcatExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, " world"));
     Assert.assertEquals(
-        "hello world", new BeamSqlConcatExpression(operands).evaluate(row, null).getValue());
+        "hello world",
+        new BeamSqlConcatExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -37,16 +38,19 @@ public class BeamSqlInitCapExpressionTest extends BeamSqlFnExecutorTestBase {
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello world"));
     assertEquals(
-        "Hello World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+        "Hello World",
+        new BeamSqlInitCapExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hEllO wOrld"));
     assertEquals(
-        "Hello World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+        "Hello World",
+        new BeamSqlInitCapExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello     world"));
     assertEquals(
-        "Hello     World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+        "Hello     World",
+        new BeamSqlInitCapExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -36,6 +37,8 @@ public class BeamSqlLowerExpressionTest extends BeamSqlFnExecutorTestBase {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "HELLO"));
-    assertEquals("hello", new BeamSqlLowerExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello",
+        new BeamSqlLowerExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -57,7 +58,8 @@ public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "resou"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     Assert.assertEquals(
-        "w3resou3rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+        "w3resou3rce",
+        new BeamSqlOverlayExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
@@ -65,7 +67,8 @@ public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 4));
     Assert.assertEquals(
-        "w3resou33rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+        "w3resou33rce",
+        new BeamSqlOverlayExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
@@ -73,7 +76,8 @@ public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
     Assert.assertEquals(
-        "w3resou3rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+        "w3resou3rce",
+        new BeamSqlOverlayExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
@@ -81,6 +85,7 @@ public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 7));
     Assert.assertEquals(
-        "w3resouce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+        "w3resouce",
+        new BeamSqlOverlayExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -66,18 +67,24 @@ public class BeamSqlPositionExpressionTest extends BeamSqlFnExecutorTestBase {
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "worldhello"));
-    assertEquals(5, new BeamSqlPositionExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        5,
+        new BeamSqlPositionExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "worldhello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(5, new BeamSqlPositionExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        5,
+        new BeamSqlPositionExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals(-1, new BeamSqlPositionExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        -1,
+        new BeamSqlPositionExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpressionTest.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -53,41 +54,55 @@ public class BeamSqlSubstringExpressionTest extends BeamSqlFnExecutorTestBase {
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    assertEquals("he", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "he",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
-    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 100));
-    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "hello",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 0));
-    assertEquals("", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    assertEquals("", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    assertEquals("o", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "o",
+        new BeamSqlSubstringExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpressionTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -62,25 +63,30 @@ public class BeamSqlTrimExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hehe__hehe"));
     Assert.assertEquals(
-        "__hehe", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+        "__hehe",
+        new BeamSqlTrimExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, SqlTrimFunction.Flag.TRAILING));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hehe__hehe"));
     Assert.assertEquals(
-        "hehe__", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+        "hehe__",
+        new BeamSqlTrimExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, SqlTrimFunction.Flag.BOTH));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "__"));
-    Assert.assertEquals("__", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "__",
+        new BeamSqlTrimExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, " hello "));
     Assert.assertEquals(
-        "hello", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+        "hello",
+        new BeamSqlTrimExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpressionTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
@@ -36,6 +37,8 @@ public class BeamSqlUpperExpressionTest extends BeamSqlFnExecutorTestBase {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
-    assertEquals("HELLO", new BeamSqlUpperExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "HELLO",
+        new BeamSqlUpperExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }


### PR DESCRIPTION
Implements UNNEST. The two forms I've tested are UNNEST of constants and simple correlated UNNEST of a column.

There are some hacks about assuming the form of plan that UNNEST has. My rationale is: before my change, any use of UNNEST caused "cannot plan" errors. Now there are fewer :-)

Things I didn't do that this brings up:

 - the "environment" for evaluating an expression (the window & the correlation environment) would have less churn if made into some combined thingie
 - the way we explode every operator into its own expression could be re-collapsed and save some boilerplate changes

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
