### PR TITLE
[BEAM-4415] Add jenkins job for HDFS ParquetIOIT

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
@@ -78,6 +78,17 @@ def testsConfigurations = [
                         numberOfRecords: '100000',
                         charset: 'UTF-8'
                 ]
+        ],
+        [
+                jobName           : 'beam_PerformanceTests_ParquetIOIT_HDFS',
+                jobDescription    : 'Runs PerfKit tests for beam_PerformanceTests_ParquetIOIT on HDFS',
+                itClass           : 'org.apache.beam.sdk.io.parquet.ParquetIOIT',
+                bqTable           : 'beam_performance.parquetioit_hdfs_pkb_results',
+                prCommitStatusName: 'Java ParquetIOPerformance Test on HDFS',
+                prTriggerPhase    : 'Run Java ParquetIO Performance Test HDFS',
+                extraPipelineArgs: [
+                        numberOfRecords: '1000000'
+                ]
         ]
 ]
 


### PR DESCRIPTION
This PR adds the jenkins job for the ParquetIOIT but now on HDFS filesystem.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
