### PR TITLE
[BEAM-4536] Remove with_attributes keyword from ReadFromPubSub.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -108,7 +108,7 @@ class ReadFromPubSub(PTransform):
   # Implementation note: This ``PTransform`` is overridden by Directrunner.
 
   def __init__(self, topic=None, subscription=None, id_label=None,
-               with_attributes=False, timestamp_attribute=None):
+               timestamp_attribute=None):
     """Initializes ``ReadFromPubSub``.
 
     Args:
@@ -118,12 +118,8 @@ class ReadFromPubSub(PTransform):
         deduplication of messages. If not provided, we cannot guarantee
         that no duplicate data will be delivered on the Pub/Sub stream. In this
         case, deduplication of the stream will be strictly best effort.
-      with_attributes:
-        True - output elements will be :class:`~PubsubMessage` objects.
-        False - output elements will be of type ``str`` (message payload only).
       timestamp_attribute: Message value to use as element timestamp. If None,
         uses message publishing time as the timestamp.
-        Note that this argument doesn't require with_attributes=True.
 
         Timestamp values should be in one of two formats:
 
@@ -135,12 +131,13 @@ class ReadFromPubSub(PTransform):
           units smaller than milliseconds) may be ignored.
     """
     super(ReadFromPubSub, self).__init__()
-    self.with_attributes = with_attributes
+    # TODO(BEAM-4536): Add with_attributes to kwargs once fixed.
+    self.with_attributes = False
     self._source = _PubSubSource(
         topic=topic,
         subscription=subscription,
         id_label=id_label,
-        with_attributes=with_attributes,
+        with_attributes=self.with_attributes,
         timestamp_attribute=timestamp_attribute)
 
   def expand(self, pvalue):
@@ -174,8 +171,7 @@ class ReadStringsFromPubSub(PTransform):
 
   def expand(self, pvalue):
     p = (pvalue.pipeline
-         | ReadFromPubSub(self.topic, self.subscription, self.id_label,
-                          with_attributes=False)
+         | ReadFromPubSub(self.topic, self.subscription, self.id_label)
          | 'DecodeString' >> Map(lambda b: b.decode('utf-8')))
     p.element_type = text_type
     return p

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -63,7 +63,7 @@ class TestReadFromPubSubOverride(unittest.TestCase):
     p.options.view_as(StandardOptions).streaming = True
     pcoll = (p
              | ReadFromPubSub('projects/fakeprj/topics/a_topic',
-                              None, 'a_label', with_attributes=False,
+                              None, 'a_label',
                               timestamp_attribute=None)
              | beam.Map(lambda x: x))
     self.assertEqual(str, pcoll.element_type)
@@ -87,7 +87,7 @@ class TestReadFromPubSubOverride(unittest.TestCase):
     pcoll = (p
              | ReadFromPubSub(
                  None, 'projects/fakeprj/subscriptions/a_subscription',
-                 'a_label', with_attributes=False, timestamp_attribute=None)
+                 'a_label', timestamp_attribute=None)
              | beam.Map(lambda x: x))
     self.assertEqual(str, pcoll.element_type)
 
@@ -107,16 +107,17 @@ class TestReadFromPubSubOverride(unittest.TestCase):
   def test_expand_with_no_topic_or_subscription(self):
     with self.assertRaisesRegexp(
         ValueError, "Either a topic or subscription must be provided."):
-      ReadFromPubSub(None, None, 'a_label', with_attributes=False,
+      ReadFromPubSub(None, None, 'a_label',
                      timestamp_attribute=None)
 
   def test_expand_with_both_topic_and_subscription(self):
     with self.assertRaisesRegexp(
         ValueError, "Only one of topic or subscription should be provided."):
       ReadFromPubSub('a_topic', 'a_subscription', 'a_label',
-                     with_attributes=False, timestamp_attribute=None)
+                     timestamp_attribute=None)
 
-  def test_expand_with_other_options(self):
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
+  def _test_expand_with_other_options(self):
     p = TestPipeline()
     p.options.view_as(StandardOptions).streaming = True
     pcoll = (p
@@ -291,8 +292,9 @@ def create_client_message(payload, message_id, attributes, publish_time):
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
 class TestReadFromPubSub(unittest.TestCase):
 
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
   @mock.patch('google.cloud.pubsub')
-  def test_read_messages_success(self, mock_pubsub):
+  def _test_read_messages_success(self, mock_pubsub):
     payload = 'payload'
     message_id = 'message_id'
     publish_time = '2018-03-12T13:37:01.234567Z'
@@ -353,8 +355,9 @@ class TestReadFromPubSub(unittest.TestCase):
     assert_that(pcoll, equal_to(expected_data))
     p.run()
 
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
   @mock.patch('google.cloud.pubsub')
-  def test_read_messages_timestamp_attribute_milli_success(self, mock_pubsub):
+  def _test_read_messages_timestamp_attribute_milli_success(self, mock_pubsub):
     payload = 'payload'
     message_id = 'message_id'
     attributes = {'time': '1337'}
@@ -380,8 +383,10 @@ class TestReadFromPubSub(unittest.TestCase):
     assert_that(pcoll, equal_to(expected_data), reify_windows=True)
     p.run()
 
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
   @mock.patch('google.cloud.pubsub')
-  def test_read_messages_timestamp_attribute_rfc3339_success(self, mock_pubsub):
+  def _test_read_messages_timestamp_attribute_rfc3339_success(self,
+                                                              mock_pubsub):
     payload = 'payload'
     message_id = 'message_id'
     attributes = {'time': '2018-03-12T13:37:01.234567Z'}
@@ -407,8 +412,9 @@ class TestReadFromPubSub(unittest.TestCase):
     assert_that(pcoll, equal_to(expected_data), reify_windows=True)
     p.run()
 
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
   @mock.patch('google.cloud.pubsub')
-  def test_read_messages_timestamp_attribute_fail_missing(self, mock_pubsub):
+  def _test_read_messages_timestamp_attribute_fail_missing(self, mock_pubsub):
     payload = 'payload'
     message_id = 'message_id'
     attributes = {'time': '1337'}
@@ -428,8 +434,9 @@ class TestReadFromPubSub(unittest.TestCase):
     with self.assertRaisesRegexp(KeyError, r'Timestamp.*nonexistent'):
       p.run()
 
+  # TODO(BEAM-4536): Reenable test when bug is fixed.
   @mock.patch('google.cloud.pubsub')
-  def test_read_messages_timestamp_attribute_fail_parse(self, mock_pubsub):
+  def _test_read_messages_timestamp_attribute_fail_parse(self, mock_pubsub):
     payload = 'payload'
     message_id = 'message_id'
     attributes = {'time': '1337 unparseable'}


### PR DESCRIPTION
BEAM-4536: with_attributes is broken for Dataflow. This commit removes
the feature for the 2.5.0 release of Beam.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
