### PR TITLE
Heap-based global top.

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -19,16 +19,19 @@
 
 from __future__ import absolute_import
 
+import heapq
 import operator
 import random
 
 from apache_beam.transforms import core
 from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
+from apache_beam.transforms import window
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.typehints import KV
 from apache_beam.typehints import Any
 from apache_beam.typehints import Dict
+from apache_beam.typehints import Iterable
 from apache_beam.typehints import List
 from apache_beam.typehints import Tuple
 from apache_beam.typehints import TypeVariable
@@ -181,8 +184,22 @@ class Top(object):
     """
     key = kwargs.pop('key', None)
     reverse = kwargs.pop('reverse', False)
-    return pcoll | core.CombineGlobally(
-        TopCombineFn(n, compare, key, reverse), *args, **kwargs)
+    if not args and not kwargs and not key and pcoll.windowing.is_default():
+      if reverse:
+        if compare is None or compare is operator.lt:
+          compare = operator.gt
+        else:
+          original_compare = compare
+          compare = lambda a, b: original_compare(b, a)
+      # This is a more efficient global algorithm.
+      return (
+          pcoll
+          | core.ParDo(_TopPerShard(n, compare))
+          | core.GroupByKey()
+          | core.ParDo(_MergeTopPerShard(n, compare)))
+    else:
+      return pcoll | core.CombineGlobally(
+          TopCombineFn(n, compare, key, reverse), *args, **kwargs)
 
   @staticmethod
   @ptransform.ptransform_fn
@@ -241,6 +258,92 @@ class Top(object):
   def SmallestPerKey(pcoll, n, reverse=True):
     """Identifies the N least elements associated with each key."""
     return pcoll | Top.PerKey(n, reverse=True)
+
+
+class _ComparableValue(object):
+
+  __slots__ = ('value', 'less_than')
+
+  def __init__(self, value, less_than):
+    self.value = value
+    self.less_than = less_than
+
+  def __lt__(self, other):
+    return self.less_than(self.value, other.value)
+
+  def __repr__(self):
+    return "_ComparableValue[%s]" % self.value
+
+
+@with_input_types(T)
+@with_output_types(KV[None, List[T]])
+class _TopPerShard(core.DoFn):
+  def __init__(self, n, less_than):
+    self._n = n
+    self._less_than = None if less_than is operator.le else less_than
+
+  def start_bundle(self):
+    self._heap = []
+
+  def process(self, element):
+    if self._less_than is not None:
+      element = _ComparableValue(element, self._less_than)
+    if len(self._heap) < self._n:
+      heapq.heappush(self._heap, element)
+    else:
+      heapq.heappushpop(self._heap, element)
+
+  def finish_bundle(self):
+    # Though sorting here results in more total work, this allows us to
+    # skip most elements in the reducer.
+    # Essentially, given s map shards, we are trading about O(sn) compares in
+    # the (single) reducer for O(sn log n) compares across all mappers.
+    self._heap.sort()
+
+    # Unwrap to avoid serialization via pickle.
+    if self._less_than:
+      yield window.GlobalWindows.windowed_value(
+          (None, [wrapper.value for wrapper in self._heap]))
+    else:
+      yield window.GlobalWindows.windowed_value(
+          (None, self._heap))
+
+
+@with_input_types(KV[None, Iterable[List[T]]])
+@with_output_types(List[T])
+class _MergeTopPerShard(core.DoFn):
+  def __init__(self, n, less_than):
+    self._n = n
+    self._less_than = None if less_than is operator.le else less_than
+
+  def process(self, key_and_shards):
+    _, shards = key_and_shards
+    heap = []
+    for shard in shards:
+      if not heap:
+        if self._less_than:
+          heap = [
+              _ComparableValue(element, self._less_than) for element in shard]
+        else:
+          heap = shard
+        continue
+      for element in reversed(shard):
+        if self._less_than is not None:
+          element = _ComparableValue(element, self._less_than)
+        if len(heap) < self._n:
+          heapq.heappush(heap, element)
+        elif element <= heap[0]:
+          # Because _TopPerShard returns sorted lists, all other elements
+          # will also be smaller.
+          break
+        else:
+          heapq.heappushpop(heap, element)
+
+    heap.sort()
+    if self._less_than:
+      yield [wrapper.value for wrapper in reversed(heap)]
+    else:
+      yield heap[::-1]
 
 
 @with_input_types(T)

--- a/sdks/python/apache_beam/transforms/combiners_test.py
+++ b/sdks/python/apache_beam/transforms/combiners_test.py
@@ -17,6 +17,7 @@
 
 """Unit tests for our libraries of combine PTransforms."""
 
+import random
 import unittest
 
 import hamcrest as hc
@@ -107,6 +108,17 @@ class CombineTest(unittest.TestCase):
                 label='key:bot')
     assert_that(result_key_cmp, equal_to([('a', [9, 6, 6, 5, 3, 2])]),
                 label='key:cmp')
+    pipeline.run()
+
+  def test_sharded_top(self):
+    elements = list(range(100))
+    random.shuffle(elements)
+
+    pipeline = TestPipeline()
+    shards = [pipeline | 'Shard%s' % shard >> beam.Create(elements[shard::7])
+              for shard in range(7)]
+    assert_that(shards | beam.Flatten() | combine.Top.Largest(10),
+                equal_to([[99, 98, 97, 96, 95, 94, 93, 92, 91, 90]]))
     pipeline.run()
 
   def test_top_key(self):


### PR DESCRIPTION
This adds a specialized implementation for global top that greatly reduces the number of compares required in the (single) reducer. Also uses heapq rather than repeated buffer + sort + truncate. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
