### PR TITLE
[BEAM-4371] Namespace shares the same name between Jenkins Performance test jobs

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -290,8 +290,9 @@ class common_job_properties {
     }
   }
 
+  // Namespace must contain lower case alphanumeric characters or '-'
   static String getKubernetesNamespace(def testName) {
-    return "${testName}-${new Date().getTime()}"
+    return "${testName}-\${BUILD_ID}"
   }
 
   static String getKubeconfigLocationForNamespace(def namespace) {


### PR DESCRIPTION
A new name for kubernetes namespace now is created from the name of the test and Jenkins `BUILD_ID` job instead of `Timestamp`. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ x  ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
