### PR TITLE
Improve consistency of hadoop and hbase scripts, fix shellcheck issues

### DIFF
--- a/.test-infra/kubernetes/hadoop/LargeITCluster/setup.sh
+++ b/.test-infra/kubernetes/hadoop/LargeITCluster/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -14,7 +15,6 @@
 #    limitations under the License.
 #
 
-#!/bin/sh
 set -e
 
 kubectl create -f hdfs-multi-datanode-cluster.yml

--- a/.test-infra/kubernetes/hadoop/LargeITCluster/teardown-all.sh
+++ b/.test-infra/kubernetes/hadoop/LargeITCluster/teardown-all.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -15,19 +16,15 @@
 #
 # This script terminates hdfs cluster and hadoop service. It checks /etc/hosts file
 # for any unneeded entries and notifies user about them.
-#
 
-#!/bin/sh
 set -e
 
 external_ip="$(kubectl get svc hadoop -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-
 hadoop_master_pod_name="$(kubectl get pods --selector=name=namenode -o jsonpath='{.items[*].metadata.name}')"
 
 kubectl delete -f hdfs-multi-datanode-cluster.yml
-
 kubectl delete -f hdfs-multi-datanode-cluster-for-local-dev.yml
 
-if grep "$external_ip\|$hadoop_master_pod_name" /etc/hosts ; then
+if grep "$external_ip\\|$hadoop_master_pod_name" /etc/hosts ; then
     echo "Remove entries from /etc/hosts."
 fi

--- a/.test-infra/kubernetes/hadoop/LargeITCluster/teardown.sh
+++ b/.test-infra/kubernetes/hadoop/LargeITCluster/teardown.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -14,7 +15,6 @@
 #    limitations under the License.
 #
 
-#!/bin/sh
 set -e
 
 kubectl delete -f hdfs-multi-datanode-cluster.yml

--- a/.test-infra/kubernetes/hadoop/SmallITCluster/setup-all.sh
+++ b/.test-infra/kubernetes/hadoop/SmallITCluster/setup-all.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -17,13 +18,10 @@
 # from developer's machine. Once the cluster is working, scripts waits till
 # external cluster endpoint will be available. It prints out configuration line that
 # should be added to /etc/hosts file in order to work with hdfs cluster.
-#
 
-#!/bin/sh
 set -e
 
 kubectl create -f hdfs-single-datanode-cluster.yml
-
 kubectl create -f hdfs-single-datanode-cluster-for-local-dev.yml
 
 external_ip="$(kubectl get svc hadoop-external -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
@@ -39,4 +37,5 @@ done
 hadoop_master_pod_name="$(kubectl get pods --selector=name=hadoop -o jsonpath='{.items[*].metadata.name}')"
 
 echo "For local tests please add the following entry to /etc/hosts file"
-echo $external_ip$'\t'$hadoop_master_pod_name
+printf "%s\\t%s\\n" "${external_ip}" "${hadoop_master_pod_name}"
+

--- a/.test-infra/kubernetes/hadoop/SmallITCluster/setup.sh
+++ b/.test-infra/kubernetes/hadoop/SmallITCluster/setup.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -14,8 +15,7 @@
 #    limitations under the License.
 #
 # Simply starts hdfs cluster.
-#
-#!/bin/sh
+
 set -e
 
 kubectl create -f hdfs-single-datanode-cluster.yml

--- a/.test-infra/kubernetes/hadoop/SmallITCluster/teardown-all.sh
+++ b/.test-infra/kubernetes/hadoop/SmallITCluster/teardown-all.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -15,19 +16,15 @@
 #
 # This script terminates hdfs cluster and hadoop-external service. It checks /etc/hosts file
 # for any unneeded entries and notifies user about them.
-#
 
-#!/bin/sh
 set -e
 
 external_ip="$(kubectl get svc hadoop-external -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-
 hadoop_master_pod_name="$(kubectl get pods --selector=name=hadoop -o jsonpath='{.items[*].metadata.name}')"
 
 kubectl delete -f hdfs-single-datanode-cluster.yml
-
 kubectl delete -f hdfs-single-datanode-cluster-for-local-dev.yml
 
-if grep "$external_ip\|$hadoop_master_pod_name" /etc/hosts ; then
+if grep "$external_ip\\|$hadoop_master_pod_name" /etc/hosts ; then
     echo "Remove entry from /etc/hosts."
 fi

--- a/.test-infra/kubernetes/hadoop/SmallITCluster/teardown.sh
+++ b/.test-infra/kubernetes/hadoop/SmallITCluster/teardown.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 #    Licensed to the Apache Software Foundation (ASF) under one or more
 #    contributor license agreements.  See the NOTICE file distributed with
 #    this work for additional information regarding copyright ownership.
@@ -14,9 +15,7 @@
 #    limitations under the License.
 #
 # Hdfs cluster termination script.
-#
 
-#!/bin/sh
 set -e
 
 kubectl delete -f hdfs-single-datanode-cluster.yml

--- a/.test-infra/kubernetes/hbase/SmallITCluster/setup-all.sh
+++ b/.test-infra/kubernetes/hbase/SmallITCluster/setup-all.sh
@@ -37,4 +37,4 @@ hbase_master_pod_name="$(kubectl get pods --selector=name=hbase -o jsonpath='{.i
 hbase_master_namespace="$(kubectl get pods --selector=name=hbase -o jsonpath='{.items[*].metadata.namespace}')"
 
 echo "For local tests please add the following entry to /etc/hosts file"
-printf "%s\\t%s.hbase.%s.svc.cluster.local\n" "${external_ip}" "${hbase_master_pod_name}" "${hbase_master_namespace}"
+printf "%s\\t%s.hbase.%s.svc.cluster.local\\n" "${external_ip}" "${hbase_master_pod_name}" "${hbase_master_namespace}"


### PR DESCRIPTION
While working on hbase infra, we discussed improving consistency of shell scripts using tools like shellcheck. 
- This PR fixes all issues found by this tool in hdfs and hbase scripts.
- This PR fixes issue in Large HDFS cluster creation. Now /etc/hosts configuration is printed out correctly. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
