### PR TITLE
[BEAM-3773][SQL] Init compiler factory with JDBC class loader

### DIFF
--- a/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/JdbcIT.java
+++ b/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/JdbcIT.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.jdbc;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -49,5 +50,20 @@ public class JdbcIT {
     Statement statement = connection.createStatement();
     // SELECT 1 is a special case and does not reach the parser
     assertTrue(statement.execute("SELECT 1"));
+  }
+
+  @Test
+  public void classLoader_parse() throws Exception {
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    assertTrue(statement.execute("SELECT 'beam'"));
+  }
+
+  @Test
+  public void classLoader_ddl() throws Exception {
+    Connection connection = getConnection();
+    Statement statement = connection.createStatement();
+    assertEquals(0, statement.executeUpdate("CREATE TABLE test (id INTEGER) TYPE 'text'"));
+    assertEquals(0, statement.executeUpdate("DROP TABLE test"));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl;
 
+import static org.codehaus.commons.compiler.CompilerFactoryFactory.getDefaultCompilerFactory;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Properties;
@@ -37,6 +39,17 @@ public class JdbcDriver extends Driver {
   private static final String BEAM_CALCITE_SCHEMA = "beamCalciteSchema";
 
   static {
+    ClassLoader origLoader = Thread.currentThread().getContextClassLoader();
+    try {
+      Thread.currentThread().setContextClassLoader(JdbcDriver.class.getClassLoader());
+
+      // init the compiler factory using correct class loader
+      getDefaultCompilerFactory();
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    } finally {
+      Thread.currentThread().setContextClassLoader(origLoader);
+    }
     INSTANCE.register();
   }
 


### PR DESCRIPTION
We should load the CompilerFactory at JDBC Driver loading time.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
