### PR TITLE
[BEAM-4491] Fix ProvisionInfo in DockerJobBundleFactory

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/provisioning/JobInfo.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/provisioning/JobInfo.java
@@ -21,6 +21,7 @@ package org.apache.beam.runners.fnexecution.provisioning;
 import com.google.auto.value.AutoValue;
 import com.google.protobuf.Struct;
 import java.io.Serializable;
+import org.apache.beam.model.fnexecution.v1.ProvisionApi;
 
 /**
  * A subset of {@link org.apache.beam.model.fnexecution.v1.ProvisionApi.ProvisionInfo} that
@@ -35,4 +36,13 @@ public abstract class JobInfo implements Serializable {
   public abstract String jobId();
   public abstract String jobName();
   public abstract Struct pipelineOptions();
+
+  public ProvisionApi.ProvisionInfo toProvisionInfo() {
+    return ProvisionApi.ProvisionInfo
+        .newBuilder()
+        .setJobId(jobId())
+        .setJobName(jobName())
+        .setPipelineOptions(pipelineOptions())
+        .build();
+  }
 }


### PR DESCRIPTION
DockerJobBundleFactory was previously setting up a provisioning
service that served the default empty ProvisionInfo to workers.
This change accepts JobInfo to the create call, so that it can
serve the correct ProvisionInfo for a job.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
