### PR TITLE
Undeprecate Reshuffle transform.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reshuffle.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Reshuffle.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.transforms;
 
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.ReshuffleTrigger;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
@@ -32,22 +31,17 @@ import org.apache.beam.sdk.values.WindowingStrategy;
 import org.joda.time.Duration;
 
 /**
- * <b>For internal use only; no backwards compatibility guarantees.</b>
- *
- * <p>A {@link PTransform} that returns a {@link PCollection} equivalent to its input but
- * operationally provides some of the side effects of a {@link GroupByKey}, in particular preventing
- * fusion of the surrounding transforms, checkpointing and deduplication by id.
- *
  * <p>Performs a {@link GroupByKey} so that the data is key-partitioned. Configures the {@link
  * WindowingStrategy} so that no data is dropped, but doesn't affect the need for the user to
- * specify allowed lateness and accumulation mode before a user-inserted GroupByKey.
+ * specify allowed lateness and accumulation mode before a user-inserted GroupByKey. This
+ * transform is often helpful for limiting or expanding key cardinality and allowed parallelism
+ * of processing the input. E.g. {@link #viaRandomKey()} pairs each element with a random key
+ * allowing processing of each of them in parallel downstream of this transform.
  *
  * @param <K> The type of key being reshuffled on.
  * @param <V> The type of value being reshuffled.
- * @deprecated this transform's intended side effects are not portable; it will likely be removed
  */
-@Internal
-@Deprecated
+@Experimental
 public class Reshuffle<K, V> extends PTransform<PCollection<KV<K, V>>, PCollection<KV<K, V>>> {
 
   private Reshuffle() {
@@ -59,7 +53,7 @@ public class Reshuffle<K, V> extends PTransform<PCollection<KV<K, V>>, PCollecti
 
   /**
    * Encapsulates the sequence "pair input with unique key, apply {@link
-   * Reshuffle#of}, drop the key" commonly used to break fusion.
+   * Reshuffle#of}, drop the key" commonly used to increase allowed parallelism of a PCollection.
    */
   @Experimental
   public static <T> ViaRandomKey<T> viaRandomKey() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/ReshuffleTrigger.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/ReshuffleTrigger.java
@@ -29,11 +29,8 @@ import org.joda.time.Instant;
  * state.
  *
  * @param <W> The kind of window that is being reshuffled.
- * @deprecated The intended side effect of {@link Reshuffle} is not portable; it will likely be
- *     removed
  */
 @Internal
-@Deprecated
 public class ReshuffleTrigger<W extends BoundedWindow> extends Trigger {
 
   public ReshuffleTrigger() {


### PR DESCRIPTION
Undeprecates Reshuffle transform.
Removes references to fusion break in comments. Warnings about unprofitability of durability guarantees of GBK should probably be in documentation for GBK itself. 

Please see [dev thread](https://lists.apache.org/thread.html/820064a81c86a6d44f21f0d6c68ea3f46cec151e5e1a0b52eeed3fbf@%3Cdev.beam.apache.org%3E) for more discussion :

CC: @robertwb, @jkff, @kennknowles, @iemejia. 