### PR TITLE
[BEAM-4319]  Enforce ErrorProne analysis in build-tools project

### DIFF
--- a/sdks/java/build-tools/build.gradle
+++ b/sdks/java/build-tools/build.gradle
@@ -17,6 +17,6 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: Build Tools"


### PR DESCRIPTION
Enables the `failOnWarning` for the gradle file.