### PR TITLE
[BEAM-4402] Run test on shadowJar only and always

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -344,6 +344,7 @@ class JavaNatureConfiguration {
 
   //TODO(https://issues.apache.org/jira/browse/BEAM-4394): Should this default to true?
   boolean enableSpotless = false // Controls whether spotless plugin enforces autoformat
+  boolean testShadowJar = false  // Controls whether tests are run with shadowJar
 
   // The shadowJar / shadowTestJar tasks execute the following closure to configure themselves.
   // Users can compose their closure with the default closure via:
@@ -581,6 +582,22 @@ ext.applyJavaNature = {
   artifacts.shadow shadowJar
   artifacts.shadowTest shadowTestJar
 
+  if (configuration.testShadowJar) {
+    // Use a configuration and dependency set which represents the execution classpath using shaded artifacts for tests.
+    configurations {
+      shadowTestRuntimeClasspath
+    }
+
+    dependencies {
+      shadowTestRuntimeClasspath project(path: project.path, configuration: "shadowTest")
+      shadowTestRuntimeClasspath project(path: project.path, configuration: "provided")
+    }
+
+    test {
+      classpath = configurations.shadowTestRuntimeClasspath
+    }
+  }
+
   if (isRelease() || project.hasProperty('publishing')) {
     apply plugin: "maven-publish"
 
@@ -631,21 +648,6 @@ artifactId=${project.name}
       from javadoc.destinationDir
     }
     artifacts.archives javadocJar
-
-    // Use a configuration and dependency set which represents the execution classpath using shaded artifacts for tests.
-    configurations {
-      shadowTestRuntimeClasspath
-    }
-
-    dependencies {
-      shadowTestRuntimeClasspath project(path: project.path, configuration: "shadowTest")
-      shadowTestRuntimeClasspath project(path: project.path, configuration: "provided")
-      shadowTestRuntimeClasspath project(path: project.path, configuration: "runtime")
-    }
-
-    test {
-      classpath = configurations.shadowTestRuntimeClasspath
-    }
 
     // Only sign artifacts if we are performing a release
     if (isRelease()) {

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -19,7 +19,7 @@ import groovy.json.JsonOutput
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableSpotless: true, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
+applyJavaNature(enableSpotless: true, testShadowJar: true, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
   dependencies {
     include(dependency(library.java.protobuf_java))
     include(dependency(library.java.protobuf_java_util))


### PR DESCRIPTION
This moves the rules to run tests on the shadowJar out of the isRelease block. It also removes the "runtime" configuration, which includes the non-shadow jar.
 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
