### PR TITLE
[BEAM-4392] Fix :beam-runners-java-fn-execution failure

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -319,9 +319,12 @@ ext.getJavaRelocatedPath = { String suffix ->
           + suffix)
 }
 
+// By default if there is at least one include rule then all included dependencies must be specified.
+// This overrides the default behavior of include all if no includes are specified.
+// See details here:
+// https://github.com/johnrengelman/shadow/blob/98191096a94674245c7b3e63975df9e14f67074e/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/internal/DefaultDependencyFilter.groovy#L123
 ext.DEFAULT_SHADOW_CLOSURE = {
   dependencies {
-    exclude(".*")
     include(dependency(library.java.guava))
   }
   relocate("com.google.common", getJavaRelocatedPath("com.google.common")) {

--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -16,6 +16,15 @@
  * limitations under the License.
  */
 
+
+// We specifically enumerate all the projects that we depend on since
+// the list is used in both defining the included set for the uber jar
+// and also the set of project level dependencies.
+def dependOnProjects = [":beam-model-pipeline", ":beam-model-fn-execution", ":beam-sdks-java-core",
+                        ":beam-sdks-java-fn-execution",
+                        ":beam-sdks-java-extensions-google-cloud-platform-core",
+                        ":beam-runners-core-java", ":beam-runners-core-construction-java"]
+
 apply from: project(":").file("build_rules.gradle")
 applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE <<
   // Create an uber jar without repackaging for the SDK harness
@@ -24,7 +33,12 @@ applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE <<
   // jars.
   {
     dependencies {
-      include('**/*.class')
+      // Directly include all projects depended on
+      dependOnProjects.each {
+        include(project(path: it, configuration: "shadow"))
+      }
+      // Include all dependencies and transitive dependencies
+      include(dependency(".*:.*"))
     }
   })
 
@@ -32,13 +46,9 @@ description = "Apache Beam :: SDKs :: Java :: Harness"
 ext.summary = "This contains the SDK Fn Harness for Beam Java"
 
 dependencies {
-  compile project(path: ":beam-model-pipeline", configuration: "shadow")
-  compile project(path: ":beam-model-fn-execution", configuration: "shadow")
-  compile project(path: ":beam-sdks-java-core", configuration: "shadow")
-  compile project(path: ":beam-sdks-java-fn-execution", configuration: "shadow")
-  compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
-  compile project(path: ":beam-runners-core-java", configuration: "shadow")
-  compile project(path: ":beam-runners-core-construction-java", configuration: "shadow")
+  dependOnProjects.each {
+    compile project(path: it, configuration: "shadow")
+  }
   compile library.java.jackson_databind
   compile library.java.findbugs_jsr305
   compile library.java.guava

--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -24,9 +24,7 @@ applyJavaNature(
   // Bigtable needs to expose Guava types.
   shadowClosure: {
     dependencies {
-      exclude(".*")
-      // Exclude netty due to conflict with spark runner, see [BEAM-3519].
-      exclude("io/netty/**")
+      exclude(dependency(".*:.*"))
     }
   })
 


### PR DESCRIPTION
Root cause:
We have wrong shadowClosure configurations in beam/sdks/java/harness/build.gradle: https://github.com/apache/beam/blob/master/sdks/java/harness/build.gradle#L27, which cause produced jar doesn't include expected dependencies.

Solution:
Change bulid rules of sdks/java/harness to make harness as a uber-jar.

r: @lukecwik @aaltay 