### PR TITLE
[BEAM-4477] support EXISTS operator

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
@@ -79,9 +79,9 @@ public class BeamSqlCastExpression extends BeamSqlExpression {
     switch (castOutputType) {
       case BOOLEAN:
         return BeamSqlPrimitive.of(
-                SqlTypeName.BOOLEAN,
-                SqlFunctions.toBoolean(
-                        (Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
+            SqlTypeName.BOOLEAN,
+            SqlFunctions.toBoolean(
+                (Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case INTEGER:
         return BeamSqlPrimitive.of(
             SqlTypeName.INTEGER,

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
@@ -77,6 +77,11 @@ public class BeamSqlCastExpression extends BeamSqlExpression {
       Row inputRow, BoundedWindow window, ImmutableMap<Integer, Object> correlateEnv) {
     SqlTypeName castOutputType = getOutputType();
     switch (castOutputType) {
+      case BOOLEAN:
+        return BeamSqlPrimitive.of(
+                SqlTypeName.BOOLEAN,
+                SqlFunctions.toBoolean(
+                        (Object) opValueEvaluated(index, inputRow, window, correlateEnv)));
       case INTEGER:
         return BeamSqlPrimitive.of(
             SqlTypeName.INTEGER,

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rule/BeamAggregationRule.java
@@ -69,18 +69,16 @@ public class BeamAggregationRule extends RelOptRule {
       windowField = AggregateWindowFactory.getWindowFieldAt((RexCall) projNode, groupFieldIndex);
     }
 
-    BeamAggregationRel newAggregator =
-        new BeamAggregationRel(
-            aggregate.getCluster(),
-            aggregate.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
-            convert(
-                aggregate.getInput(),
-                aggregate.getInput().getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
-            aggregate.indicator,
-            aggregate.getGroupSet(),
-            aggregate.getGroupSets(),
-            aggregate.getAggCallList(),
-            windowField);
-    return newAggregator;
+    return new BeamAggregationRel(
+        aggregate.getCluster(),
+        aggregate.getTraitSet().replace(BeamLogicalConvention.INSTANCE),
+        convert(
+            aggregate.getInput(),
+            aggregate.getInput().getTraitSet().replace(BeamLogicalConvention.INSTANCE)),
+        aggregate.indicator,
+        aggregate.getGroupSet(),
+        aggregate.getGroupSets(),
+        aggregate.getAggCallList(),
+        windowField);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -46,6 +46,8 @@ class BeamBuiltinAggregations {
   /** {@link CombineFn} for MAX based on {@link Max} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createMax(SqlTypeName fieldType) {
     switch (fieldType) {
+      case BOOLEAN:
+        return new CustMax<Boolean>();
       case INTEGER:
         return Max.ofIntegers();
       case SMALLINT:
@@ -68,9 +70,11 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /** {@link CombineFn} for MAX based on {@link Min} and {@link Combine.BinaryCombineFn}. */
+  /** {@link CombineFn} for MIN based on {@link Min} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createMin(SqlTypeName fieldType) {
     switch (fieldType) {
+      case BOOLEAN:
+        return new CustMin<Boolean>();
       case INTEGER:
         return Min.ofIntegers();
       case SMALLINT:
@@ -93,7 +97,7 @@ class BeamBuiltinAggregations {
     }
   }
 
-  /** {@link CombineFn} for MAX based on {@link Sum} and {@link Combine.BinaryCombineFn}. */
+  /** {@link CombineFn} for Sum based on {@link Sum} and {@link Combine.BinaryCombineFn}. */
   public static CombineFn createSum(SqlTypeName fieldType) {
     switch (fieldType) {
       case INTEGER:

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslExistsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslExistsTest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.extensions.sql;
+
+import org.apache.beam.sdk.extensions.sql.impl.rel.BaseRelTest;
+import org.apache.beam.sdk.extensions.sql.mock.MockedBoundedTable;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Tests for comparison operator in queries. */
+public class BeamSqlDslExistsTest extends BaseRelTest {
+  @Rule public final TestPipeline pipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void prepare() {
+    registerTable(
+        "CUSTOMER",
+        MockedBoundedTable.of(
+                Schema.FieldType.INT32, "c_custkey",
+                Schema.FieldType.DOUBLE, "c_acctbal",
+                Schema.FieldType.STRING, "c_city")
+            .addRows(1, 1.0, "Seattle", 5, 1.0, "Mountain View", 4, 4.0, "Portland"));
+
+    registerTable(
+        "ORDERS",
+        MockedBoundedTable.of(
+                Schema.FieldType.INT32, "o_orderkey",
+                Schema.FieldType.INT32, "o_custkey",
+                Schema.FieldType.DOUBLE, "o_totalprice")
+            .addRows(1, 1, 1.0, 2, 2, 2.0, 3, 3, 3.0));
+  }
+
+  @Test
+  public void testExistsSubquery() {
+    String sql =
+        "select * from CUSTOMER "
+            + " where exists ( "
+            + " select * from ORDERS "
+            + " where o_custkey = c_custkey )";
+
+    PCollection<Row> rows = compilePipeline(sql, pipeline);
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    Schema.FieldType.INT32, "c_custkey",
+                    Schema.FieldType.DOUBLE, "c_acctbal",
+                    Schema.FieldType.STRING, "c_city")
+                .addRows(1, 1.0, "Seattle")
+                .getRows());
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testNotExistsSubquery() {
+    String sql =
+        "select * from CUSTOMER "
+            + " where not exists ( "
+            + " select * from ORDERS "
+            + " where o_custkey = c_custkey )";
+
+    PCollection<Row> rows = compilePipeline(sql, pipeline);
+    PAssert.that(rows)
+        .containsInAnyOrder(
+            TestUtils.RowsBuilder.of(
+                    Schema.FieldType.INT32, "c_custkey",
+                    Schema.FieldType.DOUBLE, "c_acctbal",
+                    Schema.FieldType.STRING, "c_city")
+                .addRows(4, 4.0, "Portland", 5, 1.0, "Mountain View")
+                .getRows());
+
+    pipeline.run().waitUntilFinish();
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
@@ -28,12 +28,11 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 
 /** Base class for rel test. */
-abstract class BaseRelTest {
+public abstract class BaseRelTest {
   private static Map<String, BeamSqlTable> tables = new HashMap<>();
   private static BeamSqlEnv env = BeamSqlEnv.readOnly("test", tables);
 
-  protected static PCollection<Row> compilePipeline(String sql, Pipeline pipeline)
-      throws Exception {
+  protected static PCollection<Row> compilePipeline(String sql, Pipeline pipeline) {
     return PCollectionTuple.empty(pipeline).apply(env.parseQuery(sql));
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/transform/BeamAggregationTransformTest.java
@@ -46,6 +46,7 @@ import org.apache.calcite.sql.fun.SqlSumAggFunction;
 import org.apache.calcite.sql.type.BasicSqlType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.Pair;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -54,7 +55,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
 
   @Rule public TestPipeline p = TestPipeline.create();
 
-  private List<AggregateCall> aggCalls;
+  private List<Pair<AggregateCall, String>> aggCalls;
 
   private Schema keyType;
   private Schema aggPartType;
@@ -127,8 +128,7 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
     PCollection<Row> mergedStream =
         aggregatedStream.apply(
             "mergeRecord",
-            ParDo.of(
-                new BeamAggregationTransforms.MergeAggregationRecord(outputType, aggCalls, -1)));
+            ParDo.of(new BeamAggregationTransforms.MergeAggregationRecord(outputType, -1)));
     mergedStream.setCoder(outRecordCoder);
 
     // assert function BeamAggregationTransform.AggregationGroupByKeyFn
@@ -154,200 +154,259 @@ public class BeamAggregationTransformTest extends BeamTransformBaseTest {
     // aggregations for all data type
     aggCalls = new ArrayList<>();
     aggCalls.add(
-        new AggregateCall(
-            new SqlCountAggFunction("COUNT"),
-            false,
-            Arrays.asList(),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlCountAggFunction("COUNT"),
+                false,
+                Arrays.asList(),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+                "count"),
             "count"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT)),
-            false,
-            Arrays.asList(1),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT)),
+                false,
+                Arrays.asList(1),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+                "sum1"),
             "sum1"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(1),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(1),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+                "avg1"),
             "avg1"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(1),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(1),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+                "max1"),
             "max1"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(1),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(1),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.BIGINT),
+                "min1"),
             "min1"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(
-                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT)),
-            false,
-            Arrays.asList(2),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT)),
+                false,
+                Arrays.asList(2),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+                "sum2"),
             "sum2"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(2),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(2),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+                "avg2"),
             "avg2"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(2),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(2),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+                "max2"),
             "max2"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(2),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(2),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.SMALLINT),
+                "min2"),
             "min2"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT)),
-            false,
-            Arrays.asList(3),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT)),
+                false,
+                Arrays.asList(3),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+                "sum3"),
             "sum3"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(3),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(3),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+                "avg3"),
             "avg3"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(3),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(3),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+                "max3"),
             "max3"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(3),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(3),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TINYINT),
+                "min3"),
             "min3"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT)),
-            false,
-            Arrays.asList(4),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT)),
+                false,
+                Arrays.asList(4),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+                "sum4"),
             "sum4"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(4),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(4),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+                "avg4"),
             "avg4"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(4),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(4),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+                "max4"),
             "max4"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(4),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(4),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.FLOAT),
+                "min4"),
             "min4"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE)),
-            false,
-            Arrays.asList(5),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE)),
+                false,
+                Arrays.asList(5),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+                "sum5"),
             "sum5"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(5),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(5),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+                "avg5"),
             "avg5"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(5),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(5),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+                "max5"),
             "max5"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(5),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(5),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.DOUBLE),
+                "min5"),
             "min5"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(7),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TIMESTAMP),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(7),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TIMESTAMP),
+                "max7"),
             "max7"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(7),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TIMESTAMP),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(7),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.TIMESTAMP),
+                "min7"),
             "min7"));
 
     aggCalls.add(
-        new AggregateCall(
-            new SqlSumAggFunction(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER)),
-            false,
-            Arrays.asList(8),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+        Pair.of(
+            new AggregateCall(
+                new SqlSumAggFunction(
+                    new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER)),
+                false,
+                Arrays.asList(8),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+                "sum8"),
             "sum8"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlAvgAggFunction(SqlKind.AVG),
-            false,
-            Arrays.asList(8),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+        Pair.of(
+            new AggregateCall(
+                new SqlAvgAggFunction(SqlKind.AVG),
+                false,
+                Arrays.asList(8),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+                "avg8"),
             "avg8"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MAX),
-            false,
-            Arrays.asList(8),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MAX),
+                false,
+                Arrays.asList(8),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+                "max8"),
             "max8"));
     aggCalls.add(
-        new AggregateCall(
-            new SqlMinMaxAggFunction(SqlKind.MIN),
-            false,
-            Arrays.asList(8),
-            new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+        Pair.of(
+            new AggregateCall(
+                new SqlMinMaxAggFunction(SqlKind.MIN),
+                false,
+                Arrays.asList(8),
+                new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.INTEGER),
+                "min8"),
             "min8"));
   }
 


### PR DESCRIPTION
`EXISTS` utilizes aggregation function `min`. 

1.  support `min` for `boolean` type.
2. rename aggregation function name when it is null.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
