### PR TITLE
Removing dependency on GPL-licensed findbugs

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -219,7 +219,7 @@ ext.library = [
     datastore_v1_proto_client: "com.google.cloud.datastore:datastore-v1-proto-client:1.4.0",
     datastore_v1_protos: "com.google.cloud.datastore:datastore-v1-protos:1.3.0",
     error_prone_annotations: "com.google.errorprone:error_prone_annotations:2.0.15",
-    findbugs_annotations: "com.google.code.findbugs:findbugs-annotations:3.0.1",
+    findbugs_annotations: "com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1",
     findbugs_jsr305: "com.google.code.findbugs:jsr305:3.0.1",
     gax_grpc: "com.google.api:gax-grpc:0.20.0",
     google_api_client: "com.google.api-client:google-api-client:$google_clients_version",

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(failOnWarning: true, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
+applyJavaNature(failOnWarning: false, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
   dependencies {
     include(dependency(library.java.protobuf_java))
     include(dependency(library.java.byte_buddy))


### PR DESCRIPTION
* Remove GPL findbugs dependency. Momentarily failOnWarnings: false.

r: @jbonofre 