### PR TITLE
[BEAM-4480] Fixed deprecated method invoking for AvroCoder

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/AvroCoder.java
@@ -197,7 +197,7 @@ public class AvroCoder<T> extends CustomCoder<T> {
     }
 
     private Object readResolve() throws IOException, ClassNotFoundException {
-      return new SerializableSchemaSupplier(Schema.parse(schema));
+      return new SerializableSchemaSupplier(new Schema.Parser().parse(schema));
     }
   }
 


### PR DESCRIPTION
**Please** add a meaningful description for your change here

This is a very minor change. Fixed the deprecated Avro API
 from _Schema.parse(schema)_ to _new Schema.Parser().parse(schema)_

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
