### PR TITLE
Improving documentation for Metrics results

### DIFF
--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -85,9 +85,9 @@ class MetricResult(object):
   Attributes:
     key: A ``MetricKey`` that identifies the metric and bundle of this result.
     committed: The committed updates of the metric. This attribute's type is
-      that of the underlying cell data (e.g. int, DistributionData).
+      of metric type result (e.g. int, DistributionResult, GaugeResult).
     attempted: The logical updates of the metric. This attribute's type is that
-      of the underlying cell data (e.g. int, DistributionData).
+      of metric type result (e.g. int, DistributionResult, GaugeResult).
   """
   def __init__(self, key, committed, attempted):
     """Initializes ``MetricResult``.

--- a/sdks/python/apache_beam/metrics/metric.py
+++ b/sdks/python/apache_beam/metrics/metric.py
@@ -133,6 +133,10 @@ class Metrics(object):
 
 
 class MetricResults(object):
+  COUNTERS = "counters"
+  DISTRIBUTIONS = "distributions"
+  GAUGES = "gauges"
+
   @staticmethod
   def _matches_name(filter, metric_key):
     if not filter.names and not filter.namespaces:
@@ -180,6 +184,20 @@ class MetricResults(object):
     return False
 
   def query(self, filter=None):
+    """Queries the runner for existing user metrics that match the filter.
+
+    It should return a dictionary, with lists of each kind of metric, and
+    each list contains the corresponding kind of MetricResult. Like so:
+
+        {
+          "counters": [MetricResult(counter_key, committed, attempted), ...],
+          "distributions": [MetricResult(dist_key, committed, attempted), ...],
+          "gauges": []  // Empty list if nothing matched the filter.
+        }
+
+    The committed / attempted values are DistributionResult / GaugeResult / int
+    objects.
+    """
     raise NotImplementedError
 
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_metrics.py
@@ -199,10 +199,10 @@ class DataflowMetrics(MetricResults):
   def query(self, filter=None):
     response = self._get_metrics_from_dataflow()
     metric_results = self._populate_metric_results(response)
-    return {'counters': [elm for elm in metric_results
-                         if self.matches(filter, elm.key)
-                         and DataflowMetrics._is_counter(elm)],
-            'distributions': [elm for elm in metric_results
-                              if self.matches(filter, elm.key)
-                              and DataflowMetrics._is_distribution(elm)],
-            'gauges': []}  # TODO(pabloem): Add Gauge support for dataflow.
+    return {self.COUNTERS: [elm for elm in metric_results
+                            if self.matches(filter, elm.key)
+                            and DataflowMetrics._is_counter(elm)],
+            self.DISTRIBUTIONS: [elm for elm in metric_results
+                                 if self.matches(filter, elm.key)
+                                 and DataflowMetrics._is_distribution(elm)],
+            self.GAUGES: []}  # TODO(pabloem): Add Gauge support for dataflow.

--- a/sdks/python/apache_beam/runners/direct/direct_metrics.py
+++ b/sdks/python/apache_beam/runners/direct/direct_metrics.py
@@ -79,9 +79,9 @@ class DirectMetrics(MetricResults):
               for k, v in self._gauges.items()
               if self.matches(filter, k)]
 
-    return {'counters': counters,
-            'distributions': distributions,
-            'gauges': gauges}
+    return {self.COUNTERS: counters,
+            self.DISTRIBUTIONS: distributions,
+            self.GAUGES: gauges}
 
 
 class DirectMetric(object):


### PR DESCRIPTION
The documentation for metrics results was limited, and unclear. Implementers would need to refer to unit tests to understand the expectations. Fixing that.

r: @aaltay 