### PR TITLE
Make hash function in Coder base class more conservative.

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -220,11 +220,10 @@ class Coder(object):
   def __eq__(self, other):
     return (self.__class__ == other.__class__
             and self._dict_without_impl() == other._dict_without_impl())
+  # pylint: enable=protected-access
 
   def __hash__(self):
-    return hash((self.__class__,) +
-                tuple(sorted(self._dict_without_impl().items())))
-  # pylint: enable=protected-access
+    return hash(type(self))
 
   _known_urns = {}
 


### PR DESCRIPTION
[BEAM-3724]
Make hash function in Coder base class more conservative, to avoid evaluating hash based on potentially mutable collection.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
