### PR TITLE
Fix the test to properly run.

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricsTest.java
@@ -75,7 +75,7 @@ public class MetricsTest implements Serializable {
   }
 
   /** Shared test helpers and setup/teardown. */
-  public abstract static class SharedTestBase {
+  public abstract static class SharedTestBase implements Serializable {
     @Rule
     public final transient ExpectedException thrown = ExpectedException.none();
 


### PR DESCRIPTION
This test fails to execute since the SharedTestBase abstract
class isn't serializable. This wasn't detected because this test only
executes in the currently-disabled ValidateRunner suite.

R: @jkff 