### PR TITLE
[BEAM-4276] Surface graph.Fn encoding functions.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/user.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/user.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
@@ -78,6 +79,28 @@ func DecodeFn(data string) (reflectx.Func, error) {
 		return nil, err
 	}
 	return fn.Fn, nil
+}
+
+// EncodeGraphFn encodes a *graph.Fn as a string.
+func EncodeGraphFn(u *graph.Fn) (string, error) {
+	ref, err := encodeFn(u)
+	if err != nil {
+		return "", err
+	}
+	return protox.EncodeBase64(ref)
+}
+
+// DecodeGraphFn decodes an encoded *graph.Fn.
+func DecodeGraphFn(data string) (*graph.Fn, error) {
+	var ref v1.Fn
+	if err := protox.DecodeBase64(data, &ref); err != nil {
+		return nil, err
+	}
+	fn, err := decodeFn(&ref)
+	if err != nil {
+		return nil, err
+	}
+	return fn, nil
 }
 
 // EncodeCoder encodes a coder as a string. Any custom coder function


### PR DESCRIPTION
This surfaces encoding functions for the higher level *graph.Fn representations. This permits users to serialize them for other uses, such as prototyping within bundle precombines within a ParDo.  Types & functions should still be registered with beam within the binary for deserialization to produce a sensible result.