### PR TITLE
[BEAM-3981] Cleanup of coders futurization.

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# cython: language_level=3
+
 """Coder implementations.
 
 The actual encode/decode implementations are split off from coders to
@@ -310,13 +312,7 @@ class FastPrimitivesCoderImpl(StreamCoderImpl):
       dict_value = value  # for typing
       stream.write_byte(DICT_TYPE)
       stream.write_var_int64(len(dict_value))
-      # Use iteritems() on Python 2 instead of future.builtins.iteritems to
-      # avoid performance regression in Cython compiled code.
-      if sys.version_info[0] == 2:
-        items = dict_value.iteritems()  # pylint: disable=dict-iter-method
-      else:
-        items = dict_value.items()
-      for k, v in items:
+      for k, v in dict_value.items():
         self.encode_to_stream(k, stream, True)
         self.encode_to_stream(v, stream, True)
     elif t is bool:


### PR DESCRIPTION
Specifying language_level=3 allows the dict.items() optimization.

This is about a 40% speedup for 1-element dicts as well as cleaner code.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
