### PR TITLE
Fix build break from PR 5676, which modified method signatures.

### DIFF
--- a/sdks/go/cmd/beamctl/cmd/artifact.go
+++ b/sdks/go/cmd/beamctl/cmd/artifact.go
@@ -42,10 +42,13 @@ var (
 		RunE:  listFn,
 		Args:  cobra.NoArgs,
 	}
+
+	stagingToken string
 )
 
 func init() {
 	artifactCmd.AddCommand(stageCmd, listCmd)
+	stageCmd.PersistentFlags().StringVarP(&stagingToken, "token", "e", "", "Session Storage token")
 }
 
 func stageFn(cmd *cobra.Command, args []string) error {
@@ -65,11 +68,11 @@ func stageFn(cmd *cobra.Command, args []string) error {
 	// (2) Stage files in parallel, commit and print out token
 
 	client := pb.NewArtifactStagingServiceClient(cc)
-	list, err := artifact.MultiStage(ctx, client, 10, files)
+	list, err := artifact.MultiStage(ctx, client, 10, files, stagingToken)
 	if err != nil {
 		return err
 	}
-	token, err := artifact.Commit(ctx, client, list)
+	token, err := artifact.Commit(ctx, client, list, stagingToken)
 	if err != nil {
 		return err
 	}

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
@@ -39,12 +39,12 @@ func Execute(ctx context.Context, p *pb.Pipeline, endpoint string, opt *JobOptio
 	defer cc.Close()
 	client := jobpb.NewJobServiceClient(cc)
 
-	prepID, artifactEndpoint, err := Prepare(ctx, client, p, opt)
+	prepID, artifactEndpoint, st, err := Prepare(ctx, client, p, opt)
 	if err != nil {
 		return "", err
 	}
 
-	log.Infof(ctx, "Prepared job with id: %v", prepID)
+	log.Infof(ctx, "Prepared job with id: %v and staging token: %v", prepID, st)
 
 	// (2) Stage artifacts.
 
@@ -61,7 +61,7 @@ func Execute(ctx context.Context, p *pb.Pipeline, endpoint string, opt *JobOptio
 		log.Infof(ctx, "Using specified worker binary: '%v'", bin)
 	}
 
-	token, err := Stage(ctx, prepID, artifactEndpoint, bin)
+	token, err := Stage(ctx, prepID, artifactEndpoint, st, bin)
 	if err != nil {
 		return "", err
 	}

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
@@ -26,8 +26,8 @@ import (
 )
 
 // Stage stages the worker binary and any additional files to the given
-// artifact staging endpoint. It returns the commit token if successful.
-func Stage(ctx context.Context, id, endpoint, binary string, files ...artifact.KeyedFile) (string, error) {
+// artifact staging endpoint. It returns the retrieval token if successful.
+func Stage(ctx context.Context, id, endpoint, binary, st string, files ...artifact.KeyedFile) (retrievalToken string, err error) {
 	ctx = grpcx.WriteWorkerID(ctx, id)
 	cc, err := grpcx.Dial(ctx, endpoint, 2*time.Minute)
 	if err != nil {
@@ -39,11 +39,11 @@ func Stage(ctx context.Context, id, endpoint, binary string, files ...artifact.K
 
 	files = append(files, artifact.KeyedFile{Key: "worker", Filename: binary})
 
-	md, err := artifact.MultiStage(ctx, client, 10, files)
+	md, err := artifact.MultiStage(ctx, client, 10, files, st)
 	if err != nil {
 		return "", fmt.Errorf("failed to stage artifacts: %v", err)
 	}
-	token, err := artifact.Commit(ctx, client, md)
+	token, err := artifact.Commit(ctx, client, md, st)
 	if err != nil {
 		return "", fmt.Errorf("failed to commit artifacts: %v", err)
 	}


### PR DESCRIPTION
The presubmits don't build/check all the go code, but it's still a good habit to run go test ./... from the beam root anyway.

This PR is my best guess of the right fix, and propagating the token appropriately.

This fixes beamctl, as well as the universal runner, which flink uses.