### PR TITLE
[BEAM-2281] Refactoring literal expression type conversion 

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutor.java
@@ -149,7 +149,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
    * represent each {@link SqlOperator} with a corresponding {@link BeamSqlExpression}.
    */
   static BeamSqlExpression buildExpression(RexNode rexNode) {
-    BeamSqlExpression ret = null;
+    BeamSqlExpression ret;
     if (rexNode instanceof RexLiteral) {
       RexLiteral node = (RexLiteral) rexNode;
       SqlTypeName type = node.getTypeName();
@@ -174,6 +174,7 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
 
         SqlTypeName realType = node.getType().getSqlTypeName();
         Object realValue = value;
+
         if (SqlTypeName.NUMERIC_TYPES.contains(type)) {
           switch (realType) {
             case TINYINT:
@@ -199,7 +200,12 @@ public class BeamSqlFnExecutor implements BeamSqlExpressionExecutor {
               break;
             default:
               throw new IllegalStateException(
-                  "type / realType mismatch: " + type + " <-> " + realType);
+                  "Unsupported conversion: Attempted convert node "
+                      + node.toString()
+                      + " of type "
+                      + type
+                      + "to "
+                      + realType);
           }
         }
 


### PR DESCRIPTION
call `SqlFunctions` in `BeamSqlFnExecutor` for refactoring literal expression type conversion.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
