### PR TITLE
[BEAM-3905] Update Flink Runner to Flink 1.5.0

### DIFF
--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -45,7 +45,7 @@ configurations {
   validatesRunner
 }
 
-def flink_version = "1.4.0"
+def flink_version = "1.5.0"
 
 dependencies {
   compile library.java.guava

--- a/runners/flink/pom.xml
+++ b/runners/flink/pom.xml
@@ -31,7 +31,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <flink.version>1.4.0</flink.version>
+    <flink.version>1.5.0</flink.version>
   </properties>
 
   <profiles>

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -415,6 +415,7 @@ class FlinkStreamingTransformTranslators {
           Map<TupleTag<?>, Integer> tagsToIds,
           Coder<WindowedValue<InputT>> inputCoder,
           Coder keyCoder,
+          KeySelector<WindowedValue<InputT>, ?> keySelector,
           Map<Integer, PCollectionView<?>> transformedSideInputs);
     }
 
@@ -464,6 +465,7 @@ class FlinkStreamingTransformTranslators {
       DataStream<WindowedValue<InputT>> inputDataStream = context.getInputDataStream(input);
 
       Coder keyCoder = null;
+      KeySelector keySelector = null;
       boolean stateful = false;
       DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
       if (signature.stateDeclarations().size() > 0
@@ -471,7 +473,8 @@ class FlinkStreamingTransformTranslators {
         // Based on the fact that the signature is stateful, DoFnSignatures ensures
         // that it is also keyed
         keyCoder = ((KvCoder) input.getCoder()).getKeyCoder();
-        inputDataStream = inputDataStream.keyBy(new KvToByteBufferKeySelector(keyCoder));
+        keySelector = new KvToByteBufferKeySelector(keyCoder);
+        inputDataStream = inputDataStream.keyBy(keySelector);
         stateful = true;
       } else if (doFn instanceof SplittableParDoViaKeyedWorkItems.ProcessFn) {
         // we know that it is keyed on String
@@ -498,6 +501,7 @@ class FlinkStreamingTransformTranslators {
                 tagsToIds,
                 inputCoder,
                 keyCoder,
+                keySelector,
                 new HashMap<>() /* side-input mapping */);
 
         outputStream = inputDataStream
@@ -521,6 +525,7 @@ class FlinkStreamingTransformTranslators {
                 tagsToIds,
                 inputCoder,
                 keyCoder,
+                keySelector,
                 transformedSideInputs.f0);
 
         if (stateful) {
@@ -627,6 +632,7 @@ class FlinkStreamingTransformTranslators {
               tagsToIds,
               inputCoder,
               keyCoder,
+              keySelector,
               transformedSideInputs) ->
               new DoFnOperator<>(
                   doFn1,
@@ -640,7 +646,8 @@ class FlinkStreamingTransformTranslators {
                   transformedSideInputs,
                   sideInputs1,
                   context1.getPipelineOptions(),
-                  keyCoder));
+                  keyCoder,
+                  keySelector));
     }
   }
 
@@ -676,6 +683,7 @@ class FlinkStreamingTransformTranslators {
               tagsToIds,
               inputCoder,
               keyCoder,
+              keySelector,
               transformedSideInputs) ->
               new SplittableDoFnOperator<>(
                   doFn,
@@ -689,7 +697,8 @@ class FlinkStreamingTransformTranslators {
                   transformedSideInputs,
                   sideInputs,
                   context1.getPipelineOptions(),
-                  keyCoder));
+                  keyCoder,
+                  keySelector));
     }
   }
 
@@ -803,6 +812,9 @@ class FlinkStreamingTransformTranslators {
               .returns(workItemTypeInfo)
               .name("ToKeyedWorkItem");
 
+      WorkItemKeySelector keySelector = new WorkItemKeySelector<>(
+          inputKvCoder.getKeyCoder());
+
       KeyedStream<WindowedValue<SingletonKeyedWorkItem<K, InputT>>, ByteBuffer>
           keyedWorkItemStream =
               workItemStream.keyBy(new WorkItemKeySelector<>(inputKvCoder.getKeyCoder()));
@@ -830,7 +842,8 @@ class FlinkStreamingTransformTranslators {
               new HashMap<>(), /* side-input mapping */
               Collections.emptyList(), /* side inputs */
               context.getPipelineOptions(),
-              inputKvCoder.getKeyCoder());
+              inputKvCoder.getKeyCoder(),
+              keySelector);
 
       // our operator excepts WindowedValue<KeyedWorkItem> while our input stream
       // is WindowedValue<SingletonKeyedWorkItem>, which is fine but Java doesn't like it ...
@@ -883,9 +896,11 @@ class FlinkStreamingTransformTranslators {
               .returns(workItemTypeInfo)
               .name("ToKeyedWorkItem");
 
+      WorkItemKeySelector keySelector = new WorkItemKeySelector<>(
+          inputKvCoder.getKeyCoder());
       KeyedStream<WindowedValue<SingletonKeyedWorkItem<K, InputT>>, ByteBuffer>
           keyedWorkItemStream =
-              workItemStream.keyBy(new WorkItemKeySelector<>(inputKvCoder.getKeyCoder()));
+              workItemStream.keyBy(keySelector);
 
       GlobalCombineFn<? super InputT, ?, OutputT> combineFn;
       try {
@@ -918,7 +933,8 @@ class FlinkStreamingTransformTranslators {
               new HashMap<>(), /* side-input mapping */
               Collections.emptyList(), /* side inputs */
               context.getPipelineOptions(),
-              inputKvCoder.getKeyCoder());
+              inputKvCoder.getKeyCoder(),
+              keySelector);
 
       // our operator excepts WindowedValue<KeyedWorkItem> while our input stream
       // is WindowedValue<SingletonKeyedWorkItem>, which is fine but Java doesn't like it ...

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -20,11 +20,8 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,9 +29,12 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.core.DoFnRunners;
@@ -63,7 +63,6 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkB
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkKeyGroupStateInternals;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkSplitStateInternals;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.state.KeyGroupCheckpointedOperator;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
@@ -81,19 +80,17 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
-import org.apache.flink.runtime.state.KeyGroupsList;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
-import org.apache.flink.streaming.api.operators.HeapInternalTimerService;
 import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.Triggerable;
@@ -114,7 +111,7 @@ public class DoFnOperator<InputT, OutputT>
     extends AbstractStreamOperator<WindowedValue<OutputT>>
     implements OneInputStreamOperator<WindowedValue<InputT>, WindowedValue<OutputT>>,
       TwoInputStreamOperator<WindowedValue<InputT>, RawUnionValue, WindowedValue<OutputT>>,
-    KeyGroupCheckpointedOperator, Triggerable<Object, TimerData> {
+      Triggerable<Object, TimerData> {
 
   protected DoFn<InputT, OutputT> doFn;
 
@@ -147,8 +144,6 @@ public class DoFnOperator<InputT, OutputT>
 
   protected transient long currentOutputWatermark;
 
-  private transient StateTag<BagState<WindowedValue<InputT>>> pushedBackTag;
-
   protected transient FlinkStateInternals<?> keyedStateInternals;
 
   private final String stepName;
@@ -157,19 +152,23 @@ public class DoFnOperator<InputT, OutputT>
 
   private final Coder<?> keyCoder;
 
+  private final KeySelector<WindowedValue<InputT>, ?> keySelector;
+
   private final TimerInternals.TimerDataCoder timerCoder;
 
   private final long maxBundleSize;
 
   private final long maxBundleTimeMills;
 
-  protected transient HeapInternalTimerService<?, TimerInternals.TimerData> timerService;
+  protected transient InternalTimerService<TimerData> timerService;
 
   protected transient FlinkTimerInternals timerInternals;
 
   private transient StateInternals nonKeyedStateInternals;
 
-  private transient Optional<Long> pushedBackWatermark;
+  private transient long pushedBackWatermark;
+
+  private transient PushedBackElementsHandler<WindowedValue<InputT>> pushedBackElementsHandler;
 
   // bundle control
   private transient boolean bundleStarted = false;
@@ -188,7 +187,8 @@ public class DoFnOperator<InputT, OutputT>
       Map<Integer, PCollectionView<?>> sideInputTagMapping,
       Collection<PCollectionView<?>> sideInputs,
       PipelineOptions options,
-      Coder<?> keyCoder) {
+      Coder<?> keyCoder,
+      KeySelector<WindowedValue<InputT>, ?> keySelector) {
     this.doFn = doFn;
     this.stepName = stepName;
     this.inputCoder = inputCoder;
@@ -203,6 +203,7 @@ public class DoFnOperator<InputT, OutputT>
     setChainingStrategy(ChainingStrategy.ALWAYS);
 
     this.keyCoder = keyCoder;
+    this.keySelector = keySelector;
 
     this.timerCoder =
         TimerInternals.TimerDataCoder.of(windowingStrategy.getWindowFn().windowCoder());
@@ -266,9 +267,25 @@ public class DoFnOperator<InputT, OutputT>
     super.setup(containingTask, config, output);
   }
 
+
   @Override
-  public void open() throws Exception {
-    super.open();
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    ListStateDescriptor<WindowedValue<InputT>> pushedBackStateDescriptor =
+        new ListStateDescriptor<>(
+            "pushed-back-elements", new CoderTypeSerializer<>(inputCoder));
+
+    if (keySelector != null) {
+      pushedBackElementsHandler = KeyedPushedBackElementsHandler.create(
+          keySelector,
+          getKeyedStateBackend(),
+          pushedBackStateDescriptor);
+    } else {
+      ListState<WindowedValue<InputT>> listState = getOperatorStateBackend()
+          .getListState(pushedBackStateDescriptor);
+      pushedBackElementsHandler = NonKeyedPushedBackElementsHandler.create(listState);
+    }
 
     setCurrentInputWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
     setCurrentSideInputWatermark(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis());
@@ -291,8 +308,6 @@ public class DoFnOperator<InputT, OutputT>
 
     if (!sideInputs.isEmpty()) {
 
-      pushedBackTag = StateTags.bag("pushed-back-values", inputCoder);
-
       FlinkBroadcastStateInternals sideInputStateInternals =
           new FlinkBroadcastStateInternals<>(
               getContainingTask().getIndexInSubtaskGroup(), getOperatorStateBackend());
@@ -300,7 +315,13 @@ public class DoFnOperator<InputT, OutputT>
       sideInputHandler = new SideInputHandler(sideInputs, sideInputStateInternals);
       sideInputReader = sideInputHandler;
 
-      pushedBackWatermark = Optional.absent();
+      Stream<WindowedValue<InputT>> pushedBack = pushedBackElementsHandler.getElements();
+      long min = pushedBack
+          .map(v -> v.getTimestamp().getMillis())
+          .reduce(Long.MAX_VALUE, Math::min);
+      setPushedBackWatermark(min);
+    } else {
+      setPushedBackWatermark(Long.MAX_VALUE);
     }
 
     outputManager = outputManagerFactory.create(output, nonKeyedStateInternals);
@@ -311,8 +332,8 @@ public class DoFnOperator<InputT, OutputT>
           keyCoder);
 
       if (timerService == null) {
-        timerService = (HeapInternalTimerService<?, TimerInternals.TimerData>)
-            getInternalTimerService("beam-timer", new CoderTypeSerializer<>(timerCoder), this);
+        timerService = getInternalTimerService(
+            "beam-timer", new CoderTypeSerializer<>(timerCoder), this);
       }
 
       timerInternals = new FlinkTimerInternals();
@@ -396,8 +417,13 @@ public class DoFnOperator<InputT, OutputT>
       // in processWatermark*() but have holds, so we have to re-evaluate here.
       processWatermark(new Watermark(Long.MAX_VALUE));
       if (currentOutputWatermark < Long.MAX_VALUE) {
-        throw new RuntimeException("There are still watermark holds. Watermark held at "
-            + keyedStateInternals.watermarkHold().getMillis() + ".");
+        if (keyedStateInternals == null) {
+          throw new RuntimeException("Current watermark is still " + currentOutputWatermark + ".");
+
+        } else {
+          throw new RuntimeException("There are still watermark holds. Watermark held at "
+              + keyedStateInternals.watermarkHold().getMillis() + ".");
+        }
       }
     } finally {
       super.close();
@@ -405,12 +431,13 @@ public class DoFnOperator<InputT, OutputT>
 
     // sanity check: these should have been flushed out by +Inf watermarks
     if (!sideInputs.isEmpty() && nonKeyedStateInternals != null) {
-      BagState<WindowedValue<InputT>> pushedBack =
-          nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
 
-      Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
-      if (!Iterables.isEmpty(pushedBackContents)) {
-        String pushedBackString = Joiner.on(",").join(pushedBackContents);
+      List<WindowedValue<InputT>> pushedBackElements = pushedBackElementsHandler
+          .getElements()
+          .collect(Collectors.toList());
+
+      if (pushedBackElements.size() > 0) {
+        String pushedBackString = Joiner.on(",").join(pushedBackElements);
         throw new RuntimeException(
             "Leftover pushed-back data: " + pushedBackString + ". This indicates a bug.");
       }
@@ -418,33 +445,7 @@ public class DoFnOperator<InputT, OutputT>
   }
 
   private long getPushbackWatermarkHold() {
-    // if we don't have side inputs we never hold the watermark
-    if (sideInputs.isEmpty()) {
-      return Long.MAX_VALUE;
-    }
-
-    try {
-      checkInitPushedBackWatermark();
-      return pushedBackWatermark.get();
-    } catch (Exception e) {
-      throw new RuntimeException("Error retrieving pushed back watermark state.", e);
-    }
-  }
-
-  private void checkInitPushedBackWatermark() {
-    // init and restore from pushedBack state.
-    // Not done in initializeState, because OperatorState is not ready.
-    if (!pushedBackWatermark.isPresent()) {
-
-      BagState<WindowedValue<InputT>> pushedBack =
-          nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
-
-      long min = Long.MAX_VALUE;
-      for (WindowedValue<InputT> value : pushedBack.read()) {
-        min = Math.min(min, value.getTimestamp().getMillis());
-      }
-      setPushedBackWatermark(min);
-    }
+    return pushedBackWatermark;
   }
 
   @Override
@@ -456,7 +457,7 @@ public class DoFnOperator<InputT, OutputT>
   }
 
   private void setPushedBackWatermark(long watermark) {
-    pushedBackWatermark = Optional.fromNullable(watermark);
+    pushedBackWatermark = watermark;
   }
 
   @Override
@@ -466,17 +467,13 @@ public class DoFnOperator<InputT, OutputT>
     Iterable<WindowedValue<InputT>> justPushedBack =
         pushbackDoFnRunner.processElementInReadyWindows(streamRecord.getValue());
 
-    BagState<WindowedValue<InputT>> pushedBack =
-        nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
-
-    checkInitPushedBackWatermark();
-
-    long min = pushedBackWatermark.get();
+    long min = pushedBackWatermark;
     for (WindowedValue<InputT> pushedBackValue : justPushedBack) {
       min = Math.min(min, pushedBackValue.getTimestamp().getMillis());
-      pushedBack.add(pushedBackValue);
+      pushedBackElementsHandler.pushBack(pushedBackValue);
     }
     setPushedBackWatermark(min);
+
     checkInvokeFinishBundleByCount();
   }
 
@@ -497,28 +494,26 @@ public class DoFnOperator<InputT, OutputT>
     PCollectionView<?> sideInput = sideInputTagMapping.get(streamRecord.getValue().getUnionTag());
     sideInputHandler.addSideInputValue(sideInput, value);
 
-    BagState<WindowedValue<InputT>> pushedBack =
-        nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
-
     List<WindowedValue<InputT>> newPushedBack = new ArrayList<>();
 
-    Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
-    for (WindowedValue<InputT> elem : pushedBackContents) {
+    Iterator<WindowedValue<InputT>> it = pushedBackElementsHandler.getElements().iterator();
 
+    while (it.hasNext()) {
+      WindowedValue<InputT> element = it.next();
       // we need to set the correct key in case the operator is
       // a (keyed) window operator
-      setKeyContextElement1(new StreamRecord<>(elem));
+      setKeyContextElement1(new StreamRecord<>(element));
 
       Iterable<WindowedValue<InputT>> justPushedBack =
-          pushbackDoFnRunner.processElementInReadyWindows(elem);
+          pushbackDoFnRunner.processElementInReadyWindows(element);
       Iterables.addAll(newPushedBack, justPushedBack);
     }
 
-    pushedBack.clear();
+    pushedBackElementsHandler.clear();
     long min = Long.MAX_VALUE;
     for (WindowedValue<InputT> pushedBackValue : newPushedBack) {
       min = Math.min(min, pushedBackValue.getTimestamp().getMillis());
-      pushedBack.add(pushedBackValue);
+      pushedBackElementsHandler.pushBack(pushedBackValue);
     }
     setPushedBackWatermark(min);
 
@@ -561,7 +556,8 @@ public class DoFnOperator<InputT, OutputT>
       // hold back by the pushed back values waiting for side inputs
       long pushedBackInputWatermark = Math.min(getPushbackWatermarkHold(), mark.getTimestamp());
 
-      timerService.advanceWatermark(toFlinkRuntimeWatermark(pushedBackInputWatermark));
+      timeServiceManager.advanceWatermark(
+          new Watermark(toFlinkRuntimeWatermark(pushedBackInputWatermark)));
 
       Instant watermarkHold = keyedStateInternals.watermarkHold();
 
@@ -616,20 +612,18 @@ public class DoFnOperator<InputT, OutputT>
    */
   private void emitAllPushedBackData() throws Exception {
 
-    BagState<WindowedValue<InputT>> pushedBack =
-        nonKeyedStateInternals.state(StateNamespaces.global(), pushedBackTag);
+    Iterator<WindowedValue<InputT>> it = pushedBackElementsHandler.getElements().iterator();
 
-    Iterable<WindowedValue<InputT>> pushedBackContents = pushedBack.read();
-    for (WindowedValue<InputT> elem : pushedBackContents) {
-
+    while (it.hasNext()) {
+      WindowedValue<InputT> element = it.next();
       // we need to set the correct key in case the operator is
       // a (keyed) window operator
-      setKeyContextElement1(new StreamRecord<>(elem));
+      setKeyContextElement1(new StreamRecord<>(element));
 
-      doFnRunner.processElement(elem);
+      doFnRunner.processElement(element);
     }
 
-    pushedBack.clear();
+    pushedBackElementsHandler.clear();
 
     setPushedBackWatermark(Long.MAX_VALUE);
 
@@ -692,102 +686,7 @@ public class DoFnOperator<InputT, OutputT>
     invokeFinishBundle();
     outputManager.closeBuffer();
 
-    // copy from AbstractStreamOperator
-    if (getKeyedStateBackend() != null) {
-      KeyedStateCheckpointOutputStream out;
-
-      try {
-        out = context.getRawKeyedOperatorStateOutput();
-      } catch (Exception exception) {
-        throw new Exception("Could not open raw keyed operator state stream for "
-            + getOperatorName() + '.', exception);
-      }
-
-      try {
-        KeyGroupsList allKeyGroups = out.getKeyGroupList();
-        for (int keyGroupIdx : allKeyGroups) {
-          out.startNewKeyGroup(keyGroupIdx);
-
-          DataOutputViewStreamWrapper dov = new DataOutputViewStreamWrapper(out);
-
-          // if (this instanceof KeyGroupCheckpointedOperator)
-          snapshotKeyGroupState(keyGroupIdx, dov);
-
-          // We can't get all timerServices, so we just snapshot our timerService
-          // Maybe this is a normal DoFn that has no timerService
-          if (keyCoder != null) {
-            timerService.snapshotTimersForKeyGroup(dov, keyGroupIdx);
-          }
-
-        }
-      } catch (Exception exception) {
-        throw new Exception("Could not write timer service of " + getOperatorName()
-            + " to checkpoint state stream.", exception);
-      } finally {
-        try {
-          out.close();
-        } catch (Exception closeException) {
-          LOG.warn("Could not close raw keyed operator state stream for {}. This "
-              + "might have prevented deleting some state data.", getOperatorName(),
-              closeException);
-        }
-      }
-    }
-  }
-
-  @Override
-  public void snapshotKeyGroupState(int keyGroupIndex, DataOutputStream out) throws Exception {
-    if (keyCoder != null) {
-      ((FlinkKeyGroupStateInternals) nonKeyedStateInternals).snapshotKeyGroupState(
-          keyGroupIndex, out);
-    }
-  }
-
-  @Override
-  public void initializeState(StateInitializationContext context) throws Exception {
-    if (getKeyedStateBackend() != null) {
-      int totalKeyGroups = getKeyedStateBackend().getNumberOfKeyGroups();
-      KeyGroupsList localKeyGroupRange = getKeyedStateBackend().getKeyGroupRange();
-
-      for (KeyGroupStatePartitionStreamProvider streamProvider : context.getRawKeyedStateInputs()) {
-        DataInputViewStreamWrapper div = new DataInputViewStreamWrapper(streamProvider.getStream());
-
-        int keyGroupIdx = streamProvider.getKeyGroupId();
-        checkArgument(localKeyGroupRange.contains(keyGroupIdx),
-            "Key Group " + keyGroupIdx + " does not belong to the local range.");
-
-        // if (this instanceof KeyGroupRestoringOperator)
-        restoreKeyGroupState(keyGroupIdx, div);
-
-        // We just initialize our timerService
-        if (keyCoder != null) {
-          if (timerService == null) {
-            final HeapInternalTimerService<Object, TimerData> localService =
-                new HeapInternalTimerService<>(
-                    totalKeyGroups,
-                    localKeyGroupRange,
-                    this,
-                    getRuntimeContext().getProcessingTimeService());
-            localService.startTimerService(getKeyedStateBackend().getKeySerializer(),
-                new CoderTypeSerializer<>(timerCoder), this);
-            timerService = localService;
-          }
-          timerService.restoreTimersForKeyGroup(div, keyGroupIdx, getUserCodeClassloader());
-        }
-      }
-    }
-  }
-
-  @Override
-  public void restoreKeyGroupState(int keyGroupIndex, DataInputStream in) throws Exception {
-    if (keyCoder != null) {
-      if (nonKeyedStateInternals == null) {
-        nonKeyedStateInternals = new FlinkKeyGroupStateInternals<>(keyCoder,
-            getKeyedStateBackend());
-      }
-      ((FlinkKeyGroupStateInternals) nonKeyedStateInternals)
-          .restoreKeyGroupState(keyGroupIndex, in, getUserCodeClassloader());
-    }
+    super.snapshotState(context);
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -93,7 +93,7 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
     super(new NoOpDoFn(),
             stepName, inputCoder, mainOutputTag, additionalOutputTags,
             outputManagerFactory, WindowingStrategy.globalDefault() /* unused */,
-            sideInputTagMapping, sideInputs, options, null /*keyCoder*/);
+            sideInputTagMapping, sideInputs, options, null /*keyCoder*/, null /* key selector */);
       this.payload = payload;
       this.jobInfo = jobInfo;
       this.contextFactory = contextFactory;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+
+/**
+ * {@link PushedBackElementsHandler} that stores elements in Flink keyed state, for use when an
+ * operation is keyed and pushed-back data needs to stay in the correct partition when they get
+ * moved.
+ */
+class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<T> {
+
+  static <K, T> KeyedPushedBackElementsHandler<K, T> create(
+      KeySelector<T, K> keySelector,
+      KeyedStateBackend<K> backend,
+      ListStateDescriptor<T> stateDescriptor) {
+    return new KeyedPushedBackElementsHandler<>(keySelector, backend, stateDescriptor);
+  }
+
+  private final KeySelector<T, K> keySelector;
+  private final KeyedStateBackend<K> backend;
+  private final ListStateDescriptor<T> stateDescriptor;
+
+  private KeyedPushedBackElementsHandler(
+      KeySelector<T, K> keySelector,
+      KeyedStateBackend<K> backend,
+      ListStateDescriptor<T> stateDescriptor) {
+    this.keySelector = keySelector;
+    this.backend = backend;
+    this.stateDescriptor = stateDescriptor;
+  }
+
+  @Override
+  public Stream<T> getElements() {
+
+    return backend.getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+        .flatMap((key) -> {
+          try {
+            backend.setCurrentKey(key);
+
+            ListState<T> state = backend.getPartitionedState(
+                VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+            return StreamSupport.stream(state.get().spliterator(), false);
+          } catch (Exception e) {
+            throw new RuntimeException("Error reading keyed state.", e);
+          }
+
+        });
+  }
+
+  @Override
+  public void clear() throws Exception {
+    // TODO we have to collect all keys because otherwise we get ConcurrentModificationExceptions
+    // from flink. We can change this once it's fixed in Flink
+
+    List<K> keys = backend
+        .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
+        .collect(Collectors.toList());
+
+    for (K key : keys) {
+      backend.setCurrentKey(key);
+
+      ListState<T> state = backend.getPartitionedState(
+          VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+      state.clear();
+    }
+  }
+
+  @Override
+  public void pushBack(T element) throws Exception {
+    ListState<T> state = backend.getPartitionedState(
+        VoidNamespace.INSTANCE, VoidNamespaceSerializer.INSTANCE, stateDescriptor);
+
+    backend.setCurrentKey(keySelector.getKey(element));
+    state.add(element);
+  }
+
+  @Override
+  public void pushBackAll(Iterable<T> elements) throws Exception {
+    for (T e : elements) {
+      pushBack(e);
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/NonKeyedPushedBackElementsHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.flink.api.common.state.ListState;
+
+/**
+ * {@link PushedBackElementsHandler} that stores elements in a Flink operator state list.
+ */
+class NonKeyedPushedBackElementsHandler<T> implements PushedBackElementsHandler<T> {
+
+  static <T> NonKeyedPushedBackElementsHandler<T> create(ListState<T> elementState) {
+    return new NonKeyedPushedBackElementsHandler<>(elementState);
+  }
+
+  private final ListState<T> elementState;
+
+  private NonKeyedPushedBackElementsHandler(ListState<T> elementState) {
+    this.elementState = checkNotNull(elementState);
+  }
+
+  @Override
+  public Stream<T> getElements() throws Exception {
+    return StreamSupport.stream(elementState.get().spliterator(), false);
+  }
+
+  @Override
+  public void clear() {
+    elementState.clear();
+  }
+
+  @Override
+  public void pushBack(T element) throws Exception {
+    elementState.add(element);
+  }
+
+  @Override
+  public void pushBackAll(Iterable<T> elements) throws Exception {
+    for (T e : elements) {
+      // TODO: use addAll() once Flink has addAll(Iterable<T>)
+      elementState.add(e);
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PushedBackElementsHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming;
+
+import java.util.stream.Stream;
+
+/**
+ * Helper that keeps pushed-back data, most likely due to side inputs that are not available.
+ *
+ * <p>Implementations of this must use Flink state to make sure pushed-back data is fault tolerant.
+ *
+ * @param <T> The type of pushed back elements.
+ */
+interface PushedBackElementsHandler<T> {
+
+  /**
+   * Returns all pushed back elements.
+   */
+  Stream<T> getElements() throws Exception;
+
+  /**
+   * Clears the pushed back elements.
+   */
+  void clear() throws Exception;
+
+  /**
+   * Adds the given element to the pushed back elements.
+   */
+  void pushBack(T element) throws Exception;
+
+  /**
+   * Adds all the given element to the pushed back elements.
+   */
+  void pushBackAll(Iterable<T> elements) throws Exception;
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -48,6 +48,8 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -73,7 +75,8 @@ public class SplittableDoFnOperator<
       Map<Integer, PCollectionView<?>> sideInputTagMapping,
       Collection<PCollectionView<?>> sideInputs,
       PipelineOptions options,
-      Coder<?> keyCoder) {
+      Coder<?> keyCoder,
+      KeySelector<WindowedValue<KeyedWorkItem<String, KV<InputT, RestrictionT>>>, ?> keySelector) {
     super(
         doFn,
         stepName,
@@ -85,7 +88,8 @@ public class SplittableDoFnOperator<
         sideInputTagMapping,
         sideInputs,
         options,
-        keyCoder);
+        keyCoder,
+        keySelector);
   }
 
   @Override
@@ -98,8 +102,8 @@ public class SplittableDoFnOperator<
   }
 
   @Override
-  public void open() throws Exception {
-    super.open();
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
 
     checkState(doFn instanceof ProcessFn);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperator.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 
 /**
@@ -62,7 +63,8 @@ public class WindowDoFnOperator<K, InputT, OutputT>
       Map<Integer, PCollectionView<?>> sideInputTagMapping,
       Collection<PCollectionView<?>> sideInputs,
       PipelineOptions options,
-      Coder<K> keyCoder) {
+      Coder<K> keyCoder,
+      KeySelector<WindowedValue<KeyedWorkItem<K, InputT>>, ?> keySelector) {
     super(
         null,
         stepName,
@@ -74,7 +76,8 @@ public class WindowDoFnOperator<K, InputT, OutputT>
         sideInputTagMapping,
         sideInputs,
         options,
-        keyCoder);
+        keyCoder,
+        keySelector);
 
     this.systemReduceFn = systemReduceFn;
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/DedupingOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/DedupingOperator.java
@@ -17,34 +17,20 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.io;
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.nio.ByteBuffer;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.state.KeyGroupCheckpointedOperator;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
-import org.apache.beam.sdk.coders.Coder.Context;
-import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.ValueWithRecordId;
-import org.apache.flink.core.memory.DataInputViewStreamWrapper;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
-import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
-import org.apache.flink.runtime.state.KeyGroupsList;
-import org.apache.flink.runtime.state.KeyedStateBackend;
-import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.state.StateInitializationContext;
-import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.joda.time.Duration;
 
@@ -53,138 +39,59 @@ import org.joda.time.Duration;
  */
 public class DedupingOperator<T> extends AbstractStreamOperator<WindowedValue<T>>
     implements OneInputStreamOperator<WindowedValue<ValueWithRecordId<T>>, WindowedValue<T>>,
-    KeyGroupCheckpointedOperator {
+    Triggerable<ByteBuffer, VoidNamespace>{
 
   private static final long MAX_RETENTION_SINCE_ACCESS = Duration.standardMinutes(10L).getMillis();
-  private static final long MAX_CACHE_SIZE = 100_000L;
 
-  private transient LoadingCache<Integer, LoadingCache<ByteBuffer, AtomicBoolean>> dedupingCache;
-  private transient KeyedStateBackend<ByteBuffer> keyedStateBackend;
+  // we keep the time when we last saw an element id for cleanup
+  private ValueStateDescriptor<Long> dedupingStateDescriptor =
+      new ValueStateDescriptor<>("dedup-cache", LongSerializer.INSTANCE);
+
+  private transient InternalTimerService<VoidNamespace> timerService;
 
   @Override
-  public void open() throws Exception {
-    super.open();
-    checkInitCache();
-    keyedStateBackend = getKeyedStateBackend();
-  }
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
 
-  private void checkInitCache() {
-    if (dedupingCache == null) {
-      dedupingCache = CacheBuilder.newBuilder().build(new KeyGroupLoader());
-    }
-  }
+    timerService =
+        getInternalTimerService("dedup-cleanup-timer", VoidNamespaceSerializer.INSTANCE, this);
 
-  private static class KeyGroupLoader extends
-      CacheLoader<Integer, LoadingCache<ByteBuffer, AtomicBoolean>> {
-    @Override
-    public LoadingCache<ByteBuffer, AtomicBoolean> load(Integer ignore) throws Exception {
-      return CacheBuilder.newBuilder()
-          .expireAfterAccess(MAX_RETENTION_SINCE_ACCESS, TimeUnit.MILLISECONDS)
-          .maximumSize(MAX_CACHE_SIZE).build(new TrueBooleanLoader());
-    }
-  }
-
-  private static class TrueBooleanLoader extends CacheLoader<ByteBuffer, AtomicBoolean> {
-    @Override
-    public AtomicBoolean load(ByteBuffer ignore) throws Exception {
-      return new AtomicBoolean(true);
-    }
   }
 
   @Override
   public void processElement(
       StreamRecord<WindowedValue<ValueWithRecordId<T>>> streamRecord) throws Exception {
-    ByteBuffer currentKey = keyedStateBackend.getCurrentKey();
-    int groupIndex = keyedStateBackend.getCurrentKeyGroupIndex();
-    if (shouldOutput(groupIndex, currentKey)) {
+
+    ValueState<Long> dedupingState = getPartitionedState(dedupingStateDescriptor);
+
+    Long lastSeenTimestamp = dedupingState.value();
+
+    if (lastSeenTimestamp == null) {
+      // we have never seen this, emit
       WindowedValue<ValueWithRecordId<T>> value = streamRecord.getValue();
       output.collect(streamRecord.replace(value.withValue(value.getValue().getValue())));
     }
-  }
 
-  private boolean shouldOutput(int groupIndex, ByteBuffer id) throws ExecutionException {
-    return dedupingCache.get(groupIndex).getUnchecked(id).getAndSet(false);
-  }
-
-  @Override
-  public void restoreKeyGroupState(int keyGroupIndex, DataInputStream in) throws Exception {
-    checkInitCache();
-    Integer size = VarIntCoder.of().decode(in, Context.NESTED);
-    for (int i = 0; i < size; i++) {
-      byte[] idBytes = ByteArrayCoder.of().decode(in, Context.NESTED);
-      // restore the ids which not expired.
-      shouldOutput(keyGroupIndex, ByteBuffer.wrap(idBytes));
-    }
+    long currentProcessingTime = timerService.currentProcessingTime();
+    dedupingState.update(currentProcessingTime);
+    timerService.registerProcessingTimeTimer(
+        VoidNamespace.INSTANCE, currentProcessingTime + MAX_RETENTION_SINCE_ACCESS);
   }
 
   @Override
-  public void snapshotKeyGroupState(int keyGroupIndex, DataOutputStream out) throws Exception {
-    Set<ByteBuffer> ids = dedupingCache.get(keyGroupIndex).asMap().keySet();
-    VarIntCoder.of().encode(ids.size(), out, Context.NESTED);
-    for (ByteBuffer id : ids) {
-      byte[] bytes = new byte[id.remaining()];
-      id.get(bytes);
-      id.position(id.position() - bytes.length);
-      ByteArrayCoder.of().encode(bytes, out, Context.NESTED);
-    }
+  public void onEventTime(InternalTimer<ByteBuffer, VoidNamespace> internalTimer) {
+    // will never happen
   }
 
   @Override
-  public void snapshotState(StateSnapshotContext context) throws Exception {
-    // copy from AbstractStreamOperator
-    if (getKeyedStateBackend() != null) {
-      KeyedStateCheckpointOutputStream out;
+  public void onProcessingTime(InternalTimer<ByteBuffer, VoidNamespace> internalTimer)
+      throws Exception {
+    ValueState<Long> dedupingState = getPartitionedState(dedupingStateDescriptor);
 
-      try {
-        out = context.getRawKeyedOperatorStateOutput();
-      } catch (Exception exception) {
-        throw new Exception("Could not open raw keyed operator state stream for "
-            + getOperatorName() + '.', exception);
-      }
-
-      try {
-        KeyGroupsList allKeyGroups = out.getKeyGroupList();
-        for (int keyGroupIdx : allKeyGroups) {
-          out.startNewKeyGroup(keyGroupIdx);
-
-          DataOutputViewStreamWrapper dov = new DataOutputViewStreamWrapper(out);
-
-          // if (this instanceof KeyGroupCheckpointedOperator)
-          snapshotKeyGroupState(keyGroupIdx, dov);
-
-        }
-      } catch (Exception exception) {
-        throw new Exception("Could not write timer service of " + getOperatorName()
-            + " to checkpoint state stream.", exception);
-      } finally {
-        try {
-          out.close();
-        } catch (Exception closeException) {
-          LOG.warn("Could not close raw keyed operator state stream for {}. This "
-                  + "might have prevented deleting some state data.", getOperatorName(),
-              closeException);
-        }
-      }
+    Long lastSeenTimestamp = dedupingState.value();
+    if (lastSeenTimestamp != null
+        && lastSeenTimestamp.equals(internalTimer.getTimestamp() - MAX_RETENTION_SINCE_ACCESS)) {
+      dedupingState.clear();
     }
   }
-
-  @Override
-  public void initializeState(StateInitializationContext context) throws Exception {
-    if (getKeyedStateBackend() != null) {
-      KeyGroupsList localKeyGroupRange = getKeyedStateBackend().getKeyGroupRange();
-
-      for (KeyGroupStatePartitionStreamProvider streamProvider : context.getRawKeyedStateInputs()) {
-        DataInputViewStreamWrapper div = new DataInputViewStreamWrapper(streamProvider.getStream());
-
-        int keyGroupIdx = streamProvider.getKeyGroupId();
-        checkArgument(localKeyGroupRange.contains(keyGroupIdx),
-            "Key Group " + keyGroupIdx + " does not belong to the local range.");
-
-        // if (this instanceof KeyGroupRestoringOperator)
-        restoreKeyGroupState(keyGroupIdx, div);
-
-      }
-    }
-  }
-
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PipelineOptionsTest.java
@@ -73,7 +73,8 @@ public class PipelineOptionsTest {
         new HashMap<>(),
         Collections.emptyList(),
         null,
-        null);
+        null, /* key coder */
+        null /* key selector */);
   }
 
   /**
@@ -97,7 +98,8 @@ public class PipelineOptionsTest {
             new HashMap<>(),
             Collections.emptyList(),
             options,
-            null);
+            null, /* key coder */
+            null /* key selector */);
 
     final byte[] serialized = SerializationUtils.serialize(doFnOperator);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/BoundedSourceRestoreTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/BoundedSourceRestoreTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.ValueWithRecordId;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamSource;
@@ -41,7 +42,6 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.util.OutputTag;
 import org.junit.Test;
@@ -114,7 +114,7 @@ public class BoundedSourceRestoreTest {
     assertTrue("Did not successfully read first batch of elements.", readFirstBatchOfElements);
 
     // draw a snapshot
-    OperatorStateHandles snapshot = testHarness.snapshot(0, 0);
+    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
 
     // finalize checkpoint
     final ArrayList<Integer> finalizeList = new ArrayList<>();

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DedupingOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/DedupingOperatorTest.java
@@ -27,8 +27,8 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.DedupingO
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,7 +73,7 @@ public class DedupingOperatorTest {
         contains(WindowedValue.valueInGlobalWindow(key1),
             WindowedValue.valueInGlobalWindow(key2)));
 
-    OperatorStateHandles snapshot = harness.snapshot(0L, 0L);
+    OperatorSubtaskState snapshot = harness.snapshot(0L, 0L);
 
     harness.close();
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/UnboundedSourceWrapperTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.ValueWithRecordId;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamSource;
@@ -44,7 +45,6 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatus;
 import org.apache.flink.streaming.runtime.streamstatus.StreamStatusMaintainer;
-import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.OutputTag;
@@ -355,7 +355,7 @@ public class UnboundedSourceWrapperTest {
       assertTrue("Did not successfully read first batch of elements.", readFirstBatchOfElements);
 
       // draw a snapshot
-      OperatorStateHandles snapshot = testHarness.snapshot(0, 0);
+      OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
 
       // test that finalizeCheckpoint on CheckpointMark is called
       final ArrayList<Integer> finalizeList = new ArrayList<>();
@@ -477,7 +477,7 @@ public class UnboundedSourceWrapperTest {
 
       testHarness.open();
 
-      OperatorStateHandles snapshot = testHarness.snapshot(0, 0);
+      OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
 
       UnboundedSourceWrapper<
           KV<Integer, Integer>, TestCountingSource.CounterMark> restoredFlinkWrapper =

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/WindowDoFnOperatorTest.java
@@ -55,8 +55,8 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.runtime.tasks.OperatorStateHandles;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -88,7 +88,7 @@ public class WindowDoFnOperatorTest {
         Item.builder().key(2L).timestamp(3L).value(77L).window(window).build().toStreamRecord());
 
     // create snapshot
-    OperatorStateHandles snapshot = testHarness.snapshot(0, 0);
+    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
     testHarness.close();
 
     // restore from the snapshot
@@ -148,7 +148,9 @@ public class WindowDoFnOperatorTest {
         emptyMap(),
         emptyList(),
         PipelineOptionsFactory.as(FlinkPipelineOptions.class),
-        VarLongCoder.of()
+        VarLongCoder.of(),
+        null /* key selector */
+
     );
   }
 


### PR DESCRIPTION
While doing this, we also have to re-do how we store non-keyed state in
the DoFnOperator and fix usage of some interfaces that were removed.