### PR TITLE
Defer calling formatTimestamp() to achieve better performance

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
@@ -115,14 +115,13 @@ class WatermarkHold<W extends BoundedWindow> implements Serializable {
         windowingStrategy
             .getTimestampCombiner()
             .assign(window, windowingStrategy.getWindowFn().getOutputTime(timestamp, window));
-    // check if shifted is before timestamp first, before calling checkState()
-    // to avoid calling BoundedWindow.formatTimestamp() every time
+    // Don't call checkState(), to avoid calling BoundedWindow.formatTimestamp() every time
     if (shifted.isBefore(timestamp)) {
-      checkState(false,
+      throw new IllegalStateException(String.format(
           "TimestampCombiner moved element from %s to earlier time %s for window %s",
           BoundedWindow.formatTimestamp(timestamp),
           BoundedWindow.formatTimestamp(shifted),
-          window);
+          window));
     }
     checkState(timestamp.isAfter(window.maxTimestamp())
             || !shifted.isAfter(window.maxTimestamp()),

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
@@ -115,11 +115,15 @@ class WatermarkHold<W extends BoundedWindow> implements Serializable {
         windowingStrategy
             .getTimestampCombiner()
             .assign(window, windowingStrategy.getWindowFn().getOutputTime(timestamp, window));
-    checkState(!shifted.isBefore(timestamp),
-        "TimestampCombiner moved element from %s to earlier time %s for window %s",
-        BoundedWindow.formatTimestamp(timestamp),
-        BoundedWindow.formatTimestamp(shifted),
-        window);
+    // check if shifted is before timestamp first, before calling checkState()
+    // to avoid calling BoundedWindow.formatTimestamp() every time
+    if (shifted.isBefore(timestamp)) {
+      checkState(false,
+          "TimestampCombiner moved element from %s to earlier time %s for window %s",
+          BoundedWindow.formatTimestamp(timestamp),
+          BoundedWindow.formatTimestamp(shifted),
+          window);
+    }
     checkState(timestamp.isAfter(window.maxTimestamp())
             || !shifted.isAfter(window.maxTimestamp()),
         "TimestampCombiner moved element from %s to %s which is beyond end of "


### PR DESCRIPTION
Defer calling formatTimestamp() to achieve better performance
Reviewer: @kennknowles 
