### PR TITLE
Upgrading python dependency on httplib2

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -100,7 +100,7 @@ REQUIRED_PACKAGES = [
     'dill==0.2.6',
     'grpcio>=1.8,<2',
     'hdfs>=2.1.0,<3.0.0',
-    'httplib2>=0.8,<0.10',
+    'httplib2>=0.8,<=0.11.3',
     'mock>=1.0.1,<3.0.0',
     'oauth2client>=2.0.1,<5',
     # grpcio 1.8.1 and above requires protobuf 3.5.0.post1.


### PR DESCRIPTION
Per dependency email, we need to upgrade the dependency on httplib2.

r: @chamikaramj 

![image](https://user-images.githubusercontent.com/1301740/41488686-1ff9d636-70a2-11e8-98bf-d61c51002a3a.png)
