### PR TITLE
[BEAM-3949] IOIT's setup() and teardown() db connection attempt sometimes fail resulting in test flakiness

### DIFF
--- a/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOITHelper.java
+++ b/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOITHelper.java
@@ -21,33 +21,81 @@ import java.util.Map;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Methods common to all types of IOITs.
- */
+/** Methods common to all types of IOITs. */
 public class IOITHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(IOITHelper.class);
+  private static final int maxAttempts = 3;
+  private static final long minDelay = 1_000;
 
-  private IOITHelper() {
-  }
+  private IOITHelper() {}
 
   public static String getHashForRecordCount(int recordCount, Map<Integer, String> hashes) {
     String hash = hashes.get(recordCount);
     if (hash == null) {
       throw new UnsupportedOperationException(
-        String.format("No hash for that record count: %s", recordCount)
-      );
+          String.format("No hash for that record count: %s", recordCount));
     }
     return hash;
   }
 
   public static <T extends IOTestPipelineOptions> T readIOTestPipelineOptions(
-    Class<T> optionsType) {
+      Class<T> optionsType) {
 
     PipelineOptionsFactory.register(optionsType);
-    IOTestPipelineOptions options = TestPipeline
-        .testingPipelineOptions()
-        .as(optionsType);
+    IOTestPipelineOptions options = TestPipeline.testingPipelineOptions().as(optionsType);
 
     return PipelineOptionsValidator.validate(optionsType, options);
+  }
+
+  /** Interface for passing any method to executeWithRetry function. */
+  @FunctionalInterface
+  public interface RetryFunction {
+    void run() throws Exception;
+  }
+
+  /**
+   * This function executes the method and retries it in case of failure.
+   *
+   * @param function The function to retry
+   * @throws Exception
+   */
+  public static void executeWithRetry(RetryFunction function) throws Exception {
+    executeWithRetry(maxAttempts, minDelay, function);
+  }
+
+  /**
+   * This function executes the method and retries it in case of failure. The method is retried when
+   * an exception is thrown and it does not depend on the error response. This can be used for tests
+   * which await for infrastructure setup i.e. database connection.
+   *
+   * @param maxAttempts The number of retry attempts
+   * @param minDelay Minimal delay which will grow exponentially
+   * @param function The function to retry
+   * @throws Exception
+   */
+  public static void executeWithRetry(int maxAttempts, long minDelay, RetryFunction function)
+      throws Exception {
+    int attempts = 1;
+    long delay = minDelay;
+
+    while (attempts <= maxAttempts) {
+      try {
+        function.run();
+        return;
+      } catch (Exception e) {
+        LOG.warn("Attempt #{} of {} failed: {}.", attempts, maxAttempts, e.getMessage());
+        if (attempts == maxAttempts) {
+          throw e;
+        } else {
+          long nextDelay = (long) Math.pow(2, attempts) * delay;
+          LOG.warn("Retrying in {} ms.", nextDelay);
+          Thread.sleep(nextDelay);
+        }
+        attempts++;
+      }
+    }
   }
 }

--- a/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOITHelperTest.java
+++ b/sdks/java/io/common/src/test/java/org/apache/beam/sdk/io/common/IOITHelperTest.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.common;
+
+import static org.apache.beam.sdk.io.common.IOITHelper.executeWithRetry;
+import static org.junit.Assert.assertEquals;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for functions in {@link IOITHelper}. */
+@RunWith(JUnit4.class)
+public class IOITHelperTest {
+  private static long startTimeMeasure;
+  private static String message = "";
+  private static ArrayList<Exception> listOfExceptionsThrown;
+
+  @Rule public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    listOfExceptionsThrown = new ArrayList<>();
+  }
+
+  @Test
+  public void retryHealthyFunction() throws Exception {
+    executeWithRetry(IOITHelperTest::validFunction);
+    assertEquals("The healthy function.", message);
+  }
+
+  @Test
+  public void retryFunctionThatWillFail() throws Exception {
+    exceptionRule.expect(SQLException.class);
+    exceptionRule.expectMessage("Problem with connection");
+    executeWithRetry(IOITHelperTest::failingFunction);
+    assertEquals(3, listOfExceptionsThrown.size());
+  }
+
+  @Test
+  public void retryFunctionThatFailsWithMoreAttempts() throws Exception {
+    exceptionRule.expect(SQLException.class);
+    exceptionRule.expectMessage("Problem with connection");
+    executeWithRetry(4, 1_000, IOITHelperTest::failingFunction);
+    assertEquals(4, listOfExceptionsThrown.size());
+  }
+
+  @Test
+  public void retryFunctionThatRecovers() throws Exception {
+    startTimeMeasure = System.currentTimeMillis();
+    executeWithRetry(IOITHelperTest::recoveringFunction);
+    assertEquals(1, listOfExceptionsThrown.size());
+  }
+
+  @Test
+  public void retryFunctionThatRecoversAfterBiggerDelay() throws Exception {
+    startTimeMeasure = System.currentTimeMillis();
+    executeWithRetry(3, 2_000, IOITHelperTest::recoveringFunctionWithBiggerDelay);
+    assertEquals(1, listOfExceptionsThrown.size());
+  }
+
+  private static void failingFunction() throws SQLException {
+    SQLException e = new SQLException("Problem with connection");
+    listOfExceptionsThrown.add(e);
+    throw e;
+  }
+
+  private static void recoveringFunction() throws SQLException {
+    if (System.currentTimeMillis() - startTimeMeasure < 1_001) {
+      SQLException e = new SQLException("Problem with connection");
+      listOfExceptionsThrown.add(e);
+      throw e;
+    }
+  }
+
+  private static void recoveringFunctionWithBiggerDelay() throws SQLException {
+    if (System.currentTimeMillis() - startTimeMeasure < 2_001) {
+      SQLException e = new SQLException("Problem with connection");
+      listOfExceptionsThrown.add(e);
+      throw e;
+    }
+  }
+
+  private static void validFunction() throws SQLException {
+    message = "The healthy function.";
+  }
+}

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBIOIT.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBIOIT.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.mongodb;
 
+import static org.apache.beam.sdk.io.common.IOITHelper.executeWithRetry;
 import static org.apache.beam.sdk.io.common.IOITHelper.getHashForRecordCount;
 
 import com.google.common.collect.ImmutableMap;
@@ -106,7 +107,11 @@ public class MongoDBIOIT {
   }
 
   @AfterClass
-  public static void tearDown() {
+  public static void tearDown() throws Exception {
+    executeWithRetry(MongoDBIOIT::dropDatabase);
+  }
+
+  public static void dropDatabase() throws Exception {
     new MongoClient(options.getMongoDBHostName())
         .getDatabase(options.getMongoDBDatabaseName())
         .drop();


### PR DESCRIPTION
This is a retry mechanism which should prevent failures of IOIT tests which use database connections.
The mechanism can be configured by specifying a method name which will be retried in case of failure, 
a number of attempts and a delay between attempts. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ x ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
