### PR TITLE
[BEAM-BEAM-4573] Add framework for exhaustively checking SQL operator support

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -107,7 +107,7 @@ public class BeamSqlEnv {
     try {
       return planner.convertToBeamRel(query).toPTransform();
     } catch (ValidationException | RelConversionException | SqlParseException e) {
-      throw new ParseException("Unable to parse query", e);
+      throw new ParseException(String.format("Unable to parse query %s", query), e);
     }
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
@@ -18,10 +18,13 @@
 package org.apache.beam.sdk.extensions.sql;
 
 import org.apache.beam.sdk.extensions.sql.integrationtest.BeamSqlBuiltinFunctionsIntegrationTestBase;
+import org.apache.beam.sdk.schemas.Schema;
 import org.junit.Test;
 
-/** Integration test for string functions. */
-public class BeamSqlDslStringOperatorsTest extends BeamSqlBuiltinFunctionsIntegrationTestBase {
+/**
+ * DSL compliance tests for the operators of {@link org.apache.calcite.sql.fun.SqlStdOperatorTable}.
+ */
+public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegrationTestBase {
   @Test
   public void testStringFunctions() throws Exception {
     ExpressionChecker checker =
@@ -49,6 +52,27 @@ public class BeamSqlDslStringOperatorsTest extends BeamSqlBuiltinFunctionsIntegr
             .addExpr("SUBSTRING('hello' FROM 2 FOR 100)", "ello")
             .addExpr("SUBSTRING('hello' FROM -3 for 2)", "ll")
             .addExpr("UPPER('hello')", "HELLO");
+
+    checker.buildRunAndCheck();
+  }
+
+  @Test
+  @SqlOperatorTest({
+      "ARRAY",
+      "CARDINALITY",
+      "ELEMENT",
+  })
+  public void testArrayFunctions() {
+    ExpressionChecker checker =
+        new ExpressionChecker()
+            .addExpr(
+                "ARRAY []", ImmutableList.of(), Schema.FieldType.array(Schema.FieldType.BOOLEAN))
+            .addExpr(
+                "ARRAY ['a', 'b']",
+                ImmutableList.of('a', 'b'),
+                Schema.FieldType.array(Schema.FieldType.STRING))
+            .addExpr("CARDINALITY(ARRAY ['a', 'b', 'c'])", 3)
+            .addExpr("ELEMENT(ARRAY [1])", 1);
 
     checker.buildRunAndCheck();
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
@@ -17,16 +17,193 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Ordering;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.extensions.sql.integrationtest.BeamSqlBuiltinFunctionsIntegrationTestBase;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
- * DSL compliance tests for the operators of {@link org.apache.calcite.sql.fun.SqlStdOperatorTable}.
+ * DSL compliance tests for the row-level operators of {@link
+ * org.apache.calcite.sql.fun.SqlStdOperatorTable}.
  */
 public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegrationTestBase {
+
+  /** Calcite operators are identified by name and kind. */
+  @AutoValue
+  abstract static class SqlOperatorId {
+    abstract String name();
+
+    abstract SqlKind kind();
+  }
+
+  private static SqlOperatorId sqlOperatorId(String nameAndKind) {
+    return sqlOperatorId(nameAndKind, SqlKind.valueOf(nameAndKind));
+  }
+
+  private static SqlOperatorId sqlOperatorId(String name, SqlKind kind) {
+    return new AutoValue_BeamSqlDslSqlStdOperatorsTest_SqlOperatorId(name, kind);
+  }
+
+  private static SqlOperatorId sqlOperatorId(SqlOperatorTest annotation) {
+    return sqlOperatorId(annotation.name(), SqlKind.valueOf(annotation.kind()));
+  }
+
+  private static final List<SqlOperatorId> NON_ROW_OPERATORS =
+      ImmutableList.of(
+          sqlOperatorId("UNION"),
+          sqlOperatorId("UNION ALL", SqlKind.UNION),
+          sqlOperatorId("EXCEPT"),
+          sqlOperatorId("EXCEPT ALL", SqlKind.EXCEPT),
+          sqlOperatorId("INTERSECT"),
+          sqlOperatorId("INTERSECT ALL", SqlKind.INTERSECT));
+
+  /**
+   * LEGACY ADAPTER - DO NOT USE DIRECTLY. Use {@code getAnnotationsByType(SqlOperatorTest.class)},
+   * a more reliable method for retrieving repeated annotations.
+   *
+   * <p>This is a virtual annotation that is only present when there are more than one {@link
+   * SqlOperatorTest} annotations. When there is just one {@link SqlOperatorTest} annotation the
+   * proxying is not in place.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD})
+  private @interface SqlOperatorTests {
+    SqlOperatorTest[] value();
+  }
+
+  /**
+   * Annotation that declares a test method has the tests for the {@link SqlOperatorId}.
+   *
+   * <p>It is almost identical to {@link SqlOperatorId} but complex types cannot be part of
+   * annotations and there are minor benefits to having a non-annotation class for passing around
+   * the ids.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.METHOD})
+  @Repeatable(SqlOperatorTests.class)
+  private @interface SqlOperatorTest {
+    String name();
+
+    String kind();
+  }
+
+  private Set<SqlOperatorId> getTestedOperators() {
+    Set<SqlOperatorId> testedOperators = new HashSet<>();
+
+    for (Method method : getClass().getMethods()) {
+      testedOperators.addAll(
+          Arrays.stream(method.getAnnotationsByType(SqlOperatorTest.class))
+              .map(annotation -> sqlOperatorId(annotation))
+              .collect(Collectors.toList()));
+    }
+
+    return testedOperators;
+  }
+
+  private Set<SqlOperatorId> getDeclaredOperators() {
+    Set<SqlOperatorId> declaredOperators = new HashSet<>();
+
+    declaredOperators.addAll(
+        SqlStdOperatorTable.instance()
+            .getOperatorList()
+            .stream()
+            .map(operator -> sqlOperatorId(operator.getName(), operator.getKind()))
+            .collect(Collectors.toList()));
+
+    return declaredOperators;
+  }
+
+  private final Comparator<SqlOperatorId> orderByNameThenKind =
+      Ordering.compound(
+          ImmutableList.of(
+              Comparator.comparing((SqlOperatorId operator) -> operator.name()),
+              Comparator.comparing((SqlOperatorId operator) -> operator.kind())));
+
+  /** Smoke test that the whitelists and utility functions actually work. */
   @Test
-  public void testStringFunctions() throws Exception {
+  @SqlOperatorTest(name = "CARDINALITY", kind = "OTHER_FUNCTION")
+  public void testAnnotationEquality() throws Exception {
+    Method thisMethod = getClass().getMethod("testAnnotationEquality");
+    SqlOperatorTest sqlOperatorTest = thisMethod.getAnnotationsByType(SqlOperatorTest.class)[0];
+    assertThat(
+        sqlOperatorId(sqlOperatorTest),
+        equalTo(sqlOperatorId("CARDINALITY", SqlKind.OTHER_FUNCTION)));
+  }
+
+  /**
+   * Tests that all operators in {@link SqlStdOperatorTable} have DSL-level tests. Operators in the
+   * table are uniquely identified by (kind, name).
+   */
+  @Ignore("https://issues.apache.org/jira/browse/BEAM-4573")
+  @Test
+  public void testThatAllOperatorsAreTested() {
+    Set<SqlOperatorId> untestedOperators = new HashSet<>();
+    untestedOperators.addAll(getDeclaredOperators());
+
+    // Query-level operators need their own larger test suites
+    untestedOperators.removeAll(NON_ROW_OPERATORS);
+    untestedOperators.removeAll(getTestedOperators());
+
+    if (!untestedOperators.isEmpty()) {
+      // Sorting is just to make failures more readable until we have 100% coverage
+      List<SqlOperatorId> untestedList = Lists.newArrayList(untestedOperators);
+      untestedList.sort(orderByNameThenKind);
+      fail("No tests declared for operators:\n\t" + Joiner.on("\n\t").join(untestedList));
+    }
+  }
+
+  /**
+   * Tests that we didn't typo an annotation, that all things we claim to test are real operators.
+   */
+  @Test
+  public void testThatOperatorsExist() {
+    Set<SqlOperatorId> undeclaredOperators = new HashSet<>();
+    undeclaredOperators.addAll(getTestedOperators());
+    undeclaredOperators.removeAll(getDeclaredOperators());
+
+    if (!undeclaredOperators.isEmpty()) {
+      // Sorting is just to make failures more readable
+      List<SqlOperatorId> undeclaredList = Lists.newArrayList(undeclaredOperators);
+      undeclaredList.sort(orderByNameThenKind);
+      fail(
+          "Tests declared for nonexistent operators:\n\t" + Joiner.on("\n\t").join(undeclaredList));
+    }
+  }
+
+  @Test
+  @SqlOperatorTest(name = "CHARACTER_LENGTH", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "CHAR_LENGTH", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "INITCAP", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "LOWER", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "POSITION", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "OVERLAY", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "SUBSTRING", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "TRIM", kind = "TRIM")
+  @SqlOperatorTest(name = "UPPER", kind = "OTHER_FUNCTION")
+  public void testStringFunctions() {
     ExpressionChecker checker =
         new ExpressionChecker()
             .addExpr("'hello' || ' world'", "hello world")
@@ -57,19 +234,19 @@ public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegr
   }
 
   @Test
-  @SqlOperatorTest({
-      "ARRAY",
-      "CARDINALITY",
-      "ELEMENT",
-  })
+  @SqlOperatorTest(name = "ARRAY", kind = "ARRAY_VALUE_CONSTRUCTOR")
+  @SqlOperatorTest(name = "CARDINALITY", kind = "OTHER_FUNCTION")
+  @SqlOperatorTest(name = "ELEMENT", kind = "OTHER_FUNCTION")
   public void testArrayFunctions() {
     ExpressionChecker checker =
         new ExpressionChecker()
-            .addExpr(
-                "ARRAY []", ImmutableList.of(), Schema.FieldType.array(Schema.FieldType.BOOLEAN))
+            //            Calcite throws a parse error on this syntax for an empty array
+            //            .addExpr(
+            //                "ARRAY []", ImmutableList.of(),
+            // Schema.FieldType.array(Schema.FieldType.BOOLEAN))
             .addExpr(
                 "ARRAY ['a', 'b']",
-                ImmutableList.of('a', 'b'),
+                ImmutableList.of("a", "b"),
                 Schema.FieldType.array(Schema.FieldType.STRING))
             .addExpr("CARDINALITY(ARRAY ['a', 'b', 'c'])", 3)
             .addExpr("ELEMENT(ARRAY [1])", 1);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -18,6 +18,9 @@
 
 package org.apache.beam.sdk.extensions.sql.integrationtest;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -33,7 +36,6 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
-import org.apache.calcite.util.Pair;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.junit.Rule;
@@ -100,6 +102,22 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
     return DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC().parseDateTime(str);
   }
 
+  @AutoValue
+  abstract static class ExpressionTestCase {
+
+    private static ExpressionTestCase of(
+        String sqlExpr, Object expectedResult, FieldType resultFieldType) {
+      return new AutoValue_BeamSqlBuiltinFunctionsIntegrationTestBase_ExpressionTestCase(
+          sqlExpr, expectedResult, resultFieldType);
+    }
+
+    abstract String sqlExpr();
+
+    abstract Object expectedResult();
+
+    abstract FieldType resultFieldType();
+  }
+
   /**
    * Helper class to make write integration test for built-in functions easier.
    *
@@ -116,10 +134,22 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
    * }</pre>
    */
   public class ExpressionChecker {
-    private transient List<Pair<String, Object>> exps = new ArrayList<>();
+    private transient List<ExpressionTestCase> exps = new ArrayList<>();
 
     public ExpressionChecker addExpr(String expression, Object expectedValue) {
-      exps.add(Pair.of(expression, expectedValue));
+      // Because of erasure, we can only automatically infer non-parameterized types
+      TypeName resultTypeName = JAVA_CLASS_TO_TYPENAME.get(expectedValue.getClass());
+      checkArgument(
+          resultTypeName != null,
+          "Could not infer a Beam type for %s."
+              + " Parameterized types must be provided explicitly.");
+      addExpr(expression, expectedValue, FieldType.of(resultTypeName));
+      return this;
+    }
+
+    public ExpressionChecker addExpr(
+        String expression, Object expectedValue, FieldType resultFieldType) {
+      exps.add(ExpressionTestCase.of(expression, expectedValue, resultFieldType));
       return this;
     }
 
@@ -127,15 +157,11 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
     public void buildRunAndCheck() {
       PCollection<Row> inputCollection = getTestPCollection();
 
-      for (Pair<String, Object> testCase : exps) {
-        String expression = testCase.left;
-        Object expectedValue = testCase.right;
+      for (ExpressionTestCase testCase : exps) {
+        String expression = testCase.sqlExpr();
+        Object expectedValue = testCase.expectedResult();
         String sql = String.format("SELECT %s FROM PCOLLECTION", expression);
-        Schema schema =
-            Schema.builder()
-                .addField(
-                    expression, FieldType.of(JAVA_CLASS_TO_TYPENAME.get(expectedValue.getClass())))
-                .build();
+        Schema schema = Schema.builder().addField(expression, testCase.resultFieldType()).build();
 
         PCollection<Row> output =
             inputCollection.apply(testCase.toString(), SqlTransform.query(sql));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -40,7 +40,8 @@ import org.junit.Rule;
 
 /** Base class for all built-in functions integration tests. */
 public class BeamSqlBuiltinFunctionsIntegrationTestBase {
-  private static final Map<Class, TypeName> JAVA_CLASS_TO_FIELDTYPE =
+
+  private static final Map<Class, TypeName> JAVA_CLASS_TO_TYPENAME =
       ImmutableMap.<Class, TypeName>builder()
           .put(Byte.class, TypeName.BYTE)
           .put(Short.class, TypeName.INT16)
@@ -133,7 +134,7 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
         Schema schema =
             Schema.builder()
                 .addField(
-                    expression, FieldType.of(JAVA_CLASS_TO_FIELDTYPE.get(expectedValue.getClass())))
+                    expression, FieldType.of(JAVA_CLASS_TO_TYPENAME.get(expectedValue.getClass())))
                 .build();
 
         PCollection<Row> output =


### PR DESCRIPTION
This adds a test class intended to hold tests for all the row-level operators that we claim to support. I added a lightweight annotation just for this test class so that we can keep track of which operators are tested.

Currently I have added only the tests from our existing string operators and array operators. To make progress in small pieces, you can remove the `@Ignore` and add some that are missing. Many are probably not supported and some are query-level.

Here is the current output of the failure:

```
No tests declared for operators:
	SqlOperatorId{name=, kind=PATTERN_CONCAT}
	SqlOperatorId{name=$ELEMENT_SLICE, kind=OTHER}
	SqlOperatorId{name=$HISTOGRAM, kind=OTHER_FUNCTION}
	SqlOperatorId{name=$HISTOGRAM_FIRST_VALUE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=$HISTOGRAM_LAST_VALUE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=$HISTOGRAM_MAX, kind=OTHER_FUNCTION}
	SqlOperatorId{name=$HISTOGRAM_MIN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=$IS_DIFFERENT_FROM, kind=OTHER}
	SqlOperatorId{name=$LiteralChain, kind=LITERAL_CHAIN}
	SqlOperatorId{name=$SCALAR_QUERY, kind=SCALAR_QUERY}
	SqlOperatorId{name=$SLICE, kind=OTHER}
	SqlOperatorId{name=$SUM0, kind=SUM0}
	SqlOperatorId{name=$throw, kind=OTHER}
	SqlOperatorId{name=%, kind=MOD}
	SqlOperatorId{name=*, kind=TIMES}
	SqlOperatorId{name=+, kind=PLUS}
	SqlOperatorId{name=+, kind=PLUS_PREFIX}
	SqlOperatorId{name=-, kind=MINUS}
	SqlOperatorId{name=-, kind=MINUS_PREFIX}
	SqlOperatorId{name=/, kind=DIVIDE}
	SqlOperatorId{name=/INT, kind=DIVIDE}
	SqlOperatorId{name=<, kind=LESS_THAN}
	SqlOperatorId{name=< ALL, kind=ALL}
	SqlOperatorId{name=< SOME, kind=SOME}
	SqlOperatorId{name=<=, kind=LESS_THAN_OR_EQUAL}
	SqlOperatorId{name=<= ALL, kind=ALL}
	SqlOperatorId{name=<= SOME, kind=SOME}
	SqlOperatorId{name=<>, kind=NOT_EQUALS}
	SqlOperatorId{name=<> ALL, kind=ALL}
	SqlOperatorId{name=<> SOME, kind=SOME}
	SqlOperatorId{name==, kind=EQUALS}
	SqlOperatorId{name== ALL, kind=ALL}
	SqlOperatorId{name== SOME, kind=SOME}
	SqlOperatorId{name==>, kind=ARGUMENT_ASSIGNMENT}
	SqlOperatorId{name=>, kind=GREATER_THAN}
	SqlOperatorId{name=> ALL, kind=ALL}
	SqlOperatorId{name=> SOME, kind=SOME}
	SqlOperatorId{name=>=, kind=GREATER_THAN_OR_EQUAL}
	SqlOperatorId{name=>= ALL, kind=ALL}
	SqlOperatorId{name=>= SOME, kind=SOME}
	SqlOperatorId{name=ABS, kind=OTHER_FUNCTION}
	SqlOperatorId{name=ACOS, kind=OTHER_FUNCTION}
	SqlOperatorId{name=AND, kind=AND}
	SqlOperatorId{name=APPROX_COUNT_DISTINCT, kind=COUNT}
	SqlOperatorId{name=ARRAY, kind=ARRAY_QUERY_CONSTRUCTOR}
	SqlOperatorId{name=AS, kind=AS}
	SqlOperatorId{name=ASIN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=ATAN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=ATAN2, kind=OTHER_FUNCTION}
	SqlOperatorId{name=AVG, kind=AVG}
	SqlOperatorId{name=BETWEEN ASYMMETRIC, kind=BETWEEN}
	SqlOperatorId{name=BETWEEN SYMMETRIC, kind=BETWEEN}
	SqlOperatorId{name=CALL, kind=PROCEDURE_CALL}
	SqlOperatorId{name=CASE, kind=CASE}
	SqlOperatorId{name=CAST, kind=CAST}
	SqlOperatorId{name=CEIL, kind=CEIL}
	SqlOperatorId{name=CLASSIFIER, kind=CLASSIFIER}
	SqlOperatorId{name=COALESCE, kind=COALESCE}
	SqlOperatorId{name=COLLECT, kind=COLLECT}
	SqlOperatorId{name=COLUMN_LIST, kind=COLUMN_LIST}
	SqlOperatorId{name=CONTAINS, kind=CONTAINS}
	SqlOperatorId{name=CONVERT, kind=OTHER_FUNCTION}
	SqlOperatorId{name=COS, kind=OTHER_FUNCTION}
	SqlOperatorId{name=COT, kind=OTHER_FUNCTION}
	SqlOperatorId{name=COUNT, kind=COUNT}
	SqlOperatorId{name=COVAR_POP, kind=COVAR_POP}
	SqlOperatorId{name=COVAR_SAMP, kind=COVAR_SAMP}
	SqlOperatorId{name=CUBE, kind=CUBE}
	SqlOperatorId{name=CUME_DIST, kind=CUME_DIST}
	SqlOperatorId{name=CURRENT_CATALOG, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_DATE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_PATH, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_ROLE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_SCHEMA, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_TIME, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_TIMESTAMP, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_USER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=CURRENT_VALUE, kind=CURRENT_VALUE}
	SqlOperatorId{name=CURSOR, kind=CURSOR}
	SqlOperatorId{name=DATETIME_PLUS, kind=PLUS}
	SqlOperatorId{name=DAYOFMONTH, kind=OTHER}
	SqlOperatorId{name=DAYOFWEEK, kind=OTHER}
	SqlOperatorId{name=DAYOFYEAR, kind=OTHER}
	SqlOperatorId{name=DEFAULT, kind=DEFAULT}
	SqlOperatorId{name=DEGREES, kind=OTHER_FUNCTION}
	SqlOperatorId{name=DENSE_RANK, kind=DENSE_RANK}
	SqlOperatorId{name=DESC, kind=DESCENDING}
	SqlOperatorId{name=DOT, kind=DOT}
	SqlOperatorId{name=EQUALS, kind=PERIOD_EQUALS}
	SqlOperatorId{name=ESCAPE, kind=ESCAPE}
	SqlOperatorId{name=EXISTS, kind=EXISTS}
	SqlOperatorId{name=EXP, kind=OTHER_FUNCTION}
	SqlOperatorId{name=EXTEND, kind=EXTEND}
	SqlOperatorId{name=EXTRACT, kind=EXTRACT}
	SqlOperatorId{name=FILTER, kind=FILTER}
	SqlOperatorId{name=FINAL, kind=FINAL}
	SqlOperatorId{name=FIRST, kind=FIRST}
	SqlOperatorId{name=FIRST_VALUE, kind=FIRST_VALUE}
	SqlOperatorId{name=FLOOR, kind=FLOOR}
	SqlOperatorId{name=FUSION, kind=FUSION}
	SqlOperatorId{name=GROUPING, kind=GROUPING}
	SqlOperatorId{name=GROUPING SETS, kind=GROUPING_SETS}
	SqlOperatorId{name=GROUPING_ID, kind=GROUPING}
	SqlOperatorId{name=GROUP_ID, kind=GROUP_ID}
	SqlOperatorId{name=HOP, kind=HOP}
	SqlOperatorId{name=HOP_END, kind=HOP_END}
	SqlOperatorId{name=HOP_START, kind=HOP_START}
	SqlOperatorId{name=HOUR, kind=OTHER}
	SqlOperatorId{name=IMMEDIATELY PRECEDES, kind=IMMEDIATELY_PRECEDES}
	SqlOperatorId{name=IMMEDIATELY SUCCEEDS, kind=IMMEDIATELY_SUCCEEDS}
	SqlOperatorId{name=IN, kind=IN}
	SqlOperatorId{name=IN_FENNEL, kind=OTHER_FUNCTION}
	SqlOperatorId{name=IS A SET, kind=OTHER}
	SqlOperatorId{name=IS DISTINCT FROM, kind=IS_DISTINCT_FROM}
	SqlOperatorId{name=IS FALSE, kind=IS_FALSE}
	SqlOperatorId{name=IS NOT DISTINCT FROM, kind=IS_NOT_DISTINCT_FROM}
	SqlOperatorId{name=IS NOT FALSE, kind=IS_NOT_FALSE}
	SqlOperatorId{name=IS NOT NULL, kind=IS_NOT_NULL}
	SqlOperatorId{name=IS NOT TRUE, kind=IS_NOT_TRUE}
	SqlOperatorId{name=IS NOT UNKNOWN, kind=IS_NOT_NULL}
	SqlOperatorId{name=IS NULL, kind=IS_NULL}
	SqlOperatorId{name=IS TRUE, kind=IS_TRUE}
	SqlOperatorId{name=IS UNKNOWN, kind=IS_NULL}
	SqlOperatorId{name=ITEM, kind=OTHER_FUNCTION}
	SqlOperatorId{name=LAG, kind=LAG}
	SqlOperatorId{name=LAST, kind=LAST}
	SqlOperatorId{name=LAST_VALUE, kind=LAST_VALUE}
	SqlOperatorId{name=LATERAL, kind=LATERAL}
	SqlOperatorId{name=LEAD, kind=LEAD}
	SqlOperatorId{name=LIKE, kind=LIKE}
	SqlOperatorId{name=LN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=LOCALTIME, kind=OTHER_FUNCTION}
	SqlOperatorId{name=LOCALTIMESTAMP, kind=OTHER_FUNCTION}
	SqlOperatorId{name=LOG10, kind=OTHER_FUNCTION}
	SqlOperatorId{name=MAP, kind=MAP_VALUE_CONSTRUCTOR}
	SqlOperatorId{name=MAP, kind=MAP_QUERY_CONSTRUCTOR}
	SqlOperatorId{name=MATCH_NUMBER , kind=MATCH_NUMBER}
	SqlOperatorId{name=MAX, kind=MAX}
	SqlOperatorId{name=MEMBER OF, kind=OTHER}
	SqlOperatorId{name=MIN, kind=MIN}
	SqlOperatorId{name=MINUTE, kind=OTHER}
	SqlOperatorId{name=MOD, kind=MOD}
	SqlOperatorId{name=MONTH, kind=OTHER}
	SqlOperatorId{name=MULTISET, kind=MULTISET_VALUE_CONSTRUCTOR}
	SqlOperatorId{name=MULTISET, kind=MULTISET_QUERY_CONSTRUCTOR}
	SqlOperatorId{name=MULTISET EXCEPT, kind=OTHER}
	SqlOperatorId{name=MULTISET EXCEPT ALL, kind=OTHER}
	SqlOperatorId{name=MULTISET INTERSECT, kind=OTHER}
	SqlOperatorId{name=MULTISET INTERSECT ALL, kind=OTHER}
	SqlOperatorId{name=MULTISET UNION, kind=OTHER}
	SqlOperatorId{name=MULTISET UNION ALL, kind=OTHER}
	SqlOperatorId{name=NEW, kind=NEW_SPECIFICATION}
	SqlOperatorId{name=NEXT, kind=NEXT}
	SqlOperatorId{name=NEXT_VALUE, kind=NEXT_VALUE}
	SqlOperatorId{name=NOT, kind=NOT}
	SqlOperatorId{name=NOT BETWEEN ASYMMETRIC, kind=BETWEEN}
	SqlOperatorId{name=NOT BETWEEN SYMMETRIC, kind=BETWEEN}
	SqlOperatorId{name=NOT IN, kind=NOT_IN}
	SqlOperatorId{name=NOT LIKE, kind=LIKE}
	SqlOperatorId{name=NOT SIMILAR TO, kind=SIMILAR}
	SqlOperatorId{name=NTILE, kind=NTILE}
	SqlOperatorId{name=NULLIF, kind=NULLIF}
	SqlOperatorId{name=NULLS FIRST, kind=NULLS_FIRST}
	SqlOperatorId{name=NULLS LAST, kind=NULLS_LAST}
	SqlOperatorId{name=OR, kind=OR}
	SqlOperatorId{name=OVER, kind=OVER}
	SqlOperatorId{name=OVERLAPS, kind=OVERLAPS}
	SqlOperatorId{name=PATTERN_EXCLUDE, kind=PATTERN_EXCLUDED}
	SqlOperatorId{name=PATTERN_PERMUTE, kind=PATTERN_PERMUTE}
	SqlOperatorId{name=PATTERN_QUANTIFIER, kind=PATTERN_QUANTIFIER}
	SqlOperatorId{name=PERCENT_RANK, kind=PERCENT_RANK}
	SqlOperatorId{name=PI, kind=OTHER_FUNCTION}
	SqlOperatorId{name=POWER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=PRECEDES, kind=PRECEDES}
	SqlOperatorId{name=PREV, kind=PREV}
	SqlOperatorId{name=QUARTER, kind=OTHER}
	SqlOperatorId{name=RADIANS, kind=OTHER_FUNCTION}
	SqlOperatorId{name=RAND, kind=OTHER_FUNCTION}
	SqlOperatorId{name=RAND_INTEGER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=RANK, kind=RANK}
	SqlOperatorId{name=REGR_SXX, kind=REGR_SXX}
	SqlOperatorId{name=REGR_SYY, kind=REGR_SYY}
	SqlOperatorId{name=REPLACE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=ROLLUP, kind=ROLLUP}
	SqlOperatorId{name=ROUND, kind=OTHER_FUNCTION}
	SqlOperatorId{name=ROW, kind=ROW}
	SqlOperatorId{name=ROW_NUMBER, kind=ROW_NUMBER}
	SqlOperatorId{name=RUNNING, kind=RUNNING}
	SqlOperatorId{name=Reinterpret, kind=REINTERPRET}
	SqlOperatorId{name=SECOND, kind=OTHER}
	SqlOperatorId{name=SESSION, kind=SESSION}
	SqlOperatorId{name=SESSION_END, kind=SESSION_END}
	SqlOperatorId{name=SESSION_START, kind=SESSION_START}
	SqlOperatorId{name=SESSION_USER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=SIGN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=SIMILAR TO, kind=SIMILAR}
	SqlOperatorId{name=SIN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=SINGLE_VALUE, kind=SINGLE_VALUE}
	SqlOperatorId{name=SQRT, kind=OTHER_FUNCTION}
	SqlOperatorId{name=STDDEV, kind=STDDEV_SAMP}
	SqlOperatorId{name=STDDEV_POP, kind=STDDEV_POP}
	SqlOperatorId{name=STDDEV_SAMP, kind=STDDEV_SAMP}
	SqlOperatorId{name=SUBMULTISET OF, kind=OTHER}
	SqlOperatorId{name=SUCCEEDS, kind=SUCCEEDS}
	SqlOperatorId{name=SUM, kind=SUM}
	SqlOperatorId{name=SYSTEM_USER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=TABLE, kind=EXPLICIT_TABLE}
	SqlOperatorId{name=TABLE, kind=COLLECTION_TABLE}
	SqlOperatorId{name=TABLESAMPLE, kind=TABLESAMPLE}
	SqlOperatorId{name=TAN, kind=OTHER_FUNCTION}
	SqlOperatorId{name=TIMESTAMPADD, kind=TIMESTAMP_ADD}
	SqlOperatorId{name=TIMESTAMPDIFF, kind=TIMESTAMP_DIFF}
	SqlOperatorId{name=TRANSLATE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=TRUNCATE, kind=OTHER_FUNCTION}
	SqlOperatorId{name=TUMBLE, kind=TUMBLE}
	SqlOperatorId{name=TUMBLE_END, kind=TUMBLE_END}
	SqlOperatorId{name=TUMBLE_START, kind=TUMBLE_START}
	SqlOperatorId{name=UNNEST, kind=UNNEST}
	SqlOperatorId{name=USER, kind=OTHER_FUNCTION}
	SqlOperatorId{name=VALUES, kind=VALUES}
	SqlOperatorId{name=VARIANCE, kind=VAR_SAMP}
	SqlOperatorId{name=VAR_POP, kind=VAR_POP}
	SqlOperatorId{name=VAR_SAMP, kind=VAR_SAMP}
	SqlOperatorId{name=WEEK, kind=OTHER}
	SqlOperatorId{name=YEAR, kind=OTHER}
	SqlOperatorId{name=|, kind=PATTERN_ALTER}
	SqlOperatorId{name=||, kind=OTHER}
```

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
