### PR TITLE
[BEAM-4558] Bigtable: upgrade to the latest version

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -55,7 +55,8 @@ dependencies {
   shadow library.java.joda_time
   shadow library.java.google_cloud_core
   shadow library.java.google_cloud_spanner
-  shadow library.java.bigtable_protos
+  shadow library.java.proto-google-cloud-bigtable-v2
+  shadow library.java.proto-google-cloud-bigtable-admin-v2
   shadow library.java.bigtable_client_core
   shadow library.java.google_api_client
   shadow library.java.google_http_client

--- a/sdks/java/io/google-cloud-platform/pom.xml
+++ b/sdks/java/io/google-cloud-platform/pom.xml
@@ -271,10 +271,13 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.cloud.bigtable</groupId>
-      <artifactId>bigtable-protos</artifactId>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-v2</artifactId>
     </dependency>
-
+    <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-cloud-bigtable-admin-v2</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud.bigtable</groupId>
       <artifactId>bigtable-client-core</artifactId>


### PR DESCRIPTION
There are some stability changes since the 1.0.0 release, which will positively affect some customers
Also, remove the deprecated bigtable-proto dependency in favor of dependences managed under the `com.google.api.grpc` groupId.
