### PR TITLE
[BEAM-4084] Finish RowType -> Schema rename

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/DefaultSchemaFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/DefaultSchemaFactory.java
@@ -29,7 +29,7 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.joda.time.DateTime;
 
 /**
- * A default implementation of the {@link RowTypeFactory} interface. The purpose of
+ * A default implementation of the {@link SchemaFactory} interface. The purpose of
  * the factory is to create a row types given a list of getters.
  *
  * <p>Row type is represented by {@link Schema} which essentially is a
@@ -42,10 +42,10 @@ import org.joda.time.DateTime;
  * <p>This is the default factory implementation used in {@link RowFactory}.
  *
  * <p>In other cases, when mapping requires extra logic, another implentation of the
- * {@link RowTypeFactory} should be used instead of this class.
+ * {@link SchemaFactory} should be used instead of this class.
  *
  */
-public class DefaultRowTypeFactory implements RowTypeFactory {
+public class DefaultSchemaFactory implements SchemaFactory {
   private static final ImmutableMap<Class, TypeName> SUPPORTED_TYPES =
       ImmutableMap.<Class, TypeName>builder()
           .put(Boolean.class, TypeName.BOOLEAN)
@@ -74,7 +74,7 @@ public class DefaultRowTypeFactory implements RowTypeFactory {
    * Uses {@link CoderRegistry#createDefault()} to get coders for {@link FieldValueGetter#type()}.
    */
   @Override
-  public Schema createRowType(Iterable<FieldValueGetter> fieldValueGetters) {
+  public Schema createSchema(Iterable<FieldValueGetter> fieldValueGetters) {
     List<Schema.Field> fields = Lists.newArrayList();
     for (FieldValueGetter getter : fieldValueGetters) {
       fields.add(Schema.Field.of(getter.name(), getTypeDescriptor(getter.type())));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/InferredRowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/InferredRowCoder.java
@@ -67,10 +67,10 @@ public abstract class InferredRowCoder<T> extends CustomCoder<T> {
   }
 
   /**
-   * Returns a {@link InferredRowCoder} with row type factory overridden by {@code rowTypeFactory}.
+   * Returns a {@link InferredRowCoder} with row type factory overridden by {@code schemaFactory}.
    */
-  public InferredRowCoder<T> withRowTypeFactory(RowTypeFactory rowTypeFactory) {
-    return toBuilder().setRowFactory(RowFactory.withRowTypeFactory(rowTypeFactory)).build();
+  public InferredRowCoder<T> withSchemaFactory(SchemaFactory schemaFactory) {
+    return toBuilder().setRowFactory(RowFactory.withSchemaFactory(schemaFactory)).build();
   }
 
   static <W> Builder<W> builder() {
@@ -79,12 +79,12 @@ public abstract class InferredRowCoder<T> extends CustomCoder<T> {
 
   abstract Builder<T> toBuilder();
 
-  public Schema rowType() {
-    return rowFactory().getRowType(elementType());
+  public Schema schema() {
+    return rowFactory().getSchema(elementType());
   }
 
   public RowCoder rowCoder() {
-    return rowType().getRowCoder();
+    return schema().getRowCoder();
   }
 
   public Row createRow(T element) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/SchemaFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/SchemaFactory.java
@@ -30,15 +30,15 @@ import org.apache.beam.sdk.schemas.Schema;
  * <p>Different implementations can have different ways of mapping getter types to coders.
  * For example Beam SQL uses custom mapping via java.sql.Types.
  *
- * <p>Default implementation is {@link DefaultRowTypeFactory}.
+ * <p>Default implementation is {@link DefaultSchemaFactory}.
  * It returns instances of {@link Schema}, mapping {@link FieldValueGetter#type()}
  * to known coders.
  */
 @Internal
-public interface RowTypeFactory extends Serializable {
+public interface SchemaFactory extends Serializable {
 
   /**
    * Create a {@link Schema} for the list of the pojo field getters.
    */
-  Schema createRowType(Iterable<FieldValueGetter> getters);
+  Schema createSchema(Iterable<FieldValueGetter> getters);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/SchemaGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/SchemaGetters.java
@@ -28,11 +28,11 @@ import org.apache.beam.sdk.values.Row;
  *
  * <p>This is used in {@link RowFactory} to create instances of {@link Row}s.
  */
-class RowTypeGetters {
+class SchemaGetters {
   private Schema schema;
   private List<FieldValueGetter> fieldValueGetters;
 
-  RowTypeGetters(Schema schema, List<FieldValueGetter> fieldValueGetters) {
+  SchemaGetters(Schema schema, List<FieldValueGetter> fieldValueGetters) {
     this.schema = schema;
     this.fieldValueGetters = fieldValueGetters;
   }
@@ -40,13 +40,13 @@ class RowTypeGetters {
   /**
    * Returns a {@link Schema}.
    */
-  Schema rowType() {
+  Schema schema() {
     return schema;
   }
 
   /**
    * Returns the list of {@link FieldValueGetter}s which
-   * were used to create {@link RowTypeGetters#rowType()}.
+   * were used to create {@link SchemaGetters#schema()}.
    */
   List<FieldValueGetter> valueGetters() {
     return fieldValueGetters;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/DefaultSchemaFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/DefaultSchemaFactoryTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /**
- * Unit tests for {@link DefaultRowTypeFactory}.
+ * Unit tests for {@link DefaultSchemaFactory}.
  */
 public class DefaultSchemaFactoryTest {
 
@@ -53,9 +53,9 @@ public class DefaultSchemaFactoryTest {
 
   @Test
   public void testContainsCorrectFields() throws Exception {
-    DefaultRowTypeFactory factory = new DefaultRowTypeFactory();
+    DefaultSchemaFactory factory = new DefaultSchemaFactory();
 
-    Schema schema = factory.createRowType(GETTERS);
+    Schema schema = factory.createSchema(GETTERS);
 
     assertEquals(GETTERS.size(), schema.getFieldCount());
     assertEquals(
@@ -73,9 +73,9 @@ public class DefaultSchemaFactoryTest {
   public void testThrowsForUnsupportedTypes() throws Exception {
     thrown.expect(UnsupportedOperationException.class);
 
-    DefaultRowTypeFactory factory = new DefaultRowTypeFactory();
+    DefaultSchemaFactory factory = new DefaultSchemaFactory();
 
-    factory.createRowType(
+    factory.createSchema(
         Arrays.<FieldValueGetter>asList(getter("unsupportedGetter", UnsupportedClass.class)));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/InferredRowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/InferredRowCoderTest.java
@@ -73,13 +73,13 @@ public class InferredRowCoderTest {
   }
 
   @Test
-  public void testCreatesRowType() {
+  public void testCreatesSchema() {
     InferredRowCoder<PersonPojo> inferredCoder = InferredRowCoder.ofSerializable(PersonPojo.class);
-    Schema rowType = inferredCoder.rowType();
+    Schema schema = inferredCoder.schema();
 
-    assertEquals(2, rowType.getFieldCount());
+    assertEquals(2, schema.getFieldCount());
     assertThat(
-        rowType.getFields(),
+        schema.getFields(),
         containsInAnyOrder(PERSON_ROW_TYPE.getField(0), PERSON_ROW_TYPE.getField(1)));
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/RowFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/RowFactoryTest.java
@@ -142,6 +142,6 @@ public class RowFactoryTest {
   }
 
   private RowFactory newFactory() {
-    return new RowFactory(new DefaultRowTypeFactory(), getterFactory);
+    return new RowFactory(new DefaultSchemaFactory(), getterFactory);
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/SchemaGettersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/reflect/SchemaGettersTest.java
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link RowTypeGetters}.
+ * Unit tests for {@link SchemaGetters}.
  */
 public class SchemaGettersTest {
 
@@ -35,9 +35,9 @@ public class SchemaGettersTest {
     Schema schema = Schema.builder().build();
     List<FieldValueGetter> fieldValueGetters = emptyList();
 
-    RowTypeGetters getters = new RowTypeGetters(schema, fieldValueGetters);
+    SchemaGetters getters = new SchemaGetters(schema, fieldValueGetters);
 
-    assertSame(schema, getters.rowType());
+    assertSame(schema, getters.schema());
     assertSame(fieldValueGetters, getters.valueGetters());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/RowSqlTypes.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/RowSqlTypes.java
@@ -153,7 +153,7 @@ public class RowSqlTypes {
       return this;
     }
 
-    /** Adds an ARRAY field with elements of {@code rowType}. */
+    /** Adds an ARRAY field with elements of {@code schema}. */
     public Builder withArrayField(String fieldName, Schema schema) {
       FieldType collectionElementType = FieldType.of(TypeName.ROW).withRowSchema(schema);
       builder.addField(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -76,7 +76,7 @@ public class CalciteUtils {
           TypeName.DATETIME.type(), SqlTypeName.TIMESTAMP,
           TypeName.STRING.type(), SqlTypeName.VARCHAR);
 
-  /** Generate {@code BeamSqlRowType} from {@code RelDataType} which is used to create table. */
+  /** Generate {@link Schema} from {@code RelDataType} which is used to create table. */
   public static Schema toBeamSchema(RelDataType tableInfo) {
     return tableInfo
         .getFieldList()

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/SqlSchemaFactoryTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/SqlSchemaFactoryTest.java
@@ -26,9 +26,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.values.reflect.DefaultRowTypeFactory;
+import org.apache.beam.sdk.values.reflect.DefaultSchemaFactory;
 import org.apache.beam.sdk.values.reflect.FieldValueGetter;
-import org.apache.beam.sdk.values.reflect.RowTypeFactory;
+import org.apache.beam.sdk.values.reflect.SchemaFactory;
 import org.joda.time.DateTime;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,9 +56,9 @@ public class SqlSchemaFactoryTest {
 
   @Test
   public void testContainsCorrectFields() throws Exception {
-    RowTypeFactory factory = new DefaultRowTypeFactory();
+    SchemaFactory factory = new DefaultSchemaFactory();
 
-    Schema schema = factory.createRowType(GETTERS_FOR_KNOWN_TYPES);
+    Schema schema = factory.createSchema(GETTERS_FOR_KNOWN_TYPES);
 
     assertEquals(GETTERS_FOR_KNOWN_TYPES.size(), schema.getFieldCount());
     assertEquals(
@@ -81,9 +81,9 @@ public class SqlSchemaFactoryTest {
   public void testThrowsForUnsupportedTypes() throws Exception {
     thrown.expect(UnsupportedOperationException.class);
 
-    RowTypeFactory factory = new DefaultRowTypeFactory();
+    SchemaFactory factory = new DefaultSchemaFactory();
 
-    factory.createRowType(
+    factory.createSchema(
         Arrays.<FieldValueGetter>asList(getter("arrayListGetter", ArrayList.class)));
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
@@ -103,7 +103,7 @@ public class TestUtils {
      * @args pairs of column type and column names.
      */
     public static RowsBuilder of(final Object... args) {
-      Schema beamSQLSchema = buildBeamSqlRowType(args);
+      Schema beamSQLSchema = buildBeamSqlSchema(args);
       RowsBuilder builder = new RowsBuilder();
       builder.type = beamSQLSchema;
 
@@ -120,8 +120,6 @@ public class TestUtils {
      *   schema
      * )
      * }</pre>
-     *
-     * @beamSQLRowType the row type.
      */
     public static RowsBuilder of(final Schema schema) {
       RowsBuilder builder = new RowsBuilder();
@@ -159,7 +157,7 @@ public class TestUtils {
     }
 
     public PCollectionBuilder getPCollectionBuilder() {
-      return pCollectionBuilder().withRowType(type).withRows(rows);
+      return pCollectionBuilder().withSchema(type).withRows(rows);
     }
   }
 
@@ -173,7 +171,7 @@ public class TestUtils {
     private String timestampField;
     private Pipeline pipeline;
 
-    public PCollectionBuilder withRowType(Schema type) {
+    public PCollectionBuilder withSchema(Schema type) {
       this.type = type;
       return this;
     }
@@ -224,12 +222,12 @@ public class TestUtils {
   }
 
   /**
-   * Convenient way to build a {@code BeamSqlRowType}.
+   * Convenient way to build a {@link Schema}.
    *
    * <p>e.g.
    *
    * <pre>{@code
-   * buildBeamSqlRowType(
+   * buildBeamSqlSchema(
    *     SqlCoders.BIGINT, "order_id",
    *     SqlCoders.INTEGER, "site_id",
    *     SqlCoders.DOUBLE, "price",
@@ -237,7 +235,7 @@ public class TestUtils {
    * )
    * }</pre>
    */
-  public static Schema buildBeamSqlRowType(Object... args) {
+  public static Schema buildBeamSqlSchema(Object... args) {
     return Stream.iterate(0, i -> i + 2)
         .limit(args.length / 2)
         .map(i -> toRecordField(args, i))

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -101,7 +101,7 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     registerTable(
         "SITE_LKP",
         new SiteLookupTable(
-            TestUtils.buildBeamSqlRowType(
+            TestUtils.buildBeamSqlSchema(
                 TypeName.INT32, "site_id",
                 TypeName.STRING, "site_name")));
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
@@ -124,7 +124,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
                     new BeamAggregationTransforms.AggregationAdaptor(aggCalls, inputSchema)))
             .setCoder(KvCoder.of(keyCoder, aggCoder));
 
-    //4. flat KV to a single record
+    // 4. flat KV to a single record
     PCollection<Row> mergedStream =
         aggregatedStream.apply(
             "mergeRecord",
@@ -132,13 +132,13 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
                 new BeamAggregationTransforms.MergeAggregationRecord(outputType, aggCalls, -1)));
     mergedStream.setCoder(outRecordCoder);
 
-    //assert function BeamAggregationTransform.AggregationGroupByKeyFn
+    // assert function BeamAggregationTransform.AggregationGroupByKeyFn
     PAssert.that(exGroupByStream).containsInAnyOrder(prepareResultOfAggregationGroupByKeyFn());
 
-    //assert BeamAggregationTransform.AggregationCombineFn
+    // assert BeamAggregationTransform.AggregationCombineFn
     PAssert.that(aggregatedStream).containsInAnyOrder(prepareResultOfAggregationCombineFn());
 
-    //assert BeamAggregationTransform.MergeAggregationRecord
+    // assert BeamAggregationTransform.MergeAggregationRecord
     PAssert.that(mergedStream).containsInAnyOrder(prepareResultOfMergeAggregationRow());
 
     p.run();
@@ -152,7 +152,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
   /** create list of all {@link AggregateCall}. */
   @SuppressWarnings("deprecation")
   private void prepareAggregationCalls() {
-    //aggregations for all data type
+    // aggregations for all data type
     aggCalls = new ArrayList<>();
     aggCalls.add(
         new AggregateCall(
@@ -393,7 +393,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
 
     aggCoder = aggPartType.getRowCoder();
 
-    outputType = prepareFinalRowType();
+    outputType = prepareFinalSchema();
     outRecordCoder = outputType.getRowCoder();
   }
 
@@ -446,7 +446,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
   }
 
   /** Row type of final output row. */
-  private Schema prepareFinalRowType() {
+  private Schema prepareFinalSchema() {
     return RowSqlTypes.builder()
         .withIntegerField("f_int")
         .withBigIntField("count")

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
@@ -41,9 +41,9 @@ import org.junit.Test;
 public class BeamKafkaCSVTableTest {
   @Rule public TestPipeline pipeline = TestPipeline.create();
 
-  private static final Row ROW1 = Row.withSchema(genRowType()).addValues(1L, 1, 1.0).build();
+  private static final Row ROW1 = Row.withSchema(genSchema()).addValues(1L, 1, 1.0).build();
 
-  private static final Row ROW2 = Row.withSchema(genRowType()).addValues(2L, 2, 2.0).build();
+  private static final Row ROW2 = Row.withSchema(genSchema()).addValues(2L, 2, 2.0).build();
 
   @Test
   public void testCsvRecorderDecoder() throws Exception {
@@ -51,7 +51,7 @@ public class BeamKafkaCSVTableTest {
         pipeline
             .apply(Create.of("1,\"1\",1.0", "2,2,2.0"))
             .apply(ParDo.of(new String2KvBytes()))
-            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT));
+            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genSchema(), CSVFormat.DEFAULT));
 
     PAssert.that(result).containsInAnyOrder(ROW1, ROW2);
 
@@ -63,15 +63,15 @@ public class BeamKafkaCSVTableTest {
     PCollection<Row> result =
         pipeline
             .apply(Create.of(ROW1, ROW2))
-            .apply(new BeamKafkaCSVTable.CsvRecorderEncoder(genRowType(), CSVFormat.DEFAULT))
-            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genRowType(), CSVFormat.DEFAULT));
+            .apply(new BeamKafkaCSVTable.CsvRecorderEncoder(genSchema(), CSVFormat.DEFAULT))
+            .apply(new BeamKafkaCSVTable.CsvRecorderDecoder(genSchema(), CSVFormat.DEFAULT));
 
     PAssert.that(result).containsInAnyOrder(ROW1, ROW2);
 
     pipeline.run();
   }
 
-  private static Schema genRowType() {
+  private static Schema genSchema() {
     JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     return CalciteUtils.toBeamSchema(
         typeFactory

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedBoundedTable.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.mock;
 
-import static org.apache.beam.sdk.extensions.sql.TestUtils.buildBeamSqlRowType;
+import static org.apache.beam.sdk.extensions.sql.TestUtils.buildBeamSqlSchema;
 import static org.apache.beam.sdk.extensions.sql.TestUtils.buildRows;
 
 import java.util.ArrayList;
@@ -62,7 +62,7 @@ public class MockedBoundedTable extends MockedTable {
    * }</pre>
    */
   public static MockedBoundedTable of(final Object... args) {
-    return new MockedBoundedTable(buildBeamSqlRowType(args));
+    return new MockedBoundedTable(buildBeamSqlSchema(args));
   }
 
   /** Build a mocked bounded table with the specified type. */

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedUnboundedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedUnboundedTable.java
@@ -58,7 +58,7 @@ public class MockedUnboundedTable extends MockedTable {
    * }</pre>
    */
   public static MockedUnboundedTable of(final Object... args) {
-    return new MockedUnboundedTable(TestUtils.buildBeamSqlRowType(args));
+    return new MockedUnboundedTable(TestUtils.buildBeamSqlSchema(args));
   }
 
   public MockedUnboundedTable timestampColumnIndex(int idx) {


### PR DESCRIPTION
When RowType was moved to SDK core and renamed Schema there were a few holdout methods and classes. I think I got them all. Checked with grep. Calcite uses the term `rowType` and all the remaining occurrences are overrides of Calcite methods.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

R: @reuvenlax 
CC: @akedin @apilloud 