### PR TITLE
[BEAM-4276] Add missing scope line

### DIFF
--- a/sdks/go/pkg/beam/combine.go
+++ b/sdks/go/pkg/beam/combine.go
@@ -50,6 +50,7 @@ func TryCombine(s Scope, combinefn interface{}, col PCollection) (PCollection, e
 // for multiple reasons, notably that the combinefn is not valid or cannot be bound
 // -- due to type mismatch, say -- to the incoming PCollection.
 func TryCombinePerKey(s Scope, combinefn interface{}, col PCollection) (PCollection, error) {
+	s = s.Scope(graph.CombinePerKeyScope)
 	ValidateKVType(col)
 	col, err := TryGroupByKey(s, col)
 	if err != nil {


### PR DESCRIPTION
Without this line, no transforms can get lifted. It was missed from the previous PR.