### PR TITLE
[BEAM-4425] Force load JDBC drivers

### DIFF
--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
@@ -32,10 +32,16 @@ import org.apache.beam.sdk.extensions.sql.meta.provider.BeamSqlTableProvider;
 import org.apache.beam.sdk.extensions.sql.mock.MockedBoundedTable;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.calcite.jdbc.CalciteConnection;
+import org.junit.Before;
 import org.junit.Test;
 
 /** Test for {@link JdbcDriver}. */
 public class JdbcDriverTest {
+
+  @Before
+  public void before() throws Exception {
+    Class.forName("org.apache.beam.sdk.extensions.sql.impl.JdbcDriver");
+  }
 
   @Test
   public void testDriverManager_getDriver() throws Exception {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
@@ -84,6 +84,11 @@ public class BeamSqlFnExecutorTestBase {
             .typeSystem(TYPE_FACTORY.getTypeSystem())
             .build();
 
+    try {
+      Class.forName("org.apache.calcite.jdbc.Driver");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
     relBuilder = RelBuilder.create(config);
   }
 }


### PR DESCRIPTION
In some environments (known to be OSX) the JDBC drivers are not loaded by the time they are used. This is a cherry-pick from #5490 to make it easy for anyone to review just these commits.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
