### PR TITLE
Improve default value for experiments set in RuntimeValueProvider

### DIFF
--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -75,7 +75,7 @@ class StaticValueProvider(ValueProvider):
 
 class RuntimeValueProvider(ValueProvider):
   runtime_options = None
-  experiments = None
+  experiments = set()
 
   def __init__(self, option_name, value_type, default_value):
     self.option_name = option_name

--- a/sdks/python/apache_beam/options/value_provider_test.py
+++ b/sdks/python/apache_beam/options/value_provider_test.py
@@ -187,6 +187,8 @@ class ValueProviderTests(unittest.TestCase):
     self.assertEqual(options.vpt_vp_arg14.get(), 2)
 
   def test_experiments_setup(self):
+    self.assertFalse('feature_1' in RuntimeValueProvider.experiments)
+
     RuntimeValueProvider.set_runtime_options(
         {'experiments': ['feature_1', 'feature_2']}
     )


### PR DESCRIPTION
This fixes a bug where checking for experiments would cause an issue (TypeError).

r: @boyuanzz 