### PR TITLE
[BEAM-4376] Add Nexmark events generation based on ParDo

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
@@ -452,4 +452,9 @@ public interface NexmarkOptions
   int getMaxNumWorkers();
 
   void setMaxNumWorkers(int value);
+
+  @Description("Use source API for synthetic generation.")
+  boolean getUseParDoGenerator();
+
+  void setUseParDoGenerator(boolean value);
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
@@ -351,7 +351,7 @@ public class NexmarkUtils {
   }
 
   /** Return a generator config to match the given {@code options}. */
-  private static GeneratorConfig standardGeneratorConfig(NexmarkConfiguration configuration) {
+  static GeneratorConfig standardGeneratorConfig(NexmarkConfiguration configuration) {
     return new GeneratorConfig(
         configuration,
         configuration.useWallclockEventTime ? System.currentTimeMillis() : BASE_TIME,

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/EventGeneratorDoFn.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/sources/EventGeneratorDoFn.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.sources;
+
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.sources.generator.Generator;
+import org.apache.beam.sdk.nexmark.sources.generator.GeneratorConfig;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.values.TimestampedValue;
+
+/** A DoFn to generate bounded event records. */
+public class EventGeneratorDoFn extends DoFn<Void, Event> {
+  /** Configuration we generate events against. */
+  private final GeneratorConfig config;
+  /** Generator we are reading from. */
+  private transient Generator generator;
+
+  public EventGeneratorDoFn(GeneratorConfig config) {
+    this.config = config;
+  }
+
+  @Setup
+  public void setup() {
+    generator = new Generator(config);
+  }
+
+  @ProcessElement
+  public void processElement(ProcessContext c) {
+    while (generator.hasNext()) {
+      final TimestampedValue<Event> next = generator.next();
+      c.outputWithTimestamp(next.getValue(), next.getTimestamp());
+    }
+  }
+}

--- a/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/sources/EventGeneratorDoFnTest.java
+++ b/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/sources/EventGeneratorDoFnTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark.sources;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.nexmark.NexmarkConfiguration;
+import org.apache.beam.sdk.nexmark.model.Event;
+import org.apache.beam.sdk.nexmark.sources.generator.Generator;
+import org.apache.beam.sdk.nexmark.sources.generator.GeneratorConfig;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test {@link BoundedEventSource}. */
+@RunWith(JUnit4.class)
+public class EventGeneratorDoFnTest {
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+  @Rule public final transient TestPipeline sourcePipeline = TestPipeline.create();
+
+  @Test
+  public void testNumGeneratedEvents() {
+    final int numEvents = 100;
+    GeneratorConfig config =
+        new GeneratorConfig(
+            NexmarkConfiguration.DEFAULT, System.currentTimeMillis(), 0, numEvents, 0);
+    PCollection<Event> events =
+        p.apply(Create.of((Void) null)).apply(ParDo.of(new EventGeneratorDoFn(config)));
+    PAssert.thatSingleton(events.apply("Count All", Count.globally())).isEqualTo((long) numEvents);
+    p.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testGeneratesSameEvents() {
+    final int numEvents = 100;
+    GeneratorConfig config =
+        new GeneratorConfig(
+            NexmarkConfiguration.DEFAULT, System.currentTimeMillis(), 0, numEvents, 0);
+    List<Event> eventsFromGenerator = generateEvents(config);
+
+    PCollection<Event> eventsFromParDo =
+        p.apply(Create.of((Void) null)).apply(ParDo.of(new EventGeneratorDoFn(config)));
+    PAssert.that(eventsFromParDo).containsInAnyOrder(eventsFromGenerator);
+    p.run().waitUntilFinish();
+
+    PCollection<Event> eventsFromSource =
+        sourcePipeline.apply(Read.from(new BoundedEventSource(config, 1)));
+    PAssert.that(eventsFromSource).containsInAnyOrder(eventsFromGenerator);
+    sourcePipeline.run().waitUntilFinish();
+
+    p.run().waitUntilFinish();
+  }
+
+  private static List<Event> generateEvents(GeneratorConfig config) {
+    Generator generator = new Generator(config);
+    List<Event> events = new ArrayList<>();
+    while (generator.hasNext()) {
+      final TimestampedValue<Event> timestampedEvent = generator.next();
+      events.add(timestampedEvent.getValue());
+    }
+    return events;
+  }
+}


### PR DESCRIPTION
R: @kennknowles 
CC: @jkff 

Hi, I ping you guys because I found something weird and I am not sure if it is a direct runner issue or a issue with ParDo (or a Nexmark thing that I didn't identify). I added this new generation mode for Nexmark to be able to test the PortableRunner. However when the Nexmark executions produce different results.
I print the generated events (the input of the different queries) and both (the ParDo based and the Source generator) produce exactly the same output (I validate this in `EventGeneratorDoFnTest#testGeneratesSameEvents`). 

Do you have any idea why this can be wrong? am I missing something that can change the results?
As a reference to execute this I do:
```
./gradlew :beam-sdks-java-nexmark:run \
    -Pnexmark.runner=":beam-runners-direct-java" \
    -Pnexmark.args="
        --runner=DirectRunner
        --streaming=false
        --suite=SMOKE
        --manageResources=false
        --monitorJobs=true
        --enforceEncodability=true
        --enforceImmutability=true --useParDoGenerator=true"
```
You can change useParDoGenerator to false to see the different results.