### PR TITLE
Fix FileSystems.match() for local paths on Windows.

### DIFF
--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -528,8 +528,7 @@ class FileSystem(BeamPlugin):
     """
     raise NotImplementedError
 
-  @staticmethod
-  def _url_dirname(url_or_path):
+  def _url_dirname(self, url_or_path):
     """Like posixpath.dirname, but preserves scheme:// prefix.
 
     Args:

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -81,6 +81,17 @@ class LocalFileSystem(FileSystem):
     """Whether this FileSystem supports directories."""
     return True
 
+  def _url_dirname(self, url_or_path):
+    """Pass through to os.path.dirname.
+
+    This version uses os.path instead of posixpath to be compatible with the
+    host OS.
+
+    Args:
+      url_or_path: A string in the form of /some/path.
+    """
+    return os.path.dirname(url_or_path)
+
   def _list(self, dir_or_prefix):
     """List files in a location.
 


### PR DESCRIPTION
Uses os.path instead of posixpath on local filesystems.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
