### PR TITLE
[BEAM-4322] Enforce ErrorProne analysis in protobuf extensions project

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -421,7 +421,7 @@ ext.applyJavaNature = {
     if (configuration.enableErrorProne) {
       options.compilerArgs += [
         "-XepDisableWarningsInGeneratedCode",
-        "-XepExcludedPaths:.*/build/generated.*avro-java/.*",
+        "-XepExcludedPaths:(.*/)?(build/generated.*avro-java|build/generated)/.*",
         "-Xep:MutableConstantField:OFF" // Guava's immutable collections cannot appear on API surface.
       ]
     }

--- a/sdks/java/extensions/protobuf/build.gradle
+++ b/sdks/java/extensions/protobuf/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 applyGrpcNature()
 
 description = "Apache Beam :: SDKs :: Java :: Extensions :: Protobuf"
@@ -27,6 +27,7 @@ dependencies {
   compile library.java.guava
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.protobuf_java
+  shadow library.java.findbugs_annotations
   testCompile project(path: ":beam-sdks-java-core", configuration: "shadowTest")
   testCompile library.java.hamcrest_core
   testCompile library.java.mockito_core

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ByteStringCoderTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ByteStringCoderTest.java
@@ -56,7 +56,7 @@ public class ByteStringCoderTest {
   static {
     ImmutableList.Builder<ByteString> builder = ImmutableList.builder();
     for (String s : TEST_STRING_VALUES) {
-      builder.add(ByteString.copyFrom(s.getBytes()));
+      builder.add(ByteString.copyFromUtf8(s));
     }
     TEST_VALUES = builder.build();
   }


### PR DESCRIPTION
1. Enforces `failOnWarning`
2. Adds `build/generated` as an excluded error prone directory
3. Fixes error-prone, `DefaultCharset` warning. Just assumed to use utf-8