### PR TITLE
[BEAM-4348] Enforce ErrorProne analysis in kinesis IO

### DIFF
--- a/sdks/java/io/kinesis/build.gradle
+++ b/sdks/java/io/kinesis/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 provideIntegrationTestingDependencies()
 enableJavaPerformanceTesting()
 
@@ -33,6 +33,7 @@ def aws_version = "1.11.255"
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
   shadow library.java.joda_time
@@ -51,4 +52,5 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.slf4j_jdk14
   testCompile "org.assertj:assertj-core:2.5.0"
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardReadersPool.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/ShardReadersPool.java
@@ -106,6 +106,8 @@ class ShardReadersPool {
     }
   }
 
+  // Note: readLoop() will log any Throwable raised so opt to ignore the future result
+  @SuppressWarnings("FutureReturnValueIgnored")
   void startReadingShards(Iterable<ShardRecordsIterator> shardRecordsIterators) {
     for (final ShardRecordsIterator recordsIterator : shardRecordsIterators) {
       numberOfRecordsInAQueueByShard.put(recordsIterator.getShardId(), new AtomicInteger());

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisIOIT.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisIOIT.java
@@ -22,6 +22,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kinesis.clientlibrary.lib.worker.InitialPositionInStream;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -106,7 +107,7 @@ public class KinesisIOIT implements Serializable {
   private List<byte[]> prepareData() {
     List<byte[]> data = newArrayList();
     for (int i = 0; i < NUM_RECORDS; i++) {
-      data.add(String.valueOf(i).getBytes());
+      data.add(String.valueOf(i).getBytes(StandardCharsets.UTF_8));
     }
     return data;
   }

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockWriteTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisMockWriteTest.java
@@ -31,6 +31,7 @@ import com.amazonaws.services.kinesis.producer.IKinesisProducer;
 import com.amazonaws.services.kinesis.producer.KinesisProducerConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 import org.apache.beam.sdk.testing.PAssert;
@@ -131,7 +132,7 @@ public class KinesisMockWriteTest {
 
   @Test
   public void testNotExistedStream() {
-    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes(StandardCharsets.UTF_8));
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -149,7 +150,7 @@ public class KinesisMockWriteTest {
     Properties properties = new Properties();
     properties.setProperty("KinesisPort", "qwe");
 
-    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes(StandardCharsets.UTF_8));
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -171,7 +172,11 @@ public class KinesisMockWriteTest {
     properties.setProperty("KinesisPort", "4567");
     properties.setProperty("VerifyCertificate", "false");
 
-    Iterable<byte[]> data = ImmutableList.of("1".getBytes(), "2".getBytes(), "3".getBytes());
+    Iterable<byte[]> data =
+        ImmutableList.of(
+            "1".getBytes(StandardCharsets.UTF_8),
+            "2".getBytes(StandardCharsets.UTF_8),
+            "3".getBytes(StandardCharsets.UTF_8));
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -186,7 +191,7 @@ public class KinesisMockWriteTest {
 
   @Test
   public void testWriteFailed() {
-    Iterable<byte[]> data = ImmutableList.of("1".getBytes());
+    Iterable<byte[]> data = ImmutableList.of("1".getBytes(StandardCharsets.UTF_8));
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()
@@ -203,7 +208,9 @@ public class KinesisMockWriteTest {
   public void testWriteAndReadFromMockKinesis() {
     KinesisServiceMock kinesisService = KinesisServiceMock.getInstance();
 
-    Iterable<byte[]> data = ImmutableList.of("1".getBytes(), "2".getBytes());
+    Iterable<byte[]> data =
+        ImmutableList.of(
+            "1".getBytes(StandardCharsets.UTF_8), "2".getBytes(StandardCharsets.UTF_8));
     p.apply(Create.of(data))
         .apply(
             KinesisIO.write()

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisRecordCoderTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisRecordCoderTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.kinesis;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.joda.time.Instant;
 import org.junit.Test;
@@ -30,7 +31,7 @@ public class KinesisRecordCoderTest {
   @Test
   public void encodingAndDecodingWorks() throws Exception {
     KinesisRecord record = new KinesisRecord(
-        ByteBuffer.wrap("data".getBytes()),
+        ByteBuffer.wrap("data".getBytes(StandardCharsets.UTF_8)),
         "sequence",
         128L,
         "partition",

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisServiceMock.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisServiceMock.java
@@ -27,7 +27,7 @@ import org.joda.time.DateTime;
 
 /** Simple mock implementation of Kinesis service for testing, singletone. */
 public class KinesisServiceMock {
-  private static volatile KinesisServiceMock instance;
+  private static KinesisServiceMock instance;
 
   // Mock stream where client is supposed to write
   private String existedStream;
@@ -38,13 +38,9 @@ public class KinesisServiceMock {
 
   private KinesisServiceMock() {}
 
-  public static KinesisServiceMock getInstance() {
+  public static synchronized KinesisServiceMock getInstance() {
     if (instance == null) {
-      synchronized (KinesisServiceMock.class) {
-        if (instance == null) {
-          instance = new KinesisServiceMock();
-        }
-      }
+      instance = new KinesisServiceMock();
     }
     return instance;
   }

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisServiceMock.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisServiceMock.java
@@ -27,7 +27,7 @@ import org.joda.time.DateTime;
 
 /** Simple mock implementation of Kinesis service for testing, singletone. */
 public class KinesisServiceMock {
-  private static KinesisServiceMock instance;
+  private static volatile KinesisServiceMock instance;
 
   // Mock stream where client is supposed to write
   private String existedStream;


### PR DESCRIPTION
Simple PR to enforce ErrorProne analysis in Kinesis IO.

Please take note of the `@SuppressWarnings("FutureReturnValueIgnored")` and ensure my understanding that it can be safely ignored is accurate.

CC @iemejia - please can you assign a reviewer?