### PR TITLE
[BEAM-4326] Enforce ErrorProne analysis in the fn-execution project

### DIFF
--- a/sdks/java/fn-execution/build.gradle
+++ b/sdks/java/fn-execution/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
 
 description = "Apache Beam :: SDKs :: Java :: Fn Execution"
 ext.summary = """Contains code shared across the Beam Java SDK Harness and Java Runners to execute using
@@ -27,6 +27,7 @@ the Beam Portability Framework."""
 dependencies {
   compile library.java.guava
   compile library.java.findbugs_jsr305
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-model-pipeline", configuration: "shadow")
   shadow project(path: ":beam-model-fn-execution", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
@@ -41,4 +42,5 @@ dependencies {
   testCompile library.java.hamcrest_library
   testCompile library.java.mockito_core
   testCompile library.java.slf4j_jdk14
+  testCompileOnly library.java.findbugs_annotations
 }

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexerTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexerTest.java
@@ -80,7 +80,7 @@ public class BeamFnDataGrpcMultiplexerTest {
           // Purposefully sleep to simulate a delay in a consumer connecting.
           Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
           multiplexer.registerConsumer(OUTPUT_LOCATION, inboundValues::add);
-        });
+        }).get();
     multiplexer.getInboundObserver().onNext(ELEMENTS);
     assertTrue(multiplexer.hasConsumer(OUTPUT_LOCATION));
     // Ensure that when we see a terminal Elements object, we remove the consumer

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/CompletableFutureInboundDataClientTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/CompletableFutureInboundDataClientTest.java
@@ -21,6 +21,7 @@ package org.apache.beam.sdk.fn.data;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -100,6 +101,7 @@ public class CompletableFutureInboundDataClientTest {
 
     try {
       waitingFuture.get(50, TimeUnit.MILLISECONDS);
+      fail();
     } catch (TimeoutException expected) {
       // This should time out, as the client should never complete without external completion
     }

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/AdvancingPhaserTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/AdvancingPhaserTest.java
@@ -37,7 +37,7 @@ public class AdvancingPhaserTest {
     final AdvancingPhaser phaser = new AdvancingPhaser(1);
     int currentPhase = phaser.getPhase();
     ExecutorService service = Executors.newSingleThreadExecutor();
-    service.submit((Runnable) phaser::arrive);
+    service.submit((Runnable) phaser::arrive).get();
     phaser.awaitAdvance(currentPhase);
     assertFalse(phaser.isTerminated());
     service.shutdown();

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/test/TestExecutorsTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/test/TestExecutorsTest.java
@@ -45,7 +45,7 @@ public class TestExecutorsTest {
             new Statement() {
               @Override
               public void evaluate() throws Throwable {
-                testService.submit(() -> taskRan.set(true));
+                testService.submit(() -> taskRan.set(true)).get();
               }
             },
             null)
@@ -55,6 +55,10 @@ public class TestExecutorsTest {
   }
 
   @Test
+  // FutureReturnValueIgnored suppression is safe because testService is
+  // expected to *not* shutdown cleanly on the task it was given to execute.
+  // If we try to obtain the result of the future the test will timeout.
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void testTaskBlocksForeverCausesFailure() throws Throwable {
     ExecutorService service = Executors.newSingleThreadExecutor();
     final TestExecutorService testService = TestExecutors.from(service);
@@ -115,6 +119,10 @@ public class TestExecutorsTest {
   }
 
   @Test
+  // FutureReturnValueIgnored suppression is safe because testService is
+  // expected to *not* shutdown cleanly on the task it was given to execute.
+  // If we try to obtain the result of the future the test will timeout.
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void testStatementFailurePropagatedWhenExecutorServiceFailingToTerminate()
       throws Throwable {
     ExecutorService service = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
1. Enables `failOnWarning` for `fn-execution` project
2. Cleans up related code to get error prone to pass