### PR TITLE
[BEAM-4325] Enforce ErrorProne analysis in the SQL project

### DIFF
--- a/build_rules.gradle
+++ b/build_rules.gradle
@@ -335,25 +335,38 @@ ext.DEFAULT_SHADOW_CLOSURE = {
   }
 }
 
-// A class defining the set of configurable properties accepted by applyJavaNature
+/** A class defining the set of configurable properties accepted by applyJavaNature */
 class JavaNatureConfiguration {
-  double javaVersion = 1.8        // Controls the JDK source language and target compatibility
-  boolean enableFindbugs = true   // Controls whether the findbugs plugin is enabled and configured
-  boolean enableErrorProne = true // Controls whether the errorprone plugin is enabled and configured
-  boolean failOnWarning = false // Controls whether compiler warnings are treated as errors
-
+  /** Controls the JDK source language and target compatibility */
+  double javaVersion = 1.8
+  /** Controls whether the findbugs plugin is enabled and configured */
+  boolean enableFindbugs = true
+  /** Controls whether the errorprone plugin is enabled and configured */
+  boolean enableErrorProne = true
+  /** Controls whether compiler warnings are treated as errors */
+  boolean failOnWarning = false
+  /**
+   * List of additional lint warnings to disable.
+   * In addition, defaultLintSuppressions defined below
+   * will be applied to all projects.
+   */
+  List<String> disableLintWarnings = []
+  /** Controls whether spotless plugin enforces autoformat */
   //TODO(https://issues.apache.org/jira/browse/BEAM-4394): Should this default to true?
-  boolean enableSpotless = false // Controls whether spotless plugin enforces autoformat
-  boolean testShadowJar = false  // Controls whether tests are run with shadowJar
+  boolean enableSpotless = false
+  /** Controls whether tests are run with shadowJar */
+  boolean testShadowJar = false
 
-  // The shadowJar / shadowTestJar tasks execute the following closure to configure themselves.
-  // Users can compose their closure with the default closure via:
-  // DEFAULT_SHADOW_CLOSURE << {
-  //    dependencies {
-  //      include(...)
-  //    }
-  //    relocate(...)
-  // }
+  /**
+   * The shadowJar / shadowTestJar tasks execute the following closure to configure themselves.
+   * Users can compose their closure with the default closure via:
+   * DEFAULT_SHADOW_CLOSURE << {
+   *    dependencies {
+   *      include(...)
+   *    }
+   *    relocate(...)
+   * }
+   */
   Closure shadowClosure;
 }
 
@@ -417,8 +430,22 @@ ext.applyJavaNature = {
   sourceCompatibility = configuration.javaVersion
   targetCompatibility = configuration.javaVersion
   tasks.withType(JavaCompile) {
+    def defaultLintSuppressions = [
+      'options',
+      'cast',
+      'deprecation',
+      'processing',
+      'rawtypes',
+      'serial',
+      'try',
+      'unchecked',
+      'varargs',
+    ]
+
     options.encoding = "UTF-8"
-    options.compilerArgs += ["-Xlint:all","-Xlint:-options","-Xlint:-cast","-Xlint:-deprecation","-Xlint:-processing","-Xlint:-rawtypes","-Xlint:-serial","-Xlint:-try","-Xlint:-unchecked","-Xlint:-varargs","-parameters"]
+    options.compilerArgs += ['-parameters', '-Xlint:all'] + (
+      defaultLintSuppressions + configuration.disableLintWarnings
+    ).collect { "-Xlint:-${it}" }
     if (configuration.enableErrorProne) {
       options.compilerArgs += [
         "-XepDisableWarningsInGeneratedCode",

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -19,16 +19,22 @@ import groovy.json.JsonOutput
  */
 
 apply from: project(":").file("build_rules.gradle")
-applyJavaNature(enableSpotless: true, testShadowJar: true, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
-  dependencies {
-    include(dependency(library.java.protobuf_java))
-    include(dependency(library.java.protobuf_java_util))
-    include(dependency("org.apache.calcite:.*"))
-    include(dependency("org.apache.calcite.avatica:.*"))
-    include(dependency("org.codehaus.janino:.*"))
-  }
-  relocate "com.google.protobuf", getJavaRelocatedPath("com.google.protobuf")
-  relocate "org.apache.calcite", getJavaRelocatedPath("org.apache.calcite")
+applyJavaNature(
+  enableSpotless: true,
+  failOnWarning: true,
+  // javacc generated code produces lint warnings
+  disableLintWarnings: ['dep-ann'],
+  testShadowJar: true,
+  shadowClosure: DEFAULT_SHADOW_CLOSURE << {
+    dependencies {
+      include(dependency(library.java.protobuf_java))
+      include(dependency(library.java.protobuf_java_util))
+      include(dependency("org.apache.calcite:.*"))
+      include(dependency("org.apache.calcite.avatica:.*"))
+      include(dependency("org.codehaus.janino:.*"))
+    }
+    relocate "com.google.protobuf", getJavaRelocatedPath("com.google.protobuf")
+    relocate "org.apache.calcite", getJavaRelocatedPath("org.apache.calcite")
 
   // Looking up the compiler factory in Calcite depends on having a properties
   // file in the right location. We package one that is shading compatible

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlBinaryOperator.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlBinaryOperator.java
@@ -23,11 +23,13 @@ import java.util.List;
 
 /** An operator that is applied to already-evaluated arguments. */
 public interface BeamSqlBinaryOperator extends BeamSqlOperator {
+  @Override
   default BeamSqlPrimitive apply(List<BeamSqlPrimitive> arguments) {
     checkArgument(arguments.size() == 2, "Unary operator %s received more than one argument", this);
     return apply(arguments.get(0), arguments.get(1));
   }
 
+  @Override
   default boolean accept(List<BeamSqlExpression> arguments) {
     return arguments.size() == 2 && accept(arguments.get(0), arguments.get(1));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCaseExpression.java
@@ -26,6 +26,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 
 /** {@code BeamSqlCaseExpression} represents CASE, NULLIF, COALESCE in SQL. */
 public class BeamSqlCaseExpression extends BeamSqlExpression {
+
   public BeamSqlCaseExpression(List<BeamSqlExpression> operands) {
     // the return type of CASE is the type of the `else` condition
     super(operands, operands.get(operands.size() - 1).getOutputType());
@@ -53,7 +54,7 @@ public class BeamSqlCaseExpression extends BeamSqlExpression {
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
     for (int i = 0; i < operands.size() - 1; i += 2) {
-      Boolean wasOpEvaluated = opValueEvaluated(i, inputRow, window, env);
+      Boolean wasOpEvaluated = (Boolean) opValueEvaluated(i, inputRow, window, env);
       if (wasOpEvaluated != null && wasOpEvaluated) {
         return BeamSqlPrimitive.of(outputType, opValueEvaluated(i + 1, inputRow, window, env));
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlCastExpression.java
@@ -80,19 +80,19 @@ public class BeamSqlCastExpression extends BeamSqlExpression {
       case BOOLEAN:
         return BeamSqlPrimitive.of(
             SqlTypeName.BOOLEAN,
-            SqlFunctions.toBoolean((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toBoolean(opValueEvaluated(index, inputRow, window, env)));
       case INTEGER:
         return BeamSqlPrimitive.of(
             SqlTypeName.INTEGER,
-            SqlFunctions.toInt((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toInt(opValueEvaluated(index, inputRow, window, env)));
       case DOUBLE:
         return BeamSqlPrimitive.of(
             SqlTypeName.DOUBLE,
-            SqlFunctions.toDouble((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toDouble(opValueEvaluated(index, inputRow, window, env)));
       case SMALLINT:
         return BeamSqlPrimitive.of(
             SqlTypeName.SMALLINT,
-            SqlFunctions.toShort((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toShort(opValueEvaluated(index, inputRow, window, env)));
       case TINYINT:
         return BeamSqlPrimitive.of(
             SqlTypeName.TINYINT,
@@ -100,28 +100,29 @@ public class BeamSqlCastExpression extends BeamSqlExpression {
       case BIGINT:
         return BeamSqlPrimitive.of(
             SqlTypeName.BIGINT,
-            SqlFunctions.toLong((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toLong(opValueEvaluated(index, inputRow, window, env)));
       case DECIMAL:
         return BeamSqlPrimitive.of(
             SqlTypeName.DECIMAL,
-            SqlFunctions.toBigDecimal((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toBigDecimal(opValueEvaluated(index, inputRow, window, env)));
       case FLOAT:
         return BeamSqlPrimitive.of(
             SqlTypeName.FLOAT,
-            SqlFunctions.toFloat((Object) opValueEvaluated(index, inputRow, window, env)));
+            SqlFunctions.toFloat(opValueEvaluated(index, inputRow, window, env)));
       case CHAR:
       case VARCHAR:
         return BeamSqlPrimitive.of(
-            SqlTypeName.VARCHAR, opValueEvaluated(index, inputRow, window, env).toString());
+            SqlTypeName.VARCHAR, (String) opValueEvaluated(index, inputRow, window, env));
       case DATE:
         return BeamSqlPrimitive.of(
             SqlTypeName.DATE, toDate(opValueEvaluated(index, inputRow, window, env)));
       case TIMESTAMP:
         return BeamSqlPrimitive.of(
             SqlTypeName.TIMESTAMP, toTimeStamp(opValueEvaluated(index, inputRow, window, env)));
+      default:
+        throw new UnsupportedOperationException(
+            String.format("Cast to type %s not supported", castOutputType));
     }
-    throw new UnsupportedOperationException(
-        String.format("Cast to type %s not supported", castOutputType));
   }
 
   private ReadableInstant toDate(Object inputDate) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlDotExpression.java
@@ -43,8 +43,8 @@ public class BeamSqlDotExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    Row dynamicRow = opValueEvaluated(0, inputRow, window, env);
-    String fieldName = opValueEvaluated(1, inputRow, window, env);
+    Row dynamicRow = (Row) opValueEvaluated(0, inputRow, window, env);
+    String fieldName = (String) opValueEvaluated(1, inputRow, window, env);
     SqlTypeName fieldType = getFieldType(dynamicRow, fieldName);
 
     return BeamSqlPrimitive.of(fieldType, dynamicRow.getValue(fieldName));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlExpression.java
@@ -50,9 +50,9 @@ public abstract class BeamSqlExpression implements Serializable {
     return op(idx).getOutputType();
   }
 
-  public <T> T opValueEvaluated(
+  public Object opValueEvaluated(
       int idx, Row row, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    return (T) op(idx).evaluate(row, window, env).getValue();
+    return op(idx).evaluate(row, window, env).getValue();
   }
 
   /** assertion to make sure the input and output are supported in this expression. */

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUdfExpression.java
@@ -80,7 +80,7 @@ public class BeamSqlUdfExpression extends BeamSqlExpression {
       }
       method = Class.forName(className).getMethod(methodName, paraClass.toArray(new Class<?>[] {}));
       if (!Modifier.isStatic(method.getModifiers())) {
-        udfIns = Class.forName(className).newInstance();
+        udfIns = Class.forName(className).getDeclaredConstructor().newInstance();
       }
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUnaryOperator.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlUnaryOperator.java
@@ -24,11 +24,13 @@ import java.util.List;
 /** An operator that is applied to already-evaluated arguments. */
 public interface BeamSqlUnaryOperator extends BeamSqlOperator {
 
+  @Override
   default BeamSqlPrimitive apply(List<BeamSqlPrimitive> arguments) {
     checkArgument(arguments.size() == 1, "Unary operator %s received more than one argument", this);
     return apply(arguments.get(0));
   }
 
+  @Override
   default boolean accept(List<BeamSqlExpression> arguments) {
     return arguments.size() == 1 && accept(arguments.get(0));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/StringOperators.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/StringOperators.java
@@ -28,6 +28,7 @@ public class StringOperators {
 
   /** A {@link BeamSqlOperator} that returns a string. */
   public interface StringOperator extends BeamSqlOperator {
+    @Override
     default SqlTypeName getOutputType() {
       return SqlTypeName.VARCHAR;
     }
@@ -35,10 +36,13 @@ public class StringOperators {
 
   @FunctionalInterface
   private interface StringUnaryOperator extends BeamSqlUnaryOperator {
+
+    @Override
     default boolean accept(BeamSqlExpression arg) {
       return SqlTypeName.CHAR_TYPES.contains(arg.getOutputType());
     }
 
+    @Override
     default SqlTypeName getOutputType() {
       return SqlTypeName.VARCHAR;
     }
@@ -190,10 +194,10 @@ public class StringOperators {
                   && SqlTypeName.CHAR_TYPES.contains(operands.get(1).getOutputType())
                   && SqlTypeName.INT_TYPES.contains(operands.get(2).getOutputType()))
               || (operands.size() == 4
-                      && SqlTypeName.CHAR_TYPES.contains(operands.get(0).getOutputType())
-                      && SqlTypeName.CHAR_TYPES.contains(operands.get(1).getOutputType())
-                      && SqlTypeName.INT_TYPES.contains(operands.get(2).getOutputType()))
-                  && SqlTypeName.INT_TYPES.contains(operands.get(3).getOutputType());
+                  && SqlTypeName.CHAR_TYPES.contains(operands.get(0).getOutputType())
+                  && SqlTypeName.CHAR_TYPES.contains(operands.get(1).getOutputType())
+                  && SqlTypeName.INT_TYPES.contains(operands.get(2).getOutputType())
+                  && SqlTypeName.INT_TYPES.contains(operands.get(3).getOutputType()));
         }
 
         @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/arithmetic/BeamSqlArithmeticExpression.java
@@ -56,10 +56,8 @@ public abstract class BeamSqlArithmeticExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive<? extends Number> evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    BigDecimal left =
-        SqlFunctions.toBigDecimal((Object) opValueEvaluated(0, inputRow, window, env));
-    BigDecimal right =
-        SqlFunctions.toBigDecimal((Object) opValueEvaluated(1, inputRow, window, env));
+    BigDecimal left = SqlFunctions.toBigDecimal(opValueEvaluated(0, inputRow, window, env));
+    BigDecimal right = SqlFunctions.toBigDecimal(opValueEvaluated(1, inputRow, window, env));
 
     BigDecimal result = calc(left, right);
     return getCorrectlyTypedResult(result);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/array/BeamSqlArrayItemExpression.java
@@ -41,8 +41,8 @@ public class BeamSqlArrayItemExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    List<Object> array = opValueEvaluated(0, inputRow, window, env);
-    Integer index = opValueEvaluated(1, inputRow, window, env);
+    List<Object> array = (List) opValueEvaluated(0, inputRow, window, env);
+    Integer index = (Integer) opValueEvaluated(1, inputRow, window, env);
 
     return BeamSqlPrimitive.of(outputType, array.get(index));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlCardinalityExpression.java
@@ -44,7 +44,7 @@ public class BeamSqlCardinalityExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    Collection<Object> collection = opValueEvaluated(0, inputRow, window, env);
+    Collection<Object> collection = (Collection) opValueEvaluated(0, inputRow, window, env);
     return BeamSqlPrimitive.of(outputType, collection.size());
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/collection/BeamSqlSingleElementExpression.java
@@ -46,7 +46,7 @@ public class BeamSqlSingleElementExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    Collection<Object> collection = opValueEvaluated(0, inputRow, window, env);
+    Collection<Object> collection = (Collection) opValueEvaluated(0, inputRow, window, env);
 
     if (collection.size() <= 1) {
       return (collection.size() == 0)

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateCeilExpression.java
@@ -48,9 +48,9 @@ public class BeamSqlDateCeilExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    ReadableInstant date = opValueEvaluated(0, inputRow, window, env);
+    ReadableInstant date = (ReadableInstant) opValueEvaluated(0, inputRow, window, env);
     long time = date.getMillis();
-    TimeUnitRange unit = opValueEvaluated(1, inputRow, window, env);
+    TimeUnitRange unit = (TimeUnitRange) opValueEvaluated(1, inputRow, window, env);
 
     long newTime = DateTimeUtils.unixTimestampCeil(unit, time);
     DateTime newDate = new DateTime(newTime, date.getZone());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateFloorExpression.java
@@ -48,9 +48,9 @@ public class BeamSqlDateFloorExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    ReadableInstant date = opValueEvaluated(0, inputRow, window, env);
+    ReadableInstant date = (ReadableInstant) opValueEvaluated(0, inputRow, window, env);
     long time = date.getMillis();
-    TimeUnitRange unit = opValueEvaluated(1, inputRow, window, env);
+    TimeUnitRange unit = (TimeUnitRange) opValueEvaluated(1, inputRow, window, env);
 
     long newTime = DateTimeUtils.unixTimestampFloor(unit, time);
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlExtractExpression.java
@@ -61,9 +61,9 @@ public class BeamSqlExtractExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    ReadableInstant time = opValueEvaluated(1, inputRow, window, env);
+    ReadableInstant time = (ReadableInstant) opValueEvaluated(1, inputRow, window, env);
 
-    TimeUnitRange unit = opValueEvaluated(0, inputRow, window, env);
+    TimeUnitRange unit = (TimeUnitRange) opValueEvaluated(0, inputRow, window, env);
 
     switch (unit) {
       case YEAR:

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
@@ -59,7 +59,7 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row row, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    DateTime date = new DateTime((Object) opValueEvaluated(0, row, window, env));
+    DateTime date = new DateTime(opValueEvaluated(0, row, window, env));
     Period period = intervalToPeriod(op(1).evaluate(row, window, env));
 
     return BeamSqlPrimitive.of(outputType, date.minus(period));

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
@@ -71,8 +71,8 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    DateTime timestampStart = new DateTime((Object) opValueEvaluated(1, inputRow, window, env));
-    DateTime timestampEnd = new DateTime((Object) opValueEvaluated(0, inputRow, window, env));
+    DateTime timestampStart = new DateTime(opValueEvaluated(1, inputRow, window, env));
+    DateTime timestampEnd = new DateTime(opValueEvaluated(0, inputRow, window, env));
 
     long numberOfIntervals = numberOfIntervalsBetweenDates(timestampStart, timestampEnd);
     long multiplier = TimeUnitUtils.timeUnitInternalMultiplier(intervalType).longValue();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/logical/BeamSqlNotExpression.java
@@ -39,7 +39,7 @@ public class BeamSqlNotExpression extends BeamSqlLogicalExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    Boolean value = opValueEvaluated(0, inputRow, window, env);
+    Boolean value = (Boolean) opValueEvaluated(0, inputRow, window, env);
     if (value == null) {
       return BeamSqlPrimitive.of(SqlTypeName.BOOLEAN, window);
     } else {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/map/BeamSqlMapItemExpression.java
@@ -42,7 +42,7 @@ public class BeamSqlMapItemExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    Map<Object, Object> map = opValueEvaluated(0, inputRow, window, env);
+    Map<Object, Object> map = (Map) opValueEvaluated(0, inputRow, window, env);
     Object key = opValueEvaluated(1, inputRow, window, env);
     return BeamSqlPrimitive.of(outputType, map.get(key));
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandExpression.java
@@ -45,7 +45,7 @@ public class BeamSqlRandExpression extends BeamSqlExpression {
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
     if (operands.size() == 1) {
-      int rowSeed = opValueEvaluated(0, inputRow, window, env);
+      int rowSeed = (Integer) opValueEvaluated(0, inputRow, window, env);
       if (seed == null || seed != rowSeed) {
         rand.setSeed(rowSeed);
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/math/BeamSqlRandIntegerExpression.java
@@ -46,7 +46,7 @@ public class BeamSqlRandIntegerExpression extends BeamSqlExpression {
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
     int numericIdx = 0;
     if (operands.size() == 2) {
-      int rowSeed = opValueEvaluated(0, inputRow, window, env);
+      int rowSeed = (Integer) opValueEvaluated(0, inputRow, window, env);
       if (seed == null || seed != rowSeed) {
         rand.setSeed(rowSeed);
       }
@@ -54,6 +54,6 @@ public class BeamSqlRandIntegerExpression extends BeamSqlExpression {
     }
     return BeamSqlPrimitive.of(
         SqlTypeName.INTEGER,
-        rand.nextInt((int) opValueEvaluated(numericIdx, inputRow, window, env)));
+        rand.nextInt((Integer) opValueEvaluated(numericIdx, inputRow, window, env)));
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/row/BeamSqlFieldAccessExpression.java
@@ -61,7 +61,7 @@ public class BeamSqlFieldAccessExpression extends BeamSqlExpression {
     } else {
       throw new IllegalArgumentException(
           "Attempt to access field of unsupported type "
-              + targetFieldType.getClass().getSimpleName()
+              + targetFieldType.getDeclaringClass().getSimpleName()
               + ". Field access operator is only supported for arrays or rows");
     }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
@@ -57,6 +57,7 @@ public class BeamSetOperatorRelBase extends PTransform<PCollectionList<Row>, PCo
     this.all = all;
   }
 
+  @Override
   public PCollection<Row> expand(PCollectionList<Row> inputs) {
     checkArgument(
         inputs.size() == 2,

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTable.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql.meta.provider.kafka;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.sdk.extensions.sql.impl.schema.BeamTableUtils.beamRow2CsvLine;
 import static org.apache.beam.sdk.extensions.sql.impl.schema.BeamTableUtils.csvLine2BeamRow;
 
@@ -73,7 +74,7 @@ public class BeamKafkaCSVTable extends BeamKafkaTable {
               new DoFn<KV<byte[], byte[]>, Row>() {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
-                  String rowInString = new String(c.element().getValue());
+                  String rowInString = new String(c.element().getValue(), UTF_8);
                   c.output(csvLine2BeamRow(format, rowInString, schema));
                 }
               }));
@@ -100,7 +101,7 @@ public class BeamKafkaCSVTable extends BeamKafkaTable {
                 @ProcessElement
                 public void processElement(ProcessContext c) {
                   Row in = c.element();
-                  c.output(KV.of(new byte[] {}, beamRow2CsvLine(in, format).getBytes()));
+                  c.output(KV.of(new byte[] {}, beamRow2CsvLine(in, format).getBytes(UTF_8)));
                 }
               }));
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
@@ -33,7 +33,7 @@ import org.apache.commons.csv.CSVFormat;
  */
 public class BeamTextCSVTable extends BeamTextTable {
 
-  private String filePattern;
+  private String csvFilePattern;
   private CSVFormat csvFormat;
 
   /** CSV table with {@link CSVFormat#DEFAULT DEFAULT} format. */
@@ -41,9 +41,9 @@ public class BeamTextCSVTable extends BeamTextTable {
     this(beamSchema, filePattern, CSVFormat.DEFAULT);
   }
 
-  public BeamTextCSVTable(Schema schema, String filePattern, CSVFormat csvFormat) {
-    super(schema, filePattern);
-    this.filePattern = filePattern;
+  public BeamTextCSVTable(Schema schema, String csvFilePattern, CSVFormat csvFormat) {
+    super(schema, csvFilePattern);
+    this.csvFilePattern = csvFilePattern;
     this.csvFormat = csvFormat;
   }
 
@@ -63,7 +63,7 @@ public class BeamTextCSVTable extends BeamTextTable {
     return csvFormat;
   }
 
-  public String getFilePattern() {
-    return filePattern;
+  public String getCsvFilePattern() {
+    return csvFilePattern;
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMapTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlMapTest.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.sql;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -60,25 +60,10 @@ public class BeamSqlMapTest {
     PAssert.that(result)
         .containsInAnyOrder(
             Row.withSchema(resultType)
-                .addValues(
-                    1,
-                    new HashMap<String, Integer>() {
-                      {
-                        put("key11", 11);
-                        put("key22", 22);
-                      }
-                    })
+                .addValues(1, ImmutableMap.of("key11", 11, "key22", 22))
                 .build(),
             Row.withSchema(resultType)
-                .addValues(
-                    2,
-                    new HashMap<String, Integer>() {
-                      {
-                        put("key33", 33);
-                        put("key44", 44);
-                        put("key55", 55);
-                      }
-                    })
+                .addValues(2, ImmutableMap.of("key33", 33, "key44", 44, "key55", 55))
                 .build());
 
     pipeline.run();
@@ -100,24 +85,8 @@ public class BeamSqlMapTest {
 
     PAssert.that(result)
         .containsInAnyOrder(
-            Row.withSchema(resultType)
-                .addValues(
-                    42,
-                    new HashMap<String, Integer>() {
-                      {
-                        put("aa", 1);
-                      }
-                    })
-                .build(),
-            Row.withSchema(resultType)
-                .addValues(
-                    42,
-                    new HashMap<String, Integer>() {
-                      {
-                        put("aa", 1);
-                      }
-                    })
-                .build());
+            Row.withSchema(resultType).addValues(42, ImmutableMap.of("aa", 1)).build(),
+            Row.withSchema(resultType).addValues(42, ImmutableMap.of("aa", 1)).build());
 
     pipeline.run();
   }
@@ -148,24 +117,11 @@ public class BeamSqlMapTest {
             Create.of(
                     Row.withSchema(INPUT_ROW_TYPE)
                         .addValues(1)
-                        .addValue(
-                            new HashMap<String, Integer>() {
-                              {
-                                put("key11", 11);
-                                put("key22", 22);
-                              }
-                            })
+                        .addValue(ImmutableMap.of("key11", 11, "key22", 22))
                         .build(),
                     Row.withSchema(INPUT_ROW_TYPE)
                         .addValues(2)
-                        .addValue(
-                            new HashMap<String, Integer>() {
-                              {
-                                put("key33", 33);
-                                put("key44", 44);
-                                put("key55", 55);
-                              }
-                            })
+                        .addValue(ImmutableMap.of("key33", 33, "key44", 44, "key55", 55))
                         .build())
                 .withCoder(INPUT_ROW_TYPE.getRowCoder()));
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.beam.sdk.extensions.sql.meta.provider.kafka;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.Serializable;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
@@ -86,7 +88,7 @@ public class BeamKafkaCSVTableTest {
       implements Serializable {
     @ProcessElement
     public void processElement(ProcessContext ctx) {
-      ctx.output(KV.of(new byte[] {}, ctx.element().getBytes()));
+      ctx.output(KV.of(new byte[] {}, ctx.element().getBytes(UTF_8)));
     }
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.UncheckedIOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -150,7 +151,7 @@ public class BeamTextCSVTableTest {
         printer.println();
       }
     } catch (IOException e) {
-      e.printStackTrace();
+      throw new UncheckedIOException(e);
     }
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
@@ -49,7 +49,7 @@ public class TextTableProviderTest {
 
     BeamTextCSVTable csvTable = (BeamTextCSVTable) sqlTable;
     assertEquals(CSVFormat.DEFAULT, csvTable.getCsvFormat());
-    assertEquals("/home/admin/hello", csvTable.getFilePattern());
+    assertEquals("/home/admin/hello", csvTable.getCsvFilePattern());
   }
 
   @Test


### PR DESCRIPTION
Adds the following:
- `Xlint:-dep-ann` to compiler options because generated code by javacc has `deprecated` in the javadoc but not marked on the method itself.
- Enables `failOnWarning`
- Changes signature of `opValueEvaluated` to explicitly pass the `Class` to cast in order to avoid the [TypeParameterUnusedInFormals](http://errorprone.info/bugpattern/TypeParameterUnusedInFormals) ErrorProne warning.