### PR TITLE
[BEAM-4423] Mark pull requests stale after 60 days; close 7 days after warning

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,27 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - pinned
+  - security
+
+# Limit to only `issues` or `pulls`
+only: pulls
+
+# Configuration settings that are specific to just 'issues' or 'pulls':
+pulls:
+  daysUntilStale: 60
+  daysUntilClose: 7
+  markComment: >
+    This pull request has been marked as stale due to 60 days of inactivity.
+    It will be closed in 1 week if no further activity occurs. If you think
+    that’s incorrect or this pull request requires a review, please simply
+    write any comment. If closed, you can revive the PR at any time and @mention
+    a reviewer or discuss it on the dev@beam.apache.org list.
+    Thank you for your contributions.
+  unmarkComment: >
+    This pull request is no longer marked as stale.
+  closeComment: >
+    This pull request has been closed due to lack of activity. If you think that
+    is incorrect, or the pull request requires review, you can revive the PR at
+    any time.


### PR DESCRIPTION
Create probot/stale config file to mark pull requests stale after 60 days; close 7 days after warning.
Currently only applied to pull requests, not stale issues.

https://beam.apache.org/contribute/#stale-pull-requests

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
