### PR TITLE
[BEAM-4475] Make Go precommit build all Go code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,13 @@ task javaPostCommit() {
 task goPreCommit() {
   dependsOn ":rat"
   dependsOn ":beam-sdks-go:test"
+
+  // Ensure all container Go boot code builds as well.
+  dependsOn ":beam-sdks-java-container:build"
+  dependsOn ":beam-sdks-python-container:build"
+  dependsOn ":beam-sdks-go-container:build"
+  dependsOn ":beam-runners-gcp-gcemd:build"
+  dependsOn ":beam-runners-gcp-gcsproxy:build"
 }
 
 task goPostCommit() {

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,8 @@ task javaPostCommit() {
 task goPreCommit() {
   dependsOn ":rat"
   dependsOn ":beam-sdks-go:test"
+  dependsOn ":beam-sdks-go-examples:build"
+  dependsOn ":beam-sdks-go-test:build"
 
   // Ensure all container Go boot code builds as well.
   dependsOn ":beam-sdks-java-container:build"


### PR DESCRIPTION
This should prevent Go build breaks silently slipping through the cracks.