### PR TITLE
[BEAM-3669] clean generated files prior to lint

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -87,6 +87,7 @@ deps =
 commands =
   python --version
   pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_pylint.sh
 
 [testenv:py27-lint3]
@@ -105,6 +106,7 @@ modules =
 commands =
   python --version
   pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_pylint_2to3.sh {[testenv:py27-lint3]modules}
 
 
@@ -120,6 +122,7 @@ setenv =
 commands =
   python --version
   pip --version
+  {toxinidir}/scripts/run_tox_cleanup.sh
   time {toxinidir}/scripts/run_mini_py3lint.sh
 
 [testenv:docs]


### PR DESCRIPTION
Fixing/Cleaning up Tox and Lint error when there is generated cython files.

@pabloem 