### PR TITLE
Establish and enforce exact Java format in sdks/java/extensions/sql

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -340,6 +340,9 @@ class JavaNatureConfiguration {
   boolean enableErrorProne = true // Controls whether the errorprone plugin is enabled and configured
   boolean failOnWarning = false // Controls whether compiler warnings are treated as errors
 
+  //TODO(https://issues.apache.org/jira/browse/BEAM-4394): Should this default to true?
+  boolean enableSpotless = false // Controls whether spotless plugin enforces autoformat
+
   // The shadowJar / shadowTestJar tasks execute the following closure to configure themselves.
   // Users can compose their closure with the default closure via:
   // DEFAULT_SHADOW_CLOSURE << {
@@ -495,8 +498,15 @@ ext.applyJavaNature = {
   apply plugin: "net.ltgt.apt-eclipse"
 
   // Enables a plugin which can apply code formatting to source.
-  // TODO: Should this plugin be enabled for all projects?
-  apply plugin: "com.diffplug.gradle.spotless"
+  // TODO(https://issues.apache.org/jira/browse/BEAM-4394): Should this plugin be enabled for all projects?
+  if (configuration.enableSpotless) {
+    apply plugin: "com.diffplug.gradle.spotless"
+    spotless {
+      java {
+        googleJavaFormat()
+      }
+    }
+  }
 
   // Enables a plugin which performs code analysis for common bugs.
   // This plugin is configured to only analyze the "main" source set.

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -19,7 +19,7 @@ import groovy.json.JsonOutput
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(enableSpotless: true)
 apply plugin: 'ca.coglinc.javacc'
 
 description = "Apache Beam :: SDKs :: Java :: Extensions :: SQL"

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSql.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSql.java
@@ -25,41 +25,40 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 
 /**
- * {@code BeamSql} is the DSL interface of BeamSQL. It translates a SQL query as a
- * {@link PTransform}, so developers can use standard SQL queries in a Beam pipeline.
+ * {@code BeamSql} is the DSL interface of BeamSQL. It translates a SQL query as a {@link
+ * PTransform}, so developers can use standard SQL queries in a Beam pipeline.
  *
  * <h1>Beam SQL DSL usage:</h1>
- * A typical pipeline with Beam SQL DSL is:
- * <pre>
- *{@code
-PipelineOptions options = PipelineOptionsFactory.create();
-Pipeline p = Pipeline.create(options);
-
-//create table from TextIO;
-PCollection<Row> inputTableA = p.apply(TextIO.read().from("/my/input/patha")).apply(...);
-PCollection<Row> inputTableB = p.apply(TextIO.read().from("/my/input/pathb")).apply(...);
-
-//run a simple query, and register the output as a table in BeamSql;
-String sql1 = "select MY_FUNC(c1), c2 from PCOLLECTION";
-PCollection<Row> outputTableA = inputTableA.apply(
-    BeamSql
-        .query(sql1)
-        .registerUdf("MY_FUNC", MY_FUNC.class, "FUNC");
-
-//run a JOIN with one table from TextIO, and one table from another query
-PCollection<Row> outputTableB =
-    PCollectionTuple
-        .of(new TupleTag<>("TABLE_O_A"), outputTableA)
-        .and(new TupleTag<>("TABLE_B"), inputTableB)
-        .apply(BeamSql.query("select * from TABLE_O_A JOIN TABLE_B where ..."));
-
-//output the final result with TextIO
-outputTableB.apply(...).apply(TextIO.write().to("/my/output/path"));
-
-p.run().waitUntilFinish();
- * }
- * </pre>
  *
+ * <p>A typical pipeline with Beam SQL DSL is:
+ *
+ * <pre>{@code
+ * PipelineOptions options = PipelineOptionsFactory.create();
+ * Pipeline p = Pipeline.create(options);
+ *
+ * //create table from TextIO;
+ * PCollection<Row> inputTableA = p.apply(TextIO.read().from("/my/input/patha")).apply(...);
+ * PCollection<Row> inputTableB = p.apply(TextIO.read().from("/my/input/pathb")).apply(...);
+ *
+ * //run a simple query, and register the output as a table in BeamSql;
+ * String sql1 = "select MY_FUNC(c1), c2 from PCOLLECTION";
+ * PCollection<Row> outputTableA = inputTableA.apply(
+ *    BeamSql
+ *        .query(sql1)
+ *        .registerUdf("MY_FUNC", MY_FUNC.class, "FUNC");
+ *
+ * //run a JOIN with one table from TextIO, and one table from another query
+ * PCollection<Row> outputTableB =
+ *     PCollectionTuple
+ *     .of(new TupleTag<>("TABLE_O_A"), outputTableA)
+ *     .and(new TupleTag<>("TABLE_B"), inputTableB)
+ *         .apply(BeamSql.query("select * from TABLE_O_A JOIN TABLE_B where ..."));
+ *
+ * //output the final result with TextIO
+ * outputTableB.apply(...).apply(TextIO.write().to("/my/output/path"));
+ *
+ * p.run().waitUntilFinish();
+ * }</pre>
  */
 @Experimental
 public class BeamSql {
@@ -67,28 +66,27 @@ public class BeamSql {
   /**
    * Returns a {@link QueryTransform} representing an equivalent execution plan.
    *
-   * <p>The {@link QueryTransform} can be applied to a {@link PCollection}
-   * or {@link PCollectionTuple} representing all the input tables.
+   * <p>The {@link QueryTransform} can be applied to a {@link PCollection} or {@link
+   * PCollectionTuple} representing all the input tables.
    *
    * <p>The {@link PTransform} outputs a {@link PCollection} of {@link Row}.
    *
    * <p>If the {@link PTransform} is applied to {@link PCollection} then it gets registered with
    * name <em>PCOLLECTION</em>.
    *
-   * <p>If the {@link PTransform} is applied to {@link PCollectionTuple} then
-   * {@link TupleTag#getId()} is used as the corresponding {@link PCollection}s name.
+   * <p>If the {@link PTransform} is applied to {@link PCollectionTuple} then {@link
+   * TupleTag#getId()} is used as the corresponding {@link PCollection}s name.
    *
    * <ul>
-   * <li>If the sql query only uses a subset of tables from the upstream {@link PCollectionTuple},
-   *     this is valid;</li>
-   * <li>If the sql query references a table not included in the upstream {@link PCollectionTuple},
-   *     an {@code IllegalStateException} is thrown during query validation;</li>
-   * <li>Always, tables from the upstream {@link PCollectionTuple} are only valid in the scope
-   *     of the current query call.</li>
+   *   <li>If the sql query only uses a subset of tables from the upstream {@link PCollectionTuple},
+   *       this is valid;
+   *   <li>If the sql query references a table not included in the upstream {@link
+   *       PCollectionTuple}, an {@code IllegalStateException} is thrown during query validation;
+   *   <li>Always, tables from the upstream {@link PCollectionTuple} are only valid in the scope of
+   *       the current query call.
    * </ul>
    */
   public static QueryTransform query(String sqlQuery) {
     return QueryTransform.withQueryString(sqlQuery);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
@@ -31,15 +31,11 @@ import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.tools.RelConversionException;
 import org.apache.calcite.tools.ValidationException;
 
-/**
- * {@link BeamSqlCli} provides methods to execute Beam SQL with an interactive client.
- */
+/** {@link BeamSqlCli} provides methods to execute Beam SQL with an interactive client. */
 @Experimental
 public class BeamSqlCli {
   private BeamSqlEnv env;
-  /**
-   * The store which persists all the table meta data.
-   */
+  /** The store which persists all the table meta data. */
   private MetaStore metaStore;
 
   public BeamSqlCli metaStore(MetaStore metaStore) {
@@ -53,9 +49,7 @@ public class BeamSqlCli {
     return metaStore;
   }
 
-  /**
-   * Returns a human readable representation of the query execution plan.
-   */
+  /** Returns a human readable representation of the query execution plan. */
   public String explainQuery(String sqlString)
       throws ValidationException, RelConversionException, SqlParseException {
     BeamRelNode exeTree = env.getPlanner().convertToBeamRel(sqlString);
@@ -63,9 +57,7 @@ public class BeamSqlCli {
     return beamPlan;
   }
 
-  /**
-   * Executes the given sql.
-   */
+  /** Executes the given sql. */
   public void execute(String sqlString)
       throws ValidationException, RelConversionException, SqlParseException {
     SqlNode sqlNode = env.getPlanner().parse(sqlString);
@@ -74,8 +66,10 @@ public class BeamSqlCli {
     if (sqlNode instanceof SqlExecutableStatement) {
       ((SqlExecutableStatement) sqlNode).execute(env.getContext());
     } else {
-      PipelineOptions options = PipelineOptionsFactory.fromArgs(new String[] {}).withValidation()
-          .as(PipelineOptions.class);
+      PipelineOptions options =
+          PipelineOptionsFactory.fromArgs(new String[] {})
+              .withValidation()
+              .as(PipelineOptions.class);
       options.setJobName("BeamPlanCreator");
       Pipeline pipeline = Pipeline.create(options);
       env.getPlanner().compileBeamPipeline(sqlString, pipeline);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlSeekableTable.java
@@ -23,23 +23,17 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.values.Row;
 
 /**
- * A seekable table converts a JOIN operator to an inline lookup.
- * It's triggered by {@code SELECT * FROM FACT_TABLE JOIN LOOKUP_TABLE ON ...}.
+ * A seekable table converts a JOIN operator to an inline lookup. It's triggered by {@code SELECT *
+ * FROM FACT_TABLE JOIN LOOKUP_TABLE ON ...}.
  */
 @Experimental
-public interface BeamSqlSeekableTable extends Serializable{
-  /**
-   * prepare the instance.
-   */
-  default void setUp(){};
+public interface BeamSqlSeekableTable extends Serializable {
+  /** prepare the instance. */
+  default void setUp() {};
 
-  /**
-   * return a list of {@code Row} with given key set.
-   */
+  /** return a list of {@code Row} with given key set. */
   List<Row> seekRow(Row lookupSubRow);
 
-  /**
-   * cleanup resources of the instance.
-   */
-  default void tearDown(){};
+  /** cleanup resources of the instance. */
+  default void tearDown() {};
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
@@ -26,30 +26,20 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * This interface defines a Beam Sql Table.
- */
+/** This interface defines a Beam Sql Table. */
 public interface BeamSqlTable {
   /**
-   * In Beam SQL, there's no difference between a batch query and a streaming
-   * query. {@link BeamIOType} is used to validate the sources.
+   * In Beam SQL, there's no difference between a batch query and a streaming query. {@link
+   * BeamIOType} is used to validate the sources.
    */
   BeamIOType getSourceType();
 
-  /**
-   * create a {@code PCollection<BeamSqlRow>} from source.
-   *
-   */
+  /** create a {@code PCollection<BeamSqlRow>} from source. */
   PCollection<Row> buildIOReader(Pipeline pipeline);
 
-  /**
-   * create a {@code IO.write()} instance to write to target.
-   *
-   */
-   PTransform<? super PCollection<Row>, POutput> buildIOWriter();
+  /** create a {@code IO.write()} instance to write to target. */
+  PTransform<? super PCollection<Row>, POutput> buildIOWriter();
 
-  /**
-   * Get the schema info of the table.
-   */
-   Schema getSchema();
+  /** Get the schema info of the table. */
+  Schema getSchema();
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlUdf.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlUdf.java
@@ -25,17 +25,21 @@ import org.apache.beam.sdk.annotations.Experimental;
  *
  * <p>A static method {@code eval} is required. Here is an example:
  *
- * <blockquote><pre>
+ * <blockquote>
+ *
+ * <pre>
  * public static class MyLeftFunction {
  *   public String eval(
  *       &#64;Parameter(name = "s") String s,
  *       &#64;Parameter(name = "n", optional = true) Integer n) {
  *     return s.substring(0, n == null ? 1 : n);
  *   }
- * }</pre></blockquote>
+ * }</pre>
  *
- * <p>The first parameter is named "s" and is mandatory,
- * and the second parameter is named "n" and is optional(always NULL if not specified).
+ * </blockquote>
+ *
+ * <p>The first parameter is named "s" and is mandatory, and the second parameter is named "n" and
+ * is optional(always NULL if not specified).
  */
 @Experimental
 public interface BeamSqlUdf extends Serializable {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/RowSqlTypes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/RowSqlTypes.java
@@ -27,16 +27,14 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-
 /**
  * Type builder for {@link Row} with SQL types.
  *
- * <p>Limited SQL types are supported now, visit
- * <a href="https://beam.apache.org/documentation/dsls/sql/#data-types">data types</a>
- * for more details.
+ * <p>Limited SQL types are supported now, visit <a
+ * href="https://beam.apache.org/documentation/dsls/sql/#data-types">data types</a> for more
+ * details.
  *
  * <p>TODO: We should remove this class in favor of directly using Beam.Schema.Builder
- *
  */
 @Experimental
 public class RowSqlTypes {
@@ -59,9 +57,7 @@ public class RowSqlTypes {
     return new Builder();
   }
 
-  /**
-   * Builder class to construct {@link Schema}.
-   */
+  /** Builder class to construct {@link Schema}. */
   public static class Builder {
     Schema.Builder builder;
 
@@ -106,12 +102,12 @@ public class RowSqlTypes {
     }
 
     public Builder withCharField(String fieldName) {
-           builder.addField(Field.of(fieldName, CHAR).withNullable(true));
-       return this;
+      builder.addField(Field.of(fieldName, CHAR).withNullable(true));
+      return this;
     }
 
     public Builder withVarcharField(String fieldName) {
-          builder.addField(Field.of(fieldName, VARCHAR).withNullable(true));
+      builder.addField(Field.of(fieldName, VARCHAR).withNullable(true));
       return this;
     }
 
@@ -130,57 +126,45 @@ public class RowSqlTypes {
       return this;
     }
 
-    /**
-     * Adds an ARRAY field with elements of the given type.
-     */
+    /** Adds an ARRAY field with elements of the given type. */
     public Builder withArrayField(String fieldName, RelDataType relDataType) {
       builder.addField(Field.of(fieldName, CalciteUtils.toArrayType(relDataType)));
       return this;
     }
 
-    /**
-     * Adds an ARRAY field with elements of the given type.
-     */
+    /** Adds an ARRAY field with elements of the given type. */
     public Builder withArrayField(String fieldName, SqlTypeName typeName) {
       builder.addField(Field.of(fieldName, CalciteUtils.toArrayType(typeName)));
       return this;
     }
 
-    /**
-     * Adds a MAP field with elements of the given key/value type.
-     */
-    public Builder withMapField(String fieldName, RelDataType keyRelDataType,
-        RelDataType valueRelDataType) {
-      builder
-          .addField(Field.of(fieldName, CalciteUtils.toMapType(keyRelDataType, valueRelDataType)));
+    /** Adds a MAP field with elements of the given key/value type. */
+    public Builder withMapField(
+        String fieldName, RelDataType keyRelDataType, RelDataType valueRelDataType) {
+      builder.addField(
+          Field.of(fieldName, CalciteUtils.toMapType(keyRelDataType, valueRelDataType)));
       return this;
     }
 
-    /**
-     * Adds a MAP field with elements of the given key/value type.
-     */
-    public Builder withMapField(String fieldName, SqlTypeName keyTypeName,
-        SqlTypeName valueTypeName) {
+    /** Adds a MAP field with elements of the given key/value type. */
+    public Builder withMapField(
+        String fieldName, SqlTypeName keyTypeName, SqlTypeName valueTypeName) {
       builder.addField(Field.of(fieldName, CalciteUtils.toMapType(keyTypeName, valueTypeName)));
       return this;
     }
 
-    /**
-     * Adds an ARRAY field with elements of {@code rowType}.
-     */
+    /** Adds an ARRAY field with elements of {@code rowType}. */
     public Builder withArrayField(String fieldName, Schema schema) {
-      FieldType collectionElementType =
-          FieldType
-              .of(TypeName.ROW)
-              .withRowSchema(schema);
-      builder.addField(Field.of(fieldName,
-          TypeName.ARRAY.type().withCollectionElementType(collectionElementType)));
+      FieldType collectionElementType = FieldType.of(TypeName.ROW).withRowSchema(schema);
+      builder.addField(
+          Field.of(
+              fieldName, TypeName.ARRAY.type().withCollectionElementType(collectionElementType)));
       return this;
     }
 
     public Builder withRowField(String fieldName, Schema schema) {
-       builder.addRowField(fieldName, schema, true);
-       return this;
+      builder.addRowField(fieldName, schema, true);
+      return this;
     }
 
     private Builder() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SchemaHelper.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SchemaHelper.java
@@ -28,9 +28,7 @@ import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.reflect.InferredRowCoder;
 
-/**
- * Utility methods to help wire up schema inferring using {@link InferredRowCoder}.
- */
+/** Utility methods to help wire up schema inferring using {@link InferredRowCoder}. */
 class SchemaHelper {
 
   static PCollection<Row> toRows(PInput input) {
@@ -43,27 +41,26 @@ class SchemaHelper {
 
     if (coder instanceof InferredRowCoder) {
       InferredRowCoder inferredSchemaCoder = (InferredRowCoder) coder;
-      return
-          pCollection
-              .apply(
-                  pCollection.getName() + "_transformToRows",
-                  transformToRows(inferredSchemaCoder))
-              .setCoder(inferredSchemaCoder.rowCoder());
+      return pCollection
+          .apply(pCollection.getName() + "_transformToRows", transformToRows(inferredSchemaCoder))
+          .setCoder(inferredSchemaCoder.rowCoder());
     }
 
-    throw new UnsupportedOperationException("Input PCollections for Beam SQL should either "
-                                                + "have RowCoder set and contain Rows or "
-                                                + "have InferredRowCoder for its elements");
+    throw new UnsupportedOperationException(
+        "Input PCollections for Beam SQL should either "
+            + "have RowCoder set and contain Rows or "
+            + "have InferredRowCoder for its elements");
   }
 
   private static PTransform<PCollection<?>, PCollection<Row>> transformToRows(
       InferredRowCoder coder) {
 
-    return ParDo.of(new DoFn<Object, Row>() {
-      @ProcessElement
-      public void processElement(DoFn<Object, Row>.ProcessContext c) {
-        c.output(coder.createRow(c.element()));
-      }
-    });
+    return ParDo.of(
+        new DoFn<Object, Row>() {
+          @ProcessElement
+          public void processElement(DoFn<Object, Row>.ProcessContext c) {
+            c.output(coder.createRow(c.element()));
+          }
+        });
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlExample.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlExample.java
@@ -37,13 +37,14 @@ import org.apache.beam.sdk.values.TupleTag;
  * This is a quick example, which uses Beam SQL DSL to create a data pipeline.
  *
  * <p>Run the example from the Beam source root with
+ *
  * <pre>
  *   ./gradlew :beam-sdks-java-extensions-sql:runBasicExample
  * </pre>
  *
- * <p>The above command executes the example locally using direct runner.
- * Running the pipeline in other runners require additional setup and are out of scope
- * of the SQL examples. Please consult Beam documentation on how to run pipelines.
+ * <p>The above command executes the example locally using direct runner. Running the pipeline in
+ * other runners require additional setup and are out of scope of the SQL examples. Please consult
+ * Beam documentation on how to run pipelines.
  */
 class BeamSqlExample {
   public static void main(String[] args) {
@@ -51,32 +52,31 @@ class BeamSqlExample {
     Pipeline p = Pipeline.create(options);
 
     //define the input row format
-    Schema type = RowSqlTypes
-        .builder()
-        .withIntegerField("c1")
-        .withVarcharField("c2")
-        .withDoubleField("c3")
-        .build();
+    Schema type =
+        RowSqlTypes.builder()
+            .withIntegerField("c1")
+            .withVarcharField("c2")
+            .withDoubleField("c3")
+            .build();
 
     Row row1 = Row.withSchema(type).addValues(1, "row", 1.0).build();
     Row row2 = Row.withSchema(type).addValues(2, "row", 2.0).build();
     Row row3 = Row.withSchema(type).addValues(3, "row", 3.0).build();
 
     //create a source PCollection with Create.of();
-    PCollection<Row> inputTable = PBegin.in(p).apply(Create.of(row1, row2, row3)
-        .withCoder(type.getRowCoder()));
+    PCollection<Row> inputTable =
+        PBegin.in(p).apply(Create.of(row1, row2, row3).withCoder(type.getRowCoder()));
 
     //Case 1. run a simple SQL query over input PCollection with BeamSql.simpleQuery;
-    PCollection<Row> outputStream = inputTable.apply(
-        BeamSql.query("select c1, c2, c3 from PCOLLECTION where c1 > 1"));
+    PCollection<Row> outputStream =
+        inputTable.apply(BeamSql.query("select c1, c2, c3 from PCOLLECTION where c1 > 1"));
 
     // print the output record of case 1;
     outputStream.apply(
         "log_result",
         MapElements.via(
             new SimpleFunction<Row, Void>() {
-              public @Nullable
-              Void apply(Row input) {
+              public @Nullable Void apply(Row input) {
                 // expect output:
                 //  PCOLLECTION: [3, row, 3.0]
                 //  PCOLLECTION: [2, row, 2.0]
@@ -96,8 +96,7 @@ class BeamSqlExample {
         MapElements.via(
             new SimpleFunction<Row, Void>() {
               @Override
-              public @Nullable
-              Void apply(Row input) {
+              public @Nullable Void apply(Row input) {
                 // expect output:
                 //  CASE1_RESULT: [row, 5.0]
                 System.out.println("CASE1_RESULT: " + input.getValues());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlPojoExample.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/BeamSqlPojoExample.java
@@ -38,22 +38,24 @@ import org.apache.beam.sdk.values.reflect.InferredRowCoder;
  * This example uses Beam SQL DSL to query a data pipeline with Java objects in it.
  *
  * <p>Run the example from the Beam source root with
+ *
  * <pre>
  *   ./gradlew :beam-sdks-java-extensions-sql:runPojoExample
  * </pre>
  *
- * <p>The above command executes the example locally using direct runner.
- * Running the pipeline in other runners require additional setup and are out of scope
- * of the SQL examples. Please consult Beam documentation on how to run pipelines.
+ * <p>The above command executes the example locally using direct runner. Running the pipeline in
+ * other runners require additional setup and are out of scope of the SQL examples. Please consult
+ * Beam documentation on how to run pipelines.
  *
  * <p>This example models a scenario of customers buying goods.
+ *
  * <ul>
- *   <li>{@link Customer} represents a customer</li>
- *   <li>{@link Order} represents an order by a customer</li>
+ *   <li>{@link Customer} represents a customer
+ *   <li>{@link Order} represents an order by a customer
  * </ul>
  *
- * <p>{@link InferredRowCoder} is used to adapt Java objects to {@link Row Rows}
- * that are understood by Beam SQL.
+ * <p>{@link InferredRowCoder} is used to adapt Java objects to {@link Row Rows} that are understood
+ * by Beam SQL.
  */
 class BeamSqlPojoExample {
   public static void main(String[] args) {
@@ -70,32 +72,33 @@ class BeamSqlPojoExample {
     PCollection<Order> orders = loadOrders(pipeline);
 
     // Example 1. Run a simple query over java objects:
-    PCollection<Row> customersFromWonderland = customers.apply(
-        BeamSql.query(
-            "SELECT id, name "
-            + " FROM PCOLLECTION "
-            + " WHERE countryOfResidence = 'Wonderland'"));
+    PCollection<Row> customersFromWonderland =
+        customers.apply(
+            BeamSql.query(
+                "SELECT id, name "
+                    + " FROM PCOLLECTION "
+                    + " WHERE countryOfResidence = 'Wonderland'"));
 
     // Output the results of the query:
     customersFromWonderland.apply(logRecords(": is from Wonderland"));
 
     // Example 2. Query the results of the first query:
-    PCollection<Row> totalInWonderland = customersFromWonderland.apply(
-        BeamSql.query("SELECT COUNT(id) FROM PCOLLECTION"));
+    PCollection<Row> totalInWonderland =
+        customersFromWonderland.apply(BeamSql.query("SELECT COUNT(id) FROM PCOLLECTION"));
 
     // Output the results of the query:
     totalInWonderland.apply(logRecords(": total customers in Wonderland"));
 
     // Example 3. Query multiple PCollections of Java objects:
-    PCollection<Row> ordersByGrault = PCollectionTuple
-        .of(new TupleTag<>("customers"), customers)
-        .and(new TupleTag<>("orders"), orders)
-        .apply(
-            BeamSql.query(
-                "SELECT customers.name, ('order id:' || CAST(orders.id AS VARCHAR))"
-                + " FROM orders "
-                + "   JOIN customers ON orders.customerId = customers.id"
-                + " WHERE customers.name = 'Grault'"));
+    PCollection<Row> ordersByGrault =
+        PCollectionTuple.of(new TupleTag<>("customers"), customers)
+            .and(new TupleTag<>("orders"), orders)
+            .apply(
+                BeamSql.query(
+                    "SELECT customers.name, ('order id:' || CAST(orders.id AS VARCHAR))"
+                        + " FROM orders "
+                        + "   JOIN customers ON orders.customerId = customers.id"
+                        + " WHERE customers.name = 'Grault'"));
 
     // Output the results of the query:
     ordersByGrault.apply(logRecords(": ordered by 'Grault'"));
@@ -106,8 +109,7 @@ class BeamSqlPojoExample {
   private static MapElements<Row, Void> logRecords(String suffix) {
     return MapElements.via(
         new SimpleFunction<Row, Void>() {
-          public @Nullable
-          Void apply(Row input) {
+          public @Nullable Void apply(Row input) {
             System.out.println(input.getValues() + suffix);
             return null;
           }
@@ -120,25 +122,21 @@ class BeamSqlPojoExample {
   }
 
   private static PCollection<Customer> loadCustomers(Pipeline pipeline) {
-    return
-        PBegin
-            .in(pipeline)
-            .apply(
-                Create.of(
+    return PBegin.in(pipeline)
+        .apply(
+            Create.of(
                     new Customer(1, "Foo", "Wonderland"),
                     new Customer(2, "Bar", "Super Kingdom"),
                     new Customer(3, "Baz", "Wonderland"),
                     new Customer(4, "Grault", "Wonderland"),
                     new Customer(5, "Qux", "Super Kingdom"))
-                      .withCoder(InferredRowCoder.ofSerializable(Customer.class)));
+                .withCoder(InferredRowCoder.ofSerializable(Customer.class)));
   }
 
   private static PCollection<Order> loadOrders(Pipeline pipeline) {
-    return
-        PBegin
-            .in(pipeline)
-            .apply(
-                Create.of(
+    return PBegin.in(pipeline)
+        .apply(
+            Create.of(
                     new Order(1, 5),
                     new Order(2, 2),
                     new Order(3, 1),
@@ -148,6 +146,6 @@ class BeamSqlPojoExample {
                     new Order(7, 4),
                     new Order(8, 4),
                     new Order(9, 1))
-                      .withCoder(InferredRowCoder.ofSerializable(Order.class)));
+                .withCoder(InferredRowCoder.ofSerializable(Order.class)));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Customer.java
@@ -19,9 +19,7 @@ package org.apache.beam.sdk.extensions.sql.example.model;
 
 import java.io.Serializable;
 
-/**
- * Describes a customer.
- */
+/** Describes a customer. */
 public class Customer implements Serializable {
   private String name;
   private int id;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/Order.java
@@ -19,9 +19,7 @@ package org.apache.beam.sdk.extensions.sql.example.model;
 
 import java.io.Serializable;
 
-/**
- * Describes an order.
- */
+/** Describes an order. */
 public class Order implements Serializable {
   private int id;
   private int customerId;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/model/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Java classes used to for modeling the examples.
- */
+/** Java classes used to for modeling the examples. */
 package org.apache.beam.sdk.extensions.sql.example.model;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/example/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Examples on how to use Beam SQL.
- */
+/** Examples on how to use Beam SQL. */
 package org.apache.beam.sdk.extensions.sql.example;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteSchema.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteSchema.java
@@ -29,9 +29,7 @@ import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Schemas;
 
-/**
- * Adapter from {@link TableProvider} to {@link Schema}.
- */
+/** Adapter from {@link TableProvider} to {@link Schema}. */
 public class BeamCalciteSchema implements Schema {
   private TableProvider tableProvider;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteSchemaFactory.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteSchemaFactory.java
@@ -28,18 +28,14 @@ import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.SchemaFactory;
 import org.apache.calcite.schema.SchemaPlus;
 
-/**
- * Factory that creates a {@link BeamCalciteSchema}.
- */
+/** Factory that creates a {@link BeamCalciteSchema}. */
 public class BeamCalciteSchemaFactory implements SchemaFactory {
   public static final BeamCalciteSchemaFactory INSTANCE = new BeamCalciteSchemaFactory();
 
-  private BeamCalciteSchemaFactory() {
-  }
+  private BeamCalciteSchemaFactory() {}
 
   @Override
-  public Schema create(SchemaPlus parentSchema, String name,
-      Map<String, Object> operand) {
+  public Schema create(SchemaPlus parentSchema, String name, Map<String, Object> operand) {
     MetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new BigQueryTableProvider());
     metaStore.registerProvider(new KafkaTableProvider());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamCalciteTable.java
@@ -38,9 +38,7 @@ import org.apache.calcite.schema.ModifiableTable;
 import org.apache.calcite.schema.SchemaPlus;
 import org.apache.calcite.schema.TranslatableTable;
 
-/**
- * Adapter from {@link BeamSqlTable} to a calcite Table.
- */
+/** Adapter from {@link BeamSqlTable} to a calcite Table. */
 class BeamCalciteTable extends AbstractQueryableTable
     implements ModifiableTable, TranslatableTable {
   private final BeamSqlTable beamTable;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -47,16 +47,12 @@ public class BeamSqlEnv {
     planner = new BeamQueryPlanner(connection);
   }
 
-  /**
-   * Register a UDF function which can be used in SQL expression.
-   */
+  /** Register a UDF function which can be used in SQL expression. */
   public void registerUdf(String functionName, Class<?> clazz, String method) {
     defaultSchema.add(functionName, ScalarFunctionImpl.create(clazz, method));
   }
 
-  /**
-   * Register a UDF function which can be used in SQL expression.
-   */
+  /** Register a UDF function which can be used in SQL expression. */
   public void registerUdf(String functionName, Class<? extends BeamSqlUdf> clazz) {
     registerUdf(functionName, clazz, BeamSqlUdf.UDF_METHOD);
   }
@@ -70,8 +66,8 @@ public class BeamSqlEnv {
   }
 
   /**
-   * Register a UDAF function which can be used in GROUP-BY expression.
-   * See {@link org.apache.beam.sdk.transforms.Combine.CombineFn} on how to implement a UDAF.
+   * Register a UDAF function which can be used in GROUP-BY expression. See {@link
+   * org.apache.beam.sdk.transforms.Combine.CombineFn} on how to implement a UDAF.
    */
   public void registerUdaf(String functionName, Combine.CombineFn combineFn) {
     defaultSchema.add(functionName, new UdafImpl(combineFn));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
@@ -30,9 +30,7 @@ import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
 
-/**
- * Calcite JDBC driver with Beam defaults.
- */
+/** Calcite JDBC driver with Beam defaults. */
 public class JdbcDriver extends Driver {
   public static final JdbcDriver INSTANCE = new JdbcDriver();
   public static final String CONNECT_STRING_PREFIX = "jdbc:beam:";
@@ -42,28 +40,31 @@ public class JdbcDriver extends Driver {
     INSTANCE.register();
   }
 
-  @Override protected String getConnectStringPrefix() {
+  @Override
+  protected String getConnectStringPrefix() {
     return CONNECT_STRING_PREFIX;
   }
 
-  @Override public Connection connect(String url, Properties info) throws SQLException {
+  @Override
+  public Connection connect(String url, Properties info) throws SQLException {
     final BeamCalciteSchema beamCalciteSchema = (BeamCalciteSchema) info.get(BEAM_CALCITE_SCHEMA);
 
     Properties info2 = new Properties(info);
     setDefault(info2, CalciteConnectionProperty.LEX, Lex.JAVA.name());
-    setDefault(info2, CalciteConnectionProperty.PARSER_FACTORY,
+    setDefault(
+        info2,
+        CalciteConnectionProperty.PARSER_FACTORY,
         BeamSqlParserImpl.class.getName() + "#FACTORY");
-    setDefault(info2, CalciteConnectionProperty.TYPE_SYSTEM,
-        BeamRelDataTypeSystem.class.getName());
+    setDefault(info2, CalciteConnectionProperty.TYPE_SYSTEM, BeamRelDataTypeSystem.class.getName());
     setDefault(info2, CalciteConnectionProperty.SCHEMA, "beam");
-    setDefault(info2, CalciteConnectionProperty.SCHEMA_FACTORY,
-        BeamCalciteSchemaFactory.class.getName());
+    setDefault(
+        info2, CalciteConnectionProperty.SCHEMA_FACTORY, BeamCalciteSchemaFactory.class.getName());
 
     CalciteConnection connection = (CalciteConnection) super.connect(url, info2);
     final SchemaPlus defaultSchema;
     if (beamCalciteSchema != null) {
-      defaultSchema = connection.getRootSchema()
-          .add(connection.config().schema(), beamCalciteSchema);
+      defaultSchema =
+          connection.getRootSchema().add(connection.config().schema(), beamCalciteSchema);
       connection.setSchema(defaultSchema.getName());
     } else {
       defaultSchema = getDefaultSchema(connection);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlExpressionExecutor.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlExpressionExecutor.java
@@ -23,21 +23,15 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 
 /**
- * {@code BeamSqlExpressionExecutor} fills the gap between relational
- * expressions in Calcite SQL and executable code.
- *
+ * {@code BeamSqlExpressionExecutor} fills the gap between relational expressions in Calcite SQL and
+ * executable code.
  */
 public interface BeamSqlExpressionExecutor extends Serializable {
 
-  /**
-   * invoked before data processing.
-   */
+  /** invoked before data processing. */
   void prepare();
 
-  /**
-   * apply transformation to input record {@link Row} with {@link BoundedWindow}.
-   *
-   */
+  /** apply transformation to input record {@link Row} with {@link BoundedWindow}. */
   List<Object> execute(Row inputRow, BoundedWindow window);
 
   void close();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
@@ -115,10 +115,9 @@ import org.apache.calcite.util.NlsString;
 import org.joda.time.DateTime;
 
 /**
- * Executor based on {@link BeamSqlExpression} and {@link BeamSqlPrimitive}.
- * {@code BeamSqlFnExecutor} converts a {@link BeamRelNode} to a {@link BeamSqlExpression},
- * which can be evaluated against the {@link Row}.
- *
+ * Executor based on {@link BeamSqlExpression} and {@link BeamSqlPrimitive}. {@code
+ * BeamSqlFnExecutor} converts a {@link BeamRelNode} to a {@link BeamSqlExpression}, which can be
+ * evaluated against the {@link Row}.
  */
 public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
   protected List<BeamSqlExpression> exps;
@@ -142,8 +141,8 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
   }
 
   /**
-   * {@link #buildExpression(RexNode)} visits the operands of {@link RexNode} recursively,
-   * and represent each {@link SqlOperator} with a corresponding {@link BeamSqlExpression}.
+   * {@link #buildExpression(RexNode)} visits the operands of {@link RexNode} recursively, and
+   * represent each {@link SqlOperator} with a corresponding {@link BeamSqlExpression}.
    */
   static BeamSqlExpression buildExpression(RexNode rexNode) {
     BeamSqlExpression ret = null;
@@ -152,8 +151,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
       SqlTypeName type = node.getTypeName();
       Object value = node.getValue();
 
-      if (SqlTypeName.CHAR_TYPES.contains(type)
-          && node.getValue() instanceof NlsString) {
+      if (SqlTypeName.CHAR_TYPES.contains(type) && node.getValue() instanceof NlsString) {
         // NlsString is not serializable, we need to convert
         // it to string explicitly.
         return BeamSqlPrimitive.of(type, ((NlsString) value).getValue());
@@ -190,8 +188,8 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
               realValue = rawValue;
               break;
             default:
-              throw new IllegalStateException("type/realType mismatch: "
-                  + type + " VS " + realType);
+              throw new IllegalStateException(
+                  "type/realType mismatch: " + type + " VS " + realType);
           }
         } else if (type == SqlTypeName.DOUBLE) {
           Double rawValue = (Double) value;
@@ -210,10 +208,8 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
       int nestedFieldIndex = fieldAccessNode.getField().getIndex();
       SqlTypeName nestedFieldType = fieldAccessNode.getField().getType().getSqlTypeName();
 
-      ret = new BeamSqlFieldAccessExpression(
-          referenceExpression,
-          nestedFieldIndex,
-          nestedFieldType);
+      ret =
+          new BeamSqlFieldAccessExpression(referenceExpression, nestedFieldIndex, nestedFieldType);
     } else if (rexNode instanceof RexCall) {
       RexCall node = (RexCall) rexNode;
       String opName = node.op.getName();
@@ -222,7 +218,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
         subExps.add(buildExpression(subNode));
       }
       switch (opName) {
-        // logical operators
+          // logical operators
         case "AND":
           ret = new BeamSqlAndExpression(subExps);
           break;
@@ -251,7 +247,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
           ret = new BeamSqlLessThanOrEqualsExpression(subExps);
           break;
 
-        // arithmetic operators
+          // arithmetic operators
         case "+":
           ret = new BeamSqlPlusExpression(subExps);
           break;
@@ -341,7 +337,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
           ret = new BeamSqlRandIntegerExpression(subExps);
           break;
 
-        // string operators
+          // string operators
         case "||":
           ret = new BeamSqlConcatExpression(subExps);
           break;
@@ -371,7 +367,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
           ret = new BeamSqlInitCapExpression(subExps);
           break;
 
-        // date functions
+          // date functions
         case "Reinterpret":
           return new BeamSqlReinterpretExpression(subExps, node.type.getSqlTypeName());
         case "CEIL":
@@ -404,24 +400,25 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
         case "DATETIME_PLUS":
           return new BeamSqlDatetimePlusExpression(subExps);
 
-        // array functions
+          // array functions
         case "ARRAY":
           return new BeamSqlArrayExpression(subExps);
-       // map functions
+          // map functions
         case "MAP":
           return new BeamSqlMapExpression(subExps);
 
         case "ITEM":
-        switch (subExps.get(0).getOutputType()) {
-        case MAP:
-          return new BeamSqlMapItemExpression(subExps, node.type.getSqlTypeName());
-        case ARRAY:
-          return new BeamSqlArrayItemExpression(subExps, node.type.getSqlTypeName());
-        default:
-          throw new UnsupportedOperationException("Operator: " + opName + " is not supported yet");
-        }
+          switch (subExps.get(0).getOutputType()) {
+            case MAP:
+              return new BeamSqlMapItemExpression(subExps, node.type.getSqlTypeName());
+            case ARRAY:
+              return new BeamSqlArrayItemExpression(subExps, node.type.getSqlTypeName());
+            default:
+              throw new UnsupportedOperationException(
+                  "Operator: " + opName + " is not supported yet");
+          }
 
-        // collections functions
+          // collections functions
         case "ELEMENT":
           return new BeamSqlSingleElementExpression(subExps, node.type.getSqlTypeName());
 
@@ -431,7 +428,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
         case "DOT":
           return new BeamSqlDotExpression(subExps, node.type.getSqlTypeName());
 
-        //DEFAULT keyword for UDF with optional parameter
+          //DEFAULT keyword for UDF with optional parameter
         case "DEFAULT":
           return new BeamSqlDefaultExpression();
 
@@ -469,8 +466,9 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
           if (((RexCall) rexNode).getOperator() instanceof SqlUserDefinedFunction) {
             SqlUserDefinedFunction udf = (SqlUserDefinedFunction) ((RexCall) rexNode).getOperator();
             ScalarFunctionImpl fn = (ScalarFunctionImpl) udf.getFunction();
-            ret = new BeamSqlUdfExpression(fn.method, subExps,
-              ((RexCall) rexNode).type.getSqlTypeName());
+            ret =
+                new BeamSqlUdfExpression(
+                    fn.method, subExps, ((RexCall) rexNode).type.getSqlTypeName());
           } else {
             throw new UnsupportedOperationException(
                 "Operator: " + opName + " is not supported yet");
@@ -482,21 +480,19 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
     }
 
     if (ret != null && !ret.accept()) {
-      throw new IllegalStateException(ret.getClass().getSimpleName()
-          + " does not accept the operands.(" + rexNode + ")");
+      throw new IllegalStateException(
+          ret.getClass().getSimpleName() + " does not accept the operands.(" + rexNode + ")");
     }
 
     return ret;
   }
 
   private static boolean isDateNode(SqlTypeName type, Object value) {
-    return (type == SqlTypeName.DATE || type == SqlTypeName.TIMESTAMP)
-        && value instanceof Calendar;
+    return (type == SqlTypeName.DATE || type == SqlTypeName.TIMESTAMP) && value instanceof Calendar;
   }
 
   @Override
-  public void prepare() {
-  }
+  public void prepare() {}
 
   @Override
   public List<Object> execute(Row inputRow, BoundedWindow window) {
@@ -508,7 +504,5 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
   }
 
   @Override
-  public void close() {
-  }
-
+  public void close() {}
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
@@ -23,16 +23,15 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- *  {@code BeamSqlCaseExpression} represents CASE, NULLIF, COALESCE in SQL.
- */
+/** {@code BeamSqlCaseExpression} represents CASE, NULLIF, COALESCE in SQL. */
 public class BeamSqlCaseExpression extends BeamSqlExpression {
   public BeamSqlCaseExpression(List<BeamSqlExpression> operands) {
     // the return type of CASE is the type of the `else` condition
     super(operands, operands.get(operands.size() - 1).getOutputType());
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     // `when`-`then` pair + `else`
     if (operands.size() % 2 != 1) {
       return false;
@@ -49,17 +48,14 @@ public class BeamSqlCaseExpression extends BeamSqlExpression {
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     for (int i = 0; i < operands.size() - 1; i += 2) {
       Boolean wasOpEvaluated = opValueEvaluated(i, inputRow, window);
       if (wasOpEvaluated != null && wasOpEvaluated) {
-        return BeamSqlPrimitive.of(
-            outputType,
-            opValueEvaluated(i + 1, inputRow, window)
-        );
+        return BeamSqlPrimitive.of(outputType, opValueEvaluated(i + 1, inputRow, window));
       }
     }
-    return BeamSqlPrimitive.of(outputType,
-        opValueEvaluated(operands.size() - 1, inputRow, window));
+    return BeamSqlPrimitive.of(outputType, opValueEvaluated(operands.size() - 1, inputRow, window));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
@@ -29,35 +29,38 @@ import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.DateTimeParser;
 
-/**
- * Base class to support 'CAST' operations for all {@link SqlTypeName}.
- */
-public class  BeamSqlCastExpression extends BeamSqlExpression {
+/** Base class to support 'CAST' operations for all {@link SqlTypeName}. */
+public class BeamSqlCastExpression extends BeamSqlExpression {
 
   private static final int index = 0;
   /**
-   * Date and Timestamp formats used to parse
-   * {@link SqlTypeName#DATE}, {@link SqlTypeName#TIMESTAMP}.
+   * Date and Timestamp formats used to parse {@link SqlTypeName#DATE}, {@link
+   * SqlTypeName#TIMESTAMP}.
    */
-  private static final DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
-      .append(null/*printer*/, new DateTimeParser[] {
-          // date formats
-          DateTimeFormat.forPattern("yy-MM-dd").getParser(),
-          DateTimeFormat.forPattern("yy/MM/dd").getParser(),
-          DateTimeFormat.forPattern("yy.MM.dd").getParser(),
-          DateTimeFormat.forPattern("yyMMdd").getParser(),
-          DateTimeFormat.forPattern("yyyyMMdd").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd").getParser(),
-          DateTimeFormat.forPattern("yyyy/MM/dd").getParser(),
-          DateTimeFormat.forPattern("yyyy.MM.dd").getParser(),
-          // datetime formats
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ssz").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss z").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSSz").getParser(),
-          DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS z").getParser() }).toFormatter()
-      .withPivotYear(2020);
+  private static final DateTimeFormatter dateTimeFormatter =
+      new DateTimeFormatterBuilder()
+          .append(
+              null /*printer*/,
+              new DateTimeParser[] {
+                // date formats
+                DateTimeFormat.forPattern("yy-MM-dd").getParser(),
+                DateTimeFormat.forPattern("yy/MM/dd").getParser(),
+                DateTimeFormat.forPattern("yy.MM.dd").getParser(),
+                DateTimeFormat.forPattern("yyMMdd").getParser(),
+                DateTimeFormat.forPattern("yyyyMMdd").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd").getParser(),
+                DateTimeFormat.forPattern("yyyy/MM/dd").getParser(),
+                DateTimeFormat.forPattern("yyyy.MM.dd").getParser(),
+                // datetime formats
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ssz").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss z").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSSz").getParser(),
+                DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSSSSSSSS z").getParser()
+              })
+          .toFormatter()
+          .withPivotYear(2020);
 
   public BeamSqlCastExpression(List<BeamSqlExpression> operands, SqlTypeName castType) {
     super(operands, castType);
@@ -73,38 +76,42 @@ public class  BeamSqlCastExpression extends BeamSqlExpression {
     SqlTypeName castOutputType = getOutputType();
     switch (castOutputType) {
       case INTEGER:
-        return BeamSqlPrimitive
-            .of(SqlTypeName.INTEGER,
-                    SqlFunctions.toInt((Object) opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.INTEGER,
+            SqlFunctions.toInt((Object) opValueEvaluated(index, inputRow, window)));
       case DOUBLE:
-        return BeamSqlPrimitive.of(SqlTypeName.DOUBLE,
+        return BeamSqlPrimitive.of(
+            SqlTypeName.DOUBLE,
             SqlFunctions.toDouble((Object) opValueEvaluated(index, inputRow, window)));
       case SMALLINT:
-        return BeamSqlPrimitive.of(SqlTypeName.SMALLINT,
+        return BeamSqlPrimitive.of(
+            SqlTypeName.SMALLINT,
             SqlFunctions.toShort((Object) opValueEvaluated(index, inputRow, window)));
       case TINYINT:
-        return BeamSqlPrimitive.of(SqlTypeName.TINYINT,
-            SqlFunctions.toByte(opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.TINYINT, SqlFunctions.toByte(opValueEvaluated(index, inputRow, window)));
       case BIGINT:
-        return BeamSqlPrimitive
-            .of(SqlTypeName.BIGINT,
-                    SqlFunctions.toLong((Object) opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.BIGINT,
+            SqlFunctions.toLong((Object) opValueEvaluated(index, inputRow, window)));
       case DECIMAL:
-        return BeamSqlPrimitive.of(SqlTypeName.DECIMAL,
+        return BeamSqlPrimitive.of(
+            SqlTypeName.DECIMAL,
             SqlFunctions.toBigDecimal((Object) opValueEvaluated(index, inputRow, window)));
       case FLOAT:
-        return BeamSqlPrimitive.of(SqlTypeName.FLOAT,
-                SqlFunctions.toFloat((Object) opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.FLOAT,
+            SqlFunctions.toFloat((Object) opValueEvaluated(index, inputRow, window)));
       case CHAR:
       case VARCHAR:
-        return BeamSqlPrimitive
-            .of(SqlTypeName.VARCHAR, opValueEvaluated(index, inputRow, window).toString());
+        return BeamSqlPrimitive.of(
+            SqlTypeName.VARCHAR, opValueEvaluated(index, inputRow, window).toString());
       case DATE:
-        return BeamSqlPrimitive.of(SqlTypeName.DATE,
-            toDate(opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.DATE, toDate(opValueEvaluated(index, inputRow, window)));
       case TIMESTAMP:
-        return BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-            toTimeStamp(opValueEvaluated(index, inputRow, window)));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.TIMESTAMP, toTimeStamp(opValueEvaluated(index, inputRow, window)));
     }
     throw new UnsupportedOperationException(
         String.format("Cast to type %s not supported", castOutputType));
@@ -112,11 +119,12 @@ public class  BeamSqlCastExpression extends BeamSqlExpression {
 
   private ReadableInstant toDate(Object inputDate) {
     return dateTimeFormatter.parseLocalDate(inputDate.toString()).toDateTimeAtStartOfDay();
-
   }
 
   private ReadableInstant toTimeStamp(Object inputTimestamp) {
-    return dateTimeFormatter.parseDateTime(inputTimestamp.toString()).secondOfMinute()
+    return dateTimeFormatter
+        .parseDateTime(inputTimestamp.toString())
+        .secondOfMinute()
         .roundCeilingCopy();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDefaultExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDefaultExpression.java
@@ -21,9 +21,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * DEFAULT keyword for UDF with optional parameter.
- */
+/** DEFAULT keyword for UDF with optional parameter. */
 public class BeamSqlDefaultExpression extends BeamSqlExpression {
 
   @Override
@@ -35,5 +33,4 @@ public class BeamSqlDefaultExpression extends BeamSqlExpression {
   public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     return BeamSqlPrimitive.of(SqlTypeName.ANY, null);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpression.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Implements DOT operator to access fields of dynamic ROWs.
- */
+/** Implements DOT operator to access fields of dynamic ROWs. */
 public class BeamSqlDotExpression extends BeamSqlExpression {
 
   public BeamSqlDotExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
@@ -35,8 +33,7 @@ public class BeamSqlDotExpression extends BeamSqlExpression {
 
   @Override
   public boolean accept() {
-    return
-        operands.size() == 2
+    return operands.size() == 2
         && SqlTypeName.ROW.equals(operands.get(0).getOutputType())
         && (SqlTypeName.VARCHAR.equals(operands.get(1).getOutputType())
             || SqlTypeName.CHAR.equals(operands.get(1).getOutputType()));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
@@ -27,15 +27,14 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * {@code BeamSqlExpression} is an equivalent expression in BeamSQL, of {@link RexNode} in Calcite.
  *
- * <p>An implementation of {@link BeamSqlExpression} takes one or more {@code BeamSqlExpression}
- * as its operands, and return a value with type {@link SqlTypeName}.
- *
+ * <p>An implementation of {@link BeamSqlExpression} takes one or more {@code BeamSqlExpression} as
+ * its operands, and return a value with type {@link SqlTypeName}.
  */
 public abstract class BeamSqlExpression implements Serializable {
   protected List<BeamSqlExpression> operands;
   protected SqlTypeName outputType;
 
-  protected BeamSqlExpression(){}
+  protected BeamSqlExpression() {}
 
   public BeamSqlExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     this.operands = operands;
@@ -54,14 +53,12 @@ public abstract class BeamSqlExpression implements Serializable {
     return (T) op(idx).evaluate(row, window).getValue();
   }
 
-  /**
-   * assertion to make sure the input and output are supported in this expression.
-   */
+  /** assertion to make sure the input and output are supported in this expression. */
   public abstract boolean accept();
 
   /**
-   * Apply input record {@link Row} with {@link BoundedWindow} to this expression,
-   * the output value is wrapped with {@link BeamSqlPrimitive}.
+   * Apply input record {@link Row} with {@link BoundedWindow} to this expression, the output value
+   * is wrapped with {@link BeamSqlPrimitive}.
    */
   public abstract BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window);
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
@@ -21,9 +21,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * A primitive operation for direct field extraction.
- */
+/** A primitive operation for direct field extraction. */
 public class BeamSqlInputRefExpression extends BeamSqlExpression {
   private int inputRef;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
@@ -27,17 +27,15 @@ import org.apache.calcite.util.NlsString;
 import org.joda.time.ReadableInstant;
 
 /**
- * {@link BeamSqlPrimitive} is a special, self-reference {@link BeamSqlExpression}.
- * It holds the value, and return it directly during {@link #evaluate(Row, BoundedWindow)}.
- *
+ * {@link BeamSqlPrimitive} is a special, self-reference {@link BeamSqlExpression}. It holds the
+ * value, and return it directly during {@link #evaluate(Row, BoundedWindow)}.
  */
 public class BeamSqlPrimitive<T> extends BeamSqlExpression {
   private T value;
 
-  private BeamSqlPrimitive() {
-  }
+  private BeamSqlPrimitive() {}
 
-  private  BeamSqlPrimitive(T value, SqlTypeName typeName) {
+  private BeamSqlPrimitive(T value, SqlTypeName typeName) {
     this.outputType = typeName;
     this.value = value;
     if (!accept()) {
@@ -50,9 +48,7 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
     super(operands, outputType);
   }
 
-  /**
-   * A builder function to create from Type and value directly.
-   */
+  /** A builder function to create from Type and value directly. */
   public static <T> BeamSqlPrimitive<T> of(SqlTypeName outputType, T value) {
     return new BeamSqlPrimitive<>(value, outputType);
   }
@@ -88,6 +84,7 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
   public byte getByte() {
     return (Byte) getValue();
   }
+
   public boolean getBoolean() {
     return (Boolean) getValue();
   }
@@ -111,49 +108,49 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
     }
 
     switch (outputType) {
-    case BIGINT:
-      return value instanceof Long;
-    case DECIMAL:
-      return value instanceof BigDecimal;
-    case DOUBLE:
-      return value instanceof Double;
-    case FLOAT:
-      return value instanceof Float;
-    case INTEGER:
-      return value instanceof Integer;
-    case SMALLINT:
-      return value instanceof Short;
-    case TINYINT:
-      return value instanceof Byte;
-    case BOOLEAN:
-      return value instanceof Boolean;
-    case CHAR:
-    case VARCHAR:
-      return value instanceof String || value instanceof NlsString;
-    case TIME:
-      return value instanceof ReadableInstant;
-    case TIMESTAMP:
-    case DATE:
-      return value instanceof ReadableInstant;
-    case INTERVAL_SECOND:
-    case INTERVAL_MINUTE:
-    case INTERVAL_HOUR:
-    case INTERVAL_DAY:
-    case INTERVAL_MONTH:
-    case INTERVAL_YEAR:
-      return value instanceof BigDecimal;
-    case SYMBOL:
-      // for SYMBOL, it supports anything...
-      return true;
-    case ARRAY:
-      return value instanceof List;
-    case MAP:
-      return value instanceof Map;
-    case ROW:
-      return value instanceof Row;
-    default:
-      throw new UnsupportedOperationException(
-          "Unsupported Beam SQL type in expression: " + outputType.name());
+      case BIGINT:
+        return value instanceof Long;
+      case DECIMAL:
+        return value instanceof BigDecimal;
+      case DOUBLE:
+        return value instanceof Double;
+      case FLOAT:
+        return value instanceof Float;
+      case INTEGER:
+        return value instanceof Integer;
+      case SMALLINT:
+        return value instanceof Short;
+      case TINYINT:
+        return value instanceof Byte;
+      case BOOLEAN:
+        return value instanceof Boolean;
+      case CHAR:
+      case VARCHAR:
+        return value instanceof String || value instanceof NlsString;
+      case TIME:
+        return value instanceof ReadableInstant;
+      case TIMESTAMP:
+      case DATE:
+        return value instanceof ReadableInstant;
+      case INTERVAL_SECOND:
+      case INTERVAL_MINUTE:
+      case INTERVAL_HOUR:
+      case INTERVAL_DAY:
+      case INTERVAL_MONTH:
+      case INTERVAL_YEAR:
+        return value instanceof BigDecimal;
+      case SYMBOL:
+        // for SYMBOL, it supports anything...
+        return true;
+      case ARRAY:
+        return value instanceof List;
+      case MAP:
+        return value instanceof Map;
+      case ROW:
+        return value instanceof Row;
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported Beam SQL type in expression: " + outputType.name());
     }
   }
 
@@ -161,5 +158,4 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
   public BeamSqlPrimitive<T> evaluate(Row inputRow, BoundedWindow window) {
     return this;
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
@@ -25,9 +25,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * invoke a UDF function.
- */
+/** invoke a UDF function. */
 public class BeamSqlUdfExpression extends BeamSqlExpression {
   //as Method is not Serializable, need to keep class/method information, and rebuild it.
   private transient Method method;
@@ -36,8 +34,8 @@ public class BeamSqlUdfExpression extends BeamSqlExpression {
   private String methodName;
   private List<String> paraClassName = new ArrayList<>();
 
-  public BeamSqlUdfExpression(Method method, List<BeamSqlExpression> subExps,
-      SqlTypeName sqlTypeName) {
+  public BeamSqlUdfExpression(
+      Method method, List<BeamSqlExpression> subExps, SqlTypeName sqlTypeName) {
     super(subExps, sqlTypeName);
     this.method = method;
 
@@ -64,16 +62,14 @@ public class BeamSqlUdfExpression extends BeamSqlExpression {
         paras.add(e.evaluate(inputRow, window).getValue());
       }
 
-      return BeamSqlPrimitive.of(getOutputType(),
-          method.invoke(udfIns, paras.toArray(new Object[]{})));
+      return BeamSqlPrimitive.of(
+          getOutputType(), method.invoke(udfIns, paras.toArray(new Object[] {})));
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
   }
 
-  /**
-   * re-construct method from class/method.
-   */
+  /** re-construct method from class/method. */
   private void reConstructMethod() {
     try {
       List<Class<?>> paraClass = new ArrayList<>();
@@ -88,5 +84,4 @@ public class BeamSqlUdfExpression extends BeamSqlExpression {
       throw new RuntimeException(e);
     }
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowEndExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowEndExpression.java
@@ -38,12 +38,11 @@ public class BeamSqlWindowEndExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive<DateTime> evaluate(Row inputRow, BoundedWindow window) {
     if (window instanceof IntervalWindow) {
-      return BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-          new DateTime(((IntervalWindow) window).end()));
+      return BeamSqlPrimitive.of(
+          SqlTypeName.TIMESTAMP, new DateTime(((IntervalWindow) window).end()));
     } else {
       throw new UnsupportedOperationException(
           "Cannot run HOP_END|TUMBLE_END|SESSION_END on GlobalWindow.");
     }
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowExpression.java
@@ -26,8 +26,8 @@ import org.joda.time.ReadableInstant;
 /**
  * {@code BeamSqlExpression} for {@code HOP}, {@code TUMBLE}, {@code SESSION} operation.
  *
- * <p>These functions don't change the timestamp field, instead it's used to indicate
- * the event_timestamp field, and how the window is defined.
+ * <p>These functions don't change the timestamp field, instead it's used to indicate the
+ * event_timestamp field, and how the window is defined.
  */
 public class BeamSqlWindowExpression extends BeamSqlExpression {
 
@@ -44,8 +44,8 @@ public class BeamSqlWindowExpression extends BeamSqlExpression {
 
   @Override
   public BeamSqlPrimitive<ReadableInstant> evaluate(Row inputRow, BoundedWindow window) {
-    return BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
+    return BeamSqlPrimitive.of(
+        SqlTypeName.TIMESTAMP,
         (ReadableInstant) operands.get(0).evaluate(inputRow, window).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowStartExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlWindowStartExpression.java
@@ -24,8 +24,8 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 
 /**
- * {@code BeamSqlExpression} for {@code HOP_START}, {@code TUMBLE_START},
- * {@code SESSION_START} operation.
+ * {@code BeamSqlExpression} for {@code HOP_START}, {@code TUMBLE_START}, {@code SESSION_START}
+ * operation.
  *
  * <p>These operators returns the <em>start</em> timestamp of window.
  */
@@ -39,12 +39,11 @@ public class BeamSqlWindowStartExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive<DateTime> evaluate(Row inputRow, BoundedWindow window) {
     if (window instanceof IntervalWindow) {
-      return BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-          new DateTime(((IntervalWindow) window).start()));
+      return BeamSqlPrimitive.of(
+          SqlTypeName.TIMESTAMP, new DateTime(((IntervalWindow) window).start()));
     } else {
       throw new UnsupportedOperationException(
           "Cannot run HOP_START|TUMBLE_START|SESSION_START on GlobalWindow.");
     }
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/UdafImpl.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/UdafImpl.java
@@ -29,11 +29,9 @@ import org.apache.calcite.schema.AggregateFunction;
 import org.apache.calcite.schema.FunctionParameter;
 import org.apache.calcite.schema.ImplementableAggFunction;
 
-/**
- * Implement {@link AggregateFunction} to take a {@link CombineFn} as UDAF.
- */
+/** Implement {@link AggregateFunction} to take a {@link CombineFn} as UDAF. */
 public final class UdafImpl<InputT, AccumT, OutputT>
-    implements AggregateFunction, ImplementableAggFunction, Serializable{
+    implements AggregateFunction, ImplementableAggFunction, Serializable {
   private CombineFn<InputT, AccumT, OutputT> combineFn;
 
   public UdafImpl(CombineFn<InputT, AccumT, OutputT> combineFn) {
@@ -47,7 +45,8 @@ public final class UdafImpl<InputT, AccumT, OutputT>
   @Override
   public List<FunctionParameter> getParameters() {
     List<FunctionParameter> para = new ArrayList<>();
-    para.add(new FunctionParameter() {
+    para.add(
+        new FunctionParameter() {
           public int getOrdinal() {
             return 0; //up to one parameter is supported in UDAF.
           }
@@ -60,7 +59,7 @@ public final class UdafImpl<InputT, AccumT, OutputT>
           public RelDataType getType(RelDataTypeFactory typeFactory) {
             ParameterizedType parameterizedType = findCombineFnSuperClass();
             return typeFactory.createJavaType(
-              (Class) parameterizedType.getActualTypeArguments()[0]);
+                (Class) parameterizedType.getActualTypeArguments()[0]);
           }
 
           private ParameterizedType findCombineFnSuperClass() {
@@ -96,4 +95,3 @@ public final class UdafImpl<InputT, AccumT, OutputT>
     return typeFactory.createJavaType((Class) combineFn.getOutputType().getType());
   }
 }
-

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
@@ -28,11 +28,10 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Base class for all arithmetic operators.
- */
+/** Base class for all arithmetic operators. */
 public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
   private static final List<SqlTypeName> ORDERED_APPROX_TYPES = new ArrayList<>();
+
   static {
     ORDERED_APPROX_TYPES.add(SqlTypeName.TINYINT);
     ORDERED_APPROX_TYPES.add(SqlTypeName.SMALLINT);
@@ -44,16 +43,17 @@ public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
   }
 
   protected BeamSqlArithmeticExpression(List<BeamSqlExpression> operands) {
-    super(operands, deduceOutputType(operands.get(0).getOutputType(),
-        operands.get(1).getOutputType()));
+    super(
+        operands,
+        deduceOutputType(operands.get(0).getOutputType(), operands.get(1).getOutputType()));
   }
 
   protected BeamSqlArithmeticExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow,
-      BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
     BigDecimal left = SqlFunctions.toBigDecimal((Object) opValueEvaluated(0, inputRow, window));
     BigDecimal right = SqlFunctions.toBigDecimal((Object) opValueEvaluated(1, inputRow, window));
 
@@ -80,7 +80,8 @@ public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
     }
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() != 2) {
       return false;
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlDivideExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlDivideExpression.java
@@ -23,15 +23,14 @@ import java.math.RoundingMode;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * '/' operator.
- */
+/** '/' operator. */
 public class BeamSqlDivideExpression extends BeamSqlArithmeticExpression {
   public BeamSqlDivideExpression(List<BeamSqlExpression> operands) {
     super(operands);
   }
 
-  @Override protected BigDecimal calc(BigDecimal left, BigDecimal right) {
+  @Override
+  protected BigDecimal calc(BigDecimal left, BigDecimal right) {
     return left.divide(right, 10, RoundingMode.HALF_EVEN);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlMinusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlMinusExpression.java
@@ -22,15 +22,14 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * '-' operator.
- */
+/** '-' operator. */
 public class BeamSqlMinusExpression extends BeamSqlArithmeticExpression {
   public BeamSqlMinusExpression(List<BeamSqlExpression> operands) {
     super(operands);
   }
 
-  @Override protected BigDecimal calc(BigDecimal left, BigDecimal right) {
+  @Override
+  protected BigDecimal calc(BigDecimal left, BigDecimal right) {
     return left.subtract(right);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlModExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlModExpression.java
@@ -22,15 +22,14 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * '%' operator.
- */
+/** '%' operator. */
 public class BeamSqlModExpression extends BeamSqlArithmeticExpression {
   public BeamSqlModExpression(List<BeamSqlExpression> operands) {
     super(operands, operands.get(1).getOutputType());
   }
 
-  @Override protected BigDecimal calc(BigDecimal left, BigDecimal right) {
+  @Override
+  protected BigDecimal calc(BigDecimal left, BigDecimal right) {
     return BigDecimal.valueOf(left.doubleValue() % right.doubleValue());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlMultiplyExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlMultiplyExpression.java
@@ -22,15 +22,14 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * '*' operator.
- */
+/** '*' operator. */
 public class BeamSqlMultiplyExpression extends BeamSqlArithmeticExpression {
   public BeamSqlMultiplyExpression(List<BeamSqlExpression> operands) {
     super(operands);
   }
 
-  @Override protected BigDecimal calc(BigDecimal left, BigDecimal right) {
+  @Override
+  protected BigDecimal calc(BigDecimal left, BigDecimal right) {
     return left.multiply(right);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlPlusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlPlusExpression.java
@@ -22,15 +22,14 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * '+' operator.
- */
+/** '+' operator. */
 public class BeamSqlPlusExpression extends BeamSqlArithmeticExpression {
   public BeamSqlPlusExpression(List<BeamSqlExpression> operands) {
     super(operands);
   }
 
-  @Override protected BigDecimal calc(BigDecimal left, BigDecimal right) {
+  @Override
+  protected BigDecimal calc(BigDecimal left, BigDecimal right) {
     return left.add(right);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Arithmetic operators.
- */
+/** Arithmetic operators. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.arithmetic;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpression.java
@@ -26,9 +26,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Represents ARRAY expression in SQL.
- */
+/** Represents ARRAY expression in SQL. */
 public class BeamSqlArrayExpression extends BeamSqlExpression {
   public BeamSqlArrayExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.ARRAY);
@@ -36,12 +34,7 @@ public class BeamSqlArrayExpression extends BeamSqlExpression {
 
   @Override
   public boolean accept() {
-    return
-        operands
-            .stream()
-            .map(BeamSqlExpression::getOutputType)
-            .distinct()
-            .count() == 1;
+    return operands.stream().map(BeamSqlExpression::getOutputType).distinct().count() == 1;
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
@@ -24,14 +24,10 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Implements array element access expression.
- */
+/** Implements array element access expression. */
 public class BeamSqlArrayItemExpression extends BeamSqlExpression {
 
-  public BeamSqlArrayItemExpression(
-      List<BeamSqlExpression> operands,
-      SqlTypeName sqlTypeName) {
+  public BeamSqlArrayItemExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
 
     super(operands, sqlTypeName);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/package-info.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * Expressions implementing array operations.
- */
+/** Expressions implementing array operations. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.array;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
@@ -26,14 +26,12 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 /**
- * Implements CARDINALITY(collection) operation which returns
- * the number of elements in the collection.
+ * Implements CARDINALITY(collection) operation which returns the number of elements in the
+ * collection.
  */
 public class BeamSqlCardinalityExpression extends BeamSqlExpression {
 
-  public BeamSqlCardinalityExpression(
-      List<BeamSqlExpression> operands,
-      SqlTypeName sqlTypeName) {
+  public BeamSqlCardinalityExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
 
     super(operands, sqlTypeName);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
@@ -32,9 +32,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
  */
 public class BeamSqlSingleElementExpression extends BeamSqlExpression {
 
-  public BeamSqlSingleElementExpression(
-      List<BeamSqlExpression> operands,
-      SqlTypeName sqlTypeName) {
+  public BeamSqlSingleElementExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
 
     super(operands, sqlTypeName);
   }
@@ -56,9 +54,9 @@ public class BeamSqlSingleElementExpression extends BeamSqlExpression {
 
     throw new IllegalArgumentException(
         "ELEMENT expression accepts either empty collections "
-        + "or collections with a single element. "
-        + "Received collection with "
-        + collection.size()
-        + " elements");
+            + "or collections with a single element. "
+            + "Received collection with "
+            + collection.size()
+            + " elements");
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/package-info.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * Expressions implementing collections operations.
- */
+/** Expressions implementing collections operations. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.collection;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
@@ -27,11 +27,9 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * {@link BeamSqlCompareExpression} is used for compare operations.
  *
- * <p>See {@link BeamSqlEqualsExpression}, {@link BeamSqlLessThanExpression},
- * {@link BeamSqlLessThanOrEqualsExpression}, {@link BeamSqlGreaterThanExpression},
- * {@link BeamSqlGreaterThanOrEqualsExpression} and {@link BeamSqlNotEqualsExpression}
- * for more details.
- *
+ * <p>See {@link BeamSqlEqualsExpression}, {@link BeamSqlLessThanExpression}, {@link
+ * BeamSqlLessThanOrEqualsExpression}, {@link BeamSqlGreaterThanExpression}, {@link
+ * BeamSqlGreaterThanOrEqualsExpression} and {@link BeamSqlNotEqualsExpression} for more details.
  */
 public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
 
@@ -43,9 +41,7 @@ public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
     this(operands, SqlTypeName.BOOLEAN);
   }
 
-  /**
-   * Compare operation must have 2 operands.
-   */
+  /** Compare operation must have 2 operands. */
   @Override
   public boolean accept() {
     return operands.size() == 2;
@@ -56,42 +52,36 @@ public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
     Object leftValue = operands.get(0).evaluate(inputRow, window).getValue();
     Object rightValue = operands.get(1).evaluate(inputRow, window).getValue();
     switch (operands.get(0).getOutputType()) {
-    case BIGINT:
-    case DECIMAL:
-    case DOUBLE:
-    case FLOAT:
-    case INTEGER:
-    case SMALLINT:
-    case TINYINT:
-      return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN,
-          compare((Number) leftValue, (Number) rightValue));
-    case BOOLEAN:
-      return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN,
-          compare((Boolean) leftValue, (Boolean) rightValue));
-    case VARCHAR:
-      return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN,
-          compare((CharSequence) leftValue, (CharSequence) rightValue));
-    default:
-      throw new UnsupportedOperationException(toString());
+      case BIGINT:
+      case DECIMAL:
+      case DOUBLE:
+      case FLOAT:
+      case INTEGER:
+      case SMALLINT:
+      case TINYINT:
+        return BeamSqlPrimitive.of(
+            SqlTypeName.BOOLEAN, compare((Number) leftValue, (Number) rightValue));
+      case BOOLEAN:
+        return BeamSqlPrimitive.of(
+            SqlTypeName.BOOLEAN, compare((Boolean) leftValue, (Boolean) rightValue));
+      case VARCHAR:
+        return BeamSqlPrimitive.of(
+            SqlTypeName.BOOLEAN, compare((CharSequence) leftValue, (CharSequence) rightValue));
+      default:
+        throw new UnsupportedOperationException(toString());
     }
   }
 
-  /**
-   * Compare between String values, mapping to {@link SqlTypeName#VARCHAR}.
-   */
+  /** Compare between String values, mapping to {@link SqlTypeName#VARCHAR}. */
   public abstract Boolean compare(CharSequence leftValue, CharSequence rightValue);
 
-  /**
-   * Compare between Boolean values, mapping to {@link SqlTypeName#BOOLEAN}.
-   */
+  /** Compare between Boolean values, mapping to {@link SqlTypeName#BOOLEAN}. */
   public abstract Boolean compare(Boolean leftValue, Boolean rightValue);
 
   /**
-   * Compare between Number values, including {@link SqlTypeName#BIGINT},
-   * {@link SqlTypeName#DECIMAL}, {@link SqlTypeName#DOUBLE}, {@link SqlTypeName#FLOAT},
-   * {@link SqlTypeName#INTEGER}, {@link SqlTypeName#SMALLINT} and {@link SqlTypeName#TINYINT}.
+   * Compare between Number values, including {@link SqlTypeName#BIGINT}, {@link
+   * SqlTypeName#DECIMAL}, {@link SqlTypeName#DOUBLE}, {@link SqlTypeName#FLOAT}, {@link
+   * SqlTypeName#INTEGER}, {@link SqlTypeName#SMALLINT} and {@link SqlTypeName#TINYINT}.
    */
   public abstract Boolean compare(Number leftValue, Number rightValue);
-
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlEqualsExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code =} operation.
- */
+/** {@code BeamSqlExpression} for {@code =} operation. */
 public class BeamSqlEqualsExpression extends BeamSqlCompareExpression {
 
   public BeamSqlEqualsExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlEqualsExpression extends BeamSqlCompareExpression {
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() == (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() == (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code >} operation.
- */
+/** {@code BeamSqlExpression} for {@code >} operation. */
 public class BeamSqlGreaterThanExpression extends BeamSqlCompareExpression {
 
   public BeamSqlGreaterThanExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlGreaterThanExpression extends BeamSqlCompareExpression {
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() > (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() > (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanOrEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanOrEqualsExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code >=} operation.
- */
+/** {@code BeamSqlExpression} for {@code >=} operation. */
 public class BeamSqlGreaterThanOrEqualsExpression extends BeamSqlCompareExpression {
 
   public BeamSqlGreaterThanOrEqualsExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlGreaterThanOrEqualsExpression extends BeamSqlCompareExpressi
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() >= (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() >= (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNotNullExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNotNullExpression.java
@@ -25,9 +25,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlExpression} for 'IS NOT NULL' operation.
- */
+/** {@code BeamSqlExpression} for 'IS NOT NULL' operation. */
 public class BeamSqlIsNotNullExpression extends BeamSqlExpression {
 
   private BeamSqlIsNotNullExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
@@ -38,9 +36,7 @@ public class BeamSqlIsNotNullExpression extends BeamSqlExpression {
     this(Arrays.asList(operand), SqlTypeName.BOOLEAN);
   }
 
-  /**
-   * only one operand is required.
-   */
+  /** only one operand is required. */
   @Override
   public boolean accept() {
     return operands.size() == 1;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNullExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlIsNullExpression.java
@@ -25,9 +25,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlExpression} for 'IS NULL' operation.
- */
+/** {@code BeamSqlExpression} for 'IS NULL' operation. */
 public class BeamSqlIsNullExpression extends BeamSqlExpression {
 
   private BeamSqlIsNullExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
@@ -38,9 +36,7 @@ public class BeamSqlIsNullExpression extends BeamSqlExpression {
     this(Arrays.asList(operand), SqlTypeName.BOOLEAN);
   }
 
-  /**
-   * only one operand is required.
-   */
+  /** only one operand is required. */
   @Override
   public boolean accept() {
     return operands.size() == 1;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code <} operation.
- */
+/** {@code BeamSqlExpression} for {@code <} operation. */
 public class BeamSqlLessThanExpression extends BeamSqlCompareExpression {
 
   public BeamSqlLessThanExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlLessThanExpression extends BeamSqlCompareExpression {
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() < (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() < (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanOrEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanOrEqualsExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code <=} operation.
- */
+/** {@code BeamSqlExpression} for {@code <=} operation. */
 public class BeamSqlLessThanOrEqualsExpression extends BeamSqlCompareExpression {
 
   public BeamSqlLessThanOrEqualsExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlLessThanOrEqualsExpression extends BeamSqlCompareExpression 
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() <= (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() <= (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlNotEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlNotEqualsExpression.java
@@ -20,9 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 
-/**
- * {@code BeamSqlExpression} for {@code <>} operation.
- */
+/** {@code BeamSqlExpression} for {@code <>} operation. */
 public class BeamSqlNotEqualsExpression extends BeamSqlCompareExpression {
 
   public BeamSqlNotEqualsExpression(List<BeamSqlExpression> operands) {
@@ -42,8 +40,8 @@ public class BeamSqlNotEqualsExpression extends BeamSqlCompareExpression {
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     return (leftValue == null && rightValue == null)
-        || (leftValue != null && rightValue != null
-              && leftValue.floatValue() != (rightValue).floatValue());
+        || (leftValue != null
+            && rightValue != null
+            && leftValue.floatValue() != (rightValue).floatValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Comparison operators.
- */
+/** Comparison operators. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpression.java
@@ -36,11 +36,13 @@ public class BeamSqlCurrentDateExpression extends BeamSqlExpression {
     super(Collections.emptyList(), SqlTypeName.DATE);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     return getOperands().isEmpty();
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpression.java
@@ -39,12 +39,14 @@ public class BeamSqlCurrentTimeExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.TIME);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     int opCount = getOperands().size();
     return opCount <= 1;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpression.java
@@ -39,12 +39,14 @@ public class BeamSqlCurrentTimestampExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.TIMESTAMP);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     int opCount = getOperands().size();
     return opCount <= 1;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     return BeamSqlPrimitive.of(outputType, DateTime.now());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
@@ -39,12 +39,13 @@ public class BeamSqlDateCeilExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.TIMESTAMP);
   }
 
-  @Override public boolean accept() {
-    return operands.size() == 2
-        && opType(1) == SqlTypeName.SYMBOL;
+  @Override
+  public boolean accept() {
+    return operands.size() == 2 && opType(1) == SqlTypeName.SYMBOL;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     ReadableInstant date = opValueEvaluated(0, inputRow, window);
     long time = date.getMillis();
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(1)).getValue();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
@@ -39,12 +39,13 @@ public class BeamSqlDateFloorExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.DATE);
   }
 
-  @Override public boolean accept() {
-    return operands.size() == 2
-        && opType(1) == SqlTypeName.SYMBOL;
+  @Override
+  public boolean accept() {
+    return operands.size() == 2 && opType(1) == SqlTypeName.SYMBOL;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     ReadableInstant date = opValueEvaluated(0, inputRow, window);
     long time = date.getMillis();
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(1)).getValue();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
@@ -31,18 +31,18 @@ import org.joda.time.DurationFieldType;
 /**
  * Infix '-' operation for timestamps.
  *
- * <p>Implements 2 SQL subtraction operations at the moment:
- * 'timestampdiff(timeunit, timestamp, timestamp)', and 'timestamp - interval'
+ * <p>Implements 2 SQL subtraction operations at the moment: 'timestampdiff(timeunit, timestamp,
+ * timestamp)', and 'timestamp - interval'
  *
  * <p>Calcite converts both of the above into infix '-' expression, with different operands and
  * return types.
  *
- * <p>This class delegates evaluation to specific implementation of one of the above operations,
- * see {@link BeamSqlTimestampMinusTimestampExpression}
- * and {@link BeamSqlTimestampMinusIntervalExpression}
+ * <p>This class delegates evaluation to specific implementation of one of the above operations, see
+ * {@link BeamSqlTimestampMinusTimestampExpression} and {@link
+ * BeamSqlTimestampMinusIntervalExpression}
  *
- * <p>Calcite supports one more subtraction kind: 'interval - interval',
- * but it is not implemented yet.
+ * <p>Calcite supports one more subtraction kind: 'interval - interval', but it is not implemented
+ * yet.
  */
 public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
 
@@ -102,4 +102,3 @@ public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
     return delegateExpression.evaluate(inputRow, window);
   }
 }
-

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
@@ -33,29 +33,27 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 
 /**
- * DATETIME_PLUS operation.
- * Calcite converts 'TIMESTAMPADD(..)' or 'DATE + INTERVAL' from the user input
- * into DATETIME_PLUS.
+ * DATETIME_PLUS operation. Calcite converts 'TIMESTAMPADD(..)' or 'DATE + INTERVAL' from the user
+ * input into DATETIME_PLUS.
  *
  * <p>Input and output are expected to be of type TIMESTAMP.
  */
 public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
 
-  private static final Set<SqlTypeName> SUPPORTED_INTERVAL_TYPES = ImmutableSet.of(
-      SqlTypeName.INTERVAL_SECOND,
-      SqlTypeName.INTERVAL_MINUTE,
-      SqlTypeName.INTERVAL_HOUR,
-      SqlTypeName.INTERVAL_DAY,
-      SqlTypeName.INTERVAL_MONTH,
-      SqlTypeName.INTERVAL_YEAR);
+  private static final Set<SqlTypeName> SUPPORTED_INTERVAL_TYPES =
+      ImmutableSet.of(
+          SqlTypeName.INTERVAL_SECOND,
+          SqlTypeName.INTERVAL_MINUTE,
+          SqlTypeName.INTERVAL_HOUR,
+          SqlTypeName.INTERVAL_DAY,
+          SqlTypeName.INTERVAL_MONTH,
+          SqlTypeName.INTERVAL_YEAR);
 
   public BeamSqlDatetimePlusExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.TIMESTAMP);
   }
 
-  /**
-   * Requires exactly 2 operands. One should be a timestamp, another an interval
-   */
+  /** Requires exactly 2 operands. One should be a timestamp, another an interval */
   @Override
   public boolean accept() {
     return operands.size() == 2
@@ -68,10 +66,10 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
    *
    * <p>Interval has a value of 'multiplier * TimeUnit.multiplier'.
    *
-   * <p>For example, '3 years' is going to have a type of INTERVAL_YEAR, and a value of 36.
-   * And '2 minutes' is going to be an INTERVAL_MINUTE with a value of 120000. This is the way
-   * Calcite handles interval expressions, and {@link BeamSqlIntervalMultiplyExpression} also works
-   * the same way.
+   * <p>For example, '3 years' is going to have a type of INTERVAL_YEAR, and a value of 36. And '2
+   * minutes' is going to be an INTERVAL_MINUTE with a value of 120000. This is the way Calcite
+   * handles interval expressions, and {@link BeamSqlIntervalMultiplyExpression} also works the same
+   * way.
    */
   @Override
   public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
@@ -86,14 +84,16 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
 
   private int getIntervalMultiplier(BeamSqlPrimitive intervalOperandPrimitive) {
     BigDecimal intervalOperandValue = intervalOperandPrimitive.getDecimal();
-    BigDecimal multiplier = intervalOperandValue.divide(
-        timeUnitInternalMultiplier(intervalOperandPrimitive.getOutputType()),
-        BigDecimal.ROUND_CEILING);
+    BigDecimal multiplier =
+        intervalOperandValue.divide(
+            timeUnitInternalMultiplier(intervalOperandPrimitive.getOutputType()),
+            BigDecimal.ROUND_CEILING);
     return multiplier.intValueExact();
   }
 
   private BeamSqlPrimitive getIntervalOperand(Row inputRow, BoundedWindow window) {
-    return findExpressionOfType(operands, SUPPORTED_INTERVAL_TYPES).get()
+    return findExpressionOfType(operands, SUPPORTED_INTERVAL_TYPES)
+        .get()
         .evaluate(inputRow, window);
   }
 
@@ -103,8 +103,7 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
     return new DateTime(timestampOperandPrimitive.getDate());
   }
 
-  private DateTime addInterval(
-      DateTime dateTime, SqlTypeName intervalType, int numberOfIntervals) {
+  private DateTime addInterval(DateTime dateTime, SqlTypeName intervalType, int numberOfIntervals) {
 
     switch (intervalType) {
       case INTERVAL_SECOND:
@@ -120,8 +119,8 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
       case INTERVAL_YEAR:
         return dateTime.plusYears(numberOfIntervals);
       default:
-        throw new IllegalArgumentException("Adding "
-            + intervalType.getName() + " to date is not supported");
+        throw new IllegalArgumentException(
+            "Adding " + intervalType.getName() + " to date is not supported");
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
@@ -32,18 +32,19 @@ import org.joda.time.ReadableInstant;
  * {@code BeamSqlExpression} for EXTRACT.
  *
  * <p>The following date functions also implicitly converted to {@code EXTRACT}:
+ *
  * <ul>
- *   <li>YEAR(date) =&gt; EXTRACT(YEAR FROM date)</li>
- *   <li>MONTH(date) =&gt; EXTRACT(MONTH FROM date)</li>
- *   <li>DAY(date) =&gt; EXTRACT(DAY FROM date)</li>
- *   <li>QUARTER(date) =&gt; EXTRACT(QUARTER FROM date)</li>
- *   <li>WEEK(date) =&gt; EXTRACT(WEEK FROM date)</li>
- *   <li>DAYOFYEAR(date) =&gt; EXTRACT(DOY FROM date)</li>
- *   <li>DAYOFMONTH(date) =&gt; EXTRACT(DAY FROM date)</li>
- *   <li>DAYOFWEEK(date) =&gt; EXTRACT(DOW FROM date)</li>
- *   <li>HOUR(date) =&gt; EXTRACT(HOUR FROM date)</li>
- *   <li>MINUTE(date) =&gt; EXTRACT(MINUTE FROM date)</li>
- *   <li>SECOND(date) =&gt; EXTRACT(SECOND FROM date)</li>
+ *   <li>YEAR(date) =&gt; EXTRACT(YEAR FROM date)
+ *   <li>MONTH(date) =&gt; EXTRACT(MONTH FROM date)
+ *   <li>DAY(date) =&gt; EXTRACT(DAY FROM date)
+ *   <li>QUARTER(date) =&gt; EXTRACT(QUARTER FROM date)
+ *   <li>WEEK(date) =&gt; EXTRACT(WEEK FROM date)
+ *   <li>DAYOFYEAR(date) =&gt; EXTRACT(DOY FROM date)
+ *   <li>DAYOFMONTH(date) =&gt; EXTRACT(DAY FROM date)
+ *   <li>DAYOFWEEK(date) =&gt; EXTRACT(DOW FROM date)
+ *   <li>HOUR(date) =&gt; EXTRACT(HOUR FROM date)
+ *   <li>MINUTE(date) =&gt; EXTRACT(MINUTE FROM date)
+ *   <li>SECOND(date) =&gt; EXTRACT(SECOND FROM date)
  * </ul>
  */
 public class BeamSqlExtractExpression extends BeamSqlExpression {
@@ -51,12 +52,13 @@ public class BeamSqlExtractExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.BIGINT);
   }
 
-  @Override public boolean accept() {
-    return operands.size() == 2
-        && opType(1) == SqlTypeName.TIMESTAMP;
+  @Override
+  public boolean accept() {
+    return operands.size() == 2 && opType(1) == SqlTypeName.TIMESTAMP;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     ReadableInstant time = opValueEvaluated(1, inputRow, window);
 
     TimeUnitRange unit = ((BeamSqlPrimitive<TimeUnitRange>) op(0)).getValue();
@@ -72,20 +74,14 @@ public class BeamSqlExtractExpression extends BeamSqlExpression {
       case CENTURY:
       case MILLENNIUM:
         Long timeByDay = time.getMillis() / DateTimeUtils.MILLIS_PER_DAY;
-        Long extracted = DateTimeUtils.unixDateExtract(
-            unit,
-            timeByDay
-        );
+        Long extracted = DateTimeUtils.unixDateExtract(unit, timeByDay);
         return BeamSqlPrimitive.of(outputType, extracted);
 
       case HOUR:
       case MINUTE:
       case SECOND:
         int timeInDay = (int) (time.getMillis() % DateTimeUtils.MILLIS_PER_DAY);
-        extracted = (long) DateTimeUtils.unixTimeExtract(
-            unit,
-            timeInDay
-        );
+        extracted = (long) DateTimeUtils.unixTimeExtract(unit, timeInDay);
         return BeamSqlPrimitive.of(outputType, extracted);
 
       default:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpression.java
@@ -31,15 +31,13 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
 /**
- * Multiplication operator for intervals.
- * For example, allows to express things like '3 years'.
+ * Multiplication operator for intervals. For example, allows to express things like '3 years'.
  *
- * <p>One use case of this is implementation of TIMESTAMPADD().
- * Calcite converts TIMESTAMPADD(date, multiplier, inteval) into
- * DATETIME_PLUS(date, multiplier * interval).
- * The 'multiplier * interval' part is what this class implements. It's not a regular
- * numerical multiplication because the return type is expected to be an interval, and the value
- * is expected to use corresponding TimeUnit's internal value (e.g. 12 for YEAR, 60000 for MINUTE).
+ * <p>One use case of this is implementation of TIMESTAMPADD(). Calcite converts TIMESTAMPADD(date,
+ * multiplier, inteval) into DATETIME_PLUS(date, multiplier * interval). The 'multiplier * interval'
+ * part is what this class implements. It's not a regular numerical multiplication because the
+ * return type is expected to be an interval, and the value is expected to use corresponding
+ * TimeUnit's internal value (e.g. 12 for YEAR, 60000 for MINUTE).
  */
 public class BeamSqlIntervalMultiplyExpression extends BeamSqlExpression {
   public BeamSqlIntervalMultiplyExpression(List<BeamSqlExpression> operands) {
@@ -47,21 +45,17 @@ public class BeamSqlIntervalMultiplyExpression extends BeamSqlExpression {
   }
 
   /**
-   * Output type is null if no operands found with matching types.
-   * Execution will later fail when calling accept()
+   * Output type is null if no operands found with matching types. Execution will later fail when
+   * calling accept()
    */
   private static SqlTypeName deduceOutputType(List<BeamSqlExpression> operands) {
     Optional<BeamSqlExpression> intervalOperand =
         findExpressionOfType(operands, SqlTypeName.INTERVAL_TYPES);
 
-    return intervalOperand.isPresent()
-        ? intervalOperand.get().getOutputType()
-        : null;
+    return intervalOperand.isPresent() ? intervalOperand.get().getOutputType() : null;
   }
 
-  /**
-   * Requires exactly 2 operands. One should be integer, another should be interval
-   */
+  /** Requires exactly 2 operands. One should be integer, another should be interval */
   @Override
   public boolean accept() {
     return operands.size() == 2
@@ -77,10 +71,8 @@ public class BeamSqlIntervalMultiplyExpression extends BeamSqlExpression {
    * those internal multipliers. This means we need to do similar thing, so that this multiplication
    * expression behaves the same way as literal interval expression.
    *
-   * <p>That is, we need to make sure that this:
-   *   "TIMESTAMP '1984-04-19 01:02:03' + INTERVAL '2' YEAR"
-   * is equivalent tot this:
-   *   "TIMESTAMPADD(YEAR, 2, TIMESTAMP '1984-04-19 01:02:03')"
+   * <p>That is, we need to make sure that this: "TIMESTAMP '1984-04-19 01:02:03' + INTERVAL '2'
+   * YEAR" is equivalent tot this: "TIMESTAMPADD(YEAR, 2, TIMESTAMP '1984-04-19 01:02:03')"
    */
   @Override
   public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
@@ -93,8 +85,7 @@ public class BeamSqlIntervalMultiplyExpression extends BeamSqlExpression {
     BigDecimal integerOperandValue = new BigDecimal(integerOperandPrimitive.getInteger());
 
     BigDecimal multiplicationResult =
-        integerOperandValue.multiply(
-            timeUnitInternalMultiplier(intervalOperandType));
+        integerOperandValue.multiply(timeUnitInternalMultiplier(intervalOperandType));
 
     return BeamSqlPrimitive.of(outputType, multiplicationResult);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
@@ -67,8 +67,10 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
     BigDecimal intervalValue = operand.getDecimal();
     SqlTypeName intervalType = operand.getOutputType();
 
-    int numberOfIntervals = intervalValue
-        .divide(TimeUnitUtils.timeUnitInternalMultiplier(intervalType)).intValueExact();
+    int numberOfIntervals =
+        intervalValue
+            .divide(TimeUnitUtils.timeUnitInternalMultiplier(intervalType))
+            .intValueExact();
 
     return new Period().withField(durationFieldType(intervalType), numberOfIntervals);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
@@ -34,9 +34,9 @@ import org.joda.time.PeriodType;
 /**
  * Infix '-' operation for timestamps.
  *
- * <p>Currently this implementation is specific to how Calcite parses 'TIMESTAMPDIFF(..)'.
- * It converts the TIMESTAMPDIFF() call into infix minus and normalizes it
- * with corresponding TimeUnit's multiplier.
+ * <p>Currently this implementation is specific to how Calcite parses 'TIMESTAMPDIFF(..)'. It
+ * converts the TIMESTAMPDIFF() call into infix minus and normalizes it with corresponding
+ * TimeUnit's multiplier.
  *
  * <p>See {@link BeamSqlDatetimeMinusExpression} for other kinds of datetime types subtraction.
  */
@@ -49,9 +49,7 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
     this.intervalType = intervalType;
   }
 
-  /**
-   * Requires exactly 2 operands. One should be a timestamp, another an interval
-   */
+  /** Requires exactly 2 operands. One should be a timestamp, another an interval */
   @Override
   public boolean accept() {
     return accept(operands, intervalType);
@@ -80,15 +78,18 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
   }
 
   private long numberOfIntervalsBetweenDates(DateTime timestampStart, DateTime timestampEnd) {
-    Period period = new Period(timestampStart, timestampEnd,
-        PeriodType.forFields(new DurationFieldType[] { durationFieldType(intervalType) }));
+    Period period =
+        new Period(
+            timestampStart,
+            timestampEnd,
+            PeriodType.forFields(new DurationFieldType[] {durationFieldType(intervalType)}));
     return period.get(durationFieldType(intervalType));
   }
 
   private static DurationFieldType durationFieldType(SqlTypeName intervalTypeToCount) {
     if (!INTERVALS_DURATIONS_TYPES.containsKey(intervalTypeToCount)) {
-      throw new IllegalArgumentException("Counting "
-          + intervalTypeToCount.getName() + "s between dates is not supported");
+      throw new IllegalArgumentException(
+          "Counting " + intervalTypeToCount.getName() + "s between dates is not supported");
     }
 
     return INTERVALS_DURATIONS_TYPES.get(intervalTypeToCount);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtils.java
@@ -22,9 +22,7 @@ import java.math.BigDecimal;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Utils to convert between Calcite's TimeUnit and Sql intervals.
- */
+/** Utils to convert between Calcite's TimeUnit and Sql intervals. */
 public abstract class TimeUnitUtils {
 
   /**
@@ -46,8 +44,8 @@ public abstract class TimeUnitUtils {
       case INTERVAL_YEAR:
         return TimeUnit.YEAR.multiplier;
       default:
-        throw new IllegalArgumentException("Interval " + sqlIntervalType
-            + " cannot be converted to TimeUnit");
+        throw new IllegalArgumentException(
+            "Interval " + sqlIntervalType + " cannot be converted to TimeUnit");
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * date functions.
- */
+/** date functions. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlAndExpression.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlExpression} for 'AND' operation.
- */
+/** {@code BeamSqlExpression} for 'AND' operation. */
 public class BeamSqlAndExpression extends BeamSqlLogicalExpression {
   public BeamSqlAndExpression(List<BeamSqlExpression> operands) {
     super(operands);
@@ -44,5 +42,4 @@ public class BeamSqlAndExpression extends BeamSqlLogicalExpression {
     }
     return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, result);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlLogicalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlLogicalExpression.java
@@ -22,9 +22,7 @@ import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlExpression} for Logical operators.
- */
+/** {@code BeamSqlExpression} for Logical operators. */
 public abstract class BeamSqlLogicalExpression extends BeamSqlExpression {
   private BeamSqlLogicalExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
@@ -35,7 +35,8 @@ public class BeamSqlNotExpression extends BeamSqlLogicalExpression {
     super(operands);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     Boolean value = opValueEvaluated(0, inputRow, window);
     if (value == null) {
       return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, window);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlOrExpression.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlExpression} for 'OR' operation.
- */
+/** {@code BeamSqlExpression} for 'OR' operation. */
 public class BeamSqlOrExpression extends BeamSqlLogicalExpression {
   public BeamSqlOrExpression(List<BeamSqlExpression> operands) {
     super(operands);
@@ -37,12 +35,11 @@ public class BeamSqlOrExpression extends BeamSqlLogicalExpression {
     boolean result = false;
     for (BeamSqlExpression exp : operands) {
       BeamSqlPrimitive<Boolean> expOut = exp.evaluate(inputRow, window);
-        result = expOut.getValue();
-        if (result) {
-          break;
-        }
+      result = expOut.getValue();
+      if (result) {
+        break;
+      }
     }
     return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, result);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Logical operators.
- */
+/** Logical operators. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.logical;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapExpression.java
@@ -27,9 +27,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Represents MAP expression in SQL.
- */
+/** Represents MAP expression in SQL. */
 public class BeamSqlMapExpression extends BeamSqlExpression {
   public BeamSqlMapExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.MAP);
@@ -37,19 +35,15 @@ public class BeamSqlMapExpression extends BeamSqlExpression {
 
   @Override
   public boolean accept() {
-    return
-        operands
-            .stream()
-            .map(BeamSqlExpression::getOutputType)
-            .distinct()
-            .count() == 1;
+    return operands.stream().map(BeamSqlExpression::getOutputType).distinct().count() == 1;
   }
 
   @Override
   public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     Map<Object, Object> elements = new HashMap<>();
     for (int idx = 0; idx < operands.size() / 2; ++idx) {
-      elements.put(operands.get(idx * 2).evaluate(inputRow, window).getValue(),
+      elements.put(
+          operands.get(idx * 2).evaluate(inputRow, window).getValue(),
           operands.get(idx * 2 + 1).evaluate(inputRow, window).getValue());
     }
     return BeamSqlPrimitive.of(outputType, elements);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
@@ -25,14 +25,10 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Implements map key access expression.
- */
+/** Implements map key access expression. */
 public class BeamSqlMapItemExpression extends BeamSqlExpression {
 
-  public BeamSqlMapItemExpression(
-      List<BeamSqlExpression> operands,
-      SqlTypeName sqlTypeName) {
+  public BeamSqlMapItemExpression(List<BeamSqlExpression> operands, SqlTypeName sqlTypeName) {
 
     super(operands, sqlTypeName);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/package-info.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * Expressions implementing map operations.
- */
+/** Expressions implementing map operations. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.map;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAbsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAbsExpression.java
@@ -24,46 +24,37 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-
-/**
- * {@code BeamSqlMathUnaryExpression} for 'ABS' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'ABS' function. */
 public class BeamSqlAbsExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlAbsExpression(List<BeamSqlExpression> operands) {
     super(operands, operands.get(0).getOutputType());
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
     BeamSqlPrimitive result = null;
     switch (op.getOutputType()) {
       case INTEGER:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.INTEGER, SqlFunctions.abs(op.getInteger()));
+        result = BeamSqlPrimitive.of(SqlTypeName.INTEGER, SqlFunctions.abs(op.getInteger()));
         break;
       case BIGINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.BIGINT, SqlFunctions.abs(op.getLong()));
+        result = BeamSqlPrimitive.of(SqlTypeName.BIGINT, SqlFunctions.abs(op.getLong()));
         break;
       case TINYINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.TINYINT, SqlFunctions.abs(op.getByte()));
+        result = BeamSqlPrimitive.of(SqlTypeName.TINYINT, SqlFunctions.abs(op.getByte()));
         break;
       case SMALLINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.SMALLINT, SqlFunctions.abs(op.getShort()));
+        result = BeamSqlPrimitive.of(SqlTypeName.SMALLINT, SqlFunctions.abs(op.getShort()));
         break;
       case FLOAT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.FLOAT, SqlFunctions.abs(op.getFloat()));
+        result = BeamSqlPrimitive.of(SqlTypeName.FLOAT, SqlFunctions.abs(op.getFloat()));
         break;
       case DECIMAL:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DECIMAL, SqlFunctions.abs(op.getDecimal()));
+        result = BeamSqlPrimitive.of(SqlTypeName.DECIMAL, SqlFunctions.abs(op.getDecimal()));
         break;
       case DOUBLE:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DOUBLE, SqlFunctions.abs(op.getDouble()));
+        result = BeamSqlPrimitive.of(SqlTypeName.DOUBLE, SqlFunctions.abs(op.getDouble()));
         break;
       default:
         break;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAcosExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAcosExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'ACOS' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'ACOS' function. */
 public class BeamSqlAcosExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlAcosExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.acos(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.acos(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAsinExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAsinExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'ASIN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'ASIN' function. */
 public class BeamSqlAsinExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlAsinExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.asin(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.asin(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAtan2Expression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAtan2Expression.java
@@ -24,19 +24,19 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@link BeamSqlMathBinaryExpression} for 'ATAN2' function.
- */
+/** {@link BeamSqlMathBinaryExpression} for 'ATAN2' function. */
 public class BeamSqlAtan2Expression extends BeamSqlMathBinaryExpression {
 
   public BeamSqlAtan2Expression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> calculate(BeamSqlPrimitive leftOp,
-      BeamSqlPrimitive rightOp) {
-    return BeamSqlPrimitive.of(SqlTypeName.DOUBLE, SqlFunctions
-        .atan2(SqlFunctions.toDouble(leftOp.getValue()),
-            SqlFunctions.toDouble(rightOp.getValue())));
+  @Override
+  public BeamSqlPrimitive<? extends Number> calculate(
+      BeamSqlPrimitive leftOp, BeamSqlPrimitive rightOp) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE,
+        SqlFunctions.atan2(
+            SqlFunctions.toDouble(leftOp.getValue()), SqlFunctions.toDouble(rightOp.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAtanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlAtanExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'ATAN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'ATAN' function. */
 public class BeamSqlAtanExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlAtanExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.atan(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.atan(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCeilExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCeilExpression.java
@@ -24,22 +24,21 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'CEIL' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'CEIL' function. */
 public class BeamSqlCeilExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlCeilExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
     switch (getOutputType()) {
       case DECIMAL:
         return BeamSqlPrimitive.of(SqlTypeName.DECIMAL, SqlFunctions.ceil(op.getDecimal()));
       default:
-        return BeamSqlPrimitive
-            .of(SqlTypeName.DOUBLE, SqlFunctions.ceil(SqlFunctions.toDouble(op.getValue())));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.DOUBLE, SqlFunctions.ceil(SqlFunctions.toDouble(op.getValue())));
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCosExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCosExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'COS' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'COS' function. */
 public class BeamSqlCosExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlCosExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.cos(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.cos(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlCotExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'COT' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'COT' function. */
 public class BeamSqlCotExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlCotExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.cot(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.cot(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlDegreesExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlDegreesExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'DEGREES' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'DEGREES' function. */
 public class BeamSqlDegreesExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlDegreesExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.degrees(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.degrees(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlExpExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlExpExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'EXP' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'EXP' function. */
 public class BeamSqlExpExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlExpExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.exp(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.exp(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlFloorExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlFloorExpression.java
@@ -24,22 +24,21 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'FLOOR' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'FLOOR' function. */
 public class BeamSqlFloorExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlFloorExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
     switch (getOutputType()) {
       case DECIMAL:
         return BeamSqlPrimitive.of(SqlTypeName.DECIMAL, SqlFunctions.floor(op.getDecimal()));
       default:
-        return BeamSqlPrimitive
-            .of(SqlTypeName.DOUBLE, SqlFunctions.floor(SqlFunctions.toDouble(op.getValue())));
+        return BeamSqlPrimitive.of(
+            SqlTypeName.DOUBLE, SqlFunctions.floor(SqlFunctions.toDouble(op.getValue())));
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlLnExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlLnExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'LN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'LN' function. */
 public class BeamSqlLnExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlLnExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.ln(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.ln(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlLogExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlLogExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'Log10' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'Log10' function. */
 public class BeamSqlLogExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlLogExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.log10(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.log10(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpression.java
@@ -25,22 +25,20 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Base class for all binary functions such as
- * POWER, MOD, RAND_INTEGER, ATAN2, ROUND, TRUNCATE.
- */
+/** Base class for all binary functions such as POWER, MOD, RAND_INTEGER, ATAN2, ROUND, TRUNCATE. */
 public abstract class BeamSqlMathBinaryExpression extends BeamSqlExpression {
 
   public BeamSqlMathBinaryExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     return numberOfOperands() == 2 && isOperandNumeric(opType(0)) && isOperandNumeric(opType(1));
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow,
-      BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
     BeamSqlExpression leftOp = op(0);
     BeamSqlExpression rightOp = op(1);
     return calculate(leftOp.evaluate(inputRow, window), rightOp.evaluate(inputRow, window));
@@ -53,12 +51,10 @@ public abstract class BeamSqlMathBinaryExpression extends BeamSqlExpression {
    * @param rightOp {@link BeamSqlPrimitive}
    * @return {@link BeamSqlPrimitive}
    */
-  public abstract BeamSqlPrimitive<? extends Number> calculate(BeamSqlPrimitive leftOp,
-      BeamSqlPrimitive rightOp);
+  public abstract BeamSqlPrimitive<? extends Number> calculate(
+      BeamSqlPrimitive leftOp, BeamSqlPrimitive rightOp);
 
-  /**
-   * The method to check whether operands are numeric or not.
-   */
+  /** The method to check whether operands are numeric or not. */
   public boolean isOperandNumeric(SqlTypeName opType) {
     return SqlTypeName.NUMERIC_TYPES.contains(opType);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpression.java
@@ -25,10 +25,8 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-
 /**
- * Base class for all unary functions such as
- * ABS, SQRT, LN, LOG10, EXP, CEIL, FLOOR, RAND, ACOS,
+ * Base class for all unary functions such as ABS, SQRT, LN, LOG10, EXP, CEIL, FLOOR, RAND, ACOS,
  * ASIN, ATAN, COS, COT, DEGREES, RADIANS, SIGN, SIN, TAN.
  */
 public abstract class BeamSqlMathUnaryExpression extends BeamSqlExpression {
@@ -37,7 +35,8 @@ public abstract class BeamSqlMathUnaryExpression extends BeamSqlExpression {
     super(operands, outputType);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     boolean acceptance = false;
 
     if (numberOfOperands() == 1 && SqlTypeName.NUMERIC_TYPES.contains(opType(0))) {
@@ -46,15 +45,12 @@ public abstract class BeamSqlMathUnaryExpression extends BeamSqlExpression {
     return acceptance;
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow,
-      BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive<? extends Number> evaluate(Row inputRow, BoundedWindow window) {
     BeamSqlExpression operand = op(0);
     return calculate(operand.evaluate(inputRow, window));
   }
 
-  /**
-   * For the operands of other type {@link SqlTypeName#NUMERIC_TYPES}.
-   * */
-
+  /** For the operands of other type {@link SqlTypeName#NUMERIC_TYPES}. */
   public abstract BeamSqlPrimitive calculate(BeamSqlPrimitive op);
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPiExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPiExpression.java
@@ -24,20 +24,20 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Base class for the PI function.
- */
+/** Base class for the PI function. */
 public class BeamSqlPiExpression extends BeamSqlExpression {
 
   public BeamSqlPiExpression() {
     this.outputType = SqlTypeName.DOUBLE;
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     return BeamSqlPrimitive.of(SqlTypeName.DOUBLE, Math.PI);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPowerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlPowerExpression.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathBinaryExpression} for 'POWER' function.
- */
+/** {@code BeamSqlMathBinaryExpression} for 'POWER' function. */
 public class BeamSqlPowerExpression extends BeamSqlMathBinaryExpression {
 
   public BeamSqlPowerExpression(List<BeamSqlExpression> operands) {
@@ -34,11 +32,11 @@ public class BeamSqlPowerExpression extends BeamSqlMathBinaryExpression {
   }
 
   @Override
-  public BeamSqlPrimitive<? extends Number> calculate(BeamSqlPrimitive leftOp,
-      BeamSqlPrimitive rightOp) {
-    return BeamSqlPrimitive.of(SqlTypeName.DOUBLE, SqlFunctions
-        .power(SqlFunctions.toDouble(leftOp.getValue()),
-            SqlFunctions.toDouble(rightOp.getValue())));
+  public BeamSqlPrimitive<? extends Number> calculate(
+      BeamSqlPrimitive leftOp, BeamSqlPrimitive rightOp) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE,
+        SqlFunctions.power(
+            SqlFunctions.toDouble(leftOp.getValue()), SqlFunctions.toDouble(rightOp.getValue())));
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRadiansExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRadiansExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'RADIANS' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'RADIANS' function. */
 public class BeamSqlRadiansExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlRadiansExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.radians(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.radians(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
@@ -26,9 +26,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'RAND([seed])' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'RAND([seed])' function. */
 public class BeamSqlRandExpression extends BeamSqlExpression {
   private Random rand = new Random();
   private Integer seed = null;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
@@ -26,10 +26,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'RAND_INTEGER([seed, ] numeric)'
- * function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'RAND_INTEGER([seed, ] numeric)' function. */
 public class BeamSqlRandIntegerExpression extends BeamSqlExpression {
   private Random rand = new Random();
   private Integer seed = null;
@@ -53,7 +50,7 @@ public class BeamSqlRandIntegerExpression extends BeamSqlExpression {
       }
       numericIdx = 1;
     }
-    return BeamSqlPrimitive.of(SqlTypeName.INTEGER,
-        rand.nextInt((int) opValueEvaluated(numericIdx, inputRow, window)));
+    return BeamSqlPrimitive.of(
+        SqlTypeName.INTEGER, rand.nextInt((int) opValueEvaluated(numericIdx, inputRow, window)));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRoundExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRoundExpression.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathBinaryExpression} for 'ROUND' function.
- */
+/** {@code BeamSqlMathBinaryExpression} for 'ROUND' function. */
 public class BeamSqlRoundExpression extends BeamSqlMathBinaryExpression {
 
   private final BeamSqlPrimitive zero = BeamSqlPrimitive.of(SqlTypeName.INTEGER, 0);
@@ -42,37 +40,49 @@ public class BeamSqlRoundExpression extends BeamSqlMathBinaryExpression {
     }
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> calculate(BeamSqlPrimitive leftOp,
-      BeamSqlPrimitive rightOp) {
+  @Override
+  public BeamSqlPrimitive<? extends Number> calculate(
+      BeamSqlPrimitive leftOp, BeamSqlPrimitive rightOp) {
     BeamSqlPrimitive result = null;
     switch (leftOp.getOutputType()) {
       case SMALLINT:
-        result = BeamSqlPrimitive.of(SqlTypeName.SMALLINT,
-            (short) roundInt(toInt(leftOp.getValue()), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.SMALLINT,
+                (short) roundInt(toInt(leftOp.getValue()), toInt(rightOp.getValue())));
         break;
       case TINYINT:
-        result = BeamSqlPrimitive.of(SqlTypeName.TINYINT,
-            (byte) roundInt(toInt(leftOp.getValue()), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.TINYINT,
+                (byte) roundInt(toInt(leftOp.getValue()), toInt(rightOp.getValue())));
         break;
       case INTEGER:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.INTEGER, roundInt(leftOp.getInteger(), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.INTEGER, roundInt(leftOp.getInteger(), toInt(rightOp.getValue())));
         break;
       case BIGINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.BIGINT, roundLong(leftOp.getLong(), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.BIGINT, roundLong(leftOp.getLong(), toInt(rightOp.getValue())));
         break;
       case DOUBLE:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DOUBLE, roundDouble(leftOp.getDouble(), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DOUBLE, roundDouble(leftOp.getDouble(), toInt(rightOp.getValue())));
         break;
       case FLOAT:
-        result = BeamSqlPrimitive.of(SqlTypeName.FLOAT,
-            (float) roundDouble(leftOp.getFloat(), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.FLOAT,
+                (float) roundDouble(leftOp.getFloat(), toInt(rightOp.getValue())));
         break;
       case DECIMAL:
-        result = BeamSqlPrimitive.of(SqlTypeName.DECIMAL,
-            roundBigDecimal(toBigDecimal(leftOp.getValue()), toInt(rightOp.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DECIMAL,
+                roundBigDecimal(toBigDecimal(leftOp.getValue()), toInt(rightOp.getValue())));
         break;
       default:
         break;
@@ -103,5 +113,4 @@ public class BeamSqlRoundExpression extends BeamSqlMathBinaryExpression {
   private BigDecimal toBigDecimal(Object value) {
     return SqlFunctions.toBigDecimal(value);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlSignExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlSignExpression.java
@@ -24,45 +24,52 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'SIGN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'SIGN' function. */
 public class BeamSqlSignExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlSignExpression(List<BeamSqlExpression> operands) {
     super(operands, operands.get(0).getOutputType());
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
     BeamSqlPrimitive result = null;
     switch (op.getOutputType()) {
       case TINYINT:
-        result = BeamSqlPrimitive
-          .of(SqlTypeName.TINYINT, (byte) SqlFunctions.sign(SqlFunctions.toByte(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.TINYINT, (byte) SqlFunctions.sign(SqlFunctions.toByte(op.getValue())));
         break;
       case SMALLINT:
-        result = BeamSqlPrimitive
-          .of(SqlTypeName.SMALLINT, (short) SqlFunctions.sign(SqlFunctions.toShort(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.SMALLINT,
+                (short) SqlFunctions.sign(SqlFunctions.toShort(op.getValue())));
         break;
       case INTEGER:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.INTEGER, SqlFunctions.sign(SqlFunctions.toInt(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.INTEGER, SqlFunctions.sign(SqlFunctions.toInt(op.getValue())));
         break;
       case BIGINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.BIGINT, SqlFunctions.sign(SqlFunctions.toLong(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.BIGINT, SqlFunctions.sign(SqlFunctions.toLong(op.getValue())));
         break;
       case FLOAT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.FLOAT, (float) SqlFunctions.sign(SqlFunctions.toFloat(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.FLOAT, (float) SqlFunctions.sign(SqlFunctions.toFloat(op.getValue())));
         break;
       case DOUBLE:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DOUBLE, SqlFunctions.sign(SqlFunctions.toDouble(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DOUBLE, SqlFunctions.sign(SqlFunctions.toDouble(op.getValue())));
         break;
       case DECIMAL:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DECIMAL, SqlFunctions.sign(SqlFunctions.toBigDecimal(op.getValue())));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DECIMAL, SqlFunctions.sign(SqlFunctions.toBigDecimal(op.getValue())));
         break;
       default:
         break;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlSinExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlSinExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'SIN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'SIN' function. */
 public class BeamSqlSinExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlSinExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.sin(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.sin(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlTanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlTanExpression.java
@@ -24,17 +24,16 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathUnaryExpression} for 'TAN' function.
- */
+/** {@code BeamSqlMathUnaryExpression} for 'TAN' function. */
 public class BeamSqlTanExpression extends BeamSqlMathUnaryExpression {
 
   public BeamSqlTanExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.DOUBLE);
   }
 
-  @Override public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
-    return BeamSqlPrimitive
-        .of(SqlTypeName.DOUBLE, SqlFunctions.tan(SqlFunctions.toDouble(op.getValue())));
+  @Override
+  public BeamSqlPrimitive calculate(BeamSqlPrimitive op) {
+    return BeamSqlPrimitive.of(
+        SqlTypeName.DOUBLE, SqlFunctions.tan(SqlFunctions.toDouble(op.getValue())));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlTruncateExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlTruncateExpression.java
@@ -24,48 +24,62 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * {@code BeamSqlMathBinaryExpression} for 'TRUNCATE' function.
- */
+/** {@code BeamSqlMathBinaryExpression} for 'TRUNCATE' function. */
 public class BeamSqlTruncateExpression extends BeamSqlMathBinaryExpression {
 
   public BeamSqlTruncateExpression(List<BeamSqlExpression> operands) {
     super(operands, operands.get(0).getOutputType());
   }
 
-  @Override public BeamSqlPrimitive<? extends Number> calculate(BeamSqlPrimitive leftOp,
-      BeamSqlPrimitive rightOp) {
+  @Override
+  public BeamSqlPrimitive<? extends Number> calculate(
+      BeamSqlPrimitive leftOp, BeamSqlPrimitive rightOp) {
     BeamSqlPrimitive result = null;
     int rightIntOperand = SqlFunctions.toInt(rightOp.getValue());
     switch (leftOp.getOutputType()) {
       case SMALLINT:
-        result = BeamSqlPrimitive.of(SqlTypeName.SMALLINT,
-            (short) SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.SMALLINT,
+                (short)
+                    SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
         break;
       case TINYINT:
-        result = BeamSqlPrimitive.of(SqlTypeName.TINYINT,
-            (byte) SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.TINYINT,
+                (byte)
+                    SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
         break;
       case INTEGER:
-        result = BeamSqlPrimitive.of(SqlTypeName.INTEGER,
-            SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.INTEGER,
+                SqlFunctions.struncate(SqlFunctions.toInt(leftOp.getValue()), rightIntOperand));
         break;
       case BIGINT:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.BIGINT, SqlFunctions.struncate(leftOp.getLong(), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.BIGINT, SqlFunctions.struncate(leftOp.getLong(), rightIntOperand));
         break;
       case FLOAT:
-        result = BeamSqlPrimitive.of(SqlTypeName.FLOAT,
-            (float) SqlFunctions.struncate(SqlFunctions.toFloat(leftOp.getValue()),
-                rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.FLOAT,
+                (float)
+                    SqlFunctions.struncate(
+                        SqlFunctions.toFloat(leftOp.getValue()), rightIntOperand));
         break;
       case DOUBLE:
-        result = BeamSqlPrimitive.of(SqlTypeName.DOUBLE,
-            SqlFunctions.struncate(SqlFunctions.toDouble(leftOp.getValue()), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DOUBLE,
+                SqlFunctions.struncate(SqlFunctions.toDouble(leftOp.getValue()), rightIntOperand));
         break;
       case DECIMAL:
-        result = BeamSqlPrimitive
-            .of(SqlTypeName.DECIMAL, SqlFunctions.struncate(leftOp.getDecimal(), rightIntOperand));
+        result =
+            BeamSqlPrimitive.of(
+                SqlTypeName.DECIMAL, SqlFunctions.struncate(leftOp.getDecimal(), rightIntOperand));
         break;
       default:
         break;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * MATH functions/operators.
- */
+/** MATH functions/operators. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.math;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Implementation for operators in {@link org.apache.calcite.sql.fun.SqlStdOperatorTable}.
- */
+/** Implementation for operators in {@link org.apache.calcite.sql.fun.SqlStdOperatorTable}. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/BeamSqlReinterpretExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/BeamSqlReinterpretExpression.java
@@ -28,30 +28,29 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * {@code BeamSqlExpression} for Reinterpret call.
  *
- * <p>Currently supported conversions:
- *  - {@link SqlTypeName#DATETIME_TYPES} to {@code BIGINT};
- *  - {@link SqlTypeName#INTEGER} to {@code BIGINT};
+ * <p>Currently supported conversions: - {@link SqlTypeName#DATETIME_TYPES} to {@code BIGINT}; -
+ * {@link SqlTypeName#INTEGER} to {@code BIGINT};
  */
 public class BeamSqlReinterpretExpression extends BeamSqlExpression {
 
-  private static final Reinterpreter REINTERPRETER = Reinterpreter.builder()
-      .withConversion(DatetimeReinterpretConversions.TIME_TO_BIGINT)
-      .withConversion(DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT)
-      .withConversion(IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT)
-      .build();
+  private static final Reinterpreter REINTERPRETER =
+      Reinterpreter.builder()
+          .withConversion(DatetimeReinterpretConversions.TIME_TO_BIGINT)
+          .withConversion(DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT)
+          .withConversion(IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT)
+          .build();
 
   public BeamSqlReinterpretExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
 
-  @Override public boolean accept() {
-    return getOperands().size() == 1
-        && REINTERPRETER.canConvert(opType(0), SqlTypeName.BIGINT);
+  @Override
+  public boolean accept() {
+    return getOperands().size() == 1 && REINTERPRETER.canConvert(opType(0), SqlTypeName.BIGINT);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
-    return REINTERPRETER.convert(
-            SqlTypeName.BIGINT,
-            operands.get(0).evaluate(inputRow, window));
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+    return REINTERPRETER.convert(SqlTypeName.BIGINT, operands.get(0).evaluate(inputRow, window));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/DatetimeReinterpretConversions.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/DatetimeReinterpretConversions.java
@@ -22,9 +22,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.ReadableInstant;
 
-/**
- * Utility class to contain implementations of datetime SQL type conversions.
- */
+/** Utility class to contain implementations of datetime SQL type conversions. */
 public abstract class DatetimeReinterpretConversions {
 
   public static final ReinterpretConversion TIME_TO_BIGINT =

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/IntegerReinterpretConversions.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/IntegerReinterpretConversions.java
@@ -21,9 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.reinterpret
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Utility class to contain implementations of SQL integer type conversions.
- */
+/** Utility class to contain implementations of SQL integer type conversions. */
 public abstract class IntegerReinterpretConversions {
 
   public static final ReinterpretConversion INTEGER_TYPES_TO_BIGINT =

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpretConversion.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpretConversion.java
@@ -27,15 +27,11 @@ import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Defines conversion between 2 SQL types.
- */
+/** Defines conversion between 2 SQL types. */
 public class ReinterpretConversion {
 
-  /**
-   * Builder for {@link ReinterpretConversion}.
-   */
-  public static class Builder  {
+  /** Builder for {@link ReinterpretConversion}. */
+  public static class Builder {
 
     private Set<SqlTypeName> from = new HashSet<>();
     private SqlTypeName to;
@@ -51,7 +47,7 @@ public class ReinterpretConversion {
       return this;
     }
 
-    public Builder from(SqlTypeName ... from) {
+    public Builder from(SqlTypeName... from) {
       return from(Arrays.asList(from));
     }
 
@@ -67,8 +63,8 @@ public class ReinterpretConversion {
 
     public ReinterpretConversion build() {
       if (from.isEmpty() || to == null || convert == null) {
-        throw new IllegalArgumentException("All arguments to ReinterpretConversion.Builder"
-            + " are mandatory.");
+        throw new IllegalArgumentException(
+            "All arguments to ReinterpretConversion.Builder" + " are mandatory.");
       }
       return new ReinterpretConversion(this);
     }
@@ -90,8 +86,13 @@ public class ReinterpretConversion {
 
   public BeamSqlPrimitive convert(BeamSqlPrimitive input) {
     if (!from.contains(input.getOutputType())) {
-      throw new IllegalArgumentException("Unable to convert from " + input.getOutputType().name()
-          + " to " + to.name() + ". This conversion only supports " + toString());
+      throw new IllegalArgumentException(
+          "Unable to convert from "
+              + input.getOutputType().name()
+              + " to "
+              + to.name()
+              + ". This conversion only supports "
+              + toString());
     }
 
     return convertFunction.apply(input);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/Reinterpreter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/Reinterpreter.java
@@ -25,14 +25,10 @@ import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Class that tracks conversions between SQL types.
- */
+/** Class that tracks conversions between SQL types. */
 public class Reinterpreter {
 
-  /**
-   * Builder for Reinterpreter.
-   */
+  /** Builder for Reinterpreter. */
   public static class Builder {
 
     private Map<SqlTypeName, Map<SqlTypeName, ReinterpretConversion>> conversions = new HashMap<>();
@@ -78,8 +74,8 @@ public class Reinterpreter {
   public BeamSqlPrimitive convert(SqlTypeName to, BeamSqlPrimitive value) {
     Optional<ReinterpretConversion> conversion = getConversion(value.getOutputType(), to);
     if (!conversion.isPresent()) {
-      throw new UnsupportedOperationException("Unsupported conversion: "
-          + value.getOutputType().name() + "->" + to.name());
+      throw new UnsupportedOperationException(
+          "Unsupported conversion: " + value.getOutputType().name() + "->" + to.name());
     }
 
     return conversion.get().convert(value);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Implementation for Reinterpret type conversions.
- */
+/** Implementation for Reinterpret type conversions. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.reinterpret;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
@@ -26,18 +26,14 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Represents a field access expression.
- */
+/** Represents a field access expression. */
 public class BeamSqlFieldAccessExpression extends BeamSqlExpression {
 
   private BeamSqlExpression referenceExpression;
   private int nestedFieldIndex;
 
   public BeamSqlFieldAccessExpression(
-      BeamSqlExpression referenceExpression,
-      int nestedFieldIndex,
-      SqlTypeName nestedFieldType) {
+      BeamSqlExpression referenceExpression, int nestedFieldIndex, SqlTypeName nestedFieldType) {
 
     super(Collections.emptyList(), nestedFieldType);
     this.referenceExpression = referenceExpression;
@@ -63,8 +59,8 @@ public class BeamSqlFieldAccessExpression extends BeamSqlExpression {
     } else {
       throw new IllegalArgumentException(
           "Attempt to access field of unsupported type "
-          + targetFieldType.getClass().getSimpleName()
-          + ". Field access operator is only supported for arrays or rows");
+              + targetFieldType.getClass().getSimpleName()
+              + ". Field access operator is only supported for arrays or rows");
     }
 
     return BeamSqlPrimitive.of(outputType, targetFieldValue);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/package-info.java
@@ -16,12 +16,9 @@
  * limitations under the License.
  */
 
-/**
- * Support for fields of type ROW.
- */
+/** Support for fields of type ROW. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.row;
 
 import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
 import edu.umd.cs.findbugs.annotations.NonNull;
-

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpression.java
@@ -25,15 +25,14 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * 'CHAR_LENGTH' operator.
- */
+/** 'CHAR_LENGTH' operator. */
 public class BeamSqlCharLengthExpression extends BeamSqlStringUnaryExpression {
   public BeamSqlCharLengthExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.INTEGER);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
     return BeamSqlPrimitive.of(SqlTypeName.INTEGER, str.length());
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpression.java
@@ -25,9 +25,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * String concat operator.
- */
+/** String concat operator. */
 public class BeamSqlConcatExpression extends BeamSqlExpression {
 
   protected BeamSqlConcatExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
@@ -38,7 +36,8 @@ public class BeamSqlConcatExpression extends BeamSqlExpression {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() != 2) {
       return false;
     }
@@ -52,12 +51,13 @@ public class BeamSqlConcatExpression extends BeamSqlExpression {
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String left = opValueEvaluated(0, inputRow, window);
     String right = opValueEvaluated(1, inputRow, window);
 
-    return BeamSqlPrimitive.of(SqlTypeName.VARCHAR,
-        new StringBuilder(left.length() + right.length())
-            .append(left).append(right).toString());
+    return BeamSqlPrimitive.of(
+        SqlTypeName.VARCHAR,
+        new StringBuilder(left.length() + right.length()).append(left).append(right).toString());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpression.java
@@ -25,15 +25,14 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * 'INITCAP' operator.
- */
+/** 'INITCAP' operator. */
 public class BeamSqlInitCapExpression extends BeamSqlStringUnaryExpression {
   public BeamSqlInitCapExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
 
     StringBuilder ret = new StringBuilder(str);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpression.java
@@ -25,15 +25,14 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * 'LOWER' operator.
- */
+/** 'LOWER' operator. */
 public class BeamSqlLowerExpression extends BeamSqlStringUnaryExpression {
   public BeamSqlLowerExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
     return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, str.toLowerCase());
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpression.java
@@ -28,16 +28,15 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * 'OVERLAY' operator.
  *
- * <p>
- *   OVERLAY(string1 PLACING string2 FROM integer [ FOR integer2 ])
- * </p>
+ * <p>OVERLAY(string1 PLACING string2 FROM integer [ FOR integer2 ])
  */
 public class BeamSqlOverlayExpression extends BeamSqlExpression {
   public BeamSqlOverlayExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() < 3 || operands.size() > 4) {
       return false;
     }
@@ -55,7 +54,8 @@ public class BeamSqlOverlayExpression extends BeamSqlExpression {
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
     String replaceStr = opValueEvaluated(1, inputRow, window);
     int idx = opValueEvaluated(2, inputRow, window);
@@ -66,11 +66,8 @@ public class BeamSqlOverlayExpression extends BeamSqlExpression {
       length = opValueEvaluated(3, inputRow, window);
     }
 
-    StringBuilder result = new StringBuilder(
-        str.length() + replaceStr.length() - length);
-    result.append(str.substring(0, idx))
-        .append(replaceStr)
-        .append(str.substring(idx + length));
+    StringBuilder result = new StringBuilder(str.length() + replaceStr.length() - length);
+    result.append(str.substring(0, idx)).append(replaceStr).append(str.substring(idx + length));
 
     return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, result.toString());
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpression.java
@@ -28,18 +28,20 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * String position operator.
  *
- * <p>
- *   example:
- *     POSITION(string1 IN string2)
- *     POSITION(string1 IN string2 FROM integer)
- * </p>
+ * <p>example:
+ *
+ * <ul>
+ *   <li>{@code POSITION(string1 IN string2)}
+ *   <li>{@code POSITION(string1 IN string2 FROM integer)}
+ * </ul>
  */
 public class BeamSqlPositionExpression extends BeamSqlExpression {
   public BeamSqlPositionExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.INTEGER);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() < 2 || operands.size() > 3) {
       return false;
     }
@@ -49,15 +51,15 @@ public class BeamSqlPositionExpression extends BeamSqlExpression {
       return false;
     }
 
-    if (operands.size() == 3
-        && !SqlTypeName.INT_TYPES.contains(opType(2))) {
+    if (operands.size() == 3 && !SqlTypeName.INT_TYPES.contains(opType(2))) {
       return false;
     }
 
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String targetStr = opValueEvaluated(0, inputRow, window);
     String containingStr = opValueEvaluated(1, inputRow, window);
     int from = -1;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlStringUnaryExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlStringUnaryExpression.java
@@ -22,15 +22,14 @@ import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Base class for all string unary operators.
- */
+/** Base class for all string unary operators. */
 public abstract class BeamSqlStringUnaryExpression extends BeamSqlExpression {
   public BeamSqlStringUnaryExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() != 1) {
       return false;
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpression.java
@@ -28,23 +28,25 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * 'SUBSTRING' operator.
  *
- * <p>
- *   SUBSTRING(string FROM integer)
- *   SUBSTRING(string FROM integer FOR integer)
- * </p>
+ * <p>Examples usage:
+ *
+ * <ul>
+ *   <li>{@code SUBSTRING(string FROM integer)}
+ *   <li>{@code SUBSTRING(string FROM integer FOR integer)}
+ * </ul>
  */
 public class BeamSqlSubstringExpression extends BeamSqlExpression {
   public BeamSqlSubstringExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() < 2 || operands.size() > 3) {
       return false;
     }
 
-    if (!SqlTypeName.CHAR_TYPES.contains(opType(0))
-        || !SqlTypeName.INT_TYPES.contains(opType(1))) {
+    if (!SqlTypeName.CHAR_TYPES.contains(opType(0)) || !SqlTypeName.INT_TYPES.contains(opType(1))) {
       return false;
     }
 
@@ -55,7 +57,8 @@ public class BeamSqlSubstringExpression extends BeamSqlExpression {
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
     int idx = opValueEvaluated(1, inputRow, window);
     int startIdx = idx;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpression.java
@@ -29,16 +29,15 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * Trim operator.
  *
- * <p>
- * TRIM( { BOTH | LEADING | TRAILING } string1 FROM string2)
- * </p>
+ * <p>TRIM( { BOTH | LEADING | TRAILING } string1 FROM string2)
  */
 public class BeamSqlTrimExpression extends BeamSqlExpression {
   public BeamSqlTrimExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public boolean accept() {
+  @Override
+  public boolean accept() {
     if (operands.size() != 1 && operands.size() != 3) {
       return false;
     }
@@ -48,21 +47,20 @@ public class BeamSqlTrimExpression extends BeamSqlExpression {
     }
 
     if (operands.size() == 3
-        && (
-        SqlTypeName.SYMBOL != opType(0)
+        && (SqlTypeName.SYMBOL != opType(0)
             || !SqlTypeName.CHAR_TYPES.contains(opType(1))
-            || !SqlTypeName.CHAR_TYPES.contains(opType(2)))
-        ) {
+            || !SqlTypeName.CHAR_TYPES.contains(opType(2)))) {
       return false;
     }
 
     return true;
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     if (operands.size() == 1) {
-      return BeamSqlPrimitive.of(SqlTypeName.VARCHAR,
-          opValueEvaluated(0, inputRow, window).toString().trim());
+      return BeamSqlPrimitive.of(
+          SqlTypeName.VARCHAR, opValueEvaluated(0, inputRow, window).toString().trim());
     } else {
       SqlTrimFunction.Flag type = opValueEvaluated(0, inputRow, window);
       String targetStr = opValueEvaluated(1, inputRow, window);
@@ -75,8 +73,8 @@ public class BeamSqlTrimExpression extends BeamSqlExpression {
           return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, trailingTrim(containingStr, targetStr));
         case BOTH:
         default:
-          return BeamSqlPrimitive.of(SqlTypeName.VARCHAR,
-              trailingTrim(leadingTrim(containingStr, targetStr), targetStr));
+          return BeamSqlPrimitive.of(
+              SqlTypeName.VARCHAR, trailingTrim(leadingTrim(containingStr, targetStr), targetStr));
       }
     }
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpression.java
@@ -25,15 +25,14 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * 'UPPER' operator.
- */
+/** 'UPPER' operator. */
 public class BeamSqlUpperExpression extends BeamSqlStringUnaryExpression {
   public BeamSqlUpperExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.VARCHAR);
   }
 
-  @Override public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
+  @Override
+  public BeamSqlPrimitive evaluate(Row inputRow, BoundedWindow window) {
     String str = opValueEvaluated(0, inputRow, window);
     return BeamSqlPrimitive.of(SqlTypeName.VARCHAR, str.toUpperCase());
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * String operators.
- */
+/** String operators. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.string;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * interpreter generate runnable 'code' to execute SQL relational expressions.
- */
+/** interpreter generate runnable 'code' to execute SQL relational expressions. */
 package org.apache.beam.sdk.extensions.sql.impl.interpreter;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Implementation classes of BeamSql.
- */
+/** Implementation classes of BeamSql. */
 package org.apache.beam.sdk.extensions.sql.impl;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCheckConstraint.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCheckConstraint.java
@@ -33,29 +33,30 @@ import org.apache.calcite.util.ImmutableNullableList;
  * <p>And {@code FOREIGN KEY}, when we support it.
  */
 public class SqlCheckConstraint extends SqlCall {
-  private static final SqlSpecialOperator OPERATOR =
-      new SqlSpecialOperator("CHECK", SqlKind.CHECK);
+  private static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("CHECK", SqlKind.CHECK);
 
   private final SqlIdentifier name;
   private final SqlNode expression;
 
   /** Creates a SqlCheckConstraint; use {@link SqlDdlNodes#check}. */
-  SqlCheckConstraint(SqlParserPos pos, SqlIdentifier name,
-      SqlNode expression) {
+  SqlCheckConstraint(SqlParserPos pos, SqlIdentifier name, SqlNode expression) {
     super(pos);
     this.name = name; // may be null
     this.expression = expression;
   }
 
-  @Override public SqlOperator getOperator() {
+  @Override
+  public SqlOperator getOperator() {
     return OPERATOR;
   }
 
-  @Override public List<SqlNode> getOperandList() {
+  @Override
+  public List<SqlNode> getOperandList() {
     return ImmutableNullableList.of(name, expression);
   }
 
-  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     if (name != null) {
       writer.keyword("CONSTRAINT");
       name.unparse(writer, 0, 0);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlColumnDeclaration.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlColumnDeclaration.java
@@ -28,9 +28,7 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-/**
- * Parse tree for column.
- */
+/** Parse tree for column. */
 public class SqlColumnDeclaration extends SqlCall {
   private static final SqlSpecialOperator OPERATOR =
       new SqlSpecialOperator("COLUMN_DECL", SqlKind.COLUMN_DECL);
@@ -40,23 +38,26 @@ public class SqlColumnDeclaration extends SqlCall {
   final SqlNode comment;
 
   /** Creates a SqlColumnDeclaration; use {@link SqlDdlNodes#column}. */
-  SqlColumnDeclaration(SqlParserPos pos, SqlIdentifier name,
-      SqlDataTypeSpec dataType, SqlNode comment) {
+  SqlColumnDeclaration(
+      SqlParserPos pos, SqlIdentifier name, SqlDataTypeSpec dataType, SqlNode comment) {
     super(pos);
     this.name = name;
     this.dataType = dataType;
     this.comment = comment;
   }
 
-  @Override public SqlOperator getOperator() {
+  @Override
+  public SqlOperator getOperator() {
     return OPERATOR;
   }
 
-  @Override public List<SqlNode> getOperandList() {
+  @Override
+  public List<SqlNode> getOperandList() {
     return ImmutableList.of(name, dataType);
   }
 
-  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     name.unparse(writer, 0, 0);
     dataType.unparse(writer, 0, 0);
     if (dataType.getNullable() != null && !dataType.getNullable()) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
@@ -43,11 +43,8 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
 
-/**
- * Parse tree for {@code CREATE TABLE} statement.
- */
-public class SqlCreateTable extends SqlCreate
-    implements SqlExecutableStatement {
+/** Parse tree for {@code CREATE TABLE} statement. */
+public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement {
   private final SqlIdentifier name;
   private final List<Schema.Field> columnList;
   private final SqlNode type;
@@ -58,9 +55,7 @@ public class SqlCreateTable extends SqlCreate
   private static final SqlOperator OPERATOR =
       new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
 
-  /**
-   * Creates a SqlCreateTable.
-   */
+  /** Creates a SqlCreateTable. */
   public SqlCreateTable(
       SqlParserPos pos,
       boolean replace,
@@ -118,14 +113,13 @@ public class SqlCreateTable extends SqlCreate
 
   @Override
   public void execute(CalcitePrepare.Context context) {
-    final Pair<CalciteSchema, String> pair =
-        SqlDdlNodes.schema(context, true, name);
+    final Pair<CalciteSchema, String> pair = SqlDdlNodes.schema(context, true, name);
     if (pair.left.plus().getTable(pair.right) != null) {
       // Table exists.
       if (!ifNotExists) {
         // They did not specify IF NOT EXISTS, so give error.
-        throw SqlUtil.newContextException(name.getParserPosition(),
-                                          RESOURCE.tableExists(pair.right));
+        throw SqlUtil.newContextException(
+            name.getParserPosition(), RESOURCE.tableExists(pair.right));
       }
       return;
     }
@@ -159,18 +153,15 @@ public class SqlCreateTable extends SqlCreate
   }
 
   Table toTable() {
-    return
-        Table
-            .builder()
-            .type(getString(type))
-            .name(name.getSimple())
-            .schema(columnList.stream().collect(toSchema()))
-            .comment(getString(comment))
-            .location(getString(location))
-            .properties((tblProperties == null)
-                            ? new JSONObject()
-                            : parseObject(getString(tblProperties)))
-            .build();
+    return Table.builder()
+        .type(getString(type))
+        .name(name.getSimple())
+        .schema(columnList.stream().collect(toSchema()))
+        .comment(getString(comment))
+        .location(getString(location))
+        .properties(
+            (tblProperties == null) ? new JSONObject() : parseObject(getString(tblProperties)))
+        .build();
   }
 }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDdlNodes.java
@@ -26,27 +26,24 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
 
-/**
- * Utilities concerning {@link SqlNode} for DDL.
- */
+/** Utilities concerning {@link SqlNode} for DDL. */
 public class SqlDdlNodes {
   private SqlDdlNodes() {}
 
   /** Creates a DROP TABLE. */
-  public static SqlDropTable dropTable(SqlParserPos pos, boolean ifExists,
-      SqlIdentifier name) {
+  public static SqlDropTable dropTable(SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
     return new SqlDropTable(pos, ifExists, name);
   }
 
   /** Creates a column declaration. */
-  public static SqlNode column(SqlParserPos pos, SqlIdentifier name,
-      SqlDataTypeSpec dataType, SqlNode comment) {
+  public static SqlNode column(
+      SqlParserPos pos, SqlIdentifier name, SqlDataTypeSpec dataType, SqlNode comment) {
     return new SqlColumnDeclaration(pos, name, dataType, comment);
   }
 
   /** Returns the schema in which to create an object. */
-  static Pair<CalciteSchema, String> schema(CalcitePrepare.Context context,
-      boolean mutable, SqlIdentifier id) {
+  static Pair<CalciteSchema, String> schema(
+      CalcitePrepare.Context context, boolean mutable, SqlIdentifier id) {
     final String name;
     final List<String> path;
     if (id.isSimple()) {
@@ -56,8 +53,7 @@ public class SqlDdlNodes {
       path = Util.skipLast(id.names);
       name = Util.last(id.names);
     }
-    CalciteSchema schema = mutable ? context.getMutableRootSchema()
-        : context.getRootSchema();
+    CalciteSchema schema = mutable ? context.getMutableRootSchema() : context.getRootSchema();
     for (String p : path) {
       schema = schema.getSubSchema(p, true);
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropObject.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropObject.java
@@ -33,16 +33,14 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
 /**
- * Base class for parse trees of {@code DROP TABLE}, {@code DROP VIEW} and
- * {@code DROP MATERIALIZED VIEW} statements.
+ * Base class for parse trees of {@code DROP TABLE}, {@code DROP VIEW} and {@code DROP MATERIALIZED
+ * VIEW} statements.
  */
-abstract class SqlDropObject extends SqlDrop
-    implements SqlExecutableStatement {
+abstract class SqlDropObject extends SqlDrop implements SqlExecutableStatement {
   protected final SqlIdentifier name;
 
   /** Creates a SqlDropObject. */
-  SqlDropObject(SqlOperator operator, SqlParserPos pos, boolean ifExists,
-      SqlIdentifier name) {
+  SqlDropObject(SqlOperator operator, SqlParserPos pos, boolean ifExists, SqlIdentifier name) {
     super(operator, pos, ifExists);
     this.name = name;
   }
@@ -51,7 +49,8 @@ abstract class SqlDropObject extends SqlDrop
     return ImmutableList.<SqlNode>of(name);
   }
 
-  @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword(getOperator().getName()); // "DROP TABLE" etc.
     if (ifExists) {
       writer.keyword("IF EXISTS");
@@ -67,21 +66,21 @@ abstract class SqlDropObject extends SqlDrop
     }
     final boolean existed;
     switch (getKind()) {
-    case DROP_TABLE:
-      if (schema.schema instanceof BeamCalciteSchema) {
-        BeamCalciteSchema beamSchema = (BeamCalciteSchema) schema.schema;
-        beamSchema.getTableProvider().dropTable(name.getSimple());
-        existed = true;
-      } else {
-        existed = schema.removeTable(name.getSimple());
-      }
-      if (!existed && !ifExists) {
-        throw SqlUtil.newContextException(name.getParserPosition(),
-            RESOURCE.tableNotFound(name.getSimple()));
-      }
-      break;
-    default:
-      throw new AssertionError(getKind());
+      case DROP_TABLE:
+        if (schema.schema instanceof BeamCalciteSchema) {
+          BeamCalciteSchema beamSchema = (BeamCalciteSchema) schema.schema;
+          beamSchema.getTableProvider().dropTable(name.getSimple());
+          existed = true;
+        } else {
+          existed = schema.removeTable(name.getSimple());
+        }
+        if (!existed && !ifExists) {
+          throw SqlUtil.newContextException(
+              name.getParserPosition(), RESOURCE.tableNotFound(name.getSimple()));
+        }
+        break;
+      default:
+        throw new AssertionError(getKind());
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlDropTable.java
@@ -22,9 +22,7 @@ import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.parser.SqlParserPos;
 
-/**
- * Parse tree for {@code DROP TABLE} statement.
- */
+/** Parse tree for {@code DROP TABLE} statement. */
 public class SqlDropTable extends SqlDropObject {
   private static final SqlOperator OPERATOR =
       new SqlSpecialOperator("DROP TABLE", SqlKind.DROP_TABLE);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Created by xumingmingv on 16/06/2017.
- */
+/** Beam SQL parsing additions to Calcite SQL. */
 package org.apache.beam.sdk.extensions.sql.impl.parser;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamQueryPlanner.java
@@ -53,9 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The core component to handle through a SQL statement, from explain execution plan,
- * to generate a Beam pipeline.
- *
+ * The core component to handle through a SQL statement, from explain execution plan, to generate a
+ * Beam pipeline.
  */
 public class BeamQueryPlanner {
   private static final Logger LOG = LoggerFactory.getLogger(BeamQueryPlanner.class);
@@ -64,12 +63,13 @@ public class BeamQueryPlanner {
 
   public BeamQueryPlanner(CalciteConnection connection) {
     final CalciteConnectionConfig config = connection.config();
-    final SqlParser.ConfigBuilder parserConfig = SqlParser.configBuilder()
-        .setQuotedCasing(config.quotedCasing())
-        .setUnquotedCasing(config.unquotedCasing())
-        .setQuoting(config.quoting())
-        .setConformance(config.conformance())
-        .setCaseSensitive(config.caseSensitive());
+    final SqlParser.ConfigBuilder parserConfig =
+        SqlParser.configBuilder()
+            .setQuotedCasing(config.quotedCasing())
+            .setUnquotedCasing(config.unquotedCasing())
+            .setQuoting(config.quoting())
+            .setConformance(config.conformance())
+            .setCaseSensitive(config.caseSensitive());
     final SqlParserImplFactory parserFactory =
         config.parserFactory(SqlParserImplFactory.class, null);
     if (parserFactory != null) {
@@ -79,9 +79,8 @@ public class BeamQueryPlanner {
     final SchemaPlus schema = connection.getRootSchema();
     final SchemaPlus defaultSchema = JdbcDriver.getDefaultSchema(connection);
 
-    final ImmutableList<RelTraitDef> traitDefs = ImmutableList.of(
-      ConventionTraitDef.INSTANCE,
-      RelCollationTraitDef.INSTANCE);
+    final ImmutableList<RelTraitDef> traitDefs =
+        ImmutableList.of(ConventionTraitDef.INSTANCE, RelCollationTraitDef.INSTANCE);
 
     final CalciteCatalogReader catalogReader =
         new CalciteCatalogReader(
@@ -90,8 +89,7 @@ public class BeamQueryPlanner {
             connection.getTypeFactory(),
             connection.config());
     final SqlOperatorTable opTab0 =
-        connection.config().fun(SqlOperatorTable.class,
-            SqlStdOperatorTable.instance());
+        connection.config().fun(SqlOperatorTable.class, SqlStdOperatorTable.instance());
 
     this.config =
         Frameworks.newConfigBuilder()
@@ -106,9 +104,7 @@ public class BeamQueryPlanner {
             .build();
   }
 
-  /**
-   * Parse input SQL query, and return a {@link SqlNode} as grammar tree.
-   */
+  /** Parse input SQL query, and return a {@link SqlNode} as grammar tree. */
   public SqlNode parse(String sqlStatement) throws SqlParseException {
     Planner planner = getPlanner();
     SqlNode parsed;
@@ -121,9 +117,9 @@ public class BeamQueryPlanner {
   }
 
   /**
-   * {@code compileBeamPipeline} translate a SQL statement to executed as Beam data flow,
-   * which is linked with the given {@code pipeline}. The final output stream is returned as
-   * {@code PCollection} so more operations can be applied.
+   * {@code compileBeamPipeline} translate a SQL statement to executed as Beam data flow, which is
+   * linked with the given {@code pipeline}. The final output stream is returned as {@code
+   * PCollection} so more operations can be applied.
    */
   public PCollection<Row> compileBeamPipeline(String sqlStatement, Pipeline basePipeline)
       throws ValidationException, RelConversionException, SqlParseException {
@@ -133,11 +129,7 @@ public class BeamQueryPlanner {
     return PCollectionTuple.empty(basePipeline).apply(relNode.toPTransform());
   }
 
-  /**
-   * It parses and validate the input query, then convert into a
-   * {@link BeamRelNode} tree.
-   *
-   */
+  /** It parses and validate the input query, then convert into a {@link BeamRelNode} tree. */
   public BeamRelNode convertToBeamRel(String sqlStatement)
       throws ValidationException, RelConversionException, SqlParseException {
     BeamRelNode beamRelNode;
@@ -150,10 +142,12 @@ public class BeamQueryPlanner {
       RelRoot root = planner.rel(validated);
       LOG.info("SQLPlan>\n" + RelOptUtil.toString(root.rel));
 
-      RelTraitSet desiredTraits = root.rel.getTraitSet()
-          .replace(BeamLogicalConvention.INSTANCE)
-          .replace(root.collation)
-          .simplify();
+      RelTraitSet desiredTraits =
+          root.rel
+              .getTraitSet()
+              .replace(BeamLogicalConvention.INSTANCE)
+              .replace(root.collation)
+              .simplify();
       beamRelNode = (BeamRelNode) planner.transform(0, desiredTraits, root.rel);
     } finally {
       planner.close();
@@ -164,5 +158,4 @@ public class BeamQueryPlanner {
   private Planner getPlanner() {
     return Frameworks.getPlanner(config);
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamRelDataTypeSystem.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/BeamRelDataTypeSystem.java
@@ -20,15 +20,11 @@ package org.apache.beam.sdk.extensions.sql.impl.planner;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
 
-/**
- * customized data type in Beam.
- *
- */
+/** customized data type in Beam. */
 public class BeamRelDataTypeSystem extends RelDataTypeSystemImpl {
   public static final RelDataTypeSystem INSTANCE = new BeamRelDataTypeSystem();
 
-  private BeamRelDataTypeSystem() {
-  }
+  private BeamRelDataTypeSystem() {}
 
   @Override
   public int getMaxNumericScale() {
@@ -39,5 +35,4 @@ public class BeamRelDataTypeSystem extends RelDataTypeSystemImpl {
   public int getMaxNumericPrecision() {
     return 38;
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/planner/package-info.java
@@ -18,7 +18,6 @@
 
 /**
  * {@link org.apache.beam.sdk.extensions.sql.impl.planner.BeamQueryPlanner} is the main interface.
- * It defines data sources, validate a SQL statement, and convert it as a Beam
- * pipeline.
+ * It defines data sources, validate a SQL statement, and convert it as a Beam pipeline.
  */
 package org.apache.beam.sdk.extensions.sql.impl.planner;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -51,9 +51,7 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.joda.time.Duration;
 
-/**
- * {@link BeamRelNode} to replace a {@link Aggregate} node.
- */
+/** {@link BeamRelNode} to replace a {@link Aggregate} node. */
 public class BeamAggregationRel extends Aggregate implements BeamRelNode {
   private final int windowFieldIndex;
   private Optional<AggregateWindowField> windowField;
@@ -87,115 +85,116 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
       PCollection<Row> upstream =
           inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
       if (windowField.isPresent()) {
-        upstream = upstream.apply(stageName + "assignEventTimestamp", WithTimestamps
-          .of(new BeamAggregationTransforms.WindowTimestampFn(windowFieldIndex))
-          .withAllowedTimestampSkew(new Duration(Long.MAX_VALUE)))
-          .setCoder(upstream.getCoder());
+        upstream =
+            upstream
+                .apply(
+                    stageName + "assignEventTimestamp",
+                    WithTimestamps.of(
+                            new BeamAggregationTransforms.WindowTimestampFn(windowFieldIndex))
+                        .withAllowedTimestampSkew(new Duration(Long.MAX_VALUE)))
+                .setCoder(upstream.getCoder());
       }
 
-    PCollection<Row> windowedStream =
-        windowField.isPresent()
-            ? upstream.apply(stageName + "window", Window.into(windowField.get().windowFn()))
-            : upstream;
+      PCollection<Row> windowedStream =
+          windowField.isPresent()
+              ? upstream.apply(stageName + "window", Window.into(windowField.get().windowFn()))
+              : upstream;
 
-    validateWindowIsSupported(windowedStream);
+      validateWindowIsSupported(windowedStream);
 
-    Schema keySchema = exKeyFieldsSchema(input.getRowType());
-    RowCoder keyCoder = keySchema.getRowCoder();
-    PCollection<KV<Row, Row>> exCombineByStream = windowedStream.apply(
-        stageName + "exCombineBy",
-        WithKeys
-            .of(new BeamAggregationTransforms.AggregationGroupByKeyFn(
-                keySchema, windowFieldIndex, groupSet)))
-        .setCoder(KvCoder.of(keyCoder, upstream.getCoder()));
+      Schema keySchema = exKeyFieldsSchema(input.getRowType());
+      RowCoder keyCoder = keySchema.getRowCoder();
+      PCollection<KV<Row, Row>> exCombineByStream =
+          windowedStream
+              .apply(
+                  stageName + "exCombineBy",
+                  WithKeys.of(
+                      new BeamAggregationTransforms.AggregationGroupByKeyFn(
+                          keySchema, windowFieldIndex, groupSet)))
+              .setCoder(KvCoder.of(keyCoder, upstream.getCoder()));
 
-    RowCoder aggCoder = exAggFieldsSchema().getRowCoder();
+      RowCoder aggCoder = exAggFieldsSchema().getRowCoder();
 
-    PCollection<KV<Row, Row>> aggregatedStream =
-        exCombineByStream
-            .apply(
-                stageName + "combineBy",
-                Combine.perKey(
-                    new BeamAggregationTransforms.AggregationAdaptor(
-                        getAggCallList(), CalciteUtils.toBeamSchema(input.getRowType()))))
-            .setCoder(KvCoder.of(keyCoder, aggCoder));
+      PCollection<KV<Row, Row>> aggregatedStream =
+          exCombineByStream
+              .apply(
+                  stageName + "combineBy",
+                  Combine.perKey(
+                      new BeamAggregationTransforms.AggregationAdaptor(
+                          getAggCallList(), CalciteUtils.toBeamSchema(input.getRowType()))))
+              .setCoder(KvCoder.of(keyCoder, aggCoder));
 
-    PCollection<Row> mergedStream = aggregatedStream.apply(
-        stageName + "mergeRecord",
-        ParDo.of(
-            new BeamAggregationTransforms.MergeAggregationRecord(
-                CalciteUtils.toBeamSchema(getRowType()),
-                getAggCallList(),
-                windowFieldIndex)));
-    mergedStream.setCoder(CalciteUtils.toBeamSchema(getRowType()).getRowCoder());
+      PCollection<Row> mergedStream =
+          aggregatedStream.apply(
+              stageName + "mergeRecord",
+              ParDo.of(
+                  new BeamAggregationTransforms.MergeAggregationRecord(
+                      CalciteUtils.toBeamSchema(getRowType()),
+                      getAggCallList(),
+                      windowFieldIndex)));
+      mergedStream.setCoder(CalciteUtils.toBeamSchema(getRowType()).getRowCoder());
 
-    return mergedStream;
-  }
-
-
-  /**
-   * Performs the same check as {@link GroupByKey}, provides more context in exception.
-   *
-   * <p>Verifies that the input PCollection is bounded, or that there is windowing/triggering being
-   * used. Without this, the watermark (at end of global window) will never be reached.
-   *
-   * <p>Throws {@link UnsupportedOperationException} if validation fails.
-   */
-  private void validateWindowIsSupported(PCollection<Row> upstream) {
-    WindowingStrategy<?, ?> windowingStrategy = upstream.getWindowingStrategy();
-    if (windowingStrategy.getWindowFn() instanceof GlobalWindows
-        && windowingStrategy.getTrigger() instanceof DefaultTrigger
-        && upstream.isBounded() != BOUNDED) {
-
-      throw new UnsupportedOperationException(
-          "Please explicitly specify windowing in SQL query using HOP/TUMBLE/SESSION functions "
-              + "(default trigger will be used in this case). "
-              + "Unbounded input with global windowing and default trigger is not supported "
-              + "in Beam SQL aggregations. "
-              + "See GroupByKey section in Beam Programming Guide");
+      return mergedStream;
     }
-  }
 
-  /**
-   * Type of sub-rowrecord used as Group-By keys.
-   */
-  private Schema exKeyFieldsSchema(RelDataType relDataType) {
-    Schema inputSchema = CalciteUtils.toBeamSchema(relDataType);
-    return groupSet
-        .asList()
-        .stream()
-        .filter(i -> i != windowFieldIndex)
-        .map(i -> newRowField(inputSchema, i))
-        .collect(toSchema());
-  }
+    /**
+     * Performs the same check as {@link GroupByKey}, provides more context in exception.
+     *
+     * <p>Verifies that the input PCollection is bounded, or that there is windowing/triggering
+     * being used. Without this, the watermark (at end of global window) will never be reached.
+     *
+     * <p>Throws {@link UnsupportedOperationException} if validation fails.
+     */
+    private void validateWindowIsSupported(PCollection<Row> upstream) {
+      WindowingStrategy<?, ?> windowingStrategy = upstream.getWindowingStrategy();
+      if (windowingStrategy.getWindowFn() instanceof GlobalWindows
+          && windowingStrategy.getTrigger() instanceof DefaultTrigger
+          && upstream.isBounded() != BOUNDED) {
 
-  private Schema.Field newRowField(Schema schema, int i) {
-    return schema.getField(i);
-  }
+        throw new UnsupportedOperationException(
+            "Please explicitly specify windowing in SQL query using HOP/TUMBLE/SESSION functions "
+                + "(default trigger will be used in this case). "
+                + "Unbounded input with global windowing and default trigger is not supported "
+                + "in Beam SQL aggregations. "
+                + "See GroupByKey section in Beam Programming Guide");
+      }
+    }
 
-  /**
-   * Type of sub-rowrecord, that represents the list of aggregation fields.
-   */
-  private Schema exAggFieldsSchema() {
-    return
-        getAggCallList()
-            .stream()
-            .map(this::newRowField)
-            .collect(toSchema());
-  }
+    /** Type of sub-rowrecord used as Group-By keys. */
+    private Schema exKeyFieldsSchema(RelDataType relDataType) {
+      Schema inputSchema = CalciteUtils.toBeamSchema(relDataType);
+      return groupSet
+          .asList()
+          .stream()
+          .filter(i -> i != windowFieldIndex)
+          .map(i -> newRowField(inputSchema, i))
+          .collect(toSchema());
+    }
 
-  private Schema.Field newRowField(AggregateCall aggCall) {
-    return Schema.Field.of(aggCall.getName(), CalciteUtils.toFieldType(aggCall.getType()))
-        .withNullable(aggCall.getType().isNullable());
-  }
+    private Schema.Field newRowField(Schema schema, int i) {
+      return schema.getField(i);
+    }
+
+    /** Type of sub-rowrecord, that represents the list of aggregation fields. */
+    private Schema exAggFieldsSchema() {
+      return getAggCallList().stream().map(this::newRowField).collect(toSchema());
+    }
+
+    private Schema.Field newRowField(AggregateCall aggCall) {
+      return Schema.Field.of(aggCall.getName(), CalciteUtils.toFieldType(aggCall.getType()))
+          .withNullable(aggCall.getType().isNullable());
+    }
   }
 
   @Override
   public Aggregate copy(
-      RelTraitSet traitSet, RelNode input, boolean indicator
-      , ImmutableBitSet groupSet,
-      List<ImmutableBitSet> groupSets, List<AggregateCall> aggCalls) {
-    return new BeamAggregationRel(getCluster(), traitSet, input, indicator
-        , groupSet, groupSets, aggCalls, windowField);
+      RelTraitSet traitSet,
+      RelNode input,
+      boolean indicator,
+      ImmutableBitSet groupSet,
+      List<ImmutableBitSet> groupSets,
+      List<AggregateCall> aggCalls) {
+    return new BeamAggregationRel(
+        getCluster(), traitSet, input, indicator, groupSet, groupSets, aggCalls, windowField);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamFilterRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamFilterRel.java
@@ -32,14 +32,11 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rex.RexNode;
 
-/**
- * BeamRelNode to replace a {@code Filter} node.
- *
- */
+/** BeamRelNode to replace a {@code Filter} node. */
 public class BeamFilterRel extends Filter implements BeamRelNode {
 
-  public BeamFilterRel(RelOptCluster cluster, RelTraitSet traits, RelNode child,
-      RexNode condition) {
+  public BeamFilterRel(
+      RelOptCluster cluster, RelTraitSet traits, RelNode child, RexNode condition) {
     super(cluster, traits, child, condition);
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
@@ -67,16 +67,17 @@ public class BeamIOSinkRel extends TableModify
   @Override
   public RelNode copy(RelTraitSet traitSet, List<RelNode> inputs) {
     boolean flattened = isFlattened() || isFlattening;
-    BeamIOSinkRel newRel = new BeamIOSinkRel(
-        getCluster(),
-        getTable(),
-        getCatalogReader(),
-        sole(inputs),
-        getOperation(),
-        getUpdateColumnList(),
-        getSourceExpressionList(),
-        flattened,
-        sqlTable);
+    BeamIOSinkRel newRel =
+        new BeamIOSinkRel(
+            getCluster(),
+            getTable(),
+            getCatalogReader(),
+            sole(inputs),
+            getOperation(),
+            getUpdateColumnList(),
+            getSourceExpressionList(),
+            flattened,
+            sqlTable);
     newRel.traitSet = traitSet;
     return newRel;
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
@@ -26,16 +26,12 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
 import org.apache.calcite.rel.core.TableScan;
 
-/**
- * BeamRelNode to replace a {@code TableScan} node.
- *
- */
+/** BeamRelNode to replace a {@code TableScan} node. */
 public class BeamIOSourceRel extends TableScan implements BeamRelNode {
 
   private BeamSqlTable sqlTable;
 
-  public BeamIOSourceRel(
-      RelOptCluster cluster, RelOptTable table, BeamSqlTable sqlTable) {
+  public BeamIOSourceRel(RelOptCluster cluster, RelOptTable table, BeamSqlTable sqlTable) {
     super(cluster, cluster.traitSetOf(BeamLogicalConvention.INSTANCE), table);
     this.sqlTable = sqlTable;
   }
@@ -49,8 +45,7 @@ public class BeamIOSourceRel extends TableScan implements BeamRelNode {
 
     @Override
     public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      return sqlTable
-          .buildIOReader(inputPCollections.getPipeline());
+      return sqlTable.buildIOReader(inputPCollections.getPipeline());
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
@@ -64,30 +64,30 @@ import org.apache.calcite.util.Pair;
  * {@code BeamRelNode} to replace a {@code Join} node.
  *
  * <p>Support for join can be categorized into 3 cases:
+ *
  * <ul>
- *   <li>BoundedTable JOIN BoundedTable</li>
- *   <li>UnboundedTable JOIN UnboundedTable</li>
- *   <li>BoundedTable JOIN UnboundedTable</li>
+ *   <li>BoundedTable JOIN BoundedTable
+ *   <li>UnboundedTable JOIN UnboundedTable
+ *   <li>BoundedTable JOIN UnboundedTable
  * </ul>
  *
- * <p>For the first two cases, a standard join is utilized as long as the windowFn of the both
- * sides match.
+ * <p>For the first two cases, a standard join is utilized as long as the windowFn of the both sides
+ * match.
  *
  * <p>For the third case, {@code sideInput} is utilized to implement the join, so there are some
  * constraints:
  *
  * <ul>
- *   <li>{@code FULL OUTER JOIN} is not supported.</li>
- *   <li>If it's a {@code LEFT OUTER JOIN}, the unbounded table should on the left side.</li>
- *   <li>If it's a {@code RIGHT OUTER JOIN}, the unbounded table should on the right side.</li>
+ *   <li>{@code FULL OUTER JOIN} is not supported.
+ *   <li>If it's a {@code LEFT OUTER JOIN}, the unbounded table should on the left side.
+ *   <li>If it's a {@code RIGHT OUTER JOIN}, the unbounded table should on the right side.
  * </ul>
- *
  *
  * <p>There are also some general constraints:
  *
  * <ul>
- *  <li>Only equi-join is supported.</li>
- *  <li>CROSS JOIN is not supported.</li>
+ *   <li>Only equi-join is supported.
+ *   <li>CROSS JOIN is not supported.
  * </ul>
  */
 public class BeamJoinRel extends Join implements BeamRelNode {
@@ -111,8 +111,8 @@ public class BeamJoinRel extends Join implements BeamRelNode {
       RelNode right,
       JoinRelType joinType,
       boolean semiJoinDone) {
-    return new BeamJoinRel(getCluster(), traitSet, left, right, conditionExpr, variablesSet,
-        joinType);
+    return new BeamJoinRel(
+        getCluster(), traitSet, left, right, conditionExpr, variablesSet, joinType);
   }
 
   @Override
@@ -134,8 +134,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
       }
 
       PCollection<Row> leftRows = inputPCollections.apply("left", leftRelNode.toPTransform());
-      PCollection<Row> rightRows =
-          inputPCollections.apply("right", rightRelNode.toPTransform());
+      PCollection<Row> rightRows = inputPCollections.apply("right", rightRelNode.toPTransform());
 
       verifySupportedTrigger(leftRows);
       verifySupportedTrigger(rightRows);
@@ -151,10 +150,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
       // build the extract key type
       // the name of the join field is not important
       Schema extractKeySchema =
-          pairs
-              .stream()
-              .map(pair -> leftSchema.getField(pair.getKey()))
-              .collect(toSchema());
+          pairs.stream().map(pair -> leftSchema.getField(pair.getKey())).collect(toSchema());
 
       Coder extractKeyRowCoder = extractKeySchema.getRowCoder();
 
@@ -367,9 +363,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
   }
 
   private PCollection<Row> joinAsLookup(
-      BeamRelNode leftRelNode,
-      BeamRelNode rightRelNode,
-      PCollectionTuple inputPCollections) {
+      BeamRelNode leftRelNode, BeamRelNode rightRelNode, PCollectionTuple inputPCollections) {
     PCollection<Row> factStream = inputPCollections.apply(leftRelNode.toPTransform());
     BeamIOSourceRel srcRel = (BeamIOSourceRel) rightRelNode;
     BeamSqlSeekableTable seekableTable = (BeamSqlSeekableTable) srcRel.getBeamSqlTable();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamLogicalConvention.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamLogicalConvention.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -26,10 +26,7 @@ import org.apache.calcite.plan.RelTrait;
 import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.plan.RelTraitSet;
 
-/**
- * Convertion for Beam SQL.
- *
- */
+/** Convertion for Beam SQL. */
 public enum BeamLogicalConvention implements Convention {
   INSTANCE;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
@@ -38,14 +38,14 @@ public class BeamMinusRel extends Minus implements BeamRelNode {
 
   private BeamSetOperatorRelBase delegate;
 
-  public BeamMinusRel(RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs,
-      boolean all) {
+  public BeamMinusRel(
+      RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
     super(cluster, traits, inputs, all);
-    delegate = new BeamSetOperatorRelBase(this,
-        BeamSetOperatorRelBase.OpType.MINUS, inputs, all);
+    delegate = new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.MINUS, inputs, all);
   }
 
-  @Override public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+  @Override
+  public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
     return new BeamMinusRel(getCluster(), traitSet, inputs, all);
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamProjectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamProjectRel.java
@@ -37,24 +37,22 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 
-/**
- * BeamRelNode to replace a {@code Project} node.
- *
- */
+/** BeamRelNode to replace a {@code Project} node. */
 public class BeamProjectRel extends Project implements BeamRelNode {
 
-  /**
-   * projects: {@link RexLiteral}, {@link RexInputRef}, {@link RexCall}.
-   *
-   */
-  public BeamProjectRel(RelOptCluster cluster, RelTraitSet traits, RelNode input,
-      List<? extends RexNode> projects, RelDataType rowType) {
+  /** projects: {@link RexLiteral}, {@link RexInputRef}, {@link RexCall}. */
+  public BeamProjectRel(
+      RelOptCluster cluster,
+      RelTraitSet traits,
+      RelNode input,
+      List<? extends RexNode> projects,
+      RelDataType rowType) {
     super(cluster, traits, input, projects, rowType);
   }
 
   @Override
-  public Project copy(RelTraitSet traitSet, RelNode input, List<RexNode> projects,
-      RelDataType rowType) {
+  public Project copy(
+      RelTraitSet traitSet, RelNode input, List<RexNode> projects, RelDataType rowType) {
     return new BeamProjectRel(getCluster(), traitSet, input, projects, rowType);
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
@@ -35,13 +35,11 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.calcite.rel.RelNode;
 
 /**
- * Delegate for Set operators: {@code BeamUnionRel}, {@code BeamIntersectRel}
- * and {@code BeamMinusRel}.
+ * Delegate for Set operators: {@code BeamUnionRel}, {@code BeamIntersectRel} and {@code
+ * BeamMinusRel}.
  */
 public class BeamSetOperatorRelBase {
-  /**
-   * Set operator type.
-   */
+  /** Set operator type. */
   public enum OpType implements Serializable {
     UNION,
     INTERSECT,
@@ -53,8 +51,8 @@ public class BeamSetOperatorRelBase {
   private boolean all;
   private OpType opType;
 
-  public BeamSetOperatorRelBase(BeamRelNode beamRelNode, OpType opType,
-      List<RelNode> inputs, boolean all) {
+  public BeamSetOperatorRelBase(
+      BeamRelNode beamRelNode, OpType opType, List<RelNode> inputs, boolean all) {
     this.beamRelNode = beamRelNode;
     this.opType = opType;
     this.inputs = inputs;
@@ -73,8 +71,12 @@ public class BeamSetOperatorRelBase {
     WindowFn rightWindow = rightRows.getWindowingStrategy().getWindowFn();
     if (!leftWindow.isCompatible(rightWindow)) {
       throw new IllegalArgumentException(
-          "inputs of " + opType + " have different window strategy: "
-          + leftWindow + " VS " + rightWindow);
+          "inputs of "
+              + opType
+              + " have different window strategy: "
+              + leftWindow
+              + " VS "
+              + rightWindow);
     }
 
     final TupleTag<Row> leftTag = new TupleTag<>();
@@ -94,9 +96,11 @@ public class BeamSetOperatorRelBase {
                     stageName + "_CreateRightIndex",
                     MapElements.via(new BeamSetOperatorsTransforms.BeamSqlRow2KvFn())))
             .apply(CoGroupByKey.create());
-    PCollection<Row> ret = coGbkResultCollection
-        .apply(ParDo.of(new BeamSetOperatorsTransforms.SetOperatorFilteringDoFn(leftTag, rightTag,
-            opType, all)));
+    PCollection<Row> ret =
+        coGbkResultCollection.apply(
+            ParDo.of(
+                new BeamSetOperatorsTransforms.SetOperatorFilteringDoFn(
+                    leftTag, rightTag, opType, all)));
     return ret;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -51,27 +51,27 @@ import org.apache.calcite.sql.type.SqlTypeName;
 /**
  * {@code BeamRelNode} to replace a {@code Sort} node.
  *
- * <p>Since Beam does not fully supported global sort we are using {@link Top} to implement
- * the {@code Sort} algebra. The following types of ORDER BY are supported:
-
+ * <p>Since Beam does not fully supported global sort we are using {@link Top} to implement the
+ * {@code Sort} algebra. The following types of ORDER BY are supported:
+ *
  * <pre>{@code
- *     select * from t order by id desc limit 10;
- *     select * from t order by id desc limit 10 offset 5;
+ * select * from t order by id desc limit 10;
+ * select * from t order by id desc limit 10 offset 5;
  * }</pre>
  *
  * <p>but Order BY without a limit is NOT supported:
  *
  * <pre>{@code
- *   select * from t order by id desc
+ * select * from t order by id desc
  * }</pre>
  *
  * <h3>Constraints</h3>
+ *
  * <ul>
- *   <li>Due to the constraints of {@link Top}, the result of a `ORDER BY LIMIT`
- *   must fit into the memory of a single machine.</li>
- *   <li>Since `WINDOW`(HOP, TUMBLE, SESSION etc) is always associated with `GroupBy`,
- *   it does not make much sense to use `ORDER BY` with `WINDOW`.
- *   </li>
+ *   <li>Due to the constraints of {@link Top}, the result of a `ORDER BY LIMIT` must fit into the
+ *       memory of a single machine.
+ *   <li>Since `WINDOW`(HOP, TUMBLE, SESSION etc) is always associated with `GroupBy`, it does not
+ *       make much sense to use `ORDER BY` with `WINDOW`.
  * </ul>
  */
 public class BeamSortRel extends Sort implements BeamRelNode {
@@ -180,8 +180,13 @@ public class BeamSortRel extends Sort implements BeamRelNode {
     }
   }
 
-  @Override public Sort copy(RelTraitSet traitSet, RelNode newInput, RelCollation newCollation,
-      RexNode offset, RexNode fetch) {
+  @Override
+  public Sort copy(
+      RelTraitSet traitSet,
+      RelNode newInput,
+      RelCollation newCollation,
+      RexNode offset,
+      RexNode fetch) {
     return new BeamSortRel(getCluster(), traitSet, newInput, newCollation, offset, fetch);
   }
 
@@ -190,15 +195,15 @@ public class BeamSortRel extends Sort implements BeamRelNode {
     private List<Boolean> orientation;
     private List<Boolean> nullsFirst;
 
-    public BeamSqlRowComparator(List<Integer> fieldsIndices,
-        List<Boolean> orientation,
-        List<Boolean> nullsFirst) {
+    public BeamSqlRowComparator(
+        List<Integer> fieldsIndices, List<Boolean> orientation, List<Boolean> nullsFirst) {
       this.fieldsIndices = fieldsIndices;
       this.orientation = orientation;
       this.nullsFirst = nullsFirst;
     }
 
-    @Override public int compare(Row row1, Row row2) {
+    @Override
+    public int compare(Row row1, Row row2) {
       for (int i = 0; i < fieldsIndices.size(); i++) {
         int fieldIndex = fieldsIndices.get(i);
         int fieldRet = 0;
@@ -244,5 +249,4 @@ public class BeamSortRel extends Sort implements BeamRelNode {
       return 0;
     }
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
@@ -25,9 +25,7 @@ import org.apache.calcite.sql.SqlExplainLevel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Utilities for {@code BeamRelNode}.
- */
+/** Utilities for {@code BeamRelNode}. */
 class BeamSqlRelUtils {
   private static final Logger LOG = LoggerFactory.getLogger(BeamSqlRelUtils.class);
 
@@ -35,13 +33,20 @@ class BeamSqlRelUtils {
   private static final AtomicInteger classSequence = new AtomicInteger(0);
 
   public static String getStageName(BeamRelNode relNode) {
-    return relNode.getClass().getSimpleName().toUpperCase() + "_" + relNode.getId() + "_"
+    return relNode.getClass().getSimpleName().toUpperCase()
+        + "_"
+        + relNode.getId()
+        + "_"
         + sequence.getAndIncrement();
   }
 
   public static String getClassName(BeamRelNode relNode) {
-    return "Generated_" + relNode.getClass().getSimpleName().toUpperCase() + "_" + relNode.getId()
-        + "_" + classSequence.getAndIncrement();
+    return "Generated_"
+        + relNode.getClass().getSimpleName().toUpperCase()
+        + "_"
+        + relNode.getId()
+        + "_"
+        + classSequence.getAndIncrement();
   }
 
   public static BeamRelNode getBeamRelInput(RelNode input) {
@@ -61,11 +66,13 @@ class BeamSqlRelUtils {
     try {
       explain = RelOptUtil.toString(rel);
     } catch (StackOverflowError e) {
-      LOG.error("StackOverflowError occurred while extracting plan. "
-          + "Please report it to the dev@ mailing list.");
+      LOG.error(
+          "StackOverflowError occurred while extracting plan. "
+              + "Please report it to the dev@ mailing list.");
       LOG.error("RelNode " + rel + " ExplainLevel " + detailLevel, e);
-      LOG.error("Forcing plan to empty string and continue... "
-          + "SQL Runner may not working properly after.");
+      LOG.error(
+          "Forcing plan to empty string and continue... "
+              + "SQL Runner may not working properly after.");
     }
     return explain;
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
@@ -39,40 +39,41 @@ import org.apache.calcite.rel.core.Union;
  * <p>1) Do not use {@code grouped window function}:
  *
  * <pre>{@code
- *   select * from person UNION select * from person
+ * select * from person UNION select * from person
  * }</pre>
  *
  * <p>2) Use the same {@code grouped window function}, with the same param:
+ *
  * <pre>{@code
- *   select id, count(*) from person
- *   group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
- *   UNION
- *   select * from person
- *   group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
+ * select id, count(*) from person
+ * group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
+ * UNION
+ * select * from person
+ * group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
  * }</pre>
  *
  * <p>Inputs with different group functions are NOT supported:
+ *
  * <pre>{@code
- *   select id, count(*) from person
- *   group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
- *   UNION
- *   select * from person
- *   group by id, TUMBLE(order_time, INTERVAL '2' HOUR)
+ * select id, count(*) from person
+ * group by id, TUMBLE(order_time, INTERVAL '1' HOUR)
+ * UNION
+ * select * from person
+ * group by id, TUMBLE(order_time, INTERVAL '2' HOUR)
  * }</pre>
  */
 public class BeamUnionRel extends Union implements BeamRelNode {
   private BeamSetOperatorRelBase delegate;
-  public BeamUnionRel(RelOptCluster cluster,
-      RelTraitSet traits,
-      List<RelNode> inputs,
-      boolean all) {
+
+  public BeamUnionRel(
+      RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
     super(cluster, traits, inputs, all);
-    this.delegate = new BeamSetOperatorRelBase(this,
-        BeamSetOperatorRelBase.OpType.UNION,
-        inputs, all);
+    this.delegate =
+        new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.UNION, inputs, all);
   }
 
-  @Override public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
+  @Override
+  public SetOp copy(RelTraitSet traitSet, List<RelNode> inputs, boolean all) {
     return new BeamUnionRel(getCluster(), traitSet, inputs, all);
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
@@ -42,9 +42,10 @@ import org.apache.calcite.rex.RexLiteral;
  * {@code BeamRelNode} to replace a {@code Values} node.
  *
  * <p>{@code BeamValuesRel} will be used in the following SQLs:
+ *
  * <ul>
- *   <li>{@code insert into t (name, desc) values ('hello', 'world')}</li>
- *   <li>{@code select 1, '1', LOCALTIME}</li>
+ *   <li>{@code insert into t (name, desc) values ('hello', 'world')}
+ *   <li>{@code select 1, '1', LOCALTIME}
  * </ul>
  */
 public class BeamValuesRel extends Values implements BeamRelNode {
@@ -55,7 +56,6 @@ public class BeamValuesRel extends Values implements BeamRelNode {
       ImmutableList<ImmutableList<RexLiteral>> tuples,
       RelTraitSet traits) {
     super(cluster, rowType, tuples, traits);
-
   }
 
   @Override
@@ -85,10 +85,8 @@ public class BeamValuesRel extends Values implements BeamRelNode {
   }
 
   private Row tupleToRow(Schema schema, ImmutableList<RexLiteral> tuple) {
-    return
-        IntStream
-            .range(0, tuple.size())
-            .mapToObj(i -> autoCastField(schema.getField(i), tuple.get(i).getValue()))
-            .collect(toRow(schema));
+    return IntStream.range(0, tuple.size())
+        .mapToObj(i -> autoCastField(schema.getField(i), tuple.get(i).getValue()))
+        .collect(toRow(schema));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/package-info.java
@@ -16,10 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * BeamSQL specified nodes, to replace {@link org.apache.calcite.rel.RelNode}.
- *
- */
+/** BeamSQL specified nodes, to replace {@link org.apache.calcite.rel.RelNode}. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowFactory.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowFactory.java
@@ -30,17 +30,15 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
 import org.joda.time.Duration;
 
-/**
- * Creates {@link WindowFn} wrapper based on HOP/TUMBLE/SESSION call in a query.
- */
+/** Creates {@link WindowFn} wrapper based on HOP/TUMBLE/SESSION call in a query. */
 class AggregateWindowFactory {
 
   /**
-   * Returns optional of {@link AggregateWindowField} which represents a
-   * windowing function specified by HOP/TUMBLE/SESSION in the SQL query.
+   * Returns optional of {@link AggregateWindowField} which represents a windowing function
+   * specified by HOP/TUMBLE/SESSION in the SQL query.
    *
-   * <p>If no known windowing function is specified in the query, then {@link Optional#empty()}
-   * is returned.
+   * <p>If no known windowing function is specified in the query, then {@link Optional#empty()} is
+   * returned.
    *
    * <p>Throws {@link UnsupportedOperationException} if it cannot convert SQL windowing function
    * call to Beam model, see {@link #getWindowFieldAt(RexCall, int)} for details.
@@ -49,38 +47,34 @@ class AggregateWindowFactory {
 
     Optional<WindowFn> windowFnOptional = createWindowFn(call.operands, call.op.kind);
 
-    return
-        windowFnOptional
-            .map(windowFn ->
-                     AggregateWindowField
-                         .builder()
-                         .setFieldIndex(groupField)
-                         .setWindowFn(windowFn)
-                         .build());
+    return windowFnOptional.map(
+        windowFn ->
+            AggregateWindowField.builder().setFieldIndex(groupField).setWindowFn(windowFn).build());
   }
 
   /**
    * Returns a {@link WindowFn} based on the SQL windowing function defined by {#code operatorKind}.
    * Supported {@link SqlKind}s:
+   *
    * <ul>
-   *   <li>{@link SqlKind#TUMBLE}, mapped to {@link FixedWindows};</li>
-   *   <li>{@link SqlKind#HOP}, mapped to {@link SlidingWindows};</li>
-   *   <li>{@link SqlKind#SESSION}, mapped to {@link Sessions};</li>
+   *   <li>{@link SqlKind#TUMBLE}, mapped to {@link FixedWindows};
+   *   <li>{@link SqlKind#HOP}, mapped to {@link SlidingWindows};
+   *   <li>{@link SqlKind#SESSION}, mapped to {@link Sessions};
    * </ul>
    *
    * <p>For example:
+   *
    * <pre>{@code
-   *   SELECT event_timestamp, COUNT(*)
-   *   FROM PCOLLECTION
-   *   GROUP BY TUMBLE(event_timestamp, INTERVAL '1' HOUR)
+   * SELECT event_timestamp, COUNT(*)
+   * FROM PCOLLECTION
+   * GROUP BY TUMBLE(event_timestamp, INTERVAL '1' HOUR)
    * }</pre>
    *
-   * <p>SQL window functions support optional window_offset parameter which indicates a
-   * how window definition is offset from the event time. Offset is zero if not specified.
+   * <p>SQL window functions support optional window_offset parameter which indicates a how window
+   * definition is offset from the event time. Offset is zero if not specified.
    *
-   * <p>Beam model does not support offset for session windows, so this method will throw
-   * {@link UnsupportedOperationException} if offset is specified
-   * in SQL query for {@link SqlKind#SESSION}.
+   * <p>Beam model does not support offset for session windows, so this method will throw {@link
+   * UnsupportedOperationException} if offset is specified in SQL query for {@link SqlKind#SESSION}.
    */
   private static Optional<WindowFn> createWindowFn(List<RexNode> parameters, SqlKind operatorKind) {
     switch (operatorKind) {
@@ -112,9 +106,9 @@ class AggregateWindowFactory {
         // Example:
         //   HOP(event_timestamp_field, INTERVAL '1' MINUTE, INTERVAL '1' HOUR)
 
-        SlidingWindows slidingWindows = SlidingWindows
-            .of(durationParameter(parameters, 2))
-            .every(durationParameter(parameters, 1));
+        SlidingWindows slidingWindows =
+            SlidingWindows.of(durationParameter(parameters, 2))
+                .every(durationParameter(parameters, 1));
 
         if (parameters.size() == 4) {
           slidingWindows = slidingWindows.withOffset(durationParameter(parameters, 3));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowField.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/AggregateWindowField.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.values.Row;
 @AutoValue
 public abstract class AggregateWindowField {
   public abstract int fieldIndex();
+
   public abstract WindowFn<Row, ? extends BoundedWindow> windowFn();
 
   static Builder builder() {
@@ -42,7 +43,9 @@ public abstract class AggregateWindowField {
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setFieldIndex(int fieldIndex);
+
     abstract Builder setWindowFn(WindowFn<Row, ? extends BoundedWindow> window);
+
     abstract AggregateWindowField build();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
@@ -32,10 +32,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 
-/**
- * Rule to detect the window/trigger settings.
- *
- */
+/** Rule to detect the window/trigger settings. */
 public class BeamAggregationRule extends RelOptRule {
   public static final BeamAggregationRule INSTANCE =
       new BeamAggregationRule(Aggregate.class, Project.class, RelFactories.LOGICAL_BUILDER);
@@ -44,10 +41,7 @@ public class BeamAggregationRule extends RelOptRule {
       Class<? extends Aggregate> aggregateClass,
       Class<? extends Project> projectClass,
       RelBuilderFactory relBuilderFactory) {
-    super(
-        operand(aggregateClass,
-            operand(projectClass, any())),
-        relBuilderFactory, null);
+    super(operand(aggregateClass, operand(projectClass, any())), relBuilderFactory, null);
   }
 
   @Override
@@ -60,8 +54,7 @@ public class BeamAggregationRule extends RelOptRule {
     }
   }
 
-  private static RelNode updateWindow(RelOptRuleCall call, Aggregate aggregate,
-                            Project project) {
+  private static RelNode updateWindow(RelOptRuleCall call, Aggregate aggregate, Project project) {
     ImmutableBitSet groupByFields = aggregate.getGroupSet();
     List<RexNode> projectMapping = project.getProjects();
 
@@ -76,16 +69,18 @@ public class BeamAggregationRule extends RelOptRule {
       windowField = AggregateWindowFactory.getWindowFieldAt((RexCall) projNode, groupFieldIndex);
     }
 
-    BeamAggregationRel newAggregator = new BeamAggregationRel(aggregate.getCluster(),
-        aggregate.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
-        convert(aggregate.getInput(),
-            aggregate.getInput().getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
-        aggregate.indicator,
-        aggregate.getGroupSet(),
-        aggregate.getGroupSets(),
-        aggregate.getAggCallList(),
-        windowField);
+    BeamAggregationRel newAggregator =
+        new BeamAggregationRel(
+            aggregate.getCluster(),
+            aggregate.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
+            convert(
+                aggregate.getInput(),
+                aggregate.getInput().getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
+            aggregate.indicator,
+            aggregate.getGroupSet(),
+            aggregate.getGroupSets(),
+            aggregate.getAggCallList(),
+            windowField);
     return newAggregator;
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamEnumerableConverterRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamEnumerableConverterRule.java
@@ -25,16 +25,16 @@ import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterRule;
 
-/**
- * A {@code ConverterRule} to Convert {@link BeamRelNode} to {@link EnumerableConvention}.
- *
- */
+/** A {@code ConverterRule} to Convert {@link BeamRelNode} to {@link EnumerableConvention}. */
 public class BeamEnumerableConverterRule extends ConverterRule {
   public static final BeamEnumerableConverterRule INSTANCE = new BeamEnumerableConverterRule();
 
   private BeamEnumerableConverterRule() {
-    super(RelNode.class, BeamLogicalConvention.INSTANCE,
-        EnumerableConvention.INSTANCE, "BeamEnumerableConverterRule");
+    super(
+        RelNode.class,
+        BeamLogicalConvention.INSTANCE,
+        EnumerableConvention.INSTANCE,
+        "BeamEnumerableConverterRule");
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamFilterRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamFilterRule.java
@@ -25,10 +25,7 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.logical.LogicalFilter;
 
-/**
- * A {@code ConverterRule} to replace {@link Filter} with {@link BeamFilterRel}.
- *
- */
+/** A {@code ConverterRule} to replace {@link Filter} with {@link BeamFilterRel}. */
 public class BeamFilterRule extends ConverterRule {
   public static final BeamFilterRule INSTANCE = new BeamFilterRule();
 
@@ -41,7 +38,8 @@ public class BeamFilterRule extends ConverterRule {
     final Filter filter = (Filter) rel;
     final RelNode input = filter.getInput();
 
-    return new BeamFilterRel(filter.getCluster(),
+    return new BeamFilterRel(
+        filter.getCluster(),
         filter.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
         convert(input, input.getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
         filter.getCondition());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamIOSinkRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamIOSinkRule.java
@@ -38,10 +38,7 @@ public class BeamIOSinkRule extends ConverterRule {
 
   @Override
   public RelNode convert(RelNode rel) {
-    final RelNode convertedInput = convert(
-        rel.getInput(0),
-        rel.getTraitSet());
-    return rel.copy(rel.getTraitSet(),
-        Arrays.asList(convertedInput));
+    final RelNode convertedInput = convert(rel.getInput(0), rel.getTraitSet());
+    return rel.copy(rel.getTraitSet(), Arrays.asList(convertedInput));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamIntersectRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamIntersectRule.java
@@ -27,24 +27,26 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Intersect;
 import org.apache.calcite.rel.logical.LogicalIntersect;
 
-/**
- * {@code ConverterRule} to replace {@code Intersect} with {@code BeamIntersectRel}.
- */
+/** {@code ConverterRule} to replace {@code Intersect} with {@code BeamIntersectRel}. */
 public class BeamIntersectRule extends ConverterRule {
   public static final BeamIntersectRule INSTANCE = new BeamIntersectRule();
+
   private BeamIntersectRule() {
-    super(LogicalIntersect.class, Convention.NONE,
-        BeamLogicalConvention.INSTANCE, "BeamIntersectRule");
+    super(
+        LogicalIntersect.class,
+        Convention.NONE,
+        BeamLogicalConvention.INSTANCE,
+        "BeamIntersectRule");
   }
 
-  @Override public RelNode convert(RelNode rel) {
+  @Override
+  public RelNode convert(RelNode rel) {
     Intersect intersect = (Intersect) rel;
     final List<RelNode> inputs = intersect.getInputs();
     return new BeamIntersectRel(
         intersect.getCluster(),
         intersect.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
         convertList(inputs, BeamLogicalConvention.INSTANCE),
-        intersect.all
-    );
+        intersect.all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamMinusRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamMinusRule.java
@@ -27,24 +27,22 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Minus;
 import org.apache.calcite.rel.logical.LogicalMinus;
 
-/**
- * {@code ConverterRule} to replace {@code Minus} with {@code BeamMinusRel}.
- */
+/** {@code ConverterRule} to replace {@code Minus} with {@code BeamMinusRel}. */
 public class BeamMinusRule extends ConverterRule {
   public static final BeamMinusRule INSTANCE = new BeamMinusRule();
+
   private BeamMinusRule() {
-    super(LogicalMinus.class, Convention.NONE,
-        BeamLogicalConvention.INSTANCE, "BeamMinusRule");
+    super(LogicalMinus.class, Convention.NONE, BeamLogicalConvention.INSTANCE, "BeamMinusRule");
   }
 
-  @Override public RelNode convert(RelNode rel) {
+  @Override
+  public RelNode convert(RelNode rel) {
     Minus minus = (Minus) rel;
     final List<RelNode> inputs = minus.getInputs();
     return new BeamMinusRel(
         minus.getCluster(),
         minus.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
         convertList(inputs, BeamLogicalConvention.INSTANCE),
-        minus.all
-    );
+        minus.all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamSortRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamSortRule.java
@@ -26,17 +26,16 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Sort;
 import org.apache.calcite.rel.logical.LogicalSort;
 
-/**
- * {@code ConverterRule} to replace {@code Sort} with {@code BeamSortRel}.
- */
+/** {@code ConverterRule} to replace {@code Sort} with {@code BeamSortRel}. */
 public class BeamSortRule extends ConverterRule {
   public static final BeamSortRule INSTANCE = new BeamSortRule();
+
   private BeamSortRule() {
-    super(LogicalSort.class, Convention.NONE,
-        BeamLogicalConvention.INSTANCE, "BeamSortRule");
+    super(LogicalSort.class, Convention.NONE, BeamLogicalConvention.INSTANCE, "BeamSortRule");
   }
 
-  @Override public RelNode convert(RelNode rel) {
+  @Override
+  public RelNode convert(RelNode rel) {
     Sort sort = (Sort) rel;
     final RelNode input = sort.getInput();
     return new BeamSortRel(
@@ -45,7 +44,6 @@ public class BeamSortRule extends ConverterRule {
         convert(input, input.getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
         sort.getCollation(),
         sort.offset,
-        sort.fetch
-    );
+        sort.fetch);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUnionRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamUnionRule.java
@@ -27,24 +27,24 @@ import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.logical.LogicalUnion;
 
 /**
- * A {@code ConverterRule} to replace {@link org.apache.calcite.rel.core.Union} with
- * {@link BeamUnionRule}.
+ * A {@code ConverterRule} to replace {@link org.apache.calcite.rel.core.Union} with {@link
+ * BeamUnionRule}.
  */
 public class BeamUnionRule extends ConverterRule {
   public static final BeamUnionRule INSTANCE = new BeamUnionRule();
+
   private BeamUnionRule() {
-    super(LogicalUnion.class, Convention.NONE, BeamLogicalConvention.INSTANCE,
-        "BeamUnionRule");
+    super(LogicalUnion.class, Convention.NONE, BeamLogicalConvention.INSTANCE, "BeamUnionRule");
   }
 
-  @Override public RelNode convert(RelNode rel) {
+  @Override
+  public RelNode convert(RelNode rel) {
     Union union = (Union) rel;
 
     return new BeamUnionRel(
         union.getCluster(),
         union.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
         convertList(union.getInputs(), BeamLogicalConvention.INSTANCE),
-        union.all
-    );
+        union.all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamValuesRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamValuesRule.java
@@ -26,23 +26,21 @@ import org.apache.calcite.rel.convert.ConverterRule;
 import org.apache.calcite.rel.core.Values;
 import org.apache.calcite.rel.logical.LogicalValues;
 
-/**
- * {@code ConverterRule} to replace {@code Values} with {@code BeamValuesRel}.
- */
+/** {@code ConverterRule} to replace {@code Values} with {@code BeamValuesRel}. */
 public class BeamValuesRule extends ConverterRule {
   public static final BeamValuesRule INSTANCE = new BeamValuesRule();
+
   private BeamValuesRule() {
-    super(LogicalValues.class, Convention.NONE,
-        BeamLogicalConvention.INSTANCE, "BeamValuesRule");
+    super(LogicalValues.class, Convention.NONE, BeamLogicalConvention.INSTANCE, "BeamValuesRule");
   }
 
-  @Override public RelNode convert(RelNode rel) {
+  @Override
+  public RelNode convert(RelNode rel) {
     Values values = (Values) rel;
     return new BeamValuesRel(
         values.getCluster(),
         values.getRowType(),
         values.getTuples(),
-        values.getTraitSet().replace(BeamLogicalConvention.INSTANCE)
-    );
+        values.getTraitSet().replace(BeamLogicalConvention.INSTANCE));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/package-info.java
@@ -17,8 +17,8 @@
  */
 
 /**
- * {@link org.apache.calcite.plan.RelOptRule} to generate
- * {@link org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode}.
+ * {@link org.apache.calcite.plan.RelOptRule} to generate {@link
+ * org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode}.
  */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.rule;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BaseBeamTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BaseBeamTable.java
@@ -21,16 +21,16 @@ import java.io.Serializable;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.schemas.Schema;
 
-/**
- * Each IO in Beam has one table schema, by extending {@link BaseBeamTable}.
- */
+/** Each IO in Beam has one table schema, by extending {@link BaseBeamTable}. */
 public abstract class BaseBeamTable implements BeamSqlTable, Serializable {
   protected Schema schema;
+
   public BaseBeamTable(Schema schema) {
     this.schema = schema;
   }
 
-  @Override public Schema getSchema() {
+  @Override
+  public Schema getSchema() {
     return schema;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamIOType.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamIOType.java
@@ -19,10 +19,8 @@ package org.apache.beam.sdk.extensions.sql.impl.schema;
 
 import java.io.Serializable;
 
-/**
- * Type as a source IO, determined whether it's a STREAMING process, or batch
- * process.
- */
+/** Type as a source IO, determined whether it's a STREAMING process, or batch process. */
 public enum BeamIOType implements Serializable {
-  BOUNDED, UNBOUNDED;
+  BOUNDED,
+  UNBOUNDED;
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
@@ -26,8 +26,8 @@ import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
 /**
- * {@code BeamPCollectionTable} converts a {@code PCollection<Row>} as a virtual table,
- * then a downstream query can query directly.
+ * {@code BeamPCollectionTable} converts a {@code PCollection<Row>} as a virtual table, then a
+ * downstream query can query directly.
  */
 public class BeamPCollectionTable extends BaseBeamTable {
   private BeamIOType ioType;
@@ -35,8 +35,8 @@ public class BeamPCollectionTable extends BaseBeamTable {
 
   public BeamPCollectionTable(PCollection<Row> upstream) {
     super(((RowCoder) upstream.getCoder()).getSchema());
-    ioType = upstream.isBounded().equals(IsBounded.BOUNDED)
-        ? BeamIOType.BOUNDED : BeamIOType.UNBOUNDED;
+    ioType =
+        upstream.isBounded().equals(IsBounded.BOUNDED) ? BeamIOType.BOUNDED : BeamIOType.UNBOUNDED;
     this.upstream = upstream;
   }
 
@@ -54,5 +54,4 @@ public class BeamPCollectionTable extends BaseBeamTable {
   public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     throw new IllegalArgumentException("cannot use [BeamPCollectionTable] as target");
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
@@ -40,27 +40,21 @@ import org.apache.commons.csv.CSVRecord;
  * <p>TODO: Does not yet support nested types.
  */
 public final class BeamTableUtils {
-  public static Row csvLine2BeamRow(
-      CSVFormat csvFormat,
-      String line,
-      Schema schema) {
+  public static Row csvLine2BeamRow(CSVFormat csvFormat, String line, Schema schema) {
 
     try (StringReader reader = new StringReader(line)) {
       CSVParser parser = csvFormat.parse(reader);
       CSVRecord rawRecord = parser.getRecords().get(0);
 
       if (rawRecord.size() != schema.getFieldCount()) {
-        throw new IllegalArgumentException(String.format(
-            "Expect %d fields, but actually %d",
-            schema.getFieldCount(), rawRecord.size()
-        ));
+        throw new IllegalArgumentException(
+            String.format(
+                "Expect %d fields, but actually %d", schema.getFieldCount(), rawRecord.size()));
       }
 
-      return
-          IntStream
-              .range(0, schema.getFieldCount())
-              .mapToObj(idx -> autoCastField(schema.getField(idx), rawRecord.get(idx)))
-              .collect(toRow(schema));
+      return IntStream.range(0, schema.getFieldCount())
+          .mapToObj(idx -> autoCastField(schema.getField(idx), rawRecord.get(idx)))
+          .collect(toRow(schema));
 
     } catch (IOException e) {
       throw new IllegalArgumentException("decodeRecord failed!", e);
@@ -95,8 +89,9 @@ public final class BeamTableUtils {
       } else {
         return rawObj;
       }
-    } else if (type.isNumericType() && ((rawObj instanceof String)
-          || (rawObj instanceof BigDecimal && type != TypeName.DECIMAL))) {
+    } else if (type.isNumericType()
+        && ((rawObj instanceof String)
+            || (rawObj instanceof BigDecimal && type != TypeName.DECIMAL))) {
       String raw = rawObj.toString();
       switch (type) {
         case BYTE:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/package-info.java
@@ -15,8 +15,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * define table schema, to map with Beam IO components.
- *
- */
+/** define table schema, to map with Beam IO components. */
 package org.apache.beam.sdk.extensions.sql.impl.schema;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -43,11 +43,7 @@ import org.joda.time.ReadableInstant;
 class BeamBuiltinAggregations {
   private static MathContext mc = new MathContext(10, RoundingMode.HALF_UP);
 
-
-
-  /**
-   * {@link CombineFn} for MAX based on {@link Max} and {@link Combine.BinaryCombineFn}.
-   */
+  /** {@link CombineFn} for MAX based on {@link Max} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createMax(SqlTypeName fieldType) {
     switch (fieldType) {
       case INTEGER:
@@ -72,9 +68,7 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /**
-   * {@link CombineFn} for MAX based on {@link Min} and {@link Combine.BinaryCombineFn}.
-   */
+  /** {@link CombineFn} for MAX based on {@link Min} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createMin(SqlTypeName fieldType) {
     switch (fieldType) {
       case INTEGER:
@@ -99,9 +93,7 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /**
-   * {@link CombineFn} for MAX based on {@link Sum} and {@link Combine.BinaryCombineFn}.
-   */
+  /** {@link CombineFn} for MAX based on {@link Sum} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createSum(SqlTypeName fieldType) {
     switch (fieldType) {
       case INTEGER:
@@ -124,9 +116,7 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /**
-   * {@link CombineFn} for AVG.
-   */
+  /** {@link CombineFn} for AVG. */
   public static CombineFn createAvg(SqlTypeName fieldType) {
     switch (fieldType) {
       case INTEGER:
@@ -185,11 +175,8 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /**
-   * {@link CombineFn} for <em>AVG</em> on {@link Number} types.
-   */
-  abstract static class Avg<T extends Number>
-      extends CombineFn<T, KV<Integer, BigDecimal>, T> {
+  /** {@link CombineFn} for <em>AVG</em> on {@link Number} types. */
+  abstract static class Avg<T extends Number> extends CombineFn<T, KV<Integer, BigDecimal>, T> {
     @Override
     public KV<Integer, BigDecimal> createAccumulator() {
       return KV.of(0, BigDecimal.ZERO);
@@ -213,8 +200,8 @@ class BeamBuiltinAggregations {
     }
 
     @Override
-    public Coder<KV<Integer, BigDecimal>> getAccumulatorCoder(CoderRegistry registry,
-                                                              Coder<T> inputCoder) {
+    public Coder<KV<Integer, BigDecimal>> getAccumulatorCoder(
+        CoderRegistry registry, Coder<T> inputCoder) {
       return KvCoder.of(BigEndianIntegerCoder.of(), BigDecimalCoder.of());
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamJoinTransforms.java
@@ -41,24 +41,16 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.util.Pair;
 
-/**
- * Collections of {@code PTransform} and {@code DoFn} used to perform JOIN operation.
- */
+/** Collections of {@code PTransform} and {@code DoFn} used to perform JOIN operation. */
 public class BeamJoinTransforms {
 
-  /**
-   * A {@code SimpleFunction} to extract join fields from the specified row.
-   */
-  public static class ExtractJoinFields
-      extends SimpleFunction<Row, KV<Row, Row>> {
+  /** A {@code SimpleFunction} to extract join fields from the specified row. */
+  public static class ExtractJoinFields extends SimpleFunction<Row, KV<Row, Row>> {
     private final List<Integer> joinColumns;
 
     public ExtractJoinFields(boolean isLeft, List<Pair<Integer, Integer>> joinColumns) {
       this.joinColumns =
-          joinColumns
-              .stream()
-              .map(pair -> isLeft ? pair.left : pair.right)
-              .collect(toList());
+          joinColumns.stream().map(pair -> isLeft ? pair.left : pair.right).collect(toList());
     }
 
     @Override
@@ -69,11 +61,7 @@ public class BeamJoinTransforms {
               .map(fieldIndex -> toField(input.getSchema(), fieldIndex))
               .collect(toSchema());
 
-      Row row =
-          joinColumns
-              .stream()
-              .map(input::getValue)
-              .collect(toRow(schema));
+      Row row = joinColumns.stream().map(input::getValue).collect(toRow(schema));
 
       return KV.of(row, input);
     }
@@ -84,16 +72,16 @@ public class BeamJoinTransforms {
     }
   }
 
-  /**
-   * A {@code DoFn} which implement the sideInput-JOIN.
-   */
+  /** A {@code DoFn} which implement the sideInput-JOIN. */
   public static class SideInputJoinDoFn extends DoFn<KV<Row, Row>, Row> {
     private final PCollectionView<Map<Row, Iterable<Row>>> sideInputView;
     private final JoinRelType joinType;
     private final Row rightNullRow;
     private final boolean swap;
 
-    public SideInputJoinDoFn(JoinRelType joinType, Row rightNullRow,
+    public SideInputJoinDoFn(
+        JoinRelType joinType,
+        Row rightNullRow,
         PCollectionView<Map<Row, Iterable<Row>>> sideInputView,
         boolean swap) {
       this.joinType = joinType;
@@ -102,7 +90,8 @@ public class BeamJoinTransforms {
       this.swap = swap;
     }
 
-    @ProcessElement public void processElement(ProcessContext context) {
+    @ProcessElement
+    public void processElement(ProcessContext context) {
       Row key = context.element().getKey();
       Row leftRow = context.element().getValue();
       Map<Row, Iterable<Row>> key2Rows = context.sideInput(sideInputView);
@@ -120,13 +109,10 @@ public class BeamJoinTransforms {
     }
   }
 
-
-  /**
-   * A {@code SimpleFunction} to combine two rows into one.
-   */
-  public static class JoinParts2WholeRow
-      extends SimpleFunction<KV<Row, KV<Row, Row>>, Row> {
-    @Override public Row apply(KV<Row, KV<Row, Row>> input) {
+  /** A {@code SimpleFunction} to combine two rows into one. */
+  public static class JoinParts2WholeRow extends SimpleFunction<KV<Row, KV<Row, Row>>, Row> {
+    @Override
+    public Row apply(KV<Row, KV<Row, Row>> input) {
       KV<Row, Row> parts = input.getValue();
       Row leftRow = parts.getKey();
       Row rightRow = parts.getValue();
@@ -134,11 +120,8 @@ public class BeamJoinTransforms {
     }
   }
 
-  /**
-   * As the method name suggests: combine two rows into one wide row.
-   */
-  private static Row combineTwoRowsIntoOne(Row leftRow,
-                                           Row rightRow, boolean swap) {
+  /** As the method name suggests: combine two rows into one wide row. */
+  private static Row combineTwoRowsIntoOne(Row leftRow, Row rightRow, boolean swap) {
     if (swap) {
       return combineTwoRowsIntoOneHelper(rightRow, leftRow);
     } else {
@@ -146,37 +129,33 @@ public class BeamJoinTransforms {
     }
   }
 
-  /**
-   * As the method name suggests: combine two rows into one wide row.
-   */
+  /** As the method name suggests: combine two rows into one wide row. */
   private static Row combineTwoRowsIntoOneHelper(Row leftRow, Row rightRow) {
     // build the type
-    List<Schema.Field> fields = new ArrayList<>(
-        leftRow.getFieldCount() + rightRow.getFieldCount());
+    List<Schema.Field> fields = new ArrayList<>(leftRow.getFieldCount() + rightRow.getFieldCount());
     fields.addAll(leftRow.getSchema().getFields());
     fields.addAll(rightRow.getSchema().getFields());
     Schema type = Schema.builder().addFields(fields).build();
 
-    return Row
-            .withSchema(type)
-            .addValues(leftRow.getValues())
-            .addValues(rightRow.getValues())
-            .build();
+    return Row.withSchema(type)
+        .addValues(leftRow.getValues())
+        .addValues(rightRow.getValues())
+        .build();
   }
 
-  /**
-   * Transform to execute Join as Lookup.
-   */
-  public static class JoinAsLookup
-      extends PTransform<PCollection<Row>, PCollection<Row>> {
+  /** Transform to execute Join as Lookup. */
+  public static class JoinAsLookup extends PTransform<PCollection<Row>, PCollection<Row>> {
 
     BeamSqlSeekableTable seekableTable;
     Schema lkpSchema;
     Schema joinSubsetType;
     List<Integer> factJoinIdx;
 
-    public JoinAsLookup(RexNode joinCondition, BeamSqlSeekableTable seekableTable,
-                        Schema lkpSchema, int factTableColSize) {
+    public JoinAsLookup(
+        RexNode joinCondition,
+        BeamSqlSeekableTable seekableTable,
+        Schema lkpSchema,
+        int factTableColSize) {
       this.seekableTable = seekableTable;
       this.lkpSchema = lkpSchema;
       joinFieldsMapping(joinCondition, factTableColSize);
@@ -191,14 +170,14 @@ public class BeamJoinTransforms {
         List<RexNode> operands = call.getOperands();
         for (RexNode rexNode : operands) {
           factJoinIdx.add(((RexInputRef) ((RexCall) rexNode).getOperands().get(0)).getIndex());
-          int lkpJoinIdx = ((RexInputRef) ((RexCall) rexNode).getOperands().get(1)).getIndex()
-              - factTableColSize;
+          int lkpJoinIdx =
+              ((RexInputRef) ((RexCall) rexNode).getOperands().get(1)).getIndex()
+                  - factTableColSize;
           lkpJoinFields.add(lkpSchema.getField(lkpJoinIdx));
         }
       } else if ("=".equals(call.getOperator().getName())) {
         factJoinIdx.add(((RexInputRef) call.getOperands().get(0)).getIndex());
-        int lkpJoinIdx = ((RexInputRef) call.getOperands().get(1)).getIndex()
-            - factTableColSize;
+        int lkpJoinIdx = ((RexInputRef) call.getOperands().get(1)).getIndex() - factTableColSize;
         lkpJoinFields.add(lkpSchema.getField(lkpJoinIdx));
       } else {
         throw new UnsupportedOperationException(
@@ -210,43 +189,37 @@ public class BeamJoinTransforms {
 
     @Override
     public PCollection<Row> expand(PCollection<Row> input) {
-      return input.apply("join_as_lookup", ParDo.of(new DoFn<Row, Row>(){
-        @Setup
-        public void setup(){
-          seekableTable.setUp();
-        }
+      return input.apply(
+          "join_as_lookup",
+          ParDo.of(
+              new DoFn<Row, Row>() {
+                @Setup
+                public void setup() {
+                  seekableTable.setUp();
+                }
 
-        @ProcessElement
-        public void processElement(ProcessContext context) {
-          Row factRow = context.element();
-          Row joinSubRow = extractJoinSubRow(factRow);
-          List<Row> lookupRows = seekableTable.seekRow(joinSubRow);
-          for (Row lr : lookupRows) {
-            context.output(combineTwoRowsIntoOneHelper(factRow, lr));
-          }
-        }
+                @ProcessElement
+                public void processElement(ProcessContext context) {
+                  Row factRow = context.element();
+                  Row joinSubRow = extractJoinSubRow(factRow);
+                  List<Row> lookupRows = seekableTable.seekRow(joinSubRow);
+                  for (Row lr : lookupRows) {
+                    context.output(combineTwoRowsIntoOneHelper(factRow, lr));
+                  }
+                }
 
-        @Teardown
-        public void teardown(){
-          seekableTable.tearDown();
-        }
+                @Teardown
+                public void teardown() {
+                  seekableTable.tearDown();
+                }
 
-        private Row extractJoinSubRow(Row factRow) {
-          List<Object> joinSubsetValues =
-              factJoinIdx
-                  .stream()
-                  .map(factRow::getValue)
-                  .collect(toList());
+                private Row extractJoinSubRow(Row factRow) {
+                  List<Object> joinSubsetValues =
+                      factJoinIdx.stream().map(factRow::getValue).collect(toList());
 
-          return
-              Row
-                  .withSchema(joinSubsetType)
-                  .addValues(joinSubsetValues)
-                  .build();
-        }
-
-      }));
+                  return Row.withSchema(joinSubsetType).addValues(joinSubsetValues).build();
+                }
+              }));
     }
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSetOperatorsTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSetOperatorsTransforms.java
@@ -27,40 +27,37 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 
-/**
- * Collections of {@code PTransform} and {@code DoFn} used to perform Set operations.
- */
+/** Collections of {@code PTransform} and {@code DoFn} used to perform Set operations. */
 public abstract class BeamSetOperatorsTransforms {
-  /**
-   * Transform a {@code BeamSqlRow} to a {@code KV<BeamSqlRow, BeamSqlRow>}.
-   */
-  public static class BeamSqlRow2KvFn extends
-      SimpleFunction<Row, KV<Row, Row>> {
-    @Override public KV<Row, Row> apply(Row input) {
+  /** Transform a {@code BeamSqlRow} to a {@code KV<BeamSqlRow, BeamSqlRow>}. */
+  public static class BeamSqlRow2KvFn extends SimpleFunction<Row, KV<Row, Row>> {
+    @Override
+    public KV<Row, Row> apply(Row input) {
       return KV.of(input, input);
     }
   }
 
-  /**
-   * Filter function used for Set operators.
-   */
-  public static class SetOperatorFilteringDoFn extends
-      DoFn<KV<Row, CoGbkResult>, Row> {
+  /** Filter function used for Set operators. */
+  public static class SetOperatorFilteringDoFn extends DoFn<KV<Row, CoGbkResult>, Row> {
     private TupleTag<Row> leftTag;
     private TupleTag<Row> rightTag;
     private BeamSetOperatorRelBase.OpType opType;
     // ALL?
     private boolean all;
 
-    public SetOperatorFilteringDoFn(TupleTag<Row> leftTag, TupleTag<Row> rightTag,
-                                    BeamSetOperatorRelBase.OpType opType, boolean all) {
+    public SetOperatorFilteringDoFn(
+        TupleTag<Row> leftTag,
+        TupleTag<Row> rightTag,
+        BeamSetOperatorRelBase.OpType opType,
+        boolean all) {
       this.leftTag = leftTag;
       this.rightTag = rightTag;
       this.opType = opType;
       this.all = all;
     }
 
-    @ProcessElement public void processElement(ProcessContext ctx) {
+    @ProcessElement
+    public void processElement(ProcessContext ctx) {
       CoGbkResult coGbkResult = ctx.element().getValue();
       Iterable<Row> leftRows = coGbkResult.getAll(leftTag);
       Iterable<Row> rightRows = coGbkResult.getAll(rightTag);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlFilterFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlFilterFn.java
@@ -24,10 +24,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * {@code BeamSqlFilterFn} is the executor for a {@link BeamFilterRel} step.
- *
- */
+/** {@code BeamSqlFilterFn} is the executor for a {@link BeamFilterRel} step. */
 public class BeamSqlFilterFn extends DoFn<Row, Row> {
 
   private String stepName;
@@ -59,5 +56,4 @@ public class BeamSqlFilterFn extends DoFn<Row, Row> {
   public void close() {
     executor.close();
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlOutputToConsoleFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlOutputToConsoleFn.java
@@ -20,10 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.transform;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * A test PTransform to display output in console.
- *
- */
+/** A test PTransform to display output in console. */
 public class BeamSqlOutputToConsoleFn extends DoFn<Row, Void> {
 
   private String stepName;
@@ -37,5 +34,4 @@ public class BeamSqlOutputToConsoleFn extends DoFn<Row, Void> {
   public void processElement(ProcessContext c) {
     System.out.println("Output: " + c.element().getValues());
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlProjectFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlProjectFn.java
@@ -29,17 +29,14 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * {@code BeamSqlProjectFn} is the executor for a {@link BeamProjectRel} step.
- */
+/** {@code BeamSqlProjectFn} is the executor for a {@link BeamProjectRel} step. */
 public class BeamSqlProjectFn extends DoFn<Row, Row> {
   private String stepName;
   private BeamSqlExpressionExecutor executor;
   private Schema outputSchema;
 
   public BeamSqlProjectFn(
-      String stepName, BeamSqlExpressionExecutor executor,
-      Schema outputSchema) {
+      String stepName, BeamSqlExpressionExecutor executor, Schema outputSchema) {
     super();
     this.stepName = stepName;
     this.executor = executor;
@@ -57,16 +54,11 @@ public class BeamSqlProjectFn extends DoFn<Row, Row> {
     List<Object> rawResultValues = executor.execute(inputRow, window);
 
     List<Object> castResultValues =
-        IntStream
-            .range(0, outputSchema.getFieldCount())
+        IntStream.range(0, outputSchema.getFieldCount())
             .mapToObj(i -> castField(rawResultValues, i))
             .collect(toList());
 
-    c.output(
-        Row
-            .withSchema(outputSchema)
-            .addValues(castResultValues)
-            .build());
+    c.output(Row.withSchema(outputSchema).addValues(castResultValues).build());
   }
 
   private Object castField(List<Object> resultValues, int i) {
@@ -77,5 +69,4 @@ public class BeamSqlProjectFn extends DoFn<Row, Row> {
   public void close() {
     executor.close();
   }
-
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceAccumulator.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceAccumulator.java
@@ -22,22 +22,20 @@ import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
-/**
- * Accumulates current variance of a sample, its sum, and number of elements.
- */
+/** Accumulates current variance of a sample, its sum, and number of elements. */
 @AutoValue
 abstract class VarianceAccumulator implements Serializable {
   static final VarianceAccumulator EMPTY =
       newVarianceAccumulator(BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO);
 
   abstract BigDecimal variance();
+
   abstract BigDecimal count();
+
   abstract BigDecimal sum();
 
   static VarianceAccumulator newVarianceAccumulator(
-      BigDecimal variance,
-      BigDecimal count,
-      BigDecimal sum) {
+      BigDecimal variance, BigDecimal count, BigDecimal sum) {
 
     return new AutoValue_VarianceAccumulator(variance, count, sum);
   }
@@ -50,9 +48,7 @@ abstract class VarianceAccumulator implements Serializable {
     return newVarianceAccumulator(BigDecimal.ZERO, BigDecimal.ONE, inputElement);
   }
 
-  /**
-   * See {@link VarianceFn} doc above for explanation.
-   */
+  /** See {@link VarianceFn} doc above for explanation. */
   VarianceAccumulator combineWith(VarianceAccumulator otherVariance) {
     if (EMPTY.equals(this)) {
       return otherVariance;
@@ -63,10 +59,7 @@ abstract class VarianceAccumulator implements Serializable {
     }
 
     BigDecimal increment = calculateIncrement(this, otherVariance);
-    BigDecimal combinedVariance =
-        this.variance()
-            .add(otherVariance.variance())
-            .add(increment);
+    BigDecimal combinedVariance = this.variance().add(otherVariance.variance()).add(increment);
 
     return newVarianceAccumulator(
         combinedVariance,
@@ -74,12 +67,9 @@ abstract class VarianceAccumulator implements Serializable {
         this.sum().add(otherVariance.sum()));
   }
 
-  /**
-   * Implements this part: {@code increment = m/(n(m+n)) * (sum(x) * n/m  - sum(y))^2 }.
-   */
+  /** Implements this part: {@code increment = m/(n(m+n)) * (sum(x) * n/m - sum(y))^2 }. */
   private BigDecimal calculateIncrement(
-      VarianceAccumulator varianceX,
-      VarianceAccumulator varianceY) {
+      VarianceAccumulator varianceX, VarianceAccumulator varianceY) {
 
     BigDecimal m = varianceX.count();
     BigDecimal n = varianceY.count();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFn.java
@@ -33,38 +33,38 @@ import org.apache.calcite.runtime.SqlFunctions;
 /**
  * {@link Combine.CombineFn} for <em>Variance</em> on {@link Number} types.
  *
- * <p>Calculates Population Variance and Sample Variance using incremental formulas described,
- * for example, by Chan, Golub, and LeVeque in "Algorithms for computing the sample variance:
- * analysis and recommendations", The American Statistician, 37 (1983) pp. 242--247.</p>
+ * <p>Calculates Population Variance and Sample Variance using incremental formulas described, for
+ * example, by Chan, Golub, and LeVeque in "Algorithms for computing the sample variance: analysis
+ * and recommendations", The American Statistician, 37 (1983) pp. 242--247.
  *
  * <p>If variance is defined like this:
- * <ul>
- *   <li>Input elements: {@code (x[1], ... , x[n])}</li>
- *   <li>Sum of elements: {sum(x) = x[1] + ... + x[n]}</li>
- *   <li>Average of all elements in the input: {@code mean(x) = sum(x) / n}</li>
- *   <li>Deviation of {@code i}th element from the current mean:
- *         {@code deviation(x, i) = x[i] - mean(n)}</li>
- *   <li>Variance: {@code variance(x) = deviation(x, 1)^2 + ... + deviation(x, n)^2}</li>
- * </ul>
- *
- * <p>Then variance of combined input of 2 samples {@code (x[1], ... , x[n])}
- * and {@code (y[1], ... , y[m])} is calculated using this formula:</p>
  *
  * <ul>
- *   <li>{@code variance(concat(x,y)) = variance(x) + variance(y) + increment}, where:</li>
- *   <li>{@code increment = m/(n(m+n)) * (n/m * sum(x) - sum(y))^2}</li>
+ *   <li>Input elements: {@code (x[1], ... , x[n])}
+ *   <li>Sum of elements: {sum(x) = x[1] + ... + x[n]}
+ *   <li>Average of all elements in the input: {@code mean(x) = sum(x) / n}
+ *   <li>Deviation of {@code i}th element from the current mean: {@code deviation(x, i) = x[i] -
+ *       mean(n)}
+ *   <li>Variance: {@code variance(x) = deviation(x, 1)^2 + ... + deviation(x, n)^2}
  * </ul>
  *
- * <p>This is also applicable for a single element increment, assuming that variance of
- * a single element input is zero</p>
+ * <p>Then variance of combined input of 2 samples {@code (x[1], ... , x[n])} and {@code (y[1], ...
+ * , y[m])} is calculated using this formula:
  *
- * <p>To implement the above formula we keep track of the current variation, sum,
- * and count of elements, and then use the formula whenever new element comes or we need to merge
- * variances for 2 samples.
+ * <ul>
+ *   <li>{@code variance(concat(x,y)) = variance(x) + variance(y) + increment}, where:
+ *   <li>{@code increment = m/(n(m+n)) * (n/m * sum(x) - sum(y))^2}
+ * </ul>
+ *
+ * <p>This is also applicable for a single element increment, assuming that variance of a single
+ * element input is zero
+ *
+ * <p>To implement the above formula we keep track of the current variation, sum, and count of
+ * elements, and then use the formula whenever new element comes or we need to merge variances for 2
+ * samples.
  */
 @Internal
-public class VarianceFn<T extends Number>
-    extends Combine.CombineFn<T, VarianceAccumulator, T> {
+public class VarianceFn<T extends Number> extends Combine.CombineFn<T, VarianceAccumulator, T> {
 
   static final MathContext MATH_CTX = new MathContext(10, RoundingMode.HALF_UP);
 
@@ -103,20 +103,19 @@ public class VarianceFn<T extends Number>
       return currentVariance;
     }
 
-    return currentVariance.combineWith(VarianceAccumulator.ofSingleElement(
-        SqlFunctions.toBigDecimal(rawInput)));
+    return currentVariance.combineWith(
+        VarianceAccumulator.ofSingleElement(SqlFunctions.toBigDecimal(rawInput)));
   }
 
   @Override
   public VarianceAccumulator mergeAccumulators(Iterable<VarianceAccumulator> variances) {
-    return StreamSupport
-        .stream(variances.spliterator(), false)
+    return StreamSupport.stream(variances.spliterator(), false)
         .reduce(VarianceAccumulator.ofZeroElements(), VarianceAccumulator::combineWith);
   }
 
   @Override
-  public Coder<VarianceAccumulator> getAccumulatorCoder(CoderRegistry registry,
-                                                        Coder<T> inputCoder) {
+  public Coder<VarianceAccumulator> getAccumulatorCoder(
+      CoderRegistry registry, Coder<T> inputCoder) {
     return SerializableCoder.of(VarianceAccumulator.class);
   }
 
@@ -127,9 +126,8 @@ public class VarianceFn<T extends Number>
 
   private BigDecimal getVariance(VarianceAccumulator variance) {
 
-    BigDecimal adjustedCount = this.isSample
-        ? variance.count().subtract(BigDecimal.ONE)
-        : variance.count();
+    BigDecimal adjustedCount =
+        this.isSample ? variance.count().subtract(BigDecimal.ONE) : variance.count();
 
     return variance.variance().divide(adjustedCount, MATH_CTX);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/package-info.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * Implementation of standard SQL aggregation functions, e.g. VAR_POP, VAR_SAMP.
- */
+/** Implementation of standard SQL aggregation functions, e.g. VAR_POP, VAR_SAMP. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.impl.transform.agg;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * {@link org.apache.beam.sdk.transforms.PTransform} used in a BeamSql pipeline.
- */
+/** {@link org.apache.beam.sdk.transforms.PTransform} used in a BeamSql pipeline. */
 package org.apache.beam.sdk.extensions.sql.impl.transform;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/BigDecimalConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/BigDecimalConverter.java
@@ -25,25 +25,24 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /**
- * Provides converters from {@link BigDecimal} to other numeric types based on
- * the input {@link TypeName}.
+ * Provides converters from {@link BigDecimal} to other numeric types based on the input {@link
+ * TypeName}.
  */
 public class BigDecimalConverter {
 
   private static final Map<TypeName, SerializableFunction<BigDecimal, ? extends Number>>
-      CONVERTER_MAP = ImmutableMap
-      .<TypeName, SerializableFunction<BigDecimal, ? extends Number>>builder()
-      .put(TypeName.INT32, BigDecimal::intValue)
-      .put(TypeName.INT16, BigDecimal::shortValue)
-      .put(TypeName.BYTE, BigDecimal::byteValue)
-      .put(TypeName.INT64, BigDecimal::longValue)
-      .put(TypeName.FLOAT, BigDecimal::floatValue)
-      .put(TypeName.DOUBLE, BigDecimal::doubleValue)
-      .put(TypeName.DECIMAL, v -> v)
-      .build();
+      CONVERTER_MAP =
+          ImmutableMap.<TypeName, SerializableFunction<BigDecimal, ? extends Number>>builder()
+              .put(TypeName.INT32, BigDecimal::intValue)
+              .put(TypeName.INT16, BigDecimal::shortValue)
+              .put(TypeName.BYTE, BigDecimal::byteValue)
+              .put(TypeName.INT64, BigDecimal::longValue)
+              .put(TypeName.FLOAT, BigDecimal::floatValue)
+              .put(TypeName.DOUBLE, BigDecimal::doubleValue)
+              .put(TypeName.DECIMAL, v -> v)
+              .build();
 
-  public static SerializableFunction<BigDecimal, ? extends Number> forSqlType(
-      TypeName typeName) {
+  public static SerializableFunction<BigDecimal, ? extends Number> forSqlType(TypeName typeName) {
     if (!CONVERTER_MAP.containsKey(typeName)) {
       throw new UnsupportedOperationException(
           "Conversion from " + typeName + " to BigDecimal is not supported");

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -33,9 +33,7 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Utility methods for Calcite related operations.
- */
+/** Utility methods for Calcite related operations. */
 public class CalciteUtils {
   private static final long UNLIMITED_ARRAY_SIZE = -1L;
   // Beam's Schema class has a single DATETIME type, so we need a way to distinguish the different
@@ -49,23 +47,21 @@ public class CalciteUtils {
           .put(TypeName.INT16.type(), SqlTypeName.SMALLINT)
           .put(TypeName.INT32.type(), SqlTypeName.INTEGER)
           .put(TypeName.INT64.type(), SqlTypeName.BIGINT)
-
           .put(TypeName.FLOAT.type(), SqlTypeName.FLOAT)
           .put(TypeName.DOUBLE.type(), SqlTypeName.DOUBLE)
-
           .put(TypeName.DECIMAL.type(), SqlTypeName.DECIMAL)
-
           .put(TypeName.BOOLEAN.type(), SqlTypeName.BOOLEAN)
-
           .put(TypeName.MAP.type(), SqlTypeName.MAP)
           .put(TypeName.ARRAY.type(), SqlTypeName.ARRAY)
           .put(TypeName.ROW.type(), SqlTypeName.ROW)
           .put(TypeName.DATETIME.type().withMetadata("DATE"), SqlTypeName.DATE)
           .put(TypeName.DATETIME.type().withMetadata("TIME"), SqlTypeName.TIME)
-          .put(TypeName.DATETIME.type().withMetadata("TIME_WITH_LOCAL_TZ"),
+          .put(
+              TypeName.DATETIME.type().withMetadata("TIME_WITH_LOCAL_TZ"),
               SqlTypeName.TIME_WITH_LOCAL_TIME_ZONE)
           .put(TypeName.DATETIME.type().withMetadata("TS"), SqlTypeName.TIMESTAMP)
-          .put(TypeName.DATETIME.type().withMetadata("TS_WITH_LOCAL_TZ"),
+          .put(
+              TypeName.DATETIME.type().withMetadata("TS_WITH_LOCAL_TZ"),
               SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE)
           .put(TypeName.STRING.type().withMetadata("CHAR"), SqlTypeName.CHAR)
           .put(TypeName.STRING.type().withMetadata("VARCHAR"), SqlTypeName.VARCHAR)
@@ -75,26 +71,24 @@ public class CalciteUtils {
 
   // Since there are multiple Calcite type that correspond to a single Beam type, this is the
   // default mapping.
-  private static final Map<FieldType, SqlTypeName>
-      BEAM_TO_CALCITE_DEFAULT_MAPPING = ImmutableMap.of(
+  private static final Map<FieldType, SqlTypeName> BEAM_TO_CALCITE_DEFAULT_MAPPING =
+      ImmutableMap.of(
           TypeName.DATETIME.type(), SqlTypeName.TIMESTAMP,
           TypeName.STRING.type(), SqlTypeName.VARCHAR);
 
-  /**
-   * Generate {@code BeamSqlRowType} from {@code RelDataType} which is used to create table.
-   */
+  /** Generate {@code BeamSqlRowType} from {@code RelDataType} which is used to create table. */
   public static Schema toBeamSchema(RelDataType tableInfo) {
-    return
-        tableInfo
-            .getFieldList()
-            .stream()
-            .map(CalciteUtils::toBeamSchemaField)
-            .collect(toSchema());
+    return tableInfo
+        .getFieldList()
+        .stream()
+        .map(CalciteUtils::toBeamSchemaField)
+        .collect(toSchema());
   }
 
   public static SqlTypeName toSqlTypeName(FieldType type) {
-    SqlTypeName typeName = BEAM_TO_CALCITE_TYPE_MAPPING.get(
-        type.withCollectionElementType(null).withRowSchema(null).withMapType(null, null));
+    SqlTypeName typeName =
+        BEAM_TO_CALCITE_TYPE_MAPPING.get(
+            type.withCollectionElementType(null).withRowSchema(null).withMapType(null, null));
     if (typeName != null) {
       return typeName;
     } else {
@@ -117,9 +111,9 @@ public class CalciteUtils {
       type = type.withRowSchema(toBeamSchema(calciteType));
     }
     if (calciteType.getKeyType() != null && calciteType.getValueType() != null) {
-      type = type.withMapType(
-          toFieldType(calciteType.getKeyType()),
-          toFieldType(calciteType.getValueType()));
+      type =
+          type.withMapType(
+              toFieldType(calciteType.getKeyType()), toFieldType(calciteType.getValueType()));
     }
     return type;
   }
@@ -133,36 +127,32 @@ public class CalciteUtils {
   }
 
   public static FieldType toMapType(SqlTypeName componentKeyType, SqlTypeName componentValueType) {
-    return TypeName.MAP.type().withMapType(
-        toFieldType(componentKeyType),
-        toFieldType(componentValueType));
+    return TypeName.MAP
+        .type()
+        .withMapType(toFieldType(componentKeyType), toFieldType(componentValueType));
   }
 
   public static FieldType toMapType(RelDataType componentKeyType, RelDataType componentValueType) {
-    return TypeName.MAP.type().withMapType(
-        toFieldType(componentKeyType),
-        toFieldType(componentValueType));
+    return TypeName.MAP
+        .type()
+        .withMapType(toFieldType(componentKeyType), toFieldType(componentValueType));
   }
 
   public static Schema.Field toBeamSchemaField(RelDataTypeField calciteField) {
     FieldType fieldType = toFieldType(calciteField.getType());
     // TODO: We should support Calcite's nullable annotations.
-    return Schema.Field.of(calciteField.getName(), fieldType)
-        .withNullable(true);
+    return Schema.Field.of(calciteField.getName(), fieldType).withNullable(true);
   }
 
-  /**
-   * Create an instance of {@code RelDataType} so it can be used to create a table.
-   */
+  /** Create an instance of {@code RelDataType} so it can be used to create a table. */
   public static RelDataType toCalciteRowType(Schema schema, RelDataTypeFactory dataTypeFactory) {
     RelDataTypeFactory.Builder builder = new RelDataTypeFactory.Builder(dataTypeFactory);
 
-    IntStream
-        .range(0, schema.getFieldCount())
-        .forEach(idx ->
-                     builder.add(
-                         schema.getField(idx).getName(),
-                         toRelDataType(dataTypeFactory, schema, idx)));
+    IntStream.range(0, schema.getFieldCount())
+        .forEach(
+            idx ->
+                builder.add(
+                    schema.getField(idx).getName(), toRelDataType(dataTypeFactory, schema, idx)));
     return builder.build();
   }
 
@@ -170,14 +160,12 @@ public class CalciteUtils {
       RelDataTypeFactory dataTypeFactory, FieldType fieldType) {
     SqlTypeName typeName = toSqlTypeName(fieldType);
     if (SqlTypeName.ARRAY.equals(typeName)) {
-      RelDataType collectionElementType = toRelDataType(
-          dataTypeFactory, fieldType.getCollectionElementType());
+      RelDataType collectionElementType =
+          toRelDataType(dataTypeFactory, fieldType.getCollectionElementType());
       return dataTypeFactory.createArrayType(collectionElementType, UNLIMITED_ARRAY_SIZE);
     } else if (SqlTypeName.MAP.equals(typeName)) {
-      RelDataType componentKeyType = toRelDataType(
-          dataTypeFactory, fieldType.getMapKeyType());
-      RelDataType componentValueType = toRelDataType(
-          dataTypeFactory, fieldType.getMapValueType());
+      RelDataType componentKeyType = toRelDataType(dataTypeFactory, fieldType.getMapKeyType());
+      RelDataType componentValueType = toRelDataType(dataTypeFactory, fieldType.getMapValueType());
       return dataTypeFactory.createMapType(componentKeyType, componentValueType);
     } else if (SqlTypeName.ROW.equals(typeName)) {
       return toCalciteRowType(fieldType.getRowSchema(), dataTypeFactory);
@@ -187,9 +175,7 @@ public class CalciteUtils {
   }
 
   private static RelDataType toRelDataType(
-      RelDataTypeFactory dataTypeFactory,
-      Schema schema,
-      int fieldIndex) {
+      RelDataTypeFactory dataTypeFactory, Schema schema, int fieldIndex) {
     Schema.Field field = schema.getField(fieldIndex);
     return toRelDataType(dataTypeFactory, field.getType());
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SqlTypeUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/SqlTypeUtils.java
@@ -23,13 +23,11 @@ import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-/**
- * Utils to help with SqlTypes.
- */
+/** Utils to help with SqlTypes. */
 public class SqlTypeUtils {
   /**
-   * Finds an operand with provided type.
-   * Returns Optional.absent() if no operand found with matching type
+   * Finds an operand with provided type. Returns Optional.absent() if no operand found with
+   * matching type
    */
   public static Optional<BeamSqlExpression> findExpressionOfType(
       List<BeamSqlExpression> operands, SqlTypeName type) {
@@ -44,8 +42,8 @@ public class SqlTypeUtils {
   }
 
   /**
-   * Finds an operand with the type in typesToFind.
-   * Returns Optional.absent() if no operand found with matching type
+   * Finds an operand with the type in typesToFind. Returns Optional.absent() if no operand found
+   * with matching type
    */
   public static Optional<BeamSqlExpression> findExpressionOfType(
       List<BeamSqlExpression> operands, Collection<SqlTypeName> typesToFind) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Utility classes.
- */
+/** Utility classes. */
 package org.apache.beam.sdk.extensions.sql.impl.utils;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/Table.java
@@ -24,19 +24,22 @@ import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.Schema;
 
-/**
- * Represents the metadata of a {@code BeamSqlTable}.
- */
+/** Represents the metadata of a {@code BeamSqlTable}. */
 @AutoValue
 public abstract class Table implements Serializable {
   /** type of the table. */
   public abstract String getType();
+
   public abstract String getName();
+
   public abstract Schema getSchema();
+
   @Nullable
   public abstract String getComment();
+
   @Nullable
   public abstract String getLocation();
+
   @Nullable
   public abstract JSONObject getProperties();
 
@@ -46,17 +49,21 @@ public abstract class Table implements Serializable {
     return new org.apache.beam.sdk.extensions.sql.meta.AutoValue_Table.Builder();
   }
 
-  /**
-   * Builder class for {@link Table}.
-   */
+  /** Builder class for {@link Table}. */
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder type(String type);
+
     public abstract Builder name(String name);
+
     public abstract Builder schema(Schema getSchema);
+
     public abstract Builder comment(String name);
+
     public abstract Builder location(String location);
+
     public abstract Builder properties(JSONObject properties);
+
     public abstract Table build();
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Metadata related classes.
- */
+/** Metadata related classes. */
 package org.apache.beam.sdk.extensions.sql.meta;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/BeamSqlTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/BeamSqlTableProvider.java
@@ -24,9 +24,7 @@ import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
 import org.apache.beam.sdk.schemas.Schema;
 
-/**
- * A {@code BeamSqlTableProvider} provides read only set of {@code BeamSqlTable}.
- */
+/** A {@code BeamSqlTableProvider} provides read only set of {@code BeamSqlTable}. */
 public class BeamSqlTableProvider implements TableProvider {
   private final String typeName;
   private final Map<String, BeamSqlTable> tables;
@@ -36,7 +34,8 @@ public class BeamSqlTableProvider implements TableProvider {
     this.tables = tables;
   }
 
-  @Override public String getTableType() {
+  @Override
+  public String getTableType() {
     return typeName;
   }
 
@@ -54,12 +53,13 @@ public class BeamSqlTableProvider implements TableProvider {
   public Map<String, Table> getTables() {
     ImmutableMap.Builder<String, Table> map = ImmutableMap.builder();
     for (Map.Entry<String, BeamSqlTable> table : tables.entrySet()) {
-      map.put(table.getKey(),
+      map.put(
+          table.getKey(),
           Table.builder()
-            .type(getTableType())
-            .name(table.getKey())
-            .schema(Schema.builder().build())
-            .build());
+              .type(getTableType())
+              .name(table.getKey())
+              .schema(Schema.builder().build())
+              .build());
     }
     return map.build();
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/InMemoryMetaTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/InMemoryMetaTableProvider.java
@@ -22,9 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.meta.Table;
 
-/**
- * A {@code InMemoryMetaTableProvider} is an abstract {@code TableProvider} for in-memory types.
- */
+/** A {@code InMemoryMetaTableProvider} is an abstract {@code TableProvider} for in-memory types. */
 public abstract class InMemoryMetaTableProvider implements TableProvider {
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/TableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/TableProvider.java
@@ -29,14 +29,10 @@ import org.apache.beam.sdk.extensions.sql.meta.Table;
  * handle MySQL based tables, a provider to handle Casandra based tables etc.
  */
 public interface TableProvider {
-  /**
-   * Gets the table type this provider handles.
-   */
+  /** Gets the table type this provider handles. */
   String getTableType();
 
-  /**
-   * Creates a table.
-   */
+  /** Creates a table. */
   void createTable(Table table);
 
   /**
@@ -46,13 +42,9 @@ public interface TableProvider {
    */
   void dropTable(String tableName);
 
-  /**
-   * Get all tables from this provider.
-   */
+  /** Get all tables from this provider. */
   Map<String, Table> getTables();
 
-  /**
-   * Build a {@link BeamSqlTable} using the given table meta info.
-   */
+  /** Build a {@link BeamSqlTable} using the given table meta info. */
   BeamSqlTable buildBeamSqlTable(Table table);
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamBigQueryTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamBigQueryTable.java
@@ -32,9 +32,8 @@ import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
 /**
- * {@code BeamBigQueryTable} represent a BigQuery table as a target.
- * This provider does not currently support being a source.
- *
+ * {@code BeamBigQueryTable} represent a BigQuery table as a target. This provider does not
+ * currently support being a source.
  */
 @Experimental
 public class BeamBigQueryTable extends BaseBeamTable implements Serializable {
@@ -60,10 +59,11 @@ public class BeamBigQueryTable extends BaseBeamTable implements Serializable {
     return new PTransform<PCollection<Row>, POutput>() {
       @Override
       public WriteResult expand(PCollection<Row> input) {
-        return input.apply(BigQueryIO.<Row>write()
-          .withSchema(BigQueryUtils.toTableSchema(getSchema()))
-          .withFormatFunction(BigQueryUtils.toTableRow())
-          .to(tableSpec));
+        return input.apply(
+            BigQueryIO.<Row>write()
+                .withSchema(BigQueryUtils.toTableSchema(getSchema()))
+                .withFormatFunction(BigQueryUtils.toTableRow())
+                .to(tableSpec));
       }
     };
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTableProvider.java
@@ -27,6 +27,7 @@ import org.apache.beam.sdk.schemas.Schema;
  * BigQuery table provider.
  *
  * <p>A sample of text table is:
+ *
  * <pre>{@code
  * CREATE TABLE ORDERS(
  *   ID INT COMMENT 'this is the primary key',
@@ -39,11 +40,13 @@ import org.apache.beam.sdk.schemas.Schema;
  */
 public class BigQueryTableProvider extends InMemoryMetaTableProvider {
 
-  @Override public String getTableType() {
+  @Override
+  public String getTableType() {
     return "bigquery";
   }
 
-  @Override public BeamSqlTable buildBeamSqlTable(Table table) {
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
     Schema schema = table.getSchema();
     String filePattern = table.getLocation();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Table schema for BigQuery.
- */
+/** Table schema for BigQuery. */
 package org.apache.beam.sdk.extensions.sql.meta.provider.bigquery;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProvider.java
@@ -43,7 +43,8 @@ import org.apache.beam.sdk.schemas.Schema;
  * }</pre>
  */
 public class KafkaTableProvider extends InMemoryMetaTableProvider {
-  @Override public BeamSqlTable buildBeamSqlTable(Table table) {
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
     Schema schema = table.getSchema();
 
     JSONObject properties = table.getProperties();
@@ -57,7 +58,8 @@ public class KafkaTableProvider extends InMemoryMetaTableProvider {
     return txtTable;
   }
 
-  @Override public String getTableType() {
+  @Override
+  public String getTableType() {
     return "kafka";
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Table schema for KafkaIO.
- */
+/** Table schema for KafkaIO. */
 package org.apache.beam.sdk.extensions.sql.meta.provider.kafka;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Table providers.
- */
+/** Table providers. */
 package org.apache.beam.sdk.extensions.sql.meta.provider;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
@@ -48,15 +48,16 @@ import org.apache.beam.sdk.values.TupleTagList;
  * <p>This enables {@link PubsubIO} registration in Beam SQL environment as a table, including DDL
  * support.
  *
- * <p>Pubsub messages include metadata along with the payload, and it has to be explicitly
- * specified in the schema to make sure it is available to the queries.
+ * <p>Pubsub messages include metadata along with the payload, and it has to be explicitly specified
+ * in the schema to make sure it is available to the queries.
  *
- * <p>The fields included in the Pubsub message model are:
- * 'event_timestamp', 'attributes', and 'payload'.
+ * <p>The fields included in the Pubsub message model are: 'event_timestamp', 'attributes', and
+ * 'payload'.
  *
  * <p>For example:
  *
  * <p>If the messages have JSON messages in the payload that look like this:
+ *
  * <pre>
  *  {
  *    "id" : 5,
@@ -65,12 +66,13 @@ import org.apache.beam.sdk.values.TupleTagList;
  * </pre>
  *
  * <p>Then SQL statements to declare and query such topic will look like this:
+ *
  * <pre>
  *  CREATE TABLE topic_table (
  *        event_timestamp TIMESTAMP,
  *        attributes MAP&lt;VARCHAR, VARCHAR&gt;,
  *        payload ROW&lt;name VARCHAR, age INTEGER&gt;
-*      )
+ *      )
  *     TYPE 'pubsub'
  *     LOCATION projects/&lt;GCP project id&gt;/topics/&lt;topic name&gt;
  *     TBLPROPERTIES '{ \"timestampAttributeKey\" : &lt;timestamp attribute&gt; }';
@@ -79,10 +81,10 @@ import org.apache.beam.sdk.values.TupleTagList;
  * </pre>
  *
  * <p>Note, 'payload' field is defined as ROW with schema matching the JSON payload of the message.
- * If 'timestampAttributeKey' is specified in TBLPROPERTIES then 'event_timestamp' will be set
- * to the value of that attribute. If it is not specified, then message publish time will be used as
- * event timestamp. 'attributes' map contains Pubsub message attributes map unchanged and can
- * be referenced in the queries as well.
+ * If 'timestampAttributeKey' is specified in TBLPROPERTIES then 'event_timestamp' will be set to
+ * the value of that attribute. If it is not specified, then message publish time will be used as
+ * event timestamp. 'attributes' map contains Pubsub message attributes map unchanged and can be
+ * referenced in the queries as well.
  */
 @AutoValue
 @Internal
@@ -97,10 +99,11 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
    *
    * <p>Short version: it has to be either millis since epoch or string in RFC 3339 format.
    *
-   * <p>If the attribute is specified then event timestamps will be extracted from
-   * the specified attribute. If it is not specified then message publish timestamp will be used.
+   * <p>If the attribute is specified then event timestamps will be extracted from the specified
+   * attribute. If it is not specified then message publish timestamp will be used.
    */
-  @Nullable abstract String getTimestampAttribute();
+  @Nullable
+  abstract String getTimestampAttribute();
 
   /**
    * Optional topic path which will be used as a dead letter queue.
@@ -108,7 +111,8 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
    * <p>Messages that cannot be processed will be sent to this topic. If it is not specified then
    * exception will be thrown for errors during processing causing the pipeline to crash.
    */
-  @Nullable abstract String getDeadLetterQueue();
+  @Nullable
+  abstract String getDeadLetterQueue();
 
   private boolean useDlq() {
     return getDeadLetterQueue() != null;
@@ -129,10 +133,10 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   /**
    * Table schema, describes Pubsub message schema.
    *
-   * <p>Includes fields 'event_timestamp', 'attributes, and 'payload'.
-   * See {@link PubsubMessageToRow}.
+   * <p>Includes fields 'event_timestamp', 'attributes, and 'payload'. See {@link
+   * PubsubMessageToRow}.
    */
-   public abstract Schema getSchema();
+  public abstract Schema getSchema();
 
   @Override
   public BeamIOType getSourceType() {
@@ -142,8 +146,7 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   @Override
   public PCollection<Row> buildIOReader(Pipeline pipeline) {
     PCollectionTuple rowsWithDlq =
-        PBegin
-            .in(pipeline)
+        PBegin.in(pipeline)
             .apply("readFromPubsub", readMessagesWithAttributes())
             .apply("parseMessageToRow", createParserParDo());
 
@@ -155,24 +158,16 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   }
 
   private ParDo.MultiOutput<PubsubMessage, Row> createParserParDo() {
-    return
-        ParDo
-            .of(PubsubMessageToRow
-                    .builder()
-                    .messageSchema(getSchema())
-                    .useDlq(getDeadLetterQueue() != null)
-                    .build())
-            .withOutputTags(
-                MAIN_TAG,
-                useDlq()
-                    ? TupleTagList.of(DLQ_TAG)
-                    : TupleTagList.empty());
+    return ParDo.of(
+            PubsubMessageToRow.builder()
+                .messageSchema(getSchema())
+                .useDlq(getDeadLetterQueue() != null)
+                .build())
+        .withOutputTags(MAIN_TAG, useDlq() ? TupleTagList.of(DLQ_TAG) : TupleTagList.empty());
   }
 
   private PubsubIO.Read<PubsubMessage> readMessagesWithAttributes() {
-    PubsubIO.Read<PubsubMessage> read = PubsubIO
-        .readMessagesWithAttributes()
-        .fromTopic(getTopic());
+    PubsubIO.Read<PubsubMessage> read = PubsubIO.readMessagesWithAttributes().fromTopic(getTopic());
 
     return (getTimestampAttribute() == null)
         ? read
@@ -180,9 +175,7 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   }
 
   private PubsubIO.Write<PubsubMessage> writeMessagesToDlq() {
-    PubsubIO.Write<PubsubMessage> write = PubsubIO
-        .writeMessages()
-        .to(getDeadLetterQueue());
+    PubsubIO.Write<PubsubMessage> write = PubsubIO.writeMessages().to(getDeadLetterQueue());
 
     return (getTimestampAttribute() == null)
         ? write
@@ -197,8 +190,11 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   @AutoValue.Builder
   abstract static class Builder {
     abstract Builder setSchema(Schema schema);
+
     abstract Builder setTimestampAttribute(String timestampAttribute);
+
     abstract Builder setDeadLetterQueue(String deadLetterQueue);
+
     abstract Builder setTopic(String topic);
 
     abstract PubsubIOJsonTable build();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProvider.java
@@ -36,8 +36,8 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.schemas.Schema;
 
 /**
- * {@link TableProvider} for {@link PubsubIOJsonTable} which wraps {@link PubsubIO}
- * for consumption by Beam SQL.
+ * {@link TableProvider} for {@link PubsubIOJsonTable} which wraps {@link PubsubIO} for consumption
+ * by Beam SQL.
  */
 @Internal
 @Experimental
@@ -57,14 +57,12 @@ public class PubsubJsonTableProvider extends InMemoryMetaTableProvider {
     String deadLetterQueue = tableProperties.getString("deadLetterQueue");
     validateDlq(deadLetterQueue);
 
-    return
-        PubsubIOJsonTable
-            .builder()
-            .setSchema(tableDefintion.getSchema())
-            .setTimestampAttribute(timestampAttributeKey)
-            .setDeadLetterQueue(deadLetterQueue)
-            .setTopic(tableDefintion.getLocation())
-            .build();
+    return PubsubIOJsonTable.builder()
+        .setSchema(tableDefintion.getSchema())
+        .setTimestampAttribute(timestampAttributeKey)
+        .setDeadLetterQueue(deadLetterQueue)
+        .setTopic(tableDefintion.getLocation())
+        .build();
   }
 
   private void validatePubsubMessageSchema(Table tableDefinition) {
@@ -74,14 +72,14 @@ public class PubsubJsonTableProvider extends InMemoryMetaTableProvider {
         || !fieldPresent(schema, TIMESTAMP_FIELD, TIMESTAMP)
         || !fieldPresent(schema, ATTRIBUTES_FIELD, MAP.type().withMapType(VARCHAR, VARCHAR))
         || !(schema.hasField(PAYLOAD_FIELD)
-             && ROW.equals(schema.getField(PAYLOAD_FIELD).getType().getTypeName()))) {
+            && ROW.equals(schema.getField(PAYLOAD_FIELD).getType().getTypeName()))) {
 
       throw new IllegalArgumentException(
           "Unsupported schema specified for Pubsub source in CREATE TABLE. "
-          + "CREATE TABLE for Pubsub topic should define exactly the following fields: "
-          + "'event_timestamp' field of type 'TIMESTAMP', 'attributes' field of type "
-          + "MAP<VARCHAR, VARCHAR>, and 'payload' field of type 'ROW<...>' which matches the "
-          + "payload JSON format.");
+              + "CREATE TABLE for Pubsub topic should define exactly the following fields: "
+              + "'event_timestamp' field of type 'TIMESTAMP', 'attributes' field of type "
+              + "MAP<VARCHAR, VARCHAR>, and 'payload' field of type 'ROW<...>' which matches the "
+              + "payload JSON format.");
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRow.java
@@ -39,9 +39,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Instant;
 
-/**
- * A {@link DoFn} to convert {@link PubsubMessage} with JSON payload to {@link Row}.
- */
+/** A {@link DoFn} to convert {@link PubsubMessage} with JSON payload to {@link Row}. */
 @Internal
 @Experimental
 @AutoValue
@@ -58,10 +56,11 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
    * Schema of the Pubsub message.
    *
    * <p>Required to have exactly 3 top level fields at the moment:
+   *
    * <ul>
-   *   <li>'event_timestamp' of type {@link RowSqlTypes#TIMESTAMP}</li>
-   *   <li>'attributes' of type {@link TypeName#MAP MAP&lt;VARCHAR,VARCHAR&gt;}</li>
-   *   <li>'payload' of type {@link TypeName#ROW ROW&lt;...&gt;}</li>
+   *   <li>'event_timestamp' of type {@link RowSqlTypes#TIMESTAMP}
+   *   <li>'attributes' of type {@link TypeName#MAP MAP&lt;VARCHAR,VARCHAR&gt;}
+   *   <li>'payload' of type {@link TypeName#ROW ROW&lt;...&gt;}
    * </ul>
    *
    * <p>Only UTF-8 JSON objects are supported.
@@ -93,26 +92,19 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
   }
 
   /**
-   * Get values for fields in the same order they're specified in schema, including
-   * timestamp, payload, and attributes.
+   * Get values for fields in the same order they're specified in schema, including timestamp,
+   * payload, and attributes.
    */
   private List<Object> getFieldValues(ProcessContext context) {
-    return
-        messageSchema()
-            .getFields()
-            .stream()
-            .map(field ->
-                     getValueForField(
-                         field,
-                         context.timestamp(),
-                         context.element()))
-            .collect(toList());
+    return messageSchema()
+        .getFields()
+        .stream()
+        .map(field -> getValueForField(field, context.timestamp(), context.element()))
+        .collect(toList());
   }
 
   private Object getValueForField(
-      Schema.Field field,
-      Instant timestamp,
-      PubsubMessage pubsubMessage) {
+      Schema.Field field, Instant timestamp, PubsubMessage pubsubMessage) {
 
     switch (field.getName()) {
       case TIMESTAMP_FIELD:
@@ -123,9 +115,11 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
         return parsePayloadJsonRow(pubsubMessage);
       default:
         throw new IllegalArgumentException(
-            "Unexpected field '" + field.getName() + "' in top level schema"
-            + " for Pubsub message. Top level schema should only contain "
-            + "'timestamp', 'attributes', and 'payload' fields");
+            "Unexpected field '"
+                + field.getName()
+                + "' in top level schema"
+                + " for Pubsub message. Top level schema should only contain "
+                + "'timestamp', 'attributes', and 'payload' fields");
     }
   }
 
@@ -133,8 +127,7 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
     String payloadJson = new String(pubsubMessage.getPayload(), StandardCharsets.UTF_8);
 
     if (objectMapper == null) {
-      objectMapper =
-          newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema()));
+      objectMapper = newObjectMapperWith(RowJsonDeserializer.forSchema(payloadSchema()));
     }
 
     return JsonToRowUtils.jsonToRow(objectMapper, payloadJson);
@@ -143,6 +136,7 @@ public abstract class PubsubMessageToRow extends DoFn<PubsubMessage, Row> {
   @AutoValue.Builder
   abstract static class Builder {
     public abstract Builder messageSchema(Schema messageSchema);
+
     public abstract Builder useDlq(boolean useDlq);
 
     public abstract PubsubMessageToRow build();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/package-info.java
@@ -16,9 +16,7 @@
  * limitations under the License.
  */
 
-/**
- * Table schema for {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubIO}.
- */
+/** Table schema for {@link org.apache.beam.sdk.io.gcp.pubsub.PubsubIO}. */
 @DefaultAnnotation(NonNull.class)
 package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
@@ -31,24 +31,19 @@ import org.apache.commons.csv.CSVFormat;
 /**
  * {@code BeamTextCSVTable} is a {@code BeamTextTable} which formatted in CSV.
  *
- * <p>
- * {@link CSVFormat} itself has many dialects, check its javadoc for more info.
- * </p>
+ * <p>{@link CSVFormat} itself has many dialects, check its javadoc for more info.
  */
 public class BeamTextCSVTable extends BeamTextTable {
 
   private String filePattern;
   private CSVFormat csvFormat;
 
-  /**
-   * CSV table with {@link CSVFormat#DEFAULT DEFAULT} format.
-   */
-  public BeamTextCSVTable(Schema beamSchema, String filePattern)  {
+  /** CSV table with {@link CSVFormat#DEFAULT DEFAULT} format. */
+  public BeamTextCSVTable(Schema beamSchema, String filePattern) {
     this(beamSchema, filePattern, CSVFormat.DEFAULT);
   }
 
-  public BeamTextCSVTable(Schema schema, String filePattern,
-                          CSVFormat csvFormat) {
+  public BeamTextCSVTable(Schema schema, String filePattern, CSVFormat csvFormat) {
     super(schema, filePattern);
     this.filePattern = filePattern;
     this.csvFormat = csvFormat;
@@ -56,9 +51,9 @@ public class BeamTextCSVTable extends BeamTextTable {
 
   @Override
   public PCollection<Row> buildIOReader(Pipeline pipeline) {
-    return PBegin.in(pipeline).apply("decodeRecord", TextIO.read().from(filePattern))
-        .apply("parseCSVLine",
-            new BeamTextCSVTableIOReader(schema, filePattern, csvFormat));
+    return PBegin.in(pipeline)
+        .apply("decodeRecord", TextIO.read().from(filePattern))
+        .apply("parseCSVLine", new BeamTextCSVTableIOReader(schema, filePattern, csvFormat));
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOReader.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOReader.java
@@ -29,18 +29,14 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.commons.csv.CSVFormat;
 
-/**
- * IOReader for {@code BeamTextCSVTable}.
- */
-public class BeamTextCSVTableIOReader
-    extends PTransform<PCollection<String>, PCollection<Row>>
+/** IOReader for {@code BeamTextCSVTable}. */
+public class BeamTextCSVTableIOReader extends PTransform<PCollection<String>, PCollection<Row>>
     implements Serializable {
   private String filePattern;
   protected Schema schema;
   protected CSVFormat csvFormat;
 
-  public BeamTextCSVTableIOReader(Schema schema, String filePattern,
-                                  CSVFormat csvFormat) {
+  public BeamTextCSVTableIOReader(Schema schema, String filePattern, CSVFormat csvFormat) {
     this.filePattern = filePattern;
     this.schema = schema;
     this.csvFormat = csvFormat;
@@ -48,12 +44,14 @@ public class BeamTextCSVTableIOReader
 
   @Override
   public PCollection<Row> expand(PCollection<String> input) {
-    return input.apply(ParDo.of(new DoFn<String, Row>() {
-          @ProcessElement
-          public void processElement(ProcessContext ctx) {
-            String str = ctx.element();
-            ctx.output(csvLine2BeamRow(csvFormat, str, schema));
-          }
-        }));
+    return input.apply(
+        ParDo.of(
+            new DoFn<String, Row>() {
+              @ProcessElement
+              public void processElement(ProcessContext ctx) {
+                String str = ctx.element();
+                ctx.output(csvLine2BeamRow(csvFormat, str, schema));
+              }
+            }));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOWriter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableIOWriter.java
@@ -31,18 +31,14 @@ import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.commons.csv.CSVFormat;
 
-/**
- * IOWriter for {@code BeamTextCSVTable}.
- */
+/** IOWriter for {@code BeamTextCSVTable}. */
 public class BeamTextCSVTableIOWriter extends PTransform<PCollection<Row>, POutput>
     implements Serializable {
   private String filePattern;
   protected Schema schema;
   protected CSVFormat csvFormat;
 
-  public BeamTextCSVTableIOWriter(Schema schema,
-                                  String filePattern,
-                                  CSVFormat csvFormat) {
+  public BeamTextCSVTableIOWriter(Schema schema, String filePattern, CSVFormat csvFormat) {
     this.filePattern = filePattern;
     this.schema = schema;
     this.csvFormat = csvFormat;
@@ -50,13 +46,18 @@ public class BeamTextCSVTableIOWriter extends PTransform<PCollection<Row>, POutp
 
   @Override
   public POutput expand(PCollection<Row> input) {
-    return input.apply("encodeRecord", ParDo.of(new DoFn<Row, String>() {
+    return input
+        .apply(
+            "encodeRecord",
+            ParDo.of(
+                new DoFn<Row, String>() {
 
-      @ProcessElement
-      public void processElement(ProcessContext ctx) {
-        Row row = ctx.element();
-        ctx.output(beamRow2CsvLine(row, csvFormat));
-      }
-    })).apply(TextIO.write().to(filePattern));
+                  @ProcessElement
+                  public void processElement(ProcessContext ctx) {
+                    Row row = ctx.element();
+                    ctx.output(beamRow2CsvLine(row, csvFormat));
+                  }
+                }))
+        .apply(TextIO.write().to(filePattern));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextTable.java
@@ -22,9 +22,7 @@ import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamIOType;
 import org.apache.beam.sdk.schemas.Schema;
 
-/**
- * {@code BeamTextTable} represents a text file/directory(backed by {@code TextIO}).
- */
+/** {@code BeamTextTable} represents a text file/directory(backed by {@code TextIO}). */
 public abstract class BeamTextTable extends BaseBeamTable {
   protected String filePattern;
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProvider.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProvider.java
@@ -29,6 +29,7 @@ import org.apache.commons.csv.CSVFormat;
  * Text table provider.
  *
  * <p>A sample of text table is:
+ *
  * <pre>{@code
  * CREATE TABLE ORDERS(
  *   ID INT COMMENT 'this is the primary key',
@@ -42,11 +43,13 @@ import org.apache.commons.csv.CSVFormat;
  */
 public class TextTableProvider extends InMemoryMetaTableProvider {
 
-  @Override public String getTableType() {
+  @Override
+  public String getTableType() {
     return "text";
   }
 
-  @Override public BeamSqlTable buildBeamSqlTable(Table table) {
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
     Schema schema = table.getSchema();
 
     String filePattern = table.getLocation();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Table schema for text files.
- */
+/** Table schema for text files. */
 package org.apache.beam.sdk.extensions.sql.meta.provider.text;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStore.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStore.java
@@ -28,19 +28,21 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 /**
  * A {@link MetaStore} which stores the meta info in memory.
  *
- * <p>NOTE, because this implementation is memory based, the metadata is NOT persistent.
- * for tables which created, you need to create again every time you launch the
- * {@link org.apache.beam.sdk.extensions.sql.BeamSqlCli}.
+ * <p>NOTE, because this implementation is memory based, the metadata is NOT persistent. for tables
+ * which created, you need to create again every time you launch the {@link
+ * org.apache.beam.sdk.extensions.sql.BeamSqlCli}.
  */
 public class InMemoryMetaStore implements MetaStore {
   private Map<String, Table> tables = new HashMap<>();
   private Map<String, TableProvider> providers = new HashMap<>();
 
-  @Override public String getTableType() {
+  @Override
+  public String getTableType() {
     return "store";
   }
 
-  @Override public void createTable(Table table) {
+  @Override
+  public void createTable(Table table) {
     validateTableType(table);
 
     // first assert the table name is unique
@@ -55,7 +57,8 @@ public class InMemoryMetaStore implements MetaStore {
     tables.put(table.getName(), table);
   }
 
-  @Override public void dropTable(String tableName) {
+  @Override
+  public void dropTable(String tableName) {
     if (!tables.containsKey(tableName)) {
       throw new IllegalArgumentException("No such table: " + tableName);
     }
@@ -65,11 +68,13 @@ public class InMemoryMetaStore implements MetaStore {
     tables.remove(tableName);
   }
 
-  @Override public Map<String, Table> getTables() {
+  @Override
+  public Map<String, Table> getTables() {
     return ImmutableMap.copyOf(tables);
   }
 
-  @Override public BeamSqlTable buildBeamSqlTable(Table table) {
+  @Override
+  public BeamSqlTable buildBeamSqlTable(Table table) {
     TableProvider provider = providers.get(table.getType());
 
     return provider.buildBeamSqlTable(table);
@@ -77,15 +82,15 @@ public class InMemoryMetaStore implements MetaStore {
 
   private void validateTableType(Table table) {
     if (!providers.containsKey(table.getType())) {
-      throw new IllegalArgumentException(
-          "Table type: " + table.getType() + " not supported!");
+      throw new IllegalArgumentException("Table type: " + table.getType() + " not supported!");
     }
   }
 
-  @Override public void registerProvider(TableProvider provider) {
+  @Override
+  public void registerProvider(TableProvider provider) {
     if (providers.containsKey(provider.getTableType())) {
-      throw new IllegalArgumentException("Provider is already registered for table type: "
-          + provider.getTableType());
+      throw new IllegalArgumentException(
+          "Provider is already registered for table type: " + provider.getTableType());
     }
 
     initTablesFromProvider(provider);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/MetaStore.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/MetaStore.java
@@ -20,12 +20,11 @@ package org.apache.beam.sdk.extensions.sql.meta.store;
 
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 
-/**
- * The interface to handle CRUD of {@code BeamSql} table metadata.
- */
+/** The interface to handle CRUD of {@code BeamSql} table metadata. */
 public interface MetaStore extends TableProvider {
   /**
    * Register a table provider.
+   *
    * @param provider
    */
   void registerProvider(TableProvider provider);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/store/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * Meta stores.
- */
+/** Meta stores. */
 package org.apache.beam.sdk.extensions.sql.meta.store;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/package-info.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/package-info.java
@@ -16,7 +16,5 @@
  * limitations under the License.
  */
 
-/**
- * BeamSQL provides a new interface to run a SQL statement with Beam.
- */
+/** BeamSQL provides a new interface to run a SQL statement with Beam. */
 package org.apache.beam.sdk.extensions.sql;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlArrayTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlArrayTest.java
@@ -30,17 +30,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Tests for SQL arrays.
- */
+/** Tests for SQL arrays. */
 public class BeamSqlArrayTest {
 
   private static final Schema INPUT_ROW_TYPE =
-      RowSqlTypes
-        .builder()
-        .withIntegerField("f_int")
-        .withArrayField("f_stringArr", SqlTypeName.VARCHAR)
-        .build();
+      RowSqlTypes.builder()
+          .withIntegerField("f_int")
+          .withArrayField("f_stringArr", SqlTypeName.VARCHAR)
+          .build();
 
   @Rule public final TestPipeline pipeline = TestPipeline.create();
   @Rule public ExpectedException exceptions = ExpectedException.none();
@@ -50,29 +47,19 @@ public class BeamSqlArrayTest {
     PCollection<Row> input = pCollectionOf2Elements();
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withArrayField("f_arr", SqlTypeName.VARCHAR)
             .build();
 
     PCollection<Row> result =
-        input
-            .apply(
-                "sqlQuery",
-                BeamSql.query("SELECT 42, ARRAY ['aa', 'bb'] as `f_arr` FROM PCOLLECTION"));
+        input.apply(
+            "sqlQuery", BeamSql.query("SELECT 42, ARRAY ['aa', 'bb'] as `f_arr` FROM PCOLLECTION"));
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row
-                   .withSchema(resultType)
-                   .addValues(42, Arrays.asList("aa", "bb"))
-                   .build(),
-
-               Row
-                   .withSchema(resultType)
-                   .addValues(42, Arrays.asList("aa", "bb"))
-                   .build());
+        .containsInAnyOrder(
+            Row.withSchema(resultType).addValues(42, Arrays.asList("aa", "bb")).build(),
+            Row.withSchema(resultType).addValues(42, Arrays.asList("aa", "bb")).build());
 
     pipeline.run();
   }
@@ -82,30 +69,21 @@ public class BeamSqlArrayTest {
     PCollection<Row> input = pCollectionOf2Elements();
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withArrayField("f_stringArr", SqlTypeName.VARCHAR)
             .build();
 
     PCollection<Row> result =
-        input
-            .apply(
-                "sqlQuery",
-                BeamSql.query("SELECT f_int, f_stringArr FROM PCOLLECTION"));
+        input.apply("sqlQuery", BeamSql.query("SELECT f_int, f_stringArr FROM PCOLLECTION"));
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row
-                   .withSchema(resultType)
-                   .addValues(1)
-                   .addArray(Arrays.asList("111", "222"))
-                   .build(),
-               Row
-                   .withSchema(resultType)
-                   .addValues(2)
-                   .addArray(Arrays.asList("33", "44", "55"))
-                   .build());
+        .containsInAnyOrder(
+            Row.withSchema(resultType).addValues(1).addArray(Arrays.asList("111", "222")).build(),
+            Row.withSchema(resultType)
+                .addValues(2)
+                .addArray(Arrays.asList("33", "44", "55"))
+                .build());
 
     pipeline.run();
   }
@@ -114,66 +92,34 @@ public class BeamSqlArrayTest {
   public void testAccessArrayElement() {
     PCollection<Row> input = pCollectionOf2Elements();
 
-    Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_arrElem")
-            .build();
+    Schema resultType = RowSqlTypes.builder().withVarcharField("f_arrElem").build();
 
     PCollection<Row> result =
-        input
-            .apply(
-                "sqlQuery",
-                BeamSql.query("SELECT f_stringArr[0] FROM PCOLLECTION"));
+        input.apply("sqlQuery", BeamSql.query("SELECT f_stringArr[0] FROM PCOLLECTION"));
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row
-                   .withSchema(resultType)
-                   .addValues("111")
-                   .build(),
-               Row
-                   .withSchema(resultType)
-                   .addValues("33")
-                   .build());
+        .containsInAnyOrder(
+            Row.withSchema(resultType).addValues("111").build(),
+            Row.withSchema(resultType).addValues("33").build());
 
     pipeline.run();
   }
 
   @Test
   public void testSingleElement() throws Exception {
-    Row inputRow = Row.withSchema(INPUT_ROW_TYPE)
-        .addValues(1)
-        .addArray(Arrays.asList("111"))
-        .build();
+    Row inputRow =
+        Row.withSchema(INPUT_ROW_TYPE).addValues(1).addArray(Arrays.asList("111")).build();
 
     PCollection<Row> input =
-        PBegin
-            .in(pipeline)
-            .apply(
-                "boundedInput1",
-                Create
-                    .of(inputRow)
-                    .withCoder(INPUT_ROW_TYPE.getRowCoder()));
+        PBegin.in(pipeline)
+            .apply("boundedInput1", Create.of(inputRow).withCoder(INPUT_ROW_TYPE.getRowCoder()));
 
-    Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_arrElem")
-            .build();
+    Schema resultType = RowSqlTypes.builder().withVarcharField("f_arrElem").build();
 
     PCollection<Row> result =
-        input
-            .apply(
-                "sqlQuery",
-                BeamSql.query("SELECT ELEMENT(f_stringArr) FROM PCOLLECTION"));
+        input.apply("sqlQuery", BeamSql.query("SELECT ELEMENT(f_stringArr) FROM PCOLLECTION"));
 
-    PAssert.that(result)
-           .containsInAnyOrder(
-               Row
-                   .withSchema(resultType)
-                   .addValues("111")
-                   .build());
+    PAssert.that(result).containsInAnyOrder(Row.withSchema(resultType).addValues("111").build());
 
     pipeline.run();
   }
@@ -182,28 +128,15 @@ public class BeamSqlArrayTest {
   public void testCardinality() {
     PCollection<Row> input = pCollectionOf2Elements();
 
-    Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_size")
-            .build();
+    Schema resultType = RowSqlTypes.builder().withIntegerField("f_size").build();
 
     PCollection<Row> result =
-        input
-            .apply(
-                "sqlQuery",
-                BeamSql.query("SELECT CARDINALITY(f_stringArr) FROM PCOLLECTION"));
+        input.apply("sqlQuery", BeamSql.query("SELECT CARDINALITY(f_stringArr) FROM PCOLLECTION"));
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row
-                   .withSchema(resultType)
-                   .addValues(2)
-                   .build(),
-               Row
-                   .withSchema(resultType)
-                   .addValues(3)
-                   .build());
+        .containsInAnyOrder(
+            Row.withSchema(resultType).addValues(2).build(),
+            Row.withSchema(resultType).addValues(3).build());
 
     pipeline.run();
   }
@@ -211,67 +144,56 @@ public class BeamSqlArrayTest {
   @Test
   public void testSelectRowsFromArrayOfRows() {
     Schema elementRowType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_rowString")
-            .withIntegerField("f_rowInt")
-            .build();
+        RowSqlTypes.builder().withVarcharField("f_rowString").withIntegerField("f_rowInt").build();
 
     Schema resultRowType =
-        RowSqlTypes
-            .builder()
-            .withArrayField("f_resultArray", elementRowType)
-            .build();
+        RowSqlTypes.builder().withArrayField("f_resultArray", elementRowType).build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withArrayField("f_arrayOfRows", elementRowType)
             .build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("AA", 11).build(),
-                                 Row.withSchema(elementRowType).addValues("BB", 22).build()))
-                         .build(),
-                      Row.withSchema(inputType)
-                         .addValues(
-                             2,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("CC", 33).build(),
-                                 Row.withSchema(elementRowType).addValues("DD", 44).build()))
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("AA", 11).build(),
+                                    Row.withSchema(elementRowType).addValues("BB", 22).build()))
+                            .build(),
+                        Row.withSchema(inputType)
+                            .addValues(
+                                2,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("CC", 33).build(),
+                                    Row.withSchema(elementRowType).addValues("DD", 44).build()))
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
-            .apply(
-                BeamSql.query(
-                    "SELECT f_arrayOfRows FROM PCOLLECTION"))
+            .apply(BeamSql.query("SELECT f_arrayOfRows FROM PCOLLECTION"))
             .setCoder(resultRowType.getRowCoder());
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row.withSchema(resultRowType)
-                  .addArray(
-                      Arrays.asList(
-                          Row.withSchema(elementRowType).addValues("AA", 11).build(),
-                          Row.withSchema(elementRowType).addValues("BB", 22).build()))
-                  .build(),
-               Row.withSchema(resultRowType)
-                  .addArray(
-                      Arrays.asList(
-                          Row.withSchema(elementRowType).addValues("CC", 33).build(),
-                          Row.withSchema(elementRowType).addValues("DD", 44).build()))
-                  .build()
-           );
+        .containsInAnyOrder(
+            Row.withSchema(resultRowType)
+                .addArray(
+                    Arrays.asList(
+                        Row.withSchema(elementRowType).addValues("AA", 11).build(),
+                        Row.withSchema(elementRowType).addValues("BB", 22).build()))
+                .build(),
+            Row.withSchema(resultRowType)
+                .addArray(
+                    Arrays.asList(
+                        Row.withSchema(elementRowType).addValues("CC", 33).build(),
+                        Row.withSchema(elementRowType).addValues("DD", 44).build()))
+                .build());
 
     pipeline.run();
   }
@@ -279,52 +201,45 @@ public class BeamSqlArrayTest {
   @Test
   public void testSelectSingleRowFromArrayOfRows() {
     Schema elementRowType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_rowString")
-            .withIntegerField("f_rowInt")
-            .build();
+        RowSqlTypes.builder().withVarcharField("f_rowString").withIntegerField("f_rowInt").build();
 
     Schema resultRowType = elementRowType;
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withArrayField("f_arrayOfRows", elementRowType)
             .build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("AA", 11).build(),
-                                 Row.withSchema(elementRowType).addValues("BB", 22).build()))
-                         .build(),
-                      Row.withSchema(inputType)
-                         .addValues(
-                             2,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("CC", 33).build(),
-                                 Row.withSchema(elementRowType).addValues("DD", 44).build()))
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("AA", 11).build(),
+                                    Row.withSchema(elementRowType).addValues("BB", 22).build()))
+                            .build(),
+                        Row.withSchema(inputType)
+                            .addValues(
+                                2,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("CC", 33).build(),
+                                    Row.withSchema(elementRowType).addValues("DD", 44).build()))
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
-            .apply(
-                BeamSql.query(
-                    "SELECT f_arrayOfRows[1] FROM PCOLLECTION"))
+            .apply(BeamSql.query("SELECT f_arrayOfRows[1] FROM PCOLLECTION"))
             .setCoder(resultRowType.getRowCoder());
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row.withSchema(elementRowType).addValues("BB", 22).build(),
-               Row.withSchema(elementRowType).addValues("DD", 44).build());
+        .containsInAnyOrder(
+            Row.withSchema(elementRowType).addValues("BB", 22).build(),
+            Row.withSchema(elementRowType).addValues("DD", 44).build());
 
     pipeline.run();
   }
@@ -332,77 +247,62 @@ public class BeamSqlArrayTest {
   @Test
   public void testSelectRowFieldFromArrayOfRows() {
     Schema elementRowType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_rowString")
-            .withIntegerField("f_rowInt")
-            .build();
+        RowSqlTypes.builder().withVarcharField("f_rowString").withIntegerField("f_rowInt").build();
 
-    Schema resultRowType =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_stringField")
-            .build();
+    Schema resultRowType = RowSqlTypes.builder().withVarcharField("f_stringField").build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withArrayField("f_arrayOfRows", elementRowType)
             .build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("AA", 11).build(),
-                                 Row.withSchema(elementRowType).addValues("BB", 22).build()))
-                         .build(),
-                      Row.withSchema(inputType)
-                         .addValues(
-                             2,
-                             Arrays.asList(
-                                 Row.withSchema(elementRowType).addValues("CC", 33).build(),
-                                 Row.withSchema(elementRowType).addValues("DD", 44).build()))
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("AA", 11).build(),
+                                    Row.withSchema(elementRowType).addValues("BB", 22).build()))
+                            .build(),
+                        Row.withSchema(inputType)
+                            .addValues(
+                                2,
+                                Arrays.asList(
+                                    Row.withSchema(elementRowType).addValues("CC", 33).build(),
+                                    Row.withSchema(elementRowType).addValues("DD", 44).build()))
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
-            .apply(
-                BeamSql.query(
-                    "SELECT f_arrayOfRows[1].f_rowString FROM PCOLLECTION"))
+            .apply(BeamSql.query("SELECT f_arrayOfRows[1].f_rowString FROM PCOLLECTION"))
             .setCoder(resultRowType.getRowCoder());
 
     PAssert.that(result)
-           .containsInAnyOrder(
-               Row.withSchema(resultRowType).addValues("BB").build(),
-               Row.withSchema(resultRowType).addValues("DD").build());
+        .containsInAnyOrder(
+            Row.withSchema(resultRowType).addValues("BB").build(),
+            Row.withSchema(resultRowType).addValues("DD").build());
 
     pipeline.run();
   }
 
   private PCollection<Row> pCollectionOf2Elements() {
-    return
-        PBegin
-            .in(pipeline)
-            .apply("boundedInput1",
-                   Create
-                       .of(
-                           Row
-                               .withSchema(INPUT_ROW_TYPE)
-                               .addValues(1)
-                               .addArray(Arrays.asList("111", "222"))
-                               .build(),
-                           Row
-                               .withSchema(INPUT_ROW_TYPE)
-                               .addValues(2)
-                               .addArray(Arrays.asList("33", "44", "55"))
-                               .build())
-                       .withCoder(INPUT_ROW_TYPE.getRowCoder()));
+    return PBegin.in(pipeline)
+        .apply(
+            "boundedInput1",
+            Create.of(
+                    Row.withSchema(INPUT_ROW_TYPE)
+                        .addValues(1)
+                        .addArray(Arrays.asList("111", "222"))
+                        .build(),
+                    Row.withSchema(INPUT_ROW_TYPE)
+                        .addValues(2)
+                        .addArray(Arrays.asList("33", "44", "55"))
+                        .build())
+                .withCoder(INPUT_ROW_TYPE.getRowCoder()));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliPubsubTest.java
@@ -22,9 +22,7 @@ import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.junit.Ignore;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlCli} Pubsub functionality.
- */
+/** Unit tests for {@link BeamSqlCli} Pubsub functionality. */
 public class BeamSqlCliPubsubTest {
 
   @Test
@@ -38,16 +36,18 @@ public class BeamSqlCliPubsubTest {
 
     cli.execute(
         "CREATE TABLE topic (\n"
-        + "event_timestamp TIMESTAMP, \n"
-        + "attributes MAP<VARCHAR, VARCHAR>, \n"
-        + "payload ROW< \n"
-        + "             `id` INTEGER, \n"
-        + "             `name` VARCHAR \n"
-        + "           > \n"
-        + ") \n"
-        + "TYPE 'pubsub' \n"
-        + "LOCATION '" + pubsubTopic + "' \n"
-        + "TBLPROPERTIES '{ \"timestampAttributeKey\" : \"ts\" }'");
+            + "event_timestamp TIMESTAMP, \n"
+            + "attributes MAP<VARCHAR, VARCHAR>, \n"
+            + "payload ROW< \n"
+            + "             `id` INTEGER, \n"
+            + "             `name` VARCHAR \n"
+            + "           > \n"
+            + ") \n"
+            + "TYPE 'pubsub' \n"
+            + "LOCATION '"
+            + pubsubTopic
+            + "' \n"
+            + "TBLPROPERTIES '{ \"timestampAttributeKey\" : \"ts\" }'");
 
     cli.execute("SELECT topic.payload.name from topic");
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliTest.java
@@ -36,30 +36,25 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.calcite.tools.ValidationException;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link BeamSqlCli}.
- */
+/** UnitTest for {@link BeamSqlCli}. */
 public class BeamSqlCliTest {
   @Test
   public void testExecute_createTextTable() throws Exception {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
-        + "id int COMMENT 'id', \n"
-        + "name varchar COMMENT 'name', \n"
-        + "age int COMMENT 'age') \n"
-        + "TYPE 'text' \n"
-        + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "id int COMMENT 'id', \n"
+            + "name varchar COMMENT 'name', \n"
+            + "age int COMMENT 'age') \n"
+            + "TYPE 'text' \n"
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     Table table = metaStore.getTables().get("person");
     assertNotNull(table);
     assertEquals(
-        Stream
-            .of(
+        Stream.of(
                 Field.of("id", INTEGER).withDescription("id").withNullable(true),
                 Field.of("name", VARCHAR).withDescription("name").withNullable(true),
                 Field.of("age", INTEGER).withDescription("age").withNullable(true))
@@ -72,32 +67,33 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
-        + "id int COMMENT 'id', \n"
-        + "name varchar COMMENT 'name', \n"
-        + "age int COMMENT 'age', \n"
-        + "tags ARRAY<VARCHAR>, \n"
-        + "matrix ARRAY<ARRAY<INTEGER>> \n"
-        + ") \n"
-        + "TYPE 'text' \n"
-        + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "id int COMMENT 'id', \n"
+            + "name varchar COMMENT 'name', \n"
+            + "age int COMMENT 'age', \n"
+            + "tags ARRAY<VARCHAR>, \n"
+            + "matrix ARRAY<ARRAY<INTEGER>> \n"
+            + ") \n"
+            + "TYPE 'text' \n"
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     Table table = metaStore.getTables().get("person");
     assertNotNull(table);
     assertEquals(
-        Stream
-            .of(
+        Stream.of(
                 Field.of("id", INTEGER).withDescription("id").withNullable(true),
                 Field.of("name", VARCHAR).withDescription("name").withNullable(true),
                 Field.of("age", INTEGER).withDescription("age").withNullable(true),
-                Field.of("tags",
-                         ARRAY.type().withCollectionElementType(VARCHAR)).withNullable(true),
-                Field.of("matrix",
-                         ARRAY.type().withCollectionElementType(
-                             ARRAY.type().withCollectionElementType(INTEGER))).withNullable(true))
+                Field.of("tags", ARRAY.type().withCollectionElementType(VARCHAR))
+                    .withNullable(true),
+                Field.of(
+                        "matrix",
+                        ARRAY
+                            .type()
+                            .withCollectionElementType(
+                                ARRAY.type().withCollectionElementType(INTEGER)))
+                    .withNullable(true))
             .collect(toSchema()),
         table.getSchema());
   }
@@ -107,33 +103,29 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
-        + "id int COMMENT 'id', \n"
-        + "name varchar COMMENT 'name', \n"
-        + "age int COMMENT 'age', \n"
-        + "tags MAP<VARCHAR, VARCHAR>, \n"
-        + "nestedMap MAP<INTEGER, MAP<VARCHAR, INTEGER>> \n"
-        + ") \n"
-        + "TYPE 'text' \n"
-        + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "id int COMMENT 'id', \n"
+            + "name varchar COMMENT 'name', \n"
+            + "age int COMMENT 'age', \n"
+            + "tags MAP<VARCHAR, VARCHAR>, \n"
+            + "nestedMap MAP<INTEGER, MAP<VARCHAR, INTEGER>> \n"
+            + ") \n"
+            + "TYPE 'text' \n"
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     Table table = metaStore.getTables().get("person");
     assertNotNull(table);
     assertEquals(
-        Stream
-            .of(
+        Stream.of(
                 Field.of("id", INTEGER).withDescription("id").withNullable(true),
                 Field.of("name", VARCHAR).withDescription("name").withNullable(true),
                 Field.of("age", INTEGER).withDescription("age").withNullable(true),
-                Field.of("tags",
-                         MAP.type().withMapType(VARCHAR, VARCHAR)).withNullable(true),
-                Field.of("nestedmap",
-                         MAP.type().withMapType(
-                             INTEGER,
-                             MAP.type().withMapType(VARCHAR, INTEGER))).withNullable(true))
+                Field.of("tags", MAP.type().withMapType(VARCHAR, VARCHAR)).withNullable(true),
+                Field.of(
+                        "nestedmap",
+                        MAP.type().withMapType(INTEGER, MAP.type().withMapType(VARCHAR, INTEGER)))
+                    .withNullable(true))
             .collect(toSchema()),
         table.getSchema());
   }
@@ -143,48 +135,49 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
-        + "id int COMMENT 'id', \n"
-        + "name varchar COMMENT 'name', \n"
-        + "age int COMMENT 'age', \n"
-        + "address ROW ( \n"
-        + "  street VARCHAR, \n"
-        + "  country VARCHAR \n"
-        + "  ), \n"
-        + "addressAngular ROW< \n"
-        + "  street VARCHAR, \n"
-        + "  country VARCHAR \n"
-        + "  >, \n"
-        + "isRobot BOOLEAN"
-        + ") \n"
-        + "TYPE 'text' \n"
-        + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "id int COMMENT 'id', \n"
+            + "name varchar COMMENT 'name', \n"
+            + "age int COMMENT 'age', \n"
+            + "address ROW ( \n"
+            + "  street VARCHAR, \n"
+            + "  country VARCHAR \n"
+            + "  ), \n"
+            + "addressAngular ROW< \n"
+            + "  street VARCHAR, \n"
+            + "  country VARCHAR \n"
+            + "  >, \n"
+            + "isRobot BOOLEAN"
+            + ") \n"
+            + "TYPE 'text' \n"
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     Table table = metaStore.getTables().get("person");
     assertNotNull(table);
     assertEquals(
-        Stream
-            .of(
+        Stream.of(
                 Field.of("id", INTEGER).withDescription("id").withNullable(true),
                 Field.of("name", VARCHAR).withDescription("name").withNullable(true),
                 Field.of("age", INTEGER).withDescription("age").withNullable(true),
-                Field.of("address",
-                         ROW.type().withRowSchema(
-                             RowSqlTypes
-                                 .builder()
-                                 .withVarcharField("street")
-                                 .withVarcharField("country")
-                                 .build())).withNullable(true),
-                Field.of("addressangular",
-                         ROW.type().withRowSchema(
-                             RowSqlTypes
-                                 .builder()
-                                 .withVarcharField("street")
-                                 .withVarcharField("country")
-                                 .build())).withNullable(true),
+                Field.of(
+                        "address",
+                        ROW.type()
+                            .withRowSchema(
+                                RowSqlTypes.builder()
+                                    .withVarcharField("street")
+                                    .withVarcharField("country")
+                                    .build()))
+                    .withNullable(true),
+                Field.of(
+                        "addressangular",
+                        ROW.type()
+                            .withRowSchema(
+                                RowSqlTypes.builder()
+                                    .withVarcharField("street")
+                                    .withVarcharField("country")
+                                    .build()))
+                    .withNullable(true),
                 Field.of("isrobot", BOOLEAN).withNullable(true))
             .collect(toSchema()),
         table.getSchema());
@@ -195,16 +188,14 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
             + "TYPE 'text' \n"
-            + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     Table table = metaStore.getTables().get("person");
     assertNotNull(table);
 
@@ -218,16 +209,14 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
         "create table person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
             + "TYPE 'text' \n"
-            + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "COMMENT '' LOCATION '/home/admin/orders'");
     cli.execute("drop table person");
     cli.explainQuery("select * from person");
   }
@@ -237,8 +226,7 @@ public class BeamSqlCliTest {
     InMemoryMetaStore metaStore = new InMemoryMetaStore();
     metaStore.registerProvider(new TextTableProvider());
 
-    BeamSqlCli cli = new BeamSqlCli()
-        .metaStore(metaStore);
+    BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
 
     cli.execute(
         "create table person (\n"
@@ -246,14 +234,12 @@ public class BeamSqlCliTest {
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
             + "TYPE 'text' \n"
-            + "COMMENT '' LOCATION '/home/admin/orders'"
-    );
+            + "COMMENT '' LOCATION '/home/admin/orders'");
 
     String plan = cli.explainQuery("select * from person");
     assertEquals(
         "BeamProjectRel(id=[$0], name=[$1], age=[$2])\n"
-        + "  BeamIOSourceRel(table=[[beam, person]])\n",
-        plan
-    );
+            + "  BeamIOSourceRel(table=[[beam, person]])\n",
+        plan);
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationCovarianceTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationCovarianceTest.java
@@ -31,86 +31,71 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Integration tests for {@code COVAR_POP} and {@code COVAR_SAMP}.
- */
+/** Integration tests for {@code COVAR_POP} and {@code COVAR_SAMP}. */
 public class BeamSqlDslAggregationCovarianceTest {
 
-    private static final double PRECISION = 1e-7;
+  private static final double PRECISION = 1e-7;
 
-    @Rule
-    public TestPipeline pipeline = TestPipeline.create();
+  @Rule public TestPipeline pipeline = TestPipeline.create();
 
-    private PCollection<Row> boundedInput;
+  private PCollection<Row> boundedInput;
 
-    @Before
-    public void setUp() {
-        Schema schema = RowSqlTypes.builder()
-                .withDoubleField("f_double1")
-                .withDoubleField("f_double2")
-                .withDoubleField("f_double3")
-                .withIntegerField("f_int1")
-                .withIntegerField("f_int2")
-                .withIntegerField("f_int3")
-                .build();
+  @Before
+  public void setUp() {
+    Schema schema =
+        RowSqlTypes.builder()
+            .withDoubleField("f_double1")
+            .withDoubleField("f_double2")
+            .withDoubleField("f_double3")
+            .withIntegerField("f_int1")
+            .withIntegerField("f_int2")
+            .withIntegerField("f_int3")
+            .build();
 
-        List<Row> rowsInTableB =
-                TestUtils.RowsBuilder
-                        .of(schema)
-                        .addRows(
-                                3.0, 1.0, 1.0, 3, 1, 0,
-                                4.0, 2.0, 2.0, 4, 2, 0,
-                                5.0, 3.0, 1.0, 5, 3, 0,
-                                6.0, 4.0, 2.0, 6, 4, 0,
-                                8.0, 4.0, 1.0, 8, 4, 0)
-                        .getRows();
+    List<Row> rowsInTableB =
+        TestUtils.RowsBuilder.of(schema)
+            .addRows(
+                3.0, 1.0, 1.0, 3, 1, 0, 4.0, 2.0, 2.0, 4, 2, 0, 5.0, 3.0, 1.0, 5, 3, 0, 6.0, 4.0,
+                2.0, 6, 4, 0, 8.0, 4.0, 1.0, 8, 4, 0)
+            .getRows();
 
-        boundedInput = PBegin
-                .in(pipeline)
-                .apply(Create.of(rowsInTableB).withCoder(schema.getRowCoder()));
-    }
+    boundedInput =
+        PBegin.in(pipeline).apply(Create.of(rowsInTableB).withCoder(schema.getRowCoder()));
+  }
 
-    @Test
-    public void testPopulationVarianceDouble() {
-        String sql = "SELECT COVAR_POP(f_double1, f_double2) FROM PCOLLECTION GROUP BY f_int3";
+  @Test
+  public void testPopulationVarianceDouble() {
+    String sql = "SELECT COVAR_POP(f_double1, f_double2) FROM PCOLLECTION GROUP BY f_int3";
 
-        PAssert
-                .that(boundedInput.apply(BeamSql.query(sql)))
-                .satisfies(matchesScalar(1.84, PRECISION));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(1.84, PRECISION));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 
-    @Test
-    public void testPopulationVarianceInt() {
-        String sql = "SELECT COVAR_POP(f_int1, f_int2) FROM PCOLLECTION GROUP BY f_int3";
+  @Test
+  public void testPopulationVarianceInt() {
+    String sql = "SELECT COVAR_POP(f_int1, f_int2) FROM PCOLLECTION GROUP BY f_int3";
 
-        PAssert
-                .that(boundedInput.apply(BeamSql.query(sql)))
-                .satisfies(matchesScalar(1));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(1));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 
-    @Test
-    public void testSampleVarianceDouble() {
-        String sql = "SELECT COVAR_SAMP(f_double1, f_double2) FROM PCOLLECTION GROUP BY f_int3";
+  @Test
+  public void testSampleVarianceDouble() {
+    String sql = "SELECT COVAR_SAMP(f_double1, f_double2) FROM PCOLLECTION GROUP BY f_int3";
 
-        PAssert
-                .that(boundedInput.apply(BeamSql.query(sql)))
-                .satisfies(matchesScalar(2.3, PRECISION));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(2.3, PRECISION));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 
-    @Test
-    public void testSampleVarianceInt() {
-        String sql = "SELECT COVAR_SAMP(f_int1, f_int2) FROM PCOLLECTION GROUP BY f_int3";
+  @Test
+  public void testSampleVarianceInt() {
+    String sql = "SELECT COVAR_SAMP(f_int1, f_int2) FROM PCOLLECTION GROUP BY f_int3";
 
-        PAssert
-                .that(boundedInput.apply(BeamSql.query(sql)))
-                .satisfies(matchesScalar(2));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(2));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationTest.java
@@ -68,31 +68,49 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     List<Row> rowsInTableB =
         TestUtils.RowsBuilder.of(schemaInTableB)
             .addRows(
-                1, 1.0, 0, new BigDecimal(1),
-                4, 4.0, 0, new BigDecimal(4),
-                7, 7.0, 0, new BigDecimal(7),
-                13, 13.0, 0, new BigDecimal(13),
-                5, 5.0, 0, new BigDecimal(5),
-                10, 10.0, 0, new BigDecimal(10),
-                17, 17.0, 0, new BigDecimal(17)
-            ).getRows();
+                1,
+                1.0,
+                0,
+                new BigDecimal(1),
+                4,
+                4.0,
+                0,
+                new BigDecimal(4),
+                7,
+                7.0,
+                0,
+                new BigDecimal(7),
+                13,
+                13.0,
+                0,
+                new BigDecimal(13),
+                5,
+                5.0,
+                0,
+                new BigDecimal(5),
+                10,
+                10.0,
+                0,
+                new BigDecimal(10),
+                17,
+                17.0,
+                0,
+                new BigDecimal(17))
+            .getRows();
 
-    boundedInput3 = PBegin.in(pipeline).apply(
-        "boundedInput3",
-        Create.of(rowsInTableB).withCoder(schemaInTableB.getRowCoder()));
+    boundedInput3 =
+        PBegin.in(pipeline)
+            .apply(
+                "boundedInput3", Create.of(rowsInTableB).withCoder(schemaInTableB.getRowCoder()));
   }
 
-  /**
-   * GROUP-BY with single aggregation function with bounded PCollection.
-   */
+  /** GROUP-BY with single aggregation function with bounded PCollection. */
   @Test
   public void testAggregationWithoutWindowWithBounded() throws Exception {
     runAggregationWithoutWindow(boundedInput1);
   }
 
-  /**
-   * GROUP-BY with single aggregation function with unbounded PCollection.
-   */
+  /** GROUP-BY with single aggregation function with unbounded PCollection. */
   @Test
   public void testAggregationWithoutWindowWithUnbounded() throws Exception {
     runAggregationWithoutWindow(unboundedInput1);
@@ -101,13 +119,10 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
   private void runAggregationWithoutWindow(PCollection<Row> input) throws Exception {
     String sql = "SELECT f_int2, COUNT(*) AS `getFieldCount` FROM PCOLLECTION GROUP BY f_int2";
 
-    PCollection<Row> result =
-        input.apply("testAggregationWithoutWindow", BeamSql.query(sql));
+    PCollection<Row> result = input.apply("testAggregationWithoutWindow", BeamSql.query(sql));
 
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int2")
-        .withBigIntField("size")
-        .build();
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int2").withBigIntField("size").build();
 
     Row row = Row.withSchema(resultType).addValues(0, 4L).build();
 
@@ -116,42 +131,42 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * GROUP-BY with multiple aggregation functions with bounded PCollection.
-   */
+  /** GROUP-BY with multiple aggregation functions with bounded PCollection. */
   @Test
   public void testAggregationFunctionsWithBounded() throws Exception {
     runAggregationFunctions(boundedInput1);
   }
 
-  /**
-   * GROUP-BY with multiple aggregation functions with unbounded PCollection.
-   */
+  /** GROUP-BY with multiple aggregation functions with unbounded PCollection. */
   @Test
   public void testAggregationFunctionsWithUnbounded() throws Exception {
     runAggregationFunctions(unboundedInput1);
   }
 
   private void runAggregationFunctions(PCollection<Row> input) throws Exception {
-    String sql = "select f_int2, count(*) as getFieldCount, "
-        + "sum(f_long) as sum1, avg(f_long) as avg1, max(f_long) as max1, min(f_long) as min1, "
-        + "sum(f_short) as sum2, avg(f_short) as avg2, max(f_short) as max2, min(f_short) as min2, "
-        + "sum(f_byte) as sum3, avg(f_byte) as avg3, max(f_byte) as max3, min(f_byte) as min3, "
-        + "sum(f_float) as sum4, avg(f_float) as avg4, max(f_float) as max4, min(f_float) as min4, "
-        + "sum(f_double) as sum5, avg(f_double) as avg5, "
-        + "max(f_double) as max5, min(f_double) as min5, "
-        + "max(f_timestamp) as max6, min(f_timestamp) as min6, "
-        + "var_pop(f_double) as varpop1, var_samp(f_double) as varsamp1, "
-        + "var_pop(f_int) as varpop2, var_samp(f_int) as varsamp2 "
-        + "FROM TABLE_A group by f_int2";
+    String sql =
+        "select f_int2, count(*) as getFieldCount, "
+            + "sum(f_long) as sum1, avg(f_long) as avg1, "
+            + "max(f_long) as max1, min(f_long) as min1, "
+            + "sum(f_short) as sum2, avg(f_short) as avg2, "
+            + "max(f_short) as max2, min(f_short) as min2, "
+            + "sum(f_byte) as sum3, avg(f_byte) as avg3, "
+            + "max(f_byte) as max3, min(f_byte) as min3, "
+            + "sum(f_float) as sum4, avg(f_float) as avg4, "
+            + "max(f_float) as max4, min(f_float) as min4, "
+            + "sum(f_double) as sum5, avg(f_double) as avg5, "
+            + "max(f_double) as max5, min(f_double) as min5, "
+            + "max(f_timestamp) as max6, min(f_timestamp) as min6, "
+            + "var_pop(f_double) as varpop1, var_samp(f_double) as varsamp1, "
+            + "var_pop(f_int) as varpop2, var_samp(f_int) as varsamp2 "
+            + "FROM TABLE_A group by f_int2";
 
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
             .apply("testAggregationFunctions", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int2")
             .withBigIntField("size")
             .withBigIntField("sum1")
@@ -183,18 +198,36 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
             .build();
 
     Row row =
-        Row
-            .withSchema(resultType)
+        Row.withSchema(resultType)
             .addValues(
-                0, 4L,
-                10000L, 2500L, 4000L, 1000L,
-                (short) 10, (short) 2, (short) 4, (short) 1,
-                (byte) 10, (byte) 2, (byte) 4, (byte) 1,
-                10.0F, 2.5F, 4.0F, 1.0F,
-                10.0, 2.5, 4.0, 1.0,
+                0,
+                4L,
+                10000L,
+                2500L,
+                4000L,
+                1000L,
+                (short) 10,
+                (short) 2,
+                (short) 4,
+                (short) 1,
+                (byte) 10,
+                (byte) 2,
+                (byte) 4,
+                (byte) 1,
+                10.0F,
+                2.5F,
+                4.0F,
+                1.0F,
+                10.0,
+                2.5,
+                4.0,
+                1.0,
                 FORMAT.parseDateTime("2017-01-01 02:04:03"),
                 FORMAT.parseDateTime("2017-01-01 01:01:03"),
-                1.25, 1.666666667, 1, 1)
+                1.25,
+                1.666666667,
+                1,
+                1)
             .build();
 
     PAssert.that(result).containsInAnyOrder(row);
@@ -221,36 +254,30 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     }
   }
 
-  /**
-   * GROUP-BY with aggregation functions with BigDeciaml Calculation (Avg, Var_Pop, etc).
-   */
+  /** GROUP-BY with aggregation functions with BigDeciaml Calculation (Avg, Var_Pop, etc). */
   @Test
   public void testAggregationFunctionsWithBoundedOnBigDecimalDivide() throws Exception {
-    String sql = "SELECT AVG(f_double) as avg1, AVG(f_int) as avg2, "
-        + "VAR_POP(f_double) as varpop1, VAR_POP(f_int) as varpop2, "
-        + "VAR_SAMP(f_double) as varsamp1, VAR_SAMP(f_int) as varsamp2 "
-        + "FROM PCOLLECTION GROUP BY f_int2";
+    String sql =
+        "SELECT AVG(f_double) as avg1, AVG(f_int) as avg2, "
+            + "VAR_POP(f_double) as varpop1, VAR_POP(f_int) as varpop2, "
+            + "VAR_SAMP(f_double) as varsamp1, VAR_SAMP(f_int) as varsamp2 "
+            + "FROM PCOLLECTION GROUP BY f_int2";
 
     PCollection<Row> result =
-        boundedInput3.apply("testAggregationWithDecimalValue",
-                            BeamSql.query(sql));
+        boundedInput3.apply("testAggregationWithDecimalValue", BeamSql.query(sql));
 
     PAssert.that(result).satisfies(new CheckerBigDecimalDivide());
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * Implicit GROUP-BY with DISTINCT with bounded PCollection.
-   */
+  /** Implicit GROUP-BY with DISTINCT with bounded PCollection. */
   @Test
   public void testDistinctWithBounded() throws Exception {
     runDistinct(boundedInput1);
   }
 
-  /**
-   * Implicit GROUP-BY with DISTINCT with unbounded PCollection.
-   */
+  /** Implicit GROUP-BY with DISTINCT with unbounded PCollection. */
   @Test
   public void testDistinctWithUnbounded() throws Exception {
     runDistinct(unboundedInput1);
@@ -259,19 +286,13 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
   private void runDistinct(PCollection<Row> input) throws Exception {
     String sql = "SELECT distinct f_int, f_long FROM PCOLLECTION ";
 
-    PCollection<Row> result =
-        input.apply("testDistinct", BeamSql.query(sql));
+    PCollection<Row> result = input.apply("testDistinct", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withBigIntField("f_long")
-            .build();
+        RowSqlTypes.builder().withIntegerField("f_int").withBigIntField("f_long").build();
 
     List<Row> expectedRows =
-        TestUtils.RowsBuilder
-            .of(resultType)
+        TestUtils.RowsBuilder.of(resultType)
             .addRows(
                 1, 1000L,
                 2, 2000L,
@@ -284,45 +305,44 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * GROUP-BY with TUMBLE window(aka fix_time_window) with bounded PCollection.
-   */
+  /** GROUP-BY with TUMBLE window(aka fix_time_window) with bounded PCollection. */
   @Test
   public void testTumbleWindowWithBounded() throws Exception {
     runTumbleWindow(boundedInput1);
   }
 
-  /**
-   * GROUP-BY with TUMBLE window(aka fix_time_window) with unbounded PCollection.
-   */
+  /** GROUP-BY with TUMBLE window(aka fix_time_window) with unbounded PCollection. */
   @Test
   public void testTumbleWindowWithUnbounded() throws Exception {
     runTumbleWindow(unboundedInput1);
   }
 
   private void runTumbleWindow(PCollection<Row> input) throws Exception {
-    String sql = "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
-        + " TUMBLE_START(f_timestamp, INTERVAL '1' HOUR) AS `window_start`"
-        + " FROM TABLE_A"
-        + " GROUP BY f_int2, TUMBLE(f_timestamp, INTERVAL '1' HOUR)";
+    String sql =
+        "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
+            + " TUMBLE_START(f_timestamp, INTERVAL '1' HOUR) AS `window_start`"
+            + " FROM TABLE_A"
+            + " GROUP BY f_int2, TUMBLE(f_timestamp, INTERVAL '1' HOUR)";
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
             .apply("testTumbleWindow", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int2")
             .withBigIntField("size")
             .withTimestampField("window_start")
             .build();
 
     List<Row> expectedRows =
-        TestUtils.RowsBuilder
-            .of(resultType)
+        TestUtils.RowsBuilder.of(resultType)
             .addRows(
-                0, 3L, FORMAT.parseDateTime("2017-01-01 01:00:00"),
-                0, 1L, FORMAT.parseDateTime("2017-01-01 02:00:00"))
+                0,
+                3L,
+                FORMAT.parseDateTime("2017-01-01 01:00:00"),
+                0,
+                1L,
+                FORMAT.parseDateTime("2017-01-01 02:00:00"))
             .getRows();
 
     PAssert.that(result).containsInAnyOrder(expectedRows);
@@ -331,8 +351,8 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
   }
 
   /**
-   * Tests that a trigger set up prior to a SQL statement still is effective
-   * within the SQL statement.
+   * Tests that a trigger set up prior to a SQL statement still is effective within the SQL
+   * statement.
    */
   @Test
   @Category(UsesTestStream.class)
@@ -386,49 +406,50 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
                 .getRows());
 
     pipeline.run().waitUntilFinish();
-
   }
 
-  /**
-   * GROUP-BY with HOP window(aka sliding_window) with bounded PCollection.
-   */
+  /** GROUP-BY with HOP window(aka sliding_window) with bounded PCollection. */
   @Test
   public void testHopWindowWithBounded() throws Exception {
     runHopWindow(boundedInput1);
   }
 
-  /**
-   * GROUP-BY with HOP window(aka sliding_window) with unbounded PCollection.
-   */
+  /** GROUP-BY with HOP window(aka sliding_window) with unbounded PCollection. */
   @Test
   public void testHopWindowWithUnbounded() throws Exception {
     runHopWindow(unboundedInput1);
   }
 
   private void runHopWindow(PCollection<Row> input) throws Exception {
-    String sql = "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
-        + " HOP_START(f_timestamp, INTERVAL '30' MINUTE, INTERVAL '1' HOUR) AS `window_start`"
-        + " FROM PCOLLECTION"
-        + " GROUP BY f_int2, HOP(f_timestamp, INTERVAL '30' MINUTE, INTERVAL '1' HOUR)";
-    PCollection<Row> result =
-        input.apply("testHopWindow", BeamSql.query(sql));
+    String sql =
+        "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
+            + " HOP_START(f_timestamp, INTERVAL '30' MINUTE, INTERVAL '1' HOUR) AS `window_start`"
+            + " FROM PCOLLECTION"
+            + " GROUP BY f_int2, HOP(f_timestamp, INTERVAL '30' MINUTE, INTERVAL '1' HOUR)";
+    PCollection<Row> result = input.apply("testHopWindow", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int2")
             .withBigIntField("size")
             .withTimestampField("window_start")
             .build();
 
     List<Row> expectedRows =
-        TestUtils.RowsBuilder
-            .of(resultType)
+        TestUtils.RowsBuilder.of(resultType)
             .addRows(
-                0, 3L, FORMAT.parseDateTime("2017-01-01 00:30:00"),
-                0, 3L, FORMAT.parseDateTime("2017-01-01 01:00:00"),
-                0, 1L, FORMAT.parseDateTime("2017-01-01 01:30:00"),
-                0, 1L, FORMAT.parseDateTime("2017-01-01 02:00:00"))
+                0,
+                3L,
+                FORMAT.parseDateTime("2017-01-01 00:30:00"),
+                0,
+                3L,
+                FORMAT.parseDateTime("2017-01-01 01:00:00"),
+                0,
+                1L,
+                FORMAT.parseDateTime("2017-01-01 01:30:00"),
+                0,
+                1L,
+                FORMAT.parseDateTime("2017-01-01 02:00:00"))
             .getRows();
 
     PAssert.that(result).containsInAnyOrder(expectedRows);
@@ -436,45 +457,44 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * GROUP-BY with SESSION window with bounded PCollection.
-   */
+  /** GROUP-BY with SESSION window with bounded PCollection. */
   @Test
   public void testSessionWindowWithBounded() throws Exception {
     runSessionWindow(boundedInput1);
   }
 
-  /**
-   * GROUP-BY with SESSION window with unbounded PCollection.
-   */
+  /** GROUP-BY with SESSION window with unbounded PCollection. */
   @Test
   public void testSessionWindowWithUnbounded() throws Exception {
     runSessionWindow(unboundedInput1);
   }
 
   private void runSessionWindow(PCollection<Row> input) throws Exception {
-    String sql = "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
-        + " SESSION_START(f_timestamp, INTERVAL '5' MINUTE) AS `window_start`"
-        + " FROM TABLE_A"
-        + " GROUP BY f_int2, SESSION(f_timestamp, INTERVAL '5' MINUTE)";
+    String sql =
+        "SELECT f_int2, COUNT(*) AS `getFieldCount`,"
+            + " SESSION_START(f_timestamp, INTERVAL '5' MINUTE) AS `window_start`"
+            + " FROM TABLE_A"
+            + " GROUP BY f_int2, SESSION(f_timestamp, INTERVAL '5' MINUTE)";
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
             .apply("testSessionWindow", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int2")
             .withBigIntField("size")
             .withTimestampField("window_start")
             .build();
 
     List<Row> expectedRows =
-        TestUtils.RowsBuilder
-            .of(resultType)
+        TestUtils.RowsBuilder.of(resultType)
             .addRows(
-                0, 3L, FORMAT.parseDateTime("2017-01-01 01:01:03"),
-                0, 1L, FORMAT.parseDateTime("2017-01-01 02:04:03"))
+                0,
+                3L,
+                FORMAT.parseDateTime("2017-01-01 01:01:03"),
+                0,
+                1L,
+                FORMAT.parseDateTime("2017-01-01 02:04:03"))
             .getRows();
 
     PAssert.that(result).containsInAnyOrder(expectedRows);
@@ -489,8 +509,9 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
         "Cannot apply 'TUMBLE' to arguments of type 'TUMBLE(<BIGINT>, <INTERVAL HOUR>)'");
     pipeline.enableAbandonedNodeEnforcement(false);
 
-    String sql = "SELECT f_int2, COUNT(*) AS `getFieldCount` FROM TABLE_A "
-        + "GROUP BY f_int2, TUMBLE(f_long, INTERVAL '1' HOUR)";
+    String sql =
+        "SELECT f_int2, COUNT(*) AS `getFieldCount` FROM TABLE_A "
+            + "GROUP BY f_int2, TUMBLE(f_long, INTERVAL '1' HOUR)";
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), boundedInput1)
             .apply("testWindowOnNonTimestampField", BeamSql.query(sql));
@@ -504,11 +525,9 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     exceptions.expectMessage("Encountered \"*\"");
     pipeline.enableAbandonedNodeEnforcement(false);
 
-    String sql = "SELECT f_int2, COUNT(DISTINCT *) AS `size` "
-        + "FROM PCOLLECTION GROUP BY f_int2";
+    String sql = "SELECT f_int2, COUNT(DISTINCT *) AS `size` " + "FROM PCOLLECTION GROUP BY f_int2";
 
-    PCollection<Row> result =
-        boundedInput1.apply("testUnsupportedDistinct", BeamSql.query(sql));
+    PCollection<Row> result = boundedInput1.apply("testUnsupportedDistinct", BeamSql.query(sql));
 
     pipeline.run().waitUntilFinish();
   }
@@ -519,9 +538,10 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
 
     pipeline.enableAbandonedNodeEnforcement(false);
 
-    PCollection<Row> input = unboundedInput1
-        .apply("unboundedInput1.globalWindow",
-               Window.<Row> into(new GlobalWindows()).triggering(DefaultTrigger.of()));
+    PCollection<Row> input =
+        unboundedInput1.apply(
+            "unboundedInput1.globalWindow",
+            Window.<Row>into(new GlobalWindows()).triggering(DefaultTrigger.of()));
 
     String sql = "SELECT f_int2, COUNT(*) AS `size` FROM PCOLLECTION GROUP BY f_int2";
 
@@ -535,40 +555,36 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     DateTime startTime = new DateTime(2017, 1, 1, 0, 0, 0, 0);
 
     Schema type =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_intGroupingKey")
             .withIntegerField("f_intValue")
             .withTimestampField("f_timestamp")
             .build();
 
-    Object[] rows = new Object[]{
-        0, 1, startTime.plusSeconds(0),
-        0, 2, startTime.plusSeconds(1),
-        0, 3, startTime.plusSeconds(2),
-        0, 4, startTime.plusSeconds(3),
-        0, 5, startTime.plusSeconds(4),
-        0, 6, startTime.plusSeconds(6)
-    };
+    Object[] rows =
+        new Object[] {
+          0, 1, startTime.plusSeconds(0),
+          0, 2, startTime.plusSeconds(1),
+          0, 3, startTime.plusSeconds(2),
+          0, 4, startTime.plusSeconds(3),
+          0, 5, startTime.plusSeconds(4),
+          0, 6, startTime.plusSeconds(6)
+        };
 
     PCollection<Row> input =
         createTestPCollection(type, rows, "f_timestamp")
-            .apply(Window
-                       .<Row>into(new GlobalWindows())
-                       .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(2)))
-                       .discardingFiredPanes()
-                       .withOnTimeBehavior(Window.OnTimeBehavior.FIRE_IF_NON_EMPTY));
+            .apply(
+                Window.<Row>into(new GlobalWindows())
+                    .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(2)))
+                    .discardingFiredPanes()
+                    .withOnTimeBehavior(Window.OnTimeBehavior.FIRE_IF_NON_EMPTY));
 
-    String sql =
-        "SELECT SUM(f_intValue) AS `sum` FROM PCOLLECTION GROUP BY f_intGroupingKey";
+    String sql = "SELECT SUM(f_intValue) AS `sum` FROM PCOLLECTION GROUP BY f_intGroupingKey";
 
     PCollection<Row> result = input.apply("sql", BeamSql.query(sql));
 
     assertEquals(new GlobalWindows(), result.getWindowingStrategy().getWindowFn());
-    PAssert
-        .that(result)
-        .containsInAnyOrder(
-            rowsWithSingleIntField("sum", Arrays.asList(3, 7, 11)));
+    PAssert.that(result).containsInAnyOrder(rowsWithSingleIntField("sum", Arrays.asList(3, 7, 11)));
 
     pipeline.run();
   }
@@ -578,68 +594,57 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     DateTime startTime = new DateTime(2017, 1, 1, 0, 0, 0, 0);
 
     Schema type =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_intGroupingKey")
             .withIntegerField("f_intValue")
             .withTimestampField("f_timestamp")
             .build();
 
-    Object[] rows = new Object[]{
-        0, 1, startTime.plusSeconds(0),
-        0, 2, startTime.plusSeconds(1),
-        0, 3, startTime.plusSeconds(2),
-        0, 4, startTime.plusSeconds(3),
-        0, 5, startTime.plusSeconds(4),
-        0, 6, startTime.plusSeconds(6)
-    };
+    Object[] rows =
+        new Object[] {
+          0, 1, startTime.plusSeconds(0),
+          0, 2, startTime.plusSeconds(1),
+          0, 3, startTime.plusSeconds(2),
+          0, 4, startTime.plusSeconds(3),
+          0, 5, startTime.plusSeconds(4),
+          0, 6, startTime.plusSeconds(6)
+        };
 
     PCollection<Row> input =
         createTestPCollection(type, rows, "f_timestamp")
-            .apply(Window
-                       .<Row>into(
-                           FixedWindows.of(Duration.standardSeconds(3)))
-                       .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(2)))
-                       .discardingFiredPanes()
-                       .withAllowedLateness(Duration.ZERO)
-                       .withOnTimeBehavior(Window.OnTimeBehavior.FIRE_IF_NON_EMPTY));
+            .apply(
+                Window.<Row>into(FixedWindows.of(Duration.standardSeconds(3)))
+                    .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(2)))
+                    .discardingFiredPanes()
+                    .withAllowedLateness(Duration.ZERO)
+                    .withOnTimeBehavior(Window.OnTimeBehavior.FIRE_IF_NON_EMPTY));
 
-    String sql =
-        "SELECT SUM(f_intValue) AS `sum` FROM PCOLLECTION GROUP BY f_intGroupingKey";
+    String sql = "SELECT SUM(f_intValue) AS `sum` FROM PCOLLECTION GROUP BY f_intGroupingKey";
 
     PCollection<Row> result = input.apply("sql", BeamSql.query(sql));
 
     assertEquals(
-        FixedWindows.of(Duration.standardSeconds(3)),
-        result.getWindowingStrategy().getWindowFn());
+        FixedWindows.of(Duration.standardSeconds(3)), result.getWindowingStrategy().getWindowFn());
 
-    PAssert
-        .that(result)
-        .containsInAnyOrder(
-            rowsWithSingleIntField("sum", Arrays.asList(3, 3, 9, 6)));
+    PAssert.that(result)
+        .containsInAnyOrder(rowsWithSingleIntField("sum", Arrays.asList(3, 3, 9, 6)));
 
     pipeline.run();
   }
 
   private List<Row> rowsWithSingleIntField(String fieldName, List<Integer> values) {
-    return
-        TestUtils
-            .rowsBuilderOf(RowSqlTypes.builder().withIntegerField(fieldName).build())
-            .addRows(values)
-            .getRows();
+    return TestUtils.rowsBuilderOf(RowSqlTypes.builder().withIntegerField(fieldName).build())
+        .addRows(values)
+        .getRows();
   }
 
   private PCollection<Row> createTestPCollection(
-      Schema type,
-      Object[] rows,
-      String timestampField) {
-    return
-        TestUtils
-            .rowsBuilderOf(type)
-            .addRows(rows)
-            .getPCollectionBuilder()
-            .inPipeline(pipeline)
-            .withTimestampField(timestampField)
-            .buildUnbounded();
+      Schema type, Object[] rows, String timestampField) {
+    return TestUtils.rowsBuilderOf(type)
+        .addRows(rows)
+        .getPCollectionBuilder()
+        .inPipeline(pipeline)
+        .withTimestampField(timestampField)
+        .buildUnbounded();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationVarianceTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationVarianceTest.java
@@ -31,52 +31,39 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Integration tests for {@code VAR_POP} and {@code VAR_SAMP}.
- */
+/** Integration tests for {@code VAR_POP} and {@code VAR_SAMP}. */
 public class BeamSqlDslAggregationVarianceTest {
 
   private static final double PRECISION = 1e-7;
 
-  @Rule
-  public TestPipeline pipeline = TestPipeline.create();
+  @Rule public TestPipeline pipeline = TestPipeline.create();
 
   private PCollection<Row> boundedInput;
 
   @Before
   public void setUp() {
     Schema schema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withDoubleField("f_double")
             .withIntegerField("f_int2")
             .build();
 
     List<Row> rowsInTableB =
-        TestUtils.RowsBuilder
-            .of(schema)
+        TestUtils.RowsBuilder.of(schema)
             .addRows(
-                1,  1.0,  0,
-                4,  4.0,  0,
-                7,  7.0,  0,
-                13, 13.0, 0,
-                5,  5.0,  0,
-                10, 10.0, 0,
-                17, 17.0, 0)
+                1, 1.0, 0, 4, 4.0, 0, 7, 7.0, 0, 13, 13.0, 0, 5, 5.0, 0, 10, 10.0, 0, 17, 17.0, 0)
             .getRows();
 
-    boundedInput = PBegin
-        .in(pipeline)
-        .apply(Create.of(rowsInTableB).withCoder(schema.getRowCoder()));
+    boundedInput =
+        PBegin.in(pipeline).apply(Create.of(rowsInTableB).withCoder(schema.getRowCoder()));
   }
 
   @Test
   public void testPopulationVarianceDouble() {
     String sql = "SELECT VAR_POP(f_double) FROM PCOLLECTION GROUP BY f_int2";
 
-    PAssert
-        .that(boundedInput.apply(BeamSql.query(sql)))
+    PAssert.that(boundedInput.apply(BeamSql.query(sql)))
         .satisfies(matchesScalar(26.40816326, PRECISION));
 
     pipeline.run().waitUntilFinish();
@@ -86,9 +73,7 @@ public class BeamSqlDslAggregationVarianceTest {
   public void testPopulationVarianceInt() {
     String sql = "SELECT VAR_POP(f_int) FROM PCOLLECTION GROUP BY f_int2";
 
-    PAssert
-        .that(boundedInput.apply(BeamSql.query(sql)))
-        .satisfies(matchesScalar(26));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(26));
 
     pipeline.run().waitUntilFinish();
   }
@@ -97,8 +82,7 @@ public class BeamSqlDslAggregationVarianceTest {
   public void testSampleVarianceDouble() {
     String sql = "SELECT VAR_SAMP(f_double) FROM PCOLLECTION GROUP BY f_int2";
 
-    PAssert
-        .that(boundedInput.apply(BeamSql.query(sql)))
+    PAssert.that(boundedInput.apply(BeamSql.query(sql)))
         .satisfies(matchesScalar(30.80952381, PRECISION));
 
     pipeline.run().waitUntilFinish();
@@ -108,9 +92,7 @@ public class BeamSqlDslAggregationVarianceTest {
   public void testSampleVarianceInt() {
     String sql = "SELECT VAR_SAMP(f_int) FROM PCOLLECTION GROUP BY f_int2";
 
-    PAssert
-        .that(boundedInput.apply(BeamSql.query(sql)))
-        .satisfies(matchesScalar(30));
+    PAssert.that(boundedInput.apply(BeamSql.query(sql))).satisfies(matchesScalar(30));
 
     pipeline.run().waitUntilFinish();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslBase.java
@@ -42,16 +42,12 @@ import org.junit.rules.ExpectedException;
  * prepare input records to test {@link BeamSql}.
  *
  * <p>Note that, any change in these records would impact tests in this package.
- *
  */
 public class BeamSqlDslBase {
-  public static final DateTimeFormatter FORMAT =
-      DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
+  public static final DateTimeFormatter FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
 
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
-  @Rule
-  public ExpectedException exceptions = ExpectedException.none();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public ExpectedException exceptions = ExpectedException.none();
 
   static Schema schemaInTableA;
   static List<Row> rowsInTableA;
@@ -67,8 +63,7 @@ public class BeamSqlDslBase {
   @BeforeClass
   public static void prepareClass() throws ParseException {
     schemaInTableA =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withBigIntField("f_long")
             .withSmallIntField("f_short")
@@ -84,60 +79,95 @@ public class BeamSqlDslBase {
     rowsInTableA =
         TestUtils.RowsBuilder.of(schemaInTableA)
             .addRows(
-                1, 1000L, (short) 1, (byte) 1, 1.0f, 1.0d, "string_row1",
-                FORMAT.parseDateTime("2017-01-01 01:01:03"), 0, new BigDecimal(1))
+                1,
+                1000L,
+                (short) 1,
+                (byte) 1,
+                1.0f,
+                1.0d,
+                "string_row1",
+                FORMAT.parseDateTime("2017-01-01 01:01:03"),
+                0,
+                new BigDecimal(1))
             .addRows(
-                2, 2000L, (short) 2, (byte) 2, 2.0f, 2.0d, "string_row2",
-                FORMAT.parseDateTime("2017-01-01 01:02:03"), 0, new BigDecimal(2))
+                2,
+                2000L,
+                (short) 2,
+                (byte) 2,
+                2.0f,
+                2.0d,
+                "string_row2",
+                FORMAT.parseDateTime("2017-01-01 01:02:03"),
+                0,
+                new BigDecimal(2))
             .addRows(
-                3, 3000L, (short) 3, (byte) 3, 3.0f, 3.0d, "string_row3",
-                FORMAT.parseDateTime("2017-01-01 01:06:03"), 0, new BigDecimal(3))
+                3,
+                3000L,
+                (short) 3,
+                (byte) 3,
+                3.0f,
+                3.0d,
+                "string_row3",
+                FORMAT.parseDateTime("2017-01-01 01:06:03"),
+                0,
+                new BigDecimal(3))
             .addRows(
-                4, 4000L, (short) 4, (byte) 4, 4.0f, 4.0d, "第四行",
-                FORMAT.parseDateTime("2017-01-01 02:04:03"), 0, new BigDecimal(4))
+                4,
+                4000L,
+                (short) 4,
+                (byte) 4,
+                4.0f,
+                4.0d,
+                "第四行",
+                FORMAT.parseDateTime("2017-01-01 02:04:03"),
+                0,
+                new BigDecimal(4))
             .getRows();
   }
 
   @Before
   public void preparePCollections() {
-    boundedInput1 = PBegin.in(pipeline).apply("boundedInput1",
-        Create.of(rowsInTableA).withCoder(schemaInTableA.getRowCoder()));
+    boundedInput1 =
+        PBegin.in(pipeline)
+            .apply(
+                "boundedInput1", Create.of(rowsInTableA).withCoder(schemaInTableA.getRowCoder()));
 
-    boundedInput2 = PBegin.in(pipeline).apply("boundedInput2",
-        Create.of(rowsInTableA.get(0)).withCoder(schemaInTableA.getRowCoder()));
+    boundedInput2 =
+        PBegin.in(pipeline)
+            .apply(
+                "boundedInput2",
+                Create.of(rowsInTableA.get(0)).withCoder(schemaInTableA.getRowCoder()));
 
     unboundedInput1 = prepareUnboundedPCollection1();
     unboundedInput2 = prepareUnboundedPCollection2();
   }
 
   private PCollection<Row> prepareUnboundedPCollection1() {
-    TestStream.Builder<Row> values = TestStream
-        .create(schemaInTableA.getRowCoder());
+    TestStream.Builder<Row> values = TestStream.create(schemaInTableA.getRowCoder());
 
     for (Row row : rowsInTableA) {
       values = values.advanceWatermarkTo(new Instant(row.getDateTime("f_timestamp")));
       values = values.addElements(row);
     }
 
-    return PBegin
-        .in(pipeline)
+    return PBegin.in(pipeline)
         .apply("unboundedInput1", values.advanceWatermarkToInfinity())
-        .apply("unboundedInput1.fixedWindow1year",
-               Window.into(FixedWindows.of(Duration.standardDays(365))));
+        .apply(
+            "unboundedInput1.fixedWindow1year",
+            Window.into(FixedWindows.of(Duration.standardDays(365))));
   }
 
   private PCollection<Row> prepareUnboundedPCollection2() {
-    TestStream.Builder<Row> values = TestStream
-        .create(schemaInTableA.getRowCoder());
+    TestStream.Builder<Row> values = TestStream.create(schemaInTableA.getRowCoder());
 
     Row row = rowsInTableA.get(0);
     values = values.advanceWatermarkTo(new Instant(row.getDateTime("f_timestamp")));
     values = values.addElements(row);
 
-    return PBegin
-        .in(pipeline)
+    return PBegin.in(pipeline)
         .apply("unboundedInput2", values.advanceWatermarkToInfinity())
-        .apply("unboundedInput2.fixedWindow1year",
-               Window.into(FixedWindows.of(Duration.standardDays(365))));
+        .apply(
+            "unboundedInput2.fixedWindow1year",
+            Window.into(FixedWindows.of(Duration.standardDays(365))));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslFilterTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslFilterTest.java
@@ -24,21 +24,15 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.junit.Test;
 
-/**
- * Tests for WHERE queries with BOUNDED PCollection.
- */
+/** Tests for WHERE queries with BOUNDED PCollection. */
 public class BeamSqlDslFilterTest extends BeamSqlDslBase {
-  /**
-   * single filter with bounded PCollection.
-   */
+  /** single filter with bounded PCollection. */
   @Test
   public void testSingleFilterWithBounded() throws Exception {
     runSingleFilter(boundedInput1);
   }
 
-  /**
-   * single filter with unbounded PCollection.
-   */
+  /** single filter with unbounded PCollection. */
   @Test
   public void testSingleFilterWithUnbounded() throws Exception {
     runSingleFilter(unboundedInput1);
@@ -47,33 +41,29 @@ public class BeamSqlDslFilterTest extends BeamSqlDslBase {
   private void runSingleFilter(PCollection<Row> input) throws Exception {
     String sql = "SELECT * FROM PCOLLECTION WHERE f_int = 1";
 
-    PCollection<Row> result =
-        input.apply("testSingleFilter", BeamSql.query(sql));
+    PCollection<Row> result = input.apply("testSingleFilter", BeamSql.query(sql));
 
     PAssert.that(result).containsInAnyOrder(rowsInTableA.get(0));
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * composite filters with bounded PCollection.
-   */
+  /** composite filters with bounded PCollection. */
   @Test
   public void testCompositeFilterWithBounded() throws Exception {
     runCompositeFilter(boundedInput1);
   }
 
-  /**
-   * composite filters with unbounded PCollection.
-   */
+  /** composite filters with unbounded PCollection. */
   @Test
   public void testCompositeFilterWithUnbounded() throws Exception {
     runCompositeFilter(unboundedInput1);
   }
 
   private void runCompositeFilter(PCollection<Row> input) throws Exception {
-    String sql = "SELECT * FROM TABLE_A"
-        + " WHERE f_int > 1 AND (f_long < 3000 OR f_string = 'string_row3')";
+    String sql =
+        "SELECT * FROM TABLE_A"
+            + " WHERE f_int > 1 AND (f_long < 3000 OR f_string = 'string_row3')";
 
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
@@ -84,17 +74,13 @@ public class BeamSqlDslFilterTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * nothing return with filters in bounded PCollection.
-   */
+  /** nothing return with filters in bounded PCollection. */
   @Test
   public void testNoReturnFilterWithBounded() throws Exception {
     runNoReturnFilter(boundedInput1);
   }
 
-  /**
-   * nothing return with filters in unbounded PCollection.
-   */
+  /** nothing return with filters in unbounded PCollection. */
   @Test
   public void testNoReturnFilterWithUnbounded() throws Exception {
     runNoReturnFilter(unboundedInput1);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslJoinTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslJoinTest.java
@@ -42,9 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Tests for joins in queries.
- */
+/** Tests for joins in queries. */
 public class BeamSqlDslJoinTest {
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
@@ -80,12 +78,9 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PAssert.that(queryFromOrderTables(sql)).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            RESULT_ROW_TYPE
-        ).addRows(
-            2, 3, 3, 1, 2, 3
-        ).getRows());
+    PAssert.that(queryFromOrderTables(sql))
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(RESULT_ROW_TYPE).addRows(2, 3, 3, 1, 2, 3).getRows());
     pipeline.run();
   }
 
@@ -98,14 +93,11 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PAssert.that(queryFromOrderTables(sql)).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            RESULT_ROW_TYPE
-        ).addRows(
-            1, 2, 3, null, null, null,
-            2, 3, 3, 1, 2, 3,
-            3, 4, 5, null, null, null
-        ).getRows());
+    PAssert.that(queryFromOrderTables(sql))
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(RESULT_ROW_TYPE)
+                .addRows(1, 2, 3, null, null, null, 2, 3, 3, 1, 2, 3, 3, 4, 5, null, null, null)
+                .getRows());
     pipeline.run();
   }
 
@@ -118,14 +110,11 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PAssert.that(queryFromOrderTables(sql)).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            RESULT_ROW_TYPE
-        ).addRows(
-            2, 3, 3, 1, 2, 3,
-            null, null, null, 2, 3, 3,
-            null, null, null, 3, 4, 5
-        ).getRows());
+    PAssert.that(queryFromOrderTables(sql))
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(RESULT_ROW_TYPE)
+                .addRows(2, 3, 3, 1, 2, 3, null, null, null, 2, 3, 3, null, null, null, 3, 4, 5)
+                .getRows());
     pipeline.run();
   }
 
@@ -138,16 +127,13 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PAssert.that(queryFromOrderTables(sql)).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            RESULT_ROW_TYPE
-        ).addRows(
-            2, 3, 3, 1, 2, 3,
-            1, 2, 3, null, null, null,
-            3, 4, 5, null, null, null,
-            null, null, null, 2, 3, 3,
-            null, null, null, 3, 4, 5
-        ).getRows());
+    PAssert.that(queryFromOrderTables(sql))
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(RESULT_ROW_TYPE)
+                .addRows(
+                    2, 3, 3, 1, 2, 3, 1, 2, 3, null, null, null, 3, 4, 5, null, null, null, null,
+                    null, null, 2, 3, 3, null, null, null, 3, 4, 5)
+                .getRows());
     pipeline.run();
   }
 
@@ -167,9 +153,7 @@ public class BeamSqlDslJoinTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void testException_crossJoin() throws Exception {
-    String sql =
-        "SELECT *  "
-            + "FROM ORDER_DETAILS1 o1, ORDER_DETAILS2 o2";
+    String sql = "SELECT *  " + "FROM ORDER_DETAILS1 o1, ORDER_DETAILS2 o2";
 
     pipeline.enableAbandonedNodeEnforcement(false);
     queryFromOrderTables(sql);
@@ -186,21 +170,16 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PCollection<Row> orders = ordersUnbounded()
-        .apply("window", Window.into(FixedWindows.of(Duration.standardSeconds(50))));
+    PCollection<Row> orders =
+        ordersUnbounded()
+            .apply("window", Window.into(FixedWindows.of(Duration.standardSeconds(50))));
     PCollectionTuple inputs = tuple("ORDER_DETAILS1", orders, "ORDER_DETAILS2", orders);
 
-    PAssert
-        .that(
-            inputs.apply("sql", BeamSql.query(sql)))
+    PAssert.that(inputs.apply("sql", BeamSql.query(sql)))
         .containsInAnyOrder(
-        TestUtils.RowsBuilder
-            .of(
-            RESULT_ROW_TYPE
-        ).addRows(
-            1, 2, 2, 2, 2, 1,
-            1, 4, 3, 3, 3, 1
-        ).getRows());
+            TestUtils.RowsBuilder.of(RESULT_ROW_TYPE)
+                .addRows(1, 2, 2, 2, 2, 1, 1, 4, 3, 3, 3, 1)
+                .getRows());
 
     pipeline.run();
   }
@@ -215,13 +194,14 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PCollection<Row> orders = ordersUnbounded()
-        .apply("window",
-               Window
-                   .<Row>into(FixedWindows.of(Duration.standardSeconds(50)))
-                   .triggering(AfterWatermark.pastEndOfWindow())
-                   .withAllowedLateness(Duration.ZERO)
-                   .accumulatingFiredPanes());
+    PCollection<Row> orders =
+        ordersUnbounded()
+            .apply(
+                "window",
+                Window.<Row>into(FixedWindows.of(Duration.standardSeconds(50)))
+                    .triggering(AfterWatermark.pastEndOfWindow())
+                    .withAllowedLateness(Duration.ZERO)
+                    .accumulatingFiredPanes());
     PCollectionTuple inputs = tuple("ORDER_DETAILS1", orders, "ORDER_DETAILS2", orders);
 
     thrown.expect(UnsupportedOperationException.class);
@@ -265,13 +245,14 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PCollection<Row> orders = ordersUnbounded()
-        .apply("window",
-               Window
-                   .<Row>into(new GlobalWindows())
-                   .triggering(AfterWatermark.pastEndOfWindow())
-                   .withAllowedLateness(Duration.ZERO)
-                   .accumulatingFiredPanes());
+    PCollection<Row> orders =
+        ordersUnbounded()
+            .apply(
+                "window",
+                Window.<Row>into(new GlobalWindows())
+                    .triggering(AfterWatermark.pastEndOfWindow())
+                    .withAllowedLateness(Duration.ZERO)
+                    .accumulatingFiredPanes());
     PCollectionTuple inputs = tuple("ORDER_DETAILS1", orders, "ORDER_DETAILS2", orders);
 
     thrown.expect(UnsupportedOperationException.class);
@@ -293,14 +274,14 @@ public class BeamSqlDslJoinTest {
             + " on "
             + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
-    PCollection<Row> orders = ordersUnbounded()
-        .apply(
-            "window",
-            Window
-                .<Row>into(FixedWindows.of(Duration.standardSeconds(203)))
-                .triggering(Repeatedly.forever(AfterWatermark.pastEndOfWindow()))
-                .withAllowedLateness(Duration.standardMinutes(2))
-                .accumulatingFiredPanes());
+    PCollection<Row> orders =
+        ordersUnbounded()
+            .apply(
+                "window",
+                Window.<Row>into(FixedWindows.of(Duration.standardSeconds(203)))
+                    .triggering(Repeatedly.forever(AfterWatermark.pastEndOfWindow()))
+                    .withAllowedLateness(Duration.standardMinutes(2))
+                    .accumulatingFiredPanes());
     PCollectionTuple inputs = tuple("ORDER_DETAILS1", orders, "ORDER_DETAILS2", orders);
 
     thrown.expect(UnsupportedOperationException.class);
@@ -315,32 +296,44 @@ public class BeamSqlDslJoinTest {
   private PCollection<Row> ordersUnbounded() {
     DateTime ts = new DateTime(2017, 1, 1, 1, 0, 0);
 
-    return
-        TestUtils
-            .rowsBuilderOf(
-                RowSqlTypes
-                    .builder()
-                    .withIntegerField("order_id")
-                    .withIntegerField("price")
-                    .withIntegerField("site_id")
-                    .withTimestampField("timestamp")
-                    .build())
-            .addRows(
-                1, 2, 2, ts.plusSeconds(0),
-                2, 2, 1, ts.plusSeconds(40),
-                1, 4, 3, ts.plusSeconds(60),
-                3, 2, 1, ts.plusSeconds(65),
-                3, 3, 1, ts.plusSeconds(70))
-            .getPCollectionBuilder()
-            .withTimestampField("timestamp")
-            .inPipeline(pipeline)
-            .buildUnbounded();
+    return TestUtils.rowsBuilderOf(
+            RowSqlTypes.builder()
+                .withIntegerField("order_id")
+                .withIntegerField("price")
+                .withIntegerField("site_id")
+                .withTimestampField("timestamp")
+                .build())
+        .addRows(
+            1,
+            2,
+            2,
+            ts.plusSeconds(0),
+            2,
+            2,
+            1,
+            ts.plusSeconds(40),
+            1,
+            4,
+            3,
+            ts.plusSeconds(60),
+            3,
+            2,
+            1,
+            ts.plusSeconds(65),
+            3,
+            3,
+            1,
+            ts.plusSeconds(70))
+        .getPCollectionBuilder()
+        .withTimestampField("timestamp")
+        .inPipeline(pipeline)
+        .buildUnbounded();
   }
 
   private PCollection<Row> queryFromOrderTables(String sql) {
     return tuple(
-        "ORDER_DETAILS1", ORDER_DETAILS1.buildIOReader(pipeline).setCoder(SOURCE_CODER),
-        "ORDER_DETAILS2", ORDER_DETAILS2.buildIOReader(pipeline).setCoder(SOURCE_CODER))
+            "ORDER_DETAILS1", ORDER_DETAILS1.buildIOReader(pipeline).setCoder(SOURCE_CODER),
+            "ORDER_DETAILS2", ORDER_DETAILS2.buildIOReader(pipeline).setCoder(SOURCE_CODER))
         .apply("join", BeamSql.query(sql))
         .setCoder(RESULT_CODER);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslNestedRowsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslNestedRowsTest.java
@@ -39,16 +39,14 @@ public class BeamSqlDslNestedRowsTest {
   @Test
   public void testRowConstructorKeyword() {
     Schema nestedSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_nestedInt")
             .withVarcharField("f_nestedString")
             .withIntegerField("f_nestedIntPlusOne")
             .build();
 
     Schema resultSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withIntegerField("f_int2")
             .withVarcharField("f_varchar")
@@ -56,24 +54,17 @@ public class BeamSqlDslNestedRowsTest {
             .build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withRowField("f_row", nestedSchema)
-            .build();
+        RowSqlTypes.builder().withIntegerField("f_int").withRowField("f_row", nestedSchema).build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Row.withSchema(nestedSchema)
-                                .addValues(312, "CC", 313)
-                                .build())
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1, Row.withSchema(nestedSchema).addValues(312, "CC", 313).build())
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
@@ -82,13 +73,8 @@ public class BeamSqlDslNestedRowsTest {
                     "SELECT 1 as `f_int`, ROW(3, 'BB', f_int + 1) as `f_row1` FROM PCOLLECTION"))
             .setCoder(resultSchema.getRowCoder());
 
-    PAssert
-        .that(result)
-        .containsInAnyOrder(
-            Row
-                .withSchema(resultSchema)
-                .addValues(1, 3, "BB", 2)
-                .build());
+    PAssert.that(result)
+        .containsInAnyOrder(Row.withSchema(resultSchema).addValues(1, 3, "BB", 2).build());
 
     pipeline.run();
   }
@@ -97,16 +83,14 @@ public class BeamSqlDslNestedRowsTest {
   public void testRowConstructorBraces() {
 
     Schema nestedSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_nestedInt")
             .withVarcharField("f_nestedString")
             .withIntegerField("f_nestedIntPlusOne")
             .build();
 
     Schema resultSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withIntegerField("f_int2")
             .withVarcharField("f_varchar")
@@ -114,24 +98,17 @@ public class BeamSqlDslNestedRowsTest {
             .build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withRowField("f_row", nestedSchema)
-            .build();
+        RowSqlTypes.builder().withIntegerField("f_int").withRowField("f_row", nestedSchema).build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Row.withSchema(nestedSchema)
-                                .addValues(312, "CC", 313)
-                                .build())
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1, Row.withSchema(nestedSchema).addValues(312, "CC", 313).build())
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
@@ -140,13 +117,8 @@ public class BeamSqlDslNestedRowsTest {
                     "SELECT 1 as `f_int`, (3, 'BB', f_int + 1) as `f_row1` FROM PCOLLECTION"))
             .setCoder(resultSchema.getRowCoder());
 
-    PAssert
-        .that(result)
-        .containsInAnyOrder(
-            Row
-                .withSchema(resultSchema)
-                .addValues(1, 3, "BB", 2)
-                .build());
+    PAssert.that(result)
+        .containsInAnyOrder(Row.withSchema(resultSchema).addValues(1, 3, "BB", 2).build());
 
     pipeline.run();
   }
@@ -155,45 +127,33 @@ public class BeamSqlDslNestedRowsTest {
   public void testNestedRowFieldAccess() {
 
     Schema nestedSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_nestedInt")
             .withVarcharField("f_nestedString")
             .withIntegerField("f_nestedIntPlusOne")
             .build();
 
-    Schema resultSchema =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_nestedString")
-            .build();
+    Schema resultSchema = RowSqlTypes.builder().withVarcharField("f_nestedString").build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withRowField("f_nestedRow", nestedSchema)
             .build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Row.withSchema(nestedSchema)
-                                .addValues(312, "CC", 313)
-                                .build())
-                         .build(),
-                      Row.withSchema(inputType)
-                         .addValues(
-                             2,
-                             Row.withSchema(nestedSchema)
-                                .addValues(412, "DD", 413)
-                                .build())
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1, Row.withSchema(nestedSchema).addValues(312, "CC", 313).build())
+                            .build(),
+                        Row.withSchema(inputType)
+                            .addValues(
+                                2, Row.withSchema(nestedSchema).addValues(412, "DD", 413).build())
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
@@ -202,17 +162,10 @@ public class BeamSqlDslNestedRowsTest {
                     "SELECT `PCOLLECTION`.`f_nestedRow`.`f_nestedString` FROM PCOLLECTION"))
             .setCoder(resultSchema.getRowCoder());
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
-            Row
-                .withSchema(resultSchema)
-                .addValues("CC")
-                .build(),
-            Row
-                .withSchema(resultSchema)
-                .addValues("DD")
-                .build());
+            Row.withSchema(resultSchema).addValues("CC").build(),
+            Row.withSchema(resultSchema).addValues("DD").build());
 
     pipeline.run();
   }
@@ -221,14 +174,10 @@ public class BeamSqlDslNestedRowsTest {
   public void testNestedRowArrayFieldAccess() {
 
     Schema resultSchema =
-        RowSqlTypes
-            .builder()
-            .withArrayField("f_nestedArray", SqlTypeName.VARCHAR)
-            .build();
+        RowSqlTypes.builder().withArrayField("f_nestedArray", SqlTypeName.VARCHAR).build();
 
     Schema nestedSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_nestedInt")
             .withVarcharField("f_nestedString")
             .withIntegerField("f_nestedIntPlusOne")
@@ -236,8 +185,7 @@ public class BeamSqlDslNestedRowsTest {
             .build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withRowField("f_nestedRow", nestedSchema)
             .build();
@@ -257,8 +205,8 @@ public class BeamSqlDslNestedRowsTest {
                             .addValues(
                                 2,
                                 Row.withSchema(nestedSchema)
-                                   .addValues(412, "DD", 413, Arrays.asList("three", "four"))
-                                   .build())
+                                    .addValues(412, "DD", 413, Arrays.asList("three", "four"))
+                                    .build())
                             .build())
                     .withCoder(inputType.getRowCoder()));
 
@@ -269,17 +217,10 @@ public class BeamSqlDslNestedRowsTest {
                     "SELECT `PCOLLECTION`.`f_nestedRow`.`f_nestedArray` FROM PCOLLECTION"))
             .setCoder(resultSchema.getRowCoder());
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
-            Row
-                .withSchema(resultSchema)
-                .addArray(Arrays.asList("one", "two"))
-                .build(),
-            Row
-                .withSchema(resultSchema)
-                .addArray(Arrays.asList("three", "four"))
-                .build());
+            Row.withSchema(resultSchema).addArray(Arrays.asList("one", "two")).build(),
+            Row.withSchema(resultSchema).addArray(Arrays.asList("three", "four")).build());
 
     pipeline.run();
   }
@@ -288,14 +229,10 @@ public class BeamSqlDslNestedRowsTest {
   public void testNestedRowArrayElementAccess() {
 
     Schema resultSchema =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_nestedArrayStringField")
-            .build();
+        RowSqlTypes.builder().withVarcharField("f_nestedArrayStringField").build();
 
     Schema nestedSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_nestedInt")
             .withVarcharField("f_nestedString")
             .withIntegerField("f_nestedIntPlusOne")
@@ -303,31 +240,30 @@ public class BeamSqlDslNestedRowsTest {
             .build();
 
     Schema inputType =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withRowField("f_nestedRow", nestedSchema)
             .build();
 
     PCollection<Row> input =
         PBegin.in(pipeline)
-              .apply(
-                  Create.of(
-                      Row.withSchema(inputType)
-                         .addValues(
-                             1,
-                             Row.withSchema(nestedSchema)
-                                .addValues(312, "CC", 313, Arrays.asList("one", "two"))
-                                .build())
-                         .build(),
-                      Row.withSchema(inputType)
-                         .addValues(
-                             2,
-                             Row.withSchema(nestedSchema)
-                                .addValues(412, "DD", 413, Arrays.asList("three", "four"))
-                                .build())
-                         .build())
-                        .withCoder(inputType.getRowCoder()));
+            .apply(
+                Create.of(
+                        Row.withSchema(inputType)
+                            .addValues(
+                                1,
+                                Row.withSchema(nestedSchema)
+                                    .addValues(312, "CC", 313, Arrays.asList("one", "two"))
+                                    .build())
+                            .build(),
+                        Row.withSchema(inputType)
+                            .addValues(
+                                2,
+                                Row.withSchema(nestedSchema)
+                                    .addValues(412, "DD", 413, Arrays.asList("three", "four"))
+                                    .build())
+                            .build())
+                    .withCoder(inputType.getRowCoder()));
 
     PCollection<Row> result =
         input
@@ -336,17 +272,10 @@ public class BeamSqlDslNestedRowsTest {
                     "SELECT `PCOLLECTION`.`f_nestedRow`.`f_nestedArray`[1] FROM PCOLLECTION"))
             .setCoder(resultSchema.getRowCoder());
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
-            Row
-                .withSchema(resultSchema)
-                .addValues("two")
-                .build(),
-            Row
-                .withSchema(resultSchema)
-                .addValues("four")
-                .build());
+            Row.withSchema(resultSchema).addValues("two").build(),
+            Row.withSchema(resultSchema).addValues("four").build());
 
     pipeline.run();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslProjectTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslProjectTest.java
@@ -29,21 +29,15 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.junit.Test;
 
-/**
- * Tests for field-project in queries with BOUNDED PCollection.
- */
+/** Tests for field-project in queries with BOUNDED PCollection. */
 public class BeamSqlDslProjectTest extends BeamSqlDslBase {
-  /**
-   * select all fields with bounded PCollection.
-   */
+  /** select all fields with bounded PCollection. */
   @Test
   public void testSelectAllWithBounded() throws Exception {
     runSelectAll(boundedInput2);
   }
 
-  /**
-   * select all fields with unbounded PCollection.
-   */
+  /** select all fields with unbounded PCollection. */
   @Test
   public void testSelectAllWithUnbounded() throws Exception {
     runSelectAll(unboundedInput2);
@@ -52,25 +46,20 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
   private void runSelectAll(PCollection<Row> input) throws Exception {
     String sql = "SELECT * FROM PCOLLECTION";
 
-    PCollection<Row> result =
-        input.apply("testSelectAll", BeamSql.query(sql));
+    PCollection<Row> result = input.apply("testSelectAll", BeamSql.query(sql));
 
     PAssert.that(result).containsInAnyOrder(rowsInTableA.get(0));
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * select partial fields with bounded PCollection.
-   */
+  /** select partial fields with bounded PCollection. */
   @Test
   public void testPartialFieldsWithBounded() throws Exception {
     runPartialFields(boundedInput2);
   }
 
-  /**
-   * select partial fields with unbounded PCollection.
-   */
+  /** select partial fields with unbounded PCollection. */
   @Test
   public void testPartialFieldsWithUnbounded() throws Exception {
     runPartialFields(unboundedInput2);
@@ -83,10 +72,8 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
             .apply("testPartialFields", BeamSql.query(sql));
 
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int")
-        .withBigIntField("f_long")
-        .build();
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int").withBigIntField("f_long").build();
 
     Row row = rowAtIndex(resultType, 0);
 
@@ -95,17 +82,13 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * select partial fields for multiple rows with bounded PCollection.
-   */
+  /** select partial fields for multiple rows with bounded PCollection. */
   @Test
   public void testPartialFieldsInMultipleRowWithBounded() throws Exception {
     runPartialFieldsInMultipleRow(boundedInput1);
   }
 
-  /**
-   * select partial fields for multiple rows with unbounded PCollection.
-   */
+  /** select partial fields for multiple rows with unbounded PCollection. */
   @Test
   public void testPartialFieldsInMultipleRowWithUnbounded() throws Exception {
     runPartialFieldsInMultipleRow(unboundedInput1);
@@ -119,45 +102,29 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
             .apply("testPartialFieldsInMultipleRow", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withBigIntField("f_long")
-            .build();
+        RowSqlTypes.builder().withIntegerField("f_int").withBigIntField("f_long").build();
 
     List<Row> expectedRows =
-        IntStream
-            .range(0, 4)
-            .mapToObj(i -> rowAtIndex(resultType, i))
-            .collect(toList());
+        IntStream.range(0, 4).mapToObj(i -> rowAtIndex(resultType, i)).collect(toList());
 
-    PAssert
-        .that(result)
-        .containsInAnyOrder(expectedRows);
+    PAssert.that(result).containsInAnyOrder(expectedRows);
 
     pipeline.run().waitUntilFinish();
   }
 
   private Row rowAtIndex(Schema schema, int index) {
-    return Row
-        .withSchema(schema)
-        .addValues(
-            rowsInTableA.get(index).getValue(0),
-            rowsInTableA.get(index).getValue(1))
+    return Row.withSchema(schema)
+        .addValues(rowsInTableA.get(index).getValue(0), rowsInTableA.get(index).getValue(1))
         .build();
   }
 
-  /**
-   * select partial fields with bounded PCollection.
-   */
+  /** select partial fields with bounded PCollection. */
   @Test
   public void testPartialFieldsInRowsWithBounded() throws Exception {
     runPartialFieldsInRows(boundedInput1);
   }
 
-  /**
-   * select partial fields with unbounded PCollection.
-   */
+  /** select partial fields with unbounded PCollection. */
   @Test
   public void testPartialFieldsInRowsWithUnbounded() throws Exception {
     runPartialFieldsInRows(unboundedInput1);
@@ -171,36 +138,23 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
             .apply("testPartialFieldsInRows", BeamSql.query(sql));
 
     Schema resultType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withBigIntField("f_long")
-            .build();
+        RowSqlTypes.builder().withIntegerField("f_int").withBigIntField("f_long").build();
 
     List<Row> expectedRows =
-        IntStream
-            .range(0, 4)
-            .mapToObj(i -> rowAtIndex(resultType, i))
-            .collect(toList());
+        IntStream.range(0, 4).mapToObj(i -> rowAtIndex(resultType, i)).collect(toList());
 
-    PAssert
-        .that(result)
-        .containsInAnyOrder(expectedRows);
+    PAssert.that(result).containsInAnyOrder(expectedRows);
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * select literal field with bounded PCollection.
-   */
+  /** select literal field with bounded PCollection. */
   @Test
   public void testLiteralFieldWithBounded() throws Exception {
     runLiteralField(boundedInput2);
   }
 
-  /**
-   * select literal field with unbounded PCollection.
-   */
+  /** select literal field with unbounded PCollection. */
   @Test
   public void testLiteralFieldWithUnbounded() throws Exception {
     runLiteralField(unboundedInput2);
@@ -213,8 +167,7 @@ public class BeamSqlDslProjectTest extends BeamSqlDslBase {
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), input)
             .apply("testLiteralField", BeamSql.query(sql));
 
-    Schema resultType =
-        RowSqlTypes.builder().withIntegerField("literal_field").build();
+    Schema resultType = RowSqlTypes.builder().withIntegerField("literal_field").build();
 
     Row row = Row.withSchema(resultType).addValues(1).build();
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslUdfUdafTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslUdfUdafTest.java
@@ -28,60 +28,45 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.calcite.linq4j.function.Parameter;
 import org.junit.Test;
 
-/**
- * Tests for UDF/UDAF.
- */
+/** Tests for UDF/UDAF. */
 public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
 
-  /**
-   * GROUP-BY with UDAF.
-   */
+  /** GROUP-BY with UDAF. */
   @Test
   public void testUdaf() throws Exception {
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int2")
-        .withIntegerField("squaresum")
-        .build();
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int2").withIntegerField("squaresum").build();
 
     Row row = Row.withSchema(resultType).addValues(0, 30).build();
 
-    String sql1 = "SELECT f_int2, squaresum1(f_int) AS `squaresum`"
-        + " FROM PCOLLECTION GROUP BY f_int2";
+    String sql1 =
+        "SELECT f_int2, squaresum1(f_int) AS `squaresum`" + " FROM PCOLLECTION GROUP BY f_int2";
     PCollection<Row> result1 =
         boundedInput1.apply(
-            "testUdaf1",
-            BeamSql.query(sql1).registerUdaf("squaresum1", new SquareSum()));
+            "testUdaf1", BeamSql.query(sql1).registerUdaf("squaresum1", new SquareSum()));
     PAssert.that(result1).containsInAnyOrder(row);
 
-    String sql2 = "SELECT f_int2, squaresum2(f_int) AS `squaresum`"
-        + " FROM PCOLLECTION GROUP BY f_int2";
+    String sql2 =
+        "SELECT f_int2, squaresum2(f_int) AS `squaresum`" + " FROM PCOLLECTION GROUP BY f_int2";
     PCollection<Row> result2 =
-        PCollectionTuple
-            .of(new TupleTag<>("PCOLLECTION"), boundedInput1)
-            .apply("testUdaf2",
-                   BeamSql
-                       .query(sql2)
-                       .registerUdaf("squaresum2", new SquareSum()));
+        PCollectionTuple.of(new TupleTag<>("PCOLLECTION"), boundedInput1)
+            .apply("testUdaf2", BeamSql.query(sql2).registerUdaf("squaresum2", new SquareSum()));
     PAssert.that(result2).containsInAnyOrder(row);
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * Test that an indirect subclass of a {@link CombineFn} works as a UDAF.
-   * BEAM-3777
-   */
+  /** Test that an indirect subclass of a {@link CombineFn} works as a UDAF. BEAM-3777 */
   @Test
   public void testUdafMultiLevelDescendent() {
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int2")
-        .withIntegerField("squaresum")
-        .build();
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int2").withIntegerField("squaresum").build();
 
     Row row = Row.withSchema(resultType).addValues(0, 354).build();
 
-    String sql1 = "SELECT f_int2, double_square_sum(f_int) AS `squaresum`"
-        + " FROM PCOLLECTION GROUP BY f_int2";
+    String sql1 =
+        "SELECT f_int2, double_square_sum(f_int) AS `squaresum`"
+            + " FROM PCOLLECTION GROUP BY f_int2";
     PCollection<Row> result1 =
         boundedInput1.apply(
             "testUdaf",
@@ -102,64 +87,51 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     exceptions.expectMessage("CombineFn");
     pipeline.enableAbandonedNodeEnforcement(false);
 
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int2")
-        .withIntegerField("squaresum")
-        .build();
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int2").withIntegerField("squaresum").build();
 
     Row row = Row.withSchema(resultType).addValues(0, 354).build();
 
-    String sql1 = "SELECT f_int2, squaresum(f_int) AS `squaresum`"
-        + " FROM PCOLLECTION GROUP BY f_int2";
+    String sql1 =
+        "SELECT f_int2, squaresum(f_int) AS `squaresum`" + " FROM PCOLLECTION GROUP BY f_int2";
     PCollection<Row> result1 =
         boundedInput1.apply(
-            "testUdaf",
-            BeamSql.query(sql1).registerUdaf("squaresum", new RawCombineFn()));
+            "testUdaf", BeamSql.query(sql1).registerUdaf("squaresum", new RawCombineFn()));
   }
 
-  /**
-   * test UDF.
-   */
+  /** test UDF. */
   @Test
-  public void testUdf() throws Exception{
-    Schema resultType = RowSqlTypes.builder()
-        .withIntegerField("f_int")
-        .withIntegerField("cubicvalue")
-        .build();
+  public void testUdf() throws Exception {
+    Schema resultType =
+        RowSqlTypes.builder().withIntegerField("f_int").withIntegerField("cubicvalue").build();
     Row row = Row.withSchema(resultType).addValues(2, 8).build();
 
     String sql1 = "SELECT f_int, cubic1(f_int) as cubicvalue FROM PCOLLECTION WHERE f_int = 2";
     PCollection<Row> result1 =
-        boundedInput1.apply("testUdf1",
-            BeamSql.query(sql1).registerUdf("cubic1", CubicInteger.class));
+        boundedInput1.apply(
+            "testUdf1", BeamSql.query(sql1).registerUdf("cubic1", CubicInteger.class));
     PAssert.that(result1).containsInAnyOrder(row);
 
     String sql2 = "SELECT f_int, cubic2(f_int) as cubicvalue FROM PCOLLECTION WHERE f_int = 2";
     PCollection<Row> result2 =
         PCollectionTuple.of(new TupleTag<>("PCOLLECTION"), boundedInput1)
-            .apply("testUdf2",
-                   BeamSql.query(sql2).registerUdf("cubic2", new CubicIntegerFn()));
+            .apply("testUdf2", BeamSql.query(sql2).registerUdf("cubic2", new CubicIntegerFn()));
     PAssert.that(result2).containsInAnyOrder(row);
 
     String sql3 = "SELECT f_int, substr(f_string) as sub_string FROM PCOLLECTION WHERE f_int = 2";
     PCollection<Row> result3 =
         PCollectionTuple.of(new TupleTag<>("PCOLLECTION"), boundedInput1)
-            .apply("testUdf3",
-                   BeamSql.query(sql3).registerUdf("substr", UdfFnWithDefault.class));
+            .apply("testUdf3", BeamSql.query(sql3).registerUdf("substr", UdfFnWithDefault.class));
 
-    Schema subStrSchema = RowSqlTypes.builder()
-        .withIntegerField("f_int")
-        .withVarcharField("sub_string")
-        .build();
+    Schema subStrSchema =
+        RowSqlTypes.builder().withIntegerField("f_int").withVarcharField("sub_string").build();
     Row subStrRow = Row.withSchema(subStrSchema).addValues(2, "s").build();
     PAssert.that(result3).containsInAnyOrder(subStrRow);
 
     pipeline.run().waitUntilFinish();
   }
 
-  /**
-   * UDAF(CombineFn) for test, which returns the sum of square.
-   */
+  /** UDAF(CombineFn) for test, which returns the sum of square. */
   public static class SquareSum extends CombineFn<Integer, Integer, Integer> {
     @Override
     public Integer createAccumulator() {
@@ -184,12 +156,11 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     public Integer extractOutput(Integer accumulator) {
       return accumulator;
     }
-
   }
 
   /**
-   * Non-parameterized CombineFn. Intended to test that non-parameterized CombineFns
-   * are correctly rejected. The methods just return null, as they should never be called.
+   * Non-parameterized CombineFn. Intended to test that non-parameterized CombineFns are correctly
+   * rejected. The methods just return null, as they should never be called.
    */
   public static class RawCombineFn extends CombineFn {
 
@@ -214,9 +185,7 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     }
   }
 
-  /**
-   * An example UDAF with two levels of descendancy from CombineFn.
-   */
+  /** An example UDAF with two levels of descendancy from CombineFn. */
   public static class SquareSquareSum extends SquareSum {
     @Override
     public Integer addInput(Integer accumulator, Integer input) {
@@ -224,18 +193,14 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     }
   }
 
-  /**
-   * An example UDF for test.
-   */
+  /** An example UDF for test. */
   public static class CubicInteger implements BeamSqlUdf {
     public static Integer eval(Integer input) {
       return input * input * input;
     }
   }
 
-  /**
-   * An example UDF with {@link SerializableFunction}.
-   */
+  /** An example UDF with {@link SerializableFunction}. */
   public static class CubicIntegerFn implements SerializableFunction<Integer, Integer> {
     @Override
     public Integer apply(Integer input) {
@@ -243,13 +208,10 @@ public class BeamSqlDslUdfUdafTest extends BeamSqlDslBase {
     }
   }
 
-  /**
-   * A UDF with default parameters.
-   *
-   */
+  /** A UDF with default parameters. */
   public static final class UdfFnWithDefault implements BeamSqlUdf {
-    public static String eval(@Parameter(name = "s") String s,
-        @Parameter(name = "n", optional = true) Integer n) {
+    public static String eval(
+        @Parameter(name = "s") String s, @Parameter(name = "n", optional = true) Integer n) {
       return s.substring(0, n == null ? 1 : n);
     }
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMapTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMapTest.java
@@ -30,44 +30,55 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Tests for SQL MAP type.
- */
+/** Tests for SQL MAP type. */
 public class BeamSqlMapTest {
 
-  private static final Schema INPUT_ROW_TYPE = RowSqlTypes.builder().withIntegerField("f_int")
-      .withMapField("f_intStringMap", SqlTypeName.VARCHAR, SqlTypeName.INTEGER).build();
+  private static final Schema INPUT_ROW_TYPE =
+      RowSqlTypes.builder()
+          .withIntegerField("f_int")
+          .withMapField("f_intStringMap", SqlTypeName.VARCHAR, SqlTypeName.INTEGER)
+          .build();
 
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
-  @Rule
-  public ExpectedException exceptions = ExpectedException.none();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public ExpectedException exceptions = ExpectedException.none();
 
   @Test
   public void testSelectAll() {
     PCollection<Row> input = pCollectionOf2Elements();
 
-    Schema resultType = RowSqlTypes.builder().withIntegerField("f_int")
-        .withMapField("f_map", SqlTypeName.VARCHAR, SqlTypeName.INTEGER).build();
+    Schema resultType =
+        RowSqlTypes.builder()
+            .withIntegerField("f_int")
+            .withMapField("f_map", SqlTypeName.VARCHAR, SqlTypeName.INTEGER)
+            .build();
 
-    PCollection<Row> result = input.apply("sqlQuery",
-        BeamSql.query("SELECT f_int, f_intStringMap as f_map FROM PCOLLECTION"));
+    PCollection<Row> result =
+        input.apply(
+            "sqlQuery", BeamSql.query("SELECT f_int, f_intStringMap as f_map FROM PCOLLECTION"));
 
     PAssert.that(result)
-        .containsInAnyOrder(Row.withSchema(resultType).addValues(1, new HashMap<String, Integer>() {
-          {
-            put("key11", 11);
-            put("key22", 22);
-          }
-        }).build(),
-
-            Row.withSchema(resultType).addValues(2, new HashMap<String, Integer>() {
-              {
-                put("key33", 33);
-                put("key44", 44);
-                put("key55", 55);
-              }
-            }).build());
+        .containsInAnyOrder(
+            Row.withSchema(resultType)
+                .addValues(
+                    1,
+                    new HashMap<String, Integer>() {
+                      {
+                        put("key11", 11);
+                        put("key22", 22);
+                      }
+                    })
+                .build(),
+            Row.withSchema(resultType)
+                .addValues(
+                    2,
+                    new HashMap<String, Integer>() {
+                      {
+                        put("key33", 33);
+                        put("key44", 44);
+                        put("key55", 55);
+                      }
+                    })
+                .build());
 
     pipeline.run();
   }
@@ -76,22 +87,36 @@ public class BeamSqlMapTest {
   public void testSelectMapField() {
     PCollection<Row> input = pCollectionOf2Elements();
 
-    Schema resultType = RowSqlTypes.builder().withIntegerField("f_int")
-        .withMapField("f_intStringMap", SqlTypeName.VARCHAR, SqlTypeName.INTEGER).build();
+    Schema resultType =
+        RowSqlTypes.builder()
+            .withIntegerField("f_int")
+            .withMapField("f_intStringMap", SqlTypeName.VARCHAR, SqlTypeName.INTEGER)
+            .build();
 
-    PCollection<Row> result = input.apply("sqlQuery",
-        BeamSql.query("SELECT 42, MAP['aa', 1] as `f_map` FROM PCOLLECTION"));
+    PCollection<Row> result =
+        input.apply(
+            "sqlQuery", BeamSql.query("SELECT 42, MAP['aa', 1] as `f_map` FROM PCOLLECTION"));
 
-    PAssert.that(result).containsInAnyOrder(
-        Row.withSchema(resultType).addValues(42, new HashMap<String, Integer>() {
-          {
-            put("aa", 1);
-          }
-        }).build(), Row.withSchema(resultType).addValues(42, new HashMap<String, Integer>() {
-          {
-            put("aa", 1);
-          }
-        }).build());
+    PAssert.that(result)
+        .containsInAnyOrder(
+            Row.withSchema(resultType)
+                .addValues(
+                    42,
+                    new HashMap<String, Integer>() {
+                      {
+                        put("aa", 1);
+                      }
+                    })
+                .build(),
+            Row.withSchema(resultType)
+                .addValues(
+                    42,
+                    new HashMap<String, Integer>() {
+                      {
+                        put("aa", 1);
+                      }
+                    })
+                .build());
 
     pipeline.run();
   }
@@ -102,30 +127,43 @@ public class BeamSqlMapTest {
 
     Schema resultType = RowSqlTypes.builder().withIntegerField("f_mapElem").build();
 
-    PCollection<Row> result = input.apply("sqlQuery",
-        BeamSql.query("SELECT f_intStringMap['key11'] FROM PCOLLECTION"));
+    PCollection<Row> result =
+        input.apply("sqlQuery", BeamSql.query("SELECT f_intStringMap['key11'] FROM PCOLLECTION"));
 
-    PAssert.that(result).containsInAnyOrder(Row.withSchema(resultType).addValues(11).build(),
-        Row.withSchema(resultType).addValue(null).build());
+    PAssert.that(result)
+        .containsInAnyOrder(
+            Row.withSchema(resultType).addValues(11).build(),
+            Row.withSchema(resultType).addValue(null).build());
 
     pipeline.run();
   }
 
   private PCollection<Row> pCollectionOf2Elements() {
-    return PBegin.in(pipeline).apply("boundedInput1", Create
-        .of(Row.withSchema(INPUT_ROW_TYPE).addValues(1).addValue(new HashMap<String, Integer>() {
-          {
-            put("key11", 11);
-            put("key22", 22);
-          }
-        }).build(),
-            Row.withSchema(INPUT_ROW_TYPE).addValues(2).addValue(new HashMap<String, Integer>() {
-              {
-                put("key33", 33);
-                put("key44", 44);
-                put("key55", 55);
-              }
-            }).build())
-        .withCoder(INPUT_ROW_TYPE.getRowCoder()));
+    return PBegin.in(pipeline)
+        .apply(
+            "boundedInput1",
+            Create.of(
+                    Row.withSchema(INPUT_ROW_TYPE)
+                        .addValues(1)
+                        .addValue(
+                            new HashMap<String, Integer>() {
+                              {
+                                put("key11", 11);
+                                put("key22", 22);
+                              }
+                            })
+                        .build(),
+                    Row.withSchema(INPUT_ROW_TYPE)
+                        .addValues(2)
+                        .addValue(
+                            new HashMap<String, Integer>() {
+                              {
+                                put("key33", 33);
+                                put("key44", 44);
+                                put("key55", 55);
+                              }
+                            })
+                        .build())
+                .withCoder(INPUT_ROW_TYPE.getRowCoder()));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlNonAsciiTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlNonAsciiTest.java
@@ -24,34 +24,32 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.junit.Test;
 
-/**
- * Tests for non ascii char in sql.
- */
+/** Tests for non ascii char in sql. */
 public class BeamSqlNonAsciiTest extends BeamSqlDslBase {
 
-    @Test
-    public void testDefaultCharsetLiteral() {
-        String sql = "SELECT * FROM TABLE_A WHERE f_string = '第四行'";
+  @Test
+  public void testDefaultCharsetLiteral() {
+    String sql = "SELECT * FROM TABLE_A WHERE f_string = '第四行'";
 
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), boundedInput1)
             .apply("testCompositeFilter", BeamSql.query(sql));
 
-        PAssert.that(result).containsInAnyOrder(rowsInTableA.get(3));
+    PAssert.that(result).containsInAnyOrder(rowsInTableA.get(3));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 
-    @Test
-    public void testNationalCharsetLiteral() {
-        String sql = "SELECT * FROM TABLE_A WHERE f_string = N'第四行'";
+  @Test
+  public void testNationalCharsetLiteral() {
+    String sql = "SELECT * FROM TABLE_A WHERE f_string = N'第四行'";
 
     PCollection<Row> result =
         PCollectionTuple.of(new TupleTag<>("TABLE_A"), boundedInput1)
             .apply("testCompositeFilter", BeamSql.query(sql));
 
-        PAssert.that(result).containsInAnyOrder(rowsInTableA.get(3));
+    PAssert.that(result).containsInAnyOrder(rowsInTableA.get(3));
 
-        pipeline.run().waitUntilFinish();
-    }
+    pipeline.run().waitUntilFinish();
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/InferredRowCoderSqlTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/InferredRowCoderSqlTest.java
@@ -31,14 +31,11 @@ import org.apache.beam.sdk.values.reflect.InferredRowCoder;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Tests for automatic inferring schema from the input {@link PCollection} of pojos.
- */
+/** Tests for automatic inferring schema from the input {@link PCollection} of pojos. */
 public class InferredRowCoderSqlTest {
 
   private static final boolean NOT_NULLABLE = false;
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   /** Person POJO. */
   public static class PersonPojo implements Serializable {
@@ -81,28 +78,23 @@ public class InferredRowCoderSqlTest {
   @Test
   public void testSelect() {
     PCollection<PersonPojo> input =
-        PBegin.in(pipeline).apply(
-            "input",
-            Create
-                .of(
-                    new PersonPojo("Foo", 5),
-                    new PersonPojo("Bar", 53))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(PersonPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "input",
+                Create.of(new PersonPojo("Foo", 5), new PersonPojo("Bar", 53))
+                    .withCoder(InferredRowCoder.ofSerializable(PersonPojo.class)));
 
     String sql = "SELECT name, ageYears FROM PCOLLECTION";
 
     PCollection<Row> result = input.apply("sql", BeamSql.query(sql));
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
             TestUtils.rowsBuilderOf(
-                Schema
-                    .builder()
-                      .addStringField("name", NOT_NULLABLE)
-                      .addInt32Field("ageYears", NOT_NULLABLE)
-                      .build())
+                    Schema.builder()
+                        .addStringField("name", NOT_NULLABLE)
+                        .addInt32Field("ageYears", NOT_NULLABLE)
+                        .build())
                 .addRows(
                     "Foo", 5,
                     "Bar", 53)
@@ -114,27 +106,19 @@ public class InferredRowCoderSqlTest {
   @Test
   public void testProject() {
     PCollection<PersonPojo> input =
-        PBegin.in(pipeline).apply(
-            "input",
-            Create
-                .of(
-                    new PersonPojo("Foo", 5),
-                    new PersonPojo("Bar", 53))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(PersonPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "input",
+                Create.of(new PersonPojo("Foo", 5), new PersonPojo("Bar", 53))
+                    .withCoder(InferredRowCoder.ofSerializable(PersonPojo.class)));
 
     String sql = "SELECT name FROM PCOLLECTION";
 
     PCollection<Row> result = input.apply("sql", BeamSql.query(sql));
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
-            TestUtils.rowsBuilderOf(
-                Schema
-                    .builder()
-                    .addStringField("name", NOT_NULLABLE)
-                    .build())
+            TestUtils.rowsBuilderOf(Schema.builder().addStringField("name", NOT_NULLABLE).build())
                 .addRows("Foo", "Bar")
                 .getRows());
 
@@ -144,28 +128,24 @@ public class InferredRowCoderSqlTest {
   @Test
   public void testJoin() {
     PCollection<PersonPojo> people =
-        PBegin.in(pipeline).apply(
-            "people",
-            Create
-                .of(
-                    new PersonPojo("Foo", 5),
-                    new PersonPojo("Bar", 53))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(PersonPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "people",
+                Create.of(new PersonPojo("Foo", 5), new PersonPojo("Bar", 53))
+                    .withCoder(InferredRowCoder.ofSerializable(PersonPojo.class)));
 
     PCollection<OrderPojo> orders =
-        PBegin.in(pipeline).apply(
-            "orders",
-            Create
-                .of(
-                    new OrderPojo("Foo", 15),
-                    new OrderPojo("Foo", 10),
-                    new OrderPojo("Foo", 5),
-                    new OrderPojo("Bar", 53),
-                    new OrderPojo("Bar", 54),
-                    new OrderPojo("Bar", 55))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(OrderPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "orders",
+                Create.of(
+                        new OrderPojo("Foo", 15),
+                        new OrderPojo("Foo", 10),
+                        new OrderPojo("Foo", 5),
+                        new OrderPojo("Bar", 53),
+                        new OrderPojo("Bar", 54),
+                        new OrderPojo("Bar", 55))
+                    .withCoder(InferredRowCoder.ofSerializable(OrderPojo.class)));
 
     String sql =
         "SELECT name, amount "
@@ -174,19 +154,18 @@ public class InferredRowCoderSqlTest {
             + "WHERE ageYears = 5";
 
     PCollection<Row> result =
-        tuple("buyers", people,
-              "orders", orders)
+        tuple(
+                "buyers", people,
+                "orders", orders)
             .apply("sql", BeamSql.query(sql));
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
             TestUtils.rowsBuilderOf(
-                Schema
-                    .builder()
-                    .addStringField("name", NOT_NULLABLE)
-                    .addInt32Field("amount", NOT_NULLABLE)
-                    .build())
+                    Schema.builder()
+                        .addStringField("name", NOT_NULLABLE)
+                        .addInt32Field("amount", NOT_NULLABLE)
+                        .build())
                 .addRows(
                     "Foo", 15,
                     "Foo", 10,
@@ -199,28 +178,24 @@ public class InferredRowCoderSqlTest {
   @Test
   public void testAggregation() {
     PCollection<PersonPojo> people =
-        PBegin.in(pipeline).apply(
-            "people",
-            Create
-                .of(
-                    new PersonPojo("Foo", 5),
-                    new PersonPojo("Bar", 53))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(PersonPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "people",
+                Create.of(new PersonPojo("Foo", 5), new PersonPojo("Bar", 53))
+                    .withCoder(InferredRowCoder.ofSerializable(PersonPojo.class)));
 
     PCollection<OrderPojo> orders =
-        PBegin.in(pipeline).apply(
-            "orders",
-            Create
-                .of(
-                    new OrderPojo("Foo", 15),
-                    new OrderPojo("Foo", 10),
-                    new OrderPojo("Foo", 5),
-                    new OrderPojo("Bar", 53),
-                    new OrderPojo("Bar", 54),
-                    new OrderPojo("Bar", 55))
-                .withCoder(
-                    InferredRowCoder.ofSerializable(OrderPojo.class)));
+        PBegin.in(pipeline)
+            .apply(
+                "orders",
+                Create.of(
+                        new OrderPojo("Foo", 15),
+                        new OrderPojo("Foo", 10),
+                        new OrderPojo("Foo", 5),
+                        new OrderPojo("Bar", 53),
+                        new OrderPojo("Bar", 54),
+                        new OrderPojo("Bar", 55))
+                    .withCoder(InferredRowCoder.ofSerializable(OrderPojo.class)));
 
     String sql =
         "SELECT name, SUM(amount) as total "
@@ -229,19 +204,18 @@ public class InferredRowCoderSqlTest {
             + "GROUP BY name";
 
     PCollection<Row> result =
-        tuple("buyers", people,
-              "orders", orders)
+        tuple(
+                "buyers", people,
+                "orders", orders)
             .apply("sql", BeamSql.query(sql));
 
-    PAssert
-        .that(result)
+    PAssert.that(result)
         .containsInAnyOrder(
             TestUtils.rowsBuilderOf(
-                Schema
-                    .builder()
-                    .addStringField("name", NOT_NULLABLE)
-                    .addInt32Field("total", NOT_NULLABLE)
-                    .build())
+                    Schema.builder()
+                        .addStringField("name", NOT_NULLABLE)
+                        .addInt32Field("total", NOT_NULLABLE)
+                        .build())
                 .addRows(
                     "Foo", 30,
                     "Bar", 162)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/JsonToRowSqlTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/JsonToRowSqlTest.java
@@ -27,20 +27,16 @@ import org.apache.beam.sdk.values.Row;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * JsonToRowSqlTest.
- */
+/** JsonToRowSqlTest. */
 public class JsonToRowSqlTest {
   private static final boolean NOT_NULLABLE = false;
 
-  @Rule
-  public transient TestPipeline pipeline = TestPipeline.create();
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
   @Test
   public void testParsesRows() throws Exception {
     Schema personSchema =
-        Schema
-            .builder()
+        Schema.builder()
             .addStringField("name", NOT_NULLABLE)
             .addInt32Field("height", NOT_NULLABLE)
             .addBooleanField("knowsJavascript", NOT_NULLABLE)
@@ -48,39 +44,36 @@ public class JsonToRowSqlTest {
 
     PCollection<String> jsonPersons =
         pipeline.apply(
-            Create
-                .of(
-                    jsonPerson("person1", "80", "true"),
-                    jsonPerson("person2", "70", "false"),
-                    jsonPerson("person3", "60", "true"),
-                    jsonPerson("person4", "50", "false"),
-                    jsonPerson("person5", "40", "true")));
+            Create.of(
+                jsonPerson("person1", "80", "true"),
+                jsonPerson("person2", "70", "false"),
+                jsonPerson("person3", "60", "true"),
+                jsonPerson("person4", "50", "false"),
+                jsonPerson("person5", "40", "true")));
 
-    Schema resultSchema =
-        Schema
-            .builder()
-            .addInt32Field("avg_height", NOT_NULLABLE)
-            .build();
+    Schema resultSchema = Schema.builder().addInt32Field("avg_height", NOT_NULLABLE).build();
 
     PCollection<Row> sqlResult =
         jsonPersons
             .apply(JsonToRow.withSchema(personSchema))
             .apply(BeamSql.query("SELECT AVG(height) as avg_height FROM PCOLLECTION"));
 
-    PAssert
-        .that(sqlResult)
-        .containsInAnyOrder(
-            row(resultSchema, 60));
+    PAssert.that(sqlResult).containsInAnyOrder(row(resultSchema, 60));
 
     pipeline.run();
   }
 
   private String jsonPerson(String name, String height, String knowsJs) {
-    return
-        "{\n"
-        + "  \"name\": \"" + name + "\",\n"
-        + "  \"height\": " + height + ",\n"
-        + "  \"knowsJavascript\": " + knowsJs + "\n"
+    return "{\n"
+        + "  \"name\": \""
+        + name
+        + "\",\n"
+        + "  \"height\": "
+        + height
+        + ",\n"
+        + "  \"knowsJavascript\": "
+        + knowsJs
+        + "\n"
         + "}";
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/SqlSchemaFactoryTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/SqlSchemaFactoryTest.java
@@ -34,27 +34,25 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- */
+/** */
 public class SqlSchemaFactoryTest {
 
-  private static final List<FieldValueGetter> GETTERS_FOR_KNOWN_TYPES = ImmutableList
-      .<FieldValueGetter>builder()
-      .add(getter("byteGetter", Byte.class))
-      .add(getter("shortGetter", Short.class))
-      .add(getter("integerGetter", Integer.class))
-      .add(getter("longGetter", Long.class))
-      .add(getter("floatGetter", Float.class))
-      .add(getter("doubleGetter", Double.class))
-      .add(getter("bigDecimalGetter", BigDecimal.class))
-      .add(getter("booleanGetter", Boolean.class))
-      .add(getter("stringGetter", String.class))
-      .add(getter("timeGetter", DateTime.class))
-      .add(getter("dateGetter", DateTime.class))
-      .build();
+  private static final List<FieldValueGetter> GETTERS_FOR_KNOWN_TYPES =
+      ImmutableList.<FieldValueGetter>builder()
+          .add(getter("byteGetter", Byte.class))
+          .add(getter("shortGetter", Short.class))
+          .add(getter("integerGetter", Integer.class))
+          .add(getter("longGetter", Long.class))
+          .add(getter("floatGetter", Float.class))
+          .add(getter("doubleGetter", Double.class))
+          .add(getter("bigDecimalGetter", BigDecimal.class))
+          .add(getter("booleanGetter", Boolean.class))
+          .add(getter("stringGetter", String.class))
+          .add(getter("timeGetter", DateTime.class))
+          .add(getter("dateGetter", DateTime.class))
+          .build();
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testContainsCorrectFields() throws Exception {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
@@ -41,13 +41,9 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.joda.time.Instant;
 
-/**
- * Test utilities.
- */
+/** Test utilities. */
 public class TestUtils {
-  /**
-   * A {@code DoFn} to convert a {@code BeamSqlRow} to a comparable {@code String}.
-   */
+  /** A {@code DoFn} to convert a {@code BeamSqlRow} to a comparable {@code String}. */
   public static class BeamSqlRow2StringDoFn extends DoFn<Row, String> {
     @ProcessElement
     public void processElement(ProcessContext ctx) {
@@ -55,9 +51,7 @@ public class TestUtils {
     }
   }
 
-  /**
-   * Convert list of {@code BeamSqlRow} to list of {@code String}.
-   */
+  /** Convert list of {@code BeamSqlRow} to list of {@code String}. */
   public static List<String> beamSqlRows2Strings(List<Row> rows) {
     List<String> strs = new ArrayList<>();
     for (Row row : rows) {
@@ -75,7 +69,7 @@ public class TestUtils {
    * Convenient way to build a list of {@code BeamSqlRow}s.
    *
    * <p>You can use it like this:
-
+   *
    * <pre>{@code
    * TestUtils.RowsBuilder.of(
    *   Types.INTEGER, "order_id",
@@ -86,6 +80,7 @@ public class TestUtils {
    *   2, 5, "bond"
    *   ).getStringRows()
    * }</pre>
+   *
    * {@code}
    */
   public static class RowsBuilder {
@@ -96,12 +91,14 @@ public class TestUtils {
      * Create a RowsBuilder with the specified row type info.
      *
      * <p>For example:
+     *
      * <pre>{@code
      * TestUtils.RowsBuilder.of(
      *   Types.INTEGER, "order_id",
      *   Types.INTEGER, "sum_site_id",
      *   Types.VARCHAR, "buyer"
-     * )}</pre>
+     * )
+     * }</pre>
      *
      * @args pairs of column type and column names.
      */
@@ -117,10 +114,12 @@ public class TestUtils {
      * Create a RowsBuilder with the specified row type info.
      *
      * <p>For example:
+     *
      * <pre>{@code
      * TestUtils.RowsBuilder.of(
      *   schema
-     * )}</pre>
+     * )
+     * }</pre>
      *
      * @beamSQLRowType the row type.
      */
@@ -160,10 +159,7 @@ public class TestUtils {
     }
 
     public PCollectionBuilder getPCollectionBuilder() {
-      return
-          pCollectionBuilder()
-              .withRowType(type)
-              .withRows(rows);
+      return pCollectionBuilder().withRowType(type).withRows(rows);
     }
   }
 
@@ -187,9 +183,7 @@ public class TestUtils {
       return this;
     }
 
-    /**
-     * Event time field, defines watermark.
-     */
+    /** Event time field, defines watermark. */
     public PCollectionBuilder withTimestampField(String timestampField) {
       this.timestampField = timestampField;
       return this;
@@ -201,11 +195,11 @@ public class TestUtils {
     }
 
     /**
-     * Builds an unbounded {@link PCollection} in {@link Pipeline}
-     * set by {@link #inPipeline(Pipeline)}.
+     * Builds an unbounded {@link PCollection} in {@link Pipeline} set by {@link
+     * #inPipeline(Pipeline)}.
      *
-     * <p>If timestamp field was set with {@link #withTimestampField(String)} then
-     * watermark will be advanced to the values from that field.
+     * <p>If timestamp field was set with {@link #withTimestampField(String)} then watermark will be
+     * advanced to the values from that field.
      */
     public PCollection<Row> buildUnbounded() {
       checkArgument(pipeline != null);
@@ -225,9 +219,7 @@ public class TestUtils {
         values = values.addElements(row);
       }
 
-      return PBegin
-          .in(pipeline)
-          .apply("unboundedPCollection", values.advanceWatermarkToInfinity());
+      return PBegin.in(pipeline).apply("unboundedPCollection", values.advanceWatermarkToInfinity());
     }
   }
 
@@ -237,28 +229,25 @@ public class TestUtils {
    * <p>e.g.
    *
    * <pre>{@code
-   *   buildBeamSqlRowType(
-   *       SqlCoders.BIGINT, "order_id",
-   *       SqlCoders.INTEGER, "site_id",
-   *       SqlCoders.DOUBLE, "price",
-   *       SqlCoders.TIMESTAMP, "order_time"
-   *   )
+   * buildBeamSqlRowType(
+   *     SqlCoders.BIGINT, "order_id",
+   *     SqlCoders.INTEGER, "site_id",
+   *     SqlCoders.DOUBLE, "price",
+   *     SqlCoders.TIMESTAMP, "order_time"
+   * )
    * }</pre>
    */
   public static Schema buildBeamSqlRowType(Object... args) {
-    return
-        Stream
-            .iterate(0, i -> i + 2)
-            .limit(args.length / 2)
-            .map(i -> toRecordField(args, i))
-            .collect(toSchema());
+    return Stream.iterate(0, i -> i + 2)
+        .limit(args.length / 2)
+        .map(i -> toRecordField(args, i))
+        .collect(toSchema());
   }
 
   // TODO: support nested.
   // TODO: support nullable.
   private static Schema.Field toRecordField(Object[] args, int i) {
-    return Schema.Field.of((String) args[i + 1],
-        FieldType.of((TypeName) args[i]))
+    return Schema.Field.of((String) args[i + 1], FieldType.of((TypeName) args[i]))
         .withNullable(true);
   }
 
@@ -268,43 +257,43 @@ public class TestUtils {
    * <p>e.g.
    *
    * <pre>{@code
-   *   buildRows(
-   *       schema,
-   *       1, 1, 1, // the first row
-   *       2, 2, 2, // the second row
-   *       ...
-   *   )
+   * buildRows(
+   *     schema,
+   *     1, 1, 1, // the first row
+   *     2, 2, 2, // the second row
+   *     ...
+   * )
    * }</pre>
    */
   public static List<Row> buildRows(Schema type, List<?> rowsValues) {
-    return
-        Lists
-            .partition(rowsValues, type.getFieldCount())
-            .stream()
-            .map(values -> values.stream().collect(toRow(type)))
-            .collect(toList());
+    return Lists.partition(rowsValues, type.getFieldCount())
+        .stream()
+        .map(values -> values.stream().collect(toRow(type)))
+        .collect(toList());
   }
 
-  public static <T> PCollectionTuple tuple(
-      String tag, PCollection<T> pCollection) {
+  public static <T> PCollectionTuple tuple(String tag, PCollection<T> pCollection) {
 
     return PCollectionTuple.of(new TupleTag<>(tag), pCollection);
   }
 
   public static <T, V> PCollectionTuple tuple(
-      String tag1, PCollection<T> pCollection1,
-      String tag2, PCollection<V> pCollection2) {
+      String tag1, PCollection<T> pCollection1, String tag2, PCollection<V> pCollection2) {
 
     return tuple(tag1, pCollection1).and(new TupleTag<>(tag2), pCollection2);
   }
 
   public static <T, V, W> PCollectionTuple tuple(
-      String tag1, PCollection<T> pCollection1,
-      String tag2, PCollection<V> pCollection2,
-      String tag3, PCollection<W> pCollection3) {
+      String tag1,
+      PCollection<T> pCollection1,
+      String tag2,
+      PCollection<V> pCollection2,
+      String tag3,
+      PCollection<W> pCollection3) {
 
     return tuple(
-        tag1, pCollection1,
-        tag2, pCollection2).and(new TupleTag<>(tag3), pCollection3);
+            tag1, pCollection1,
+            tag2, pCollection2)
+        .and(new TupleTag<>(tag3), pCollection3);
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
@@ -34,9 +34,7 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.junit.Test;
 
-/**
- * Test for {@link JdbcDriver}.
- */
+/** Test for {@link JdbcDriver}. */
 public class JdbcDriverTest {
 
   @Test
@@ -71,8 +69,7 @@ public class JdbcDriverTest {
 
     // Create tables
     Statement statement = connection.createStatement();
-    assertEquals(0, statement.executeUpdate(
-        "CREATE TABLE test (id INTEGER) TYPE 'text'"));
+    assertEquals(0, statement.executeUpdate("CREATE TABLE test (id INTEGER) TYPE 'text'"));
 
     // Ensure table test
     resultSet = metadata.getTables(null, null, null, new String[] {"TABLE"});
@@ -81,8 +78,7 @@ public class JdbcDriverTest {
     assertFalse(resultSet.next());
 
     // Create tables
-    assertEquals(0, statement.executeUpdate(
-        "DROP TABLE test"));
+    assertEquals(0, statement.executeUpdate("DROP TABLE test"));
 
     // Ensure no tables
     resultSet = metadata.getTables(null, null, null, new String[] {"TABLE"});
@@ -91,13 +87,15 @@ public class JdbcDriverTest {
 
   @Test
   public void testInternalConnect_boundedTable() throws Exception {
-    BeamSqlTableProvider tableProvider = new BeamSqlTableProvider("test", ImmutableMap.of(
-        "test",
-        MockedBoundedTable
-          .of(TypeName.INT32, "id",
-              TypeName.STRING, "name")
-          .addRows(
-              1, "first")));
+    BeamSqlTableProvider tableProvider =
+        new BeamSqlTableProvider(
+            "test",
+            ImmutableMap.of(
+                "test",
+                MockedBoundedTable.of(
+                        TypeName.INT32, "id",
+                        TypeName.STRING, "name")
+                    .addRows(1, "first")));
     CalciteConnection connection = JdbcDriver.connect(tableProvider);
     Statement statement = connection.createStatement();
     ResultSet resultSet = statement.executeQuery("SELECT * FROM test");

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTest.java
@@ -72,24 +72,28 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Unit test cases for {@link BeamSqlFnExecutor}.
- */
+/** Unit test cases for {@link BeamSqlFnExecutor}. */
 public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
 
   @Test
   public void testBeamFilterRel() {
-    RexNode condition = rexBuilder.makeCall(SqlStdOperatorTable.AND,
-        Arrays.asList(
-            rexBuilder.makeCall(SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
-                Arrays.asList(rexBuilder.makeInputRef(relDataType, 0),
-                    rexBuilder.makeBigintLiteral(new BigDecimal(1000L)))),
-            rexBuilder.makeCall(SqlStdOperatorTable.EQUALS,
-                Arrays.asList(rexBuilder.makeInputRef(relDataType, 1),
-                    rexBuilder.makeExactLiteral(BigDecimal.ZERO)))));
+    RexNode condition =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.AND,
+            Arrays.asList(
+                rexBuilder.makeCall(
+                    SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+                    Arrays.asList(
+                        rexBuilder.makeInputRef(relDataType, 0),
+                        rexBuilder.makeBigintLiteral(new BigDecimal(1000L)))),
+                rexBuilder.makeCall(
+                    SqlStdOperatorTable.EQUALS,
+                    Arrays.asList(
+                        rexBuilder.makeInputRef(relDataType, 1),
+                        rexBuilder.makeExactLiteral(BigDecimal.ZERO)))));
 
-    BeamFilterRel beamFilterRel = new BeamFilterRel(cluster, RelTraitSet.createEmpty(), null,
-        condition);
+    BeamFilterRel beamFilterRel =
+        new BeamFilterRel(cluster, RelTraitSet.createEmpty(), null, condition);
 
     BeamSqlFnExecutor executor = new BeamSqlFnExecutor(beamFilterRel);
     executor.prepare();
@@ -122,9 +126,13 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
 
   @Test
   public void testBeamProjectRel() {
-    BeamRelNode relNode = new BeamProjectRel(cluster, RelTraitSet.createEmpty(),
-        relBuilder.values(relDataType, 1234567L, 0, 8.9, null).build(),
-        rexBuilder.identityProjects(relDataType), relDataType);
+    BeamRelNode relNode =
+        new BeamProjectRel(
+            cluster,
+            RelTraitSet.createEmpty(),
+            relBuilder.values(relDataType, 1234567L, 0, 8.9, null).build(),
+            rexBuilder.identityProjects(relDataType),
+            relDataType);
     BeamSqlFnExecutor executor = new BeamSqlFnExecutor(relNode);
 
     executor.prepare();
@@ -135,56 +143,44 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
     assertTrue(executor.exps.get(3) instanceof BeamSqlInputRefExpression);
   }
 
-
   @Test
   public void testBuildExpression_logical() {
     RexNode rexNode;
     BeamSqlExpression exp;
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.AND,
-        Arrays.asList(
-            rexBuilder.makeLiteral(true),
-            rexBuilder.makeLiteral(false)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.AND,
+            Arrays.asList(rexBuilder.makeLiteral(true), rexBuilder.makeLiteral(false)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlAndExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.OR,
-        Arrays.asList(
-            rexBuilder.makeLiteral(true),
-            rexBuilder.makeLiteral(false)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.OR,
+            Arrays.asList(rexBuilder.makeLiteral(true), rexBuilder.makeLiteral(false)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlOrExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-        Arrays.asList(
-            rexBuilder.makeLiteral(true)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(SqlStdOperatorTable.NOT, Arrays.asList(rexBuilder.makeLiteral(true)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlNotExpression);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testBuildExpression_logical_andOr_invalidOperand() {
-    RexNode rexNode = rexBuilder.makeCall(SqlStdOperatorTable.AND,
-        Arrays.asList(
-            rexBuilder.makeLiteral(true),
-            rexBuilder.makeLiteral("hello")
-        )
-    );
+    RexNode rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.AND,
+            Arrays.asList(rexBuilder.makeLiteral(true), rexBuilder.makeLiteral("hello")));
     BeamSqlFnExecutor.buildExpression(rexNode);
   }
 
   @Test(expected = IllegalStateException.class)
   public void testBuildExpression_logical_not_invalidOperand() {
-    RexNode rexNode = rexBuilder.makeCall(SqlStdOperatorTable.NOT,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello")
-        )
-    );
+    RexNode rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT, Arrays.asList(rexBuilder.makeLiteral("hello")));
     BeamSqlFnExecutor.buildExpression(rexNode);
   }
 
@@ -197,143 +193,131 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
     testBuildArithmeticExpression(SqlStdOperatorTable.MOD, BeamSqlModExpression.class);
   }
 
-  private void testBuildArithmeticExpression(SqlOperator fn,
-      Class<? extends BeamSqlExpression> clazz) {
+  private void testBuildArithmeticExpression(
+      SqlOperator fn, Class<? extends BeamSqlExpression> clazz) {
     RexNode rexNode;
     BeamSqlExpression exp;
-    rexNode = rexBuilder.makeCall(fn, Arrays.asList(
-        rexBuilder.makeBigintLiteral(BigDecimal.ONE),
-        rexBuilder.makeBigintLiteral(BigDecimal.ONE)
-    ));
+    rexNode =
+        rexBuilder.makeCall(
+            fn,
+            Arrays.asList(
+                rexBuilder.makeBigintLiteral(BigDecimal.ONE),
+                rexBuilder.makeBigintLiteral(BigDecimal.ONE)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
 
     assertTrue(exp.getClass().equals(clazz));
   }
 
   @Test
-  public void testBuildExpression_string()  {
+  public void testBuildExpression_string() {
     RexNode rexNode;
     BeamSqlExpression exp;
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.CONCAT,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello "),
-            rexBuilder.makeLiteral("world")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.CONCAT,
+            Arrays.asList(rexBuilder.makeLiteral("hello "), rexBuilder.makeLiteral("world")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlConcatExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.POSITION,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello"),
-            rexBuilder.makeLiteral("worldhello")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.POSITION,
+            Arrays.asList(rexBuilder.makeLiteral("hello"), rexBuilder.makeLiteral("worldhello")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlPositionExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.POSITION,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello"),
-            rexBuilder.makeLiteral("worldhello"),
-            rexBuilder.makeCast(TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER),
-                rexBuilder.makeBigintLiteral(BigDecimal.ONE))
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.POSITION,
+            Arrays.asList(
+                rexBuilder.makeLiteral("hello"),
+                rexBuilder.makeLiteral("worldhello"),
+                rexBuilder.makeCast(
+                    TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER),
+                    rexBuilder.makeBigintLiteral(BigDecimal.ONE))));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlPositionExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.CHAR_LENGTH,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.CHAR_LENGTH, Arrays.asList(rexBuilder.makeLiteral("hello")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlCharLengthExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.UPPER,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.UPPER, Arrays.asList(rexBuilder.makeLiteral("hello")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlUpperExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.LOWER,
-        Arrays.asList(
-            rexBuilder.makeLiteral("HELLO")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.LOWER, Arrays.asList(rexBuilder.makeLiteral("HELLO")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlLowerExpression);
 
-
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.INITCAP,
-        Arrays.asList(
-            rexBuilder.makeLiteral("hello")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.INITCAP, Arrays.asList(rexBuilder.makeLiteral("hello")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlInitCapExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.TRIM,
-        Arrays.asList(
-            rexBuilder.makeFlag(SqlTrimFunction.Flag.BOTH),
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeLiteral("HELLO")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.TRIM,
+            Arrays.asList(
+                rexBuilder.makeFlag(SqlTrimFunction.Flag.BOTH),
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeLiteral("HELLO")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlTrimExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.SUBSTRING,
-        Arrays.asList(
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.SUBSTRING,
+            Arrays.asList(
+                rexBuilder.makeLiteral("HELLO"), rexBuilder.makeBigintLiteral(BigDecimal.ZERO)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlSubstringExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.SUBSTRING,
-        Arrays.asList(
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.SUBSTRING,
+            Arrays.asList(
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeBigintLiteral(BigDecimal.ZERO),
+                rexBuilder.makeBigintLiteral(BigDecimal.ZERO)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlSubstringExpression);
 
-
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.OVERLAY,
-        Arrays.asList(
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.OVERLAY,
+            Arrays.asList(
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeBigintLiteral(BigDecimal.ZERO)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlOverlayExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.OVERLAY,
-        Arrays.asList(
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO),
-            rexBuilder.makeBigintLiteral(BigDecimal.ZERO)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.OVERLAY,
+            Arrays.asList(
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeBigintLiteral(BigDecimal.ZERO),
+                rexBuilder.makeBigintLiteral(BigDecimal.ZERO)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlOverlayExpression);
 
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.CASE,
-        Arrays.asList(
-            rexBuilder.makeLiteral(true),
-            rexBuilder.makeLiteral("HELLO"),
-            rexBuilder.makeLiteral("HELLO")
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.CASE,
+            Arrays.asList(
+                rexBuilder.makeLiteral(true),
+                rexBuilder.makeLiteral("HELLO"),
+                rexBuilder.makeLiteral("HELLO")));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlCaseExpression);
   }
@@ -347,32 +331,29 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
     calendar.setTime(new Date());
 
     // CEIL
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.CEIL,
-        Arrays.asList(
-            rexBuilder.makeDateLiteral(calendar),
-            rexBuilder.makeFlag(TimeUnitRange.MONTH)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.CEIL,
+            Arrays.asList(
+                rexBuilder.makeDateLiteral(calendar), rexBuilder.makeFlag(TimeUnitRange.MONTH)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlDateCeilExpression);
 
     // FLOOR
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.FLOOR,
-        Arrays.asList(
-            rexBuilder.makeDateLiteral(calendar),
-            rexBuilder.makeFlag(TimeUnitRange.MONTH)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.FLOOR,
+            Arrays.asList(
+                rexBuilder.makeDateLiteral(calendar), rexBuilder.makeFlag(TimeUnitRange.MONTH)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlDateFloorExpression);
 
     // EXTRACT == EXTRACT_DATE?
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
-        Arrays.asList(
-            rexBuilder.makeFlag(TimeUnitRange.MONTH),
-            rexBuilder.makeDateLiteral(calendar)
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.EXTRACT,
+            Arrays.asList(
+                rexBuilder.makeFlag(TimeUnitRange.MONTH), rexBuilder.makeDateLiteral(calendar)));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlExtractExpression);
 
@@ -392,26 +373,26 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
     assertTrue(exp instanceof BeamSqlCurrentTimestampExpression);
 
     // DATETIME_PLUS
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.DATETIME_PLUS,
-        Arrays.<RexNode>asList(
-            rexBuilder.makeDateLiteral(calendar),
-            rexBuilder.makeIntervalLiteral(
-                BigDecimal.TEN,
-                new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO))
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.DATETIME_PLUS,
+            Arrays.<RexNode>asList(
+                rexBuilder.makeDateLiteral(calendar),
+                rexBuilder.makeIntervalLiteral(
+                    BigDecimal.TEN,
+                    new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO))));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlDatetimePlusExpression);
 
     // * for intervals
-    rexNode = rexBuilder.makeCall(SqlStdOperatorTable.MULTIPLY,
-        Arrays.<RexNode>asList(
-            rexBuilder.makeExactLiteral(BigDecimal.ONE),
-            rexBuilder.makeIntervalLiteral(
-                BigDecimal.TEN,
-                new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO))
-        )
-    );
+    rexNode =
+        rexBuilder.makeCall(
+            SqlStdOperatorTable.MULTIPLY,
+            Arrays.<RexNode>asList(
+                rexBuilder.makeExactLiteral(BigDecimal.ONE),
+                rexBuilder.makeIntervalLiteral(
+                    BigDecimal.TEN,
+                    new SqlIntervalQualifier(TimeUnit.DAY, TimeUnit.DAY, SqlParserPos.ZERO))));
     exp = BeamSqlFnExecutor.buildExpression(rexNode);
     assertTrue(exp instanceof BeamSqlIntervalMultiplyExpression);
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamNullExperssionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamNullExperssionTest.java
@@ -24,32 +24,28 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for {@link BeamSqlIsNullExpression} and
- * {@link BeamSqlIsNotNullExpression}.
- */
+/** Test cases for {@link BeamSqlIsNullExpression} and {@link BeamSqlIsNotNullExpression}. */
 public class BeamNullExperssionTest extends BeamSqlFnExecutorTestBase {
 
   @Test
   public void testIsNull() {
-    BeamSqlIsNullExpression exp1 = new BeamSqlIsNullExpression(
-        new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
+    BeamSqlIsNullExpression exp1 =
+        new BeamSqlIsNullExpression(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
     Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
 
-    BeamSqlIsNullExpression exp2 = new BeamSqlIsNullExpression(
-        BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
+    BeamSqlIsNullExpression exp2 =
+        new BeamSqlIsNullExpression(BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
     Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testIsNotNull() {
-    BeamSqlIsNotNullExpression exp1 = new BeamSqlIsNotNullExpression(
-        new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
+    BeamSqlIsNotNullExpression exp1 =
+        new BeamSqlIsNotNullExpression(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0));
     Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
 
-    BeamSqlIsNotNullExpression exp2 = new BeamSqlIsNotNullExpression(
-        BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
+    BeamSqlIsNotNullExpression exp2 =
+        new BeamSqlIsNotNullExpression(BeamSqlPrimitive.of(SqlTypeName.BIGINT, null));
     Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlAndOrExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlAndOrExpressionTest.java
@@ -26,9 +26,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for {@link BeamSqlAndExpression}, {@link BeamSqlOrExpression}.
- */
+/** Test cases for {@link BeamSqlAndExpression}, {@link BeamSqlOrExpression}. */
 public class BeamSqlAndOrExpressionTest extends BeamSqlFnExecutorTestBase {
 
   @Test
@@ -55,7 +53,5 @@ public class BeamSqlAndOrExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
 
     Assert.assertTrue(new BeamSqlOrExpression(operands).evaluate(row, null).getValue());
-
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpressionTest.java
@@ -28,12 +28,11 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTest
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlCaseExpression.
- */
+/** Test for BeamSqlCaseExpression. */
 public class BeamSqlCaseExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
@@ -62,24 +61,22 @@ public class BeamSqlCaseExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 10));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     assertFalse(new BeamSqlCaseExpression(operands).accept());
-
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("hello", new BeamSqlCaseExpression(operands)
-        .evaluate(row, null).getValue());
+    assertEquals("hello", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("world", new BeamSqlCaseExpression(operands)
-        .evaluate(row, null).getValue());
+    assertEquals("world", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
@@ -87,7 +84,6 @@ public class BeamSqlCaseExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello1"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "world"));
-    assertEquals("hello1", new BeamSqlCaseExpression(operands)
-        .evaluate(row, null).getValue());
+    assertEquals("hello1", new BeamSqlCaseExpression(operands).evaluate(row, null).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpressionTest.java
@@ -29,9 +29,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Test for {@link BeamSqlCastExpression}.
- */
+/** Test for {@link BeamSqlCastExpression}. */
 public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
 
   private List<BeamSqlExpression> operands;
@@ -51,23 +49,23 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
   @Test
   public void testForIntegerToBigintTypeCasting() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
-    Assert.assertEquals(5L,
-        new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
+    Assert.assertEquals(
+        5L, new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
   }
 
   @Test
   public void testForDoubleToBigIntCasting() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 5.45));
-    Assert.assertEquals(5L,
-        new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
+    Assert.assertEquals(
+        5L, new BeamSqlCastExpression(operands, SqlTypeName.BIGINT).evaluate(row, null).getLong());
   }
 
   @Test
   public void testForIntegerToDateCast() {
     // test for yyyyMMdd format
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 20170521));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 21)
-            .withTimeAtStartOfDay(),
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
         new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
   }
 
@@ -75,8 +73,8 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
   public void testyyyyMMddDateFormat() {
     //test for yyyy-MM-dd format
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21"));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 21)
-        .withTimeAtStartOfDay(),
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
         new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
   }
 
@@ -84,56 +82,55 @@ public class BeamSqlCastExpressionTest extends BeamSqlFnExecutorTestBase {
   public void testyyMMddDateFormat() {
     // test for yy.MM.dd format
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "17.05.21"));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 21)
-        .withTimeAtStartOfDay(),
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 21).withTimeAtStartOfDay(),
         new BeamSqlCastExpression(operands, SqlTypeName.DATE).evaluate(row, null).getValue());
   }
 
   @Test
   public void testForTimestampCastExpression() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "17-05-21 23:59:59.989"));
-    Assert.assertEquals(SqlTypeName.TIMESTAMP,
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null)
+    Assert.assertEquals(
+        SqlTypeName.TIMESTAMP,
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
+            .evaluate(row, null)
             .getOutputType());
   }
 
   @Test
   public void testDateTimeFormatWithMillis() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21 23:59:59.989"));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 22)
-        .withTime(0, 0, 0, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
-          .evaluate(row, null).getValue());
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 22).withTime(0, 0, 0, 0),
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
   }
 
   @Test
   public void testDateTimeFormatWithTimezone() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21 23:59:59.89079 PST"));
-    ReadableInstant expected = new DateTime()
-        .withZone(DateTimeZone.forID("US/Pacific"))
-        .withDate(2017, 05, 22)
-        .withTime(0, 0, 0, 0);
-    Assert.assertEquals(expected,
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
-          .evaluate(row, null).getValue());
+    ReadableInstant expected =
+        new DateTime()
+            .withZone(DateTimeZone.forID("US/Pacific"))
+            .withDate(2017, 05, 22)
+            .withTime(0, 0, 0, 0);
+    Assert.assertEquals(
+        expected,
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
   }
 
   @Test
   public void testDateTimeFormat() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "2017-05-21 23:59:59"));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 21)
-        .withTime(23, 59, 59, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
-          .evaluate(row, null).getValue());
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 21).withTime(23, 59, 59, 0),
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
   }
 
   @Test(expected = RuntimeException.class)
   public void testForCastTypeNotSupported() {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.TIME, DateTime.now()));
-    Assert.assertEquals(new DateTime().withDate(2017, 05, 22)
-            .withTime(0, 0, 0, 0),
-        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP)
-          .evaluate(row, null).getValue());
+    Assert.assertEquals(
+        new DateTime().withDate(2017, 05, 22).withTime(0, 0, 0, 0),
+        new BeamSqlCastExpression(operands, SqlTypeName.TIMESTAMP).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
@@ -30,86 +30,108 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for the collections of {@link BeamSqlCompareExpression}.
- */
+/** Test cases for the collections of {@link BeamSqlCompareExpression}. */
 public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
 
   @Test
   public void testEqual() {
-    BeamSqlEqualsExpression exp1 = new BeamSqlEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 100L)));
+    BeamSqlEqualsExpression exp1 =
+        new BeamSqlEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 100L)));
     Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
 
-    BeamSqlEqualsExpression exp2 = new BeamSqlEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
+    BeamSqlEqualsExpression exp2 =
+        new BeamSqlEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
     Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testLargerThan() {
-    BeamSqlGreaterThanExpression exp1 = new BeamSqlGreaterThanExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
+    BeamSqlGreaterThanExpression exp1 =
+        new BeamSqlGreaterThanExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
     Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
 
-    BeamSqlGreaterThanExpression exp2 = new BeamSqlGreaterThanExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234566L)));
+    BeamSqlGreaterThanExpression exp2 =
+        new BeamSqlGreaterThanExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234566L)));
     Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testLargerThanEqual() {
-    BeamSqlGreaterThanOrEqualsExpression exp1 = new BeamSqlGreaterThanOrEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
+    BeamSqlGreaterThanOrEqualsExpression exp1 =
+        new BeamSqlGreaterThanOrEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
     Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
 
-    BeamSqlGreaterThanOrEqualsExpression exp2 = new BeamSqlGreaterThanOrEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234568L)));
+    BeamSqlGreaterThanOrEqualsExpression exp2 =
+        new BeamSqlGreaterThanOrEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 0),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234568L)));
     Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testLessThan() {
-    BeamSqlLessThanExpression exp1 = new BeamSqlLessThanExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
-            BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1)));
+    BeamSqlLessThanExpression exp1 =
+        new BeamSqlLessThanExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
+                BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1)));
     Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
 
-    BeamSqlLessThanExpression exp2 = new BeamSqlLessThanExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
-            BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1)));
+    BeamSqlLessThanExpression exp2 =
+        new BeamSqlLessThanExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.INTEGER, 1),
+                BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1)));
     Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testLessThanEqual() {
-    BeamSqlLessThanOrEqualsExpression exp1 = new BeamSqlLessThanOrEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
-            BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.9)));
+    BeamSqlLessThanOrEqualsExpression exp1 =
+        new BeamSqlLessThanOrEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
+                BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.9)));
     Assert.assertEquals(true, exp1.evaluate(row, null).getValue());
 
-    BeamSqlLessThanOrEqualsExpression exp2 = new BeamSqlLessThanOrEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
-            BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.0)));
+    BeamSqlLessThanOrEqualsExpression exp2 =
+        new BeamSqlLessThanOrEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.DOUBLE, 2),
+                BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 8.0)));
     Assert.assertEquals(false, exp2.evaluate(row, null).getValue());
   }
 
   @Test
   public void testNotEqual() {
-    BeamSqlNotEqualsExpression exp1 = new BeamSqlNotEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
+    BeamSqlNotEqualsExpression exp1 =
+        new BeamSqlNotEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1234567L)));
     Assert.assertEquals(false, exp1.evaluate(row, null).getValue());
 
-    BeamSqlNotEqualsExpression exp2 = new BeamSqlNotEqualsExpression(
-        Arrays.asList(new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
-            BeamSqlPrimitive.of(SqlTypeName.BIGINT, 0L)));
+    BeamSqlNotEqualsExpression exp2 =
+        new BeamSqlNotEqualsExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
+                BeamSqlPrimitive.of(SqlTypeName.BIGINT, 0L)));
     Assert.assertEquals(true, exp2.evaluate(row, null).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpressionTest.java
@@ -30,9 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link BeamSqlDotExpression}.
- */
+/** Unit tests for {@link BeamSqlDotExpression}. */
 public class BeamSqlDotExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -43,20 +41,12 @@ public class BeamSqlDotExpressionTest {
   @Test
   public void testReturnsFieldValue() {
     Schema schema =
-        RowSqlTypes
-          .builder()
-          .withVarcharField("f_string")
-          .withIntegerField("f_int")
-          .build();
+        RowSqlTypes.builder().withVarcharField("f_string").withIntegerField("f_int").build();
 
     List<BeamSqlExpression> elements =
         ImmutableList.of(
             BeamSqlPrimitive.of(
-                SqlTypeName.ROW,
-                Row
-                  .withSchema(schema)
-                  .addValues("aaa", 14)
-                  .build()),
+                SqlTypeName.ROW, Row.withSchema(schema).addValues("aaa", 14).build()),
             BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "f_string"));
 
     BeamSqlDotExpression arrayExpression = new BeamSqlDotExpression(elements, SqlTypeName.VARCHAR);
@@ -67,20 +57,12 @@ public class BeamSqlDotExpressionTest {
   @Test
   public void testThrowsForNonExistentField() {
     Schema schema =
-        RowSqlTypes
-            .builder()
-            .withVarcharField("f_string")
-            .withIntegerField("f_int")
-            .build();
+        RowSqlTypes.builder().withVarcharField("f_string").withIntegerField("f_int").build();
 
     List<BeamSqlExpression> elements =
         ImmutableList.of(
             BeamSqlPrimitive.of(
-                SqlTypeName.ROW,
-                Row
-                    .withSchema(schema)
-                    .addValues("aaa", 14)
-                    .build()),
+                SqlTypeName.ROW, Row.withSchema(schema).addValues("aaa", 14).build()),
             BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "f_nonExistent"));
 
     thrown.expect(IllegalArgumentException.class);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
@@ -22,9 +22,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for {@link BeamSqlInputRefExpression}.
- */
+/** Test cases for {@link BeamSqlInputRefExpression}. */
 public class BeamSqlInputRefExpressionTest extends BeamSqlFnExecutorTestBase {
 
   @Test
@@ -41,7 +39,6 @@ public class BeamSqlInputRefExpressionTest extends BeamSqlFnExecutorTestBase {
     BeamSqlInputRefExpression ref3 = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3);
     Assert.assertEquals(row.getInt64(3), ref3.evaluate(row, null).getValue());
   }
-
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void testRefOutOfRange() {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
@@ -22,10 +22,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test cases for {@link BeamSqlPrimitive}.
- *
- */
+/** Test cases for {@link BeamSqlPrimitive}. */
 public class BeamSqlPrimitiveTest extends BeamSqlFnExecutorTestBase {
 
   @Test
@@ -39,21 +36,22 @@ public class BeamSqlPrimitiveTest extends BeamSqlFnExecutorTestBase {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.INTEGER, 100L);
     Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
   }
+
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch2() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.DECIMAL, 100L);
     Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
   }
+
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch3() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.FLOAT, 100L);
     Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
   }
+
   @Test(expected = IllegalArgumentException.class)
   public void testPrimitiveTypeUnMatch4() {
     BeamSqlPrimitive expInt = BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 100L);
     Assert.assertEquals(expInt.getValue(), expInt.evaluate(row, null).getValue());
   }
-
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlReinterpretExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlReinterpretExpressionTest.java
@@ -31,9 +31,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamSqlReinterpretExpression}.
- */
+/** Test for {@code BeamSqlReinterpretExpression}. */
 public class BeamSqlReinterpretExpressionTest extends BeamSqlFnExecutorTestBase {
   private static final long DATE_LONG = 1000L;
   private static final DateTime DATE = new DateTime(DATE_LONG);
@@ -42,29 +40,29 @@ public class BeamSqlReinterpretExpressionTest extends BeamSqlFnExecutorTestBase 
   private static final Row NULL_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
 
-  private static final BeamSqlExpression DATE_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.DATE, DATE);
+  private static final BeamSqlExpression DATE_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.DATE, DATE);
 
-  private static final BeamSqlExpression TIME_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.TIME, TIME);
+  private static final BeamSqlExpression TIME_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.TIME, TIME);
 
-  private static final BeamSqlExpression TIMESTAMP_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.TIMESTAMP, DATE);
+  private static final BeamSqlExpression TIMESTAMP_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
-  private static final BeamSqlExpression TINYINT_PRIMITIVE_5 = BeamSqlPrimitive.of(
-      SqlTypeName.TINYINT, (byte) 5);
+  private static final BeamSqlExpression TINYINT_PRIMITIVE_5 =
+      BeamSqlPrimitive.of(SqlTypeName.TINYINT, (byte) 5);
 
-  private static final BeamSqlExpression SMALLINT_PRIMITIVE_6 = BeamSqlPrimitive.of(
-      SqlTypeName.SMALLINT, (short) 6);
+  private static final BeamSqlExpression SMALLINT_PRIMITIVE_6 =
+      BeamSqlPrimitive.of(SqlTypeName.SMALLINT, (short) 6);
 
-  private static final BeamSqlExpression INTEGER_PRIMITIVE_8 = BeamSqlPrimitive.of(
-      SqlTypeName.INTEGER, 8);
+  private static final BeamSqlExpression INTEGER_PRIMITIVE_8 =
+      BeamSqlPrimitive.of(SqlTypeName.INTEGER, 8);
 
-  private static final BeamSqlExpression BIGINT_PRIMITIVE_15 = BeamSqlPrimitive.of(
-      SqlTypeName.BIGINT, 15L);
+  private static final BeamSqlExpression BIGINT_PRIMITIVE_15 =
+      BeamSqlPrimitive.of(SqlTypeName.BIGINT, 15L);
 
-  private static final BeamSqlExpression VARCHAR_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.VARCHAR, "hello");
+  private static final BeamSqlExpression VARCHAR_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello");
 
   @Test
   public void testAcceptsDateTypes() throws Exception {
@@ -124,8 +122,7 @@ public class BeamSqlReinterpretExpressionTest extends BeamSqlFnExecutorTestBase 
     return reinterpretExpression(operand).evaluate(NULL_ROW, NULL_WINDOW).getLong();
   }
 
-  private static BeamSqlReinterpretExpression reinterpretExpression(
-      BeamSqlExpression... operands) {
+  private static BeamSqlReinterpretExpression reinterpretExpression(BeamSqlExpression... operands) {
     return new BeamSqlReinterpretExpression(Arrays.asList(operands), SqlTypeName.BIGINT);
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpressionTest.java
@@ -24,9 +24,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlUdfExpression.
- */
+/** Test for BeamSqlUdfExpression. */
 public class BeamSqlUdfExpressionTest extends BeamSqlFnExecutorTestBase {
 
   @Test
@@ -34,15 +32,14 @@ public class BeamSqlUdfExpressionTest extends BeamSqlFnExecutorTestBase {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 10));
 
-    BeamSqlUdfExpression exp = new BeamSqlUdfExpression(
-        UdfFn.class.getMethod("negative", Integer.class), operands, SqlTypeName.INTEGER);
+    BeamSqlUdfExpression exp =
+        new BeamSqlUdfExpression(
+            UdfFn.class.getMethod("negative", Integer.class), operands, SqlTypeName.INTEGER);
 
     Assert.assertEquals(-10, exp.evaluate(row, null).getValue());
   }
 
-  /**
-   * UDF example.
-   */
+  /** UDF example. */
   public static final class UdfFn {
     public static int negative(Integer number) {
       return number == null ? 0 : 0 - number;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpressionTest.java
@@ -30,12 +30,11 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Tests for {@code BeamSqlArithmeticExpression}.
- */
+/** Tests for {@code BeamSqlArithmeticExpression}. */
 public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void testAccept_normal() {
+  @Test
+  public void testAccept_normal() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // byte, short
@@ -62,7 +61,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertFalse(new BeamSqlPlusExpression(operands).accept());
   }
 
-  @Test public void testAccept_exception() {
+  @Test
+  public void testAccept_exception() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // more than 2 operands
@@ -78,7 +78,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertFalse(new BeamSqlPlusExpression(operands).accept());
   }
 
-  @Test public void testPlus() {
+  @Test
+  public void testPlus() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // integer + integer => integer
@@ -102,8 +103,7 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 1.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(1.1F + 1,
-        new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
+    assertEquals(1.1F + 1, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
 
     // double + long => double
     operands.clear();
@@ -112,7 +112,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertEquals(2.1, new BeamSqlPlusExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testMinus() {
+  @Test
+  public void testMinus() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // integer + integer => long
@@ -148,7 +149,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertEquals(1.1, new BeamSqlMinusExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testMultiply() {
+  @Test
+  public void testMultiply() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // integer + integer => integer
@@ -172,8 +174,7 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 2.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1F * 1L,
-        new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
+    assertEquals(2.1F * 1L, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
 
     // double + long => double
     operands.clear();
@@ -182,7 +183,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertEquals(2.1, new BeamSqlMultiplyExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testDivide() {
+  @Test
+  public void testDivide() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // integer + integer => integer
@@ -206,8 +208,7 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.FLOAT, 2.1F));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    assertEquals(2.1F / 1,
-        new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
+    assertEquals(2.1F / 1, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
 
     // double + long => double
     operands.clear();
@@ -216,7 +217,8 @@ public class BeamSqlArithmeticExpressionTest extends BeamSqlFnExecutorTestBase {
     assertEquals(2.1, new BeamSqlDivideExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testMod() {
+  @Test
+  public void testMod() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // integer + integer => long

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayExpressionTest.java
@@ -31,9 +31,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlArrayExpression}.
- */
+/** Unit tests for {@link BeamSqlArrayExpression}. */
 public class BeamSqlArrayExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -49,8 +47,7 @@ public class BeamSqlArrayExpressionTest {
     BeamSqlArrayExpression arrayExpression = new BeamSqlArrayExpression(elements);
 
     assertEquals(
-        Arrays.asList("aaa", "bbb"),
-        arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+        Arrays.asList("aaa", "bbb"), arrayExpression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpressionTest.java
@@ -31,9 +31,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlArrayItemExpression}.
- */
+/** Unit tests for {@link BeamSqlArrayItemExpression}. */
 public class BeamSqlArrayItemExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -49,9 +47,7 @@ public class BeamSqlArrayItemExpressionTest {
     BeamSqlArrayItemExpression expression =
         new BeamSqlArrayItemExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals(
-        "aaa",
-        expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
   }
 
   @Test
@@ -64,9 +60,7 @@ public class BeamSqlArrayItemExpressionTest {
     BeamSqlArrayItemExpression expression =
         new BeamSqlArrayItemExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals(
-        "bbb",
-        expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("bbb", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
   }
 
   @Test
@@ -85,8 +79,7 @@ public class BeamSqlArrayItemExpressionTest {
   @Test
   public void testRejectsLessThanTwoOperands() {
     List<BeamSqlExpression> input =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
 
     BeamSqlArrayItemExpression expression =
         new BeamSqlArrayItemExpression(input, SqlTypeName.VARCHAR);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpressionTest.java
@@ -31,11 +31,8 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlCardinalityExpression}.
- */
+/** Unit tests for {@link BeamSqlCardinalityExpression}. */
 public class BeamSqlCardinalityExpressionTest {
-
 
   private static final Row NULL_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
@@ -43,8 +40,7 @@ public class BeamSqlCardinalityExpressionTest {
   @Test
   public void testReturnsCardinalityForTwoElements() {
     List<BeamSqlExpression> inputWith2Elements =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
 
     BeamSqlCardinalityExpression expression =
         new BeamSqlCardinalityExpression(inputWith2Elements, SqlTypeName.INTEGER);
@@ -55,8 +51,7 @@ public class BeamSqlCardinalityExpressionTest {
   @Test
   public void testReturnsCardinalityForZeroElements() {
     List<BeamSqlExpression> emptyInput =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList()));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList()));
 
     BeamSqlCardinalityExpression expression =
         new BeamSqlCardinalityExpression(emptyInput, SqlTypeName.INTEGER);
@@ -67,8 +62,7 @@ public class BeamSqlCardinalityExpressionTest {
   @Test
   public void testAcceptsOneOperand() {
     List<BeamSqlExpression> input =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb")));
 
     BeamSqlCardinalityExpression expression =
         new BeamSqlCardinalityExpression(input, SqlTypeName.INTEGER);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpressionTest.java
@@ -32,9 +32,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlSingleElementExpression}.
- */
+/** Unit tests for {@link BeamSqlSingleElementExpression}. */
 public class BeamSqlSingleElementExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -43,22 +41,18 @@ public class BeamSqlSingleElementExpressionTest {
   @Test
   public void testReturnsSingleElement() {
     List<BeamSqlExpression> input =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa")));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa")));
 
     BeamSqlSingleElementExpression expression =
         new BeamSqlSingleElementExpression(input, SqlTypeName.VARCHAR);
 
-    assertEquals(
-        "aaa",
-        expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
+    assertEquals("aaa", expression.evaluate(NULL_ROW, NULL_WINDOW).getValue());
   }
 
   @Test
   public void testReturnsNullForEmptyInput() {
     List<BeamSqlExpression> input =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList()));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList()));
 
     BeamSqlSingleElementExpression expression =
         new BeamSqlSingleElementExpression(input, SqlTypeName.VARCHAR);
@@ -69,8 +63,7 @@ public class BeamSqlSingleElementExpressionTest {
   @Test
   public void testAcceptsOneOperand() {
     List<BeamSqlExpression> input =
-        ImmutableList.of(
-            BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa")));
+        ImmutableList.of(BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa")));
 
     BeamSqlSingleElementExpression expression =
         new BeamSqlSingleElementExpression(input, SqlTypeName.VARCHAR);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentDateExpressionTest.java
@@ -23,16 +23,14 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlCurrentDateExpression.
- */
+/** Test for BeamSqlCurrentDateExpression. */
 public class BeamSqlCurrentDateExpressionTest extends BeamSqlDateExpressionTestBase {
   @Test
   public void test() {
     Assert.assertEquals(
         SqlTypeName.DATE,
         new BeamSqlCurrentDateExpression()
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getOutputType()
-    );
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimeExpressionTest.java
@@ -26,14 +26,13 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpre
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlLocalTimeExpression.
- */
+/** Test for BeamSqlLocalTimeExpression. */
 public class BeamSqlCurrentTimeExpressionTest extends BeamSqlDateExpressionTestBase {
   @Test
   public void test() {
     List<BeamSqlExpression> operands = new ArrayList<>();
-    assertEquals(SqlTypeName.TIME,
+    assertEquals(
+        SqlTypeName.TIME,
         new BeamSqlCurrentTimeExpression(operands).evaluate(row, null).getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlCurrentTimestampExpressionTest.java
@@ -26,14 +26,13 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpre
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlLocalTimestampExpression.
- */
+/** Test for BeamSqlLocalTimestampExpression. */
 public class BeamSqlCurrentTimestampExpressionTest extends BeamSqlDateExpressionTestBase {
   @Test
   public void test() {
     List<BeamSqlExpression> operands = new ArrayList<>();
-    assertEquals(SqlTypeName.TIMESTAMP,
+    assertEquals(
+        SqlTypeName.TIMESTAMP,
         new BeamSqlCurrentTimestampExpression(operands).evaluate(row, null).getOutputType());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpressionTest.java
@@ -28,23 +28,25 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamSqlDateCeilExpression}.
- */
+/** Test for {@code BeamSqlDateCeilExpression}. */
 public class BeamSqlDateCeilExpressionTest extends BeamSqlDateExpressionTestBase {
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.DATE,
-        str2DateTime("2017-05-22 09:10:11")));
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.DATE, str2DateTime("2017-05-22 09:10:11")));
     // YEAR
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.YEAR));
-    Assert.assertEquals(str2DateTime("2018-01-01 00:00:00"),
+    Assert.assertEquals(
+        str2DateTime("2018-01-01 00:00:00"),
         new BeamSqlDateCeilExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getDate());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getDate());
 
     operands.set(1, BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.MONTH));
-    Assert.assertEquals(str2DateTime("2017-06-01 00:00:00"),
+    Assert.assertEquals(
+        str2DateTime("2017-06-01 00:00:00"),
         new BeamSqlDateCeilExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getDate());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getDate());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateExpressionTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateExpressionTestBase.java
@@ -23,9 +23,7 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-/**
- * Base class for all date related expression test.
- */
+/** Base class for all date related expression test. */
 public class BeamSqlDateExpressionTestBase extends BeamSqlFnExecutorTestBase {
   static DateTime str2DateTime(String dateStr) {
     DateTimeFormatter format = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpressionTest.java
@@ -28,22 +28,21 @@ import org.apache.calcite.avatica.util.TimeUnitRange;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamSqlDateFloorExpression}.
- */
+/** Test for {@code BeamSqlDateFloorExpression}. */
 public class BeamSqlDateFloorExpressionTest extends BeamSqlDateExpressionTestBase {
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.DATE,
-        str2DateTime("2017-05-22 09:10:11")));
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.DATE, str2DateTime("2017-05-22 09:10:11")));
     // YEAR
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.YEAR));
-    assertEquals(str2DateTime("2017-01-01 00:00:00"),
+    assertEquals(
+        str2DateTime("2017-01-01 00:00:00"),
         new BeamSqlDateFloorExpression(operands).evaluate(row, null).getDate());
     // MONTH
     operands.set(1, BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.MONTH));
-    assertEquals(str2DateTime("2017-05-01 00:00:00"),
+    assertEquals(
+        str2DateTime("2017-05-01 00:00:00"),
         new BeamSqlDateFloorExpression(operands).evaluate(row, null).getDate());
-
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
@@ -33,9 +33,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamSqlDatetimeMinusExpression}.
- */
+/** Unit tests for {@link BeamSqlDatetimeMinusExpression}. */
 public class BeamSqlDatetimeMinusExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -44,19 +42,20 @@ public class BeamSqlDatetimeMinusExpressionTest {
   private static final DateTime DATE = new DateTime(329281L);
   private static final DateTime DATE_MINUS_2_SEC = DATE.minusSeconds(2);
 
-  private static final BeamSqlPrimitive TIMESTAMP = BeamSqlPrimitive.of(
-      SqlTypeName.TIMESTAMP, DATE);
+  private static final BeamSqlPrimitive TIMESTAMP =
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
-  private static final BeamSqlPrimitive TIMESTAMP_MINUS_2_SEC = BeamSqlPrimitive.of(
-      SqlTypeName.TIMESTAMP, DATE_MINUS_2_SEC);
+  private static final BeamSqlPrimitive TIMESTAMP_MINUS_2_SEC =
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE_MINUS_2_SEC);
 
-  private static final BeamSqlPrimitive INTERVAL_2_SEC = BeamSqlPrimitive.of(
-      SqlTypeName.INTERVAL_SECOND, TimeUnit.SECOND.multiplier.multiply(new BigDecimal(2)));
+  private static final BeamSqlPrimitive INTERVAL_2_SEC =
+      BeamSqlPrimitive.of(
+          SqlTypeName.INTERVAL_SECOND, TimeUnit.SECOND.multiplier.multiply(new BigDecimal(2)));
 
-  private static final BeamSqlPrimitive STRING = BeamSqlPrimitive.of(
-      SqlTypeName.VARCHAR, "hello");
+  private static final BeamSqlPrimitive STRING = BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello");
 
-  @Test public void testOutputType() {
+  @Test
+  public void testOutputType() {
     BeamSqlDatetimeMinusExpression minusExpression1 =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
     BeamSqlDatetimeMinusExpression minusExpression2 =
@@ -66,42 +65,48 @@ public class BeamSqlDatetimeMinusExpressionTest {
     assertEquals(SqlTypeName.BIGINT, minusExpression2.getOutputType());
   }
 
-  @Test public void testAcceptsTimestampMinusTimestamp() {
+  @Test
+  public void testAcceptsTimestampMinusTimestamp() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_SECOND, TIMESTAMP, TIMESTAMP_MINUS_2_SEC);
 
     assertTrue(minusExpression.accept());
   }
 
-  @Test public void testAcceptsTimestampMinusInteval() {
+  @Test
+  public void testAcceptsTimestampMinusInteval() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 
     assertTrue(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptUnsupportedReturnType() {
+  @Test
+  public void testDoesNotAcceptUnsupportedReturnType() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.BIGINT, TIMESTAMP, INTERVAL_2_SEC);
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptUnsupportedFirstOperand() {
+  @Test
+  public void testDoesNotAcceptUnsupportedFirstOperand() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, STRING, INTERVAL_2_SEC);
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptUnsupportedSecondOperand() {
+  @Test
+  public void testDoesNotAcceptUnsupportedSecondOperand() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, STRING);
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testEvaluateTimestampMinusTimestamp() {
+  @Test
+  public void testEvaluateTimestampMinusTimestamp() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_SECOND, TIMESTAMP, TIMESTAMP_MINUS_2_SEC);
 
@@ -111,7 +116,8 @@ public class BeamSqlDatetimeMinusExpressionTest {
     assertEquals(2L * TimeUnit.SECOND.multiplier.longValue(), subtractionResult.getLong());
   }
 
-  @Test public void testEvaluateTimestampMinusInteval() {
+  @Test
+  public void testEvaluateTimestampMinusInteval() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 
@@ -122,7 +128,7 @@ public class BeamSqlDatetimeMinusExpressionTest {
   }
 
   private static BeamSqlDatetimeMinusExpression minusExpression(
-      SqlTypeName outputType, BeamSqlExpression ... operands) {
+      SqlTypeName outputType, BeamSqlExpression... operands) {
     return new BeamSqlDatetimeMinusExpression(Arrays.asList(operands), outputType);
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
@@ -36,9 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Test for {@link BeamSqlDatetimePlusExpression}.
- */
+/** Test for {@link BeamSqlDatetimePlusExpression}. */
 public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTestBase {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -71,14 +69,16 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
   private static final BeamSqlExpression SQL_TIMESTAMP =
       BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
-  @Test public void testHappyPath_outputTypeAndAccept() {
+  @Test
+  public void testHappyPath_outputTypeAndAccept() {
     BeamSqlExpression plusExpression = dateTimePlus(SQL_TIMESTAMP, SQL_INTERVAL_3_DAYS);
 
     assertEquals(SqlTypeName.TIMESTAMP, plusExpression.getOutputType());
     assertTrue(plusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptTreeOperands() {
+  @Test
+  public void testDoesNotAcceptTreeOperands() {
     BeamSqlDatetimePlusExpression plusExpression =
         dateTimePlus(SQL_TIMESTAMP, SQL_INTERVAL_3_DAYS, SQL_INTERVAL_4_MONTHS);
 
@@ -86,7 +86,8 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
     assertFalse(plusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptWithoutTimestampOperand() {
+  @Test
+  public void testDoesNotAcceptWithoutTimestampOperand() {
     BeamSqlDatetimePlusExpression plusExpression =
         dateTimePlus(SQL_INTERVAL_3_DAYS, SQL_INTERVAL_4_MONTHS);
 
@@ -94,15 +95,16 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
     assertFalse(plusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptWithoutIntervalOperand() {
-    BeamSqlDatetimePlusExpression plusExpression =
-        dateTimePlus(SQL_TIMESTAMP, SQL_TIMESTAMP);
+  @Test
+  public void testDoesNotAcceptWithoutIntervalOperand() {
+    BeamSqlDatetimePlusExpression plusExpression = dateTimePlus(SQL_TIMESTAMP, SQL_TIMESTAMP);
 
     assertEquals(SqlTypeName.TIMESTAMP, plusExpression.getOutputType());
     assertFalse(plusExpression.accept());
   }
 
-  @Test public void testEvaluate() {
+  @Test
+  public void testEvaluate() {
     assertEquals(DATE_PLUS_15_SECONDS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_15_SECONDS));
     assertEquals(DATE_PLUS_10_MINUTES, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_10_MINUTES));
     assertEquals(DATE_PLUS_7_HOURS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_7_HOURS));
@@ -111,7 +113,8 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
     assertEquals(DATE_PLUS_11_YEARS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_11_YEARS));
   }
 
-  @Test public void testEvaluateThrowsForUnsupportedIntervalType() {
+  @Test
+  public void testEvaluateThrowsForUnsupportedIntervalType() {
     thrown.expect(UnsupportedOperationException.class);
 
     BeamSqlPrimitive unsupportedInterval = BeamSqlPrimitive.of(SqlTypeName.INTERVAL_YEAR_MONTH, 3);
@@ -123,14 +126,13 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
     return dateTimePlus(date, interval).evaluate(NULL_INPUT_ROW, NULL_WINDOW).getDate();
   }
 
-  private static BeamSqlDatetimePlusExpression dateTimePlus(BeamSqlExpression ... operands) {
+  private static BeamSqlDatetimePlusExpression dateTimePlus(BeamSqlExpression... operands) {
     return new BeamSqlDatetimePlusExpression(Arrays.asList(operands));
   }
 
   private static BeamSqlExpression interval(SqlTypeName type, int multiplier) {
-    return BeamSqlPrimitive.of(type,
-        timeUnitInternalMultiplier(type)
-            .multiply(new BigDecimal(multiplier)));
+    return BeamSqlPrimitive.of(
+        type, timeUnitInternalMultiplier(type).multiply(new BigDecimal(multiplier)));
   }
 
   private static BigDecimal timeUnitInternalMultiplier(final SqlTypeName sqlIntervalType) {
@@ -148,8 +150,8 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
       case INTERVAL_YEAR:
         return TimeUnit.YEAR.multiplier;
       default:
-        throw new IllegalArgumentException("Interval " + sqlIntervalType
-            + " cannot be converted to TimeUnit");
+        throw new IllegalArgumentException(
+            "Interval " + sqlIntervalType + " cannot be converted to TimeUnit");
     }
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpressionTest.java
@@ -30,75 +30,80 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamSqlExtractExpression}.
- */
+/** Test for {@code BeamSqlExtractExpression}. */
 public class BeamSqlExtractExpressionTest extends BeamSqlDateExpressionTestBase {
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
     DateTime time = str2DateTime("2017-05-22 16:17:18");
 
     // YEAR
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.YEAR));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(2017L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        2017L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // MONTH
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.MONTH));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(5L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        5L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // DAY
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.DAY));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(22L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        22L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // DAY_OF_WEEK
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.DOW));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(2L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        2L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // DAY_OF_YEAR
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.DOY));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(142L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        142L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // WEEK
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.WEEK));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(21L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        21L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
 
     // QUARTER
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, TimeUnitRange.QUARTER));
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP,
-        time));
-    assertEquals(2L,
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, time));
+    assertEquals(
+        2L,
         new BeamSqlExtractExpression(operands)
-            .evaluate(BeamSqlFnExecutorTestBase.row, null).getValue());
-
+            .evaluate(BeamSqlFnExecutorTestBase.row, null)
+            .getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlIntervalMultiplyExpressionTest.java
@@ -33,9 +33,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlIntervalMultiplyExpression.
- */
+/** Test for BeamSqlIntervalMultiplyExpression. */
 public class BeamSqlIntervalMultiplyExpressionTest {
   private static final Row NULL_INPUT_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
@@ -54,7 +52,8 @@ public class BeamSqlIntervalMultiplyExpressionTest {
   private static final BeamSqlExpression SQL_INTEGER_FIVE =
       BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5);
 
-  @Test public void testHappyPath_outputTypeAndAccept() {
+  @Test
+  public void testHappyPath_outputTypeAndAccept() {
     BeamSqlExpression multiplyExpression =
         newMultiplyExpression(SQL_INTERVAL_DAY, SQL_INTEGER_FOUR);
 
@@ -62,7 +61,8 @@ public class BeamSqlIntervalMultiplyExpressionTest {
     assertTrue(multiplyExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptTreeOperands() {
+  @Test
+  public void testDoesNotAcceptTreeOperands() {
     BeamSqlIntervalMultiplyExpression multiplyExpression =
         newMultiplyExpression(SQL_INTERVAL_DAY, SQL_INTEGER_FIVE, SQL_INTEGER_FOUR);
 
@@ -70,7 +70,8 @@ public class BeamSqlIntervalMultiplyExpressionTest {
     assertFalse(multiplyExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptWithoutIntervalOperand() {
+  @Test
+  public void testDoesNotAcceptWithoutIntervalOperand() {
     BeamSqlIntervalMultiplyExpression multiplyExpression =
         newMultiplyExpression(SQL_INTEGER_FOUR, SQL_INTEGER_FIVE);
 
@@ -78,7 +79,8 @@ public class BeamSqlIntervalMultiplyExpressionTest {
     assertFalse(multiplyExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptWithoutIntegerOperand() {
+  @Test
+  public void testDoesNotAcceptWithoutIntegerOperand() {
     BeamSqlIntervalMultiplyExpression multiplyExpression =
         newMultiplyExpression(SQL_INTERVAL_DAY, SQL_INTERVAL_MONTH);
 
@@ -86,7 +88,8 @@ public class BeamSqlIntervalMultiplyExpressionTest {
     assertFalse(multiplyExpression.accept());
   }
 
-  @Test public void testEvaluate_integerOperand() {
+  @Test
+  public void testEvaluate_integerOperand() {
     BeamSqlIntervalMultiplyExpression multiplyExpression =
         newMultiplyExpression(SQL_INTERVAL_DAY, SQL_INTEGER_FOUR);
 
@@ -100,7 +103,7 @@ public class BeamSqlIntervalMultiplyExpressionTest {
     assertEquals(SqlTypeName.INTERVAL_DAY, multiplicationResult.getOutputType());
   }
 
-  private BeamSqlIntervalMultiplyExpression newMultiplyExpression(BeamSqlExpression ... operands) {
+  private BeamSqlIntervalMultiplyExpression newMultiplyExpression(BeamSqlExpression... operands) {
     return new BeamSqlIntervalMultiplyExpression(Arrays.asList(operands));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
@@ -40,9 +40,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link BeamSqlTimestampMinusIntervalExpression}.
- */
+/** Unit tests for {@link BeamSqlTimestampMinusIntervalExpression}. */
 public class BeamSqlTimestampMinusIntervalExpressionTest {
   private static final Row NULL_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
@@ -50,18 +48,21 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
   private static final DateTime DATE = new DateTime(329281L);
   private static final DateTime DATE_MINUS_2_SEC = DATE.minusSeconds(2);
 
-  private static final BeamSqlPrimitive TIMESTAMP = BeamSqlPrimitive.of(
-      SqlTypeName.TIMESTAMP, DATE);
+  private static final BeamSqlPrimitive TIMESTAMP =
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
-  private static final BeamSqlPrimitive INTERVAL_2_SEC = BeamSqlPrimitive.of(
-      SqlTypeName.INTERVAL_SECOND, TimeUnit.SECOND.multiplier.multiply(new BigDecimal(2)));
+  private static final BeamSqlPrimitive INTERVAL_2_SEC =
+      BeamSqlPrimitive.of(
+          SqlTypeName.INTERVAL_SECOND, TimeUnit.SECOND.multiplier.multiply(new BigDecimal(2)));
 
-  private static final BeamSqlPrimitive INTERVAL_3_MONTHS = BeamSqlPrimitive.of(
-      SqlTypeName.INTERVAL_MONTH, TimeUnit.MONTH.multiplier.multiply(new BigDecimal(3)));
+  private static final BeamSqlPrimitive INTERVAL_3_MONTHS =
+      BeamSqlPrimitive.of(
+          SqlTypeName.INTERVAL_MONTH, TimeUnit.MONTH.multiplier.multiply(new BigDecimal(3)));
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void testBasicProperties() {
+  @Test
+  public void testBasicProperties() {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_DAY_MINUTE, TIMESTAMP, INTERVAL_3_MONTHS);
 
@@ -69,28 +70,32 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     assertEquals(Arrays.asList(TIMESTAMP, INTERVAL_3_MONTHS), minusExpression.getOperands());
   }
 
-  @Test public void testAcceptsHappyPath() {
+  @Test
+  public void testAcceptsHappyPath() {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 
     assertTrue(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptOneOperand() {
+  @Test
+  public void testDoesNotAcceptOneOperand() {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP);
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptThreeOperands() {
+  @Test
+  public void testDoesNotAcceptThreeOperands() {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC, INTERVAL_3_MONTHS);
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptWrongOutputType() {
+  @Test
+  public void testDoesNotAcceptWrongOutputType() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
     unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
 
@@ -102,7 +107,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     }
   }
 
-  @Test public void testDoesNotAcceptWrongFirstOperand() {
+  @Test
+  public void testDoesNotAcceptWrongFirstOperand() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
     unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
 
@@ -117,7 +123,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     }
   }
 
-  @Test public void testDoesNotAcceptWrongSecondOperand() {
+  @Test
+  public void testDoesNotAcceptWrongSecondOperand() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
     unsupportedTypes.removeAll(INTERVALS_DURATIONS_TYPES.keySet());
 
@@ -132,7 +139,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     }
   }
 
-  @Test public void testAcceptsAllSupportedIntervalTypes() {
+  @Test
+  public void testAcceptsAllSupportedIntervalTypes() {
     for (SqlTypeName unsupportedType : INTERVALS_DURATIONS_TYPES.keySet()) {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
       doReturn(unsupportedType).when(unsupportedOperand).getOutputType();
@@ -144,7 +152,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     }
   }
 
-  @Test public void testEvaluateHappyPath() {
+  @Test
+  public void testEvaluateHappyPath() {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpressionTest.java
@@ -34,17 +34,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link BeamSqlTimestampMinusTimestampExpression}.
- */
+/** Unit tests for {@link BeamSqlTimestampMinusTimestampExpression}. */
 public class BeamSqlTimestampMinusTimestampExpressionTest {
 
   private static final Row NULL_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
 
-  private static final DateTime DATE = new DateTime()
-      .withDate(2017, 3, 4)
-      .withTime(3, 2, 1, 0);
+  private static final DateTime DATE = new DateTime().withDate(2017, 3, 4).withTime(3, 2, 1, 0);
   private static final DateTime DATE_MINUS_2_SEC = DATE.minusSeconds(2);
   private static final DateTime DATE_MINUS_3_MIN = DATE.minusMinutes(3);
   private static final DateTime DATE_MINUS_4_HOURS = DATE.minusHours(4);
@@ -54,27 +50,24 @@ public class BeamSqlTimestampMinusTimestampExpressionTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void testOutputTypeIsBigint() {
+  @Test
+  public void testOutputTypeIsBigint() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            timestamp(DATE_MINUS_2_SEC),
-            timestamp(DATE));
+        minusExpression(SqlTypeName.INTERVAL_DAY, timestamp(DATE_MINUS_2_SEC), timestamp(DATE));
 
     assertEquals(SqlTypeName.BIGINT, minusExpression.getOutputType());
   }
 
-  @Test public void testAccepts2Timestamps() {
+  @Test
+  public void testAccepts2Timestamps() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            timestamp(DATE_MINUS_2_SEC),
-            timestamp(DATE));
+        minusExpression(SqlTypeName.INTERVAL_DAY, timestamp(DATE_MINUS_2_SEC), timestamp(DATE));
 
     assertTrue(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAccept3Timestamps() {
+  @Test
+  public void testDoesNotAccept3Timestamps() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
             SqlTypeName.INTERVAL_DAY,
@@ -85,131 +78,113 @@ public class BeamSqlTimestampMinusTimestampExpressionTest {
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAccept1Timestamp() {
+  @Test
+  public void testDoesNotAccept1Timestamp() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            timestamp(DATE));
+        minusExpression(SqlTypeName.INTERVAL_DAY, timestamp(DATE));
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptUnsupportedIntervalToCount() {
+  @Test
+  public void testDoesNotAcceptUnsupportedIntervalToCount() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
-            SqlTypeName.INTERVAL_DAY_MINUTE,
-            timestamp(DATE_MINUS_2_SEC),
-            timestamp(DATE));
+            SqlTypeName.INTERVAL_DAY_MINUTE, timestamp(DATE_MINUS_2_SEC), timestamp(DATE));
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptNotTimestampAsOperandOne() {
+  @Test
+  public void testDoesNotAcceptNotTimestampAsOperandOne() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3),
-            timestamp(DATE));
+            SqlTypeName.INTERVAL_DAY, BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3), timestamp(DATE));
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testDoesNotAcceptNotTimestampAsOperandTwo() {
+  @Test
+  public void testDoesNotAcceptNotTimestampAsOperandTwo() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            timestamp(DATE),
-            BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
+            SqlTypeName.INTERVAL_DAY, timestamp(DATE), BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
 
     assertFalse(minusExpression.accept());
   }
 
-  @Test public void testEvaluateDiffSeconds() {
+  @Test
+  public void testEvaluateDiffSeconds() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_SECOND,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_2_SEC));
+        minusExpression(SqlTypeName.INTERVAL_SECOND, timestamp(DATE), timestamp(DATE_MINUS_2_SEC));
 
     long expectedResult = applyMultiplier(2L, TimeUnit.SECOND);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateDiffMinutes() {
+  @Test
+  public void testEvaluateDiffMinutes() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_MINUTE,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_3_MIN));
+        minusExpression(SqlTypeName.INTERVAL_MINUTE, timestamp(DATE), timestamp(DATE_MINUS_3_MIN));
 
     long expectedResult = applyMultiplier(3L, TimeUnit.MINUTE);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateDiffHours() {
+  @Test
+  public void testEvaluateDiffHours() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_HOUR,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_4_HOURS));
+        minusExpression(SqlTypeName.INTERVAL_HOUR, timestamp(DATE), timestamp(DATE_MINUS_4_HOURS));
 
     long expectedResult = applyMultiplier(4L, TimeUnit.HOUR);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateDiffDays() {
+  @Test
+  public void testEvaluateDiffDays() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_DAY,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_7_DAYS));
+        minusExpression(SqlTypeName.INTERVAL_DAY, timestamp(DATE), timestamp(DATE_MINUS_7_DAYS));
 
     long expectedResult = applyMultiplier(7L, TimeUnit.DAY);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateDiffMonths() {
+  @Test
+  public void testEvaluateDiffMonths() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
-            SqlTypeName.INTERVAL_MONTH,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_2_MONTHS));
+            SqlTypeName.INTERVAL_MONTH, timestamp(DATE), timestamp(DATE_MINUS_2_MONTHS));
 
     long expectedResult = applyMultiplier(2L, TimeUnit.MONTH);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateDiffYears() {
+  @Test
+  public void testEvaluateDiffYears() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_YEAR,
-            timestamp(DATE),
-            timestamp(DATE_MINUS_1_YEAR));
+        minusExpression(SqlTypeName.INTERVAL_YEAR, timestamp(DATE), timestamp(DATE_MINUS_1_YEAR));
 
     long expectedResult = applyMultiplier(1L, TimeUnit.YEAR);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateNegativeDiffSeconds() {
+  @Test
+  public void testEvaluateNegativeDiffSeconds() {
     BeamSqlTimestampMinusTimestampExpression minusExpression =
-        minusExpression(
-            SqlTypeName.INTERVAL_SECOND,
-            timestamp(DATE_MINUS_2_SEC),
-            timestamp(DATE));
+        minusExpression(SqlTypeName.INTERVAL_SECOND, timestamp(DATE_MINUS_2_SEC), timestamp(DATE));
 
     long expectedResult = applyMultiplier(-2L, TimeUnit.SECOND);
     assertEquals(expectedResult, eval(minusExpression));
   }
 
-  @Test public void testEvaluateThrowsForUnsupportedIntervalType() {
+  @Test
+  public void testEvaluateThrowsForUnsupportedIntervalType() {
 
     thrown.expect(IllegalArgumentException.class);
 
     BeamSqlTimestampMinusTimestampExpression minusExpression =
         minusExpression(
-            SqlTypeName.INTERVAL_DAY_MINUTE,
-            timestamp(DATE_MINUS_2_SEC),
-            timestamp(DATE));
+            SqlTypeName.INTERVAL_DAY_MINUTE, timestamp(DATE_MINUS_2_SEC), timestamp(DATE));
 
     eval(minusExpression);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtilsTest.java
@@ -25,28 +25,34 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link TimeUnitUtils}.
- */
+/** Unit tests for {@link TimeUnitUtils}. */
 public class TimeUnitUtilsTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void testReturnsInternalTimeUnitMultipliers() {
-    assertEquals(TimeUnit.SECOND.multiplier,
+  @Test
+  public void testReturnsInternalTimeUnitMultipliers() {
+    assertEquals(
+        TimeUnit.SECOND.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_SECOND));
-    assertEquals(TimeUnit.MINUTE.multiplier,
+    assertEquals(
+        TimeUnit.MINUTE.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_MINUTE));
-    assertEquals(TimeUnit.HOUR.multiplier,
+    assertEquals(
+        TimeUnit.HOUR.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_HOUR));
-    assertEquals(TimeUnit.DAY.multiplier,
+    assertEquals(
+        TimeUnit.DAY.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_DAY));
-    assertEquals(TimeUnit.MONTH.multiplier,
+    assertEquals(
+        TimeUnit.MONTH.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_MONTH));
-    assertEquals(TimeUnit.YEAR.multiplier,
+    assertEquals(
+        TimeUnit.YEAR.multiplier,
         TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_YEAR));
   }
 
-  @Test public void testThrowsForUnsupportedIntervalType() {
+  @Test
+  public void testThrowsForUnsupportedIntervalType() {
     thrown.expect(IllegalArgumentException.class);
     TimeUnitUtils.timeUnitInternalMultiplier(SqlTypeName.INTERVAL_DAY_MINUTE);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpressionTest.java
@@ -27,11 +27,10 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamSqlNotExpression}.
- */
+/** Test for {@code BeamSqlNotExpression}. */
 public class BeamSqlNotExpressionTest extends BeamSqlFnExecutorTestBase {
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, false));
     Assert.assertTrue(new BeamSqlNotExpression(operands).evaluate(row, null).getBoolean());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
@@ -29,12 +29,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for {@link BeamSqlMathBinaryExpression}.
- */
+/** Test for {@link BeamSqlMathBinaryExpression}. */
 public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void testForGreaterThanTwoOperands() {
+  @Test
+  public void testForGreaterThanTwoOperands() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // operands more than 2 not allowed
@@ -44,14 +43,16 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     Assert.assertFalse(new BeamSqlRoundExpression(operands).accept());
   }
 
-  @Test public void testForOneOperand() {
+  @Test
+  public void testForOneOperand() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // only one operand allowed in round function
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
   }
 
-  @Test public void testForOperandsType() {
+  @Test
+  public void testForOperandsType() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // varchar operand not allowed
@@ -60,15 +61,15 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     Assert.assertFalse(new BeamSqlRoundExpression(operands).accept());
   }
 
-  @Test public void testRoundFunction() {
+  @Test
+  public void testRoundFunction() {
     // test round functions with operands of type bigint, int,
     // tinyint, smallint, double, decimal
     List<BeamSqlExpression> operands = new ArrayList<>();
     // round(double, double) => double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
-    Assert.assertEquals(2.0,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(2.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
     // round(integer,integer) => integer
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
@@ -84,7 +85,8 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // round(short) => short
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, new Short("4")));
-    Assert.assertEquals(SqlFunctions.toShort(4),
+    Assert.assertEquals(
+        SqlFunctions.toShort(4),
         new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     // round(long,long) => long
@@ -96,31 +98,26 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    Assert.assertEquals(1.1,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(1.1, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.368768));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    Assert.assertEquals(2.37,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(2.37, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 3.78683686458));
-    Assert.assertEquals(4.0,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(4.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 378.683686458));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -2));
-    Assert.assertEquals(400.0,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(400.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 378.683686458));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    Assert.assertEquals(380.0,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(380.0, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
 
     // round(integer, double) => integer
     operands.clear();
@@ -135,81 +132,78 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(ref0);
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
 
-    Assert.assertEquals(1234567L,
-        new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1234567L, new BeamSqlRoundExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testPowerFunction() {
+  @Test
+  public void testPowerFunction() {
     // test power functions with operands of type bigint, int,
     // tinyint, smallint, double, decimal
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
-    Assert.assertEquals(16.0,
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(16.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
     // power(integer,integer) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    Assert.assertEquals(4.0,
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(4.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
     // power(integer,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 3L));
-    Assert.assertEquals(8.0
-        , new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(8.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
 
     // power(long,long) => long
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 2L));
-    Assert.assertEquals(4.0,
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(4.0, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
 
     // power(double, int) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    Assert.assertEquals(1.1,
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(1.1, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
 
     // power(double, long) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 1.1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, 1L));
-    Assert.assertEquals(1.1,
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(1.1, new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
 
     // power(integer, double) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.2));
-    Assert.assertEquals(Math.pow(2, 2.2),
-        new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.pow(2, 2.2), new BeamSqlPowerExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForTruncate() {
+  @Test
+  public void testForTruncate() {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.0));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 4.0));
-    Assert.assertEquals(2.0,
-        new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2.0, new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
     // truncate(double, integer) => double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.80685));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 4));
-    Assert.assertEquals(2.8068,
-        new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        2.8068, new BeamSqlTruncateExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForAtan2() {
+  @Test
+  public void testForAtan2() {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.875));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.56));
-    Assert.assertEquals(Math.atan2(0.875, 0.56),
+    Assert.assertEquals(
+        Math.atan2(0.875, 0.56),
         new BeamSqlAtan2Expression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathUnaryExpressionTest.java
@@ -28,12 +28,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for {@link BeamSqlMathUnaryExpression}.
- */
+/** Test for {@link BeamSqlMathUnaryExpression}. */
 public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void testForGreaterThanOneOperands() {
+  @Test
+  public void testForGreaterThanOneOperands() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // operands more than 1 not allowed
@@ -42,7 +41,8 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     Assert.assertFalse(new BeamSqlAbsExpression(operands).accept());
   }
 
-  @Test public void testForOperandsType() {
+  @Test
+  public void testForOperandsType() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // varchar operand not allowed
@@ -50,7 +50,8 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     Assert.assertFalse(new BeamSqlAbsExpression(operands).accept());
   }
 
-  @Test public void testForUnaryExpressions() {
+  @Test
+  public void testForUnaryExpressions() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for sqrt function
@@ -59,227 +60,241 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for abs function
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.BIGINT, -28965734597L));
-    Assert.assertEquals(28965734597L,
-        new BeamSqlAbsExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        28965734597L, new BeamSqlAbsExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForLnExpression() {
+  @Test
+  public void testForLnExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for LN function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.log(2),
-        new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log(2), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
 
     // test for LN function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert
-        .assertEquals(Math.log(2.4),
-            new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log(2.4), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
     // test for LN function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.log(2.56),
-        new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log(2.56), new BeamSqlLnExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForLog10Expression() {
+  @Test
+  public void testForLog10Expression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for log10 function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.log10(2),
-        new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log10(2), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
     // test for log10 function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.log10(2.4),
-        new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log10(2.4), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
     // test for log10 function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.log10(2.56),
-        new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.log10(2.56), new BeamSqlLogExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForExpExpression() {
+  @Test
+  public void testForExpExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.exp(2),
-        new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.exp(2), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.exp(2.4),
-        new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.exp(2.4), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.exp(2.56),
-        new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.exp(2.56), new BeamSqlExpExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForAcosExpression() {
+  @Test
+  public void testForAcosExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Double.NaN,
-        new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Double.NaN, new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
-    Assert.assertEquals(Math.acos(0.45),
-        new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.acos(0.45), new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
-    Assert.assertEquals(Math.acos(-0.367),
-        new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.acos(-0.367), new BeamSqlAcosExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForAsinExpression() {
+  @Test
+  public void testForAsinExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
-    Assert.assertEquals(Math.asin(0.45),
-        new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.asin(0.45), new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
-    Assert.assertEquals(Math.asin(-0.367),
-        new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.asin(-0.367), new BeamSqlAsinExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForAtanExpression() {
+  @Test
+  public void testForAtanExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
-    Assert.assertEquals(Math.atan(0.45),
-        new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.atan(0.45), new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
-    Assert.assertEquals(Math.atan(-0.367),
-        new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.atan(-0.367), new BeamSqlAtanExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForCosExpression() {
+  @Test
+  public void testForCosExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 0.45));
-    Assert.assertEquals(Math.cos(0.45),
-        new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.cos(0.45), new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-0.367)));
-    Assert.assertEquals(Math.cos(-0.367),
-        new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.cos(-0.367), new BeamSqlCosExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForCotExpression() {
+  @Test
+  public void testForCotExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type double
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, .45));
-    Assert.assertEquals(1.0d / Math.tan(0.45),
-        new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.0d / Math.tan(0.45), new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(-.367)));
-    Assert.assertEquals(1.0d / Math.tan(-0.367),
-        new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        1.0d / Math.tan(-0.367), new BeamSqlCotExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForDegreesExpression() {
+  @Test
+  public void testForDegreesExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.toDegrees(2),
+    Assert.assertEquals(
+        Math.toDegrees(2), new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
+    // test for exp function with operand type double
+    operands.clear();
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
+    Assert.assertEquals(
+        Math.toDegrees(2.4), new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
+    // test for exp function with operand type decimal
+    operands.clear();
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
+    Assert.assertEquals(
+        Math.toDegrees(2.56),
         new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
-    // test for exp function with operand type double
-    operands.clear();
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.toDegrees(2.4),
-        new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
-    // test for exp function with operand type decimal
-    operands.clear();
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.toDegrees(2.56),
-        new BeamSqlDegreesExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForRadiansExpression() {
+  @Test
+  public void testForRadiansExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.toRadians(2),
-        new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.toRadians(2), new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.toRadians(2.4),
-        new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.toRadians(2.4), new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.toRadians(2.56),
+    Assert.assertEquals(
+        Math.toRadians(2.56),
         new BeamSqlRadiansExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForSinExpression() {
+  @Test
+  public void testForSinExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.sin(2),
-        new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.sin(2), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.sin(2.4),
-        new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.sin(2.4), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.sin(2.56),
-        new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.sin(2.56), new BeamSqlSinExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForTanExpression() {
+  @Test
+  public void testForTanExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals(Math.tan(2),
-        new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.tan(2), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
-    Assert.assertEquals(Math.tan(2.4),
-        new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.tan(2.4), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(Math.tan(2.56),
-        new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.tan(2.56), new BeamSqlTanExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForSignExpression() {
+  @Test
+  public void testForSignExpression() {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     // test for exp function with operand type smallint
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("2")));
-    Assert.assertEquals((short) 1
-        , new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        (short) 1, new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
     // test for exp function with operand type double
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.4));
@@ -287,26 +302,29 @@ public class BeamSqlMathUnaryExpressionTest extends BeamSqlFnExecutorTestBase {
     // test for exp function with operand type decimal
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DECIMAL, BigDecimal.valueOf(2.56)));
-    Assert.assertEquals(BigDecimal.ONE,
-        new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        BigDecimal.ONE, new BeamSqlSignExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForPi() {
+  @Test
+  public void testForPi() {
     Assert.assertEquals(Math.PI, new BeamSqlPiExpression().evaluate(row, null).getValue());
   }
 
-  @Test public void testForCeil() {
+  @Test
+  public void testForCeil() {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.68687979));
-    Assert.assertEquals(Math.ceil(2.68687979),
-        new BeamSqlCeilExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        Math.ceil(2.68687979), new BeamSqlCeilExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void testForFloor() {
+  @Test
+  public void testForFloor() {
     List<BeamSqlExpression> operands = new ArrayList<>();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.DOUBLE, 2.68687979));
-    Assert.assertEquals(Math.floor(2.68687979),
+    Assert.assertEquals(
+        Math.floor(2.68687979),
         new BeamSqlFloorExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/DatetimeReinterpretConversionsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/DatetimeReinterpretConversionsTest.java
@@ -25,45 +25,43 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Unit test for {@link DatetimeReinterpretConversions}.
- */
+/** Unit test for {@link DatetimeReinterpretConversions}. */
 public class DatetimeReinterpretConversionsTest {
   private static final long DATE_LONG = 1000L;
   private static final DateTime DATE = new DateTime(DATE_LONG);
   private static final DateTime TIME = new DateTime().withDate(2017, 8, 9);
 
-  private static final BeamSqlPrimitive DATE_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.DATE, DATE);
+  private static final BeamSqlPrimitive DATE_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.DATE, DATE);
 
-  private static final BeamSqlPrimitive TIME_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.TIME, TIME);
+  private static final BeamSqlPrimitive TIME_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.TIME, TIME);
 
-  private static final BeamSqlPrimitive TIMESTAMP_PRIMITIVE = BeamSqlPrimitive.of(
-      SqlTypeName.TIMESTAMP, DATE);
+  private static final BeamSqlPrimitive TIMESTAMP_PRIMITIVE =
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
-  @Test public void testTimeToBigint() {
+  @Test
+  public void testTimeToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        DatetimeReinterpretConversions.TIME_TO_BIGINT
-          .convert(TIME_PRIMITIVE);
+        DatetimeReinterpretConversions.TIME_TO_BIGINT.convert(TIME_PRIMITIVE);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(TIME.getMillis(), conversionResultPrimitive.getLong());
   }
 
-  @Test public void testDateToBigint() {
+  @Test
+  public void testDateToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT
-            .convert(DATE_PRIMITIVE);
+        DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT.convert(DATE_PRIMITIVE);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(DATE_LONG, conversionResultPrimitive.getLong());
   }
 
-  @Test public void testTimestampToBigint() {
+  @Test
+  public void testTimestampToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT
-            .convert(TIMESTAMP_PRIMITIVE);
+        DatetimeReinterpretConversions.DATE_TYPES_TO_BIGINT.convert(TIMESTAMP_PRIMITIVE);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(DATE_LONG, conversionResultPrimitive.getLong());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/IntegerReinterpretConversionsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/IntegerReinterpretConversionsTest.java
@@ -24,56 +24,52 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-
-/**
- * Unit tests for {@link IntegerReinterpretConversions}.
- */
-
+/** Unit tests for {@link IntegerReinterpretConversions}. */
 public class IntegerReinterpretConversionsTest {
 
-  private static final BeamSqlPrimitive TINYINT_PRIMITIVE_5 = BeamSqlPrimitive.of(
-      SqlTypeName.TINYINT, (byte) 5);
+  private static final BeamSqlPrimitive TINYINT_PRIMITIVE_5 =
+      BeamSqlPrimitive.of(SqlTypeName.TINYINT, (byte) 5);
 
-  private static final BeamSqlPrimitive SMALLINT_PRIMITIVE_6 = BeamSqlPrimitive.of(
-      SqlTypeName.SMALLINT, (short) 6);
+  private static final BeamSqlPrimitive SMALLINT_PRIMITIVE_6 =
+      BeamSqlPrimitive.of(SqlTypeName.SMALLINT, (short) 6);
 
-  private static final BeamSqlPrimitive INTEGER_PRIMITIVE_8 = BeamSqlPrimitive.of(
-      SqlTypeName.INTEGER, 8);
+  private static final BeamSqlPrimitive INTEGER_PRIMITIVE_8 =
+      BeamSqlPrimitive.of(SqlTypeName.INTEGER, 8);
 
-  private static final BeamSqlPrimitive BIGINT_PRIMITIVE_15 = BeamSqlPrimitive.of(
-      SqlTypeName.BIGINT, 15L);
+  private static final BeamSqlPrimitive BIGINT_PRIMITIVE_15 =
+      BeamSqlPrimitive.of(SqlTypeName.BIGINT, 15L);
 
-  @Test public void testTinyIntToBigint() {
+  @Test
+  public void testTinyIntToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT
-            .convert(TINYINT_PRIMITIVE_5);
+        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT.convert(TINYINT_PRIMITIVE_5);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(5L, conversionResultPrimitive.getLong());
   }
 
-  @Test public void testSmallIntToBigint() {
+  @Test
+  public void testSmallIntToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT
-            .convert(SMALLINT_PRIMITIVE_6);
+        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT.convert(SMALLINT_PRIMITIVE_6);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(6L, conversionResultPrimitive.getLong());
   }
 
-  @Test public void testIntegerToBigint() {
+  @Test
+  public void testIntegerToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT
-            .convert(INTEGER_PRIMITIVE_8);
+        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT.convert(INTEGER_PRIMITIVE_8);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(8L, conversionResultPrimitive.getLong());
   }
 
-  @Test public void testBigintToBigint() {
+  @Test
+  public void testBigintToBigint() {
     BeamSqlPrimitive conversionResultPrimitive =
-        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT
-            .convert(BIGINT_PRIMITIVE_15);
+        IntegerReinterpretConversions.INTEGER_TYPES_TO_BIGINT.convert(BIGINT_PRIMITIVE_15);
 
     assertEquals(SqlTypeName.BIGINT, conversionResultPrimitive.getOutputType());
     assertEquals(15L, conversionResultPrimitive.getLong());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpretConversionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpretConversionTest.java
@@ -34,41 +34,38 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-
-/**
- * Unit test for {@link ReinterpretConversion}.
- */
+/** Unit test for {@link ReinterpretConversion}. */
 public class ReinterpretConversionTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void testNewInstanceProperties() {
+  @Test
+  public void testNewInstanceProperties() {
     Set<SqlTypeName> from = ImmutableSet.of(SqlTypeName.FLOAT, SqlTypeName.TIME);
     SqlTypeName to = SqlTypeName.BOOLEAN;
     Function<BeamSqlPrimitive, BeamSqlPrimitive> mockConversionFunction = mock(Function.class);
 
-    ReinterpretConversion conversion = ReinterpretConversion.builder()
-        .from(from)
-        .to(to)
-        .convert(mockConversionFunction)
-        .build();
+    ReinterpretConversion conversion =
+        ReinterpretConversion.builder().from(from).to(to).convert(mockConversionFunction).build();
 
     assertEquals(from, conversion.from());
     assertEquals(to, conversion.to());
   }
 
-  @Test public void testConvert() {
+  @Test
+  public void testConvert() {
     BeamSqlPrimitive integerPrimitive = BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3);
     BeamSqlPrimitive booleanPrimitive = BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, true);
 
     Function<BeamSqlPrimitive, BeamSqlPrimitive> mockConversionFunction = mock(Function.class);
     doReturn(booleanPrimitive).when(mockConversionFunction).apply(same(integerPrimitive));
 
-    ReinterpretConversion conversion = ReinterpretConversion.builder()
-        .from(SqlTypeName.INTEGER)
-        .to(SqlTypeName.BOOLEAN)
-        .convert(mockConversionFunction)
-        .build();
+    ReinterpretConversion conversion =
+        ReinterpretConversion.builder()
+            .from(SqlTypeName.INTEGER)
+            .to(SqlTypeName.BOOLEAN)
+            .convert(mockConversionFunction)
+            .build();
 
     BeamSqlPrimitive conversionResult = conversion.convert(integerPrimitive);
 
@@ -76,38 +73,34 @@ public class ReinterpretConversionTest {
     verify(mockConversionFunction).apply(same(integerPrimitive));
   }
 
-  @Test public void testBuilderThrowsWithoutFrom() {
+  @Test
+  public void testBuilderThrowsWithoutFrom() {
     thrown.expect(IllegalArgumentException.class);
-    ReinterpretConversion.builder()
-        .to(SqlTypeName.BOOLEAN)
-        .convert(mock(Function.class))
-        .build();
+    ReinterpretConversion.builder().to(SqlTypeName.BOOLEAN).convert(mock(Function.class)).build();
   }
 
-  @Test public void testBuilderThrowsWihtoutTo() {
+  @Test
+  public void testBuilderThrowsWihtoutTo() {
     thrown.expect(IllegalArgumentException.class);
-    ReinterpretConversion.builder()
-        .from(SqlTypeName.BOOLEAN)
-        .convert(mock(Function.class))
-        .build();
+    ReinterpretConversion.builder().from(SqlTypeName.BOOLEAN).convert(mock(Function.class)).build();
   }
 
-  @Test public void testBuilderThrowsWihtoutConversionFunction() {
+  @Test
+  public void testBuilderThrowsWihtoutConversionFunction() {
     thrown.expect(IllegalArgumentException.class);
-    ReinterpretConversion.builder()
-        .from(SqlTypeName.BOOLEAN)
-        .to(SqlTypeName.SMALLINT)
-        .build();
+    ReinterpretConversion.builder().from(SqlTypeName.BOOLEAN).to(SqlTypeName.SMALLINT).build();
   }
 
-  @Test public void testConvertThrowsForUnsupportedInput() {
+  @Test
+  public void testConvertThrowsForUnsupportedInput() {
     thrown.expect(IllegalArgumentException.class);
 
-    ReinterpretConversion conversion = ReinterpretConversion.builder()
-        .from(SqlTypeName.DATE)
-        .to(SqlTypeName.BOOLEAN)
-        .convert(mock(Function.class))
-        .build();
+    ReinterpretConversion conversion =
+        ReinterpretConversion.builder()
+            .from(SqlTypeName.DATE)
+            .to(SqlTypeName.BOOLEAN)
+            .convert(mock(Function.class))
+            .build();
 
     conversion.convert(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpreterTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/reinterpret/ReinterpreterTest.java
@@ -38,43 +38,49 @@ import org.mockito.internal.util.collections.Sets;
  * limitations under the License.
  */
 
-/**
- * Unit tests for {@link Reinterpreter}.
- */
+/** Unit tests for {@link Reinterpreter}. */
 public class ReinterpreterTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
-  @Test public void testBuilderCreatesInstance() {
+  @Test
+  public void testBuilderCreatesInstance() {
     Reinterpreter reinterpreter = newReinterpreter();
     assertNotNull(reinterpreter);
   }
 
-  @Test public void testBuilderThrowsWithoutConverters() {
+  @Test
+  public void testBuilderThrowsWithoutConverters() {
     thrown.expect(IllegalArgumentException.class);
     Reinterpreter.builder().build();
   }
 
-  @Test public void testCanConvertBetweenSupportedTypes() {
-    Reinterpreter reinterpreter = Reinterpreter.builder()
-        .withConversion(mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
-        .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
-        .build();
+  @Test
+  public void testCanConvertBetweenSupportedTypes() {
+    Reinterpreter reinterpreter =
+        Reinterpreter.builder()
+            .withConversion(
+                mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
+            .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
+            .build();
 
     assertTrue(reinterpreter.canConvert(SqlTypeName.SMALLINT, SqlTypeName.SYMBOL));
     assertTrue(reinterpreter.canConvert(SqlTypeName.DATE, SqlTypeName.SYMBOL));
     assertTrue(reinterpreter.canConvert(SqlTypeName.FLOAT, SqlTypeName.INTEGER));
   }
 
-  @Test public void testCannotConvertFromUnsupportedTypes() {
-    Reinterpreter reinterpreter = Reinterpreter.builder()
-        .withConversion(mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
-        .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
-        .build();
+  @Test
+  public void testCannotConvertFromUnsupportedTypes() {
+    Reinterpreter reinterpreter =
+        Reinterpreter.builder()
+            .withConversion(
+                mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
+            .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
+            .build();
 
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
     unsupportedTypes.removeAll(
-          Sets.newSet(SqlTypeName.DATE, SqlTypeName.SMALLINT, SqlTypeName.FLOAT));
+        Sets.newSet(SqlTypeName.DATE, SqlTypeName.SMALLINT, SqlTypeName.FLOAT));
 
     for (SqlTypeName unsupportedType : unsupportedTypes) {
       assertFalse(reinterpreter.canConvert(unsupportedType, SqlTypeName.DATE));
@@ -82,11 +88,14 @@ public class ReinterpreterTest {
     }
   }
 
-  @Test public void testCannotConvertToUnsupportedTypes() {
-    Reinterpreter reinterpreter = Reinterpreter.builder()
-        .withConversion(mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
-        .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
-        .build();
+  @Test
+  public void testCannotConvertToUnsupportedTypes() {
+    Reinterpreter reinterpreter =
+        Reinterpreter.builder()
+            .withConversion(
+                mockConversion(SqlTypeName.SYMBOL, SqlTypeName.SMALLINT, SqlTypeName.DATE))
+            .withConversion(mockConversion(SqlTypeName.INTEGER, SqlTypeName.FLOAT))
+            .build();
 
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
     unsupportedTypes.removeAll(Sets.newSet(SqlTypeName.SYMBOL, SqlTypeName.INTEGER));
@@ -98,7 +107,8 @@ public class ReinterpreterTest {
     }
   }
 
-  @Test public void testConvert() {
+  @Test
+  public void testConvert() {
     DateTime date = new DateTime(12345L);
     BeamSqlPrimitive stringPrimitive = BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello");
     BeamSqlPrimitive datePrimitive = BeamSqlPrimitive.of(SqlTypeName.DATE, date);
@@ -115,17 +125,19 @@ public class ReinterpreterTest {
     verify(mockConversion).convert(same(stringPrimitive));
   }
 
-  @Test public void testConvertThrowsForUnsupportedFromType() {
+  @Test
+  public void testConvertThrowsForUnsupportedFromType() {
     thrown.expect(UnsupportedOperationException.class);
 
-    BeamSqlPrimitive intervalPrimitive = BeamSqlPrimitive
-        .of(SqlTypeName.INTERVAL_DAY, new BigDecimal(2));
+    BeamSqlPrimitive intervalPrimitive =
+        BeamSqlPrimitive.of(SqlTypeName.INTERVAL_DAY, new BigDecimal(2));
 
     Reinterpreter reinterpreter = newReinterpreter();
     reinterpreter.convert(SqlTypeName.DATE, intervalPrimitive);
   }
 
-  @Test public void testConvertThrowsForUnsupportedToType() {
+  @Test
+  public void testConvertThrowsForUnsupportedToType() {
     thrown.expect(UnsupportedOperationException.class);
 
     BeamSqlPrimitive stringPrimitive = BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello");
@@ -136,14 +148,11 @@ public class ReinterpreterTest {
 
   private Reinterpreter newReinterpreter() {
     return Reinterpreter.builder()
-        .withConversion(
-            mockConversion(
-                SqlTypeName.DATE,
-                SqlTypeName.SMALLINT, SqlTypeName.VARCHAR))
+        .withConversion(mockConversion(SqlTypeName.DATE, SqlTypeName.SMALLINT, SqlTypeName.VARCHAR))
         .build();
   }
 
-  private ReinterpretConversion mockConversion(SqlTypeName convertTo, SqlTypeName ... convertFrom) {
+  private ReinterpretConversion mockConversion(SqlTypeName convertTo, SqlTypeName... convertFrom) {
     ReinterpretConversion conversion = mock(ReinterpretConversion.class);
 
     doReturn(Sets.newSet(convertFrom)).when(conversion).from();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpressionTest.java
@@ -31,9 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link BeamSqlFieldAccessExpression}.
- */
+/** Unit tests for {@link BeamSqlFieldAccessExpression}. */
 public class BeamSqlFieldAccessExpressionTest {
 
   private static final Row NULL_ROW = null;
@@ -44,9 +42,7 @@ public class BeamSqlFieldAccessExpressionTest {
   @Test
   public void testAccessesFieldOfArray() {
     BeamSqlPrimitive<List<String>> targetArray =
-        BeamSqlPrimitive.of(
-            SqlTypeName.ARRAY,
-            Arrays.asList("aaa", "bbb", "ccc"));
+        BeamSqlPrimitive.of(SqlTypeName.ARRAY, Arrays.asList("aaa", "bbb", "ccc"));
 
     BeamSqlFieldAccessExpression arrayExpression =
         new BeamSqlFieldAccessExpression(targetArray, 1, SqlTypeName.VARCHAR);
@@ -57,8 +53,7 @@ public class BeamSqlFieldAccessExpressionTest {
   @Test
   public void testAccessesFieldOfRow() {
     Schema schema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withVarcharField("f_string1")
             .withVarcharField("f_string2")
             .withVarcharField("f_string3")
@@ -66,11 +61,7 @@ public class BeamSqlFieldAccessExpressionTest {
 
     BeamSqlPrimitive<Row> targetRow =
         BeamSqlPrimitive.of(
-            SqlTypeName.ROW,
-            Row
-                .withSchema(schema)
-                .addValues("aa", "bb", "cc")
-                .build());
+            SqlTypeName.ROW, Row.withSchema(schema).addValues("aa", "bb", "cc").build());
 
     BeamSqlFieldAccessExpression arrayExpression =
         new BeamSqlFieldAccessExpression(targetRow, 1, SqlTypeName.VARCHAR);
@@ -86,6 +77,7 @@ public class BeamSqlFieldAccessExpressionTest {
     thrown.expectMessage("unsupported type");
 
     new BeamSqlFieldAccessExpression(targetRow, 1, SqlTypeName.VARCHAR)
-        .evaluate(NULL_ROW, NULL_WINDOW).getValue();
+        .evaluate(NULL_ROW, NULL_WINDOW)
+        .getValue();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlCharLengthExpressionTest.java
@@ -28,17 +28,14 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlCharLengthExpression.
- */
+/** Test for BeamSqlCharLengthExpression. */
 public class BeamSqlCharLengthExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
-    assertEquals(5,
-        new BeamSqlCharLengthExpression(operands).evaluate(row, null).getValue());
+    assertEquals(5, new BeamSqlCharLengthExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlConcatExpressionTest.java
@@ -30,12 +30,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlConcatExpression.
- */
+/** Test for BeamSqlConcatExpression. */
 public class BeamSqlConcatExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -54,13 +53,13 @@ public class BeamSqlConcatExpressionTest extends BeamSqlFnExecutorTestBase {
     assertFalse(new BeamSqlConcatExpression(operands).accept());
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, " world"));
-    Assert.assertEquals("hello world",
-        new BeamSqlConcatExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "hello world", new BeamSqlConcatExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlInitCapExpressionTest.java
@@ -28,27 +28,25 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test of BeamSqlInitCapExpression.
- */
+/** Test of BeamSqlInitCapExpression. */
 public class BeamSqlInitCapExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello world"));
-    assertEquals("Hello World",
-        new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "Hello World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hEllO wOrld"));
-    assertEquals("Hello World",
-        new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "Hello World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello     world"));
-    assertEquals("Hello     World",
-        new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
+    assertEquals(
+        "Hello     World", new BeamSqlInitCapExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlLowerExpressionTest.java
@@ -28,17 +28,14 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test of BeamSqlLowerExpression.
- */
+/** Test of BeamSqlLowerExpression. */
 public class BeamSqlLowerExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "HELLO"));
-    assertEquals("hello",
-        new BeamSqlLowerExpression(operands).evaluate(row, null).getValue());
+    assertEquals("hello", new BeamSqlLowerExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlOverlayExpressionTest.java
@@ -29,12 +29,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlOverlayExpression.
- */
+/** Test for BeamSqlOverlayExpression. */
 public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -50,38 +49,38 @@ public class BeamSqlOverlayExpressionTest extends BeamSqlFnExecutorTestBase {
     assertTrue(new BeamSqlOverlayExpression(operands).accept());
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "resou"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
-    Assert.assertEquals("w3resou3rce",
-        new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "w3resou3rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "resou"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 4));
-    Assert.assertEquals("w3resou33rce",
-        new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "w3resou33rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "resou"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
-    Assert.assertEquals("w3resou3rce",
-        new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "w3resou3rce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "w3333333rce"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "resou"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 3));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 7));
-    Assert.assertEquals("w3resouce",
-        new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "w3resouce", new BeamSqlOverlayExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlPositionExpressionTest.java
@@ -30,12 +30,11 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlPositionExpression.
- */
+/** Test for BeamSqlPositionExpression. */
 public class BeamSqlPositionExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -61,7 +60,8 @@ public class BeamSqlPositionExpressionTest extends BeamSqlFnExecutorTestBase {
     assertFalse(new BeamSqlPositionExpression(operands).accept());
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -80,5 +80,4 @@ public class BeamSqlPositionExpressionTest extends BeamSqlFnExecutorTestBase {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     assertEquals(-1, new BeamSqlPositionExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlStringUnaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlStringUnaryExpressionTest.java
@@ -28,12 +28,11 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlStringUnaryExpression.
- */
+/** Test for BeamSqlStringUnaryExpression. */
 public class BeamSqlStringUnaryExpressionTest {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -48,5 +47,4 @@ public class BeamSqlStringUnaryExpressionTest {
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     assertFalse(new BeamSqlCharLengthExpression(operands).accept());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlSubstringExpressionTest.java
@@ -29,12 +29,11 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlSubstringExpression.
- */
+/** Test for BeamSqlSubstringExpression. */
 public class BeamSqlSubstringExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
@@ -48,54 +47,47 @@ public class BeamSqlSubstringExpressionTest extends BeamSqlFnExecutorTestBase {
     assertTrue(new BeamSqlSubstringExpression(operands).accept());
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
-    assertEquals("hello",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 2));
-    assertEquals("he",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("he", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
-    assertEquals("hello",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 100));
-    assertEquals("hello",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("hello", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 0));
-    assertEquals("",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, 1));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    assertEquals("",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.INTEGER, -1));
-    assertEquals("o",
-        new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
+    assertEquals("o", new BeamSqlSubstringExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlTrimExpressionTest.java
@@ -32,12 +32,11 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
 
-/**
- * Test for BeamSqlTrimExpression.
- */
+/** Test for BeamSqlTrimExpression. */
 public class BeamSqlTrimExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void accept() throws Exception {
+  @Test
+  public void accept() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, " hello "));
@@ -55,49 +54,50 @@ public class BeamSqlTrimExpressionTest extends BeamSqlFnExecutorTestBase {
     assertFalse(new BeamSqlTrimExpression(operands).accept());
   }
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, SqlTrimFunction.Flag.LEADING));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hehe__hehe"));
-    Assert.assertEquals("__hehe",
-        new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "__hehe", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, SqlTrimFunction.Flag.TRAILING));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hehe__hehe"));
-    Assert.assertEquals("hehe__",
-        new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "hehe__", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.SYMBOL, SqlTrimFunction.Flag.BOTH));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "he"));
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "__"));
-    Assert.assertEquals("__",
-        new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals("__", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
 
     operands.clear();
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, " hello "));
-    Assert.assertEquals("hello",
-        new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
+    Assert.assertEquals(
+        "hello", new BeamSqlTrimExpression(operands).evaluate(row, null).getValue());
   }
 
-  @Test public void leadingTrim() throws Exception {
-    assertEquals("__hehe",
-        BeamSqlTrimExpression.leadingTrim("hehe__hehe", "he"));
+  @Test
+  public void leadingTrim() throws Exception {
+    assertEquals("__hehe", BeamSqlTrimExpression.leadingTrim("hehe__hehe", "he"));
   }
 
-  @Test public void trailingTrim() throws Exception {
-    assertEquals("hehe__",
-        BeamSqlTrimExpression.trailingTrim("hehe__hehe", "he"));
+  @Test
+  public void trailingTrim() throws Exception {
+    assertEquals("hehe__", BeamSqlTrimExpression.trailingTrim("hehe__hehe", "he"));
   }
 
-  @Test public void trim() throws Exception {
-    assertEquals("__",
+  @Test
+  public void trim() throws Exception {
+    assertEquals(
+        "__",
         BeamSqlTrimExpression.leadingTrim(
-        BeamSqlTrimExpression.trailingTrim("hehe__hehe", "he"), "he"
-        ));
+            BeamSqlTrimExpression.trailingTrim("hehe__hehe", "he"), "he"));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/string/BeamSqlUpperExpressionTest.java
@@ -28,17 +28,14 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Test of BeamSqlUpperExpression.
- */
+/** Test of BeamSqlUpperExpression. */
 public class BeamSqlUpperExpressionTest extends BeamSqlFnExecutorTestBase {
 
-  @Test public void evaluate() throws Exception {
+  @Test
+  public void evaluate() throws Exception {
     List<BeamSqlExpression> operands = new ArrayList<>();
 
     operands.add(BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "hello"));
-    assertEquals("HELLO",
-        new BeamSqlUpperExpression(operands).evaluate(row, null).getValue());
+    assertEquals("HELLO", new BeamSqlUpperExpression(operands).evaluate(row, null).getValue());
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLNestedTypesTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLNestedTypesTest.java
@@ -71,9 +71,11 @@ public class BeamDDLNestedTypesTest {
   private Table executeCreateTableWith(String fieldType) {
     String createTable =
         "create table tablename ( "
-        + "fieldName " + fieldType + " ) "
-        + "TYPE 'text' "
-        + "LOCATION '/home/admin/person'\n";
+            + "fieldName "
+            + fieldType
+            + " ) "
+            + "TYPE 'text' "
+            + "LOCATION '/home/admin/person'\n";
     System.out.println(createTable);
 
     SqlNode sqlNode;
@@ -90,16 +92,13 @@ public class BeamDDLNestedTypesTest {
   }
 
   private Schema newSimpleSchemaWith(FieldType fieldType) {
-    return Schema
-        .builder()
-        .addField(Field.of("fieldname", fieldType).withNullable(true))
-        .build();
+    return Schema.builder().addField(Field.of("fieldname", fieldType).withNullable(true)).build();
   }
 
   private String unparse(FieldType fieldType) {
     if (fieldType.getTypeName().isMapType()) {
       return unparseMap(fieldType);
-    } else if (fieldType.getTypeName().isCollectionType()){
+    } else if (fieldType.getTypeName().isCollectionType()) {
       return unparseArray(fieldType);
     } else if (fieldType.getTypeName().isCompositeType()) {
       return unparseRow(fieldType);
@@ -118,14 +117,14 @@ public class BeamDDLNestedTypesTest {
 
   private String unparseMap(FieldType fieldType) {
     return "MAP<"
-           + unparse(fieldType.getMapKeyType())
-           + ", "
-           + unparse(fieldType.getMapValueType()) + ">";
+        + unparse(fieldType.getMapKeyType())
+        + ", "
+        + unparse(fieldType.getMapValueType())
+        + ">";
   }
 
   private String unparseRow(FieldType fieldType) {
-    return
-        "ROW<"
+    return "ROW<"
         + fieldType
             .getRowSchema()
             .getFields()

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -34,9 +34,7 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link BeamSqlParserImpl}.
- */
+/** UnitTest for {@link BeamSqlParserImpl}. */
 public class BeamDDLTest {
 
   @Test
@@ -47,19 +45,16 @@ public class BeamDDLTest {
     hello.add("bond");
     properties.put("hello", hello);
 
-    Table table = parseTable(
-        "create table person (\n"
-            + "id int COMMENT 'id', \n"
-            + "name varchar COMMENT 'name') \n"
-            + "TYPE 'text' \n"
-            + "COMMENT 'person table' \n"
-            + "LOCATION '/home/admin/person'\n"
-            + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
-    );
-    assertEquals(
-        mockTable("person", "text", "person table", properties),
-        table
-    );
+    Table table =
+        parseTable(
+            "create table person (\n"
+                + "id int COMMENT 'id', \n"
+                + "name varchar COMMENT 'name') \n"
+                + "TYPE 'text' \n"
+                + "COMMENT 'person table' \n"
+                + "LOCATION '/home/admin/person'\n"
+                + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'");
+    assertEquals(mockTable("person", "text", "person table", properties), table);
   }
 
   @Test(expected = SqlParseException.class)
@@ -70,8 +65,7 @@ public class BeamDDLTest {
             + "name varchar COMMENT 'name') \n"
             + "COMMENT 'person table' \n"
             + "LOCATION '/home/admin/person'\n"
-            + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
-    );
+            + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'");
   }
 
   @Test
@@ -82,47 +76,41 @@ public class BeamDDLTest {
     hello.add("bond");
     properties.put("hello", hello);
 
-    Table table = parseTable(
-        "create table person (\n"
-            + "id int COMMENT 'id', \n"
-            + "name varchar COMMENT 'name') \n"
-            + "TYPE 'text' \n"
-            + "LOCATION '/home/admin/person'\n"
-            + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'"
-    );
+    Table table =
+        parseTable(
+            "create table person (\n"
+                + "id int COMMENT 'id', \n"
+                + "name varchar COMMENT 'name') \n"
+                + "TYPE 'text' \n"
+                + "LOCATION '/home/admin/person'\n"
+                + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'");
     assertEquals(mockTable("person", "text", null, properties), table);
   }
 
   @Test
   public void testParseCreateTable_withoutTblProperties() throws Exception {
-    Table table = parseTable(
-        "create table person (\n"
-            + "id int COMMENT 'id', \n"
-            + "name varchar COMMENT 'name') \n"
-            + "TYPE 'text' \n"
-            + "COMMENT 'person table' \n"
-            + "LOCATION '/home/admin/person'\n"
-    );
-    assertEquals(
-        mockTable("person", "text", "person table", new JSONObject()),
-        table
-    );
+    Table table =
+        parseTable(
+            "create table person (\n"
+                + "id int COMMENT 'id', \n"
+                + "name varchar COMMENT 'name') \n"
+                + "TYPE 'text' \n"
+                + "COMMENT 'person table' \n"
+                + "LOCATION '/home/admin/person'\n");
+    assertEquals(mockTable("person", "text", "person table", new JSONObject()), table);
   }
 
   @Test
   public void testParseCreateTable_withoutLocation() throws Exception {
-    Table table = parseTable(
-        "create table person (\n"
-            + "id int COMMENT 'id', \n"
-            + "name varchar COMMENT 'name') \n"
-            + "TYPE 'text' \n"
-            + "COMMENT 'person table' \n"
-    );
+    Table table =
+        parseTable(
+            "create table person (\n"
+                + "id int COMMENT 'id', \n"
+                + "name varchar COMMENT 'name') \n"
+                + "TYPE 'text' \n"
+                + "COMMENT 'person table' \n");
 
-    assertEquals(
-        mockTable("person", "text", "person table", new JSONObject(), null),
-        table
-    );
+    assertEquals(mockTable("person", "text", "person table", new JSONObject(), null), table);
   }
 
   @Test
@@ -149,26 +137,23 @@ public class BeamDDLTest {
     return mockTable(name, type, comment, properties, "/home/admin/" + name);
   }
 
-  private static Table mockTable(String name, String type, String comment, JSONObject properties,
-      String location) {
+  private static Table mockTable(
+      String name, String type, String comment, JSONObject properties, String location) {
 
-    return Table
-        .builder()
+    return Table.builder()
         .name(name)
         .type(type)
         .comment(comment)
         .location(location)
         .schema(
             Stream.of(
-                Schema.Field
-                    .of("id", TypeName.INT32.type())
-                    .withNullable(true)
-                    .withDescription("id"),
-                Schema.Field
-                    .of("name", RowSqlTypes.VARCHAR)
-                    .withNullable(true)
-                    .withDescription("name"))
-                  .collect(toSchema()))
+                    Schema.Field.of("id", TypeName.INT32.type())
+                        .withNullable(true)
+                        .withDescription("id"),
+                    Schema.Field.of("name", RowSqlTypes.VARCHAR)
+                        .withNullable(true)
+                        .withDescription("name"))
+                .collect(toSchema()))
         .properties(properties)
         .build();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
@@ -27,15 +27,13 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.BeamSqlTableProvider;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * Base class for rel test.
- */
+/** Base class for rel test. */
 abstract class BaseRelTest {
   private static Map<String, BeamSqlTable> tables = new HashMap();
   private static BeamSqlEnv env = new BeamSqlEnv(new BeamSqlTableProvider("test", tables));
 
-  protected static PCollection<Row> compilePipeline (
-      String sql, Pipeline pipeline) throws Exception {
+  protected static PCollection<Row> compilePipeline(String sql, Pipeline pipeline)
+      throws Exception {
     return env.getPlanner().compileBeamPipeline(sql, pipeline);
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverterTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverterTest.java
@@ -51,9 +51,7 @@ import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexLiteral;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamEnumerableConverter}.
- */
+/** Test for {@code BeamEnumerableConverter}. */
 public class BeamEnumerableConverterTest {
   static final JavaTypeFactory TYPE_FACTORY = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
   static RexBuilder rexBuilder = new RexBuilder(TYPE_FACTORY);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRelTest.java
@@ -29,61 +29,49 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamIntersectRel}.
- */
+/** Test for {@code BeamIntersectRel}. */
 public class BeamIntersectRelTest extends BaseRelTest {
 
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void prepare() {
-    registerTable("ORDER_DETAILS1",
+    registerTable(
+        "ORDER_DETAILS1",
         MockedBoundedTable.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            1L, 1, 1.0,
-            2L, 2, 2.0,
-            4L, 4, 4.0
-        )
-    );
+                TypeName.INT64, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.DOUBLE, "price")
+            .addRows(1L, 1, 1.0, 1L, 1, 1.0, 2L, 2, 2.0, 4L, 4, 4.0));
 
-    registerTable("ORDER_DETAILS2",
+    registerTable(
+        "ORDER_DETAILS2",
         MockedBoundedTable.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            2L, 2, 2.0,
-            3L, 3, 3.0
-        )
-    );
+                TypeName.INT64, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.DOUBLE, "price")
+            .addRows(1L, 1, 1.0, 2L, 2, 2.0, 3L, 3, 3.0));
   }
 
   @Test
   public void testIntersect() throws Exception {
     String sql = "";
-    sql += "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS1 "
-        + " INTERSECT "
-        + "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS2 ";
+    sql +=
+        "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS1 "
+            + " INTERSECT "
+            + "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS2 ";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            2L, 2, 2.0
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(1L, 1, 1.0, 2L, 2, 2.0)
+                .getRows());
 
     pipeline.run().waitUntilFinish();
   }
@@ -91,25 +79,24 @@ public class BeamIntersectRelTest extends BaseRelTest {
   @Test
   public void testIntersectAll() throws Exception {
     String sql = "";
-    sql += "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS1 "
-        + " INTERSECT ALL "
-        + "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS2 ";
+    sql +=
+        "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS1 "
+            + " INTERSECT ALL "
+            + "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS2 ";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows).satisfies(new CheckSize(3));
 
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            1L, 1, 1.0,
-            2L, 2, 2.0
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(1L, 1, 1.0, 1L, 1, 1.0, 2L, 2, 2.0)
+                .getRows());
 
     pipeline.run();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelBoundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelBoundedVsBoundedTest.java
@@ -29,34 +29,23 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Bounded + Bounded Test for {@code BeamJoinRel}.
- */
+/** Bounded + Bounded Test for {@code BeamJoinRel}. */
 public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   public static final MockedBoundedTable ORDER_DETAILS1 =
       MockedBoundedTable.of(
-          TypeName.INT32, "order_id",
-          TypeName.INT32, "site_id",
-          TypeName.INT32, "price"
-      ).addRows(
-          1, 2, 3,
-          2, 3, 3,
-          3, 4, 5
-      );
+              TypeName.INT32, "order_id",
+              TypeName.INT32, "site_id",
+              TypeName.INT32, "price")
+          .addRows(1, 2, 3, 2, 3, 3, 3, 4, 5);
 
   public static final MockedBoundedTable ORDER_DETAILS2 =
       MockedBoundedTable.of(
-          TypeName.INT32, "order_id",
-          TypeName.INT32, "site_id",
-          TypeName.INT32, "price"
-      ).addRows(
-          1, 2, 3,
-          2, 3, 3,
-          3, 4, 5
-      );
+              TypeName.INT32, "order_id",
+              TypeName.INT32, "site_id",
+              TypeName.INT32, "price")
+          .addRows(1, 2, 3, 2, 3, 3, 3, 4, 5);
 
   @BeforeClass
   public static void prepare() {
@@ -68,24 +57,23 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
   public void testInnerJoin() throws Exception {
     String sql =
         "SELECT *  "
-        + "FROM ORDER_DETAILS1 o1"
-        + " JOIN ORDER_DETAILS2 o2"
-        + " on "
-        + " o1.order_id=o2.site_id AND o2.price=o1.site_id"
-        ;
+            + "FROM ORDER_DETAILS1 o1"
+            + " JOIN ORDER_DETAILS2 o2"
+            + " on "
+            + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.INT32, "order_id0",
-            TypeName.INT32, "site_id0",
-            TypeName.INT32, "price0"
-        ).addRows(
-            2, 3, 3, 1, 2, 3
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.INT32, "price",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "site_id0",
+                    TypeName.INT32, "price0")
+                .addRows(2, 3, 3, 1, 2, 3)
+                .getRows());
     pipeline.run();
   }
 
@@ -96,24 +84,21 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
             + "FROM ORDER_DETAILS1 o1"
             + " LEFT OUTER JOIN ORDER_DETAILS2 o2"
             + " on "
-            + " o1.order_id=o2.site_id AND o2.price=o1.site_id"
-        ;
+            + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     pipeline.enableAbandonedNodeEnforcement(false);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.INT32, "order_id0",
-            TypeName.INT32, "site_id0",
-            TypeName.INT32, "price0"
-        ).addRows(
-            1, 2, 3, null, null, null,
-            2, 3, 3, 1, 2, 3,
-            3, 4, 5, null, null, null
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.INT32, "price",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "site_id0",
+                    TypeName.INT32, "price0")
+                .addRows(1, 2, 3, null, null, null, 2, 3, 3, 1, 2, 3, 3, 4, 5, null, null, null)
+                .getRows());
     pipeline.run();
   }
 
@@ -124,23 +109,20 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
             + "FROM ORDER_DETAILS1 o1"
             + " RIGHT OUTER JOIN ORDER_DETAILS2 o2"
             + " on "
-            + " o1.order_id=o2.site_id AND o2.price=o1.site_id"
-        ;
+            + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.INT32, "order_id0",
-            TypeName.INT32, "site_id0",
-            TypeName.INT32, "price0"
-        ).addRows(
-            2, 3, 3, 1, 2, 3,
-            null, null, null, 2, 3, 3,
-            null, null, null, 3, 4, 5
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.INT32, "price",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "site_id0",
+                    TypeName.INT32, "price0")
+                .addRows(2, 3, 3, 1, 2, 3, null, null, null, 2, 3, 3, null, null, null, 3, 4, 5)
+                .getRows());
     pipeline.run();
   }
 
@@ -151,25 +133,22 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
             + "FROM ORDER_DETAILS1 o1"
             + " FULL OUTER JOIN ORDER_DETAILS2 o2"
             + " on "
-            + " o1.order_id=o2.site_id AND o2.price=o1.site_id"
-        ;
+            + " o1.order_id=o2.site_id AND o2.price=o1.site_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.INT32, "order_id0",
-            TypeName.INT32, "site_id0",
-            TypeName.INT32, "price0"
-        ).addRows(
-          2, 3, 3, 1, 2, 3,
-          1, 2, 3, null, null, null,
-          3, 4, 5, null, null, null,
-          null, null, null, 2, 3, 3,
-          null, null, null, 3, 4, 5
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.INT32, "price",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "site_id0",
+                    TypeName.INT32, "price0")
+                .addRows(
+                    2, 3, 3, 1, 2, 3, 1, 2, 3, null, null, null, 3, 4, 5, null, null, null, null,
+                    null, null, 2, 3, 3, null, null, null, 3, 4, 5)
+                .getRows());
     pipeline.run();
   }
 
@@ -180,8 +159,7 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
             + "FROM ORDER_DETAILS1 o1"
             + " JOIN ORDER_DETAILS2 o2"
             + " on "
-            + " o1.order_id>o2.site_id"
-        ;
+            + " o1.order_id>o2.site_id";
 
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);
@@ -190,9 +168,7 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void testException_crossJoin() throws Exception {
-    String sql =
-        "SELECT *  "
-            + "FROM ORDER_DETAILS1 o1, ORDER_DETAILS2 o2";
+    String sql = "SELECT *  " + "FROM ORDER_DETAILS1 o1, ORDER_DETAILS2 o2";
 
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -43,12 +43,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Unbounded + Unbounded Test for {@code BeamJoinRel}.
- */
+/** Unbounded + Unbounded Test for {@code BeamJoinRel}. */
 public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
   public static final DateTime FIRST_DATE = new DateTime(1);
   public static final DateTime SECOND_DATE = new DateTime(1 + 3600 * 1000);
   public static final DateTime THIRD_DATE = new DateTime(1 + 3600 * 1000 + 3600 * 1000 + 1);
@@ -56,41 +53,50 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
 
   @BeforeClass
   public static void prepare() {
-    registerTable("ORDER_DETAILS", MockedUnboundedTable
-        .of(
-            TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.DATETIME, "order_time"
-        )
-        .timestampColumnIndex(3)
-        .addRows(
-            Duration.ZERO,
-            1, 1, 1, FIRST_DATE,
-            1, 2, 2, FIRST_DATE
-        )
-        .addRows(
-            WINDOW_SIZE.plus(Duration.standardSeconds(1)),
-            2, 2, 3, SECOND_DATE,
-            2, 3, 3, SECOND_DATE,
-            // this late data is omitted
-            1, 2, 3, FIRST_DATE
-        )
-        .addRows(
-            WINDOW_SIZE.plus(WINDOW_SIZE).plus(Duration.standardSeconds(1)),
-            3, 3, 3, THIRD_DATE,
-            // this late data is omitted
-            2, 2, 3, SECOND_DATE
-        )
-    );
+    registerTable(
+        "ORDER_DETAILS",
+        MockedUnboundedTable.of(
+                TypeName.INT32, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.INT32, "price",
+                TypeName.DATETIME, "order_time")
+            .timestampColumnIndex(3)
+            .addRows(Duration.ZERO, 1, 1, 1, FIRST_DATE, 1, 2, 2, FIRST_DATE)
+            .addRows(
+                WINDOW_SIZE.plus(Duration.standardSeconds(1)),
+                2,
+                2,
+                3,
+                SECOND_DATE,
+                2,
+                3,
+                3,
+                SECOND_DATE,
+                // this late data is omitted
+                1,
+                2,
+                3,
+                FIRST_DATE)
+            .addRows(
+                WINDOW_SIZE.plus(WINDOW_SIZE).plus(Duration.standardSeconds(1)),
+                3,
+                3,
+                3,
+                THIRD_DATE,
+                // this late data is omitted
+                2,
+                2,
+                3,
+                SECOND_DATE));
 
-    registerTable("ORDER_DETAILS1", MockedBoundedTable
-        .of(TypeName.INT32, "order_id",
-            TypeName.STRING, "buyer"
-        ).addRows(
-            1, "james",
-            2, "bond"
-        ));
+    registerTable(
+        "ORDER_DETAILS1",
+        MockedBoundedTable.of(
+                TypeName.INT32, "order_id",
+                TypeName.STRING, "buyer")
+            .addRows(
+                1, "james",
+                2, "bond"));
 
     registerTable(
         "SITE_LKP",
@@ -100,11 +106,8 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
                 TypeName.STRING, "site_name")));
   }
 
-  /**
-   * Test table for JOIN-AS-LOOKUP.
-   *
-   */
-  public static class SiteLookupTable extends BaseBeamTable implements BeamSqlSeekableTable{
+  /** Test table for JOIN-AS-LOOKUP. */
+  public static class SiteLookupTable extends BaseBeamTable implements BeamSqlSeekableTable {
 
     public SiteLookupTable(Schema schema) {
       super(schema);
@@ -133,94 +136,84 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
 
   @Test
   public void testInnerJoin_unboundedTableOnTheLeftSide() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " JOIN "
-        + " ORDER_DETAILS1 o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " JOIN "
+            + " ORDER_DETAILS1 o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.STRING, "buyer"
-            ).addRows(
-                1, 3, "james",
-                2, 5, "bond"
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.STRING, "buyer")
+                .addRows(1, 3, "james", 2, 5, "bond")
+                .getStringRows());
     pipeline.run();
   }
 
   @Test
   public void testInnerJoin_boundedTableOnTheLeftSide() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + " ORDER_DETAILS1 o2 "
-        + " JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + " ORDER_DETAILS1 o2 "
+            + " JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.STRING, "buyer"
-            ).addRows(
-                1, 3, "james",
-                2, 5, "bond"
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.STRING, "buyer")
+                .addRows(1, 3, "james", 2, 5, "bond")
+                .getStringRows());
     pipeline.run();
   }
 
   @Test
   public void testLeftOuterJoin() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " LEFT OUTER JOIN "
-        + " ORDER_DETAILS1 o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " LEFT OUTER JOIN "
+            + " ORDER_DETAILS1 o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     rows.apply(ParDo.of(new BeamSqlOutputToConsoleFn("helloworld")));
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.STRING, "buyer"
-            ).addRows(
-                1, 3, "james",
-                2, 5, "bond",
-                3, 3, null
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.STRING, "buyer")
+                .addRows(1, 3, "james", 2, 5, "bond", 3, 3, null)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test(expected = UnsupportedOperationException.class)
   public void testLeftOuterJoinError() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + " ORDER_DETAILS1 o2 "
-        + " LEFT OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + " ORDER_DETAILS1 o2 "
+            + " LEFT OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " on "
+            + " o1.order_id=o2.order_id";
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);
     pipeline.run();
@@ -228,40 +221,36 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
 
   @Test
   public void testRightOuterJoin() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + " ORDER_DETAILS1 o2 "
-        + " RIGHT OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + " ORDER_DETAILS1 o2 "
+            + " RIGHT OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " on "
+            + " o1.order_id=o2.order_id";
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.STRING, "buyer"
-            ).addRows(
-                1, 3, "james",
-                2, 5, "bond",
-                3, 3, null
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.STRING, "buyer")
+                .addRows(1, 3, "james", 2, 5, "bond", 3, 3, null)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test(expected = UnsupportedOperationException.class)
   public void testRightOuterJoinError() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " RIGHT OUTER JOIN "
-        + " ORDER_DETAILS1 o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " RIGHT OUTER JOIN "
+            + " ORDER_DETAILS1 o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);
@@ -270,14 +259,14 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
 
   @Test(expected = UnsupportedOperationException.class)
   public void testFullOuterJoinError() throws Exception {
-    String sql = "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
-        + " ORDER_DETAILS1 o2 "
-        + " FULL OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT o1.order_id, o1.sum_site_id, o2.buyer FROM "
+            + " ORDER_DETAILS1 o2 "
+            + " FULL OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " on "
+            + " o1.order_id=o2.order_id";
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);
     pipeline.run();
@@ -285,23 +274,21 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
 
   @Test
   public void testJoinAsLookup() throws Exception {
-    String sql = "SELECT o1.order_id, o2.site_name FROM "
-        + " ORDER_DETAILS o1 "
-        + " JOIN SITE_LKP o2 "
-        + " on "
-        + " o1.site_id=o2.site_id "
-        + " WHERE o1.site_id=1"
-        ;
+    String sql =
+        "SELECT o1.order_id, o2.site_name FROM "
+            + " ORDER_DETAILS o1 "
+            + " JOIN SITE_LKP o2 "
+            + " on "
+            + " o1.site_id=o2.site_id "
+            + " WHERE o1.site_id=1";
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.STRING, "site_name"
-            ).addRows(
-                1, "SITE1"
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.STRING, "site_name")
+                .addRows(1, "SITE1")
+                .getStringRows());
     pipeline.run();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsUnboundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsUnboundedTest.java
@@ -33,12 +33,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Unbounded + Unbounded Test for {@code BeamJoinRel}.
- */
+/** Unbounded + Unbounded Test for {@code BeamJoinRel}. */
 public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
   public static final DateTime FIRST_DATE = new DateTime(1);
   public static final DateTime SECOND_DATE = new DateTime(1 + 3600 * 1000);
 
@@ -46,71 +43,75 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
 
   @BeforeClass
   public static void prepare() {
-    registerTable("ORDER_DETAILS", MockedUnboundedTable
-        .of(TypeName.INT32, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.INT32, "price",
-            TypeName.DATETIME, "order_time"
-        )
-        .timestampColumnIndex(3)
-        .addRows(
-            Duration.ZERO,
-            1, 1, 1, FIRST_DATE,
-            1, 2, 6, FIRST_DATE
-        )
-        .addRows(
-            WINDOW_SIZE.plus(Duration.standardMinutes(1)),
-            2, 2, 7, SECOND_DATE,
-            2, 3, 8, SECOND_DATE,
-            // this late record is omitted(First window)
-            1, 3, 3, FIRST_DATE
-        )
-        .addRows(
-            // this late record is omitted(Second window)
-            WINDOW_SIZE.plus(WINDOW_SIZE).plus(Duration.standardMinutes(1)),
-            2, 3, 3, SECOND_DATE
-        )
-    );
+    registerTable(
+        "ORDER_DETAILS",
+        MockedUnboundedTable.of(
+                TypeName.INT32, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.INT32, "price",
+                TypeName.DATETIME, "order_time")
+            .timestampColumnIndex(3)
+            .addRows(Duration.ZERO, 1, 1, 1, FIRST_DATE, 1, 2, 6, FIRST_DATE)
+            .addRows(
+                WINDOW_SIZE.plus(Duration.standardMinutes(1)),
+                2,
+                2,
+                7,
+                SECOND_DATE,
+                2,
+                3,
+                8,
+                SECOND_DATE,
+                // this late record is omitted(First window)
+                1,
+                3,
+                3,
+                FIRST_DATE)
+            .addRows(
+                // this late record is omitted(Second window)
+                WINDOW_SIZE.plus(WINDOW_SIZE).plus(Duration.standardMinutes(1)),
+                2,
+                3,
+                3,
+                SECOND_DATE));
   }
 
   @Test
   public void testInnerJoin() throws Exception {
-    String sql = "SELECT * FROM "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT * FROM "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.INT32, "order_id0",
-                TypeName.INT32, "sum_site_id0").addRows(
-                1, 3, 1, 3,
-                2, 5, 2, 5
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "sum_site_id0")
+                .addRows(1, 3, 1, 3, 2, 5, 2, 5)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test
   public void testLeftOuterJoin() throws Exception {
-    String sql = "SELECT * FROM "
-        + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " LEFT OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT * FROM "
+            + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " LEFT OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     // 1, 1 | 1, 3
     // 2, 2 | NULL, NULL
@@ -122,93 +123,79 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.INT32, "order_id0",
-                TypeName.INT32, "sum_site_id0"
-            ).addRows(
-                1, 1, 1, 3,
-                2, 2, null, null,
-                2, 2, 2, 5,
-                3, 3, null, null
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "sum_site_id0")
+                .addRows(1, 1, 1, 3, 2, 2, null, null, 2, 2, 2, 5, 3, 3, null, null)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test
   public void testRightOuterJoin() throws Exception {
-    String sql = "SELECT * FROM "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " RIGHT OUTER JOIN "
-        + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT * FROM "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " RIGHT OUTER JOIN "
+            + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id",
-                TypeName.INT32, "order_id0",
-                TypeName.INT32, "sum_site_id0"
-            ).addRows(
-                1, 3, 1, 1,
-                null, null, 2, 2,
-                2, 5, 2, 2,
-                null, null, 3, 3
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.INT32, "order_id0",
+                    TypeName.INT32, "sum_site_id0")
+                .addRows(1, 3, 1, 1, null, null, 2, 2, 2, 5, 2, 2, null, null, 3, 3)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test
   public void testFullOuterJoin() throws Exception {
-    String sql = "SELECT * FROM "
-        + "(select price as order_id1, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY price, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
-        + " FULL OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id , TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
-        + " on "
-        + " o1.order_id1=o2.order_id"
-        ;
+    String sql =
+        "SELECT * FROM "
+            + "(select price as order_id1, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY price, TUMBLE(order_time, INTERVAL '1' HOUR)) o1 "
+            + " FULL OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id , TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
+            + " on "
+            + " o1.order_id1=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     rows.apply(ParDo.of(new BeamSqlOutputToConsoleFn("hello")));
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                TypeName.INT32, "order_id1",
-                TypeName.INT32, "sum_site_id",
-                TypeName.INT32, "order_id",
-                TypeName.INT32, "sum_site_id0"
-            ).addRows(
-                1, 1, 1, 3,
-                6, 2, null, null,
-                7, 2, null, null,
-                8, 3, null, null,
-                null, null, 2, 5
-            ).getStringRows()
-        );
+                    TypeName.INT32, "order_id1",
+                    TypeName.INT32, "sum_site_id",
+                    TypeName.INT32, "order_id",
+                    TypeName.INT32, "sum_site_id0")
+                .addRows(
+                    1, 1, 1, 3, 6, 2, null, null, 7, 2, null, null, 8, 3, null, null, null, null, 2,
+                    5)
+                .getStringRows());
     pipeline.run();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testWindowsMismatch() throws Exception {
-    String sql = "SELECT * FROM "
-        + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '2' HOUR)) o1 "
-        + " LEFT OUTER JOIN "
-        + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
-        + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
-        + " on "
-        + " o1.order_id=o2.order_id"
-        ;
+    String sql =
+        "SELECT * FROM "
+            + "(select site_id as order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY site_id, TUMBLE(order_time, INTERVAL '2' HOUR)) o1 "
+            + " LEFT OUTER JOIN "
+            + "(select order_id, sum(site_id) as sum_site_id FROM ORDER_DETAILS "
+            + "          GROUP BY order_id, TUMBLE(order_time, INTERVAL '1' HOUR)) o2 "
+            + " on "
+            + " o1.order_id=o2.order_id";
     pipeline.enableAbandonedNodeEnforcement(false);
     compilePipeline(sql, pipeline);
     pipeline.run();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRelTest.java
@@ -29,60 +29,48 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamMinusRel}.
- */
+/** Test for {@code BeamMinusRel}. */
 public class BeamMinusRelTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void prepare() {
-    registerTable("ORDER_DETAILS1",
+    registerTable(
+        "ORDER_DETAILS1",
         MockedBoundedTable.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            1L, 1, 1.0,
-            2L, 2, 2.0,
-            4L, 4, 4.0,
-            4L, 4, 4.0
-        )
-    );
+                TypeName.INT64, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.DOUBLE, "price")
+            .addRows(1L, 1, 1.0, 1L, 1, 1.0, 2L, 2, 2.0, 4L, 4, 4.0, 4L, 4, 4.0));
 
-    registerTable("ORDER_DETAILS2",
+    registerTable(
+        "ORDER_DETAILS2",
         MockedBoundedTable.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            2L, 2, 2.0,
-            3L, 3, 3.0
-        )
-    );
+                TypeName.INT64, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.DOUBLE, "price")
+            .addRows(1L, 1, 1.0, 2L, 2, 2.0, 3L, 3, 3.0));
   }
 
   @Test
   public void testExcept() throws Exception {
     String sql = "";
-    sql += "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS1 "
-        + " EXCEPT "
-        + "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS2 ";
+    sql +=
+        "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS1 "
+            + " EXCEPT "
+            + "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS2 ";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            4L, 4, 4.0
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(4L, 4, 4.0)
+                .getRows());
 
     pipeline.run();
   }
@@ -90,24 +78,24 @@ public class BeamMinusRelTest extends BaseRelTest {
   @Test
   public void testExceptAll() throws Exception {
     String sql = "";
-    sql += "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS1 "
-        + " EXCEPT ALL "
-        + "SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS2 ";
+    sql +=
+        "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS1 "
+            + " EXCEPT ALL "
+            + "SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS2 ";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows).satisfies(new CheckSize(2));
 
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            4L, 4, 4.0,
-            4L, 4, 4.0
-        ).getRows());
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(4L, 4, 4.0, 4L, 4, 4.0)
+                .getRows());
 
     pipeline.run();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRelTest.java
@@ -29,72 +29,62 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamUnionRel}.
- */
+/** Test for {@code BeamUnionRel}. */
 public class BeamUnionRelTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void prepare() {
-    registerTable("ORDER_DETAILS",
+    registerTable(
+        "ORDER_DETAILS",
         MockedBoundedTable.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            2L, 2, 2.0
-        )
-    );
+                TypeName.INT64, "order_id",
+                TypeName.INT32, "site_id",
+                TypeName.DOUBLE, "price")
+            .addRows(1L, 1, 1.0, 2L, 2, 2.0));
   }
 
   @Test
   public void testUnion() throws Exception {
-    String sql = "SELECT "
-        + " order_id, site_id, price "
-        + "FROM ORDER_DETAILS "
-        + " UNION SELECT "
-        + " order_id, site_id, price "
-        + "FROM ORDER_DETAILS ";
+    String sql =
+        "SELECT "
+            + " order_id, site_id, price "
+            + "FROM ORDER_DETAILS "
+            + " UNION SELECT "
+            + " order_id, site_id, price "
+            + "FROM ORDER_DETAILS ";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            2L, 2, 2.0
-        ).getRows()
-    );
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(1L, 1, 1.0, 2L, 2, 2.0)
+                .getRows());
     pipeline.run();
   }
 
   @Test
   public void testUnionAll() throws Exception {
-    String sql = "SELECT "
-        + " order_id, site_id, price "
-        + "FROM ORDER_DETAILS"
-        + " UNION ALL "
-        + " SELECT order_id, site_id, price "
-        + "FROM ORDER_DETAILS";
+    String sql =
+        "SELECT "
+            + " order_id, site_id, price "
+            + "FROM ORDER_DETAILS"
+            + " UNION ALL "
+            + " SELECT order_id, site_id, price "
+            + "FROM ORDER_DETAILS";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT64, "order_id",
-            TypeName.INT32, "site_id",
-            TypeName.DOUBLE, "price"
-        ).addRows(
-            1L, 1, 1.0,
-            1L, 1, 1.0,
-            2L, 2, 2.0,
-            2L, 2, 2.0
-        ).getRows()
-    );
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT64, "order_id",
+                    TypeName.INT32, "site_id",
+                    TypeName.DOUBLE, "price")
+                .addRows(1L, 1, 1.0, 1L, 1, 1.0, 2L, 2, 2.0, 2L, 2, 2.0)
+                .getRows());
     pipeline.run();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRelTest.java
@@ -29,43 +29,39 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Test for {@code BeamValuesRel}.
- */
+/** Test for {@code BeamValuesRel}. */
 public class BeamValuesRelTest extends BaseRelTest {
-  @Rule
-  public final TestPipeline pipeline = TestPipeline.create();
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   @BeforeClass
   public static void prepare() {
-    registerTable("string_table",
+    registerTable(
+        "string_table",
         MockedBoundedTable.of(
             TypeName.STRING, "name",
-            TypeName.STRING, "description"
-        )
-    );
-    registerTable("int_table",
+            TypeName.STRING, "description"));
+    registerTable(
+        "int_table",
         MockedBoundedTable.of(
             TypeName.INT32, "c0",
-            TypeName.INT32, "c1"
-        )
-    );
+            TypeName.INT32, "c1"));
   }
 
   @Test
   public void testValues() throws Exception {
-    String sql = "insert into string_table(name, description) values "
-        + "('hello', 'world'), ('james', 'bond')";
+    String sql =
+        "insert into string_table(name, description) values "
+            + "('hello', 'world'), ('james', 'bond')";
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.STRING, "name",
-            TypeName.STRING, "description"
-        ).addRows(
-            "hello", "world",
-            "james", "bond"
-        ).getRows()
-    );
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.STRING, "name",
+                    TypeName.STRING, "description")
+                .addRows(
+                    "hello", "world",
+                    "james", "bond")
+                .getRows());
     pipeline.run();
   }
 
@@ -73,14 +69,13 @@ public class BeamValuesRelTest extends BaseRelTest {
   public void testValues_castInt() throws Exception {
     String sql = "insert into int_table (c0, c1) values(cast(1 as int), cast(2 as int))";
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "c0",
-            TypeName.INT32, "c1"
-        ).addRows(
-            1, 2
-        ).getRows()
-    );
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "c0",
+                    TypeName.INT32, "c1")
+                .addRows(1, 2)
+                .getRows());
     pipeline.run();
   }
 
@@ -88,14 +83,13 @@ public class BeamValuesRelTest extends BaseRelTest {
   public void testValues_onlySelect() throws Exception {
     String sql = "select 1, '1'";
     PCollection<Row> rows = compilePipeline(sql, pipeline);
-    PAssert.that(rows).containsInAnyOrder(
-        TestUtils.RowsBuilder.of(
-            TypeName.INT32, "EXPR$0",
-            TypeName.STRING, "EXPR$1"
-        ).addRows(
-            1, "1"
-        ).getRows()
-    );
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    TypeName.INT32, "EXPR$0",
+                    TypeName.STRING, "EXPR$1")
+                .addRows(1, "1")
+                .getRows());
     pipeline.run();
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/CheckSize.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/CheckSize.java
@@ -22,16 +22,16 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.junit.Assert;
 
-/**
- * Utility class to check size of BeamSQLRow iterable.
- */
+/** Utility class to check size of BeamSQLRow iterable. */
 public class CheckSize implements SerializableFunction<Iterable<Row>, Void> {
   private int size;
+
   public CheckSize(int size) {
     this.size = size;
   }
 
-  @Override public Void apply(Iterable<Row> input) {
+  @Override
+  public Void apply(Iterable<Row> input) {
     int count = 0;
     for (Row row : input) {
       count++;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
@@ -31,33 +31,31 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Tests for BeamSqlRowCoder.
- */
+/** Tests for BeamSqlRowCoder. */
 public class BeamSqlRowCoderTest {
 
   @Test
   public void encodeAndDecode() throws Exception {
-    RelDataType relDataType = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT)
-        .builder()
-        .add("col_tinyint", SqlTypeName.TINYINT)
-        .add("col_smallint", SqlTypeName.SMALLINT)
-        .add("col_integer", SqlTypeName.INTEGER)
-        .add("col_bigint", SqlTypeName.BIGINT)
-        .add("col_float", SqlTypeName.FLOAT)
-        .add("col_double", SqlTypeName.DOUBLE)
-        .add("col_decimal", SqlTypeName.DECIMAL)
-        .add("col_string_varchar", SqlTypeName.VARCHAR)
-        .add("col_time", SqlTypeName.TIME)
-        .add("col_timestamp", SqlTypeName.TIMESTAMP)
-        .add("col_boolean", SqlTypeName.BOOLEAN)
-        .build();
+    RelDataType relDataType =
+        new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT)
+            .builder()
+            .add("col_tinyint", SqlTypeName.TINYINT)
+            .add("col_smallint", SqlTypeName.SMALLINT)
+            .add("col_integer", SqlTypeName.INTEGER)
+            .add("col_bigint", SqlTypeName.BIGINT)
+            .add("col_float", SqlTypeName.FLOAT)
+            .add("col_double", SqlTypeName.DOUBLE)
+            .add("col_decimal", SqlTypeName.DECIMAL)
+            .add("col_string_varchar", SqlTypeName.VARCHAR)
+            .add("col_time", SqlTypeName.TIME)
+            .add("col_timestamp", SqlTypeName.TIMESTAMP)
+            .add("col_boolean", SqlTypeName.BOOLEAN)
+            .build();
 
     Schema beamSchema = CalciteUtils.toBeamSchema(relDataType);
 
     Row row =
-        Row
-            .withSchema(beamSchema)
+        Row.withSchema(beamSchema)
             .addValues(
                 Byte.valueOf("1"),
                 Short.valueOf("1"),

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
@@ -1,18 +1,15 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
 package org.apache.beam.sdk.extensions.sql.impl.schema.transform;
@@ -53,13 +50,10 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link BeamAggregationTransforms}.
- */
+/** Unit tests for {@link BeamAggregationTransforms}. */
 public class BeamAggregationTransformTest extends BeamTransformBaseTest {
 
-  @Rule
-  public TestPipeline p = TestPipeline.create();
+  @Rule public TestPipeline p = TestPipeline.create();
 
   private List<AggregateCall> aggCalls;
 
@@ -74,6 +68,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
 
   /**
    * This step equals to below query.
+   *
    * <pre>
    * SELECT `f_int`
    * , COUNT(*) AS `size`
@@ -102,8 +97,8 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
 
     PCollection<Row> input = p.apply(Create.of(inputRows));
 
-    Schema keySchema = Schema.builder()
-        .addFields(Lists.newArrayList(inputSchema.getField(0))).build();
+    Schema keySchema =
+        Schema.builder().addFields(Lists.newArrayList(inputSchema.getField(0))).build();
     // 1. extract fields in group-by key part
     PCollection<KV<Row, Row>> exGroupByStream =
         input
@@ -130,9 +125,11 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
             .setCoder(KvCoder.of(keyCoder, aggCoder));
 
     //4. flat KV to a single record
-    PCollection<Row> mergedStream = aggregatedStream.apply(
-        "mergeRecord",
-        ParDo.of(new BeamAggregationTransforms.MergeAggregationRecord(outputType, aggCalls, -1)));
+    PCollection<Row> mergedStream =
+        aggregatedStream.apply(
+            "mergeRecord",
+            ParDo.of(
+                new BeamAggregationTransforms.MergeAggregationRecord(outputType, aggCalls, -1)));
     mergedStream.setCoder(outRecordCoder);
 
     //assert function BeamAggregationTransform.AggregationGroupByKeyFn
@@ -152,9 +149,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
     prepareTypeAndCoder();
   }
 
-  /**
-   * create list of all {@link AggregateCall}.
-   */
+  /** create list of all {@link AggregateCall}. */
   @SuppressWarnings("deprecation")
   private void prepareAggregationCalls() {
     //aggregations for all data type
@@ -357,58 +352,44 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
             "min8"));
   }
 
-  /**
-   * Coders used in aggregation steps.
-   */
+  /** Coders used in aggregation steps. */
   private void prepareTypeAndCoder() {
     inRecordCoder = inputSchema.getRowCoder();
 
-    keyType =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .build();
+    keyType = RowSqlTypes.builder().withIntegerField("f_int").build();
 
     keyCoder = keyType.getRowCoder();
 
-    aggPartType = RowSqlTypes
-        .builder()
-        .withBigIntField("count")
-
-        .withBigIntField("sum1")
-        .withBigIntField("avg1")
-        .withBigIntField("max1")
-        .withBigIntField("min1")
-
-        .withSmallIntField("sum2")
-        .withSmallIntField("avg2")
-        .withSmallIntField("max2")
-        .withSmallIntField("min2")
-
-        .withTinyIntField("sum3")
-        .withTinyIntField("avg3")
-        .withTinyIntField("max3")
-        .withTinyIntField("min3")
-
-        .withFloatField("sum4")
-        .withFloatField("avg4")
-        .withFloatField("max4")
-        .withFloatField("min4")
-
-        .withDoubleField("sum5")
-        .withDoubleField("avg5")
-        .withDoubleField("max5")
-        .withDoubleField("min5")
-
-        .withTimestampField("max7")
-        .withTimestampField("min7")
-
-        .withIntegerField("sum8")
-        .withIntegerField("avg8")
-        .withIntegerField("max8")
-        .withIntegerField("min8")
-
-        .build();
+    aggPartType =
+        RowSqlTypes.builder()
+            .withBigIntField("count")
+            .withBigIntField("sum1")
+            .withBigIntField("avg1")
+            .withBigIntField("max1")
+            .withBigIntField("min1")
+            .withSmallIntField("sum2")
+            .withSmallIntField("avg2")
+            .withSmallIntField("max2")
+            .withSmallIntField("min2")
+            .withTinyIntField("sum3")
+            .withTinyIntField("avg3")
+            .withTinyIntField("max3")
+            .withTinyIntField("min3")
+            .withFloatField("sum4")
+            .withFloatField("avg4")
+            .withFloatField("max4")
+            .withFloatField("min4")
+            .withDoubleField("sum5")
+            .withDoubleField("avg5")
+            .withDoubleField("max5")
+            .withDoubleField("min5")
+            .withTimestampField("max7")
+            .withTimestampField("min7")
+            .withIntegerField("sum8")
+            .withIntegerField("avg8")
+            .withIntegerField("max8")
+            .withIntegerField("min8")
+            .build();
 
     aggCoder = aggPartType.getRowCoder();
 
@@ -416,35 +397,23 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
     outRecordCoder = outputType.getRowCoder();
   }
 
-  /**
-   * expected results after {@link BeamAggregationTransforms.AggregationGroupByKeyFn}.
-   */
+  /** expected results after {@link BeamAggregationTransforms.AggregationGroupByKeyFn}. */
   private List<KV<Row, Row>> prepareResultOfAggregationGroupByKeyFn() {
-    return
-        IntStream
-            .range(0, 4)
-            .mapToObj(i -> KV.of(
-                Row
-                    .withSchema(keyType)
-                    .addValues(inputRows.get(i).getInt32(0))
-                    .build(),
-                inputRows.get(i)
-            )).collect(Collectors.toList());
+    return IntStream.range(0, 4)
+        .mapToObj(
+            i ->
+                KV.of(
+                    Row.withSchema(keyType).addValues(inputRows.get(i).getInt32(0)).build(),
+                    inputRows.get(i)))
+        .collect(Collectors.toList());
   }
 
-  /**
-   * expected results.
-   */
-  private List<KV<Row, Row>> prepareResultOfAggregationCombineFn()
-      throws ParseException {
+  /** expected results. */
+  private List<KV<Row, Row>> prepareResultOfAggregationCombineFn() throws ParseException {
     return Arrays.asList(
         KV.of(
-            Row
-                .withSchema(keyType)
-                .addValues(inputRows.get(0).getInt32(0))
-                .build(),
-            Row
-                .withSchema(aggPartType)
+            Row.withSchema(keyType).addValues(inputRows.get(0).getInt32(0)).build(),
+            Row.withSchema(aggPartType)
                 .addValues(
                     4L,
                     10000L,
@@ -476,59 +445,43 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
                 .build()));
   }
 
-
-  /**
-   * Row type of final output row.
-   */
+  /** Row type of final output row. */
   private Schema prepareFinalRowType() {
-    return
-        RowSqlTypes
-            .builder()
-            .withIntegerField("f_int")
-            .withBigIntField("count")
-
-            .withBigIntField("sum1")
-            .withBigIntField("avg1")
-            .withBigIntField("max1")
-            .withBigIntField("min1")
-
-            .withSmallIntField("sum2")
-            .withSmallIntField("avg2")
-            .withSmallIntField("max2")
-            .withSmallIntField("min2")
-
-            .withTinyIntField("sum3")
-            .withTinyIntField("avg3")
-            .withTinyIntField("max3")
-            .withTinyIntField("min3")
-
-            .withFloatField("sum4")
-            .withFloatField("avg4")
-            .withFloatField("max4")
-            .withFloatField("min4")
-
-            .withDoubleField("sum5")
-            .withDoubleField("avg5")
-            .withDoubleField("max5")
-            .withDoubleField("min5")
-
-            .withTimestampField("max7")
-            .withTimestampField("min7")
-
-            .withIntegerField("sum8")
-            .withIntegerField("avg8")
-            .withIntegerField("max8")
-            .withIntegerField("min8")
-
-            .build();
+    return RowSqlTypes.builder()
+        .withIntegerField("f_int")
+        .withBigIntField("count")
+        .withBigIntField("sum1")
+        .withBigIntField("avg1")
+        .withBigIntField("max1")
+        .withBigIntField("min1")
+        .withSmallIntField("sum2")
+        .withSmallIntField("avg2")
+        .withSmallIntField("max2")
+        .withSmallIntField("min2")
+        .withTinyIntField("sum3")
+        .withTinyIntField("avg3")
+        .withTinyIntField("max3")
+        .withTinyIntField("min3")
+        .withFloatField("sum4")
+        .withFloatField("avg4")
+        .withFloatField("max4")
+        .withFloatField("min4")
+        .withDoubleField("sum5")
+        .withDoubleField("avg5")
+        .withDoubleField("max5")
+        .withDoubleField("min5")
+        .withTimestampField("max7")
+        .withTimestampField("min7")
+        .withIntegerField("sum8")
+        .withIntegerField("avg8")
+        .withIntegerField("max8")
+        .withIntegerField("min8")
+        .build();
   }
 
-  /**
-   * expected results after {@link BeamAggregationTransforms.MergeAggregationRecord}.
-   */
+  /** expected results after {@link BeamAggregationTransforms.MergeAggregationRecord}. */
   private Row prepareResultOfMergeAggregationRow() throws ParseException {
-    return Row
-        .withSchema(outputType)
+    return Row.withSchema(outputType)
         .addValues(
             1,
             4L,

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamTransformBaseTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamTransformBaseTest.java
@@ -1,14 +1,13 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- * <p>
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,9 +26,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.BeforeClass;
 
-/**
- * shared methods to test PTransforms which execute Beam SQL steps.
- */
+/** shared methods to test PTransforms which execute Beam SQL steps. */
 public class BeamTransformBaseTest {
   static final DateTimeFormatter FORMAT = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -39,8 +36,7 @@ public class BeamTransformBaseTest {
   @BeforeClass
   public static void prepareInput() throws NumberFormatException, ParseException {
     inputSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withIntegerField("f_int")
             .withBigIntField("f_long")
             .withSmallIntField("f_short")
@@ -53,8 +49,7 @@ public class BeamTransformBaseTest {
             .build();
 
     inputRows =
-        TestUtils.RowsBuilder
-            .of(inputSchema)
+        TestUtils.RowsBuilder.of(inputSchema)
             .addRows(
                 1,
                 1000L,

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceAccumulatorTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceAccumulatorTest.java
@@ -28,9 +28,7 @@ import static org.junit.Assert.assertNotEquals;
 import java.math.BigDecimal;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link VarianceAccumulator}.
- */
+/** Unit tests for {@link VarianceAccumulator}. */
 public class VarianceAccumulatorTest {
   private static final double DELTA = 1e-7;
   private static final BigDecimal FIFTEEN = new BigDecimal(15);
@@ -66,8 +64,7 @@ public class VarianceAccumulatorTest {
 
   @Test
   public void testCombinesEmptyWithEmpty() {
-    VarianceAccumulator result = VarianceAccumulator.EMPTY
-        .combineWith(VarianceAccumulator.EMPTY);
+    VarianceAccumulator result = VarianceAccumulator.EMPTY.combineWith(VarianceAccumulator.EMPTY);
 
     assertEquals(VarianceAccumulator.EMPTY, result);
   }
@@ -102,29 +99,23 @@ public class VarianceAccumulatorTest {
     // result:
     //   increment() = 3/(4(3+4))  *  (4 * 4/3 - 5)^2 = 0.107142857 * 0.111111111 = 0.011904762
     //   var(combine(x,y)) = 15 + 16 + increment() = 31.011904762
-    VarianceAccumulator expectedCombined = newVarianceAccumulator(
-        FIFTEEN.add(SIXTEEN).add(new BigDecimal(0.011904762)),
-        THREE.add(FOUR),
-        FOUR.add(FIVE));
+    VarianceAccumulator expectedCombined =
+        newVarianceAccumulator(
+            FIFTEEN.add(SIXTEEN).add(new BigDecimal(0.011904762)), THREE.add(FOUR), FOUR.add(FIVE));
 
     VarianceAccumulator combined1 = accumulator1.combineWith(accumulator2);
     VarianceAccumulator combined2 = accumulator2.combineWith(accumulator1);
 
     assertEquals(
-        expectedCombined.variance().doubleValue(),
-        combined1.variance().doubleValue(),
-        DELTA);
+        expectedCombined.variance().doubleValue(), combined1.variance().doubleValue(), DELTA);
 
     assertEquals(
-        expectedCombined.variance().doubleValue(),
-        combined2.variance().doubleValue(),
-        DELTA);
+        expectedCombined.variance().doubleValue(), combined2.variance().doubleValue(), DELTA);
 
     assertEquals(expectedCombined.count(), combined1.count());
     assertEquals(expectedCombined.sum(), combined1.sum());
 
     assertEquals(expectedCombined.count(), combined2.count());
     assertEquals(expectedCombined.sum(), combined2.sum());
-
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/transform/agg/VarianceFnTest.java
@@ -32,9 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-/**
- * Unit tests for {@link VarianceFnTest}.
- */
+/** Unit tests for {@link VarianceFnTest}. */
 @RunWith(Parameterized.class)
 public class VarianceFnTest {
   private static final BigDecimal FIFTEEN = new BigDecimal(15);
@@ -43,25 +41,29 @@ public class VarianceFnTest {
 
   @Parameters(name = "varianceFn {index}")
   public static Iterable<Object[]> varianceFns() {
-    return Arrays.asList(new Object[][]{{
-        VarianceFn.newPopulation(BigDecimal::intValue),
-        newVarianceAccumulator(FIFTEEN, THREE, ZERO),
-        5
-    }, {
-        VarianceFn.newSample(BigDecimal::intValue),
-        newVarianceAccumulator(FIFTEEN, FOUR, ZERO),
-        5
-    }
-    });
+    return Arrays.asList(
+        new Object[][] {
+          {
+            VarianceFn.newPopulation(BigDecimal::intValue),
+            newVarianceAccumulator(FIFTEEN, THREE, ZERO),
+            5
+          },
+          {
+            VarianceFn.newSample(BigDecimal::intValue),
+            newVarianceAccumulator(FIFTEEN, FOUR, ZERO),
+            5
+          }
+        });
   }
 
   private VarianceFn varianceFn;
   private VarianceAccumulator testAccumulatorInput;
   private int expectedExtractedResult;
 
-  public VarianceFnTest(VarianceFn varianceFn,
-                        VarianceAccumulator testAccumulatorInput,
-                        int expectedExtractedResult) {
+  public VarianceFnTest(
+      VarianceFn varianceFn,
+      VarianceAccumulator testAccumulatorInput,
+      int expectedExtractedResult) {
 
     this.varianceFn = varianceFn;
     this.testAccumulatorInput = testAccumulatorInput;
@@ -75,8 +77,7 @@ public class VarianceFnTest {
 
   @Test
   public void testReturnsAccumulatorUnchangedForNullInput() {
-    VarianceAccumulator accumulator =
-        newVarianceAccumulator(ZERO, BigDecimal.ONE, BigDecimal.TEN);
+    VarianceAccumulator accumulator = newVarianceAccumulator(ZERO, BigDecimal.ONE, BigDecimal.TEN);
 
     assertEquals(accumulator, varianceFn.addInput(accumulator, null));
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/BigDecimalConverterTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/BigDecimalConverterTest.java
@@ -27,9 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link BigDecimalConverter}.
- */
+/** Unit tests for {@link BigDecimalConverter}. */
 public class BigDecimalConverterTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/SqlTypeUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/SqlTypeUtilsTest.java
@@ -32,9 +32,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Test;
 
-/**
- * Tests for {@link SqlTypeUtils}.
- */
+/** Tests for {@link SqlTypeUtils}. */
 public class SqlTypeUtilsTest {
   private static final BigDecimal DECIMAL_THREE = new BigDecimal(3);
   private static final BigDecimal DECIMAL_FOUR = new BigDecimal(4);
@@ -46,27 +44,31 @@ public class SqlTypeUtilsTest {
           BeamSqlPrimitive.of(SqlTypeName.INTEGER, 4),
           BeamSqlPrimitive.of(SqlTypeName.INTEGER, 5));
 
-  @Test public void testFindExpressionOfType_success() {
+  @Test
+  public void testFindExpressionOfType_success() {
     Optional<BeamSqlExpression> typeName = findExpressionOfType(EXPRESSIONS, SqlTypeName.INTEGER);
 
     assertTrue(typeName.isPresent());
     assertEquals(SqlTypeName.INTEGER, typeName.get().getOutputType());
   }
 
-  @Test public void testFindExpressionOfType_failure() {
+  @Test
+  public void testFindExpressionOfType_failure() {
     Optional<BeamSqlExpression> typeName = findExpressionOfType(EXPRESSIONS, SqlTypeName.VARCHAR);
 
     assertFalse(typeName.isPresent());
   }
 
-  @Test public void testFindExpressionOfTypes_success() {
+  @Test
+  public void testFindExpressionOfTypes_success() {
     Optional<BeamSqlExpression> typeName = findExpressionOfType(EXPRESSIONS, SqlTypeName.INT_TYPES);
 
     assertTrue(typeName.isPresent());
     assertEquals(SqlTypeName.INTEGER, typeName.get().getOutputType());
   }
 
-  @Test public void testFindExpressionOfTypes_failure() {
+  @Test
+  public void testFindExpressionOfTypes_failure() {
     Optional<BeamSqlExpression> typeName =
         findExpressionOfType(EXPRESSIONS, SqlTypeName.CHAR_TYPES);
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlArithmeticOperatorsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlArithmeticOperatorsIntegrationTest.java
@@ -22,141 +22,139 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import org.junit.Test;
 
-/**
- * Integration test for arithmetic operators.
- */
+/** Integration test for arithmetic operators. */
 public class BeamSqlArithmeticOperatorsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
 
   private static final BigDecimal ZERO = BigDecimal.valueOf(0.0);
   private static final BigDecimal ONE = BigDecimal.valueOf(1.0);
   private static final BigDecimal ONE2 = BigDecimal.valueOf(1.0).multiply(BigDecimal.valueOf(1.0));
-  private static final BigDecimal ONE10 = BigDecimal.ONE.divide(
-      BigDecimal.ONE, 10, RoundingMode.HALF_EVEN);
+  private static final BigDecimal ONE10 =
+      BigDecimal.ONE.divide(BigDecimal.ONE, 10, RoundingMode.HALF_EVEN);
   private static final BigDecimal TWO = BigDecimal.valueOf(2.0);
   private static final BigDecimal TWO0 = BigDecimal.ONE.add(BigDecimal.ONE);
 
   @Test
   public void testPlus() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("1 + 1", 2)
-        .addExpr("1.0 + 1", TWO)
-        .addExpr("1 + 1.0", TWO)
-        .addExpr("1.0 + 1.0", TWO)
-        .addExpr("c_tinyint + c_tinyint", (byte) 2)
-        .addExpr("c_smallint + c_smallint", (short) 2)
-        .addExpr("c_bigint + c_bigint", 2L)
-        .addExpr("c_decimal + c_decimal", TWO0)
-        .addExpr("c_tinyint + c_decimal", TWO0)
-        .addExpr("c_float + c_decimal", 2.0)
-        .addExpr("c_double + c_decimal", 2.0)
-        .addExpr("c_float + c_float", 2.0f)
-        .addExpr("c_double + c_float", 2.0)
-        .addExpr("c_double + c_double", 2.0)
-        .addExpr("c_float + c_bigint", 2.0f)
-        .addExpr("c_double + c_bigint", 2.0)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("1 + 1", 2)
+            .addExpr("1.0 + 1", TWO)
+            .addExpr("1 + 1.0", TWO)
+            .addExpr("1.0 + 1.0", TWO)
+            .addExpr("c_tinyint + c_tinyint", (byte) 2)
+            .addExpr("c_smallint + c_smallint", (short) 2)
+            .addExpr("c_bigint + c_bigint", 2L)
+            .addExpr("c_decimal + c_decimal", TWO0)
+            .addExpr("c_tinyint + c_decimal", TWO0)
+            .addExpr("c_float + c_decimal", 2.0)
+            .addExpr("c_double + c_decimal", 2.0)
+            .addExpr("c_float + c_float", 2.0f)
+            .addExpr("c_double + c_float", 2.0)
+            .addExpr("c_double + c_double", 2.0)
+            .addExpr("c_float + c_bigint", 2.0f)
+            .addExpr("c_double + c_bigint", 2.0);
 
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testPlus_overflow() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_max + c_tinyint_max", (byte) -2)
-        .addExpr("c_smallint_max + c_smallint_max", (short) -2)
-        .addExpr("c_integer_max + c_integer_max", -2)
-        .addExpr("c_bigint_max + c_bigint_max", -2L)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_max + c_tinyint_max", (byte) -2)
+            .addExpr("c_smallint_max + c_smallint_max", (short) -2)
+            .addExpr("c_integer_max + c_integer_max", -2)
+            .addExpr("c_bigint_max + c_bigint_max", -2L);
 
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testMinus() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("1 - 1", 0)
-        .addExpr("1.0 - 1", ZERO)
-        .addExpr("1 - 0.0", ONE)
-        .addExpr("1.0 - 1.0", ZERO)
-        .addExpr("c_tinyint - c_tinyint", (byte) 0)
-        .addExpr("c_smallint - c_smallint", (short) 0)
-        .addExpr("c_bigint - c_bigint", 0L)
-        .addExpr("c_decimal - c_decimal", BigDecimal.ZERO)
-        .addExpr("c_tinyint - c_decimal", BigDecimal.ZERO)
-        .addExpr("c_float - c_decimal", 0.0)
-        .addExpr("c_double - c_decimal", 0.0)
-        .addExpr("c_float - c_float", 0.0f)
-        .addExpr("c_double - c_float", 0.0)
-        .addExpr("c_double - c_double", 0.0)
-        .addExpr("c_float - c_bigint", 0.0f)
-        .addExpr("c_double - c_bigint", 0.0)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("1 - 1", 0)
+            .addExpr("1.0 - 1", ZERO)
+            .addExpr("1 - 0.0", ONE)
+            .addExpr("1.0 - 1.0", ZERO)
+            .addExpr("c_tinyint - c_tinyint", (byte) 0)
+            .addExpr("c_smallint - c_smallint", (short) 0)
+            .addExpr("c_bigint - c_bigint", 0L)
+            .addExpr("c_decimal - c_decimal", BigDecimal.ZERO)
+            .addExpr("c_tinyint - c_decimal", BigDecimal.ZERO)
+            .addExpr("c_float - c_decimal", 0.0)
+            .addExpr("c_double - c_decimal", 0.0)
+            .addExpr("c_float - c_float", 0.0f)
+            .addExpr("c_double - c_float", 0.0)
+            .addExpr("c_double - c_double", 0.0)
+            .addExpr("c_float - c_bigint", 0.0f)
+            .addExpr("c_double - c_bigint", 0.0);
 
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testMultiply() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("1 * 1", 1)
-        .addExpr("1.0 * 1", ONE)
-        .addExpr("1 * 1.0", ONE)
-        .addExpr("1.0 * 1.0", ONE2)
-        .addExpr("c_tinyint * c_tinyint", (byte) 1)
-        .addExpr("c_smallint * c_smallint", (short) 1)
-        .addExpr("c_bigint * c_bigint", 1L)
-        .addExpr("c_decimal * c_decimal", BigDecimal.ONE)
-        .addExpr("c_tinyint * c_decimal", BigDecimal.ONE)
-        .addExpr("c_float * c_decimal", 1.0)
-        .addExpr("c_double * c_decimal", 1.0)
-        .addExpr("c_float * c_float", 1.0f)
-        .addExpr("c_double * c_float", 1.0)
-        .addExpr("c_double * c_double", 1.0)
-        .addExpr("c_float * c_bigint", 1.0f)
-        .addExpr("c_double * c_bigint", 1.0)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("1 * 1", 1)
+            .addExpr("1.0 * 1", ONE)
+            .addExpr("1 * 1.0", ONE)
+            .addExpr("1.0 * 1.0", ONE2)
+            .addExpr("c_tinyint * c_tinyint", (byte) 1)
+            .addExpr("c_smallint * c_smallint", (short) 1)
+            .addExpr("c_bigint * c_bigint", 1L)
+            .addExpr("c_decimal * c_decimal", BigDecimal.ONE)
+            .addExpr("c_tinyint * c_decimal", BigDecimal.ONE)
+            .addExpr("c_float * c_decimal", 1.0)
+            .addExpr("c_double * c_decimal", 1.0)
+            .addExpr("c_float * c_float", 1.0f)
+            .addExpr("c_double * c_float", 1.0)
+            .addExpr("c_double * c_double", 1.0)
+            .addExpr("c_float * c_bigint", 1.0f)
+            .addExpr("c_double * c_bigint", 1.0);
 
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testDivide() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("1 / 1", 1)
-        .addExpr("1.0 / 1", ONE10)
-        .addExpr("1 / 1.0", ONE10)
-        .addExpr("1.0 / 1.0", ONE10)
-        .addExpr("c_tinyint / c_tinyint", (byte) 1)
-        .addExpr("c_smallint / c_smallint", (short) 1)
-        .addExpr("c_bigint / c_bigint", 1L)
-        .addExpr("c_decimal / c_decimal", ONE10)
-        .addExpr("c_tinyint / c_decimal", ONE10)
-        .addExpr("c_float / c_decimal", 1.0)
-        .addExpr("c_double / c_decimal", 1.0)
-        .addExpr("c_float / c_float", 1.0f)
-        .addExpr("c_double / c_float", 1.0)
-        .addExpr("c_double / c_double", 1.0)
-        .addExpr("c_float / c_bigint", 1.0f)
-        .addExpr("c_double / c_bigint", 1.0)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("1 / 1", 1)
+            .addExpr("1.0 / 1", ONE10)
+            .addExpr("1 / 1.0", ONE10)
+            .addExpr("1.0 / 1.0", ONE10)
+            .addExpr("c_tinyint / c_tinyint", (byte) 1)
+            .addExpr("c_smallint / c_smallint", (short) 1)
+            .addExpr("c_bigint / c_bigint", 1L)
+            .addExpr("c_decimal / c_decimal", ONE10)
+            .addExpr("c_tinyint / c_decimal", ONE10)
+            .addExpr("c_float / c_decimal", 1.0)
+            .addExpr("c_double / c_decimal", 1.0)
+            .addExpr("c_float / c_float", 1.0f)
+            .addExpr("c_double / c_float", 1.0)
+            .addExpr("c_double / c_double", 1.0)
+            .addExpr("c_float / c_bigint", 1.0f)
+            .addExpr("c_double / c_bigint", 1.0);
 
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testMod() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("mod(1, 1)", 0)
-        .addExpr("mod(1.0, 1)", 0)
-        .addExpr("mod(1, 1.0)", ZERO)
-        .addExpr("mod(1.0, 1.0)", ZERO)
-        .addExpr("mod(c_tinyint, c_tinyint)", (byte) 0)
-        .addExpr("mod(c_smallint, c_smallint)", (short) 0)
-        .addExpr("mod(c_bigint, c_bigint)", 0L)
-        .addExpr("mod(c_decimal, c_decimal)", ZERO)
-        .addExpr("mod(c_tinyint, c_decimal)", ZERO)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("mod(1, 1)", 0)
+            .addExpr("mod(1.0, 1)", 0)
+            .addExpr("mod(1, 1.0)", ZERO)
+            .addExpr("mod(1.0, 1.0)", ZERO)
+            .addExpr("mod(c_tinyint, c_tinyint)", (byte) 0)
+            .addExpr("mod(c_smallint, c_smallint)", (short) 0)
+            .addExpr("mod(c_bigint, c_bigint)", 0L)
+            .addExpr("mod(c_decimal, c_decimal)", ZERO)
+            .addExpr("mod(c_tinyint, c_decimal)", ZERO);
 
     checker.buildRunAndCheck();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
@@ -26,304 +26,290 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.junit.Test;
 
-/**
- * Integration test for comparison operators.
- */
+/** Integration test for comparison operators. */
 public class BeamSqlComparisonOperatorsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
 
   @Test
   public void testEquals() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_1 = c_tinyint_1", true)
-        .addExpr("c_tinyint_1 = c_tinyint_2", false)
-        .addExpr("c_smallint_1 = c_smallint_1", true)
-        .addExpr("c_smallint_1 = c_smallint_2", false)
-        .addExpr("c_integer_1 = c_integer_1", true)
-        .addExpr("c_integer_1 = c_integer_2", false)
-        .addExpr("c_bigint_1 = c_bigint_1", true)
-        .addExpr("c_bigint_1 = c_bigint_2", false)
-        .addExpr("c_float_1 = c_float_1", true)
-        .addExpr("c_float_1 = c_float_2", false)
-        .addExpr("c_double_1 = c_double_1", true)
-        .addExpr("c_double_1 = c_double_2", false)
-        .addExpr("c_decimal_1 = c_decimal_1", true)
-        .addExpr("c_decimal_1 = c_decimal_2", false)
-        .addExpr("c_varchar_1 = c_varchar_1", true)
-        .addExpr("c_varchar_1 = c_varchar_2", false)
-        .addExpr("c_boolean_true = c_boolean_true", true)
-        .addExpr("c_boolean_true = c_boolean_false", false)
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_1 = c_tinyint_1", true)
+            .addExpr("c_tinyint_1 = c_tinyint_2", false)
+            .addExpr("c_smallint_1 = c_smallint_1", true)
+            .addExpr("c_smallint_1 = c_smallint_2", false)
+            .addExpr("c_integer_1 = c_integer_1", true)
+            .addExpr("c_integer_1 = c_integer_2", false)
+            .addExpr("c_bigint_1 = c_bigint_1", true)
+            .addExpr("c_bigint_1 = c_bigint_2", false)
+            .addExpr("c_float_1 = c_float_1", true)
+            .addExpr("c_float_1 = c_float_2", false)
+            .addExpr("c_double_1 = c_double_1", true)
+            .addExpr("c_double_1 = c_double_2", false)
+            .addExpr("c_decimal_1 = c_decimal_1", true)
+            .addExpr("c_decimal_1 = c_decimal_2", false)
+            .addExpr("c_varchar_1 = c_varchar_1", true)
+            .addExpr("c_varchar_1 = c_varchar_2", false)
+            .addExpr("c_boolean_true = c_boolean_true", true)
+            .addExpr("c_boolean_true = c_boolean_false", false);
 
-        ;
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testNotEquals() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_1 <> c_tinyint_1", false)
-        .addExpr("c_tinyint_1 <> c_tinyint_2", true)
-        .addExpr("c_smallint_1 <> c_smallint_1", false)
-        .addExpr("c_smallint_1 <> c_smallint_2", true)
-        .addExpr("c_integer_1 <> c_integer_1", false)
-        .addExpr("c_integer_1 <> c_integer_2", true)
-        .addExpr("c_bigint_1 <> c_bigint_1", false)
-        .addExpr("c_bigint_1 <> c_bigint_2", true)
-        .addExpr("c_float_1 <> c_float_1", false)
-        .addExpr("c_float_1 <> c_float_2", true)
-        .addExpr("c_double_1 <> c_double_1", false)
-        .addExpr("c_double_1 <> c_double_2", true)
-        .addExpr("c_decimal_1 <> c_decimal_1", false)
-        .addExpr("c_decimal_1 <> c_decimal_2", true)
-        .addExpr("c_varchar_1 <> c_varchar_1", false)
-        .addExpr("c_varchar_1 <> c_varchar_2", true)
-        .addExpr("c_boolean_true <> c_boolean_true", false)
-        .addExpr("c_boolean_true <> c_boolean_false", true)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_1 <> c_tinyint_1", false)
+            .addExpr("c_tinyint_1 <> c_tinyint_2", true)
+            .addExpr("c_smallint_1 <> c_smallint_1", false)
+            .addExpr("c_smallint_1 <> c_smallint_2", true)
+            .addExpr("c_integer_1 <> c_integer_1", false)
+            .addExpr("c_integer_1 <> c_integer_2", true)
+            .addExpr("c_bigint_1 <> c_bigint_1", false)
+            .addExpr("c_bigint_1 <> c_bigint_2", true)
+            .addExpr("c_float_1 <> c_float_1", false)
+            .addExpr("c_float_1 <> c_float_2", true)
+            .addExpr("c_double_1 <> c_double_1", false)
+            .addExpr("c_double_1 <> c_double_2", true)
+            .addExpr("c_decimal_1 <> c_decimal_1", false)
+            .addExpr("c_decimal_1 <> c_decimal_2", true)
+            .addExpr("c_varchar_1 <> c_varchar_1", false)
+            .addExpr("c_varchar_1 <> c_varchar_2", true)
+            .addExpr("c_boolean_true <> c_boolean_true", false)
+            .addExpr("c_boolean_true <> c_boolean_false", true);
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testGreaterThan() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_2 > c_tinyint_1", true)
-        .addExpr("c_tinyint_1 > c_tinyint_1", false)
-        .addExpr("c_tinyint_1 > c_tinyint_2", false)
-
-        .addExpr("c_smallint_2 > c_smallint_1", true)
-        .addExpr("c_smallint_1 > c_smallint_1", false)
-        .addExpr("c_smallint_1 > c_smallint_2", false)
-
-        .addExpr("c_integer_2 > c_integer_1", true)
-        .addExpr("c_integer_1 > c_integer_1", false)
-        .addExpr("c_integer_1 > c_integer_2", false)
-
-        .addExpr("c_bigint_2 > c_bigint_1", true)
-        .addExpr("c_bigint_1 > c_bigint_1", false)
-        .addExpr("c_bigint_1 > c_bigint_2", false)
-
-        .addExpr("c_float_2 > c_float_1", true)
-        .addExpr("c_float_1 > c_float_1", false)
-        .addExpr("c_float_1 > c_float_2", false)
-
-        .addExpr("c_double_2 > c_double_1", true)
-        .addExpr("c_double_1 > c_double_1", false)
-        .addExpr("c_double_1 > c_double_2", false)
-
-        .addExpr("c_decimal_2 > c_decimal_1", true)
-        .addExpr("c_decimal_1 > c_decimal_1", false)
-        .addExpr("c_decimal_1 > c_decimal_2", false)
-
-        .addExpr("c_varchar_2 > c_varchar_1", true)
-        .addExpr("c_varchar_1 > c_varchar_1", false)
-        .addExpr("c_varchar_1 > c_varchar_2", false)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_2 > c_tinyint_1", true)
+            .addExpr("c_tinyint_1 > c_tinyint_1", false)
+            .addExpr("c_tinyint_1 > c_tinyint_2", false)
+            .addExpr("c_smallint_2 > c_smallint_1", true)
+            .addExpr("c_smallint_1 > c_smallint_1", false)
+            .addExpr("c_smallint_1 > c_smallint_2", false)
+            .addExpr("c_integer_2 > c_integer_1", true)
+            .addExpr("c_integer_1 > c_integer_1", false)
+            .addExpr("c_integer_1 > c_integer_2", false)
+            .addExpr("c_bigint_2 > c_bigint_1", true)
+            .addExpr("c_bigint_1 > c_bigint_1", false)
+            .addExpr("c_bigint_1 > c_bigint_2", false)
+            .addExpr("c_float_2 > c_float_1", true)
+            .addExpr("c_float_1 > c_float_1", false)
+            .addExpr("c_float_1 > c_float_2", false)
+            .addExpr("c_double_2 > c_double_1", true)
+            .addExpr("c_double_1 > c_double_1", false)
+            .addExpr("c_double_1 > c_double_2", false)
+            .addExpr("c_decimal_2 > c_decimal_1", true)
+            .addExpr("c_decimal_1 > c_decimal_1", false)
+            .addExpr("c_decimal_1 > c_decimal_2", false)
+            .addExpr("c_varchar_2 > c_varchar_1", true)
+            .addExpr("c_varchar_1 > c_varchar_1", false)
+            .addExpr("c_varchar_1 > c_varchar_2", false);
 
     checker.buildRunAndCheck();
   }
 
   @Test(expected = RuntimeException.class)
   public void testGreaterThanException() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_boolean_false > c_boolean_true", false);
+    ExpressionChecker checker =
+        new ExpressionChecker().addExpr("c_boolean_false > c_boolean_true", false);
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testGreaterThanOrEquals() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_2 >= c_tinyint_1", true)
-        .addExpr("c_tinyint_1 >= c_tinyint_1", true)
-        .addExpr("c_tinyint_1 >= c_tinyint_2", false)
-
-        .addExpr("c_smallint_2 >= c_smallint_1", true)
-        .addExpr("c_smallint_1 >= c_smallint_1", true)
-        .addExpr("c_smallint_1 >= c_smallint_2", false)
-
-        .addExpr("c_integer_2 >= c_integer_1", true)
-        .addExpr("c_integer_1 >= c_integer_1", true)
-        .addExpr("c_integer_1 >= c_integer_2", false)
-
-        .addExpr("c_bigint_2 >= c_bigint_1", true)
-        .addExpr("c_bigint_1 >= c_bigint_1", true)
-        .addExpr("c_bigint_1 >= c_bigint_2", false)
-
-        .addExpr("c_float_2 >= c_float_1", true)
-        .addExpr("c_float_1 >= c_float_1", true)
-        .addExpr("c_float_1 >= c_float_2", false)
-
-        .addExpr("c_double_2 >= c_double_1", true)
-        .addExpr("c_double_1 >= c_double_1", true)
-        .addExpr("c_double_1 >= c_double_2", false)
-
-        .addExpr("c_decimal_2 >= c_decimal_1", true)
-        .addExpr("c_decimal_1 >= c_decimal_1", true)
-        .addExpr("c_decimal_1 >= c_decimal_2", false)
-
-        .addExpr("c_varchar_2 >= c_varchar_1", true)
-        .addExpr("c_varchar_1 >= c_varchar_1", true)
-        .addExpr("c_varchar_1 >= c_varchar_2", false)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_2 >= c_tinyint_1", true)
+            .addExpr("c_tinyint_1 >= c_tinyint_1", true)
+            .addExpr("c_tinyint_1 >= c_tinyint_2", false)
+            .addExpr("c_smallint_2 >= c_smallint_1", true)
+            .addExpr("c_smallint_1 >= c_smallint_1", true)
+            .addExpr("c_smallint_1 >= c_smallint_2", false)
+            .addExpr("c_integer_2 >= c_integer_1", true)
+            .addExpr("c_integer_1 >= c_integer_1", true)
+            .addExpr("c_integer_1 >= c_integer_2", false)
+            .addExpr("c_bigint_2 >= c_bigint_1", true)
+            .addExpr("c_bigint_1 >= c_bigint_1", true)
+            .addExpr("c_bigint_1 >= c_bigint_2", false)
+            .addExpr("c_float_2 >= c_float_1", true)
+            .addExpr("c_float_1 >= c_float_1", true)
+            .addExpr("c_float_1 >= c_float_2", false)
+            .addExpr("c_double_2 >= c_double_1", true)
+            .addExpr("c_double_1 >= c_double_1", true)
+            .addExpr("c_double_1 >= c_double_2", false)
+            .addExpr("c_decimal_2 >= c_decimal_1", true)
+            .addExpr("c_decimal_1 >= c_decimal_1", true)
+            .addExpr("c_decimal_1 >= c_decimal_2", false)
+            .addExpr("c_varchar_2 >= c_varchar_1", true)
+            .addExpr("c_varchar_1 >= c_varchar_1", true)
+            .addExpr("c_varchar_1 >= c_varchar_2", false);
 
     checker.buildRunAndCheck();
   }
 
   @Test(expected = RuntimeException.class)
   public void testGreaterThanOrEqualsException() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_boolean_false >= c_boolean_true", false);
+    ExpressionChecker checker =
+        new ExpressionChecker().addExpr("c_boolean_false >= c_boolean_true", false);
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testLessThan() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_2 < c_tinyint_1", false)
-        .addExpr("c_tinyint_1 < c_tinyint_1", false)
-        .addExpr("c_tinyint_1 < c_tinyint_2", true)
-
-        .addExpr("c_smallint_2 < c_smallint_1", false)
-        .addExpr("c_smallint_1 < c_smallint_1", false)
-        .addExpr("c_smallint_1 < c_smallint_2", true)
-
-        .addExpr("c_integer_2 < c_integer_1", false)
-        .addExpr("c_integer_1 < c_integer_1", false)
-        .addExpr("c_integer_1 < c_integer_2", true)
-
-        .addExpr("c_bigint_2 < c_bigint_1", false)
-        .addExpr("c_bigint_1 < c_bigint_1", false)
-        .addExpr("c_bigint_1 < c_bigint_2", true)
-
-        .addExpr("c_float_2 < c_float_1", false)
-        .addExpr("c_float_1 < c_float_1", false)
-        .addExpr("c_float_1 < c_float_2", true)
-
-        .addExpr("c_double_2 < c_double_1", false)
-        .addExpr("c_double_1 < c_double_1", false)
-        .addExpr("c_double_1 < c_double_2", true)
-
-        .addExpr("c_decimal_2 < c_decimal_1", false)
-        .addExpr("c_decimal_1 < c_decimal_1", false)
-        .addExpr("c_decimal_1 < c_decimal_2", true)
-
-        .addExpr("c_varchar_2 < c_varchar_1", false)
-        .addExpr("c_varchar_1 < c_varchar_1", false)
-        .addExpr("c_varchar_1 < c_varchar_2", true)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_2 < c_tinyint_1", false)
+            .addExpr("c_tinyint_1 < c_tinyint_1", false)
+            .addExpr("c_tinyint_1 < c_tinyint_2", true)
+            .addExpr("c_smallint_2 < c_smallint_1", false)
+            .addExpr("c_smallint_1 < c_smallint_1", false)
+            .addExpr("c_smallint_1 < c_smallint_2", true)
+            .addExpr("c_integer_2 < c_integer_1", false)
+            .addExpr("c_integer_1 < c_integer_1", false)
+            .addExpr("c_integer_1 < c_integer_2", true)
+            .addExpr("c_bigint_2 < c_bigint_1", false)
+            .addExpr("c_bigint_1 < c_bigint_1", false)
+            .addExpr("c_bigint_1 < c_bigint_2", true)
+            .addExpr("c_float_2 < c_float_1", false)
+            .addExpr("c_float_1 < c_float_1", false)
+            .addExpr("c_float_1 < c_float_2", true)
+            .addExpr("c_double_2 < c_double_1", false)
+            .addExpr("c_double_1 < c_double_1", false)
+            .addExpr("c_double_1 < c_double_2", true)
+            .addExpr("c_decimal_2 < c_decimal_1", false)
+            .addExpr("c_decimal_1 < c_decimal_1", false)
+            .addExpr("c_decimal_1 < c_decimal_2", true)
+            .addExpr("c_varchar_2 < c_varchar_1", false)
+            .addExpr("c_varchar_1 < c_varchar_1", false)
+            .addExpr("c_varchar_1 < c_varchar_2", true);
 
     checker.buildRunAndCheck();
   }
 
   @Test(expected = RuntimeException.class)
   public void testLessThanException() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_boolean_false < c_boolean_true", false);
+    ExpressionChecker checker =
+        new ExpressionChecker().addExpr("c_boolean_false < c_boolean_true", false);
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testLessThanOrEquals() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_tinyint_2 <= c_tinyint_1", false)
-        .addExpr("c_tinyint_1 <= c_tinyint_1", true)
-        .addExpr("c_tinyint_1 <= c_tinyint_2", true)
-
-        .addExpr("c_smallint_2 <= c_smallint_1", false)
-        .addExpr("c_smallint_1 <= c_smallint_1", true)
-        .addExpr("c_smallint_1 <= c_smallint_2", true)
-
-        .addExpr("c_integer_2 <= c_integer_1", false)
-        .addExpr("c_integer_1 <= c_integer_1", true)
-        .addExpr("c_integer_1 <= c_integer_2", true)
-
-        .addExpr("c_bigint_2 <= c_bigint_1", false)
-        .addExpr("c_bigint_1 <= c_bigint_1", true)
-        .addExpr("c_bigint_1 <= c_bigint_2", true)
-
-        .addExpr("c_float_2 <= c_float_1", false)
-        .addExpr("c_float_1 <= c_float_1", true)
-        .addExpr("c_float_1 <= c_float_2", true)
-
-        .addExpr("c_double_2 <= c_double_1", false)
-        .addExpr("c_double_1 <= c_double_1", true)
-        .addExpr("c_double_1 <= c_double_2", true)
-
-        .addExpr("c_decimal_2 <= c_decimal_1", false)
-        .addExpr("c_decimal_1 <= c_decimal_1", true)
-        .addExpr("c_decimal_1 <= c_decimal_2", true)
-
-        .addExpr("c_varchar_2 <= c_varchar_1", false)
-        .addExpr("c_varchar_1 <= c_varchar_1", true)
-        .addExpr("c_varchar_1 <= c_varchar_2", true)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_tinyint_2 <= c_tinyint_1", false)
+            .addExpr("c_tinyint_1 <= c_tinyint_1", true)
+            .addExpr("c_tinyint_1 <= c_tinyint_2", true)
+            .addExpr("c_smallint_2 <= c_smallint_1", false)
+            .addExpr("c_smallint_1 <= c_smallint_1", true)
+            .addExpr("c_smallint_1 <= c_smallint_2", true)
+            .addExpr("c_integer_2 <= c_integer_1", false)
+            .addExpr("c_integer_1 <= c_integer_1", true)
+            .addExpr("c_integer_1 <= c_integer_2", true)
+            .addExpr("c_bigint_2 <= c_bigint_1", false)
+            .addExpr("c_bigint_1 <= c_bigint_1", true)
+            .addExpr("c_bigint_1 <= c_bigint_2", true)
+            .addExpr("c_float_2 <= c_float_1", false)
+            .addExpr("c_float_1 <= c_float_1", true)
+            .addExpr("c_float_1 <= c_float_2", true)
+            .addExpr("c_double_2 <= c_double_1", false)
+            .addExpr("c_double_1 <= c_double_1", true)
+            .addExpr("c_double_1 <= c_double_2", true)
+            .addExpr("c_decimal_2 <= c_decimal_1", false)
+            .addExpr("c_decimal_1 <= c_decimal_1", true)
+            .addExpr("c_decimal_1 <= c_decimal_2", true)
+            .addExpr("c_varchar_2 <= c_varchar_1", false)
+            .addExpr("c_varchar_1 <= c_varchar_1", true)
+            .addExpr("c_varchar_1 <= c_varchar_2", true);
 
     checker.buildRunAndCheck();
   }
 
   @Test(expected = RuntimeException.class)
   public void testLessThanOrEqualsException() {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_boolean_false <= c_boolean_true", false);
+    ExpressionChecker checker =
+        new ExpressionChecker().addExpr("c_boolean_false <= c_boolean_true", false);
     checker.buildRunAndCheck();
   }
 
   @Test
   public void testIsNullAndIsNotNull() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("1 IS NOT NULL", true)
-        .addExpr("NULL IS NOT NULL", false)
-
-        .addExpr("1 IS NULL", false)
-        .addExpr("NULL IS NULL", true)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("1 IS NOT NULL", true)
+            .addExpr("NULL IS NOT NULL", false)
+            .addExpr("1 IS NULL", false)
+            .addExpr("NULL IS NULL", true);
 
     checker.buildRunAndCheck();
   }
 
-  @Override protected PCollection<Row> getTestPCollection() {
-    Schema type = RowSqlTypes.builder()
-        .withTinyIntField("c_tinyint_0")
-        .withTinyIntField("c_tinyint_1")
-        .withTinyIntField("c_tinyint_2")
-        .withSmallIntField("c_smallint_0")
-        .withSmallIntField("c_smallint_1")
-        .withSmallIntField("c_smallint_2")
-        .withIntegerField("c_integer_0")
-        .withIntegerField("c_integer_1")
-        .withIntegerField("c_integer_2")
-        .withBigIntField("c_bigint_0")
-        .withBigIntField("c_bigint_1")
-        .withBigIntField("c_bigint_2")
-        .withFloatField("c_float_0")
-        .withFloatField("c_float_1")
-        .withFloatField("c_float_2")
-        .withDoubleField("c_double_0")
-        .withDoubleField("c_double_1")
-        .withDoubleField("c_double_2")
-        .withDecimalField("c_decimal_0")
-        .withDecimalField("c_decimal_1")
-        .withDecimalField("c_decimal_2")
-        .withVarcharField("c_varchar_0")
-        .withVarcharField("c_varchar_1")
-        .withVarcharField("c_varchar_2")
-        .withBooleanField("c_boolean_false")
-        .withBooleanField("c_boolean_true")
-        .build();
+  @Override
+  protected PCollection<Row> getTestPCollection() {
+    Schema type =
+        RowSqlTypes.builder()
+            .withTinyIntField("c_tinyint_0")
+            .withTinyIntField("c_tinyint_1")
+            .withTinyIntField("c_tinyint_2")
+            .withSmallIntField("c_smallint_0")
+            .withSmallIntField("c_smallint_1")
+            .withSmallIntField("c_smallint_2")
+            .withIntegerField("c_integer_0")
+            .withIntegerField("c_integer_1")
+            .withIntegerField("c_integer_2")
+            .withBigIntField("c_bigint_0")
+            .withBigIntField("c_bigint_1")
+            .withBigIntField("c_bigint_2")
+            .withFloatField("c_float_0")
+            .withFloatField("c_float_1")
+            .withFloatField("c_float_2")
+            .withDoubleField("c_double_0")
+            .withDoubleField("c_double_1")
+            .withDoubleField("c_double_2")
+            .withDecimalField("c_decimal_0")
+            .withDecimalField("c_decimal_1")
+            .withDecimalField("c_decimal_2")
+            .withVarcharField("c_varchar_0")
+            .withVarcharField("c_varchar_1")
+            .withVarcharField("c_varchar_2")
+            .withBooleanField("c_boolean_false")
+            .withBooleanField("c_boolean_true")
+            .build();
 
     try {
-      return MockedBoundedTable
-          .of(type)
+      return MockedBoundedTable.of(type)
           .addRows(
-              (byte) 0, (byte) 1, (byte) 2,
-              (short) 0, (short) 1, (short) 2,
-              0, 1, 2,
-              0L, 1L, 2L,
-              0.0f, 1.0f, 2.0f,
-              0.0, 1.0, 2.0,
-              BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.ONE.add(BigDecimal.ONE),
-              "a", "b", "c",
-              false, true
-          )
+              (byte) 0,
+              (byte) 1,
+              (byte) 2,
+              (short) 0,
+              (short) 1,
+              (short) 2,
+              0,
+              1,
+              2,
+              0L,
+              1L,
+              2L,
+              0.0f,
+              1.0f,
+              2.0f,
+              0.0,
+              1.0,
+              2.0,
+              BigDecimal.ZERO,
+              BigDecimal.ONE,
+              BigDecimal.ONE.add(BigDecimal.ONE),
+              "a",
+              "b",
+              "c",
+              false,
+              true)
           .buildIOReader(pipeline)
           .setCoder(type.getRowCoder());
     } catch (Exception e) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlConditionalFunctionsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlConditionalFunctionsIntegrationTest.java
@@ -19,42 +19,23 @@ package org.apache.beam.sdk.extensions.sql.integrationtest;
 
 import org.junit.Test;
 
-/**
- * Integration test for conditional functions.
- */
+/** Integration test for conditional functions. */
 public class BeamSqlConditionalFunctionsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
-    @Test
-    public void testConditionalFunctions() throws Exception {
-      ExpressionChecker checker = new ExpressionChecker()
-          .addExpr(
-              "CASE 1 WHEN 1 THEN 'hello' ELSE 'world' END",
-              "hello"
-          )
-          .addExpr(
-              "CASE 2 "
-                  + "WHEN 1 THEN 'hello' "
-                  + "WHEN 3 THEN 'bond' "
-                  + "ELSE 'world' END",
-              "world"
-          )
-          .addExpr(
-              "CASE "
-                  + "WHEN 1 = 1 THEN 'hello' "
-                  + "ELSE 'world' END",
-              "hello"
-          )
-          .addExpr(
-              "CASE "
-                  + "WHEN 1 > 1 THEN 'hello' "
-                  + "ELSE 'world' END",
-              "world"
-          )
-          .addExpr("NULLIF(5, 4) ", 5)
-          .addExpr("COALESCE(1, 5) ", 1)
-          .addExpr("COALESCE(NULL, 5) ", 5)
-          ;
+  @Test
+  public void testConditionalFunctions() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("CASE 1 WHEN 1 THEN 'hello' ELSE 'world' END", "hello")
+            .addExpr(
+                "CASE 2 " + "WHEN 1 THEN 'hello' " + "WHEN 3 THEN 'bond' " + "ELSE 'world' END",
+                "world")
+            .addExpr("CASE " + "WHEN 1 = 1 THEN 'hello' " + "ELSE 'world' END", "hello")
+            .addExpr("CASE " + "WHEN 1 > 1 THEN 'hello' " + "ELSE 'world' END", "world")
+            .addExpr("NULLIF(5, 4) ", 5)
+            .addExpr("COALESCE(1, 5) ", 1)
+            .addExpr("COALESCE(NULL, 5) ", 5);
 
-      checker.buildRunAndCheck();
-    }
+    checker.buildRunAndCheck();
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlDateFunctionsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlDateFunctionsIntegrationTest.java
@@ -30,157 +30,213 @@ import org.apache.beam.sdk.values.Row;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
-/**
- * Integration test for date functions.
- */
+/** Integration test for date functions. */
 public class BeamSqlDateFunctionsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
-  @Test public void testBasicDateTimeFunctions() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("EXTRACT(YEAR FROM ts)", 1986L)
-        .addExpr("YEAR(ts)", 1986L)
-        .addExpr("QUARTER(ts)", 1L)
-        .addExpr("MONTH(ts)", 2L)
-        .addExpr("WEEK(ts)", 7L)
-        .addExpr("DAYOFMONTH(ts)", 15L)
-        .addExpr("DAYOFYEAR(ts)", 46L)
-        .addExpr("DAYOFWEEK(ts)", 7L)
-        .addExpr("HOUR(ts)", 11L)
-        .addExpr("MINUTE(ts)", 35L)
-        .addExpr("SECOND(ts)", 26L)
-        .addExpr("FLOOR(ts TO YEAR)", parseDate("1986-01-01 00:00:00"))
-        .addExpr("CEIL(ts TO YEAR)", parseDate("1987-01-01 00:00:00"))
-        ;
+  @Test
+  public void testBasicDateTimeFunctions() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("EXTRACT(YEAR FROM ts)", 1986L)
+            .addExpr("YEAR(ts)", 1986L)
+            .addExpr("QUARTER(ts)", 1L)
+            .addExpr("MONTH(ts)", 2L)
+            .addExpr("WEEK(ts)", 7L)
+            .addExpr("DAYOFMONTH(ts)", 15L)
+            .addExpr("DAYOFYEAR(ts)", 46L)
+            .addExpr("DAYOFWEEK(ts)", 7L)
+            .addExpr("HOUR(ts)", 11L)
+            .addExpr("MINUTE(ts)", 35L)
+            .addExpr("SECOND(ts)", 26L)
+            .addExpr("FLOOR(ts TO YEAR)", parseDate("1986-01-01 00:00:00"))
+            .addExpr("CEIL(ts TO YEAR)", parseDate("1987-01-01 00:00:00"));
     checker.buildRunAndCheck();
   }
 
-  @Test public void testDatetimePlusFunction() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TIMESTAMPADD(SECOND, 3, TIMESTAMP '1984-04-19 01:02:03')",
-            parseDate("1984-04-19 01:02:06"))
-        .addExpr("TIMESTAMPADD(MINUTE, 3, TIMESTAMP '1984-04-19 01:02:03')",
-            parseDate("1984-04-19 01:05:03"))
-        .addExpr("TIMESTAMPADD(HOUR, 3, TIMESTAMP '1984-04-19 01:02:03')",
-            parseDate("1984-04-19 04:02:03"))
-        .addExpr("TIMESTAMPADD(DAY, 3, TIMESTAMP '1984-04-19 01:02:03')",
-            parseDate("1984-04-22 01:02:03"))
-        .addExpr("TIMESTAMPADD(MONTH, 2, TIMESTAMP '1984-01-19 01:02:03')",
-            parseDate("1984-03-19 01:02:03"))
-        .addExpr("TIMESTAMPADD(YEAR, 2, TIMESTAMP '1985-01-19 01:02:03')",
-            parseDate("1987-01-19 01:02:03"))
-        ;
+  @Test
+  public void testDatetimePlusFunction() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "TIMESTAMPADD(SECOND, 3, TIMESTAMP '1984-04-19 01:02:03')",
+                parseDate("1984-04-19 01:02:06"))
+            .addExpr(
+                "TIMESTAMPADD(MINUTE, 3, TIMESTAMP '1984-04-19 01:02:03')",
+                parseDate("1984-04-19 01:05:03"))
+            .addExpr(
+                "TIMESTAMPADD(HOUR, 3, TIMESTAMP '1984-04-19 01:02:03')",
+                parseDate("1984-04-19 04:02:03"))
+            .addExpr(
+                "TIMESTAMPADD(DAY, 3, TIMESTAMP '1984-04-19 01:02:03')",
+                parseDate("1984-04-22 01:02:03"))
+            .addExpr(
+                "TIMESTAMPADD(MONTH, 2, TIMESTAMP '1984-01-19 01:02:03')",
+                parseDate("1984-03-19 01:02:03"))
+            .addExpr(
+                "TIMESTAMPADD(YEAR, 2, TIMESTAMP '1985-01-19 01:02:03')",
+                parseDate("1987-01-19 01:02:03"));
     checker.buildRunAndCheck();
   }
 
-  @Test public void testDatetimeInfixPlus() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '3' SECOND",
-            parseDate("1984-01-19 01:02:06"))
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' MINUTE",
-            parseDate("1984-01-19 01:04:03"))
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' HOUR",
-            parseDate("1984-01-19 03:02:03"))
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' DAY",
-            parseDate("1984-01-21 01:02:03"))
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' MONTH",
-            parseDate("1984-03-19 01:02:03"))
-        .addExpr("TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' YEAR",
-            parseDate("1986-01-19 01:02:03"))
-        ;
+  @Test
+  public void testDatetimeInfixPlus() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '3' SECOND",
+                parseDate("1984-01-19 01:02:06"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' MINUTE",
+                parseDate("1984-01-19 01:04:03"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' HOUR",
+                parseDate("1984-01-19 03:02:03"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' DAY",
+                parseDate("1984-01-21 01:02:03"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' MONTH",
+                parseDate("1984-03-19 01:02:03"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:02:03' + INTERVAL '2' YEAR",
+                parseDate("1986-01-19 01:02:03"));
     checker.buildRunAndCheck();
   }
 
-  @Test public void testTimestampDiff() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:01:58')", 0)
-        .addExpr("TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:01:59')", 1)
-        .addExpr("TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:02:00')", 2)
-
-        .addExpr("TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:02:57')", 0)
-        .addExpr("TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:02:58')", 1)
-        .addExpr("TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 01:03:58')", 2)
-
-        .addExpr("TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 02:01:57')", 0)
-        .addExpr("TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 02:01:58')", 1)
-        .addExpr("TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-19 03:01:58')", 2)
-
-        .addExpr("TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-20 01:01:57')", 0)
-        .addExpr("TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-20 01:01:58')", 1)
-        .addExpr("TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
-            + "TIMESTAMP '1984-04-21 01:01:58')", 2)
-
-        .addExpr("TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
-            + "TIMESTAMP '1984-02-19 01:01:57')", 0)
-        .addExpr("TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
-            + "TIMESTAMP '1984-02-19 01:01:58')", 1)
-        .addExpr("TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
-            + "TIMESTAMP '1984-03-19 01:01:58')", 2)
-
-        .addExpr("TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
-            + "TIMESTAMP '1982-01-19 01:01:57')", 0)
-        .addExpr("TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
-            + "TIMESTAMP '1982-01-19 01:01:58')", 1)
-        .addExpr("TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
-            + "TIMESTAMP '1983-01-19 01:01:58')", 2)
-
-        .addExpr("TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
-            + "TIMESTAMP '1980-01-19 01:01:58')", -1)
-        .addExpr("TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
-            + "TIMESTAMP '1979-01-19 01:01:58')", -2)
-    ;
+  @Test
+  public void testTimestampDiff() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:01:58')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:01:59')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(SECOND, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:02:00')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:02:57')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:02:58')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(MINUTE, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 01:03:58')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 02:01:57')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 02:01:58')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(HOUR, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-19 03:01:58')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-20 01:01:57')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-20 01:01:58')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(DAY, TIMESTAMP '1984-04-19 01:01:58', "
+                    + "TIMESTAMP '1984-04-21 01:01:58')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
+                    + "TIMESTAMP '1984-02-19 01:01:57')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
+                    + "TIMESTAMP '1984-02-19 01:01:58')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(MONTH, TIMESTAMP '1984-01-19 01:01:58', "
+                    + "TIMESTAMP '1984-03-19 01:01:58')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
+                    + "TIMESTAMP '1982-01-19 01:01:57')",
+                0)
+            .addExpr(
+                "TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
+                    + "TIMESTAMP '1982-01-19 01:01:58')",
+                1)
+            .addExpr(
+                "TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
+                    + "TIMESTAMP '1983-01-19 01:01:58')",
+                2)
+            .addExpr(
+                "TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
+                    + "TIMESTAMP '1980-01-19 01:01:58')",
+                -1)
+            .addExpr(
+                "TIMESTAMPDIFF(YEAR, TIMESTAMP '1981-01-19 01:01:58', "
+                    + "TIMESTAMP '1979-01-19 01:01:58')",
+                -2);
     checker.buildRunAndCheck();
   }
 
-  @Test public void testTimestampMinusInterval() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '2' SECOND",
-            parseDate("1984-04-19 01:01:56"))
-        .addExpr("TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '1' MINUTE",
-            parseDate("1984-04-19 01:00:58"))
-        .addExpr("TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '4' HOUR",
-            parseDate("1984-04-18 21:01:58"))
-        .addExpr("TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '5' DAY",
-            parseDate("1984-04-14 01:01:58"))
-        .addExpr("TIMESTAMP '1984-01-19 01:01:58' - INTERVAL '2' MONTH",
-            parseDate("1983-11-19 01:01:58"))
-        .addExpr("TIMESTAMP '1984-01-19 01:01:58' - INTERVAL '1' YEAR",
-            parseDate("1983-01-19 01:01:58"))
-        ;
+  @Test
+  public void testTimestampMinusInterval() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '2' SECOND",
+                parseDate("1984-04-19 01:01:56"))
+            .addExpr(
+                "TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '1' MINUTE",
+                parseDate("1984-04-19 01:00:58"))
+            .addExpr(
+                "TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '4' HOUR",
+                parseDate("1984-04-18 21:01:58"))
+            .addExpr(
+                "TIMESTAMP '1984-04-19 01:01:58' - INTERVAL '5' DAY",
+                parseDate("1984-04-14 01:01:58"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:01:58' - INTERVAL '2' MONTH",
+                parseDate("1983-11-19 01:01:58"))
+            .addExpr(
+                "TIMESTAMP '1984-01-19 01:01:58' - INTERVAL '1' YEAR",
+                parseDate("1983-01-19 01:01:58"));
     checker.buildRunAndCheck();
   }
 
-  @Test public void testDateTimeFunctions_currentTime() throws Exception {
-    String sql = "SELECT "
-        + "LOCALTIME as l,"
-        + "LOCALTIMESTAMP as l1,"
-        + "CURRENT_DATE as c1,"
-        + "CURRENT_TIME as c2,"
-        + "CURRENT_TIMESTAMP as c3"
-        + " FROM PCOLLECTION"
-        ;
-    PCollection<Row> rows = getTestPCollection().apply(
-        BeamSql.query(sql));
+  @Test
+  public void testDateTimeFunctions_currentTime() throws Exception {
+    String sql =
+        "SELECT "
+            + "LOCALTIME as l,"
+            + "LOCALTIMESTAMP as l1,"
+            + "CURRENT_DATE as c1,"
+            + "CURRENT_TIME as c2,"
+            + "CURRENT_TIMESTAMP as c3"
+            + " FROM PCOLLECTION";
+    PCollection<Row> rows = getTestPCollection().apply(BeamSql.query(sql));
     PAssert.that(rows).satisfies(new Checker());
     pipeline.run();
   }
 
   private static class Checker implements SerializableFunction<Iterable<Row>, Void> {
-    @Override public Void apply(Iterable<Row> input) {
+    @Override
+    public Void apply(Iterable<Row> input) {
       Iterator<Row> iter = input.iterator();
       assertTrue(iter.hasNext());
       Row row = iter.next();
-        // LOCALTIME
+      // LOCALTIME
       DateTime date = DateTime.now();
       assertTrue(date.getMillis() - row.getDateTime(0).getMillis() < 1000);
       assertTrue(date.getMillis() - row.getDateTime(1).getMillis() < 1000);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlLogicalFunctionsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlLogicalFunctionsIntegrationTest.java
@@ -19,25 +19,22 @@ package org.apache.beam.sdk.extensions.sql.integrationtest;
 
 import org.junit.Test;
 
-/**
- * Integration test for logical functions.
- */
+/** Integration test for logical functions. */
 public class BeamSqlLogicalFunctionsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
   @Test
   public void testStringFunctions() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("c_integer = 1 AND c_bigint = 1", true)
-        .addExpr("c_integer = 1 OR c_bigint = 2", true)
-        .addExpr("NOT c_bigint = 2", true)
-        .addExpr("(NOT c_bigint = 2) AND (c_integer = 1 OR c_bigint = 3)", true)
-        .addExpr("c_integer = 2 AND c_bigint = 1", false)
-        .addExpr("c_integer = 2 OR c_bigint = 2", false)
-        .addExpr("NOT c_bigint = 1", false)
-        .addExpr("(NOT c_bigint = 2) AND (c_integer = 2 OR c_bigint = 3)", false)
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("c_integer = 1 AND c_bigint = 1", true)
+            .addExpr("c_integer = 1 OR c_bigint = 2", true)
+            .addExpr("NOT c_bigint = 2", true)
+            .addExpr("(NOT c_bigint = 2) AND (c_integer = 1 OR c_bigint = 3)", true)
+            .addExpr("c_integer = 2 AND c_bigint = 1", false)
+            .addExpr("c_integer = 2 OR c_bigint = 2", false)
+            .addExpr("NOT c_bigint = 1", false)
+            .addExpr("(NOT c_bigint = 2) AND (c_integer = 2 OR c_bigint = 3)", false);
 
     checker.buildRunAndCheck();
   }
-
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlMathFunctionsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlMathFunctionsIntegrationTest.java
@@ -22,9 +22,7 @@ import java.util.Random;
 import org.apache.calcite.runtime.SqlFunctions;
 import org.junit.Test;
 
-/**
- * Integration test for built-in MATH functions.
- */
+/** Integration test for built-in MATH functions. */
 public class BeamSqlMathFunctionsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
   private static final int INTEGER_VALUE = 1;
@@ -36,315 +34,314 @@ public class BeamSqlMathFunctionsIntegrationTest
   private static final BigDecimal DECIMAL_VALUE = BigDecimal.ONE;
 
   @Test
-  public void testAbs() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ABS(c_integer)", Math.abs(INTEGER_VALUE))
-        .addExpr("ABS(c_bigint)", Math.abs(LONG_VALUE))
-        .addExpr("ABS(c_smallint)", (short) Math.abs(SHORT_VALUE))
-        .addExpr("ABS(c_tinyint)", (byte) Math.abs(BYTE_VALUE))
-        .addExpr("ABS(c_double)", Math.abs(DOUBLE_VALUE))
-        .addExpr("ABS(c_float)", Math.abs(FLOAT_VALUE))
-        .addExpr("ABS(c_decimal)", new BigDecimal(Math.abs(DECIMAL_VALUE.doubleValue())))
-        ;
+  public void testAbs() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ABS(c_integer)", Math.abs(INTEGER_VALUE))
+            .addExpr("ABS(c_bigint)", Math.abs(LONG_VALUE))
+            .addExpr("ABS(c_smallint)", (short) Math.abs(SHORT_VALUE))
+            .addExpr("ABS(c_tinyint)", (byte) Math.abs(BYTE_VALUE))
+            .addExpr("ABS(c_double)", Math.abs(DOUBLE_VALUE))
+            .addExpr("ABS(c_float)", Math.abs(FLOAT_VALUE))
+            .addExpr("ABS(c_decimal)", new BigDecimal(Math.abs(DECIMAL_VALUE.doubleValue())));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testSqrt() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("SQRT(c_integer)", Math.sqrt(INTEGER_VALUE))
-        .addExpr("SQRT(c_bigint)", Math.sqrt(LONG_VALUE))
-        .addExpr("SQRT(c_smallint)", Math.sqrt(SHORT_VALUE))
-        .addExpr("SQRT(c_tinyint)", Math.sqrt(BYTE_VALUE))
-        .addExpr("SQRT(c_double)", Math.sqrt(DOUBLE_VALUE))
-        .addExpr("SQRT(c_float)", Math.sqrt(FLOAT_VALUE))
-        .addExpr("SQRT(c_decimal)", Math.sqrt(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testSqrt() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("SQRT(c_integer)", Math.sqrt(INTEGER_VALUE))
+            .addExpr("SQRT(c_bigint)", Math.sqrt(LONG_VALUE))
+            .addExpr("SQRT(c_smallint)", Math.sqrt(SHORT_VALUE))
+            .addExpr("SQRT(c_tinyint)", Math.sqrt(BYTE_VALUE))
+            .addExpr("SQRT(c_double)", Math.sqrt(DOUBLE_VALUE))
+            .addExpr("SQRT(c_float)", Math.sqrt(FLOAT_VALUE))
+            .addExpr("SQRT(c_decimal)", Math.sqrt(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testRound() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ROUND(c_integer, 0)", SqlFunctions.sround(INTEGER_VALUE, 0))
-        .addExpr("ROUND(c_bigint, 0)", SqlFunctions.sround(LONG_VALUE, 0))
-        .addExpr("ROUND(c_smallint, 0)", (short) SqlFunctions.sround(SHORT_VALUE, 0))
-        .addExpr("ROUND(c_tinyint, 0)", (byte) SqlFunctions.sround(BYTE_VALUE, 0))
-        .addExpr("ROUND(c_double, 0)", SqlFunctions.sround(DOUBLE_VALUE, 0))
-        .addExpr("ROUND(c_float, 0)", (float) SqlFunctions.sround(FLOAT_VALUE, 0))
-        .addExpr("ROUND(c_decimal, 0)",
-            new BigDecimal(SqlFunctions.sround(DECIMAL_VALUE.doubleValue(), 0)))
-        ;
+  public void testRound() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ROUND(c_integer, 0)", SqlFunctions.sround(INTEGER_VALUE, 0))
+            .addExpr("ROUND(c_bigint, 0)", SqlFunctions.sround(LONG_VALUE, 0))
+            .addExpr("ROUND(c_smallint, 0)", (short) SqlFunctions.sround(SHORT_VALUE, 0))
+            .addExpr("ROUND(c_tinyint, 0)", (byte) SqlFunctions.sround(BYTE_VALUE, 0))
+            .addExpr("ROUND(c_double, 0)", SqlFunctions.sround(DOUBLE_VALUE, 0))
+            .addExpr("ROUND(c_float, 0)", (float) SqlFunctions.sround(FLOAT_VALUE, 0))
+            .addExpr(
+                "ROUND(c_decimal, 0)",
+                new BigDecimal(SqlFunctions.sround(DECIMAL_VALUE.doubleValue(), 0)));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testLn() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("LN(c_integer)", Math.log(INTEGER_VALUE))
-        .addExpr("LN(c_bigint)", Math.log(LONG_VALUE))
-        .addExpr("LN(c_smallint)", Math.log(SHORT_VALUE))
-        .addExpr("LN(c_tinyint)", Math.log(BYTE_VALUE))
-        .addExpr("LN(c_double)", Math.log(DOUBLE_VALUE))
-        .addExpr("LN(c_float)", Math.log(FLOAT_VALUE))
-        .addExpr("LN(c_decimal)", Math.log(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testLn() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("LN(c_integer)", Math.log(INTEGER_VALUE))
+            .addExpr("LN(c_bigint)", Math.log(LONG_VALUE))
+            .addExpr("LN(c_smallint)", Math.log(SHORT_VALUE))
+            .addExpr("LN(c_tinyint)", Math.log(BYTE_VALUE))
+            .addExpr("LN(c_double)", Math.log(DOUBLE_VALUE))
+            .addExpr("LN(c_float)", Math.log(FLOAT_VALUE))
+            .addExpr("LN(c_decimal)", Math.log(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testLog10() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("LOG10(c_integer)", Math.log10(INTEGER_VALUE))
-        .addExpr("LOG10(c_bigint)", Math.log10(LONG_VALUE))
-        .addExpr("LOG10(c_smallint)", Math.log10(SHORT_VALUE))
-        .addExpr("LOG10(c_tinyint)", Math.log10(BYTE_VALUE))
-        .addExpr("LOG10(c_double)", Math.log10(DOUBLE_VALUE))
-        .addExpr("LOG10(c_float)", Math.log10(FLOAT_VALUE))
-        .addExpr("LOG10(c_decimal)", Math.log10(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testLog10() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("LOG10(c_integer)", Math.log10(INTEGER_VALUE))
+            .addExpr("LOG10(c_bigint)", Math.log10(LONG_VALUE))
+            .addExpr("LOG10(c_smallint)", Math.log10(SHORT_VALUE))
+            .addExpr("LOG10(c_tinyint)", Math.log10(BYTE_VALUE))
+            .addExpr("LOG10(c_double)", Math.log10(DOUBLE_VALUE))
+            .addExpr("LOG10(c_float)", Math.log10(FLOAT_VALUE))
+            .addExpr("LOG10(c_decimal)", Math.log10(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testExp() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("EXP(c_integer)", Math.exp(INTEGER_VALUE))
-        .addExpr("EXP(c_bigint)", Math.exp(LONG_VALUE))
-        .addExpr("EXP(c_smallint)", Math.exp(SHORT_VALUE))
-        .addExpr("EXP(c_tinyint)", Math.exp(BYTE_VALUE))
-        .addExpr("EXP(c_double)", Math.exp(DOUBLE_VALUE))
-        .addExpr("EXP(c_float)", Math.exp(FLOAT_VALUE))
-        .addExpr("EXP(c_decimal)", Math.exp(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testExp() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("EXP(c_integer)", Math.exp(INTEGER_VALUE))
+            .addExpr("EXP(c_bigint)", Math.exp(LONG_VALUE))
+            .addExpr("EXP(c_smallint)", Math.exp(SHORT_VALUE))
+            .addExpr("EXP(c_tinyint)", Math.exp(BYTE_VALUE))
+            .addExpr("EXP(c_double)", Math.exp(DOUBLE_VALUE))
+            .addExpr("EXP(c_float)", Math.exp(FLOAT_VALUE))
+            .addExpr("EXP(c_decimal)", Math.exp(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testAcos() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ACOS(c_integer)", Math.acos(INTEGER_VALUE))
-        .addExpr("ACOS(c_bigint)", Math.acos(LONG_VALUE))
-        .addExpr("ACOS(c_smallint)", Math.acos(SHORT_VALUE))
-        .addExpr("ACOS(c_tinyint)", Math.acos(BYTE_VALUE))
-        .addExpr("ACOS(c_double)", Math.acos(DOUBLE_VALUE))
-        .addExpr("ACOS(c_float)", Math.acos(FLOAT_VALUE))
-        .addExpr("ACOS(c_decimal)", Math.acos(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testAcos() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ACOS(c_integer)", Math.acos(INTEGER_VALUE))
+            .addExpr("ACOS(c_bigint)", Math.acos(LONG_VALUE))
+            .addExpr("ACOS(c_smallint)", Math.acos(SHORT_VALUE))
+            .addExpr("ACOS(c_tinyint)", Math.acos(BYTE_VALUE))
+            .addExpr("ACOS(c_double)", Math.acos(DOUBLE_VALUE))
+            .addExpr("ACOS(c_float)", Math.acos(FLOAT_VALUE))
+            .addExpr("ACOS(c_decimal)", Math.acos(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testAsin() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ASIN(c_integer)", Math.asin(INTEGER_VALUE))
-        .addExpr("ASIN(c_bigint)", Math.asin(LONG_VALUE))
-        .addExpr("ASIN(c_smallint)", Math.asin(SHORT_VALUE))
-        .addExpr("ASIN(c_tinyint)", Math.asin(BYTE_VALUE))
-        .addExpr("ASIN(c_double)", Math.asin(DOUBLE_VALUE))
-        .addExpr("ASIN(c_float)", Math.asin(FLOAT_VALUE))
-        .addExpr("ASIN(c_decimal)", Math.asin(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testAsin() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ASIN(c_integer)", Math.asin(INTEGER_VALUE))
+            .addExpr("ASIN(c_bigint)", Math.asin(LONG_VALUE))
+            .addExpr("ASIN(c_smallint)", Math.asin(SHORT_VALUE))
+            .addExpr("ASIN(c_tinyint)", Math.asin(BYTE_VALUE))
+            .addExpr("ASIN(c_double)", Math.asin(DOUBLE_VALUE))
+            .addExpr("ASIN(c_float)", Math.asin(FLOAT_VALUE))
+            .addExpr("ASIN(c_decimal)", Math.asin(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testAtan() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ATAN(c_integer)", Math.atan(INTEGER_VALUE))
-        .addExpr("ATAN(c_bigint)", Math.atan(LONG_VALUE))
-        .addExpr("ATAN(c_smallint)", Math.atan(SHORT_VALUE))
-        .addExpr("ATAN(c_tinyint)", Math.atan(BYTE_VALUE))
-        .addExpr("ATAN(c_double)", Math.atan(DOUBLE_VALUE))
-        .addExpr("ATAN(c_float)", Math.atan(FLOAT_VALUE))
-        .addExpr("ATAN(c_decimal)", Math.atan(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testAtan() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ATAN(c_integer)", Math.atan(INTEGER_VALUE))
+            .addExpr("ATAN(c_bigint)", Math.atan(LONG_VALUE))
+            .addExpr("ATAN(c_smallint)", Math.atan(SHORT_VALUE))
+            .addExpr("ATAN(c_tinyint)", Math.atan(BYTE_VALUE))
+            .addExpr("ATAN(c_double)", Math.atan(DOUBLE_VALUE))
+            .addExpr("ATAN(c_float)", Math.atan(FLOAT_VALUE))
+            .addExpr("ATAN(c_decimal)", Math.atan(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testCot() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("COT(c_integer)", 1.0d / Math.tan(INTEGER_VALUE))
-        .addExpr("COT(c_bigint)", 1.0d / Math.tan(LONG_VALUE))
-        .addExpr("COT(c_smallint)", 1.0d / Math.tan(SHORT_VALUE))
-        .addExpr("COT(c_tinyint)", 1.0d / Math.tan(BYTE_VALUE))
-        .addExpr("COT(c_double)", 1.0d / Math.tan(DOUBLE_VALUE))
-        .addExpr("COT(c_float)", 1.0d / Math.tan(FLOAT_VALUE))
-        .addExpr("COT(c_decimal)", 1.0d / Math.tan(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testCot() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("COT(c_integer)", 1.0d / Math.tan(INTEGER_VALUE))
+            .addExpr("COT(c_bigint)", 1.0d / Math.tan(LONG_VALUE))
+            .addExpr("COT(c_smallint)", 1.0d / Math.tan(SHORT_VALUE))
+            .addExpr("COT(c_tinyint)", 1.0d / Math.tan(BYTE_VALUE))
+            .addExpr("COT(c_double)", 1.0d / Math.tan(DOUBLE_VALUE))
+            .addExpr("COT(c_float)", 1.0d / Math.tan(FLOAT_VALUE))
+            .addExpr("COT(c_decimal)", 1.0d / Math.tan(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testDegrees() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("DEGREES(c_integer)", Math.toDegrees(INTEGER_VALUE))
-        .addExpr("DEGREES(c_bigint)", Math.toDegrees(LONG_VALUE))
-        .addExpr("DEGREES(c_smallint)", Math.toDegrees(SHORT_VALUE))
-        .addExpr("DEGREES(c_tinyint)", Math.toDegrees(BYTE_VALUE))
-        .addExpr("DEGREES(c_double)", Math.toDegrees(DOUBLE_VALUE))
-        .addExpr("DEGREES(c_float)", Math.toDegrees(FLOAT_VALUE))
-        .addExpr("DEGREES(c_decimal)", Math.toDegrees(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testDegrees() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("DEGREES(c_integer)", Math.toDegrees(INTEGER_VALUE))
+            .addExpr("DEGREES(c_bigint)", Math.toDegrees(LONG_VALUE))
+            .addExpr("DEGREES(c_smallint)", Math.toDegrees(SHORT_VALUE))
+            .addExpr("DEGREES(c_tinyint)", Math.toDegrees(BYTE_VALUE))
+            .addExpr("DEGREES(c_double)", Math.toDegrees(DOUBLE_VALUE))
+            .addExpr("DEGREES(c_float)", Math.toDegrees(FLOAT_VALUE))
+            .addExpr("DEGREES(c_decimal)", Math.toDegrees(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testRadians() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("RADIANS(c_integer)", Math.toRadians(INTEGER_VALUE))
-        .addExpr("RADIANS(c_bigint)", Math.toRadians(LONG_VALUE))
-        .addExpr("RADIANS(c_smallint)", Math.toRadians(SHORT_VALUE))
-        .addExpr("RADIANS(c_tinyint)", Math.toRadians(BYTE_VALUE))
-        .addExpr("RADIANS(c_double)", Math.toRadians(DOUBLE_VALUE))
-        .addExpr("RADIANS(c_float)", Math.toRadians(FLOAT_VALUE))
-        .addExpr("RADIANS(c_decimal)", Math.toRadians(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testRadians() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("RADIANS(c_integer)", Math.toRadians(INTEGER_VALUE))
+            .addExpr("RADIANS(c_bigint)", Math.toRadians(LONG_VALUE))
+            .addExpr("RADIANS(c_smallint)", Math.toRadians(SHORT_VALUE))
+            .addExpr("RADIANS(c_tinyint)", Math.toRadians(BYTE_VALUE))
+            .addExpr("RADIANS(c_double)", Math.toRadians(DOUBLE_VALUE))
+            .addExpr("RADIANS(c_float)", Math.toRadians(FLOAT_VALUE))
+            .addExpr("RADIANS(c_decimal)", Math.toRadians(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testCos() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("COS(c_integer)", Math.cos(INTEGER_VALUE))
-        .addExpr("COS(c_bigint)", Math.cos(LONG_VALUE))
-        .addExpr("COS(c_smallint)", Math.cos(SHORT_VALUE))
-        .addExpr("COS(c_tinyint)", Math.cos(BYTE_VALUE))
-        .addExpr("COS(c_double)", Math.cos(DOUBLE_VALUE))
-        .addExpr("COS(c_float)", Math.cos(FLOAT_VALUE))
-        .addExpr("COS(c_decimal)", Math.cos(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testCos() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("COS(c_integer)", Math.cos(INTEGER_VALUE))
+            .addExpr("COS(c_bigint)", Math.cos(LONG_VALUE))
+            .addExpr("COS(c_smallint)", Math.cos(SHORT_VALUE))
+            .addExpr("COS(c_tinyint)", Math.cos(BYTE_VALUE))
+            .addExpr("COS(c_double)", Math.cos(DOUBLE_VALUE))
+            .addExpr("COS(c_float)", Math.cos(FLOAT_VALUE))
+            .addExpr("COS(c_decimal)", Math.cos(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testSin() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("SIN(c_integer)", Math.sin(INTEGER_VALUE))
-        .addExpr("SIN(c_bigint)", Math.sin(LONG_VALUE))
-        .addExpr("SIN(c_smallint)", Math.sin(SHORT_VALUE))
-        .addExpr("SIN(c_tinyint)", Math.sin(BYTE_VALUE))
-        .addExpr("SIN(c_double)", Math.sin(DOUBLE_VALUE))
-        .addExpr("SIN(c_float)", Math.sin(FLOAT_VALUE))
-        .addExpr("SIN(c_decimal)", Math.sin(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testSin() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("SIN(c_integer)", Math.sin(INTEGER_VALUE))
+            .addExpr("SIN(c_bigint)", Math.sin(LONG_VALUE))
+            .addExpr("SIN(c_smallint)", Math.sin(SHORT_VALUE))
+            .addExpr("SIN(c_tinyint)", Math.sin(BYTE_VALUE))
+            .addExpr("SIN(c_double)", Math.sin(DOUBLE_VALUE))
+            .addExpr("SIN(c_float)", Math.sin(FLOAT_VALUE))
+            .addExpr("SIN(c_decimal)", Math.sin(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testTan() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TAN(c_integer)", Math.tan(INTEGER_VALUE))
-        .addExpr("TAN(c_bigint)", Math.tan(LONG_VALUE))
-        .addExpr("TAN(c_smallint)", Math.tan(SHORT_VALUE))
-        .addExpr("TAN(c_tinyint)", Math.tan(BYTE_VALUE))
-        .addExpr("TAN(c_double)", Math.tan(DOUBLE_VALUE))
-        .addExpr("TAN(c_float)", Math.tan(FLOAT_VALUE))
-        .addExpr("TAN(c_decimal)", Math.tan(DECIMAL_VALUE.doubleValue()))
-        ;
+  public void testTan() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("TAN(c_integer)", Math.tan(INTEGER_VALUE))
+            .addExpr("TAN(c_bigint)", Math.tan(LONG_VALUE))
+            .addExpr("TAN(c_smallint)", Math.tan(SHORT_VALUE))
+            .addExpr("TAN(c_tinyint)", Math.tan(BYTE_VALUE))
+            .addExpr("TAN(c_double)", Math.tan(DOUBLE_VALUE))
+            .addExpr("TAN(c_float)", Math.tan(FLOAT_VALUE))
+            .addExpr("TAN(c_decimal)", Math.tan(DECIMAL_VALUE.doubleValue()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testSign() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("SIGN(c_integer)", Integer.signum(INTEGER_VALUE))
-        .addExpr("SIGN(c_bigint)", (long) (Long.signum(LONG_VALUE)))
-        .addExpr("SIGN(c_smallint)", (short) (Integer.signum(SHORT_VALUE)))
-        .addExpr("SIGN(c_tinyint)", (byte) Integer.signum(BYTE_VALUE))
-        .addExpr("SIGN(c_double)", Math.signum(DOUBLE_VALUE))
-        .addExpr("SIGN(c_float)", Math.signum(FLOAT_VALUE))
-        .addExpr("SIGN(c_decimal)", BigDecimal.valueOf(DECIMAL_VALUE.signum()))
-        ;
+  public void testSign() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("SIGN(c_integer)", Integer.signum(INTEGER_VALUE))
+            .addExpr("SIGN(c_bigint)", (long) (Long.signum(LONG_VALUE)))
+            .addExpr("SIGN(c_smallint)", (short) (Integer.signum(SHORT_VALUE)))
+            .addExpr("SIGN(c_tinyint)", (byte) Integer.signum(BYTE_VALUE))
+            .addExpr("SIGN(c_double)", Math.signum(DOUBLE_VALUE))
+            .addExpr("SIGN(c_float)", Math.signum(FLOAT_VALUE))
+            .addExpr("SIGN(c_decimal)", BigDecimal.valueOf(DECIMAL_VALUE.signum()));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testPower() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("POWER(c_integer, 2)", Math.pow(INTEGER_VALUE, 2))
-        .addExpr("POWER(c_bigint, 2)", Math.pow(LONG_VALUE, 2))
-        .addExpr("POWER(c_smallint, 2)", Math.pow(SHORT_VALUE, 2))
-        .addExpr("POWER(c_tinyint, 2)", Math.pow(BYTE_VALUE, 2))
-        .addExpr("POWER(c_double, 2)", Math.pow(DOUBLE_VALUE, 2))
-        .addExpr("POWER(c_float, 2)", Math.pow(FLOAT_VALUE, 2))
-        .addExpr("POWER(c_decimal, 2)", Math.pow(DECIMAL_VALUE.doubleValue(), 2))
-        ;
+  public void testPower() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("POWER(c_integer, 2)", Math.pow(INTEGER_VALUE, 2))
+            .addExpr("POWER(c_bigint, 2)", Math.pow(LONG_VALUE, 2))
+            .addExpr("POWER(c_smallint, 2)", Math.pow(SHORT_VALUE, 2))
+            .addExpr("POWER(c_tinyint, 2)", Math.pow(BYTE_VALUE, 2))
+            .addExpr("POWER(c_double, 2)", Math.pow(DOUBLE_VALUE, 2))
+            .addExpr("POWER(c_float, 2)", Math.pow(FLOAT_VALUE, 2))
+            .addExpr("POWER(c_decimal, 2)", Math.pow(DECIMAL_VALUE.doubleValue(), 2));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testPi() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("PI", Math.PI)
-        ;
+  public void testPi() throws Exception {
+    ExpressionChecker checker = new ExpressionChecker().addExpr("PI", Math.PI);
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testAtan2() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("ATAN2(c_integer, 2)", Math.atan2(INTEGER_VALUE, 2))
-        .addExpr("ATAN2(c_bigint, 2)", Math.atan2(LONG_VALUE, 2))
-        .addExpr("ATAN2(c_smallint, 2)", Math.atan2(SHORT_VALUE, 2))
-        .addExpr("ATAN2(c_tinyint, 2)", Math.atan2(BYTE_VALUE, 2))
-        .addExpr("ATAN2(c_double, 2)", Math.atan2(DOUBLE_VALUE, 2))
-        .addExpr("ATAN2(c_float, 2)", Math.atan2(FLOAT_VALUE, 2))
-        .addExpr("ATAN2(c_decimal, 2)", Math.atan2(DECIMAL_VALUE.doubleValue(), 2))
-        ;
+  public void testAtan2() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("ATAN2(c_integer, 2)", Math.atan2(INTEGER_VALUE, 2))
+            .addExpr("ATAN2(c_bigint, 2)", Math.atan2(LONG_VALUE, 2))
+            .addExpr("ATAN2(c_smallint, 2)", Math.atan2(SHORT_VALUE, 2))
+            .addExpr("ATAN2(c_tinyint, 2)", Math.atan2(BYTE_VALUE, 2))
+            .addExpr("ATAN2(c_double, 2)", Math.atan2(DOUBLE_VALUE, 2))
+            .addExpr("ATAN2(c_float, 2)", Math.atan2(FLOAT_VALUE, 2))
+            .addExpr("ATAN2(c_decimal, 2)", Math.atan2(DECIMAL_VALUE.doubleValue(), 2));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testTruncate() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("TRUNCATE(c_integer, 2)", SqlFunctions.struncate(INTEGER_VALUE, 2))
-        .addExpr("TRUNCATE(c_bigint, 2)", SqlFunctions.struncate(LONG_VALUE, 2))
-        .addExpr("TRUNCATE(c_smallint, 2)", (short) SqlFunctions.struncate(SHORT_VALUE, 2))
-        .addExpr("TRUNCATE(c_tinyint, 2)", (byte) SqlFunctions.struncate(BYTE_VALUE, 2))
-        .addExpr("TRUNCATE(c_double, 2)", SqlFunctions.struncate(DOUBLE_VALUE, 2))
-        .addExpr("TRUNCATE(c_float, 2)", (float) SqlFunctions.struncate(FLOAT_VALUE, 2))
-        .addExpr("TRUNCATE(c_decimal, 2)", SqlFunctions.struncate(DECIMAL_VALUE, 2))
-        ;
+  public void testTruncate() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("TRUNCATE(c_integer, 2)", SqlFunctions.struncate(INTEGER_VALUE, 2))
+            .addExpr("TRUNCATE(c_bigint, 2)", SqlFunctions.struncate(LONG_VALUE, 2))
+            .addExpr("TRUNCATE(c_smallint, 2)", (short) SqlFunctions.struncate(SHORT_VALUE, 2))
+            .addExpr("TRUNCATE(c_tinyint, 2)", (byte) SqlFunctions.struncate(BYTE_VALUE, 2))
+            .addExpr("TRUNCATE(c_double, 2)", SqlFunctions.struncate(DOUBLE_VALUE, 2))
+            .addExpr("TRUNCATE(c_float, 2)", (float) SqlFunctions.struncate(FLOAT_VALUE, 2))
+            .addExpr("TRUNCATE(c_decimal, 2)", SqlFunctions.struncate(DECIMAL_VALUE, 2));
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testRand() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("RAND(c_integer)", new Random(INTEGER_VALUE).nextDouble())
-        ;
+  public void testRand() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker().addExpr("RAND(c_integer)", new Random(INTEGER_VALUE).nextDouble());
 
     checker.buildRunAndCheck();
   }
 
   @Test
-  public void testRandInteger() throws Exception{
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("RAND_INTEGER(c_integer, c_integer)",
-            new Random(INTEGER_VALUE).nextInt(INTEGER_VALUE))
-        ;
+  public void testRandInteger() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "RAND_INTEGER(c_integer, c_integer)",
+                new Random(INTEGER_VALUE).nextInt(INTEGER_VALUE));
 
     checker.buildRunAndCheck();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlStringFunctionsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlStringFunctionsIntegrationTest.java
@@ -19,32 +19,28 @@ package org.apache.beam.sdk.extensions.sql.integrationtest;
 
 import org.junit.Test;
 
-/**
- * Integration test for string functions.
- */
+/** Integration test for string functions. */
 public class BeamSqlStringFunctionsIntegrationTest
     extends BeamSqlBuiltinFunctionsIntegrationTestBase {
   @Test
   public void testStringFunctions() throws Exception {
-    ExpressionChecker checker = new ExpressionChecker()
-        .addExpr("'hello' || ' world'", "hello world")
-        .addExpr("CHAR_LENGTH('hello')", 5)
-        .addExpr("CHARACTER_LENGTH('hello')", 5)
-        .addExpr("UPPER('hello')", "HELLO")
-        .addExpr("LOWER('HELLO')", "hello")
-
-        .addExpr("POSITION('world' IN 'helloworld')", 5)
-        .addExpr("POSITION('world' IN 'helloworldworld' FROM 7)", 10)
-        .addExpr("TRIM(' hello ')", "hello")
-        .addExpr("TRIM(LEADING ' ' FROM ' hello ')", "hello ")
-        .addExpr("TRIM(TRAILING ' ' FROM ' hello ')", " hello")
-
-        .addExpr("TRIM(BOTH ' ' FROM ' hello ')", "hello")
-        .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3)", "w3resou3rce")
-        .addExpr("SUBSTRING('hello' FROM 2)", "ello")
-        .addExpr("SUBSTRING('hello' FROM 2 FOR 2)", "el")
-        .addExpr("INITCAP('hello world')", "Hello World")
-        ;
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("'hello' || ' world'", "hello world")
+            .addExpr("CHAR_LENGTH('hello')", 5)
+            .addExpr("CHARACTER_LENGTH('hello')", 5)
+            .addExpr("UPPER('hello')", "HELLO")
+            .addExpr("LOWER('HELLO')", "hello")
+            .addExpr("POSITION('world' IN 'helloworld')", 5)
+            .addExpr("POSITION('world' IN 'helloworldworld' FROM 7)", 10)
+            .addExpr("TRIM(' hello ')", "hello")
+            .addExpr("TRIM(LEADING ' ' FROM ' hello ')", "hello ")
+            .addExpr("TRIM(TRAILING ' ' FROM ' hello ')", " hello")
+            .addExpr("TRIM(BOTH ' ' FROM ' hello ')", "hello")
+            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3)", "w3resou3rce")
+            .addExpr("SUBSTRING('hello' FROM 2)", "ello")
+            .addExpr("SUBSTRING('hello' FROM 2 FOR 2)", "el")
+            .addExpr("INITCAP('hello world')", "Hello World");
 
     checker.buildRunAndCheck();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryTableProviderTest.java
@@ -30,9 +30,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link BigQueryTableProvider}.
- */
+/** UnitTest for {@link BigQueryTableProvider}. */
 public class BigQueryTableProviderTest {
   private BigQueryTableProvider provider = new BigQueryTableProvider();
 
@@ -60,9 +58,9 @@ public class BigQueryTableProviderTest {
         .location("project:dataset.table")
         .schema(
             Stream.of(
-                Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
-                Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
-                  .collect(toSchema()))
+                    Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
+                    Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
+                .collect(toSchema()))
         .type("bigquery")
         .build();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
@@ -37,48 +37,34 @@ import org.apache.commons.csv.CSVFormat;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Test for BeamKafkaCSVTable.
- */
+/** Test for BeamKafkaCSVTable. */
 public class BeamKafkaCSVTableTest {
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
-  private static final Row ROW1 =
-      Row
-          .withSchema(genRowType())
-          .addValues(1L, 1, 1.0)
-          .build();
+  private static final Row ROW1 = Row.withSchema(genRowType()).addValues(1L, 1, 1.0).build();
 
-  private static final Row ROW2 =
-      Row.withSchema(genRowType())
-          .addValues(2L, 2, 2.0)
-          .build();
+  private static final Row ROW2 = Row.withSchema(genRowType()).addValues(2L, 2, 2.0).build();
 
-  @Test public void testCsvRecorderDecoder() throws Exception {
-    PCollection<Row> result = pipeline
-        .apply(
-            Create.of("1,\"1\",1.0", "2,2,2.0")
-        )
-        .apply(ParDo.of(new String2KvBytes()))
-        .apply(
-            new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT)
-        );
+  @Test
+  public void testCsvRecorderDecoder() throws Exception {
+    PCollection<Row> result =
+        pipeline
+            .apply(Create.of("1,\"1\",1.0", "2,2,2.0"))
+            .apply(ParDo.of(new String2KvBytes()))
+            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT));
 
     PAssert.that(result).containsInAnyOrder(ROW1, ROW2);
 
     pipeline.run();
   }
 
-  @Test public void testCsvRecorderEncoder() throws Exception {
-    PCollection<Row> result = pipeline
-        .apply(
-            Create.of(ROW1, ROW2)
-        )
-        .apply(
-            new BeamKafkaCSVTable.CsvRecorderEncoder(genRowType(), CSVFormat.DEFAULT)
-        ).apply(
-            new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT)
-        );
+  @Test
+  public void testCsvRecorderEncoder() throws Exception {
+    PCollection<Row> result =
+        pipeline
+            .apply(Create.of(ROW1, ROW2))
+            .apply(new BeamKafkaCSVTable.CsvRecorderEncoder(genRowType(), CSVFormat.DEFAULT))
+            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT));
 
     PAssert.that(result).containsInAnyOrder(ROW1, ROW2);
 
@@ -88,7 +74,8 @@ public class BeamKafkaCSVTableTest {
   private static Schema genRowType() {
     JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     return CalciteUtils.toBeamSchema(
-        typeFactory.builder()
+        typeFactory
+            .builder()
             .add("order_id", SqlTypeName.BIGINT)
             .add("site_id", SqlTypeName.INTEGER)
             .add("price", SqlTypeName.DOUBLE)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/KafkaTableProviderTest.java
@@ -33,12 +33,12 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link KafkaTableProvider}.
- */
+/** UnitTest for {@link KafkaTableProvider}. */
 public class KafkaTableProviderTest {
   private KafkaTableProvider provider = new KafkaTableProvider();
-  @Test public void testBuildBeamSqlTable() throws Exception {
+
+  @Test
+  public void testBuildBeamSqlTable() throws Exception {
     Table table = mockTable("hello");
     BeamSqlTable sqlTable = provider.buildBeamSqlTable(table);
 
@@ -63,16 +63,15 @@ public class KafkaTableProviderTest {
     topics.add("topic2");
     properties.put("topics", topics);
 
-    return Table
-        .builder()
+    return Table.builder()
         .name(name)
         .comment(name + " table")
         .location("kafka://localhost:2181/brokers?topic=test")
         .schema(
             Stream.of(
-                Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
-                Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
-                  .collect(toSchema()))
+                    Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
+                    Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
+                .collect(toSchema()))
         .type("kafka")
         .properties(properties)
         .build();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonTableProviderTest.java
@@ -30,13 +30,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/**
- * Unit tests for {@link PubsubJsonTableProvider}.
- */
+/** Unit tests for {@link PubsubJsonTableProvider}. */
 public class PubsubJsonTableProviderTest {
 
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
+  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testTableTypePubsub() {
@@ -47,12 +44,12 @@ public class PubsubJsonTableProviderTest {
   @Test
   public void testCreatesTable() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema = RowSqlTypes
-        .builder()
-        .withTimestampField("event_timestamp")
-        .withMapField("attributes", VARCHAR, VARCHAR)
-        .withRowField("payload", Schema.builder().build())
-        .build();
+    Schema messageSchema =
+        RowSqlTypes.builder()
+            .withTimestampField("event_timestamp")
+            .withMapField("attributes", VARCHAR, VARCHAR)
+            .withRowField("payload", Schema.builder().build())
+            .build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
@@ -65,11 +62,11 @@ public class PubsubJsonTableProviderTest {
   @Test
   public void testThrowsIfTimestampFieldNotProvided() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema = RowSqlTypes
-        .builder()
-        .withMapField("attributes", VARCHAR, VARCHAR)
-        .withRowField("payload", Schema.builder().build())
-        .build();
+    Schema messageSchema =
+        RowSqlTypes.builder()
+            .withMapField("attributes", VARCHAR, VARCHAR)
+            .withRowField("payload", Schema.builder().build())
+            .build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
@@ -81,11 +78,11 @@ public class PubsubJsonTableProviderTest {
   @Test
   public void testThrowsIfAttributesFieldNotProvided() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema = RowSqlTypes
-        .builder()
-        .withTimestampField("event_timestamp")
-        .withRowField("payload", Schema.builder().build())
-        .build();
+    Schema messageSchema =
+        RowSqlTypes.builder()
+            .withTimestampField("event_timestamp")
+            .withRowField("payload", Schema.builder().build())
+            .build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
@@ -97,11 +94,11 @@ public class PubsubJsonTableProviderTest {
   @Test
   public void testThrowsIfPayloadFieldNotProvided() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema = RowSqlTypes
-        .builder()
-        .withTimestampField("event_timestamp")
-        .withMapField("attributes", VARCHAR, VARCHAR)
-        .build();
+    Schema messageSchema =
+        RowSqlTypes.builder()
+            .withTimestampField("event_timestamp")
+            .withMapField("attributes", VARCHAR, VARCHAR)
+            .build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
@@ -113,13 +110,13 @@ public class PubsubJsonTableProviderTest {
   @Test
   public void testThrowsIfExtraFieldsExist() {
     PubsubJsonTableProvider provider = new PubsubJsonTableProvider();
-    Schema messageSchema = RowSqlTypes
-        .builder()
-        .withTimestampField("event_timestamp")
-        .withMapField("attributes", VARCHAR, VARCHAR)
-        .withVarcharField("someField")
-        .withRowField("payload", Schema.builder().build())
-        .build();
+    Schema messageSchema =
+        RowSqlTypes.builder()
+            .withTimestampField("event_timestamp")
+            .withMapField("attributes", VARCHAR, VARCHAR)
+            .withVarcharField("someField")
+            .withRowField("payload", Schema.builder().build())
+            .build();
 
     Table tableDefinition = tableDefinition().schema(messageSchema).build();
 
@@ -129,14 +126,12 @@ public class PubsubJsonTableProviderTest {
   }
 
   private static Table.Builder tableDefinition() {
-    return
-        Table
-            .builder()
-            .name("FakeTable")
-            .comment("fake table")
-            .location("projects/project/topics/topic")
-            .schema(Schema.builder().build())
-            .type("pubsub")
-            .properties(JSON.parseObject("{ \"timestampAttributeKey\" : \"ts_field\" }"));
+    return Table.builder()
+        .name("FakeTable")
+        .comment("fake table")
+        .location("projects/project/topics/topic")
+        .schema(Schema.builder().build())
+        .type("pubsub")
+        .properties(JSON.parseObject("{ \"timestampAttributeKey\" : \"ts_field\" }"));
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
@@ -49,62 +49,54 @@ import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link PubsubMessageToRow}.
- */
+/** Unit tests for {@link PubsubMessageToRow}. */
 public class PubsubMessageToRowTest implements Serializable {
 
-  @Rule
-  public transient TestPipeline pipeline = TestPipeline.create();
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
 
   @Test
   public void testConvertsMessages() {
     Schema payloadSchema =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("id")
-            .withVarcharField("name")
-            .build();
+        RowSqlTypes.builder().withIntegerField("id").withVarcharField("name").build();
 
     Schema messageSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withTimestampField("event_timestamp")
             .withMapField("attributes", VARCHAR, VARCHAR)
             .withRowField("payload", payloadSchema)
             .build();
 
-    PCollection<Row> rows = pipeline
-        .apply("create",
-               Create.timestamped(
-                   message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
-                   message(2, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }"),
-                   message(3, map("cttr", "vcl"), "{ \"id\" : 7, \"name\" : \"bar\" }"),
-                   message(4, map("dttr", "vdl"), "{ \"name\" : \"qaz\", \"id\" : 8 }")))
-        .apply("convert",
-               ParDo.of(
-                   PubsubMessageToRow
-                            .builder()
-                            .messageSchema(messageSchema)
-                            .useDlq(false)
-                            .build()));
+    PCollection<Row> rows =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message(1, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                    message(2, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }"),
+                    message(3, map("cttr", "vcl"), "{ \"id\" : 7, \"name\" : \"bar\" }"),
+                    message(4, map("dttr", "vdl"), "{ \"name\" : \"qaz\", \"id\" : 8 }")))
+            .apply(
+                "convert",
+                ParDo.of(
+                    PubsubMessageToRow.builder()
+                        .messageSchema(messageSchema)
+                        .useDlq(false)
+                        .build()));
 
-    PAssert
-        .that(rows)
+    PAssert.that(rows)
         .containsInAnyOrder(
             Row.withSchema(messageSchema)
-               .addValues(ts(1), map("attr", "val"), row(payloadSchema, 3, "foo"))
-               .build(),
+                .addValues(ts(1), map("attr", "val"), row(payloadSchema, 3, "foo"))
+                .build(),
             Row.withSchema(messageSchema)
-               .addValues(ts(2), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
-               .build(),
+                .addValues(ts(2), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
+                .build(),
             Row.withSchema(messageSchema)
-               .addValues(ts(3), map("cttr", "vcl"), row(payloadSchema, 7, "bar"))
-               .build(),
+                .addValues(ts(3), map("cttr", "vcl"), row(payloadSchema, 7, "bar"))
+                .build(),
             Row.withSchema(messageSchema)
-               .addValues(ts(4), map("dttr", "vdl"), row(payloadSchema, 8, "qaz"))
-               .build()
-        );
+                .addValues(ts(4), map("dttr", "vdl"), row(payloadSchema, 8, "qaz"))
+                .build());
 
     pipeline.run();
   }
@@ -112,62 +104,58 @@ public class PubsubMessageToRowTest implements Serializable {
   @Test
   public void testSendsInvalidToDLQ() {
     Schema payloadSchema =
-        RowSqlTypes
-            .builder()
-            .withIntegerField("id")
-            .withVarcharField("name")
-            .build();
+        RowSqlTypes.builder().withIntegerField("id").withVarcharField("name").build();
 
     Schema messageSchema =
-        RowSqlTypes
-            .builder()
+        RowSqlTypes.builder()
             .withTimestampField("event_timestamp")
             .withMapField("attributes", VARCHAR, VARCHAR)
             .withRowField("payload", payloadSchema)
             .build();
 
-    PCollectionTuple outputs = pipeline
-        .apply("create",
-               Create.timestamped(
-                   message(1, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }"),
-                   message(2, map("attr2", "val2"), "{ \"invalid2"),
-                   message(3, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
-                   message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
-        .apply("convert",
-               ParDo.of(
-                   PubsubMessageToRow
-                       .builder()
-                       .messageSchema(messageSchema)
-                       .useDlq(true)
-                       .build())
+    PCollectionTuple outputs =
+        pipeline
+            .apply(
+                "create",
+                Create.timestamped(
+                    message(1, map("attr1", "val1"), "{ \"invalid1\" : \"sdfsd\" }"),
+                    message(2, map("attr2", "val2"), "{ \"invalid2"),
+                    message(3, map("attr", "val"), "{ \"id\" : 3, \"name\" : \"foo\" }"),
+                    message(4, map("bttr", "vbl"), "{ \"name\" : \"baz\", \"id\" : 5 }")))
+            .apply(
+                "convert",
+                ParDo.of(
+                        PubsubMessageToRow.builder()
+                            .messageSchema(messageSchema)
+                            .useDlq(true)
+                            .build())
                     .withOutputTags(MAIN_TAG, TupleTagList.of(DLQ_TAG)));
 
     PCollection<Row> rows = outputs.get(MAIN_TAG);
     PCollection<PubsubMessage> dlqMessages = outputs.get(DLQ_TAG);
 
-    PAssert
-        .that(dlqMessages)
-        .satisfies(messages -> {
-          assertEquals(2, size(messages));
-          assertEquals(
-              ImmutableSet.of(map("attr1", "val1"), map("attr2", "val2")),
-              convertToSet(messages, m -> m.getAttributeMap()));
+    PAssert.that(dlqMessages)
+        .satisfies(
+            messages -> {
+              assertEquals(2, size(messages));
+              assertEquals(
+                  ImmutableSet.of(map("attr1", "val1"), map("attr2", "val2")),
+                  convertToSet(messages, m -> m.getAttributeMap()));
 
-          assertEquals(
-              ImmutableSet.of("{ \"invalid1\" : \"sdfsd\" }", "{ \"invalid2"),
-              convertToSet(messages, m -> new String(m.getPayload(), UTF_8)));
-          return null;
-        });
+              assertEquals(
+                  ImmutableSet.of("{ \"invalid1\" : \"sdfsd\" }", "{ \"invalid2"),
+                  convertToSet(messages, m -> new String(m.getPayload(), UTF_8)));
+              return null;
+            });
 
-    PAssert
-        .that(rows)
+    PAssert.that(rows)
         .containsInAnyOrder(
             Row.withSchema(messageSchema)
-               .addValues(ts(3), map("attr", "val"), row(payloadSchema, 3, "foo"))
-               .build(),
+                .addValues(ts(3), map("attr", "val"), row(payloadSchema, 3, "foo"))
+                .build(),
             Row.withSchema(messageSchema)
-               .addValues(ts(4), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
-               .build());
+                .addValues(ts(4), map("bttr", "vbl"), row(payloadSchema, 5, "baz"))
+                .build());
 
     pipeline.run();
   }
@@ -181,13 +169,10 @@ public class PubsubMessageToRowTest implements Serializable {
   }
 
   private TimestampedValue<PubsubMessage> message(
-      int timestamp,
-      Map<String, String> attributes,
-      String payload) {
+      int timestamp, Map<String, String> attributes, String payload) {
 
     return TimestampedValue.of(
-        new PubsubMessage(payload.getBytes(UTF_8), attributes),
-        ts(timestamp));
+        new PubsubMessage(payload.getBytes(UTF_8), attributes), ts(timestamp));
   }
 
   private Instant ts(long timestamp) {
@@ -195,8 +180,7 @@ public class PubsubMessageToRowTest implements Serializable {
   }
 
   private static <V> Set<V> convertToSet(
-      Iterable<PubsubMessage> messages,
-      Function<? super PubsubMessage, V> mapper) {
+      Iterable<PubsubMessage> messages, Function<? super PubsubMessage, V> mapper) {
 
     return StreamSupport.stream(messages.spliterator(), false).map(mapper).collect(toSet());
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
@@ -43,9 +43,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-/**
- * Tests for {@code BeamTextCSVTable}.
- */
+/** Tests for {@code BeamTextCSVTable}. */
 public class BeamTextCSVTableTest {
 
   @Rule public TestPipeline pipeline = TestPipeline.create();
@@ -54,78 +52,79 @@ public class BeamTextCSVTableTest {
   /**
    * testData.
    *
-   * <p>
-   * The types of the csv fields are:
-   *     integer,bigint,float,double,string
-   * </p>
+   * <p>The types of the csv fields are: integer,bigint,float,double,string
    */
   private static Schema schema =
-      RowSqlTypes
-          .builder()
+      RowSqlTypes.builder()
           .withIntegerField("id")
           .withBigIntField("order_id")
           .withFloatField("price")
           .withDoubleField("amount")
           .withVarcharField("user_name")
           .build();
-  private static Object[] data1 = new Object[] { 1, 1L, 1.1F, 1.1, "james" };
-  private static Object[] data2 = new Object[] { 2, 2L, 2.2F, 2.2, "bond" };
+
+  private static Object[] data1 = new Object[] {1, 1L, 1.1F, 1.1, "james"};
+  private static Object[] data2 = new Object[] {2, 2L, 2.2F, 2.2, "bond"};
 
   private static List<Object[]> testData = Arrays.asList(data1, data2);
-  private static List<Row> testDataRows = Arrays.asList(
-      Row.withSchema(schema).addValues(data1).build(),
-      Row.withSchema(schema).addValues(data2).build());
+  private static List<Row> testDataRows =
+      Arrays.asList(
+          Row.withSchema(schema).addValues(data1).build(),
+          Row.withSchema(schema).addValues(data2).build());
 
   private static Path tempFolder;
   private static File readerSourceFile;
   private static File writerTargetFile;
 
-  @Test public void testBuildIOReader() {
+  @Test
+  public void testBuildIOReader() {
     PCollection<Row> rows =
-        new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath())
-            .buildIOReader(pipeline);
+        new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath()).buildIOReader(pipeline);
     PAssert.that(rows).containsInAnyOrder(testDataRows);
     pipeline.run();
   }
 
-  @Test public void testBuildIOWriter() {
+  @Test
+  public void testBuildIOWriter() {
     new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath())
         .buildIOReader(pipeline)
-        .apply(
-            new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath())
-                .buildIOWriter());
+        .apply(new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath()).buildIOWriter());
     pipeline.run();
 
     PCollection<Row> rows =
-        new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath())
-            .buildIOReader(pipeline2);
+        new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath()).buildIOReader(pipeline2);
 
     // confirm the two reads match
     PAssert.that(rows).containsInAnyOrder(testDataRows);
     pipeline2.run();
   }
 
-  @BeforeClass public static void setUp() throws IOException {
+  @BeforeClass
+  public static void setUp() throws IOException {
     tempFolder = Files.createTempDirectory("BeamTextTableTest");
     readerSourceFile = writeToFile(testData, "readerSourceFile.txt");
     writerTargetFile = writeToFile(testData, "writerTargetFile.txt");
   }
 
-  @AfterClass public static void teardownClass() throws IOException {
-    Files.walkFileTree(tempFolder, new SimpleFileVisitor<Path>() {
+  @AfterClass
+  public static void teardownClass() throws IOException {
+    Files.walkFileTree(
+        tempFolder,
+        new SimpleFileVisitor<Path>() {
 
-      @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-          throws IOException {
-        Files.delete(file);
-        return FileVisitResult.CONTINUE;
-      }
+          @Override
+          public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
+              throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+          }
 
-      @Override public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-          throws IOException {
-        Files.delete(dir);
-        return FileVisitResult.CONTINUE;
-      }
-    });
+          @Override
+          public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+          }
+        });
   }
 
   private static File writeToFile(List<Object[]> rows, String filename) throws IOException {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
@@ -32,9 +32,7 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.commons.csv.CSVFormat;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link TextTableProvider}.
- */
+/** UnitTest for {@link TextTableProvider}. */
 public class TextTableProviderTest {
   private TextTableProvider provider = new TextTableProvider();
 
@@ -73,16 +71,15 @@ public class TextTableProviderTest {
     if (format != null) {
       properties.put("format", format);
     }
-    return Table
-        .builder()
+    return Table.builder()
         .name(name)
         .comment(name + " table")
         .location("/home/admin/" + name)
         .schema(
             Stream.of(
-                Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
-                Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
-                  .collect(toSchema()))
+                    Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
+                    Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
+                .collect(toSchema()))
         .type("text")
         .properties(properties)
         .build();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStoreTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/store/InMemoryMetaStoreTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.extensions.sql.meta.store;
 
-
 import static org.apache.beam.sdk.schemas.Schema.toSchema;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -38,9 +37,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * UnitTest for {@link InMemoryMetaStore}.
- */
+/** UnitTest for {@link InMemoryMetaStore}. */
 public class InMemoryMetaStoreTest {
   private InMemoryMetaStore store;
 
@@ -72,26 +69,25 @@ public class InMemoryMetaStoreTest {
     store.createTable(table);
   }
 
-  @Test public void testGetTables() throws Exception {
+  @Test
+  public void testGetTables() throws Exception {
     store.createTable(mockTable("hello"));
     store.createTable(mockTable("world"));
 
     assertEquals(2, store.getTables().size());
-    assertThat(store.getTables(),
-        Matchers.hasValue(mockTable("hello")));
-    assertThat(store.getTables(),
-        Matchers.hasValue(mockTable("world")));
+    assertThat(store.getTables(), Matchers.hasValue(mockTable("hello")));
+    assertThat(store.getTables(), Matchers.hasValue(mockTable("world")));
   }
 
-  @Test public void testBuildBeamSqlTable() throws Exception {
+  @Test
+  public void testBuildBeamSqlTable() throws Exception {
     Table table = mockTable("hello");
     store.createTable(table);
     BeamSqlTable actualSqlTable = store.buildBeamSqlTable(table);
     assertNotNull(actualSqlTable);
     assertEquals(
         RowSqlTypes.builder().withIntegerField("id").withVarcharField("name").build(),
-        actualSqlTable.getSchema()
-    );
+        actualSqlTable.getSchema());
   }
 
   @Test
@@ -118,16 +114,15 @@ public class InMemoryMetaStoreTest {
   }
 
   private static Table mockTable(String name, String type) {
-    return Table
-        .builder()
+    return Table.builder()
         .name(name)
         .comment(name + " table")
         .location("/home/admin/" + name)
         .schema(
             Stream.of(
-                Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
-                Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
-                  .collect(toSchema()))
+                    Schema.Field.of("id", TypeName.INT32.type()).withNullable(true),
+                    Schema.Field.of("name", RowSqlTypes.VARCHAR).withNullable(true))
+                .collect(toSchema()))
         .type(type)
         .properties(new JSONObject())
         .build();
@@ -140,24 +135,25 @@ public class InMemoryMetaStoreTest {
   private static class MockTableProvider implements TableProvider {
     private String type;
     private String[] names;
+
     public MockTableProvider(String type, String... names) {
       this.type = type;
       this.names = names;
     }
 
-    @Override public String getTableType() {
+    @Override
+    public String getTableType() {
       return type;
     }
 
-    @Override public void createTable(Table table) {
+    @Override
+    public void createTable(Table table) {}
 
-    }
+    @Override
+    public void dropTable(String tableName) {}
 
-    @Override public void dropTable(String tableName) {
-
-    }
-
-    @Override public Map<String, Table> getTables() {
+    @Override
+    public Map<String, Table> getTables() {
       Map<String, Table> ret = new HashMap(names.length);
       for (String name : names) {
         ret.put(name, mockTable(name, "mock"));
@@ -166,7 +162,8 @@ public class InMemoryMetaStoreTest {
       return ret;
     }
 
-    @Override public BeamSqlTable buildBeamSqlTable(Table table) {
+    @Override
+    public BeamSqlTable buildBeamSqlTable(Table table) {
       return null;
     }
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
@@ -37,9 +37,7 @@ import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * Mocked table for bounded data sources.
- */
+/** Mocked table for bounded data sources. */
 public class MockedBoundedTable extends MockedTable {
   /** rows written to this table. */
   private static final ConcurrentLinkedQueue<Row> CONTENT = new ConcurrentLinkedQueue<>();
@@ -67,13 +65,10 @@ public class MockedBoundedTable extends MockedTable {
     return new MockedBoundedTable(buildBeamSqlRowType(args));
   }
 
-  /**
-   * Build a mocked bounded table with the specified type.
-   */
+  /** Build a mocked bounded table with the specified type. */
   public static MockedBoundedTable of(final Schema type) {
     return new MockedBoundedTable(type);
   }
-
 
   /**
    * Add rows to the builder.
@@ -101,34 +96,33 @@ public class MockedBoundedTable extends MockedTable {
 
   @Override
   public PCollection<Row> buildIOReader(Pipeline pipeline) {
-    return PBegin.in(pipeline).apply(
-        "MockedBoundedTable_Reader_" + COUNTER.incrementAndGet(), Create.of(rows));
+    return PBegin.in(pipeline)
+        .apply("MockedBoundedTable_Reader_" + COUNTER.incrementAndGet(), Create.of(rows));
   }
 
-  @Override public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+  @Override
+  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     return new OutputStore();
   }
 
-  /**
-   * Keep output in {@code CONTENT} for validation.
-   *
-   */
+  /** Keep output in {@code CONTENT} for validation. */
   public static class OutputStore extends PTransform<PCollection<Row>, POutput> {
 
     @Override
     public PDone expand(PCollection<Row> input) {
-      input.apply(ParDo.of(new DoFn<Row, Void>() {
-        @ProcessElement
-        public void processElement(ProcessContext c) {
-          CONTENT.add(c.element());
-        }
+      input.apply(
+          ParDo.of(
+              new DoFn<Row, Void>() {
+                @ProcessElement
+                public void processElement(ProcessContext c) {
+                  CONTENT.add(c.element());
+                }
 
-        @Teardown
-        public void close() {
-          CONTENT.clear();
-        }
-
-      }));
+                @Teardown
+                public void close() {
+                  CONTENT.clear();
+                }
+              }));
       return PDone.in(input.getPipeline());
     }
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
@@ -26,11 +26,10 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * Base class for mocked table.
- */
+/** Base class for mocked table. */
 public abstract class MockedTable extends BaseBeamTable {
   public static final AtomicInteger COUNTER = new AtomicInteger();
+
   public MockedTable(Schema beamSchema) {
     super(beamSchema);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/QuickCheckGenerators.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/QuickCheckGenerators.java
@@ -32,9 +32,7 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 
-/**
- * Field type generators invoked by {@link JUnitQuickcheck}.
- */
+/** Field type generators invoked by {@link JUnitQuickcheck}. */
 public class QuickCheckGenerators {
 
   private static final FieldTypeGenerator PRIMITIVE_TYPES = new PrimitiveTypes();
@@ -43,15 +41,13 @@ public class QuickCheckGenerators {
   private static final FieldTypeGenerator ROWS = new Rows();
   private static final FieldTypeGenerator ANY_TYPE = new AnyFieldType();
 
-  /**
-   * Generates a primitive {@link TypeName SQL type} randomly.
-   */
+  /** Generates a primitive {@link TypeName SQL type} randomly. */
   public static class PrimitiveTypes extends FieldTypeGenerator {
     private static final List<FieldType> PRIMITIVE_TYPES =
         java.util.Arrays.stream(TypeName.values())
-                        .filter(TypeName::isPrimitiveType)
-                        .map(TypeName::type)
-                        .collect(toList());
+            .filter(TypeName::isPrimitiveType)
+            .map(TypeName::type)
+            .collect(toList());
 
     @Override
     public FieldType generateFieldType(SourceOfRandomness random, GenerationStatus status) {
@@ -59,14 +55,11 @@ public class QuickCheckGenerators {
     }
   }
 
-  /**
-   * Generates {@link TypeName#ARRAY SQL arrays} with random element type.
-   */
+  /** Generates {@link TypeName#ARRAY SQL arrays} with random element type. */
   public static class Arrays extends FieldTypeGenerator {
     @Override
     public FieldType generateFieldType(SourceOfRandomness random, GenerationStatus status) {
-      return TypeName.ARRAY.type().withCollectionElementType(
-          ANY_TYPE.generate(random, status));
+      return TypeName.ARRAY.type().withCollectionElementType(ANY_TYPE.generate(random, status));
     }
   }
 
@@ -76,51 +69,44 @@ public class QuickCheckGenerators {
   public static class Maps extends FieldTypeGenerator {
     @Override
     public FieldType generateFieldType(SourceOfRandomness random, GenerationStatus status) {
-      return TypeName.MAP.type().withMapType(
-          PRIMITIVE_TYPES.generate(random, status),
-          ANY_TYPE.generate(random, status));
+      return TypeName.MAP
+          .type()
+          .withMapType(PRIMITIVE_TYPES.generate(random, status), ANY_TYPE.generate(random, status));
     }
   }
 
-  /**
-   * Generates {@link TypeName#ROW SQL rows} with random field types.
-   */
+  /** Generates {@link TypeName#ROW SQL rows} with random field types. */
   public static class Rows extends FieldTypeGenerator {
     @Override
     public FieldType generateFieldType(SourceOfRandomness random, GenerationStatus status) {
       // stop at 10 levels of nesting to avoid stack overflows
       FieldTypeGenerator rowFieldTypesGenerator =
-          (nestingLevel(status) >= 10)
-              ? PRIMITIVE_TYPES
-              : ANY_TYPE;
+          (nestingLevel(status) >= 10) ? PRIMITIVE_TYPES : ANY_TYPE;
 
-      return TypeName.ROW.type().withRowSchema(
-          generateSchema(rowFieldTypesGenerator, random, status));
+      return TypeName.ROW
+          .type()
+          .withRowSchema(generateSchema(rowFieldTypesGenerator, random, status));
     }
 
     private Schema generateSchema(
-        FieldTypeGenerator fieldTypeGenerator,
-        SourceOfRandomness random,
-        GenerationStatus status) {
+        FieldTypeGenerator fieldTypeGenerator, SourceOfRandomness random, GenerationStatus status) {
 
-      return
-          IntStream
-              .range(0, status.size() + 1)
-              .mapToObj(i -> Field.of(
-                  "field_" + i,
-                  fieldTypeGenerator.generate(random, status)).withNullable(true))
-              .collect(toSchema());
+      return IntStream.range(0, status.size() + 1)
+          .mapToObj(
+              i ->
+                  Field.of("field_" + i, fieldTypeGenerator.generate(random, status))
+                      .withNullable(true))
+          .collect(toSchema());
     }
   }
 
-  /**
-   * Generates a {@link FieldType}, randomly delegating to specific type generators.
-   */
+  /** Generates a {@link FieldType}, randomly delegating to specific type generators. */
   public static class AnyFieldType extends FieldTypeGenerator {
     @Override
     public FieldType generateFieldType(SourceOfRandomness random, GenerationStatus status) {
-      return random.choose(asList(PRIMITIVE_TYPES, ARRAYS_OF_ANY, MAPS_OF_ANY, ROWS))
-                   .generate(random, status);
+      return random
+          .choose(asList(PRIMITIVE_TYPES, ARRAYS_OF_ANY, MAPS_OF_ANY, ROWS))
+          .generate(random, status);
     }
   }
 
@@ -139,8 +125,7 @@ public class QuickCheckGenerators {
     }
 
     protected abstract FieldType generateFieldType(
-        SourceOfRandomness random,
-        GenerationStatus status);
+        SourceOfRandomness random, GenerationStatus status);
 
     int nestingLevel(GenerationStatus status) {
       return status.valueOf(NESTING_KEY).orElse(-1);
@@ -151,21 +136,3 @@ public class QuickCheckGenerators {
     }
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/RowAsserts.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/RowAsserts.java
@@ -25,14 +25,10 @@ import com.google.common.collect.Iterables;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 
-/**
- * Contain helpers to assert {@link Row}s.
- */
+/** Contain helpers to assert {@link Row}s. */
 public class RowAsserts {
 
-  /**
-   * Asserts result contains single row with an int field.
-   */
+  /** Asserts result contains single row with an int field. */
   public static SerializableFunction<Iterable<Row>, Void> matchesScalar(int expected) {
     return records -> {
       Row row = Iterables.getOnlyElement(records);
@@ -42,9 +38,7 @@ public class RowAsserts {
     };
   }
 
-  /**
-   * Asserts result contains single row with a double field.
-   */
+  /** Asserts result contains single row with a double field. */
   public static SerializableFunction<Iterable<Row>, Void> matchesScalar(
       double expected, double delta) {
 


### PR DESCRIPTION
This turns on exact format enforcement, and also provides the Gradle one line command to do it.

It isn't (just) about code layout, it is about automation. We have pretty strict style rules enforced by checkstyle. The most efficient way to fix up a file is with autoformat. But if the autoformat hits a bunch of irrelevant lines, that is annoying for a reviewer and obscures `git blame`.

If we enforce autoformat all the time, then it makes sure that autoformatting a particular PR has minimal effects and is always safe to do.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
