### PR TITLE
[BEAM-4519] Java SDK passes the staging session token artifact staging service.

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
@@ -82,6 +82,7 @@ public class ArtifactServiceStagerTest {
 
   @Test
   public void testStage() throws Exception {
+    String stagingSessionToken = "token";
     File file = temp.newFile();
     byte[] content = "foo-bar-baz".getBytes(StandardCharsets.UTF_8);
     byte[] contentMd5 = MessageDigest.getInstance("MD5").digest(content);
@@ -89,7 +90,7 @@ public class ArtifactServiceStagerTest {
       contentChannel.write(ByteBuffer.wrap(content));
     }
 
-    stager.stage(Collections.singleton(StagedFile.of(file, file.getName())));
+    stager.stage(stagingSessionToken, Collections.singleton(StagedFile.of(file, file.getName())));
 
     assertThat(service.getStagedArtifacts().entrySet(), hasSize(1));
     byte[] stagedContent = Iterables.getOnlyElement(service.getStagedArtifacts().values());
@@ -106,6 +107,8 @@ public class ArtifactServiceStagerTest {
 
   @Test
   public void testStagingMultipleFiles() throws Exception {
+    String stagingSessionToken = "token";
+
     File file = temp.newFile();
     byte[] content = "foo-bar-baz".getBytes(StandardCharsets.UTF_8);
     try (FileChannel contentChannel = new FileOutputStream(file).getChannel()) {
@@ -125,6 +128,7 @@ public class ArtifactServiceStagerTest {
     }
 
     stager.stage(
+        stagingSessionToken,
         ImmutableList.of(
             StagedFile.of(file, file.getName()),
             StagedFile.of(otherFile, otherFile.getName()),

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactRetrievalServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/artifact/LocalFileSystemArtifactRetrievalServiceTest.java
@@ -194,12 +194,13 @@ public class LocalFileSystemArtifactRetrievalServiceTest {
       Files.write(artifactFile.toPath(), artifact.getValue());
       artifactFiles.add(StagedFile.of(artifactFile, artifactFile.getName()));
     }
+    String stagingSessionToken = "token";
 
     ArtifactServiceStager stager =
         ArtifactServiceStager.overChannel(
             InProcessChannelBuilder.forName(stagerServer.getApiServiceDescriptor().getUrl())
                 .build());
-    stager.stage(artifactFiles);
+    stager.stage(stagingSessionToken, artifactFiles);
 
     retrievalServer =
         GrpcFnServer.allocatePortAndCreateFor(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobServiceTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/job/ReferenceRunnerJobServiceTest.java
@@ -97,9 +97,11 @@ public class ReferenceRunnerJobServiceTest {
     ArtifactServiceStager stager =
         ArtifactServiceStager.overChannel(
             InProcessChannelBuilder.forName(stagingEndpoint.getUrl()).build());
+    String stagingSessionToken = "token";
     File foo = writeTempFile("foo", "foo, bar, baz".getBytes(UTF_8));
     File bar = writeTempFile("spam", "spam, ham, eggs".getBytes(UTF_8));
     stager.stage(
+        stagingSessionToken,
         ImmutableList.of(StagedFile.of(foo, foo.getName()), StagedFile.of(bar, bar.getName())));
     List<byte[]> tempDirFiles = readFlattenedFiles(runnerTemp.getRoot());
     assertThat(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobService.java
@@ -58,11 +58,6 @@ import org.slf4j.LoggerFactory;
 public class InMemoryJobService extends JobServiceGrpc.JobServiceImplBase implements FnService {
   private static final Logger LOG = LoggerFactory.getLogger(InMemoryJobService.class);
 
-  public static InMemoryJobService create(
-      Endpoints.ApiServiceDescriptor stagingServiceDescriptor, JobInvoker invoker) {
-    return new InMemoryJobService(stagingServiceDescriptor, (String session) -> "token", invoker);
-  }
-
   /**
    * Creates an InMemoryJobService.
    *

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobServiceTest.java
@@ -61,7 +61,7 @@ public class InMemoryJobServiceTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
     stagingServiceDescriptor = Endpoints.ApiServiceDescriptor.getDefaultInstance();
-    service = InMemoryJobService.create(stagingServiceDescriptor, invoker);
+    service = InMemoryJobService.create(stagingServiceDescriptor, session -> "token", invoker);
     when(invoker.invoke(TEST_PIPELINE, TEST_OPTIONS, TEST_RETRIEVAL_TOKEN)).thenReturn(invocation);
     when(invocation.getId()).thenReturn(TEST_JOB_ID);
   }

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
@@ -159,6 +159,7 @@ public class PortableRunner extends PipelineRunner<PipelineResult> {
 
       ApiServiceDescriptor artifactStagingEndpoint =
           prepareJobResponse.getArtifactStagingEndpoint();
+      String stagingSessionToken = prepareJobResponse.getStagingSessionToken();
 
       String retrievalToken = null;
       try (CloseableResource<ManagedChannel> artifactChannel =
@@ -166,7 +167,7 @@ public class PortableRunner extends PipelineRunner<PipelineResult> {
               channelFactory.forDescriptor(artifactStagingEndpoint), ManagedChannel::shutdown)) {
         ArtifactServiceStager stager = ArtifactServiceStager.overChannel(artifactChannel.get());
         LOG.debug("Actual files staged: {}", filesToStage);
-        retrievalToken = stager.stage(filesToStage);
+        retrievalToken = stager.stage(stagingSessionToken, filesToStage);
       } catch (CloseableResource.CloseException e) {
         LOG.warn("Error closing artifact staging channel", e);
         // CloseExceptions should only be thrown while closing the channel.


### PR DESCRIPTION
The artifact staging service gRPC protocol was recently changed to allow
the staging service to serve multiple manifests.  This implements the
corresponding changes in the client code, as well as a few related
server-side cleanup tweaks.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
