### PR TITLE
[BEAM-4253] Update dataflow worker to fix ParDoTest fails in DataflowValidatesRunner suite

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -36,7 +36,7 @@ processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
     'dataflow.legacy_environment_major_version' : '7',
     'dataflow.fnapi_environment_major_version' : '1',
-    'dataflow.container_version' : 'beam-master-20180410'
+    'dataflow.container_version' : 'beam-master-20180601'
   ]
 }
 

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -33,7 +33,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.container_version>beam-master-20180410</dataflow.container_version>
+    <dataflow.container_version>beam-master-20180601</dataflow.container_version>
     <dataflow.fnapi_environment_major_version>1</dataflow.fnapi_environment_major_version>
     <dataflow.legacy_environment_major_version>7</dataflow.legacy_environment_major_version>
   </properties>


### PR DESCRIPTION
Update dataflow worker to beam-master-20180601. Due to changes in DoFn, tests were failing with:


java.lang.AbstractMethodError: org.apache.beam.runners.core.SimpleDoFnRunner$DoFnProcessContext.element(Lorg/apache/beam/sdk/transforms/DoFn;)Ljava/lang/Object;
	at org.apache.beam.sdk.transforms.ParDoTest$StateCoderInferenceTests$7$DoFnInvoker.invokeProcessElement(Unknown Source)
	at org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:177)
	at org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:138)

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
