### PR TITLE
[BEAM-4523] Implement batch flink executable stage context

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/ArtifactSourcePool.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/ArtifactSourcePool.java
@@ -24,6 +24,7 @@ import org.apache.beam.model.jobmanagement.v1.ArtifactApi.ArtifactChunk;
 import org.apache.beam.model.jobmanagement.v1.ArtifactApi.Manifest;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
 
+// TODO: Pull in https://github.com/apache/beam/pull/5359 once we use Flink 1.6.
 /**
  * A pool of {@link ArtifactSource ArtifactSources} that can be used as a single source. At least
  * one source must be registered before artifacts can be requested from it.
@@ -38,6 +39,11 @@ import org.apache.beam.runners.fnexecution.artifact.ArtifactSource;
  */
 @ThreadSafe
 public class ArtifactSourcePool implements ArtifactSource {
+
+  /** Creates a new {@link ArtifactSourcePool}. */
+  public static ArtifactSourcePool create() {
+    return new ArtifactSourcePool();
+  }
 
   private ArtifactSourcePool() {}
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalNotification;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.flink.ArtifactSourcePool;
+import org.apache.beam.runners.fnexecution.control.DockerJobBundleFactory;
+import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
+import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Implementation of a {@link FlinkExecutableStageContext} for batch jobs. */
+class BatchFlinkExecutableStageContext implements FlinkExecutableStageContext {
+  private static final Logger LOG = LoggerFactory.getLogger(BatchFlinkExecutableStageContext.class);
+
+  private final JobBundleFactory jobBundleFactory;
+  private final ArtifactSourcePool artifactSourcePool;
+
+  private static BatchFlinkExecutableStageContext create(JobInfo jobInfo) throws Exception {
+    ArtifactSourcePool artifactSourcePool = ArtifactSourcePool.create();
+    JobBundleFactory jobBundleFactory = DockerJobBundleFactory.create(jobInfo, artifactSourcePool);
+    return new BatchFlinkExecutableStageContext(jobBundleFactory, artifactSourcePool);
+  }
+
+  private BatchFlinkExecutableStageContext(
+      JobBundleFactory jobBundleFactory, ArtifactSourcePool artifactSourcePool) {
+    this.jobBundleFactory = jobBundleFactory;
+    this.artifactSourcePool = artifactSourcePool;
+  }
+
+  @Override
+  public <InputT> StageBundleFactory getStageBundleFactory(ExecutableStage executableStage) {
+    return jobBundleFactory.<InputT>forStage(executableStage);
+  }
+
+  @Override
+  public StateRequestHandler getStateRequestHandler(
+      ExecutableStage executableStage, RuntimeContext runtimeContext) {
+    return FlinkBatchStateRequestHandler.forStage(executableStage, runtimeContext);
+  }
+
+  @Override
+  public ArtifactSourcePool getArtifactSourcePool() {
+    return artifactSourcePool;
+  }
+
+  private void cleanUp() throws Exception {
+    jobBundleFactory.close();
+  }
+
+  enum BatchFactory implements Factory {
+    INSTANCE;
+
+    private final LoadingCache<JobInfo, BatchFlinkExecutableStageContext> cachedContexts;
+
+    BatchFactory() {
+      cachedContexts =
+          CacheBuilder.newBuilder()
+              .weakValues()
+              .removalListener(
+                  (RemovalNotification<JobInfo, BatchFlinkExecutableStageContext> removal) -> {
+                    try {
+                      removal.getValue().cleanUp();
+                    } catch (Exception e) {
+                      LOG.warn(
+                          "Error cleaning up bundle factory for job " + removal.getKey().jobId(),
+                          e);
+                    }
+                  })
+              .build(
+                  new CacheLoader<JobInfo, BatchFlinkExecutableStageContext>() {
+                    @Override
+                    public BatchFlinkExecutableStageContext load(JobInfo jobInfo) throws Exception {
+                      return create(jobInfo);
+                    }
+                  });
+    }
+
+    @Override
+    public FlinkExecutableStageContext get(JobInfo jobInfo) {
+      return cachedContexts.getUnchecked(jobInfo);
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchStateRequestHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchStateRequestHandler.java
@@ -17,33 +17,26 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
-import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse.Builder;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
-import org.apache.beam.runners.flink.ArtifactSourcePool;
-import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
-import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.flink.api.common.functions.RuntimeContext;
 
-/** The Flink context required in order to execute {@link ExecutableStage stages}. */
-public interface FlinkExecutableStageContext {
+// TODO: https://issues.apache.org/jira/browse/BEAM-4285 Implement batch state handler.
+/** State request handler for flink batch runner. */
+public class FlinkBatchStateRequestHandler implements StateRequestHandler {
 
-  /**
-   * Creates {@link FlinkExecutableStageContext} instances. Serializable so that factories can be
-   * defined at translation time and distributed to TaskManagers.
-   */
-  interface Factory extends Serializable {
-    FlinkExecutableStageContext get(JobInfo jobInfo);
+  private FlinkBatchStateRequestHandler() {}
+
+  public static FlinkBatchStateRequestHandler forStage(
+      ExecutableStage stage, RuntimeContext runtimeContext) {
+    return new FlinkBatchStateRequestHandler();
   }
 
-  static Factory batchFactory() {
-    return BatchFlinkExecutableStageContext.BatchFactory.INSTANCE;
+  @Override
+  public CompletionStage<Builder> handle(StateRequest request) throws Exception {
+    throw new UnsupportedOperationException();
   }
-
-  <InputT> StageBundleFactory<InputT> getStageBundleFactory(ExecutableStage executableStage);
-
-  StateRequestHandler getStateRequestHandler(
-      ExecutableStage executableStage, RuntimeContext runtimeContext);
-
-  ArtifactSourcePool getArtifactSourcePool();
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -39,7 +39,6 @@ import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
 
-// TODO: https://issues.apache.org/jira/browse/BEAM-2597 Implement this executable stage operator.
 /**
  * Flink operator that passes its input DataSet through an SDK-executed {@link
  * org.apache.beam.runners.core.construction.graph.ExecutableStage}.
@@ -65,7 +64,7 @@ public class FlinkExecutableStageFunction<InputT>
   // Worker-local fields. These should only be constructed and consumed on Flink TaskManagers.
   private transient RuntimeContext runtimeContext;
   private transient StateRequestHandler stateRequestHandler;
-  private transient StageBundleFactory stageBundleFactory;
+  private transient StageBundleFactory<InputT> stageBundleFactory;
   private transient AutoCloseable distributedCacheCloser;
 
   public FlinkExecutableStageFunction(
@@ -85,10 +84,6 @@ public class FlinkExecutableStageFunction<InputT>
     runtimeContext = getRuntimeContext();
     // TODO: Wire this into the distributed cache and make it pluggable.
     ArtifactSource artifactSource = null;
-    // TODO: Do we really want this layer of indirection when accessing the stage bundle factory?
-    // It's a little strange because this operator is responsible for the lifetime of the stage
-    // bundle "factory" (manager?) but not the job or Flink bundle factories. How do we make
-    // ownership of the higher level "factories" explicit? Do we care?
     FlinkExecutableStageContext stageContext = contextFactory.get(jobInfo);
     ArtifactSourcePool cachePool = stageContext.getArtifactSourcePool();
     distributedCacheCloser = cachePool.addToPool(artifactSource);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/ExecutableStageDoFnOperatorTest.java
@@ -240,7 +240,7 @@ public class ExecutableStageDoFnOperatorTest {
           public void close() {}
         };
     // Wire the stage bundle factory into our context.
-    when(stageContext.getStageBundleFactory(any())).thenReturn(stageBundleFactory);
+    when(stageContext.<Void>getStageBundleFactory(any())).thenReturn(stageBundleFactory);
 
     ExecutableStageDoFnOperator<Integer, Integer> operator = getOperator(mainOutput,
             ImmutableList.of(additionalOutput1, additionalOutput2),

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunctionTest.java
@@ -65,7 +65,7 @@ public class FlinkExecutableStageFunctionTest {
   @Mock private DistributedCache distributedCache;
   @Mock private Collector<RawUnionValue> collector;
   @Mock private FlinkExecutableStageContext stageContext;
-  @Mock private StageBundleFactory stageBundleFactory;
+  @Mock private StageBundleFactory<Integer> stageBundleFactory;
   @Mock private ArtifactSourcePool artifactSourcePool;
   @Mock private StateRequestHandler stateRequestHandler;
 
@@ -87,7 +87,7 @@ public class FlinkExecutableStageFunctionTest {
     when(runtimeContext.getDistributedCache()).thenReturn(distributedCache);
     when(stageContext.getArtifactSourcePool()).thenReturn(artifactSourcePool);
     when(stageContext.getStateRequestHandler(any(), any())).thenReturn(stateRequestHandler);
-    when(stageContext.getStageBundleFactory(any())).thenReturn(stageBundleFactory);
+    when(stageContext.<Integer>getStageBundleFactory(any())).thenReturn(stageBundleFactory);
   }
 
   @Test
@@ -155,20 +155,22 @@ public class FlinkExecutableStageFunctionTest {
             "three", 3);
 
     // We use a real StageBundleFactory here in order to exercise the output receiver factory.
-    StageBundleFactory<Void> stageBundleFactory =
-        new StageBundleFactory<Void>() {
+    StageBundleFactory<Integer> stageBundleFactory =
+        new StageBundleFactory<Integer>() {
           @Override
-          public RemoteBundle<Void> getBundle(
+          public RemoteBundle<Integer> getBundle(
               OutputReceiverFactory receiverFactory, StateRequestHandler stateRequestHandler) {
-            return new RemoteBundle<Void>() {
+            return new RemoteBundle<Integer>() {
               @Override
               public String getId() {
                 return "bundle-id";
               }
 
               @Override
-              public FnDataReceiver<WindowedValue<Void>> getInputReceiver() {
-                return input -> {/* Ignore input*/};
+              public FnDataReceiver<WindowedValue<Integer>> getInputReceiver() {
+                return input -> {
+                  /* Ignore input*/
+                };
               }
 
               @Override
@@ -185,7 +187,7 @@ public class FlinkExecutableStageFunctionTest {
           public void close() throws Exception {}
         };
     // Wire the stage bundle factory into our context.
-    when(stageContext.getStageBundleFactory(any())).thenReturn(stageBundleFactory);
+    when(stageContext.<Integer>getStageBundleFactory(any())).thenReturn(stageBundleFactory);
 
     FlinkExecutableStageFunction<Integer> function = getFunction(outputTagMap);
     function.open(new Configuration());


### PR DESCRIPTION
This context wires artifact sources into a Docker job bundle factory and caches instances for callers. The caching is necessary for job bundle factory reuse for different operators in the same job.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
