### PR TITLE
Adding Shuffle Mode option to Dataflow Pipeline Options

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
@@ -131,12 +131,23 @@ public interface DataflowPipelineOptions
   void setPipelineUrl(String urlString);
 
   /**
+   * Enumeration of the possible shuffle modes.
+   */
+  enum ShuffleMode {
+    AUTO,
+    SERVICE,
+    APPLIANCE
+  }
+
+  /**
    * The mode used for shuffle: appliance (e.g. shuffling in-between the workers)
    * or "service" (e.g. workers shuffle their data into a shuffle service).
    */
-  @Description("The shuffle mode to use for this pipeline [appliance/service/auto]")
-  String getShuffleMode();
-  void setShuffleMode(String shuffleModeString);
+  @Validation.Required
+  @Description("The shuffle mode to use for this pipeline [APPLIANCE/SERVICE]")
+  @Default.Enum("AUTO")
+  ShuffleMode getShuffleMode();
+  void setShuffleMode(ShuffleMode shuffleMode);
 
   /**
    * Returns a default staging location under {@link GcpOptions#getGcpTempLocation}.

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
@@ -131,6 +131,14 @@ public interface DataflowPipelineOptions
   void setPipelineUrl(String urlString);
 
   /**
+   * The mode used for shuffle: appliance (e.g. shuffling in-between the workers)
+   * or "service" (e.g. workers shuffle their data into a shuffle service).
+   */
+  @Description("The shuffle mode to use for this pipeline [appliance/service/auto]")
+  String getShuffleMode();
+  void setShuffleMode(String shuffleModeString);
+
+  /**
    * Returns a default staging location under {@link GcpOptions#getGcpTempLocation}.
    */
   class StagingLocationFactory implements DefaultValueFactory<String> {

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
@@ -169,6 +169,20 @@ public class DataflowPipelineOptionsTest {
   }
 
   @Test
+  public void testShuffleModeDefault() {
+    DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
+    assertEquals(null, options.getShuffleMode());
+  }
+
+  @Test
+  public void testShuffleModeOption() {
+    DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
+    options.setShuffleMode("service");
+    assertEquals("service", options.getShuffleMode());
+  }
+
+
+  @Test
   public void testDefaultInvalidGcpTempLocation() {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
     options.setGcpTempLocation("file://temp_location");

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
@@ -171,14 +171,20 @@ public class DataflowPipelineOptionsTest {
   @Test
   public void testShuffleModeDefault() {
     DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    assertEquals(null, options.getShuffleMode());
+    assertEquals("AUTO", options.getShuffleMode().toString());
   }
 
   @Test
   public void testShuffleModeOption() {
-    DataflowPipelineOptions options = PipelineOptionsFactory.as(DataflowPipelineOptions.class);
-    options.setShuffleMode("service");
-    assertEquals("service", options.getShuffleMode());
+    DataflowPipelineOptions serviceOptions = PipelineOptionsFactory.as(
+        DataflowPipelineOptions.class);
+    options.setShuffleMode("SERVICE");
+    assertEquals("SERVICE", serviceOptions.getShuffleMode().toString());
+
+    DataflowPipelineOptions applianceOptions = PipelineOptionsFactory.as(
+        DataflowPipelineOptions.class);
+    applianceOptions.setShuffleMode("APPLIANCE");
+    assertEquals("APPLIANCE", applianceOptions.getShuffleMode().toString());
   }
 
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptionsTest.java
@@ -178,12 +178,12 @@ public class DataflowPipelineOptionsTest {
   public void testShuffleModeOption() {
     DataflowPipelineOptions serviceOptions = PipelineOptionsFactory.as(
         DataflowPipelineOptions.class);
-    options.setShuffleMode("SERVICE");
+    serviceOptions.setShuffleMode(DataflowPipelineOptions.ShuffleMode.SERVICE);
     assertEquals("SERVICE", serviceOptions.getShuffleMode().toString());
 
     DataflowPipelineOptions applianceOptions = PipelineOptionsFactory.as(
         DataflowPipelineOptions.class);
-    applianceOptions.setShuffleMode("APPLIANCE");
+    applianceOptions.setShuffleMode(DataflowPipelineOptions.ShuffleMode.APPLIANCE);
     assertEquals("APPLIANCE", applianceOptions.getShuffleMode().toString());
   }
 

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -384,7 +384,7 @@ class GoogleCloudOptions(PipelineOptions):
     # service).
     parser.add_argument(
         '--shuffle_mode', default=None,
-        help='The shuffle mode for this pipeline ["appliance"/"service"')
+        help='The shuffle mode for this pipeline ["APPLIANCE"/"SERVICE"]')
 
   def validate(self, validator):
     errors = []
@@ -399,6 +399,9 @@ class GoogleCloudOptions(PipelineOptions):
       if self.view_as(GoogleCloudOptions).template_location:
         errors.append('--dataflow_job_file and --template_location '
                       'are mutually exclusive.')
+    if self.view_as(GoogleCloudOptions).shuffle_mode is not None:
+      errors.extend(
+          validator.validate_shuffle_mode(self.view_as(GoogleCloudOptions)))
 
     return errors
 

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -379,6 +379,13 @@ class GoogleCloudOptions(PipelineOptions):
         help='Labels that will be applied to this Dataflow job. Labels are key '
         'value pairs separated by = (e.g. --label key=value).')
 
+    # The mode used for shuffle: appliance (e.g. shuffling in-between the
+    # workers) or "service" (e.g. workers shuffle their data into a shuffle
+    # service).
+    parser.add_argument(
+        '--shuffle_mode', default=None,
+        help='The shuffle mode for this pipeline ["appliance"/"service"')
+
   def validate(self, validator):
     errors = []
     if validator.is_service_runner():

--- a/sdks/python/apache_beam/options/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator.py
@@ -75,6 +75,10 @@ class PipelineOptionsValidator(object):
   ERR_INVALID_TEST_MATCHER_UNPICKLABLE = (
       'Invalid value (%s) for option: %s. Please make sure the test matcher '
       'is unpicklable.')
+  ERR_INVALID_SHUFFLE_MODE = (
+      'Invalid shuffle mode: %s. Please provide a valid shuffle mode ('
+      'AUTO, APPLIANCE, SERVICE), or none at all for default.')
+
 
   # GCS path specific patterns.
   GCS_URI = '(?P<SCHEME>[^:]+)://(?P<BUCKET>[^/]+)(/(?P<OBJECT>.*))?'
@@ -86,6 +90,9 @@ class PipelineOptionsValidator(object):
   PROJECT_ID_PATTERN = '[a-z][-a-z0-9:.]+[a-z0-9]'
   PROJECT_NUMBER_PATTERN = '[0-9]*'
   ENDPOINT_PATTERN = r'https://[\S]*googleapis\.com[/]?'
+
+  # Shuffle Mode valid input
+  SHUFFLE_MODE_OPTIONS = set(["SERVICE", "APPLIANCE", "AUTO"])
 
   def __init__(self, options, runner):
     self.options = options
@@ -152,6 +159,13 @@ class PipelineOptionsValidator(object):
       return self._validate_error(self.ERR_INVALID_GCS_OBJECT, arg, arg_name)
 
     return []
+
+  def validate_shuffle_mode(self, view):
+    errors = []
+    if view.shuffle_mode not in self.SHUFFLE_MODE_OPTIONS:
+      errors.extend(self._validate_error(self.ERR_INVALID_SHUFFLE_MODE,
+                                         view.shuffle_mode))
+    return errors
 
   def validate_cloud_options(self, view):
     """Validates job_name and project arguments."""

--- a/sdks/python/apache_beam/options/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator.py
@@ -79,7 +79,6 @@ class PipelineOptionsValidator(object):
       'Invalid shuffle mode: %s. Please provide a valid shuffle mode ('
       'AUTO, APPLIANCE, SERVICE), or none at all for default.')
 
-
   # GCS path specific patterns.
   GCS_URI = '(?P<SCHEME>[^:]+)://(?P<BUCKET>[^/]+)(/(?P<OBJECT>.*))?'
   GCS_BUCKET = '^[a-z0-9][-_a-z0-9.]+[a-z0-9]$'

--- a/sdks/python/apache_beam/options/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator_test.py
@@ -311,7 +311,6 @@ class SetupTest(unittest.TestCase):
       else:
         self.assertFalse(errors)
 
-
   def test_validate_dataflow_job_file(self):
     runner = MockRunners.OtherRunner()
     options = PipelineOptions([

--- a/sdks/python/apache_beam/options/pipeline_options_validator_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator_test.py
@@ -295,6 +295,23 @@ class SetupTest(unittest.TestCase):
     errors = validator.validate()
     self.assertFalse(errors)
 
+  def test_validate_shuffle_mode(self):
+    for value, errors in [('SERVICE', False),
+                          ('APPLIANCE', False),
+                          ('AUTO', False),
+                          ('OTHER', True)]:
+      runner = MockRunners.OtherRunner()
+      options = PipelineOptions([
+          '--shuffle_mode', value
+      ])
+      validator = PipelineOptionsValidator(options, runner)
+      errors = validator.validate()
+      if errors:
+        self.assertNotEqual([], errors)
+      else:
+        self.assertFalse(errors)
+
+
   def test_validate_dataflow_job_file(self):
     runner = MockRunners.OtherRunner()
     options = PipelineOptions([


### PR DESCRIPTION
This option will be used by the Dataflow service to determine which shuffle mode to run the pipeline with.