### PR TITLE
[BEAM-4445] Filter pre-commit triggering based on touched files

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -38,6 +38,7 @@ class common_job_properties {
         branch('${sha1}')
         extensions {
           cleanAfterCheckout()
+          disableRemotePoll() // needed for included regions PR triggering; see [JENKINS-23606]
           relativeTargetDirectory(checkoutDir)
         }
       }
@@ -128,7 +129,8 @@ class common_job_properties {
                                                  String commitStatusContext,
                                                  String prTriggerPhrase = '',
                                                  boolean onlyTriggerPhraseToggle = true,
-                                                 String successComment = '--none--') {
+                                                 String successComment = '--none--',
+                                                 List<String> triggerPathPatterns = []) {
     context.triggers {
       githubPullRequest {
         admins(['asfbot'])
@@ -146,6 +148,9 @@ class common_job_properties {
         }
         if (onlyTriggerPhraseToggle) {
           onlyTriggerPhrase()
+        }
+        if (!triggerPathPatterns.isEmpty()) {
+          includedRegions(triggerPathPatterns.join('\n'))
         }
 
         extensions {
@@ -193,13 +198,31 @@ class common_job_properties {
     context.switches("-Dorg.gradle.jvmargs=-Xmx${(int)perWorkerMemoryMb}m")
   }
 
-  // Sets common config for PreCommit jobs.
+  /**
+   * Sets common config for PreCommit jobs.
+   *
+   * @param commitStatusName Status displayed in pull request for the job
+   * @param prTriggerPhrase Adding a comment to the PR with this phrase will trigger the job to re-run
+   * @param triggerPathPatterns List of path includes regex which will trigger the PR. Patterns should
+   *                            match the entire file path. A default set of paths will also be added.
+   */
+
   static void setPreCommit(context,
                            String commitStatusName,
                            String prTriggerPhrase = '',
-                           String successComment = '--none--') {
+                           List<String> triggerPathPatterns = []) {
+    def defaultPathTriggers = [
+      '^build.gradle$',
+      '^build_rules.gradle$',
+      '^gradle.properties$',
+      '^gradlew$',
+      '^gradle.bat$',
+      '^settings.gradle$'
+    ]
+
     // Set pull request build trigger.
-    setPullRequestBuildTrigger(context, commitStatusName, prTriggerPhrase, false, successComment)
+    triggerPathPatterns.addAll(defaultPathTriggers)
+    setPullRequestBuildTrigger context, commitStatusName, prTriggerPhrase, false, '--none--', triggerPathPatterns
   }
 
   // Enable triggering postcommit runs against pull requests. Users can comment the trigger phrase

--- a/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
@@ -33,7 +33,12 @@ job('beam_PreCommit_Go_GradleBuild') {
     150)
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit')
+  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit', [
+      '^model/.*$',
+      '^sdks/go/.*$',
+      '^runners/.*$',
+      '^release/.*$',
+    ])
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
@@ -38,7 +38,13 @@ job('beam_PreCommit_Java_GradleBuild') {
   }
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :javaPreCommit', 'Run Java PreCommit')
+  common_job_properties.setPreCommit(delegate, './gradlew :javaPreCommit', 'Run Java PreCommit', [
+      '^model/.*$',
+      '^sdks/java/.*$',
+      '^runners/.*$',
+      '^examples/java/.*$',
+      '^release/.*$',
+    ])
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
@@ -39,7 +39,12 @@ job('beam_PreCommit_Python_GradleBuild') {
   }
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit')
+  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit', [
+      '^model/.*$',
+      '^runners/.*$',
+      '^sdks/python/.*$',
+      '^release/.*$',
+    ])
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)


### PR DESCRIPTION
This will filter pre-commit job triggered on PR's based on which files are touched. The impact is that most PRs will only run one set of relevant tests, rather than all three. This will decrease test overhead and the impact of flaky tests.

This is discussed in the [Beam-Site Automation Reliability](https://s.apache.org/beam-site-automation) design, under "Pre-Commit Job Filtering"

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
