### PR TITLE
[BEAM-4253] Add ParDoTest class to test exclusions

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -125,6 +125,10 @@ task validatesRunnerTest(type: Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedPCollections'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
     excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
+
+    // https://issues.apache.org/jira/browse/BEAM-4253
+    // This should be removed after regenerating Dataflow worker container
+    excludeCategories 'org.apache.beam.sdk.transforms.ParDoTest'
   }
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/BEAM-4253

Disabling ParDoTests until new dataflow worker container image generated.

Post commit tests have been failing for weeks. Lets make signal green.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
