### PR TITLE
[BEAM-4311] Enforce ErrorProne analysis in Flink runner

### DIFF
--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -19,7 +19,8 @@
 import groovy.json.JsonOutput
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature()
+applyJavaNature(failOnWarning: true)
+
 
 description = "Apache Beam :: Runners :: Flink"
 
@@ -48,6 +49,7 @@ def flink_version = "1.4.0"
 
 dependencies {
   compile library.java.guava
+  compileOnly library.java.findbugs_annotations
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow project(path: ":beam-runners-core-java", configuration: "shadow")
   shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink;
 
+import com.google.common.base.Splitter;
 import java.util.List;
 import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -51,12 +52,12 @@ public class FlinkExecutionEnvironments {
     } else if ("[auto]".equals(masterUrl)) {
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
-      String[] parts = masterUrl.split(":");
+      List<String> parts = Splitter.on(':').splitToList(masterUrl);
       List<String> stagingFiles = options.getFilesToStage();
       flinkBatchEnv =
           ExecutionEnvironment.createRemoteEnvironment(
-              parts[0],
-              Integer.parseInt(parts[1]),
+              parts.get(0),
+              Integer.parseInt(parts.get(1)),
               stagingFiles.toArray(new String[stagingFiles.size()]));
     } else {
       LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);
@@ -99,12 +100,12 @@ public class FlinkExecutionEnvironments {
     } else if ("[auto]".equals(masterUrl)) {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
-      String[] parts = masterUrl.split(":");
+      List<String> parts = Splitter.on(':').splitToList(masterUrl);
       List<String> stagingFiles = options.getFilesToStage();
       flinkStreamEnv =
           StreamExecutionEnvironment.createRemoteEnvironment(
-              parts[0],
-              Integer.parseInt(parts[1]),
+              parts.get(0),
+              Integer.parseInt(parts.get(1)),
               stagingFiles.toArray(new String[stagingFiles.size()]));
     } else {
       LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -401,18 +401,18 @@ public class DoFnOperator<InputT, OutputT>
       }
     } finally {
       super.close();
+    }
 
-      // sanity check: these should have been flushed out by +Inf watermarks
-      if (!sideInputs.isEmpty() && nonKeyedStateInternals != null) {
-        BagState<WindowedValue<InputT>> pushedBack =
-            nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
+    // sanity check: these should have been flushed out by +Inf watermarks
+    if (!sideInputs.isEmpty() && nonKeyedStateInternals != null) {
+      BagState<WindowedValue<InputT>> pushedBack =
+          nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
 
-        Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
-        if (!Iterables.isEmpty(pushedBackContents)) {
-          String pushedBackString = Joiner.on(",").join(pushedBackContents);
-          throw new RuntimeException(
-              "Leftover pushed-back data: " + pushedBackString + ". This indicates a bug.");
-        }
+      Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
+      if (!Iterables.isEmpty(pushedBackContents)) {
+        String pushedBackString = Joiner.on(",").join(pushedBackContents);
+        throw new RuntimeException(
+            "Leftover pushed-back data: " + pushedBackString + ". This indicates a bug.");
       }
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/DedupingOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/DedupingOperator.java
@@ -122,7 +122,10 @@ public class DedupingOperator<T> extends AbstractStreamOperator<WindowedValue<T>
     Set<ByteBuffer> ids = dedupingCache.get(keyGroupIndex).asMap().keySet();
     VarIntCoder.of().encode(ids.size(), out, Context.NESTED);
     for (ByteBuffer id : ids) {
-      ByteArrayCoder.of().encode(id.array(), out, Context.NESTED);
+      byte[] bytes = new byte[id.remaining()];
+      id.get(bytes);
+      id.position(id.position() - bytes.length);
+      ByteArrayCoder.of().encode(bytes, out, Context.NESTED);
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSocketSource.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -152,7 +153,9 @@ public class UnboundedSocketSource<CheckpointMarkT extends UnboundedSource.Check
       this.socket = new Socket();
       this.socket.connect(new InetSocketAddress(this.source.getHostname(), this.source.getPort()),
           CONNECTION_TIMEOUT_TIME);
-      this.reader = new BufferedReader(new InputStreamReader(this.socket.getInputStream()));
+      this.reader =
+          new BufferedReader(
+              new InputStreamReader(this.socket.getInputStream(), StandardCharsets.UTF_8));
       this.isRunning = true;
     }
 
@@ -175,7 +178,7 @@ public class UnboundedSocketSource<CheckpointMarkT extends UnboundedSource.Check
             try {
               Thread.sleep(this.source.getDelayBetweenRetries());
             } catch (InterruptedException e1) {
-              e1.printStackTrace();
+              LOG.error("Interrupted during retry delay", e1);
             }
           } else {
             this.isRunning = false;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -436,7 +436,7 @@ public class UnboundedSourceWrapper<
   }
 
   @Override
-  public void onProcessingTime(long timestamp) throws Exception {
+  public void onProcessingTime(long timestamp) {
     if (this.isRunning) {
       synchronized (context.getCheckpointLock()) {
         // find minimum watermark over all localReaders
@@ -457,9 +457,11 @@ public class UnboundedSourceWrapper<
     }
   }
 
+  // the callback is ourselves so there is nothing meaningful we can do with the ScheduledFuture
+  @SuppressWarnings("FutureReturnValueIgnored")
   private void setNextWatermarkTimer(StreamingRuntimeContext runtime) {
     if (this.isRunning) {
-      long watermarkInterval =  runtime.getExecutionConfig().getAutoWatermarkInterval();
+      long watermarkInterval = runtime.getExecutionConfig().getAutoWatermarkInterval();
       long timeToNextWatermark = getTimeToNextWatermark(watermarkInterval);
       runtime.getProcessingTimeService().registerTimer(timeToNextWatermark, this);
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
@@ -92,22 +92,22 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         new StateTag.StateBinder() {
 
           @Override
-          public <T> ValueState<T> bindValue(
-              StateTag<ValueState<T>> address, Coder<T> coder) {
+          public <T2> ValueState<T2> bindValue(
+              StateTag<ValueState<T2>> address, Coder<T2> coder) {
 
             return new FlinkBroadcastValueState<>(stateBackend, address, namespace, coder);
           }
 
           @Override
-          public <T> BagState<T> bindBag(
-              StateTag<BagState<T>> address, Coder<T> elemCoder) {
+          public <T2> BagState<T2> bindBag(
+              StateTag<BagState<T2>> address, Coder<T2> elemCoder) {
 
             return new FlinkBroadcastBagState<>(stateBackend, address, namespace, elemCoder);
           }
 
           @Override
-          public <T> SetState<T> bindSet(
-              StateTag<SetState<T>> address, Coder<T> elemCoder) {
+          public <T2> SetState<T2> bindSet(
+              StateTag<SetState<T2>> address, Coder<T2> elemCoder) {
             throw new UnsupportedOperationException(
                 String.format("%s is not supported", SetState.class.getSimpleName()));
           }
@@ -289,7 +289,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
 
   }
 
-  private class FlinkBroadcastValueState<K, T>
+  private class FlinkBroadcastValueState<T>
       extends AbstractBroadcastState<T> implements ValueState<T> {
 
     private final StateNamespace namespace;
@@ -331,7 +331,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         return false;
       }
 
-      FlinkBroadcastValueState<?, ?> that = (FlinkBroadcastValueState<?, ?>) o;
+      FlinkBroadcastValueState<?> that = (FlinkBroadcastValueState<?>) o;
 
       return namespace.equals(that.namespace) && address.equals(that.address);
 
@@ -350,7 +350,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkBroadcastBagState<K, T> extends AbstractBroadcastState<List<T>>
+  private class FlinkBroadcastBagState<T> extends AbstractBroadcastState<List<T>>
       implements BagState<T> {
 
     private final StateNamespace namespace;
@@ -423,7 +423,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         return false;
       }
 
-      FlinkBroadcastBagState<?, ?> that = (FlinkBroadcastBagState<?, ?>) o;
+      FlinkBroadcastBagState<?> that = (FlinkBroadcastBagState<?>) o;
 
       return namespace.equals(that.namespace) && address.equals(that.address);
 
@@ -437,7 +437,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkCombiningState<K, InputT, AccumT, OutputT>
+  private class FlinkCombiningState<InputT, AccumT, OutputT>
       extends AbstractBroadcastState<AccumT>
       implements CombiningState<InputT, AccumT, OutputT> {
 
@@ -539,8 +539,8 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         return false;
       }
 
-      FlinkCombiningState<?, ?, ?, ?> that =
-          (FlinkCombiningState<?, ?, ?, ?>) o;
+      FlinkCombiningState<?, ?, ?> that =
+          (FlinkCombiningState<?, ?, ?>) o;
 
       return namespace.equals(that.namespace) && address.equals(that.address);
 
@@ -554,14 +554,14 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkKeyedCombiningState<K, InputT, AccumT, OutputT>
+  private class FlinkKeyedCombiningState<K2, InputT, AccumT, OutputT>
       extends AbstractBroadcastState<AccumT>
       implements CombiningState<InputT, AccumT, OutputT> {
 
     private final StateNamespace namespace;
     private final StateTag<CombiningState<InputT, AccumT, OutputT>> address;
     private final Combine.CombineFn<InputT, AccumT, OutputT> combineFn;
-    private final FlinkBroadcastStateInternals<K> flinkStateInternals;
+    private final FlinkBroadcastStateInternals<K2> flinkStateInternals;
 
     FlinkKeyedCombiningState(
         OperatorStateBackend flinkStateBackend,
@@ -569,7 +569,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
-        FlinkBroadcastStateInternals<K> flinkStateInternals) {
+        FlinkBroadcastStateInternals<K2> flinkStateInternals) {
       super(flinkStateBackend, address.getId(), namespace, accumCoder);
 
       this.namespace = namespace;
@@ -690,14 +690,14 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
     }
   }
 
-  private class FlinkCombiningStateWithContext<K, InputT, AccumT, OutputT>
+  private class FlinkCombiningStateWithContext<K2, InputT, AccumT, OutputT>
       extends AbstractBroadcastState<AccumT>
       implements CombiningState<InputT, AccumT, OutputT> {
 
     private final StateNamespace namespace;
     private final StateTag<CombiningState<InputT, AccumT, OutputT>> address;
     private final CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn;
-    private final FlinkBroadcastStateInternals<K> flinkStateInternals;
+    private final FlinkBroadcastStateInternals<K2> flinkStateInternals;
     private final CombineWithContext.Context context;
 
     FlinkCombiningStateWithContext(
@@ -706,7 +706,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
-        FlinkBroadcastStateInternals<K> flinkStateInternals,
+        FlinkBroadcastStateInternals<K2> flinkStateInternals,
         CombineWithContext.Context context) {
       super(flinkStateBackend, address.getId(), namespace, accumCoder);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkSplitStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkSplitStateInternals.java
@@ -76,22 +76,22 @@ public class FlinkSplitStateInternals<K> implements StateInternals {
         new StateTag.StateBinder() {
 
           @Override
-          public <T> ValueState<T> bindValue(
-              StateTag<ValueState<T>> address, Coder<T> coder) {
+          public <T2> ValueState<T2> bindValue(
+              StateTag<ValueState<T2>> address, Coder<T2> coder) {
             throw new UnsupportedOperationException(
                 String.format("%s is not supported", ValueState.class.getSimpleName()));
           }
 
           @Override
-          public <T> BagState<T> bindBag(
-              StateTag<BagState<T>> address, Coder<T> elemCoder) {
+          public <T2> BagState<T2> bindBag(
+              StateTag<BagState<T2>> address, Coder<T2> elemCoder) {
 
             return new FlinkSplitBagState<>(stateBackend, address, namespace, elemCoder);
           }
 
           @Override
-          public <T> SetState<T> bindSet(
-              StateTag<SetState<T>> address, Coder<T> elemCoder) {
+          public <T2> SetState<T2> bindSet(
+              StateTag<SetState<T2>> address, Coder<T2> elemCoder) {
             throw new UnsupportedOperationException(
                 String.format("%s is not supported", SetState.class.getSimpleName()));
           }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -89,8 +89,11 @@ public class FlinkStateInternals<K> implements StateInternals {
   @Override
   public K getKey() {
     ByteBuffer keyBytes = flinkStateBackend.getCurrentKey();
+    byte[] bytes = new byte[keyBytes.remaining()];
+    keyBytes.get(bytes);
+    keyBytes.position(keyBytes.position() - bytes.length);
     try {
-      return CoderUtils.decodeFromByteArray(keyCoder, keyBytes.array());
+      return CoderUtils.decodeFromByteArray(keyCoder, bytes);
     } catch (CoderException e) {
       throw new RuntimeException("Error decoding key.", e);
     }
@@ -106,22 +109,22 @@ public class FlinkStateInternals<K> implements StateInternals {
         new StateTag.StateBinder() {
 
           @Override
-          public <T> ValueState<T> bindValue(
-              StateTag<ValueState<T>> address, Coder<T> coder) {
+          public <T2> ValueState<T2> bindValue(
+              StateTag<ValueState<T2>> address, Coder<T2> coder) {
 
             return new FlinkValueState<>(flinkStateBackend, address, namespace, coder);
           }
 
           @Override
-          public <T> BagState<T> bindBag(
-              StateTag<BagState<T>> address, Coder<T> elemCoder) {
+          public <T2> BagState<T2> bindBag(
+              StateTag<BagState<T2>> address, Coder<T2> elemCoder) {
 
             return new FlinkBagState<>(flinkStateBackend, address, namespace, elemCoder);
           }
 
           @Override
-          public <T> SetState<T> bindSet(
-              StateTag<SetState<T>> address, Coder<T> elemCoder) {
+          public <T2> SetState<T2> bindSet(
+              StateTag<SetState<T2>> address, Coder<T2> elemCoder) {
             return new FlinkSetState<>(
                 flinkStateBackend, address, namespace, elemCoder);
           }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DedupingOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DedupingOperatorTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThat;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.DedupingOperator;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.ValueWithRecordId;
@@ -52,14 +53,20 @@ public class DedupingOperatorTest {
     String key1 = "key1";
     String key2 = "key2";
 
-    harness.processElement(new StreamRecord<>(
-        WindowedValue.valueInGlobalWindow(new ValueWithRecordId<>(key1, key1.getBytes()))));
+    harness.processElement(
+        new StreamRecord<>(
+            WindowedValue.valueInGlobalWindow(
+                new ValueWithRecordId<>(key1, key1.getBytes(StandardCharsets.UTF_8)))));
 
-    harness.processElement(new StreamRecord<>(
-        WindowedValue.valueInGlobalWindow(new ValueWithRecordId<>(key2, key2.getBytes()))));
+    harness.processElement(
+        new StreamRecord<>(
+            WindowedValue.valueInGlobalWindow(
+                new ValueWithRecordId<>(key2, key2.getBytes(StandardCharsets.UTF_8)))));
 
-    harness.processElement(new StreamRecord<>(
-        WindowedValue.valueInGlobalWindow(new ValueWithRecordId<>(key1, key1.getBytes()))));
+    harness.processElement(
+        new StreamRecord<>(
+            WindowedValue.valueInGlobalWindow(
+                new ValueWithRecordId<>(key1, key1.getBytes(StandardCharsets.UTF_8)))));
 
     assertThat(
         stripStreamRecordFromWindowedValue(harness.getOutput()),
@@ -77,11 +84,15 @@ public class DedupingOperatorTest {
 
     String key3 = "key3";
 
-    harness.processElement(new StreamRecord<>(
-        WindowedValue.valueInGlobalWindow(new ValueWithRecordId<>(key2, key2.getBytes()))));
+    harness.processElement(
+        new StreamRecord<>(
+            WindowedValue.valueInGlobalWindow(
+                new ValueWithRecordId<>(key2, key2.getBytes(StandardCharsets.UTF_8)))));
 
-    harness.processElement(new StreamRecord<>(
-        WindowedValue.valueInGlobalWindow(new ValueWithRecordId<>(key3, key3.getBytes()))));
+    harness.processElement(
+        new StreamRecord<>(
+            WindowedValue.valueInGlobalWindow(
+                new ValueWithRecordId<>(key3, key3.getBytes(StandardCharsets.UTF_8)))));
 
     assertThat(
         stripStreamRecordFromWindowedValue(harness.getOutput()),

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByNullKeyTest.java
@@ -82,6 +82,8 @@ public class GroupByNullKeyTest extends StreamingProgramTestBase implements Seri
     }
   }
 
+  // suppress since toString() of Void is called and key is deliberately null
+  @SuppressWarnings("ObjectToString")
   @Override
   protected void testProgram() throws Exception {
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/TestCountingSource.java
@@ -114,7 +114,7 @@ public class TestCountingSource
     return splits;
   }
 
-  class CounterMark implements UnboundedSource.CheckpointMark {
+  static class CounterMark implements UnboundedSource.CheckpointMark {
     int current;
 
     public CounterMark(int current) {
@@ -239,7 +239,8 @@ public class TestCountingSource
     return KvCoder.of(VarIntCoder.of(), VarIntCoder.of());
   }
 
-  private class FromCounterMark implements DelegateCoder.CodingFunction<CounterMark, Integer> {
+  private static class FromCounterMark
+      implements DelegateCoder.CodingFunction<CounterMark, Integer> {
     @Override
     public Integer apply(CounterMark input) {
       return input.current;
@@ -256,7 +257,7 @@ public class TestCountingSource
     }
   }
 
-  private class ToCounterMark implements DelegateCoder.CodingFunction<Integer, CounterMark> {
+  private static class ToCounterMark implements DelegateCoder.CodingFunction<Integer, CounterMark> {
     @Override
     public CounterMark apply(Integer input) {
       return new CounterMark(input);


### PR DESCRIPTION
Enforce ErrorProne analysis in Flink runner and addresses the issues raised.

Please note the suppression of the ScheduledFuture check. I couldn't see anything meaningful that could be done there.

CC @swegner @iemejia 