### PR TITLE
[BEAM-3998] Futurize examples subpackage

### DIFF
--- a/sdks/python/apache_beam/examples/__init__.py
+++ b/sdks/python/apache_beam/examples/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/complete/__init__.py
+++ b/sdks/python/apache_beam/examples/complete/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/complete/autocomplete.py
+++ b/sdks/python/apache_beam/examples/complete/autocomplete.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 import argparse
 import logging
 import re
+from builtins import range
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText

--- a/sdks/python/apache_beam/examples/complete/autocomplete_test.py
+++ b/sdks/python/apache_beam/examples/complete/autocomplete_test.py
@@ -17,6 +17,8 @@
 
 """Test for the autocomplete example."""
 
+from __future__ import absolute_import
+
 import unittest
 
 import apache_beam as beam

--- a/sdks/python/apache_beam/examples/complete/estimate_pi.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi.py
@@ -25,11 +25,14 @@ we multiply our counts ratio by four to estimate π.
 """
 
 from __future__ import absolute_import
+from __future__ import division
 
 import argparse
 import json
 import logging
 import random
+from builtins import object
+from builtins import range
 
 import apache_beam as beam
 from apache_beam.io import WriteToText

--- a/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
+++ b/sdks/python/apache_beam/examples/complete/estimate_pi_test.py
@@ -17,6 +17,8 @@
 
 """Test for the estimate_pi example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/complete/game/__init__.py
+++ b/sdks/python/apache_beam/examples/complete/game/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/complete/game/game_stats.py
+++ b/sdks/python/apache_beam/examples/complete/game/game_stats.py
@@ -71,6 +71,7 @@ python game_stats.py \
 """
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import argparse
@@ -229,7 +230,7 @@ class CalculateSpammyUsers(beam.PTransform):
 class UserSessionActivity(beam.DoFn):
   """Calculate and output an element's session duration, in seconds."""
   def process(self, elem, window=beam.DoFn.WindowParam):
-    yield (window.end.micros - window.start.micros) / 1000000
+    yield (window.end.micros - window.start.micros)//1000000
 
 
 def run(argv=None):

--- a/sdks/python/apache_beam/examples/complete/game/game_stats_test.py
+++ b/sdks/python/apache_beam/examples/complete/game/game_stats_test.py
@@ -17,6 +17,8 @@
 
 """Test for the game_stats example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/complete/game/hourly_team_score.py
+++ b/sdks/python/apache_beam/examples/complete/game/hourly_team_score.py
@@ -65,6 +65,7 @@ python hourly_team_score.py \
 """
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import argparse

--- a/sdks/python/apache_beam/examples/complete/game/hourly_team_score_test.py
+++ b/sdks/python/apache_beam/examples/complete/game/hourly_team_score_test.py
@@ -17,6 +17,8 @@
 
 """Test for the user_score example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/complete/game/leader_board.py
+++ b/sdks/python/apache_beam/examples/complete/game/leader_board.py
@@ -79,6 +79,7 @@ python leader_board.py \
 """
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import argparse

--- a/sdks/python/apache_beam/examples/complete/game/leader_board_test.py
+++ b/sdks/python/apache_beam/examples/complete/game/leader_board_test.py
@@ -17,6 +17,8 @@
 
 """Test for the leader_board example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/complete/game/user_score.py
+++ b/sdks/python/apache_beam/examples/complete/game/user_score.py
@@ -54,6 +54,7 @@ python user_score.py \
 """
 
 from __future__ import absolute_import
+from __future__ import division
 
 import argparse
 import csv
@@ -87,7 +88,7 @@ class ParseGameEventFn(beam.DoFn):
           'user': row[0],
           'team': row[1],
           'score': int(row[2]),
-          'timestamp': int(row[3]) / 1000.0,
+          'timestamp': int(row[3]) /1000.0,
       }
     except:  # pylint: disable=bare-except
       # Log and count parse errors

--- a/sdks/python/apache_beam/examples/complete/game/user_score_test.py
+++ b/sdks/python/apache_beam/examples/complete/game/user_score_test.py
@@ -17,6 +17,8 @@
 
 """Test for the user_score example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/complete/juliaset/__init__.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/complete/juliaset/juliaset/__init__.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/juliaset/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/complete/juliaset/juliaset/juliaset.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/juliaset/juliaset.py
@@ -21,8 +21,10 @@ We use the quadratic polinomial f(z) = z*z + c, with c = -.62772 +.42193i
 """
 
 from __future__ import absolute_import
+from __future__ import division
 
 import argparse
+from builtins import range
 
 import apache_beam as beam
 from apache_beam.io import WriteToText
@@ -70,7 +72,7 @@ def generate_julia_set_visualization(data, n, max_iterations):
 
   xy = np.zeros((n, n, 3), dtype=np.uint8)
   for x, y, iteration in data:
-    xy[x, y] = colors[iteration * len(colors) / max_iterations]
+    xy[x, y] = colors[iteration * len(colors) // max_iterations]
 
   return xy
 

--- a/sdks/python/apache_beam/examples/complete/juliaset/juliaset/juliaset_test.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/juliaset/juliaset_test.py
@@ -17,6 +17,8 @@
 
 """Test for the juliaset example."""
 
+from __future__ import absolute_import
+
 import logging
 import os
 import re

--- a/sdks/python/apache_beam/examples/complete/juliaset/juliaset_main.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/juliaset_main.py
@@ -47,6 +47,8 @@ python juliaset_main.py \
 
 """
 
+from __future__ import absolute_import
+
 import logging
 
 from apache_beam.examples.complete.juliaset.juliaset import juliaset

--- a/sdks/python/apache_beam/examples/complete/juliaset/setup.py
+++ b/sdks/python/apache_beam/examples/complete/juliaset/setup.py
@@ -24,6 +24,8 @@ then installed in the workers when they start running.
 This behavior is triggered by specifying the --setup_file command line option
 when running the workflow for remote execution.
 """
+
+from __future__ import absolute_import
 from __future__ import print_function
 
 import subprocess

--- a/sdks/python/apache_beam/examples/complete/tfidf.py
+++ b/sdks/python/apache_beam/examples/complete/tfidf.py
@@ -22,6 +22,7 @@ http://en.wikipedia.org/wiki/Tf-idf
 """
 
 from __future__ import absolute_import
+from __future__ import division
 
 import argparse
 import glob

--- a/sdks/python/apache_beam/examples/complete/tfidf_test.py
+++ b/sdks/python/apache_beam/examples/complete/tfidf_test.py
@@ -17,6 +17,8 @@
 
 """Test for the TF-IDF example."""
 
+from __future__ import absolute_import
+
 import logging
 import os
 import re

--- a/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions_test.py
+++ b/sdks/python/apache_beam/examples/complete/top_wikipedia_sessions_test.py
@@ -17,6 +17,8 @@
 
 """Test for the top wikipedia sessions example."""
 
+from __future__ import absolute_import
+
 import json
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/__init__.py
+++ b/sdks/python/apache_beam/examples/cookbook/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_side_input.py
@@ -27,8 +27,11 @@ Users should specify the number of groups to form and optionally a corpus and/or
 a word that should be ignored when forming groups.
 """
 
+from __future__ import absolute_import
+
 import argparse
 import logging
+from builtins import range
 from random import randrange
 
 import apache_beam as beam
@@ -46,7 +49,7 @@ def create_groups(group_ids, corpus, word, ignore_corpus, ignore_word):
     selected = None
     len_corpus = len(corpus)
     while not selected:
-      c = corpus[randrange(0, len_corpus - 1)].values()[0]
+      c = list(corpus[randrange(0, len_corpus - 1)].values())[0]
       if c != ignore:
         selected = c
 
@@ -56,7 +59,7 @@ def create_groups(group_ids, corpus, word, ignore_corpus, ignore_word):
     selected = None
     len_words = len(words)
     while not selected:
-      c = words[randrange(0, len_words - 1)].values()[0]
+      c = list(words[randrange(0, len_words - 1)].values())[0]
       if c != ignore:
         selected = c
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_side_input_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_side_input_test.py
@@ -17,6 +17,8 @@
 
 """Test for the BigQuery side input example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_it_test.py
@@ -17,9 +17,12 @@
 
 """End-to-end test for Bigquery tornadoes example."""
 
+from __future__ import absolute_import
+
 import logging
 import time
 import unittest
+from builtins import round
 
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr

--- a/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/bigquery_tornadoes_test.py
@@ -17,6 +17,8 @@
 
 """Test for the BigQuery tornadoes example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/coders.py
+++ b/sdks/python/apache_beam/examples/cookbook/coders.py
@@ -33,6 +33,7 @@ from __future__ import absolute_import
 import argparse
 import json
 import logging
+from builtins import object
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText

--- a/sdks/python/apache_beam/examples/cookbook/coders_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/coders_test.py
@@ -17,6 +17,8 @@
 
 """Test for the coders example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/combiners_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/combiners_test.py
@@ -23,6 +23,8 @@ The input data is generated simply with a Create transform and the output is
 checked directly on the last PCollection produced.
 """
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/custom_ptransform_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/custom_ptransform_test.py
@@ -17,6 +17,8 @@
 
 """Tests for the various custom Count implementation examples."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
+++ b/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
@@ -67,12 +67,12 @@ import argparse
 import logging
 import re
 import uuid
+from builtins import object
 
 from google.cloud.proto.datastore.v1 import entity_pb2
 from google.cloud.proto.datastore.v1 import query_pb2
 from googledatastore import helper as datastore_helper
 from googledatastore import PropertyFilter
-import six
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText
@@ -82,6 +82,11 @@ from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):
@@ -132,7 +137,7 @@ class EntityWrapper(object):
     datastore_helper.add_key_path(entity.key, self._kind, self._ancestor,
                                   self._kind, str(uuid.uuid4()))
 
-    datastore_helper.add_properties(entity, {"content": six.text_type(content)})
+    datastore_helper.add_properties(entity, {"content": unicode(content)})
     return entity
 
 
@@ -187,7 +192,7 @@ def read_from_datastore(user_options, pipeline_options):
 
   counts = (lines
             | 'split' >> (beam.ParDo(WordExtractingDoFn())
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
             | 'group' >> beam.GroupByKey()
             | 'count' >> beam.Map(count_ones))

--- a/sdks/python/apache_beam/examples/cookbook/filters_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/filters_test.py
@@ -17,6 +17,8 @@
 
 """Test for the filters example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 import argparse
 import logging
 import sys
+from builtins import object
 
 import apache_beam as beam
 from apache_beam import coders

--- a/sdks/python/apache_beam/examples/cookbook/group_with_coder_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/group_with_coder_test.py
@@ -17,6 +17,8 @@
 
 """Test for the custom coders example."""
 
+from __future__ import absolute_import
+
 import logging
 import tempfile
 import unittest

--- a/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
+++ b/sdks/python/apache_beam/examples/cookbook/mergecontacts.py
@@ -34,6 +34,7 @@ from __future__ import absolute_import
 import argparse
 import logging
 import re
+from builtins import next
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText

--- a/sdks/python/apache_beam/examples/cookbook/mergecontacts_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/mergecontacts_test.py
@@ -17,6 +17,8 @@
 
 """Test for the mergecontacts example."""
 
+from __future__ import absolute_import
+
 import logging
 import tempfile
 import unittest

--- a/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo_test.py
+++ b/sdks/python/apache_beam/examples/cookbook/multiple_output_pardo_test.py
@@ -17,6 +17,8 @@
 
 """Test for the multiple_output_pardo example."""
 
+from __future__ import absolute_import
+
 import logging
 import re
 import tempfile

--- a/sdks/python/apache_beam/examples/hourly_team_score_it_test.py
+++ b/sdks/python/apache_beam/examples/hourly_team_score_it_test.py
@@ -30,6 +30,8 @@ Usage:
 
 """
 
+from __future__ import absolute_import
+
 import logging
 import time
 import unittest

--- a/sdks/python/apache_beam/examples/leader_board_it_test.py
+++ b/sdks/python/apache_beam/examples/leader_board_it_test.py
@@ -30,10 +30,13 @@ Usage:
 
 """
 
+from __future__ import absolute_import
+
 import logging
 import time
 import unittest
 import uuid
+from builtins import range
 
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr
@@ -95,7 +98,7 @@ class LeaderBoardIT(unittest.TestCase):
     logging.debug('Injecting %d game events to topic %s',
                   message_count, topic.full_name)
 
-    for _ in xrange(message_count):
+    for _ in range(message_count):
       topic.publish(self.INPUT_EVENT % self._test_timestamp)
 
   def _cleanup_pubsub(self):

--- a/sdks/python/apache_beam/examples/snippets/__init__.py
+++ b/sdks/python/apache_beam/examples/snippets/__init__.py
@@ -14,3 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from __future__ import absolute_import

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -29,10 +29,12 @@ automatically in the web docs. The naming convention for the tags is to have as
 prefix the PATH_TO_HTML where they are included followed by a descriptive
 string. The tags can contain only letters, digits and _.
 """
+from __future__ import absolute_import
+from __future__ import division
 
 import argparse
-
-import six
+from builtins import object
+from builtins import range
 
 import apache_beam as beam
 from apache_beam.io import iobase
@@ -52,6 +54,11 @@ from apache_beam.transforms.core import PTransform
 # pylint:disable=reimported
 # pylint:disable=unused-variable
 # pylint:disable=wrong-import-order, wrong-import-position
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class SnippetUtils(object):
@@ -1048,7 +1055,7 @@ def model_datastoreio():
     entity = entity_pb2.Entity()
     googledatastore.helper.add_key_path(entity.key, kind, str(uuid.uuid4()))
     googledatastore.helper.add_properties(entity,
-                                          {'content': six.text_type(content)})
+                                          {'content': unicode(content)})
     return entity
 
   entities = musicians | 'To Entity' >> beam.Map(to_entity)

--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -17,6 +17,8 @@
 #
 
 """Tests for all code snippets used in public docs."""
+from __future__ import absolute_import
+from __future__ import division
 
 import glob
 import gzip
@@ -25,6 +27,10 @@ import os
 import tempfile
 import unittest
 import uuid
+from builtins import map
+from builtins import object
+from builtins import range
+from builtins import zip
 
 import mock
 

--- a/sdks/python/apache_beam/examples/streaming_wordcount.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount.py
@@ -23,14 +23,17 @@ from __future__ import absolute_import
 import argparse
 import logging
 
-import six
-
 import apache_beam as beam
 import apache_beam.transforms.window as window
 from apache_beam.examples.wordcount import WordExtractingDoFn
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 def run(argv=None):
@@ -72,7 +75,7 @@ def run(argv=None):
 
   counts = (lines
             | 'split' >> (beam.ParDo(WordExtractingDoFn())
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
             | beam.WindowInto(window.FixedWindows(15, 0))
             | 'group' >> beam.GroupByKey()

--- a/sdks/python/apache_beam/examples/streaming_wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_debugging.py
@@ -38,8 +38,6 @@ import argparse
 import logging
 import re
 
-import six
-
 import apache_beam as beam
 import apache_beam.transforms.window as window
 from apache_beam.examples.wordcount import WordExtractingDoFn
@@ -49,6 +47,11 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to_per_window
 from apache_beam.transforms.core import ParDo
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class PrintFn(beam.DoFn):
@@ -119,7 +122,7 @@ def run(argv=None):
             | 'AddTimestampFn' >> beam.ParDo(AddTimestampFn())
             | 'After AddTimestampFn' >> ParDo(PrintFn('After AddTimestampFn'))
             | 'Split' >> (beam.ParDo(WordExtractingDoFn())
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'PairWithOne' >> beam.Map(lambda x: (x, 1))
             | beam.WindowInto(window.FixedWindows(5, 0))
             | 'GroupByKey' >> beam.GroupByKey()

--- a/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
@@ -17,9 +17,12 @@
 
 """End-to-end test for the streaming wordcount example."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 import uuid
+from builtins import range
 
 from hamcrest.core.core.allof import all_of
 from nose.plugins.attrib import attr

--- a/sdks/python/apache_beam/examples/user_score_it_test.py
+++ b/sdks/python/apache_beam/examples/user_score_it_test.py
@@ -30,6 +30,8 @@ Usage:
 
 """
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 import uuid

--- a/sdks/python/apache_beam/examples/windowed_wordcount.py
+++ b/sdks/python/apache_beam/examples/windowed_wordcount.py
@@ -26,10 +26,13 @@ from __future__ import absolute_import
 import argparse
 import logging
 
-import six
-
 import apache_beam as beam
 import apache_beam.transforms.window as window
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 TABLE_SCHEMA = ('word:STRING, count:INTEGER, '
                 'window_start:TIMESTAMP, window_end:TIMESTAMP')
@@ -77,7 +80,7 @@ def run(argv=None):
 
     transformed = (lines
                    | 'Split' >> (beam.FlatMap(find_words)
-                                 .with_output_types(six.text_type))
+                                 .with_output_types(unicode))
                    | 'PairWithOne' >> beam.Map(lambda x: (x, 1))
                    | beam.WindowInto(window.FixedWindows(2*60, 0))
                    | 'Group' >> beam.GroupByKey()

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -23,8 +23,6 @@ import argparse
 import logging
 import re
 
-import six
-
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
@@ -32,6 +30,11 @@ from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):
@@ -96,7 +99,7 @@ def run(argv=None):
 
   counts = (lines
             | 'split' >> (beam.ParDo(WordExtractingDoFn())
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
             | 'group' >> beam.GroupByKey()
             | 'count' >> beam.Map(count_ones))

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -45,8 +45,6 @@ import argparse
 import logging
 import re
 
-import six
-
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
@@ -55,6 +53,11 @@ from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class FilterTextFn(beam.DoFn):
@@ -101,7 +104,7 @@ class CountWords(beam.PTransform):
 
     return (pcoll
             | 'split' >> (beam.FlatMap(lambda x: re.findall(r'[A-Za-z\']+', x))
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
             | 'group' >> beam.GroupByKey()
             | 'count' >> beam.Map(count_ones))

--- a/sdks/python/apache_beam/examples/wordcount_debugging_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging_test.py
@@ -17,6 +17,8 @@
 
 """Test for the debugging wordcount example."""
 
+from __future__ import absolute_import
+
 import logging
 import re
 import tempfile

--- a/sdks/python/apache_beam/examples/wordcount_fnapi.py
+++ b/sdks/python/apache_beam/examples/wordcount_fnapi.py
@@ -28,8 +28,6 @@ import argparse
 import logging
 import re
 
-import six
-
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 # TODO(BEAM-2887): Enable after the issue is fixed.
@@ -39,6 +37,11 @@ from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):
@@ -104,7 +107,7 @@ def run(argv=None):
 
   counts = (lines
             | 'split' >> (beam.ParDo(WordExtractingDoFn())
-                          .with_output_types(six.text_type))
+                          .with_output_types(unicode))
             | 'pair_with_one' >> beam.Map(lambda x: (x, 1))
             | 'group_and_sum' >> beam.CombinePerKey(sum))
 

--- a/sdks/python/apache_beam/examples/wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_it_test.py
@@ -17,6 +17,8 @@
 
 """End-to-end test for the wordcount example."""
 
+from __future__ import absolute_import
+
 import logging
 import time
 import unittest

--- a/sdks/python/apache_beam/examples/wordcount_minimal.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal.py
@@ -50,13 +50,16 @@ import argparse
 import logging
 import re
 
-import six
-
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
+
+try:
+  unicode           # pylint: disable=unicode-builtin
+except NameError:
+  unicode = str
 
 
 def run(argv=None):
@@ -103,7 +106,7 @@ def run(argv=None):
     counts = (
         lines
         | 'Split' >> (beam.FlatMap(lambda x: re.findall(r'[A-Za-z\']+', x))
-                      .with_output_types(six.text_type))
+                      .with_output_types(unicode))
         | 'PairWithOne' >> beam.Map(lambda x: (x, 1))
         | 'GroupAndSum' >> beam.CombinePerKey(sum))
 

--- a/sdks/python/apache_beam/examples/wordcount_minimal_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal_test.py
@@ -17,6 +17,8 @@
 
 """Test for the minimal wordcount example."""
 
+from __future__ import absolute_import
+
 import collections
 import logging
 import re
@@ -52,7 +54,7 @@ class WordCountMinimalTest(unittest.TestCase):
         match = re.search(r'([a-z]+): ([0-9]+)', line)
         if match is not None:
           results.append((match.group(1), int(match.group(2))))
-    self.assertEqual(sorted(results), sorted(expected_words.iteritems()))
+    self.assertEqual(sorted(results), sorted(expected_words.items()))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/examples/wordcount_test.py
+++ b/sdks/python/apache_beam/examples/wordcount_test.py
@@ -17,6 +17,8 @@
 
 """Test for the wordcount example."""
 
+from __future__ import absolute_import
+
 import collections
 import logging
 import re
@@ -51,7 +53,7 @@ class WordCountTest(unittest.TestCase):
         match = re.search(r'([a-z]+): ([0-9]+)', line)
         if match is not None:
           results.append((match.group(1), int(match.group(2))))
-    self.assertEqual(sorted(results), sorted(expected_words.iteritems()))
+    self.assertEqual(sorted(results), sorted(expected_words.items()))
 
 
 if __name__ == '__main__':

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -100,6 +100,7 @@ deps =
   flake8==3.5.0
 modules =
   apache_beam/coders
+  apache_beam/examples
   apache_beam/portability
   apache_beam/internal
   apache_beam/metrics


### PR DESCRIPTION
This pull request prepares the examples subpackage for Python 3 support. This PR is part of a series in which all subpackages will be updated using the same approach.
This approach has been documented [here ](https://docs.google.com/document/d/1xDG0MWVlDKDPu_IW9gtMvxi2S9I0GB0VDTkPhjXT0nE/edit#heading=h.5vrnrgpkrk89) and the first pull request in the series (Futurize coders subpackage) demonstrating this approach can be found at #5053.

R: @aaltay @tvalentyn @RobbeSneyders
