### PR TITLE
[BEAM-4421] Fix for issue with reading s3 files using ParquetIO

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -1058,6 +1058,11 @@ ext.provideIntegrationTestingDependencies = {
         testCompile project(path: ":beam-sdks-java-io-hadoop-file-system", configuration: 'shadowTest')
         shadowTest library.java.hadoop_client
       }
+
+      /* include dependencies required by AWS S3 */
+      if (filesystem?.equalsIgnoreCase('s3')) {
+        testCompile project(path: ":beam-sdks-java-io-amazon-web-services", configuration: 'shadowTest')
+      }
     }
   }
 }

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3ReadableSeekableByteChannel.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3ReadableSeekableByteChannel.java
@@ -131,9 +131,11 @@ class S3ReadableSeekableByteChannel implements SeekableByteChannel {
       return this;
     }
 
-    // The position has changed, so close the object to induce a re-open on the next call to read()
+    // The position has changed, so close and destroy the object to induce a re-creation on the next
+    // call to read()
     if (s3Object != null) {
       s3Object.close();
+      s3Object = null;
     }
     position = newPosition;
     return this;


### PR DESCRIPTION
`s3Object` was properly closed in case if position in `InputStream` has been changed before but the same instance was used on the next `read()` call and it caused `IOException: Attempted read on closed stream`. In this case we need to create new instance of `s3Object`.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
