### PR TITLE
[BEAM-4194] support unbounded limit

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -80,6 +80,18 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
     }
   }
 
+  public int getLimitCountOfSortRel() {
+    if (input instanceof BeamSortRel) {
+      return ((BeamSortRel) input).getCount();
+    }
+
+    throw new RuntimeException("Could not get the limit count from a non BeamSortRel input.");
+  }
+
+  public boolean isInputSortRelAndLimitOnly() {
+    return (input instanceof BeamSortRel) && ((BeamSortRel) input).isLimitOnly();
+  }
+
   /** {@code CalcFn} is the executor for a {@link BeamCalcRel} step. */
   public static class CalcFn extends DoFn<Row, Row> {
     private BeamSqlExpressionExecutor executor;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -19,14 +19,19 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
+import org.apache.beam.runners.direct.DirectOptions;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineResult.State;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -35,8 +40,12 @@ import org.apache.beam.sdk.metrics.MetricsFilter;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.adapter.enumerable.EnumerableRel;
 import org.apache.calcite.adapter.enumerable.EnumerableRelImplementor;
@@ -56,9 +65,13 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.convert.ConverterImpl;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** BeamRelNode to replace a {@code Enumerable} node. */
 public class BeamEnumerableConverter extends ConverterImpl implements EnumerableRel {
+  private static final Logger LOG = LoggerFactory.getLogger(BeamEnumerableConverter.class);
 
   public BeamEnumerableConverter(RelOptCluster cluster, RelTraitSet traits, RelNode input) {
     super(cluster, ConventionTraitDef.INSTANCE, traits, input);
@@ -108,10 +121,34 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
       Thread.currentThread().setContextClassLoader(BeamEnumerableConverter.class.getClassLoader());
       if (node instanceof BeamIOSinkRel) {
         return count(options, node);
+      } else if (isLimitQuery(node)) {
+        return limitCollect(options, node);
       }
+
       return collect(options, node);
     } finally {
       Thread.currentThread().setContextClassLoader(originalClassLoader);
+    }
+  }
+
+  enum LimitState {
+    REACHED,
+    NOT_REACHED
+  }
+
+  private static class LimitStateVar implements Serializable {
+    private LimitState state;
+
+    public LimitStateVar() {
+      state = LimitState.NOT_REACHED;
+    }
+
+    public void setReached() {
+      state = LimitState.REACHED;
+    }
+
+    public boolean isReached() {
+      return state == LimitState.REACHED;
     }
   }
 
@@ -124,6 +161,42 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     return result;
   }
 
+  private static PipelineResult limitRun(
+      PipelineOptions options,
+      BeamRelNode node,
+      DoFn<Row, KV<String, Row>> collectDoFn,
+      DoFn<KV<String, Row>, Void> limitCounterDoFn,
+      LimitStateVar limitStateVar) {
+    options.as(DirectOptions.class).setBlockOnRun(false);
+    Pipeline pipeline = Pipeline.create(options);
+    BeamSqlRelUtils.toPCollection(pipeline, node)
+        .apply(ParDo.of(collectDoFn))
+        .apply(ParDo.of(limitCounterDoFn));
+
+    PipelineResult result = pipeline.run();
+
+    State state;
+    while (true) {
+      // Check pipeline state in every second
+      state = result.waitUntilFinish(Duration.standardSeconds(1));
+      if (state != null && state.isTerminal()) {
+        break;
+      }
+      // If state is null, or state is not null and indicates pipeline is not terminated
+      // yet, check continue checking the limit var.
+      try {
+        if (limitStateVar.isReached()) {
+          result.cancel();
+          break;
+        }
+      } catch (IOException e) {
+        LOG.warn(e.toString());
+        break;
+      }
+    }
+    return result;
+  }
+
   private static Enumerable<Object> collect(PipelineOptions options, BeamRelNode node) {
     long id = options.getOptionsId();
     Queue<Object> values = new ConcurrentLinkedQueue<Object>();
@@ -132,12 +205,98 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
         options
             .getRunner()
             .getCanonicalName()
-            .equals("org.apache.beam.runners.direct.DirectRunner"));
+            .equals("org.apache.beam.runners.direct.DirectRunner"),
+        "SELECT without INSERT is only supported in DirectRunner in SQL Shell.");
+
     Collector.globalValues.put(id, values);
     run(options, node, new Collector());
     Collector.globalValues.remove(id);
 
     return Linq4j.asEnumerable(values);
+  }
+
+  private static Enumerable<Object> limitCollect(PipelineOptions options, BeamRelNode node) {
+    long id = options.getOptionsId();
+    Queue<Object> values = new ConcurrentLinkedQueue<Object>();
+
+    checkArgument(
+        options
+            .getRunner()
+            .getCanonicalName()
+            .equals("org.apache.beam.runners.direct.DirectRunner"),
+        "SELECT without INSERT is only supported in DirectRunner in SQL Shell.");
+
+    LimitStateVar limitStateVar = new LimitStateVar();
+    int limitCount = getLimitCount(node);
+
+    LimitCanceller.globalLimitArguments.put(id, limitCount);
+    LimitCanceller.globalStates.put(id, limitStateVar);
+    LimitCollector.globalValues.put(id, values);
+    limitRun(options, node, new LimitCollector(), new LimitCanceller(), limitStateVar);
+    LimitCanceller.globalLimitArguments.remove(id);
+    LimitCanceller.globalStates.remove(id);
+    LimitCollector.globalValues.remove(id);
+
+    return Linq4j.asEnumerable(values);
+  }
+
+  private static class LimitCanceller extends DoFn<KV<String, Row>, Void> {
+    private static final Map<Long, Integer> globalLimitArguments =
+        new ConcurrentHashMap<Long, Integer>();
+    private static final Map<Long, LimitStateVar> globalStates =
+        new ConcurrentHashMap<Long, LimitStateVar>();
+
+    @Nullable private volatile Integer count;
+    @Nullable private volatile LimitStateVar limitStateVar;
+
+    @StateId("counter")
+    private final StateSpec<ValueState<Integer>> counter = StateSpecs.value(VarIntCoder.of());
+
+    @StartBundle
+    public void startBundle(StartBundleContext context) {
+      long id = context.getPipelineOptions().getOptionsId();
+      count = globalLimitArguments.get(id);
+      limitStateVar = globalStates.get(id);
+    }
+
+    @ProcessElement
+    public void processElement(
+        ProcessContext context, @StateId("counter") ValueState<Integer> counter) {
+      int current = (counter.read() != null ? counter.read() : 0);
+      current += 1;
+      if (current >= count && !limitStateVar.isReached()) {
+        // if current count reaches the limit count but limitStateVar has not been set, flip
+        // the var.
+        limitStateVar.setReached();
+      }
+
+      counter.write(current);
+    }
+  }
+
+  private static class LimitCollector extends DoFn<Row, KV<String, Row>> {
+    // This will only work on the direct runner.
+    private static final Map<Long, Queue<Object>> globalValues =
+        new ConcurrentHashMap<Long, Queue<Object>>();
+
+    @Nullable private volatile Queue<Object> values;
+
+    @StartBundle
+    public void startBundle(StartBundleContext context) {
+      long id = context.getPipelineOptions().getOptionsId();
+      values = globalValues.get(id);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      Object[] input = context.element().getValues().toArray();
+      if (input.length == 1) {
+        values.add(input[0]);
+      } else {
+        values.add(input);
+      }
+      context.output(KV.of("DummyKey", context.element()));
+    }
   }
 
   private static class Collector extends DoFn<Row, Void> {
@@ -184,5 +343,21 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     public void processElement(ProcessContext context) {
       rows.inc();
     }
+  }
+
+  private static boolean isLimitQuery(BeamRelNode node) {
+    return (node instanceof BeamSortRel && ((BeamSortRel) node).isLimitOnly())
+        || (node instanceof BeamCalcRel && ((BeamCalcRel) node).isInputSortRelAndLimitOnly());
+  }
+
+  private static int getLimitCount(BeamRelNode node) {
+    if (node instanceof BeamSortRel) {
+      return ((BeamSortRel) node).getCount();
+    } else if (node instanceof BeamCalcRel) {
+      return ((BeamCalcRel) node).getLimitCountOfSortRel();
+    }
+
+    throw new RuntimeException(
+        "Cannot get limit count from RelNode tree with root " + node.getRelTypeName());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -18,16 +18,29 @@
 package org.apache.beam.sdk.extensions.sql.meta.provider.pubsub;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.io.Serializable;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchema;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
+import org.apache.beam.sdk.extensions.sql.impl.JdbcDriver;
 import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSqlRelUtils;
+import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.store.InMemoryMetaStore;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubIO;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
@@ -37,22 +50,31 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.calcite.jdbc.CalciteConnection;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Integration tests for querying Pubsub JSON messages with SQL. */
 @RunWith(JUnit4.class)
 public class PubsubJsonIT implements Serializable {
+  private static final Logger LOG = LoggerFactory.getLogger(PubsubJsonIT.class);
 
   private static final Schema PAYLOAD_SCHEMA =
       Schema.builder()
           .addNullableField("id", Schema.FieldType.INT32)
           .addNullableField("name", Schema.FieldType.STRING)
           .build();
+
+  private static final String CONNECT_STRING_PREFIX = "jdbc:beam:";
+  private static final String BEAM_CALCITE_SCHEMA = "beamCalciteSchema";
+  private static final JdbcDriver INSTANCE = new JdbcDriver();
+  private static volatile Boolean checked = false;
 
   @Rule public transient TestPubsub eventsTopic = TestPubsub.create();
   @Rule public transient TestPubsub dlqTopic = TestPubsub.create();
@@ -140,7 +162,6 @@ public class PubsubJsonIT implements Serializable {
 
     sqlEnv.executeDdl(createTableString);
     query(sqlEnv, pipeline, queryString);
-
     PCollection<PubsubMessage> dlq =
         pipeline.apply(PubsubIO.readMessagesWithAttributes().fromTopic(dlqTopic.topicPath()));
 
@@ -152,8 +173,91 @@ public class PubsubJsonIT implements Serializable {
                 containsAll(dlqMessages, message(ts(4), "{ - }"), message(ts(5), "{ + }"))));
 
     pipeline.run();
+
     eventsTopic.publish(messages);
     signal.waitForSuccess(Duration.standardMinutes(5));
+  }
+
+  @Test
+  public void testSQLLimit() throws SQLException, IOException, InterruptedException {
+    String createTableString =
+        "CREATE TABLE message (\n"
+            + "event_timestamp TIMESTAMP, \n"
+            + "attributes MAP<VARCHAR, VARCHAR>, \n"
+            + "payload ROW< \n"
+            + "             id INTEGER, \n"
+            + "             name VARCHAR \n"
+            + "           > \n"
+            + ") \n"
+            + "TYPE 'pubsub' \n"
+            + "LOCATION '"
+            + eventsTopic.topicPath()
+            + "' \n"
+            + "TBLPROPERTIES "
+            + "    '{ "
+            + "       \"timestampAttributeKey\" : \"ts\", "
+            + "       \"deadLetterQueue\" : \""
+            + dlqTopic.topicPath()
+            + "\""
+            + "     }'";
+
+    List<PubsubMessage> messages =
+        ImmutableList.of(
+            message(ts(1), 3, "foo"),
+            message(ts(2), 5, "bar"),
+            message(ts(3), 7, "baz"),
+            message(ts(4), 9, "ba2"),
+            message(ts(5), 10, "ba3"),
+            message(ts(6), 13, "ba4"),
+            message(ts(7), 15, "ba5"));
+
+    CalciteConnection connection = connect(new PubsubJsonTableProvider());
+
+    Statement statement = connection.createStatement();
+    statement.execute(createTableString);
+
+    // Because Pubsub only allow new subscription receives message after the subscription is
+    // created, eventsTopic.publish(messages) can only be called after statement.executeQuery.
+    // However, because statement.executeQuery is a blocking call, it has to be put into a
+    // seperate thread to execute.
+    ExecutorService pool = Executors.newFixedThreadPool(1);
+    pool.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            try {
+              ResultSet resultSet =
+                  statement.executeQuery("SELECT message.payload.id FROM message LIMIT 3");
+              assertTrue(resultSet.next());
+              assertTrue(resultSet.next());
+              assertTrue(resultSet.next());
+              assertFalse(resultSet.next());
+              checked = true;
+            } catch (SQLException e) {
+              LOG.warn(e.toString());
+            }
+          }
+        });
+
+    // wait one minute to allow subscription creation.
+    Thread.sleep(60 * 1000);
+    eventsTopic.publish(messages);
+    // Wait one minute to allow the thread finishes checks.
+    Thread.sleep(60 * 1000);
+    // verify if the thread has checked returned value from LIMIT query.
+    assertTrue(checked);
+    pool.shutdown();
+  }
+
+  private CalciteConnection connect(TableProvider... tableProviders) throws SQLException {
+    InMemoryMetaStore inMemoryMetaStore = new InMemoryMetaStore();
+    for (TableProvider tableProvider : tableProviders) {
+      inMemoryMetaStore.registerProvider(tableProvider);
+    }
+
+    Properties info = new Properties();
+    info.put(BEAM_CALCITE_SCHEMA, new BeamCalciteSchema(inMemoryMetaStore));
+    return (CalciteConnection) INSTANCE.connect(CONNECT_STRING_PREFIX, info);
   }
 
   private static Boolean containsAll(Set<PubsubMessage> set, PubsubMessage... subsetCandidate) {


### PR DESCRIPTION
##### What?
Support unbounded limit in Beam SQL shell. In the past, due to default global window and default trigger, queries like "SELECT col_name FROM unbounded_table LIMIT 1" will not return in SQL Shell.

This PR tries to support unbounded limit by starting a daemon thread to monitoring return value collection in BeanEnumerableConverter, and stopping pipeline when collected values reach limit count. More detailed description can be found here: https://docs.google.com/document/d/13zeTewHH9nfwhSlcE4x77WQwr1U2Z4sTiNRjOXUj2aw/edit?usp=sharing.

##### Testing
 - [x] Unit test.
 
Adding two unit tests to mock bounded and unbounded input tables to test LIMIT functionality.

 - [x] Integration test.

Adding one e2e integration test, which utilizes Google Cloud Pub/Sub to test the unbounded limit on auto-generated Pub/Sub messages.

 - [x] Other test.

Manually tested unbounded limit in Beam SQL shell on a Google Cloud Pub/Sub table. See the screenshot:
<img width="1041" alt="screen shot 2018-06-18 at 3 48 07 pm" src="https://user-images.githubusercontent.com/1938382/41574436-106ca752-7336-11e8-91a7-33200513d4b8.png">


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
