### PR TITLE
[BEAM-4318] Enforce ErrorProne analysis in Spark runner project

### DIFF
--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -19,7 +19,7 @@
 import groovy.json.JsonOutput
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: Runners :: Spark"
 
@@ -53,6 +53,8 @@ test {
 }
 
 dependencies {
+  compileOnly library.java.findbugs_annotations
+  testCompileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-model-pipeline", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
@@ -83,8 +83,8 @@ public class SparkNativePipelineVisitor extends SparkRunner.Evaluator {
                 .stream()
                 .anyMatch(
                     debugTransform ->
-                        debugTransform.getNode().equals(node) && debugTransform.isComposite())
-            && shouldDebug(node.getEnclosingNode());
+                            (debugTransform.getNode().equals(node) && debugTransform.isComposite())
+            && shouldDebug(node.getEnclosingNode()));
   }
 
   @Override

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunnerDebugger.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunnerDebugger.java
@@ -84,8 +84,8 @@ public final class SparkRunnerDebugger extends PipelineRunner<SparkPipelineResul
 
     SparkNativePipelineVisitor visitor;
     if (options.isStreaming()
-        || options instanceof TestSparkPipelineOptions
-        && ((TestSparkPipelineOptions) options).isForceStreaming()) {
+        || (options instanceof TestSparkPipelineOptions
+        && ((TestSparkPipelineOptions) options).isForceStreaming())) {
       SparkPipelineTranslator streamingTranslator =
           new StreamingTransformTranslator.Translator(translator);
       EvaluationContext ctxt = new EvaluationContext(jsc, pipeline, options, jssc);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -96,6 +96,7 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
   }
 
   @Override
+  @SuppressWarnings("Finally")
   public SparkPipelineResult run(Pipeline pipeline) {
     // Default options suffice to set it up as a test runner
     TestSparkPipelineOptions testSparkOptions =

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/CoderHelpers.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/CoderHelpers.java
@@ -23,8 +23,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -68,7 +68,7 @@ public final class CoderHelpers {
    * @return List of bytes representing serialized objects.
    */
   public static <T> List<byte[]> toByteArrays(Iterable<T> values, Coder<T> coder) {
-    List<byte[]> res = new LinkedList<>();
+    List<byte[]> res = new ArrayList<>();
     for (T value : values) {
       res.add(toByteArray(value, coder));
     }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/StatelessJavaSerializer.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/StatelessJavaSerializer.java
@@ -64,7 +64,7 @@ class StatelessJavaSerializer extends Serializer {
     this(null, null);
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
   public void write(Kryo kryo, Output output, Object object) {
     try {
       ObjectOutputStream objectStream = new ObjectOutputStream(output);
@@ -75,7 +75,7 @@ class StatelessJavaSerializer extends Serializer {
     }
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
   public Object read (Kryo kryo, Input input, Class type) {
     try {
       return new ObjectInputStreamWithClassLoader(input, kryo.getClassLoader()).readObject();

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/examples/WordCount.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/examples/WordCount.java
@@ -44,6 +44,7 @@ public class WordCount {
    * of-line. This DoFn tokenizes lines of text into individual words; we pass it to a ParDo in the
    * pipeline.
    */
+  @SuppressWarnings("StringSplitter")
   public static class ExtractWordsFn extends DoFn<String, String> {
     private final Counter emptyLines = Metrics.counter(ExtractWordsFn.class, "emptyLines");
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/CreateStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/CreateStream.java
@@ -20,10 +20,10 @@ package org.apache.beam.runners.spark.io;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.collect.Lists;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import org.apache.beam.runners.spark.util.GlobalWatermarkHolder.SparkWatermarks;
@@ -90,8 +90,8 @@ import org.joda.time.Instant;
 public final class CreateStream<T> extends PTransform<PBegin, PCollection<T>> {
 
   private final Duration batchDuration;
-  private final Queue<Iterable<TimestampedValue<T>>> batches = new LinkedList<>();
-  private final Deque<SparkWatermarks> times = new LinkedList<>();
+  private final Queue<Iterable<TimestampedValue<T>>> batches = new ArrayDeque<>();
+  private final Deque<SparkWatermarks> times = new ArrayDeque<>();
   private final Coder<T> coder;
   private Instant initialSystemTime;
   private final boolean forceWatermarkSync;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SparkUnboundedSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SparkUnboundedSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.spark.io;
 
+import com.google.common.base.Splitter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
@@ -128,7 +129,8 @@ public class SparkUnboundedSource {
 
   private static <T> String getSourceName(Source<T> source, int id) {
     StringBuilder sb = new StringBuilder();
-    for (String s: source.getClass().getSimpleName().replace("$", "").split("(?=[A-Z])")) {
+    for (String s: Splitter.onPattern("(?=[A-Z])")
+            .split(source.getClass().getSimpleName().replace("$", ""))) {
       String trimmed = s.trim();
       if (!trimmed.isEmpty()) {
         sb.append(trimmed).append(" ");

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
@@ -282,6 +282,7 @@ class SparkStateInternals<K> implements StateInternals {
     }
   }
 
+  @SuppressWarnings("TypeParameterShadowing")
   private class SparkCombiningState<K, InputT, AccumT, OutputT>
       extends AbstractState<AccumT>
           implements CombiningState<InputT, AccumT, OutputT> {

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
@@ -211,7 +211,7 @@ public class EvaluationContext {
    * @param <T>  Type of object to return.
    * @return Native object.
    */
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public <T> T get(PValue value) {
     if (pobjects.containsKey(value)) {
       T result = (T) pobjects.get(value);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/Checkpoint.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/Checkpoint.java
@@ -77,7 +77,7 @@ public class Checkpoint {
     return is != null ? IOUtils.toByteArray(is) : null;
   }
 
-  @SuppressWarnings("unchecked")
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <T> T readObject(FileSystem fileSystem, Path checkpointfilePath)
       throws IOException, ClassNotFoundException {
     byte[] bytes = read(fileSystem, checkpointfilePath);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -377,7 +377,7 @@ public final class StreamingTransformTranslator {
 
   private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>> parDo() {
     return new TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>() {
-      public void evaluate(
+      @Override public void evaluate(
           final ParDo.MultiOutput<InputT, OutputT> transform, final EvaluationContext context) {
         final DoFn<InputT, OutputT> doFn = transform.getFn();
         rejectSplittable(doFn);

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/ForceStreamingTest.java
@@ -74,7 +74,7 @@ public class ForceStreamingTest {
   /**
    * Traverses the Pipeline to check if the input is indeed a {@link Read.Unbounded}.
    */
-  private class UnboundedReadDetector extends Pipeline.PipelineVisitor.Defaults {
+  private static class UnboundedReadDetector extends Pipeline.PipelineVisitor.Defaults {
     private boolean isUnbounded = false;
 
     @Override

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/ProvidedSparkContextTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/ProvidedSparkContextTest.java
@@ -22,9 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.ImmutableList;
 import org.apache.beam.runners.spark.examples.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -45,8 +43,8 @@ public class ProvidedSparkContextTest {
     private static final String[] WORDS_ARRAY = {
             "hi there", "hi", "hi sue bob",
             "hi sue", "", "bob hi"};
-    private static final List<String> WORDS = Arrays.asList(WORDS_ARRAY);
-    private static final Set<String> EXPECTED_COUNT_SET =
+    private static final ImmutableList<String> WORDS = ImmutableList.copyOf(WORDS_ARRAY);
+    private static final ImmutableSet<String> EXPECTED_COUNT_SET =
             ImmutableSet.of("hi: 5", "there: 1", "sue: 2", "bob: 2");
     private static final String PROVIDED_CONTEXT_EXCEPTION =
             "The provided Spark context was not created or was stopped";

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/InMemoryMetrics.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/InMemoryMetrics.java
@@ -41,7 +41,7 @@ public class InMemoryMetrics implements Sink {
     internalMetricRegistry = metricRegistry;
   }
 
-  @SuppressWarnings({"unchecked", "WeakerAccess"})
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <T> T valueOf(final String name) {
     final T retVal;
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/SparkMetricsSinkTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/SparkMetricsSinkTest.java
@@ -23,9 +23,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import com.google.common.collect.ImmutableList;
 import org.apache.beam.runners.spark.ReuseSparkContextRule;
 import org.apache.beam.runners.spark.SparkPipelineOptions;
 import org.apache.beam.runners.spark.StreamingTest;
@@ -63,9 +61,8 @@ public class SparkMetricsSinkTest {
   @Rule
   public final transient ReuseSparkContextRule noContextResue = ReuseSparkContextRule.no();
 
-  private static final List<String> WORDS = Arrays
-      .asList("hi there", "hi", "hi sue bob", "hi sue", "", "bob hi");
-  private static final Set<String> EXPECTED_COUNTS = ImmutableSet
+  private static final ImmutableList<String> WORDS = ImmutableList.of("hi there", "hi", "hi sue bob", "hi sue", "", "bob hi");
+  private static final ImmutableSet<String> EXPECTED_COUNTS = ImmutableSet
       .of("hi: 5", "there: 1", "sue: 2", "bob: 2");
 
   @Test

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
@@ -44,11 +44,15 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A test that verifies that metrics push system works in spark runner.
  */
 public class SparkMetricsPusherTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkMetricsPusherTest.class);
 
   @Rule
   public final transient ReuseSparkContextRule noContextResue = ReuseSparkContextRule.no();
@@ -108,7 +112,7 @@ public class SparkMetricsPusherTest {
         counter.inc();
         context.output(context.element());
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.warn("Exception caught" + e);
       }
     }
   }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
@@ -126,6 +126,7 @@ public class ResumeFromCheckpointStreamingTest implements Serializable {
     }
   }
 
+  @SuppressWarnings("FutureReturnValueIgnored")
   private static void produce(Map<String, Instant> messages) {
     Properties producerProps = new Properties();
     producerProps.putAll(EMBEDDED_KAFKA_CLUSTER.getProps());


### PR DESCRIPTION
This PR follows other PRs that fix the ErrorProne warnings.

Special thanks to @swegner for his help :P



------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.