### PR TITLE
[BEAM-4309] Fix ErrorProne violations in direct runner

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -24,7 +24,7 @@ def dependOnProjects = [":beam-model-pipeline", ":beam-runners-core-construction
                         ":beam-runners-java-fn-execution", ":beam-sdks-java-fn-execution"]
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE << {
+applyJavaNature(failOnWarning: true, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
   dependencies {
     include(dependency(library.java.protobuf_java))
     include(dependency(library.java.protobuf_java_util))

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CommittedBundle.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/CommittedBundle.java
@@ -37,6 +37,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollection<T>> {
   /**
    * Returns the PCollection that the elements of this bundle belong to.
    */
+  @Override
   @Nullable
   PCollection<T> getPCollection();
 
@@ -44,6 +45,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollection<T>> {
    * Returns the key that was output in the most recent {@code GroupByKey} in the
    * execution of this bundle.
    */
+  @Override
   StructuralKey<?> getKey();
 
   /**
@@ -58,6 +60,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollection<T>> {
    * <p>This should be equivalent to iterating over all of the elements within a bundle and
    * selecting the minimum timestamp from among them.
    */
+  @Override
   Instant getMinimumTimestamp();
 
   /**
@@ -69,6 +72,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollection<T>> {
    * processing time {@link TimerData timer} at the time this bundle was committed, including any
    * timers that fired to produce this bundle.
    */
+  @Override
   Instant getSynchronizedProcessingOutputWatermark();
   /**
    * Return a new {@link CommittedBundle} that is like this one, except calls to

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectMetrics.java
@@ -239,9 +239,13 @@ class DirectMetrics extends MetricResults {
   abstract static class DirectMetricResult<T> implements MetricResult<T> {
     // need to define these here so they appear in the correct order
     // and the generated constructor is usable and consistent
+    @Override
     public abstract MetricName getName();
+    @Override
     public abstract String getStep();
+    @Override
     public abstract T getCommitted();
+    @Override
     public abstract T getAttempted();
 
     public static <T> MetricResult<T> create(MetricName name, String scope,

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutor.java
@@ -142,6 +142,8 @@ final class ExecutorServiceParallelExecutor
   }
 
   @Override
+  // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void start(DirectGraph graph, RootProviderRegistry rootProviderRegistry) {
     int numTargetSplits = Math.max(3, targetParallelism);
     ImmutableMap.Builder<AppliedPTransform<?, ?, ?>, ConcurrentLinkedQueue<CommittedBundle<?>>>

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutorServices.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformExecutorServices.java
@@ -69,6 +69,8 @@ final class TransformExecutorServices {
     }
 
     @Override
+    // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+    @SuppressWarnings("FutureReturnValueIgnored")
     public void schedule(TransformExecutor work) {
       if (active.get()) {
         try {
@@ -152,6 +154,8 @@ final class TransformExecutorServices {
       workQueue.clear();
     }
 
+    // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+    @SuppressWarnings("FutureReturnValueIgnored")
     private void updateCurrentlyEvaluating() {
       if (currentlyEvaluating.get() == null) {
         // Only synchronize if we need to update what's currently evaluating

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/UnboundedReadEvaluatorFactory.java
@@ -119,6 +119,8 @@ class UnboundedReadEvaluatorFactory implements TransformEvaluatorFactory {
     }
 
     @Override
+    @SuppressWarnings("Finally") // Cannot use try-with-resources in order to ensure we don't
+                                 // double-close the reader.
     public void processElement(
         WindowedValue<UnboundedSourceShard<OutputT, CheckpointMarkT>> element) throws IOException {
       UncommittedBundle<OutputT> output =

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/CommittedBundle.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/CommittedBundle.java
@@ -39,12 +39,14 @@ interface CommittedBundle<T> extends Bundle<T, PCollectionNode> {
    * Returns the PCollection that the elements of this bundle belong to.
    */
   @Nullable
+  @Override
   PCollectionNode getPCollection();
 
   /**
    * Returns the key that was output in the most recent {@code GroupByKey} in the
    * execution of this bundle.
    */
+  @Override
   StructuralKey<?> getKey();
 
   /**
@@ -59,6 +61,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollectionNode> {
    * <p>This should be equivalent to iterating over all of the elements within a bundle and
    * selecting the minimum timestamp from among them.
    */
+  @Override
   Instant getMinimumTimestamp();
 
   /**
@@ -70,6 +73,7 @@ interface CommittedBundle<T> extends Bundle<T, PCollectionNode> {
    * processing time {@link TimerData timer} at the time this bundle was committed, including any
    * timers that fired to produce this bundle.
    */
+  @Override
   Instant getSynchronizedProcessingOutputWatermark();
   /**
    * Return a new {@link CommittedBundle} that is like this one, except calls to

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/DirectMetrics.java
@@ -110,9 +110,11 @@ class DirectMetrics extends MetricResults {
      * @param bundle The bundle being committed.
      * @param finalCumulative The final cumulative value for the given bundle.
      */
+    @SuppressWarnings("FutureReturnValueIgnored") // direct runner metrics are best-effort;
+                                                  // we choose not to block on async commit
     public void commitPhysical(final CommittedBundle<?> bundle, final UpdateT finalCumulative) {
       // To prevent a query from blocking the commit, we perform the commit in two steps.
-      // 1. We perform a non-blocking write to the uncommitted table to make the new vaule
+      // 1. We perform a non-blocking write to the uncommitted table to make the new value
       //    available immediately.
       // 2. We submit a runnable that will commit the update and remove the tentative value in
       //    a synchronized block.
@@ -247,9 +249,13 @@ class DirectMetrics extends MetricResults {
   abstract static class DirectMetricResult<T> implements MetricResult<T> {
     // need to define these here so they appear in the correct order
     // and the generated constructor is usable and consistent
+    @Override
     public abstract MetricName getName();
+    @Override
     public abstract String getStep();
+    @Override
     public abstract T getCommitted();
+    @Override
     public abstract T getAttempted();
 
     public static <T> MetricResult<T> create(MetricName name, String scope,

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ExecutorServiceParallelExecutor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ExecutorServiceParallelExecutor.java
@@ -142,6 +142,8 @@ final class ExecutorServiceParallelExecutor
   }
 
   @Override
+  // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+  @SuppressWarnings("FutureReturnValueIgnored")
   public void start() {
     int numTargetSplits = Math.max(3, targetParallelism);
     ImmutableMap.Builder<PTransformNode, ConcurrentLinkedQueue<CommittedBundle<?>>>

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/TransformExecutorServices.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/TransformExecutorServices.java
@@ -69,6 +69,8 @@ final class TransformExecutorServices {
     }
 
     @Override
+    // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+    @SuppressWarnings("FutureReturnValueIgnored")
     public void schedule(TransformExecutor work) {
       if (active.get()) {
         try {
@@ -152,6 +154,8 @@ final class TransformExecutorServices {
       workQueue.clear();
     }
 
+    // TODO: [BEAM-4563] Pass Future back to consumer to check for async errors
+    @SuppressWarnings("FutureReturnValueIgnored")
     private void updateCurrentlyEvaluating() {
       if (currentlyEvaluating.get() == null) {
         // Only synchronize if we need to update what's currently evaluating

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobService.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobService.java
@@ -130,6 +130,7 @@ public class ReferenceRunnerJobService extends JobServiceImplBase implements FnS
   }
 
   @Override
+  @SuppressWarnings("FutureReturnValueIgnored") // Run API does not block on execution
   public void run(
       JobApi.RunJobRequest request, StreamObserver<JobApi.RunJobResponse> responseObserver) {
     try {

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectRunnerTest.java
@@ -270,9 +270,10 @@ public class DirectRunnerTest implements Serializable {
         };
 
     ExecutorService executor = Executors.newCachedThreadPool();
-    executor.submit(cancelRunnable);
+    Future<?> cancelResult = executor.submit(cancelRunnable);
     Future<PipelineResult> result = executor.submit(runPipelineRunnable);
 
+    cancelResult.get();
     // If cancel doesn't work, this will hang forever
     result.get().waitUntilFinish();
   }
@@ -320,7 +321,7 @@ public class DirectRunnerTest implements Serializable {
           try {
             Thread.sleep(1000);
           } catch (final InterruptedException e) {
-            fail();
+            throw new AssertionError(e);
           }
           TEARDOWN_CALL.set(System.nanoTime());
         }

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectTransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/DirectTransformExecutorTest.java
@@ -191,9 +191,10 @@ public class DirectTransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> future = Executors.newSingleThreadExecutor().submit(executor);
 
     evaluatorCompleted.await();
+    future.get();
 
     assertThat(elementsProcessed, containsInAnyOrder(spam, third, foo));
     assertThat(completionCallback.handledResult, equalTo(result));
@@ -201,6 +202,7 @@ public class DirectTransformExecutorTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored") // expected exception checked via completionCallback
   public void processElementThrowsExceptionCallsback() throws Exception {
     final TransformResult<String> result =
         StepTransformResult.<String>withoutHold(downstreamProducer).build();
@@ -241,6 +243,7 @@ public class DirectTransformExecutorTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored") // expected exception checked via completionCallback
   public void finishBundleThrowsExceptionCallsback() throws Exception {
     final Exception exception = new Exception();
     TransformEvaluator<String> evaluator =

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.direct;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.sdk.testing.PCollectionViewTesting.materializeValuesFor;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -262,7 +263,7 @@ public class EvaluationContextTest {
 
   @Test
   public void handleResultStoresState() {
-    StructuralKey<?> myKey = StructuralKey.of("foo".getBytes(), ByteArrayCoder.of());
+    StructuralKey<?> myKey = StructuralKey.of("foo".getBytes(UTF_8), ByteArrayCoder.of());
     DirectExecutionContext fooContext =
         context.getExecutionContext(downstreamProducer, myKey);
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ExecutorServiceParallelExecutorTest.java
@@ -23,6 +23,7 @@ import static org.junit.rules.RuleChain.outerRule;
 
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -56,7 +57,7 @@ public class ExecutorServiceParallelExecutorTest {
 
   @Test
   @Ignore("https://issues.apache.org/jira/browse/BEAM-4088 Test reliably fails.")
-  public void ensureMetricsThreadDoesntLeak() {
+  public void ensureMetricsThreadDoesntLeak() throws ExecutionException, InterruptedException {
     final DirectGraph graph =
         DirectGraph.create(
             emptyMap(), emptyMap(), LinkedListMultimap.create(), emptySet(), emptyMap());
@@ -68,7 +69,7 @@ public class ExecutorServiceParallelExecutorTest {
                 .build());
 
     // fake a metrics usage
-    metricsExecutorService.submit(() -> {});
+    metricsExecutorService.submit(() -> {}).get();
 
     final EvaluationContext context =
         EvaluationContext.create(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutabilityEnforcementFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ImmutabilityEnforcementFactoryTest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.direct;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.Serializable;
 import java.util.Collections;
 import org.apache.beam.sdk.runners.AppliedPTransform;
@@ -54,7 +56,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
     factory = new ImmutabilityEnforcementFactory();
     bundleFactory = ImmutableListBundleFactory.create();
     pcollection =
-        p.apply(Create.of("foo".getBytes(), "spamhameggs".getBytes()))
+        p.apply(Create.of("foo".getBytes(UTF_8), "spamhameggs".getBytes(UTF_8)))
             .apply(
                 ParDo.of(
                     new DoFn<byte[], byte[]>() {
@@ -71,7 +73,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
 
   @Test
   public void unchangedSucceeds() {
-    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
+    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes(UTF_8));
     CommittedBundle<byte[]> elements =
         bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 
@@ -86,7 +88,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
 
   @Test
   public void mutatedDuringProcessElementThrows() {
-    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
+    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes(UTF_8));
     CommittedBundle<byte[]> elements =
         bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 
@@ -107,7 +109,7 @@ public class ImmutabilityEnforcementFactoryTest implements Serializable {
   @Test
   public void mutatedAfterProcessElementFails() {
 
-    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes());
+    WindowedValue<byte[]> element = WindowedValue.valueInGlobalWindow("bar".getBytes(UTF_8));
     CommittedBundle<byte[]> elements =
         bundleFactory.createBundle(pcollection).add(element).commit(Instant.now());
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doAnswer;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
@@ -461,7 +463,8 @@ public class SideInputContainerTest {
             invocation -> {
               Object callback = invocation.getArguments()[3];
               final Runnable callbackRunnable = (Runnable) callback;
-              Executors.newSingleThreadExecutor()
+              ListenableFuture<?> result = MoreExecutors
+                  .listeningDecorator(Executors.newSingleThreadExecutor())
                   .submit(
                       () -> {
                         try {
@@ -471,9 +474,8 @@ public class SideInputContainerTest {
                           callbackRunnable.run();
                           onComplete.countDown();
                         } catch (InterruptedException e) {
-                          fail(
-                              "Unexpectedly interrupted while waiting for latch "
-                                  + "to be counted down");
+                          throw new AssertionError(
+                              "Unexpectedly interrupted while waiting for latch ", e);
                         }
                       });
               return null;

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadDeduplicatorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/UnboundedReadDeduplicatorTest.java
@@ -22,8 +22,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -57,7 +63,7 @@ public class UnboundedReadDeduplicatorTest {
   }
 
   @Test
-  public void cachedIdDeduplicatorMultithreaded() throws InterruptedException {
+  public void cachedIdDeduplicatorMultithreaded() throws InterruptedException, ExecutionException {
     byte[] id = new byte[] {-1, 2, 4, 22};
     UnboundedReadDeduplicator dedupper = CachedIdDeduplicator.create();
     final CountDownLatch startSignal = new CountDownLatch(1);
@@ -65,22 +71,25 @@ public class UnboundedReadDeduplicatorTest {
     final CountDownLatch readyLatch = new CountDownLatch(numThreads);
     final CountDownLatch finishLine = new CountDownLatch(numThreads);
 
-    ExecutorService executor = Executors.newCachedThreadPool();
+    ListeningExecutorService executor = MoreExecutors.listeningDecorator(
+        Executors.newCachedThreadPool());
     AtomicInteger successCount = new AtomicInteger();
     AtomicInteger noOutputCount = new AtomicInteger();
+    List<ListenableFuture<?>> futures = new ArrayList<>();
     for (int i = 0; i < numThreads; i++) {
-      executor.submit(new TryOutputIdRunnable(dedupper,
+      futures.add(executor.submit(new TryOutputIdRunnable(dedupper,
           id,
           successCount,
           noOutputCount,
           readyLatch,
           startSignal,
-          finishLine));
+          finishLine)));
     }
 
     readyLatch.await();
     startSignal.countDown();
     finishLine.await(10L, TimeUnit.SECONDS);
+    Futures.allAsList(futures).get();
     executor.shutdownNow();
 
     // The first thread to run will succeed, and no others will

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/WriteWithShardingFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.direct;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
@@ -27,11 +28,13 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import com.google.common.base.Splitter;
 import java.io.File;
-import java.io.FileReader;
 import java.io.Reader;
 import java.io.Serializable;
 import java.nio.CharBuffer;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -108,12 +111,12 @@ public class WriteWithShardingFactoryTest implements Serializable {
       String filename = match.resourceId().toString();
       files.add(filename);
       CharBuffer buf = CharBuffer.allocate((int) new File(filename).length());
-      try (Reader reader = new FileReader(filename)) {
+      try (Reader reader = Files.newBufferedReader(Paths.get(filename), UTF_8)) {
         reader.read(buf);
         buf.flip();
       }
 
-      String[] readStrs = buf.toString().split("\n");
+      Iterable<String> readStrs = Splitter.on("\n").split(buf.toString());
       for (String read : readStrs) {
         if (read.length() > 0) {
           actuals.add(read);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/DirectTransformExecutorTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/DirectTransformExecutorTest.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
@@ -193,9 +194,10 @@ public class DirectTransformExecutorTest {
             completionCallback,
             transformEvaluationState);
 
-    Executors.newSingleThreadExecutor().submit(executor);
+    Future<?> future = Executors.newSingleThreadExecutor().submit(executor);
 
     evaluatorCompleted.await();
+    future.get();
 
     assertThat(elementsProcessed, containsInAnyOrder(spam, third, foo));
     assertThat(completionCallback.handledResult, Matchers.equalTo(result));
@@ -203,6 +205,7 @@ public class DirectTransformExecutorTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored") // expected exception checked via completionCallback
   public void processElementThrowsExceptionCallsback() throws Exception {
     final TransformResult<String> result =
         StepTransformResult.<String>withoutHold(downstreamProducer).build();
@@ -242,6 +245,7 @@ public class DirectTransformExecutorTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored") // expected exception checked via completionCallback
   public void finishBundleThrowsExceptionCallsback() throws Exception {
     final Exception exception = new Exception();
     TransformEvaluator<String> evaluator =

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/EvaluationContextTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/EvaluationContextTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.direct.portable;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
@@ -149,7 +150,7 @@ public class EvaluationContextTest {
 
   @Test
   public void handleResultStoresState() {
-    StructuralKey<?> myKey = StructuralKey.of("foo".getBytes(), ByteArrayCoder.of());
+    StructuralKey<?> myKey = StructuralKey.of("foo".getBytes(UTF_8), ByteArrayCoder.of());
     StepStateAndTimers fooContext = context.getStateAndTimers(downstreamProducer, myKey);
 
     StateTag<BagState<Integer>> intBag = StateTags.bag("myBag", VarIntCoder.of());

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactRetrievalServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactRetrievalServiceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.direct.portable.artifact;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -91,7 +92,7 @@ public class LocalFileSystemArtifactRetrievalServiceTest {
   @Test
   public void retrieveManifest() throws Exception {
     Map<String, byte[]> artifacts = new HashMap<>();
-    artifacts.put("foo", "bar, baz, quux".getBytes());
+    artifacts.put("foo", "bar, baz, quux".getBytes(UTF_8));
     artifacts.put("spam", new byte[] {127, -22, 5});
     stageAndCreateRetrievalService(artifacts);
 
@@ -129,7 +130,7 @@ public class LocalFileSystemArtifactRetrievalServiceTest {
   @Test
   public void retrieveArtifact() throws Exception {
     Map<String, byte[]> artifacts = new HashMap<>();
-    byte[] fooContents = "bar, baz, quux".getBytes();
+    byte[] fooContents = "bar, baz, quux".getBytes(UTF_8);
     artifacts.put("foo", fooContents);
     byte[] spamContents = {127, -22, 5};
     artifacts.put("spam", spamContents);
@@ -152,7 +153,8 @@ public class LocalFileSystemArtifactRetrievalServiceTest {
 
   @Test
   public void retrieveArtifactNotPresent() throws Exception {
-    stageAndCreateRetrievalService(Collections.singletonMap("foo", "bar, baz, quux".getBytes()));
+    stageAndCreateRetrievalService(Collections.singletonMap(
+        "foo", "bar, baz, quux".getBytes(UTF_8)));
 
     final CountDownLatch completed = new CountDownLatch(1);
     final AtomicReference<Throwable> thrown = new AtomicReference<>();

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactStagerServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactStagerServiceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.runners.direct.portable.artifact;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -79,7 +80,7 @@ public class LocalFileSystemArtifactStagerServiceTest {
 
   @Test
   public void singleDataPutArtifactSucceeds() throws Exception {
-    byte[] data = "foo-bar-baz".getBytes();
+    byte[] data = "foo-bar-baz".getBytes(UTF_8);
     RecordingStreamObserver<ArtifactApi.PutArtifactResponse> responseObserver =
         new RecordingStreamObserver<>();
     StreamObserver<ArtifactApi.PutArtifactRequest> requestObserver =
@@ -112,9 +113,9 @@ public class LocalFileSystemArtifactStagerServiceTest {
 
   @Test
   public void multiPartPutArtifactSucceeds() throws Exception {
-    byte[] partOne = "foo-".getBytes();
-    byte[] partTwo = "bar-".getBytes();
-    byte[] partThree = "baz".getBytes();
+    byte[] partOne = "foo-".getBytes(UTF_8);
+    byte[] partTwo = "bar-".getBytes(UTF_8);
+    byte[] partThree = "baz".getBytes(UTF_8);
     RecordingStreamObserver<ArtifactApi.PutArtifactResponse> responseObserver =
         new RecordingStreamObserver<>();
     StreamObserver<ArtifactApi.PutArtifactRequest> requestObserver =
@@ -158,12 +159,12 @@ public class LocalFileSystemArtifactStagerServiceTest {
     assertThat(staged.exists(), is(true));
     ByteBuffer buf = ByteBuffer.allocate("foo-bar-baz".length());
     new FileInputStream(staged).getChannel().read(buf);
-    Assert.assertArrayEquals("foo-bar-baz".getBytes(), buf.array());
+    Assert.assertArrayEquals("foo-bar-baz".getBytes(UTF_8), buf.array());
   }
 
   @Test
   public void putArtifactBeforeNameFails() {
-    byte[] data = "foo-".getBytes();
+    byte[] data = "foo-".getBytes(UTF_8);
     RecordingStreamObserver<ArtifactApi.PutArtifactResponse> responseObserver =
         new RecordingStreamObserver<>();
     StreamObserver<ArtifactApi.PutArtifactRequest> requestObserver =
@@ -200,9 +201,9 @@ public class LocalFileSystemArtifactStagerServiceTest {
   @Test
   public void commitManifestWithAllArtifactsSucceeds() {
     ArtifactApi.ArtifactMetadata firstArtifact =
-        stageBytes("first-artifact", "foo, bar, baz, quux".getBytes());
+        stageBytes("first-artifact", "foo, bar, baz, quux".getBytes(UTF_8));
     ArtifactApi.ArtifactMetadata secondArtifact =
-        stageBytes("second-artifact", "spam, ham, eggs".getBytes());
+        stageBytes("second-artifact", "spam, ham, eggs".getBytes(UTF_8));
 
     ArtifactApi.Manifest manifest =
         ArtifactApi.Manifest.newBuilder()
@@ -227,7 +228,7 @@ public class LocalFileSystemArtifactStagerServiceTest {
   @Test
   public void commitManifestWithMissingArtifactFails() {
     ArtifactApi.ArtifactMetadata firstArtifact =
-        stageBytes("first-artifact", "foo, bar, baz, quux".getBytes());
+        stageBytes("first-artifact", "foo, bar, baz, quux".getBytes(UTF_8));
     ArtifactApi.ArtifactMetadata absentArtifact =
         ArtifactApi.ArtifactMetadata.newBuilder().setName("absent").build();
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/UnsupportedArtifactRetrievalServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/UnsupportedArtifactRetrievalServiceTest.java
@@ -18,8 +18,6 @@
 
 package org.apache.beam.runners.direct.portable.artifact;
 
-import static org.junit.Assert.fail;
-
 import io.grpc.stub.StreamObserver;
 import java.util.Optional;
 import java.util.concurrent.SynchronousQueue;
@@ -69,7 +67,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.empty());
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
 
@@ -78,7 +76,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.of(t));
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
 
@@ -87,7 +85,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.empty());
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
         });
@@ -113,7 +111,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.empty());
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
 
@@ -122,7 +120,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.of(t));
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
 
@@ -131,7 +129,7 @@ public class UnsupportedArtifactRetrievalServiceTest {
             try {
               thrown.put(Optional.empty());
             } catch (InterruptedException e) {
-              fail();
+              throw new AssertionError(e);
             }
           }
         });

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobServiceTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.beam.runners.direct.portable.job;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertThat;
 
@@ -96,8 +97,8 @@ public class ReferenceRunnerJobServiceTest {
     ArtifactServiceStager stager =
         ArtifactServiceStager.overChannel(
             InProcessChannelBuilder.forName(stagingEndpoint.getUrl()).build());
-    File foo = writeTempFile("foo", "foo, bar, baz".getBytes());
-    File bar = writeTempFile("spam", "spam, ham, eggs".getBytes());
+    File foo = writeTempFile("foo", "foo, bar, baz".getBytes(UTF_8));
+    File bar = writeTempFile("spam", "spam, ham, eggs".getBytes(UTF_8));
     stager.stage(
         ImmutableList.of(StagedFile.of(foo, foo.getName()), StagedFile.of(bar, bar.getName())));
     List<byte[]> tempDirFiles = readFlattenedFiles(runnerTemp.getRoot());


### PR DESCRIPTION
This makes future ErrorProne violations become compile-time errors.

During these cleanup there were many instances for'FutureReturnValueIgnored' in the direct runner which would be difficult to fix without significant API and plumbing changes. I've filed [[BEAM-4563]](https://issues.apache.org/jira/browse/BEAM-4563) to follow-up.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
