### PR TITLE
[BEAM-4351] Enforce ErrorProne analysis in mqtt IO

### DIFF
--- a/sdks/java/io/mqtt/build.gradle
+++ b/sdks/java/io/mqtt/build.gradle
@@ -17,13 +17,14 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: MQTT"
 ext.summary = "IO to read and write to a MQTT broker."
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.slf4j_api
   shadow library.java.joda_time
@@ -37,4 +38,5 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.hamcrest_core
   testCompile library.java.slf4j_jdk14
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
+++ b/sdks/java/io/mqtt/src/main/java/org/apache/beam/sdk/io/mqtt/MqttIO.java
@@ -23,6 +23,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -543,7 +544,7 @@ public class MqttIO {
       @ProcessElement
       public void processElement(ProcessContext context) throws Exception {
         byte[] payload = context.element();
-        LOG.debug("Sending message {}", new String(payload));
+        LOG.debug("Sending message {}", new String(payload, StandardCharsets.UTF_8));
         connection.publish(spec.connectionConfiguration().getTopic(), payload, QoS.AT_LEAST_ONCE,
             false);
       }

--- a/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
+++ b/sdks/java/io/mqtt/src/test/java/org/apache/beam/sdk/io/mqtt/MqttIOTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -85,16 +86,16 @@ public class MqttIOTest {
         .withMaxNumRecords(10);
     PCollection<byte[]> output = pipeline.apply(mqttReader);
     PAssert.that(output).containsInAnyOrder(
-        "This is test 0".getBytes(),
-        "This is test 1".getBytes(),
-        "This is test 2".getBytes(),
-        "This is test 3".getBytes(),
-        "This is test 4".getBytes(),
-        "This is test 5".getBytes(),
-        "This is test 6".getBytes(),
-        "This is test 7".getBytes(),
-        "This is test 8".getBytes(),
-        "This is test 9".getBytes()
+        "This is test 0".getBytes(StandardCharsets.UTF_8),
+        "This is test 1".getBytes(StandardCharsets.UTF_8),
+        "This is test 2".getBytes(StandardCharsets.UTF_8),
+        "This is test 3".getBytes(StandardCharsets.UTF_8),
+        "This is test 4".getBytes(StandardCharsets.UTF_8),
+        "This is test 5".getBytes(StandardCharsets.UTF_8),
+        "This is test 6".getBytes(StandardCharsets.UTF_8),
+        "This is test 7".getBytes(StandardCharsets.UTF_8),
+        "This is test 8".getBytes(StandardCharsets.UTF_8),
+        "This is test 9".getBytes(StandardCharsets.UTF_8)
     );
 
     // produce messages on the brokerService in another thread
@@ -117,8 +118,11 @@ public class MqttIOTest {
           }
         }
         for (int i = 0; i < 10; i++) {
-          publishConnection.publish(topicName, ("This is test " + i).getBytes(),
-              QoS.EXACTLY_ONCE, false);
+          publishConnection.publish(
+              topicName,
+              ("This is test " + i).getBytes(StandardCharsets.UTF_8),
+              QoS.EXACTLY_ONCE,
+              false);
         }
       } catch (Exception e) {
         // nothing to do
@@ -142,16 +146,16 @@ public class MqttIOTest {
                     "READ_PIPELINE"))
             .withMaxReadTime(Duration.standardSeconds(3)));
     PAssert.that(output).containsInAnyOrder(
-        "This is test 0".getBytes(),
-        "This is test 1".getBytes(),
-        "This is test 2".getBytes(),
-        "This is test 3".getBytes(),
-        "This is test 4".getBytes(),
-        "This is test 5".getBytes(),
-        "This is test 6".getBytes(),
-        "This is test 7".getBytes(),
-        "This is test 8".getBytes(),
-        "This is test 9".getBytes()
+        "This is test 0".getBytes(StandardCharsets.UTF_8),
+        "This is test 1".getBytes(StandardCharsets.UTF_8),
+        "This is test 2".getBytes(StandardCharsets.UTF_8),
+        "This is test 3".getBytes(StandardCharsets.UTF_8),
+        "This is test 4".getBytes(StandardCharsets.UTF_8),
+        "This is test 5".getBytes(StandardCharsets.UTF_8),
+        "This is test 6".getBytes(StandardCharsets.UTF_8),
+        "This is test 7".getBytes(StandardCharsets.UTF_8),
+        "This is test 8".getBytes(StandardCharsets.UTF_8),
+        "This is test 9".getBytes(StandardCharsets.UTF_8)
     );
 
     // produce messages on the brokerService in another thread
@@ -174,8 +178,11 @@ public class MqttIOTest {
           }
         }
         for (int i = 0; i < 10; i++) {
-          publishConnection.publish("READ_TOPIC", ("This is test " + i).getBytes(),
-              QoS.EXACTLY_ONCE, false);
+          publishConnection.publish(
+              "READ_TOPIC",
+              ("This is test " + i).getBytes(StandardCharsets.UTF_8),
+              QoS.EXACTLY_ONCE,
+              false);
         }
       } catch (Exception e) {
         // nothing to do
@@ -219,7 +226,7 @@ public class MqttIOTest {
       try {
         for (int i = 0; i < numberOfTestMessages; i++) {
           Message message = connection.receive();
-          messages.add(new String(message.getPayload()));
+          messages.add(new String(message.getPayload(), StandardCharsets.UTF_8));
           message.ack();
         }
       } catch (Exception e) {
@@ -230,7 +237,7 @@ public class MqttIOTest {
 
     ArrayList<byte[]> data = new ArrayList<>();
     for (int i = 0; i < numberOfTestMessages; i++) {
-      data.add(("Test " + i).getBytes());
+      data.add(("Test " + i).getBytes(StandardCharsets.UTF_8));
     }
     pipeline.apply(Create.of(data))
         .apply(MqttIO.write()


### PR DESCRIPTION
Enforce ErrorProne analysis in mqtt IO and fixes warnings.

CC @iemejia (hopefully a super simple review)