### PR TITLE
[BEAM-4555] Revert pull request pre-commit triggering

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -38,7 +38,6 @@ class common_job_properties {
         branch('${sha1}')
         extensions {
           cleanAfterCheckout()
-          disableRemotePoll() // needed for included regions PR triggering; see [JENKINS-23606]
           relativeTargetDirectory(checkoutDir)
         }
       }
@@ -129,8 +128,7 @@ class common_job_properties {
                                                  String commitStatusContext,
                                                  String prTriggerPhrase = '',
                                                  boolean onlyTriggerPhraseToggle = true,
-                                                 String successComment = '--none--',
-                                                 List<String> triggerPathPatterns = []) {
+                                                 String successComment = '--none--') {
     context.triggers {
       githubPullRequest {
         admins(['asfbot'])
@@ -148,9 +146,6 @@ class common_job_properties {
         }
         if (onlyTriggerPhraseToggle) {
           onlyTriggerPhrase()
-        }
-        if (!triggerPathPatterns.isEmpty()) {
-          includedRegions(triggerPathPatterns.join('\n'))
         }
 
         extensions {
@@ -198,31 +193,13 @@ class common_job_properties {
     context.switches("-Dorg.gradle.jvmargs=-Xmx${(int)perWorkerMemoryMb}m")
   }
 
-  /**
-   * Sets common config for PreCommit jobs.
-   *
-   * @param commitStatusName Status displayed in pull request for the job
-   * @param prTriggerPhrase Adding a comment to the PR with this phrase will trigger the job to re-run
-   * @param triggerPathPatterns List of path includes regex which will trigger the PR. Patterns should
-   *                            match the entire file path. A default set of paths will also be added.
-   */
-
+  // Sets common config for PreCommit jobs.
   static void setPreCommit(context,
                            String commitStatusName,
                            String prTriggerPhrase = '',
-                           List<String> triggerPathPatterns = []) {
-    def defaultPathTriggers = [
-      '^build.gradle$',
-      '^build_rules.gradle$',
-      '^gradle.properties$',
-      '^gradlew$',
-      '^gradle.bat$',
-      '^settings.gradle$'
-    ]
-
+                           String successComment = '--none--') {
     // Set pull request build trigger.
-    triggerPathPatterns.addAll(defaultPathTriggers)
-    setPullRequestBuildTrigger context, commitStatusName, prTriggerPhrase, false, '--none--', triggerPathPatterns
+    setPullRequestBuildTrigger(context, commitStatusName, prTriggerPhrase, false, successComment)
   }
 
   // Enable triggering postcommit runs against pull requests. Users can comment the trigger phrase

--- a/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
@@ -33,12 +33,7 @@ job('beam_PreCommit_Go_GradleBuild') {
     150)
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit', [
-      '^model/.*$',
-      '^sdks/go/.*$',
-      '^runners/.*$',
-      '^release/.*$',
-    ])
+  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit')
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
@@ -38,13 +38,7 @@ job('beam_PreCommit_Java_GradleBuild') {
   }
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :javaPreCommit', 'Run Java PreCommit', [
-      '^model/.*$',
-      '^sdks/java/.*$',
-      '^runners/.*$',
-      '^examples/java/.*$',
-      '^release/.*$',
-    ])
+  common_job_properties.setPreCommit(delegate, './gradlew :javaPreCommit', 'Run Java PreCommit')
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)

--- a/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
@@ -39,12 +39,7 @@ job('beam_PreCommit_Python_GradleBuild') {
   }
 
   // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit', [
-      '^model/.*$',
-      '^runners/.*$',
-      '^sdks/python/.*$',
-      '^release/.*$',
-    ])
+  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit')
   steps {
     gradle {
       rootBuildScriptDir(common_job_properties.checkoutDir)


### PR DESCRIPTION
In [BEAM-4445] we changed pre-commit triggering on PR's to only run when affected file paths were changed. However as a side-effect, it is no longer possible to use trigger phrases to manually run pre-commits if include path files are not changed.

This ability to run a pre-commit even if files are not changed is useful to check the stability of the codebase before submitting.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
