### PR TITLE
[BEAM-1909] Fix BigQuery read transform fails for DirectRunner when querying non-US regions

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -703,7 +703,7 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
     if tr is None:
         source_project_id, source_dataset_id, source_table_id = \
             self._parse_query()
-        if not source_project_id: # Impossible to determine location
+        if not source_project_id:  # Impossible to determine location
           return
     else:
         source_dataset_id = tr.datasetId

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -690,28 +690,28 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
     """
     if not self.source.use_legacy_sql:
       return self._parse_results(
-        r'.*[Ff][Rr][Oo][Mm]\s*`([-\w]+)\.([-\w]+)\.([-\w]+)`',
-        r'.*[Ff][Rr][Oo][Mm]\s*`([-\w]+)\.([-\w]+)`')
+          r'.*[Ff][Rr][Oo][Mm]\s*`([-\w]+)\.([-\w]+)\.([-\w]+)`',
+          r'.*[Ff][Rr][Oo][Mm]\s*`([-\w]+)\.([-\w]+)`')
     else:
       return self._parse_results(
-        r'.*[Ff][Rr][Oo][Mm]\s*\[([\w-]+):([\w-]+)\.([\w-]+)\]',
-        r'.*[Ff][Rr][Oo][Mm]\s*\[([\w-]+)\.([\w-]+)\]'
+          r'.*[Ff][Rr][Oo][Mm]\s*\[([\w-]+):([\w-]+)\.([\w-]+)\]',
+          r'.*[Ff][Rr][Oo][Mm]\s*\[([\w-]+)\.([\w-]+)\]'
       )
 
   def _get_source_table_location(self):
     tr = self.source.table_reference
     if tr is None:
-        source_project_id, source_dataset_id, source_table_id = \
-            self._parse_query()
-        if not source_project_id:  # Impossible to determine location
-          return
+      source_project_id, source_dataset_id, source_table_id = \
+        self._parse_query()
+      if not source_project_id:  # Impossible to determine location
+        return
     else:
-        source_dataset_id = tr.datasetId
-        source_table_id = tr.tableId
-        if tr.projectId is None:
-          source_project_id = self.executing_project
-        else:
-          source_project_id = tr.projectId
+      source_dataset_id = tr.datasetId
+      source_table_id = tr.tableId
+      if tr.projectId is None:
+        source_project_id = self.executing_project
+      else:
+        source_project_id = tr.projectId
 
     source_location = self.client.get_table_location(
         source_project_id, source_dataset_id, source_table_id)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -686,7 +686,6 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
 
     The query will have text of the form "FROM `(x).y.z`" or "FROM [(x):y.z]"
      based on whether legacy or standard sql were provided.
-     :raises: ValueError if project is not supplied
     """
     if not self.source.use_legacy_sql:
       return self._parse_results(

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -655,8 +655,7 @@ class BigQueryReader(dataflow_io.NativeSourceReader):
       try:
         return mg.group(1), mg.group(2), mg.group(3)
       except IndexError:
-        raise ValueError("Project not provided, please provide it as an"
-                         " argument to the class or in the query explicitly.")
+        return None, None, None  # No location, not a breaking change
 
   def _parse_query(self):
     """


### PR DESCRIPTION
Basic
---
Added a fix to the Issue mentioned above.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [x] Format the pull request title like [BEAM-XXX] Fixes bug in ApproximateQuantiles, where you replace BEAM-XXX with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
- [x]  If this contribution is large, please file an Apache Individual Contributor License Agreement.

Includes
---
- Add regex to get projectid, datasetid and table id from both legacy and standard sql when project is provided
- Add regex to get datasetId and tableId from both legacy and standardsql when project is NOT provided.
- Add ability to use project attribute that already existed on BigQuerySource class
- If project is not provided at all, do not break the existing distributions. Therefore, nothing happens and the tables are created in location=None. This defaults back to US on directRunner but *should* work when running in dataflow.

Cavets
---
- I have not updated the unit tests, if required, please point me in the right direction.

Confirmation
---
```python
...beam.io.BigQuerySource(
                      query="""SELECT VehicleId
                               FROM [cartrack.vehicle_info]""",
                      use_standard_sql=True, project='sa-taxi-edw'))
```
```
Dataset sa-taxi-edw:temp_dataset_297f3d8de4364961bf63819985e690c8 does not exist so we will create it as temporary with location=EU
```

```python
...beam.io.BigQuerySource(
                      query="""SELECT VehicleId
                               FROM `cartrack.vehicle_info`""",
                      use_standard_sql=False, project='sa-taxi-edw'))
```
```
WARNING:root:Dataset sa-taxi-edw:temp_dataset_6cf4c45c5ff54b69a60c0851aba33398 does not exist so we will create it as temporary with location=EU
```
```python
...beam.io.BigQuerySource(
                      query="""SELECT VehicleId
                               FROM `sa-taxi-edw.cartrack.vehicle_info`""",
                      use_standard_sql=True))
```
```
WARNING:root:Dataset sa-taxi-edw:temp_dataset_16f490456e744fa78278b2cd95fe3c5b does not exist so we will create it as temporary with location=EU
```

```python
...beam.io.BigQuerySource(
                      query="""SELECT VehicleId
                               FROM [sa-taxi-edw:cartrack.vehicle_info]""",
                      use_standard_sql=False))
```
```
WARNING:root:Dataset sa-taxi-edw:temp_dataset_2cab90333b8049aab4d2adbae5fc65e0 does not exist so we will create it as temporary with location=EU
```

In the instance that the project is provided neither in the query nor as an argument, the location is set to None. In this instance, the location defaults to US when using the DirectRunner.

```
WARNING:root:Dataset sa-taxi-edw:temp_dataset_8def137665b94f1fb128a23edcf0aa19 does not exist so we will create it as temporary with location=None

```
