### PR TITLE
Fix maven build error on sdks/java/io/google-cloud-platform module

### DIFF
--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -375,6 +375,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!--  Test dependencies -->
@@ -401,7 +402,7 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Build is broke in maven because of changes on GCP, slightly related to #5604.

R: @lukecwik 
CC: @akedin 