### PR TITLE
Move transform boxing out of individual BeamRelNode classes

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSinkRel.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
 import org.apache.beam.sdk.extensions.sql.impl.rule.BeamIOSinkRule;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.Row;
@@ -100,24 +99,16 @@ public class BeamIOSinkRel extends TableModify
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new Transform();
-  }
+  public PCollection<Row> implement(PCollectionList<Row> pinput) {
+    checkArgument(
+        pinput.size() == 1,
+        "Wrong number of inputs for %s: %s",
+        BeamIOSinkRel.class.getSimpleName(),
+        pinput);
+    PCollection<Row> input = pinput.get(0);
 
-  private class Transform extends PTransform<PCollectionList<Row>, PCollection<Row>> {
+    sqlTable.buildIOWriter(input);
 
-    @Override
-    public PCollection<Row> expand(PCollectionList<Row> pinput) {
-      checkArgument(
-          pinput.size() == 1,
-          "Wrong number of inputs for %s: %s",
-          BeamIOSinkRel.class.getSimpleName(),
-          pinput);
-      PCollection<Row> input = pinput.get(0);
-
-      sqlTable.buildIOWriter(input);
-
-      return input;
-    }
+    return input;
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIOSourceRel.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.Row;
@@ -46,21 +45,13 @@ public class BeamIOSourceRel extends TableScan implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new Transform();
-  }
-
-  private class Transform extends PTransform<PCollectionList<Row>, PCollection<Row>> {
-
-    @Override
-    public PCollection<Row> expand(PCollectionList<Row> input) {
-      checkArgument(
-          input.size() == 0,
-          "Should not have received input for %s: %s",
-          BeamIOSourceRel.class.getSimpleName(),
-          input);
-      return sqlTable.buildIOReader(input.getPipeline().begin());
-    }
+  public PCollection<Row> implement(PCollectionList<Row> input) {
+    checkArgument(
+        input.size() == 0,
+        "Should not have received input for %s: %s",
+        BeamIOSourceRel.class.getSimpleName(),
+        input);
+    return sqlTable.buildIOReader(input.getPipeline().begin());
   }
 
   protected BeamSqlTable getBeamSqlTable() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamIntersectRel.java
@@ -19,7 +19,6 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.util.List;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.Row;
@@ -47,7 +46,7 @@ public class BeamIntersectRel extends Intersect implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.INTERSECT, all);
+  public PCollection<Row> implement(PCollectionList<Row> pinputs) {
+    return BeamSetOperator.implement(BeamSetOperator.OpType.INTERSECT, all, pinputs);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamMinusRel.java
@@ -19,7 +19,6 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.util.List;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.Row;
@@ -47,7 +46,7 @@ public class BeamMinusRel extends Minus implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.MINUS, all);
+  public PCollection<Row> implement(PCollectionList<Row> pinputs) {
+    return BeamSetOperator.implement(BeamSetOperator.OpType.MINUS, all, pinputs);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamRelNode.java
@@ -32,7 +32,7 @@ public interface BeamRelNode extends RelNode {
     return getInputs();
   };
 
-  PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform();
+  PCollection<Row> implement(PCollectionList<Row> pinputs);
 
   /** Perform a DFS(Depth-First-Search) to find the PipelineOptions config. */
   default Map<String, String> getPipelineOptions() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperator.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSetOperator.java
@@ -23,7 +23,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.Serializable;
 import org.apache.beam.sdk.extensions.sql.impl.transform.BeamSetOperatorsTransforms;
 import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
 import org.apache.beam.sdk.transforms.join.CoGroupByKey;
@@ -39,7 +38,7 @@ import org.apache.beam.sdk.values.TupleTag;
  * Delegate for Set operators: {@code BeamUnionRel}, {@code BeamIntersectRel} and {@code
  * BeamMinusRel}.
  */
-public class BeamSetOperatorRelBase extends PTransform<PCollectionList<Row>, PCollection<Row>> {
+public class BeamSetOperator {
   /** Set operator type. */
   public enum OpType implements Serializable {
     UNION,
@@ -47,22 +46,10 @@ public class BeamSetOperatorRelBase extends PTransform<PCollectionList<Row>, PCo
     MINUS
   }
 
-  private BeamRelNode beamRelNode;
-  private boolean all;
-  private OpType opType;
-
-  public BeamSetOperatorRelBase(BeamRelNode beamRelNode, OpType opType, boolean all) {
-    this.beamRelNode = beamRelNode;
-    this.opType = opType;
-    this.all = all;
-  }
-
-  public PCollection<Row> expand(PCollectionList<Row> inputs) {
+  public static PCollection<Row> implement(
+      OpType opType, boolean all, PCollectionList<Row> inputs) {
     checkArgument(
-        inputs.size() == 2,
-        "Wrong number of arguments to %s: %s",
-        beamRelNode.getClass().getSimpleName(),
-        inputs);
+        inputs.size() == 2, "Wrong number of arguments to set operation %s: %s", opType, inputs);
     PCollection<Row> leftRows = inputs.get(0);
     PCollection<Row> rightRows = inputs.get(1);
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -31,7 +31,6 @@ import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Top;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -123,51 +122,43 @@ public class BeamSortRel extends Sort implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new Transform();
-  }
-
-  private class Transform extends PTransform<PCollectionList<Row>, PCollection<Row>> {
-
-    @Override
-    public PCollection<Row> expand(PCollectionList<Row> pinput) {
-      checkArgument(
-          pinput.size() == 1,
-          "Wrong number of inputs for %s: %s",
-          BeamIOSinkRel.class.getSimpleName(),
-          pinput);
-      PCollection<Row> upstream = pinput.get(0);
-      Type windowType =
-          upstream.getWindowingStrategy().getWindowFn().getWindowTypeDescriptor().getType();
-      if (!windowType.equals(GlobalWindow.class)) {
-        throw new UnsupportedOperationException(
-            "`ORDER BY` is only supported for GlobalWindow, actual window: " + windowType);
-      }
-
-      BeamSqlRowComparator comparator =
-          new BeamSqlRowComparator(fieldIndices, orientation, nullsFirst);
-      // first find the top (offset + count)
-      PCollection<List<Row>> rawStream =
-          upstream
-              .apply(
-                  "extractTopOffsetAndFetch",
-                  Top.of(startIndex + count, comparator).withoutDefaults())
-              .setCoder(ListCoder.of(upstream.getCoder()));
-
-      // strip the `leading offset`
-      if (startIndex > 0) {
-        rawStream =
-            rawStream
-                .apply(
-                    "stripLeadingOffset", ParDo.of(new SubListFn<>(startIndex, startIndex + count)))
-                .setCoder(ListCoder.of(upstream.getCoder()));
-      }
-
-      PCollection<Row> orderedStream = rawStream.apply("flatten", Flatten.iterables());
-      orderedStream.setCoder(CalciteUtils.toBeamSchema(getRowType()).getRowCoder());
-
-      return orderedStream;
+  public PCollection<Row> implement(PCollectionList<Row> pinput) {
+    checkArgument(
+        pinput.size() == 1,
+        "Wrong number of inputs for %s: %s",
+        BeamIOSinkRel.class.getSimpleName(),
+        pinput);
+    PCollection<Row> upstream = pinput.get(0);
+    Type windowType =
+        upstream.getWindowingStrategy().getWindowFn().getWindowTypeDescriptor().getType();
+    if (!windowType.equals(GlobalWindow.class)) {
+      throw new UnsupportedOperationException(
+          "`ORDER BY` is only supported for GlobalWindow, actual window: " + windowType);
     }
+
+    BeamSqlRowComparator comparator =
+        new BeamSqlRowComparator(fieldIndices, orientation, nullsFirst);
+    // first find the top (offset + count)
+    PCollection<List<Row>> rawStream =
+        upstream
+            .apply(
+                "extractTopOffsetAndFetch",
+                Top.of(startIndex + count, comparator).withoutDefaults())
+            .setCoder(ListCoder.of(upstream.getCoder()));
+
+    // strip the `leading offset`
+    if (startIndex > 0) {
+      rawStream =
+          rawStream
+              .apply(
+                  "stripLeadingOffset", ParDo.of(new SubListFn<>(startIndex, startIndex + count)))
+              .setCoder(ListCoder.of(upstream.getCoder()));
+    }
+
+    PCollection<Row> orderedStream = rawStream.apply("flatten", Flatten.iterables());
+    orderedStream.setCoder(CalciteUtils.toBeamSchema(getRowType()).getRowCoder());
+
+    return orderedStream;
   }
 
   private static class SubListFn<T> extends DoFn<List<T>, List<T>> {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSqlRelUtils.java
@@ -63,7 +63,7 @@ public class BeamSqlRelUtils {
 
     String name = node.getClass().getSimpleName() + "_" + node.getId();
     PCollectionList<Row> input = buildPCollectionList(node.getPCollectionInputs(), pipeline, cache);
-    PTransform<PCollectionList<Row>, PCollection<Row>> transform = node.buildPTransform();
+    PTransform<PCollectionList<Row>, PCollection<Row>> transform = new Transform(node);
     output = Pipeline.applyTransform(name, input, transform);
 
     cache.put(node.getId(), output);
@@ -76,5 +76,18 @@ public class BeamSqlRelUtils {
       input = ((RelSubset) input).getBest();
     }
     return (BeamRelNode) input;
+  }
+
+  private static class Transform extends PTransform<PCollectionList<Row>, PCollection<Row>> {
+    private final BeamRelNode node;
+
+    public Transform(BeamRelNode node) {
+      this.node = node;
+    }
+
+    @Override
+    public PCollection<Row> expand(PCollectionList<Row> pinputs) {
+      return node.implement(pinputs);
+    }
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnionRel.java
@@ -19,7 +19,6 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import java.util.List;
-import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
@@ -74,7 +73,7 @@ public class BeamUnionRel extends Union implements BeamRelNode {
   }
 
   @Override
-  public PTransform<PCollectionList<Row>, PCollection<Row>> buildPTransform() {
-    return new BeamSetOperatorRelBase(this, BeamSetOperatorRelBase.OpType.UNION, all);
+  public PCollection<Row> implement(PCollectionList<Row> pinputs) {
+    return BeamSetOperator.implement(BeamSetOperator.OpType.UNION, all, pinputs);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSetOperatorsTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSetOperatorsTransforms.java
@@ -19,7 +19,7 @@
 package org.apache.beam.sdk.extensions.sql.impl.transform;
 
 import java.util.Iterator;
-import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSetOperatorRelBase;
+import org.apache.beam.sdk.extensions.sql.impl.rel.BeamSetOperator;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.join.CoGbkResult;
@@ -41,15 +41,12 @@ public abstract class BeamSetOperatorsTransforms {
   public static class SetOperatorFilteringDoFn extends DoFn<KV<Row, CoGbkResult>, Row> {
     private TupleTag<Row> leftTag;
     private TupleTag<Row> rightTag;
-    private BeamSetOperatorRelBase.OpType opType;
+    private BeamSetOperator.OpType opType;
     // ALL?
     private boolean all;
 
     public SetOperatorFilteringDoFn(
-        TupleTag<Row> leftTag,
-        TupleTag<Row> rightTag,
-        BeamSetOperatorRelBase.OpType opType,
-        boolean all) {
+        TupleTag<Row> leftTag, TupleTag<Row> rightTag, BeamSetOperator.OpType opType, boolean all) {
       this.leftTag = leftTag;
       this.rightTag = rightTag;
       this.opType = opType;


### PR DESCRIPTION
This removes boilerplate from `BeamRelNode`, reversing a prior decision to make them vend a `PTransform`.

I'm not 100% sure this is a great move. It doesn't really change any logic, it just moves ownership of transform boxing into `BeamSqlRelUtils`.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
