### PR TITLE
[BEAM-4575] Cleanly transform graph from Calcite to Beam SQL

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.ParseException;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamEnumerableConverter;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.meta.store.MetaStore;
 import org.apache.beam.sdk.options.PipelineOptions;
 
@@ -58,7 +59,7 @@ public class BeamSqlCli {
           BeamEnumerableConverter.createPipelineOptions(env.getPipelineOptions());
       options.setJobName("BeamPlanCreator");
       Pipeline pipeline = Pipeline.create(options);
-      env.parseQuery(pipeline, sqlString);
+      BeamSqlRelUtils.toPCollection(pipeline, env.parseQuery(sqlString));
       pipeline.run();
     }
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlCli.java
@@ -24,7 +24,6 @@ import org.apache.beam.sdk.extensions.sql.impl.ParseException;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamEnumerableConverter;
 import org.apache.beam.sdk.extensions.sql.meta.store.MetaStore;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.values.PCollectionTuple;
 
 /** {@link BeamSqlCli} provides methods to execute Beam SQL with an interactive client. */
 @Experimental
@@ -59,7 +58,7 @@ public class BeamSqlCli {
           BeamEnumerableConverter.createPipelineOptions(env.getPipelineOptions());
       options.setJobName("BeamPlanCreator");
       Pipeline pipeline = Pipeline.create(options);
-      PCollectionTuple.empty(pipeline).apply(env.parseQuery(sqlString));
+      env.parseQuery(pipeline, sqlString);
       pipeline.run();
     }
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/BeamSqlTable.java
@@ -18,20 +18,19 @@
 
 package org.apache.beam.sdk.extensions.sql;
 
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 
 /** This interface defines a Beam Sql Table. */
 public interface BeamSqlTable {
-  /** create a {@code PCollection<BeamSqlRow>} from source. */
-  PCollection<Row> buildIOReader(Pipeline pipeline);
+  /** create a {@code PCollection<Row>} from source. */
+  PCollection<Row> buildIOReader(PBegin begin);
 
   /** create a {@code IO.write()} instance to write to target. */
-  PTransform<? super PCollection<Row>, POutput> buildIOWriter();
+  POutput buildIOWriter(PCollection<Row> input);
 
   /** Get the schema info of the table. */
   Schema getSchema();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
@@ -92,7 +92,7 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
 
     registerFunctions(sqlEnv);
 
-    return PCollectionTuple.empty(input.getPipeline()).apply(sqlEnv.parseQuery(queryString()));
+    return sqlEnv.parseQuery(input.getPipeline(), queryString());
   }
 
   private Map<String, BeamSqlTable> toTableMap(PInput inputs) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/SqlTransform.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamPCollectionTable;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -92,7 +93,7 @@ public abstract class SqlTransform extends PTransform<PInput, PCollection<Row>> 
 
     registerFunctions(sqlEnv);
 
-    return sqlEnv.parseQuery(input.getPipeline(), queryString());
+    return BeamSqlRelUtils.toPCollection(input.getPipeline(), sqlEnv.parseQuery(queryString()));
   }
 
   private Map<String, BeamSqlTable> toTableMap(PInput inputs) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -18,19 +18,19 @@
 package org.apache.beam.sdk.extensions.sql.impl;
 
 import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.BeamSqlUdf;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.UdafImpl;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.apache.beam.sdk.transforms.Combine;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.CalcitePrepare;
@@ -103,10 +103,9 @@ public class BeamSqlEnv {
     defaultSchema.add(functionName, new UdafImpl(combineFn));
   }
 
-  public PTransform<PCollectionTuple, PCollection<Row>> parseQuery(String query)
-      throws ParseException {
+  public PCollection<Row> parseQuery(Pipeline pipeline, String query) throws ParseException {
     try {
-      return planner.convertToBeamRel(query).toPTransform();
+      return BeamSqlRelUtils.toPCollection(pipeline, planner.convertToBeamRel(query));
     } catch (ValidationException | RelConversionException | SqlParseException e) {
       throw new ParseException(String.format("Unable to parse query %s", query), e);
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/BeamSqlEnv.java
@@ -18,20 +18,17 @@
 package org.apache.beam.sdk.extensions.sql.impl;
 
 import java.util.Map;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.BeamSqlUdf;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.UdafImpl;
-import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamRelNode;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.jdbc.CalciteConnection;
 import org.apache.calcite.jdbc.CalcitePrepare;
 import org.apache.calcite.jdbc.CalciteSchema;
@@ -103,9 +100,9 @@ public class BeamSqlEnv {
     defaultSchema.add(functionName, new UdafImpl(combineFn));
   }
 
-  public PCollection<Row> parseQuery(Pipeline pipeline, String query) throws ParseException {
+  public BeamRelNode parseQuery(String query) throws ParseException {
     try {
-      return BeamSqlRelUtils.toPCollection(pipeline, planner.convertToBeamRel(query));
+      return planner.convertToBeamRel(query);
     } catch (ValidationException | RelConversionException | SqlParseException e) {
       throw new ParseException(String.format("Unable to parse query %s", query), e);
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -39,7 +39,7 @@ import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.calcite.plan.RelOptCluster;
@@ -73,19 +73,17 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      RelNode input = getInput();
+    public PCollection<Row> expand(PInput pinput) {
       String stageName = BeamSqlRelUtils.getStageName(BeamAggregationRel.this) + "_";
 
-      PCollection<Row> upstream =
-          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+      PCollection<Row> upstream = (PCollection<Row>) pinput;
       if (windowField.isPresent()) {
         upstream =
             upstream

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -62,15 +62,12 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
 
     @Override
     public PCollection<Row> expand(PInput pinput) {
-      String stageName = BeamSqlRelUtils.getStageName(BeamCalcRel.this);
-
       PCollection<Row> upstream = (PCollection<Row>) pinput;
 
       BeamSqlExpressionExecutor executor = new BeamSqlFnExecutor(BeamCalcRel.this.getProgram());
 
       PCollection<Row> projectStream =
-          upstream.apply(
-              stageName, ParDo.of(new CalcFn(executor, CalciteUtils.toBeamSchema(rowType))));
+          upstream.apply(ParDo.of(new CalcFn(executor, CalciteUtils.toBeamSchema(rowType))));
       projectStream.setCoder(CalciteUtils.toBeamSchema(getRowType()).getRowCoder());
 
       return projectStream;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -33,7 +33,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -54,19 +54,17 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      RelNode input = getInput();
+    public PCollection<Row> expand(PInput pinput) {
       String stageName = BeamSqlRelUtils.getStageName(BeamCalcRel.this);
 
-      PCollection<Row> upstream =
-          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+      PCollection<Row> upstream = (PCollection<Row>) pinput;
 
       BeamSqlExpressionExecutor executor = new BeamSqlFnExecutor(BeamCalcRel.this.getProgram());
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -37,7 +37,6 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
@@ -119,7 +118,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
   private static PipelineResult run(
       PipelineOptions options, BeamRelNode node, DoFn<Row, Void> doFn) {
     Pipeline pipeline = Pipeline.create(options);
-    PCollectionTuple.empty(pipeline).apply(node.toPTransform()).apply(ParDo.of(doFn));
+    BeamSqlRelUtils.toPCollection(pipeline, node).apply(ParDo.of(doFn));
     PipelineResult result = pipeline.run();
     result.waitUntilFinish();
     return result;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
@@ -104,19 +104,13 @@ public class BeamIOSinkRel extends TableModify
 
   private class Transform extends PTransform<PInput, PCollection<Row>> {
 
-    /**
-     * Note that {@code BeamIOSinkRel} returns the input PCollection, which is the persisted
-     * PCollection.
-     */
     @Override
     public PCollection<Row> expand(PInput pinput) {
-      String stageName = BeamSqlRelUtils.getStageName(BeamIOSinkRel.this);
+      PCollection<Row> input = (PCollection<Row>) pinput;
 
-      PCollection<Row> upstream = (PCollection<Row>) pinput;
+      sqlTable.buildIOWriter(input);
 
-      upstream.apply(stageName, sqlTable.buildIOWriter());
-
-      return upstream;
+      return input;
     }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
@@ -22,7 +22,7 @@ import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamIOSinkRule;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptPlanner;
@@ -98,23 +98,21 @@ public class BeamIOSinkRel extends TableModify
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     /**
      * Note that {@code BeamIOSinkRel} returns the input PCollection, which is the persisted
      * PCollection.
      */
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      RelNode input = getInput();
+    public PCollection<Row> expand(PInput pinput) {
       String stageName = BeamSqlRelUtils.getStageName(BeamIOSinkRel.this);
 
-      PCollection<Row> upstream =
-          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+      PCollection<Row> upstream = (PCollection<Row>) pinput;
 
       upstream.apply(stageName, sqlTable.buildIOWriter());
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
@@ -51,8 +52,8 @@ public class BeamIOSourceRel extends TableScan implements BeamRelNode {
   private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PInput inputPCollections) {
-      return sqlTable.buildIOReader(inputPCollections.getPipeline());
+    public PCollection<Row> expand(PInput input) {
+      return sqlTable.buildIOReader((PBegin) input);
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
@@ -44,14 +44,14 @@ public class BeamIOSourceRel extends TableScan implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
+    public PCollection<Row> expand(PInput inputPCollections) {
       return sqlTable.buildIOReader(inputPCollections.getPipeline());
     }
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRel.java
@@ -21,7 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 import java.util.List;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -36,13 +36,9 @@ import org.apache.calcite.rel.core.SetOp;
  * statement that are identical to a row in the second SELECT statement.
  */
 public class BeamIntersectRel extends Intersect implements BeamRelNode {
-  private BeamSetOperatorRelBase delegate;
-
   public BeamIntersectRel(
       RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
     super(cluster, traits, inputs, all);
-    delegate =
-        new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.INTERSECT, inputs, all);
   }
 
   @Override
@@ -51,15 +47,7 @@ public class BeamIntersectRel extends Intersect implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
-    return new Transform();
-  }
-
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
-
-    @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      return delegate.buildBeamPipeline(inputPCollections);
-    }
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
+    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.INTERSECT, all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
@@ -118,13 +118,13 @@ public class BeamJoinRel extends Join implements BeamRelNode {
   }
 
   @Override
-  public PInput buildPInput(Pipeline pipeline) {
+  public PInput buildPInput(Pipeline pipeline, Map<Integer, PCollection<Row>> cache) {
     BeamRelNode leftRelNode = BeamSqlRelUtils.getBeamRelInput(left);
     BeamRelNode rightRelNode = BeamSqlRelUtils.getBeamRelInput(right);
     if (!seekable(leftRelNode) && seekable(rightRelNode)) {
-      return BeamSqlRelUtils.toPCollection(pipeline, leftRelNode);
+      return BeamSqlRelUtils.toPCollection(pipeline, leftRelNode, cache);
     }
-    return BeamRelNode.super.buildPInput(pipeline);
+    return BeamRelNode.super.buildPInput(pipeline, cache);
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
@@ -21,7 +21,7 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 import java.util.List;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -36,12 +36,9 @@ import org.apache.calcite.rel.core.SetOp;
  */
 public class BeamMinusRel extends Minus implements BeamRelNode {
 
-  private BeamSetOperatorRelBase delegate;
-
   public BeamMinusRel(
       RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
     super(cluster, traits, inputs, all);
-    delegate = new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.MINUS, inputs, all);
   }
 
   @Override
@@ -50,15 +47,7 @@ public class BeamMinusRel extends Minus implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
-    return new Transform();
-  }
-
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
-
-    @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      return delegate.buildBeamPipeline(inputPCollections);
-    }
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
+    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.MINUS, all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
@@ -17,20 +17,37 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.rel.RelNode;
 
 /** A {@link RelNode} that can also give a {@link PTransform} that implements the expression. */
 public interface BeamRelNode extends RelNode {
-  /**
-   * A {@link BeamRelNode} is a recursive structure, the {@code BeamQueryPlanner} visits it with a
-   * DFS(Depth-First-Search) algorithm.
-   */
-  PTransform<PCollectionTuple, PCollection<Row>> toPTransform();
+
+  /** Transforms the inputs into a PInput. */
+  default PInput buildPInput(Pipeline pipeline) {
+    List<RelNode> inputs = getInputs();
+    if (inputs.size() == 0) {
+      return pipeline.begin();
+    }
+    List<PCollection<Row>> pInputs = new ArrayList(inputs.size());
+    for (RelNode input : inputs) {
+      pInputs.add(BeamSqlRelUtils.toPCollection(pipeline, (BeamRelNode) input));
+    }
+    if (pInputs.size() == 1) {
+      return pInputs.get(0);
+    }
+    return PCollectionList.of(pInputs);
+  }
+
+  PTransform<PInput, PCollection<Row>> buildPTransform();
 
   /** Perform a DFS(Depth-First-Search) to find the PipelineOptions config. */
   default Map<String, String> getPipelineOptions() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
@@ -32,14 +32,14 @@ import org.apache.calcite.rel.RelNode;
 public interface BeamRelNode extends RelNode {
 
   /** Transforms the inputs into a PInput. */
-  default PInput buildPInput(Pipeline pipeline) {
+  default PInput buildPInput(Pipeline pipeline, Map<Integer, PCollection<Row>> cache) {
     List<RelNode> inputs = getInputs();
     if (inputs.size() == 0) {
       return pipeline.begin();
     }
     List<PCollection<Row>> pInputs = new ArrayList(inputs.size());
     for (RelNode input : inputs) {
-      pInputs.add(BeamSqlRelUtils.toPCollection(pipeline, (BeamRelNode) input));
+      pInputs.add(BeamSqlRelUtils.toPCollection(pipeline, (BeamRelNode) input, cache));
     }
     if (pInputs.size() == 1) {
       return pInputs.get(0);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
@@ -78,17 +78,16 @@ public class BeamSetOperatorRelBase extends PTransform<PInput, PCollection<Row>>
     final TupleTag<Row> rightTag = new TupleTag<>();
 
     // co-group
-    String stageName = BeamSqlRelUtils.getStageName(beamRelNode);
     PCollection<KV<Row, CoGbkResult>> coGbkResultCollection =
         KeyedPCollectionTuple.of(
                 leftTag,
                 leftRows.apply(
-                    stageName + "_CreateLeftIndex",
+                    "CreateLeftIndex",
                     MapElements.via(new BeamSetOperatorsTransforms.BeamSqlRow2KvFn())))
             .and(
                 rightTag,
                 rightRows.apply(
-                    stageName + "_CreateRightIndex",
+                    "CreateRightIndex",
                     MapElements.via(new BeamSetOperatorsTransforms.BeamSqlRow2KvFn())))
             .apply(CoGroupByKey.create());
     PCollection<Row> ret =

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperatorRelBase.java
@@ -19,9 +19,9 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.io.Serializable;
-import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.transform.BeamSetOperatorsTransforms;
 import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
@@ -29,16 +29,16 @@ import org.apache.beam.sdk.transforms.join.KeyedPCollectionTuple;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.calcite.rel.RelNode;
 
 /**
  * Delegate for Set operators: {@code BeamUnionRel}, {@code BeamIntersectRel} and {@code
  * BeamMinusRel}.
  */
-public class BeamSetOperatorRelBase {
+public class BeamSetOperatorRelBase extends PTransform<PInput, PCollection<Row>> {
   /** Set operator type. */
   public enum OpType implements Serializable {
     UNION,
@@ -47,25 +47,20 @@ public class BeamSetOperatorRelBase {
   }
 
   private BeamRelNode beamRelNode;
-  private List<RelNode> inputs;
   private boolean all;
   private OpType opType;
 
-  public BeamSetOperatorRelBase(
-      BeamRelNode beamRelNode, OpType opType, List<RelNode> inputs, boolean all) {
+  public BeamSetOperatorRelBase(BeamRelNode beamRelNode, OpType opType, boolean all) {
     this.beamRelNode = beamRelNode;
     this.opType = opType;
-    this.inputs = inputs;
     this.all = all;
   }
 
-  public PCollection<Row> buildBeamPipeline(PCollectionTuple inputPCollections) {
-    PCollection<Row> leftRows =
-        inputPCollections.apply(
-            "left", BeamSqlRelUtils.getBeamRelInput(inputs.get(0)).toPTransform());
-    PCollection<Row> rightRows =
-        inputPCollections.apply(
-            "right", BeamSqlRelUtils.getBeamRelInput(inputs.get(1)).toPTransform());
+  public PCollection<Row> expand(PInput pinput) {
+    PCollectionList<Row> inputs = (PCollectionList<Row>) pinput;
+    assert inputs.size() == 2;
+    PCollection<Row> leftRows = inputs.get(0);
+    PCollection<Row> rightRows = inputs.get(1);
 
     WindowFn leftWindow = leftRows.getWindowingStrategy().getWindowFn();
     WindowFn rightWindow = rightRows.getWindowingStrategy().getWindowFn();

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -34,7 +34,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Top;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -121,17 +121,15 @@ public class BeamSortRel extends Sort implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      RelNode input = getInput();
-      PCollection<Row> upstream =
-          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+    public PCollection<Row> expand(PInput pinput) {
+      PCollection<Row> upstream = (PCollection<Row>) pinput;
       Type windowType =
           upstream.getWindowingStrategy().getWindowFn().getWindowTypeDescriptor().getType();
       if (!windowType.equals(GlobalWindow.class)) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
@@ -30,20 +30,13 @@ import org.apache.calcite.rel.RelNode;
 public class BeamSqlRelUtils {
   private static final AtomicInteger sequence = new AtomicInteger(0);
 
-  public static String getStageName(BeamRelNode relNode) {
-    return relNode.getClass().getSimpleName()
-        + "_"
-        + relNode.getId()
-        + "_"
-        + sequence.getAndIncrement();
-  }
-
   /**
    * A {@link BeamRelNode} is a recursive structure, the {@code BeamQueryPlanner} visits it with a
    * DFS(Depth-First-Search) algorithm.
    */
   public static PCollection<Row> toPCollection(Pipeline pipeline, BeamRelNode node) {
-    String name = BeamSqlRelUtils.getStageName(node);
+    String name =
+        node.getClass().getSimpleName() + "_" + node.getId() + "_" + sequence.getAndIncrement();
     PInput input = node.buildPInput(pipeline);
     PTransform<PInput, PCollection<Row>> transform = node.buildPTransform();
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
@@ -51,8 +51,6 @@ public class BeamUncollectRel extends Uncollect implements BeamRelNode {
   private class Transform extends PTransform<PInput, PCollection<Row>> {
     @Override
     public PCollection<Row> expand(PInput pinput) {
-      String stageName = BeamSqlRelUtils.getStageName(BeamUncollectRel.this);
-
       PCollection<Row> upstream = (PCollection<Row>) pinput;
 
       // Each row of the input contains a single array of things to be emitted; Calcite knows
@@ -61,7 +59,7 @@ public class BeamUncollectRel extends Uncollect implements BeamRelNode {
 
       PCollection<Row> uncollected =
           upstream
-              .apply(stageName, ParDo.of(new UncollectDoFn(outputSchema)))
+              .apply(ParDo.of(new UncollectDoFn(outputSchema)))
               .setCoder(outputSchema.getRowCoder());
 
       return uncollected;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
@@ -23,7 +23,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -44,18 +44,16 @@ public class BeamUncollectRel extends Uncollect implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      RelNode input = getInput();
+    public PCollection<Row> expand(PInput pinput) {
       String stageName = BeamSqlRelUtils.getStageName(BeamUncollectRel.this);
 
-      PCollection<Row> upstream =
-          inputPCollections.apply(BeamSqlRelUtils.getBeamRelInput(input).toPTransform());
+      PCollection<Row> upstream = (PCollection<Row>) pinput;
 
       // Each row of the input contains a single array of things to be emitted; Calcite knows
       // what the row looks like

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -63,13 +63,9 @@ import org.apache.calcite.rel.core.Union;
  * }</pre>
  */
 public class BeamUnionRel extends Union implements BeamRelNode {
-  private BeamSetOperatorRelBase delegate;
-
   public BeamUnionRel(
       RelOptCluster cluster, RelTraitSet traits, List<RelNode> inputs, boolean all) {
     super(cluster, traits, inputs, all);
-    this.delegate =
-        new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.UNION, inputs, all);
   }
 
   @Override
@@ -78,14 +74,7 @@ public class BeamUnionRel extends Union implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
-    return new Transform();
-  }
-
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
-    @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
-      return delegate.buildBeamPipeline(inputPCollections);
-    }
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
+    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.UNION, all);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -90,8 +90,6 @@ public class BeamUnnestRel extends Correlate implements BeamRelNode {
   private class Transform extends PTransform<PInput, PCollection<Row>> {
     @Override
     public PCollection<Row> expand(PInput pinput) {
-      String stageName = BeamSqlRelUtils.getStageName(BeamUnnestRel.this);
-
       // The set of rows where we run the correlated unnest for each row
       PCollection<Row> outer = (PCollection<Row>) pinput;
 
@@ -109,7 +107,6 @@ public class BeamUnnestRel extends Correlate implements BeamRelNode {
 
       return outer
           .apply(
-              stageName,
               ParDo.of(
                   new UnnestFn(correlationId.getId(), expr, joinedSchema, innerSchema.getField(0))))
           .setCoder(joinedSchema.getRowCoder());

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
@@ -77,9 +78,9 @@ public class BeamUnnestRel extends Correlate implements BeamRelNode {
   }
 
   @Override
-  public PInput buildPInput(Pipeline pipeline) {
+  public PInput buildPInput(Pipeline pipeline, Map<Integer, PCollection<Row>> cache) {
     BeamRelNode input = BeamSqlRelUtils.getBeamRelInput(left);
-    return BeamSqlRelUtils.toPCollection(pipeline, input);
+    return BeamSqlRelUtils.toPCollection(pipeline, input, cache);
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
@@ -69,7 +69,6 @@ public class BeamValuesRel extends Values implements BeamRelNode {
     @Override
     public PCollection<Row> expand(PInput pinput) {
 
-      String stageName = BeamSqlRelUtils.getStageName(BeamValuesRel.this);
       if (tuples.isEmpty()) {
         throw new IllegalStateException("Values with empty tuples!");
       }
@@ -78,7 +77,7 @@ public class BeamValuesRel extends Values implements BeamRelNode {
 
       List<Row> rows = tuples.stream().map(tuple -> tupleToRow(schema, tuple)).collect(toList());
 
-      return ((PBegin) pinput).apply(stageName, Create.of(rows)).setCoder(schema.getRowCoder());
+      return ((PBegin) pinput).apply(Create.of(rows)).setCoder(schema.getRowCoder());
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
@@ -29,8 +29,9 @@ import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
@@ -59,14 +60,14 @@ public class BeamValuesRel extends Values implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionTuple, PCollection<Row>> toPTransform() {
+  public PTransform<PInput, PCollection<Row>> buildPTransform() {
     return new Transform();
   }
 
-  private class Transform extends PTransform<PCollectionTuple, PCollection<Row>> {
+  private class Transform extends PTransform<PInput, PCollection<Row>> {
 
     @Override
-    public PCollection<Row> expand(PCollectionTuple inputPCollections) {
+    public PCollection<Row> expand(PInput pinput) {
 
       String stageName = BeamSqlRelUtils.getStageName(BeamValuesRel.this);
       if (tuples.isEmpty()) {
@@ -77,10 +78,7 @@ public class BeamValuesRel extends Values implements BeamRelNode {
 
       List<Row> rows = tuples.stream().map(tuple -> tupleToRow(schema, tuple)).collect(toList());
 
-      return inputPCollections
-          .getPipeline()
-          .apply(stageName, Create.of(rows))
-          .setCoder(schema.getRowCoder());
+      return ((PBegin) pinput).apply(stageName, Create.of(rows)).setCoder(schema.getRowCoder());
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamPCollectionTable.java
@@ -17,9 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.schema;
 
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.RowCoder;
-import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
@@ -37,12 +36,13 @@ public class BeamPCollectionTable extends BaseBeamTable {
   }
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+  public PCollection<Row> buildIOReader(PBegin begin) {
+    assert begin.getPipeline() == upstream.getPipeline();
     return upstream;
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+  public POutput buildIOWriter(PCollection<Row> input) {
     throw new IllegalArgumentException("cannot use [BeamPCollectionTable] as target");
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamBigQueryTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BeamBigQueryTable.java
@@ -18,14 +18,12 @@
 package org.apache.beam.sdk.extensions.sql.meta.provider.bigquery;
 
 import java.io.Serializable;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
-import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
@@ -44,22 +42,17 @@ public class BeamBigQueryTable extends BaseBeamTable implements Serializable {
   }
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+  public PCollection<Row> buildIOReader(PBegin begin) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
-    return new PTransform<PCollection<Row>, POutput>() {
-      @Override
-      public WriteResult expand(PCollection<Row> input) {
-        return input.apply(
-            BigQueryIO.<Row>write()
-                .withSchema(BigQueryUtils.toTableSchema(getSchema()))
-                .withFormatFunction(BigQueryUtils.toTableRow())
-                .to(tableSpec));
-      }
-    };
+  public POutput buildIOWriter(PCollection<Row> input) {
+    return input.apply(
+        BigQueryIO.<Row>write()
+            .withSchema(BigQueryUtils.toTableSchema(getSchema()))
+            .withFormatFunction(BigQueryUtils.toTableRow())
+            .to(tableSpec));
   }
 
   String getTableSpec() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
@@ -107,6 +107,7 @@ public abstract class BeamKafkaTable extends BaseBeamTable {
   public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
     checkArgument(
         topics != null && topics.size() == 1, "Only one topic can be acceptable as output.");
+    assert topics != null;
 
     return new PTransform<PCollection<Row>, POutput>() {
       @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaTable.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
@@ -30,7 +29,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
 import org.apache.kafka.common.TopicPartition;
@@ -76,7 +74,7 @@ public abstract class BeamKafkaTable extends BaseBeamTable {
       getPTransformForOutput();
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+  public PCollection<Row> buildIOReader(PBegin begin) {
     KafkaIO.Read<byte[], byte[]> kafkaRead = null;
     if (topics != null) {
       kafkaRead =
@@ -98,31 +96,26 @@ public abstract class BeamKafkaTable extends BaseBeamTable {
       throw new IllegalArgumentException("One of topics and topicPartitions must be configurated.");
     }
 
-    return PBegin.in(pipeline)
+    return begin
         .apply("read", kafkaRead.withoutMetadata())
         .apply("in_format", getPTransformForInput());
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+  public POutput buildIOWriter(PCollection<Row> input) {
     checkArgument(
         topics != null && topics.size() == 1, "Only one topic can be acceptable as output.");
     assert topics != null;
 
-    return new PTransform<PCollection<Row>, POutput>() {
-      @Override
-      public PDone expand(PCollection<Row> input) {
-        return input
-            .apply("out_reformat", getPTransformForOutput())
-            .apply(
-                "persistent",
-                KafkaIO.<byte[], byte[]>write()
-                    .withBootstrapServers(bootstrapServers)
-                    .withTopic(topics.get(0))
-                    .withKeySerializer(ByteArraySerializer.class)
-                    .withValueSerializer(ByteArraySerializer.class));
-      }
-    };
+    return input
+        .apply("out_reformat", getPTransformForOutput())
+        .apply(
+            "persistent",
+            KafkaIO.<byte[], byte[]>write()
+                .withBootstrapServers(bootstrapServers)
+                .withTopic(topics.get(0))
+                .withKeySerializer(ByteArraySerializer.class)
+                .withValueSerializer(ByteArraySerializer.class));
   }
 
   public String getBootstrapServers() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubIOJsonTable.java
@@ -23,14 +23,12 @@ import static org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubMess
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
@@ -139,9 +137,9 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   public abstract Schema getSchema();
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+  public PCollection<Row> buildIOReader(PBegin begin) {
     PCollectionTuple rowsWithDlq =
-        PBegin.in(pipeline)
+        begin
             .apply("readFromPubsub", readMessagesWithAttributes())
             .apply("parseMessageToRow", createParserParDo());
 
@@ -178,7 +176,7 @@ abstract class PubsubIOJsonTable implements BeamSqlTable, Serializable {
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+  public POutput buildIOWriter(PCollection<Row> input) {
     throw new UnsupportedOperationException("Writing to a Pubsub topic is not supported");
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTable.java
@@ -18,10 +18,8 @@
 
 package org.apache.beam.sdk.extensions.sql.meta.provider.text;
 
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
@@ -50,15 +48,15 @@ public class BeamTextCSVTable extends BeamTextTable {
   }
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
-    return PBegin.in(pipeline)
+  public PCollection<Row> buildIOReader(PBegin begin) {
+    return begin
         .apply("decodeRecord", TextIO.read().from(filePattern))
         .apply("parseCSVLine", new BeamTextCSVTableIOReader(schema, filePattern, csvFormat));
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
-    return new BeamTextCSVTableIOWriter(schema, filePattern, csvFormat);
+  public POutput buildIOWriter(PCollection<Row> input) {
+    return input.apply(new BeamTextCSVTableIOWriter(schema, filePattern, csvFormat));
   }
 
   public CSVFormat getCsvFormat() {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslJoinTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslJoinTest.java
@@ -332,8 +332,8 @@ public class BeamSqlDslJoinTest {
 
   private PCollection<Row> queryFromOrderTables(String sql) {
     return tuple(
-            "ORDER_DETAILS1", ORDER_DETAILS1.buildIOReader(pipeline).setCoder(SOURCE_CODER),
-            "ORDER_DETAILS2", ORDER_DETAILS2.buildIOReader(pipeline).setCoder(SOURCE_CODER))
+            "ORDER_DETAILS1", ORDER_DETAILS1.buildIOReader(pipeline.begin()).setCoder(SOURCE_CODER),
+            "ORDER_DETAILS2", ORDER_DETAILS2.buildIOReader(pipeline.begin()).setCoder(SOURCE_CODER))
         .apply("join", SqlTransform.query(sql))
         .setCoder(RESULT_CODER);
   }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.meta.provider.bigquery.BigQueryTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.pubsub.PubsubJsonTableProvider;
 import org.apache.beam.sdk.io.gcp.bigquery.TestBigQuery;
@@ -91,7 +92,7 @@ public class PubsubToBigqueryIT implements Serializable {
             + "  pubsub_topic.payload.name \n"
             + "FROM pubsub_topic";
 
-    sqlEnv.parseQuery(pipeline, insertStatement);
+    BeamSqlRelUtils.toPCollection(pipeline, sqlEnv.parseQuery(insertStatement));
 
     pipeline.run();
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
@@ -34,7 +34,6 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsub;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -92,7 +91,7 @@ public class PubsubToBigqueryIT implements Serializable {
             + "  pubsub_topic.payload.name \n"
             + "FROM pubsub_topic";
 
-    PCollectionTuple.empty(pipeline).apply(sqlEnv.parseQuery(insertStatement));
+    sqlEnv.parseQuery(pipeline, insertStatement);
 
     pipeline.run();
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
@@ -32,7 +32,7 @@ public abstract class BaseRelTest {
   private static BeamSqlEnv env = BeamSqlEnv.readOnly("test", tables);
 
   protected static PCollection<Row> compilePipeline(String sql, Pipeline pipeline) {
-    return env.parseQuery(pipeline, sql);
+    return BeamSqlRelUtils.toPCollection(pipeline, env.parseQuery(sql));
   }
 
   protected static void registerTable(String tableName, BeamSqlTable table) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BaseRelTest.java
@@ -24,7 +24,6 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 
 /** Base class for rel test. */
@@ -33,7 +32,7 @@ public abstract class BaseRelTest {
   private static BeamSqlEnv env = BeamSqlEnv.readOnly("test", tables);
 
   protected static PCollection<Row> compilePipeline(String sql, Pipeline pipeline) {
-    return PCollectionTuple.empty(pipeline).apply(env.parseQuery(sql));
+    return env.parseQuery(pipeline, sql);
   }
 
   protected static void registerTable(String tableName, BeamSqlTable table) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverterTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverterTest.java
@@ -24,15 +24,14 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.math.BigDecimal;
-import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
+import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.POutput;
@@ -97,26 +96,18 @@ public class BeamEnumerableConverterTest {
     enumerator.close();
   }
 
-  private static class FakeTable implements BeamSqlTable {
+  private static class FakeTable extends BaseBeamTable {
+    public FakeTable() {
+      super(null);
+    }
+
     @Override
-    public PCollection<Row> buildIOReader(Pipeline pipeline) {
+    public PCollection<Row> buildIOReader(PBegin begin) {
       return null;
     }
 
     @Override
-    public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
-      return new FakeIOWriter();
-    }
-
-    @Override
-    public Schema getSchema() {
-      return null;
-    }
-  }
-
-  private static class FakeIOWriter extends PTransform<PCollection<Row>, POutput> {
-    @Override
-    public POutput expand(PCollection<Row> input) {
+    public POutput buildIOWriter(PCollection<Row> input) {
       input.apply(
           ParDo.of(
               new DoFn<Row, Void>() {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.BeamSqlSeekableTable;
 import org.apache.beam.sdk.extensions.sql.TestUtils;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
@@ -30,8 +29,8 @@ import org.apache.beam.sdk.extensions.sql.mock.MockedUnboundedTable;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
@@ -112,12 +111,12 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     }
 
     @Override
-    public PCollection<Row> buildIOReader(Pipeline pipeline) {
+    public PCollection<Row> buildIOReader(PBegin begin) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+    public POutput buildIOWriter(PCollection<Row> input) {
       throw new UnsupportedOperationException();
     }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -91,7 +91,7 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
               (short) 32767,
               2147483647,
               9223372036854775807L)
-          .buildIOReader(pipeline)
+          .buildIOReader(pipeline.begin())
           .setCoder(ROW_TYPE.getRowCoder());
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlComparisonOperatorsIntegrationTest.java
@@ -356,7 +356,7 @@ public class BeamSqlComparisonOperatorsIntegrationTest
               true,
               "string_true_test",
               "string_false_test")
-          .buildIOReader(pipeline)
+          .buildIOReader(pipeline.begin())
           .setCoder(type.getRowCoder());
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryWriteIT.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BeamPCollectionTable;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
@@ -75,7 +76,7 @@ public class BigQueryWriteIT implements Serializable {
 
     String insertStatement = "INSERT INTO ORDERS VALUES (1, 'foo', ARRAY['123', '456'])";
 
-    sqlEnv.parseQuery(pipeline, insertStatement);
+    BeamSqlRelUtils.toPCollection(pipeline, sqlEnv.parseQuery(insertStatement));
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
 
@@ -115,7 +116,7 @@ public class BigQueryWriteIT implements Serializable {
             + "    name as `name`, \n"
             + "    arr as `arr` \n"
             + " FROM ORDERS_IN_MEMORY";
-    sqlEnv.parseQuery(pipeline, insertStatement);
+    BeamSqlRelUtils.toPCollection(pipeline, sqlEnv.parseQuery(insertStatement));
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryWriteIT.java
@@ -37,7 +37,6 @@ import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.Duration;
 import org.junit.Rule;
@@ -76,7 +75,7 @@ public class BigQueryWriteIT implements Serializable {
 
     String insertStatement = "INSERT INTO ORDERS VALUES (1, 'foo', ARRAY['123', '456'])";
 
-    PCollectionTuple.empty(pipeline).apply(sqlEnv.parseQuery(insertStatement));
+    sqlEnv.parseQuery(pipeline, insertStatement);
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
 
@@ -116,7 +115,7 @@ public class BigQueryWriteIT implements Serializable {
             + "    name as `name`, \n"
             + "    arr as `arr` \n"
             + " FROM ORDERS_IN_MEMORY";
-    PCollectionTuple.empty(pipeline).apply(sqlEnv.parseQuery(insertStatement));
+    sqlEnv.parseQuery(pipeline, insertStatement);
 
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -35,7 +35,6 @@ import org.apache.beam.sdk.io.gcp.pubsub.TestPubsubSignal;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -173,7 +172,7 @@ public class PubsubJsonIT implements Serializable {
   private PCollection<Row> query(BeamSqlEnv sqlEnv, TestPipeline pipeline, String queryString)
       throws Exception {
 
-    return PCollectionTuple.empty(pipeline).apply(sqlEnv.parseQuery(queryString));
+    return sqlEnv.parseQuery(pipeline, queryString);
   }
 
   private PubsubMessage message(Instant timestamp, int id, String name) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
@@ -172,7 +173,7 @@ public class PubsubJsonIT implements Serializable {
   private PCollection<Row> query(BeamSqlEnv sqlEnv, TestPipeline pipeline, String queryString)
       throws Exception {
 
-    return sqlEnv.parseQuery(pipeline, queryString);
+    return BeamSqlRelUtils.toPCollection(pipeline, sqlEnv.parseQuery(queryString));
   }
 
   private PubsubMessage message(Instant timestamp, int id, String name) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/BeamTextCSVTableTest.java
@@ -78,20 +78,23 @@ public class BeamTextCSVTableTest {
   @Test
   public void testBuildIOReader() {
     PCollection<Row> rows =
-        new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath()).buildIOReader(pipeline);
+        new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath())
+            .buildIOReader(pipeline.begin());
     PAssert.that(rows).containsInAnyOrder(testDataRows);
     pipeline.run();
   }
 
   @Test
   public void testBuildIOWriter() {
-    new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath())
-        .buildIOReader(pipeline)
-        .apply(new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath()).buildIOWriter());
+    PCollection<Row> input =
+        new BeamTextCSVTable(schema, readerSourceFile.getAbsolutePath())
+            .buildIOReader(pipeline.begin());
+    new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath()).buildIOWriter(input);
     pipeline.run();
 
     PCollection<Row> rows =
-        new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath()).buildIOReader(pipeline2);
+        new BeamTextCSVTable(schema, writerTargetFile.getAbsolutePath())
+            .buildIOReader(pipeline2.begin());
 
     // confirm the two reads match
     PAssert.that(rows).containsInAnyOrder(testDataRows);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedTable.java
@@ -21,7 +21,6 @@ package org.apache.beam.sdk.extensions.sql.mock;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.extensions.sql.impl.schema.BaseBeamTable;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.sdk.values.Row;
@@ -35,7 +34,7 @@ public abstract class MockedTable extends BaseBeamTable {
   }
 
   @Override
-  public PTransform<? super PCollection<Row>, POutput> buildIOWriter() {
+  public POutput buildIOWriter(PCollection<Row> input) {
     throw new UnsupportedOperationException("buildIOWriter unsupported!");
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedUnboundedTable.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/mock/MockedUnboundedTable.java
@@ -21,10 +21,10 @@ package org.apache.beam.sdk.extensions.sql.mock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.sql.TestUtils;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TimestampedValue;
@@ -87,7 +87,7 @@ public class MockedUnboundedTable extends MockedTable {
   }
 
   @Override
-  public PCollection<Row> buildIOReader(Pipeline pipeline) {
+  public PCollection<Row> buildIOReader(PBegin begin) {
     TestStream.Builder<Row> values = TestStream.create(schema.getRowCoder());
 
     for (Pair<Duration, List<Row>> pair : timestampedRows) {
@@ -101,10 +101,7 @@ public class MockedUnboundedTable extends MockedTable {
       }
     }
 
-    return pipeline
-        .begin()
-        .apply(
-            "MockedUnboundedTable_" + COUNTER.incrementAndGet(),
-            values.advanceWatermarkToInfinity());
+    return begin.apply(
+        "MockedUnboundedTable_" + COUNTER.incrementAndGet(), values.advanceWatermarkToInfinity());
   }
 }


### PR DESCRIPTION
We should transform the Calcite Rel graph into a Beam pipeline graph with a clean mapping between the two.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
