### PR TITLE
[BEAM-4385][SQL] Add LIKE operator to Beam SQL

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
@@ -50,6 +50,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.B
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlIsNullExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLessThanExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLessThanOrEqualsExpression;
+import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLikeExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlNotEqualsExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlCurrentDateExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlCurrentTimeExpression;
@@ -253,6 +254,9 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
           break;
         case "<=":
           ret = new BeamSqlLessThanOrEqualsExpression(subExps);
+          break;
+        case "LIKE":
+          ret = new BeamSqlLikeExpression(subExps);
           break;
 
           // arithmetic operators

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+
+/** {@code BeamSqlExpression} for 'LIKE' operation. */
+public class BeamSqlLikeExpression extends BeamSqlCompareExpression {
+
+  public BeamSqlLikeExpression(List<BeamSqlExpression> operands) {
+    super(operands);
+  }
+
+  @Override
+  public Boolean compare(CharSequence leftValue, CharSequence rightValue) {
+    String regexStr = rightValue.toString();
+
+    return Pattern.compile(regexStr).matcher(leftValue).matches();
+  }
+
+  @Override
+  public Boolean compare(Boolean leftValue, Boolean rightValue) {
+    throw new IllegalArgumentException("LIKE is not supported for Boolean.");
+  }
+
+  @Override
+  public Boolean compare(Number leftValue, Number rightValue) {
+    throw new IllegalArgumentException("LIKE is not supported for Number.");
+  }
+}

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
@@ -18,8 +18,8 @@
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
-import java.util.regex.Pattern;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.apache.calcite.runtime.SqlFunctions;
 
 /** {@code BeamSqlExpression} for 'LIKE' operation. */
 public class BeamSqlLikeExpression extends BeamSqlCompareExpression {
@@ -30,9 +30,7 @@ public class BeamSqlLikeExpression extends BeamSqlCompareExpression {
 
   @Override
   public Boolean compare(CharSequence leftValue, CharSequence rightValue) {
-    String regexStr = rightValue.toString();
-
-    return Pattern.compile(regexStr).matcher(leftValue).matches();
+    return SqlFunctions.like(leftValue.toString(), rightValue.toString());
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTest.java
@@ -136,11 +136,12 @@ public class BeamSqlFnExecutorTest extends BeamSqlFnExecutorTestBase {
     BeamSqlFnExecutor executor = new BeamSqlFnExecutor(relNode);
 
     executor.prepare();
-    Assert.assertEquals(4, executor.exps.size());
+    Assert.assertEquals(5, executor.exps.size());
     assertTrue(executor.exps.get(0) instanceof BeamSqlInputRefExpression);
     assertTrue(executor.exps.get(1) instanceof BeamSqlInputRefExpression);
     assertTrue(executor.exps.get(2) instanceof BeamSqlInputRefExpression);
     assertTrue(executor.exps.get(3) instanceof BeamSqlInputRefExpression);
+    assertTrue(executor.exps.get(4) instanceof BeamSqlInputRefExpression);
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
@@ -67,7 +67,7 @@ public class BeamSqlFnExecutorTestBase {
 
     row =
         Row.withSchema(CalciteUtils.toBeamSchema(relDataType))
-            .addValues(1234567L, 0, 8.9, 1234567L, "string_test_1")
+            .addValues(1234567L, 0, 8.9, 1234567L, "This is an order.")
             .build();
 
     SchemaPlus schema = Frameworks.createRootSchema(true);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
@@ -62,11 +62,12 @@ public class BeamSqlFnExecutorTestBase {
             .add("site_id", SqlTypeName.INTEGER)
             .add("price", SqlTypeName.DOUBLE)
             .add("order_time", SqlTypeName.BIGINT)
+            .add("order_info", SqlTypeName.VARCHAR)
             .build();
 
     row =
         Row.withSchema(CalciteUtils.toBeamSchema(relDataType))
-            .addValues(1234567L, 0, 8.9, 1234567L)
+            .addValues(1234567L, 0, 8.9, 1234567L, "string_test_1")
             .build();
 
     SchemaPlus schema = Frameworks.createRootSchema(true);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.B
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlGreaterThanOrEqualsExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLessThanExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLessThanOrEqualsExpression;
+import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlLikeExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison.BeamSqlNotEqualsExpression;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
@@ -134,5 +135,15 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
                 new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 3),
                 BeamSqlPrimitive.of(SqlTypeName.BIGINT, 0L)));
     Assert.assertEquals(true, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
+  }
+
+  @Test
+  public void testLike() {
+    BeamSqlLikeExpression exp1 =
+        new BeamSqlLikeExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.VARCHAR, 4),
+                BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "string_test_.")));
+    Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCompareExpressionTest.java
@@ -143,7 +143,14 @@ public class BeamSqlCompareExpressionTest extends BeamSqlFnExecutorTestBase {
         new BeamSqlLikeExpression(
             Arrays.asList(
                 new BeamSqlInputRefExpression(SqlTypeName.VARCHAR, 4),
-                BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "string_test_.")));
+                BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "This is an order_")));
     Assert.assertEquals(true, exp1.evaluate(row, null, ImmutableMap.of()).getValue());
+
+    BeamSqlLikeExpression exp2 =
+        new BeamSqlLikeExpression(
+            Arrays.asList(
+                new BeamSqlInputRefExpression(SqlTypeName.VARCHAR, 4),
+                BeamSqlPrimitive.of(SqlTypeName.VARCHAR, "This is not%")));
+    Assert.assertEquals(false, exp2.evaluate(row, null, ImmutableMap.of()).getValue());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpressionTest.java
@@ -43,7 +43,7 @@ public class BeamSqlInputRefExpressionTest extends BeamSqlFnExecutorTestBase {
 
   @Test(expected = IndexOutOfBoundsException.class)
   public void testRefOutOfRange() {
-    BeamSqlInputRefExpression ref = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 4);
+    BeamSqlInputRefExpression ref = new BeamSqlInputRefExpression(SqlTypeName.BIGINT, 5);
     ref.evaluate(row, null, ImmutableMap.of()).getValue();
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
@@ -248,6 +248,49 @@ public class BeamSqlComparisonOperatorsIntegrationTest
     checker.buildRunAndCheck();
   }
 
+  @Test
+  public void testLike() throws Exception {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr("s_string_1 LIKE 'string_true_test'", true)
+            .addExpr("s_string_1 LIKE 'string_false_test'", false)
+            .addExpr("s_string_2 LIKE 'string_false_test'", true)
+            .addExpr("s_string_2 LIKE 'string_true_test'", false)
+            .addExpr("s_string_1 LIKE 'string_true_test%'", true)
+            .addExpr("s_string_1 LIKE 'string_false_test%'", false)
+            .addExpr("s_string_1 LIKE 'string_true%'", true)
+            .addExpr("s_string_1 LIKE 'string_false%'", false)
+            .addExpr("s_string_1 LIKE 'string%test'", true)
+            .addExpr("s_string_1 LIKE '%test'", true)
+            .addExpr("s_string_1 LIKE '%string_true_test'", true)
+            .addExpr("s_string_1 LIKE '%string_false_test'", false)
+            .addExpr("s_string_1 LIKE '%false_test'", false)
+            .addExpr("s_string_2 LIKE '%false_test'", true)
+            .addExpr("s_string_1 LIKE 'string_tr_e_test'", true)
+            .addExpr("s_string_1 LIKE 'string______test'", true)
+            .addExpr("s_string_2 LIKE 'string______test'", false)
+            .addExpr("s_string_2 LIKE 'string_______test'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te__'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te___'", false)
+            .addExpr("s_string_2 LIKE 'string_false_te_'", false)
+            .addExpr("s_string_1 LIKE 'string_true_te__'", true)
+            .addExpr("s_string_1 LIKE '_ring_true_te__'", false)
+            .addExpr("s_string_2 LIKE '__ring_false_te__'", true)
+            .addExpr("s_string_1 LIKE '_%ring_true_te__'", true)
+            .addExpr("s_string_1 LIKE '_%tring_true_te__'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te%__'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te__%'", true)
+            .addExpr("s_string_2 LIKE 'string_false_t%__'", true)
+            .addExpr("s_string_2 LIKE 'string_false_t__%'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te_%'", true)
+            .addExpr("s_string_2 LIKE 'string_false_te%_'", true)
+            .addExpr("s_string_1 LIKE 'string_%test'", true)
+            .addExpr("s_string_1 LIKE 'string%_test'", true)
+            .addExpr("s_string_1 LIKE 'string_%_test'", true);
+
+    checker.buildRunAndCheck();
+  }
+
   @Override
   protected PCollection<Row> getTestPCollection() {
     Schema type =
@@ -278,6 +321,8 @@ public class BeamSqlComparisonOperatorsIntegrationTest
             .addStringField("c_varchar_2")
             .addBooleanField("c_boolean_false")
             .addBooleanField("c_boolean_true")
+            .addStringField("s_string_1")
+            .addStringField("s_string_2")
             .build();
 
     try {
@@ -308,7 +353,9 @@ public class BeamSqlComparisonOperatorsIntegrationTest
               "b",
               "c",
               false,
-              true)
+              true,
+              "string_true_test",
+              "string_false_test")
           .buildIOReader(pipeline)
           .setCoder(type.getRowCoder());
     } catch (Exception e) {


### PR DESCRIPTION
Add ```LIKE``` operator to Beam SQL to support the use case like ```SELECT * FROM table WHERE str_col LIKE <regex>```.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

to: @kennknowles could you please take a look at this PR?