### PR TITLE
Fixing some ErrorProne warnings

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/storage/GcsResourceIdTest.java
@@ -158,13 +158,10 @@ public class GcsResourceIdTest {
 
   @Test
   public void testGetFilename() throws Exception {
-    assertEquals(toResourceIdentifier("gs://my_bucket/").getFilename(), null);
-    assertEquals(toResourceIdentifier("gs://my_bucket/abc").getFilename(),
-        "abc");
-    assertEquals(toResourceIdentifier("gs://my_bucket/abc/").getFilename(),
-        "abc");
-    assertEquals(toResourceIdentifier("gs://my_bucket/abc/xyz.txt").getFilename(),
-        "xyz.txt");
+    assertEquals(null, toResourceIdentifier("gs://my_bucket/").getFilename());
+    assertEquals("abc", toResourceIdentifier("gs://my_bucket/abc").getFilename());
+    assertEquals("abc", toResourceIdentifier("gs://my_bucket/abc/").getFilename());
+    assertEquals("xyz.txt", toResourceIdentifier("gs://my_bucket/abc/xyz.txt").getFilename());
   }
 
   @Test

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
@@ -86,7 +86,7 @@ public class RetryHttpRequestInitializerTest {
 
     @Override
     public long nanoTime() {
-      return timesMs[i++ / 2] * 1000000;
+      return timesMs[i++ / 2] * 1000000L;
     }
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlMathBinaryExpressionTest.java
@@ -89,7 +89,7 @@ public class BeamSqlMathBinaryExpressionTest extends BeamSqlFnExecutorTestBase {
 
     // round(short) => short
     operands.clear();
-    operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, new Short("4")));
+    operands.add(BeamSqlPrimitive.of(SqlTypeName.SMALLINT, Short.valueOf("4")));
     Assert.assertEquals(
         SqlFunctions.toShort(4),
         new BeamSqlRoundExpression(operands).evaluate(row, null, ImmutableMap.of()).getValue());

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
@@ -111,7 +111,7 @@ public class AssignWindowsRunnerTest implements Serializable {
             new Instant(0).minus(Duration.standardMinutes(2L)), Duration.standardMinutes(4L));
     IntervalWindow thirdWindow =
         new IntervalWindow(
-            new Instant(0).minus(Duration.standardMinutes(0L)), Duration.standardMinutes(4L));
+            new Instant(0), Duration.standardMinutes(4L));
 
     WindowedValue<Integer> firstValue =
         WindowedValue.timestampedValueInGlobalWindow(-3, new Instant(-12));


### PR DESCRIPTION
Fixed the following ErrorProne warnings:

AssertEqualsArgumentOrderChecker
CanonicalDuration
BoxedPrimitiveConstructor
NullablePrimitive