### PR TITLE
[BEAM-4316] Enforce ErrorProne analysis in runners-local-java-core project

### DIFF
--- a/runners/local-java/build.gradle
+++ b/runners/local-java/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: Runners :: Local Java Core"
 
@@ -31,6 +31,7 @@ dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.joda_time
   shadow library.java.findbugs_jsr305
+  shadow library.java.findbugs_annotations
   shadowTest library.java.hamcrest_core
   shadowTest library.java.junit
 }


### PR DESCRIPTION
Adds `failOnWarning: true` for `runners-local-java-core` project and fixes the annotation warnings:

```
warning: Cannot find annotation method 'value()' in type 'DefaultAnnotation': class file for edu.umd.cs.findbugs.annotations.DefaultAnnotation not found
```


```
warning: Cannot find annotation method 'value()' in type 'DefaultAnnotation'
```

@swegner 