### PR TITLE
Adding ignore parameters for gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,3 +26,11 @@ Dockerfile text
 
 # Explicitly denote all files that are truly binary and should not be modified.
 # *.jpg binary
+
+# Declare files that should be ignored when creating an archive of the
+# git repository
+.gitignore export-ignore
+.gitattributes export-ignore
+gradlew export-ignore
+gradlew.bat export-ignore
+/gradle export-ignore


### PR DESCRIPTION
A decision has been made by the Beam community to no longer include gradle files in the published archives of Beam. This enables git to ignore them when packaging the sources.

r: @kennknowles 