### PR TITLE
[BEAM-4354] Enforce ErrorProne analysis in tika IO

### DIFF
--- a/sdks/java/io/tika/build.gradle
+++ b/sdks/java/io/tika/build.gradle
@@ -17,15 +17,18 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: IO :: Tika"
 ext.summary = "Tika Input to parse files."
 
 def tika_version = "1.18"
+def bndlib_version = "1.43.0"
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
+  compileOnly "biz.aQute:bndlib:$bndlib_version"
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.findbugs_jsr305
   shadow "org.apache.tika:tika-core:$tika_version"
@@ -34,4 +37,6 @@ dependencies {
   testCompile library.java.junit
   testCompile library.java.hamcrest_core
   testCompile "org.apache.tika:tika-parsers:$tika_version"
+  testCompileOnly library.java.findbugs_annotations
+  testCompileOnly "biz.aQute:bndlib:$bndlib_version"
 }


### PR DESCRIPTION
Enforces error prone. 
Only warnings raised relate to missing annotations for the `package-info.class`. Note that `Tika` needs to bring in the `bndlib` in addition to to `findbugs_annotations` because it [declares it as provided in scope here](https://github.com/apache/tika/blob/33f3855bf36a0d119f77e0dbb3ccf1b8af5d082d/tika-java7/pom.xml#L90).

CC @iemejia for a review please - hopefully a super simple one.