### PR TITLE
Minor documentation fixes

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/DebuggingWordCount.java
@@ -138,7 +138,7 @@ public class DebuggingWordCount {
          .apply(new WordCount.CountWords())
          .apply(ParDo.of(new FilterTextFn(options.getFilterPattern())));
 
-    /**
+    /*
      * Concept #3: PAssert is a set of convenient PTransforms in the style of
      * Hamcrest's collection matchers that can be used when writing Pipeline level tests
      * to validate the contents of PCollections. PAssert is best used in unit tests

--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -112,7 +112,7 @@ public class WindowedWordCount {
               ThreadLocalRandom.current()
                   .nextLong(minTimestamp.getMillis(), maxTimestamp.getMillis()));
 
-      /**
+      /*
        * Concept #2: Set the data element with that timestamp.
        */
       receiver.outputWithTimestamp(element, new Instant(randomTimestamp));
@@ -172,18 +172,18 @@ public class WindowedWordCount {
 
     Pipeline pipeline = Pipeline.create(options);
 
-    /**
+    /*
      * Concept #1: the Beam SDK lets us run the same pipeline with either a bounded or
      * unbounded input source.
      */
     PCollection<String> input = pipeline
-      /** Read from the GCS file. */
+      /* Read from the GCS file. */
       .apply(TextIO.read().from(options.getInputFile()))
       // Concept #2: Add an element timestamp, using an artificial time just to show windowing.
       // See AddTimestampFn for more detail on this.
       .apply(ParDo.of(new AddTimestampFn(minTimestamp, maxTimestamp)));
 
-    /**
+    /*
      * Concept #3: Window into fixed windows. The fixed window size for this example defaults to 1
      * minute (you can change this with a command-line option). See the documentation for more
      * information on how fixed windows work, and for information on the other types of windowing
@@ -193,13 +193,13 @@ public class WindowedWordCount {
         input.apply(
             Window.into(FixedWindows.of(Duration.standardMinutes(options.getWindowSize()))));
 
-    /**
+    /*
      * Concept #4: Re-use our existing CountWords transform that does not have knowledge of
      * windows over a PCollection containing windowed values.
      */
     PCollection<KV<String, Long>> wordCounts = windowedWords.apply(new WordCount.CountWords());
 
-    /**
+    /*
      * Concept #5: Format the results and write to a sharded file partitioned by window, using a
      * simple ParDo operation. Because there may be failures followed by retries, the
      * writes must be idempotent, but the details of writing to files is elided here.

--- a/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/WindowedWordCount.java
@@ -80,9 +80,9 @@ import org.joda.time.Instant;
  * <p>The input file defaults to a public data set containing the text of of King Lear,
  * by William Shakespeare. You can override it and choose your own input with {@code --inputFile}.
  *
- * <p>By default, the pipeline will do fixed windowing, on 1-minute windows.  You can
- * change this interval by setting the {@code --windowSize} parameter, e.g. {@code --windowSize=10}
- * for 10-minute windows.
+ * <p>By default, the pipeline will do fixed windowing, on 10-minute windows.  You can
+ * change this interval by setting the {@code --windowSize} parameter, e.g. {@code --windowSize=15}
+ * for 15-minute windows.
  *
  * <p>The example will try to cancel the pipeline on the signal to terminate the process (CTRL-C).
  */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
@@ -277,7 +277,7 @@ public class PCollection<T> extends PValueBase implements PValue {
   }
 
   /**
-   * Like {@link IsBounded#apply(String, PTransform)} but defaulting to the name
+   * Like {@link #apply(String, PTransform)} but defaulting to the name
    * of the {@link PTransform}.
    *
    * @return the output of the applied {@link PTransform}


### PR DESCRIPTION
These are very minor edits to the documentation, to the PCollection Javadoc and the Java examples. In PCollection, there's a Javadoc link to a nonexistent method, and in the Java word count examples, the code and comments disagree, and Javadoc conventions are not followed.