### PR TITLE
Ignoring reference runner tests, as reference runner is not yet standard

### DIFF
--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/ReferenceRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/ReferenceRunnerTest.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -48,6 +49,7 @@ import org.junit.runners.JUnit4;
 /** Tests for the {@link ReferenceRunner}. */
 @RunWith(JUnit4.class)
 public class ReferenceRunnerTest implements Serializable {
+  @Ignore
   @Test
   public void pipelineExecution() throws Exception {
     Pipeline p = Pipeline.create();


### PR DESCRIPTION
Ignoring Reference Runner tests as it is not yet the standard way to run jobs.

r: @jbonofre 
cc: @aaltay 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
