### PR TITLE
[BEAM-4526] Suppress immutability warning caused by LoadingCache in enum instance

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
@@ -74,6 +74,7 @@ class BatchFlinkExecutableStageContext implements FlinkExecutableStageContext {
   enum BatchFactory implements Factory {
     INSTANCE;
 
+    @SuppressWarnings("Immutable") // observably immutable
     private final LoadingCache<JobInfo, BatchFlinkExecutableStageContext> cachedContexts;
 
     BatchFactory() {


### PR DESCRIPTION
This is currently breaking precommit on master. The two options are to suppress it or not use an `enum`. My impression is that the code in question is trying to be too clever about ensuring the singleton is really a singleton, which can be done in other ways.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
