### PR TITLE
Simplifies API of WireCoders and LengthPrefixUnknownCoders.

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/GroupByKeyOnlyEvaluatorFactory.java
@@ -29,7 +29,6 @@ import org.apache.beam.runners.core.GroupByKeyViaGroupByKeyOnly.GroupByKeyOnly;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.KeyedWorkItems;
 import org.apache.beam.runners.direct.DirectGroupByKey.DirectGroupByKeyOnly;
-import org.apache.beam.runners.direct.StepTransformResult.Builder;
 import org.apache.beam.runners.local.StructuralKey;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -128,7 +127,7 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
 
     @Override
     public TransformResult<KV<K, V>> finishBundle() {
-      Builder resultBuilder = StepTransformResult.withoutHold(application);
+      StepTransformResult.Builder resultBuilder = StepTransformResult.withoutHold(application);
       for (Map.Entry<StructuralKey<K>, List<WindowedValue<V>>> groupedEntry :
           groupingMap.entrySet()) {
         K key = groupedEntry.getKey().getKey();

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/GroupByKeyOnlyEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/GroupByKeyOnlyEvaluatorFactory.java
@@ -26,12 +26,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components.Builder;
 import org.apache.beam.runners.core.GroupByKeyViaGroupByKeyOnly;
 import org.apache.beam.runners.core.GroupByKeyViaGroupByKeyOnly.GroupByKeyOnly;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.KeyedWorkItems;
-import org.apache.beam.runners.core.construction.CoderTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
@@ -104,14 +103,11 @@ class GroupByKeyOnlyEvaluatorFactory implements TransformEvaluatorFactory {
       try {
         // We know the type restrictions on the input PCollection, and the restrictions on the
         // Wire coder
-        MessageWithComponents wireCoderProto =
-            WireCoders.createRunnerWireCoder(
-                inputPCollection, components, components::containsCoders);
+        Builder builder = GroupByKeyOnlyEvaluatorFactory.this.components.toBuilder();
+        String wireCoderId = WireCoders.addRunnerWireCoder(inputPCollection, builder);
         Coder<WindowedValue<KV<K, V>>> wireCoder =
             (Coder<WindowedValue<KV<K, V>>>)
-                CoderTranslation.fromProto(
-                    wireCoderProto.getCoder(),
-                    RehydratedComponents.forComponents(wireCoderProto.getComponents()));
+                RehydratedComponents.forComponents(builder.build()).getCoder(wireCoderId);
 
         checkArgument(
             wireCoder instanceof WindowedValue.WindowedValueCoder,

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
@@ -418,12 +418,10 @@ public class ReferenceRunner {
       String feedSDFCollectionId =
           uniqueId(String.format("%s.feed", spkId), components::containsPcollections);
       {
-        String feedSDFCoderId =
-            uniqueId(String.format("%s/FeedSDF-wire", spkId), components::containsCoders);
         String elementRestrictionCoderId = kvComponents.valueCoderId();
-        MessageWithComponents feedSDFCoder =
-            LengthPrefixUnknownCoders.forCoder(
-                elementRestrictionCoderId, newComponents.build(), false);
+        String feedSDFCoderId =
+            LengthPrefixUnknownCoders.addLengthPrefixedCoder(
+                elementRestrictionCoderId, newComponents, false);
 
         PCollection feedSDFCollection =
             input.toBuilder().setUniqueName(feedSDFCollectionId).setCoderId(feedSDFCoderId).build();
@@ -440,8 +438,6 @@ public class ReferenceRunner {
                 .build();
 
         newComponents
-            .putCoders(feedSDFCoderId, feedSDFCoder.getCoder())
-            .putAllCoders(feedSDFCoder.getComponents().getCodersMap())
             .putPcollections(feedSDFCollectionId, feedSDFCollection)
             .putTransforms(feedSDFId, feedSDF);
         newPTransform.addSubtransforms(feedSDFId);

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/BundleFactoryOutputReceiverFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/BundleFactoryOutputReceiverFactoryTest.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
-import org.apache.beam.runners.core.construction.CoderTranslation;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components.Builder;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
@@ -61,7 +61,7 @@ public class BundleFactoryOutputReceiverFactoryTest {
   private final BundleFactory bundleFactory = ImmutableListBundleFactory.create();
   private PCollectionNode fooPC;
   private PCollectionNode barPC;
-  private RunnerApi.Components components;
+  private RunnerApi.Components baseComponents;
 
   private OutputReceiverFactory factory;
   private Collection<UncommittedBundle<?>> outputBundles;
@@ -77,14 +77,14 @@ public class BundleFactoryOutputReceiverFactoryTest {
     SdkComponents sdkComponents = SdkComponents.create();
     String fooId = sdkComponents.registerPCollection(foo);
     String barId = sdkComponents.registerPCollection(bar);
-    components = sdkComponents.toComponents();
+    baseComponents = sdkComponents.toComponents();
 
-    fooPC = PipelineNode.pCollection(fooId, components.getPcollectionsOrThrow(fooId));
-    barPC = PipelineNode.pCollection(barId, components.getPcollectionsOrThrow(barId));
+    fooPC = PipelineNode.pCollection(fooId, baseComponents.getPcollectionsOrThrow(fooId));
+    barPC = PipelineNode.pCollection(barId, baseComponents.getPcollectionsOrThrow(barId));
 
     outputBundles = new ArrayList<>();
     factory =
-        BundleFactoryOutputReceiverFactory.create(bundleFactory, components, outputBundles::add);
+        BundleFactoryOutputReceiverFactory.create(bundleFactory, baseComponents, outputBundles::add);
   }
 
   @Test
@@ -104,13 +104,14 @@ public class BundleFactoryOutputReceiverFactoryTest {
   @Test
   public void receiverAddsElementsToBundle() throws Exception {
     FnDataReceiver<WindowedValue<byte[]>> receiver = factory.create(fooPC.getId());
-    MessageWithComponents sdkWireCoder =
-        WireCoders.createSdkWireCoder(fooPC, components, components::containsCoders);
+
+    Builder builder = baseComponents.toBuilder();
+    String sdkWireCoderId = WireCoders.addSdkWireCoder(fooPC, builder);
+    Components components = builder.build();
+
     Coder<WindowedValue<String>> sdkCoder =
         (Coder<WindowedValue<String>>)
-            CoderTranslation.fromProto(
-                sdkWireCoder.getCoder(),
-                RehydratedComponents.forComponents(sdkWireCoder.getComponents()));
+            RehydratedComponents.forComponents(components).getCoder(sdkWireCoderId);
     Coder<WindowedValue<byte[]>> runnerCoder =
         WireCoders.instantiateRunnerWireCoder(fooPC, components);
 
@@ -151,13 +152,15 @@ public class BundleFactoryOutputReceiverFactoryTest {
   public void multipleInstancesOfPCollectionIndependent() throws Exception {
     FnDataReceiver<WindowedValue<byte[]>> firstReceiver = factory.create(fooPC.getId());
     FnDataReceiver<WindowedValue<byte[]>> secondReceiver = factory.create(fooPC.getId());
-    MessageWithComponents sdkWireCoder =
-        WireCoders.createSdkWireCoder(fooPC, components, components::containsCoders);
+
+    Components.Builder builder = baseComponents.toBuilder();
+    String sdkWireCoderId = WireCoders.addSdkWireCoder(fooPC, builder);
+    Components components = builder.build();
+
     Coder<WindowedValue<String>> sdkCoder =
         (Coder<WindowedValue<String>>)
-            CoderTranslation.fromProto(
-                sdkWireCoder.getCoder(),
-                RehydratedComponents.forComponents(sdkWireCoder.getComponents()));
+            RehydratedComponents.forComponents(components).getCoder(sdkWireCoderId);
+
     Coder<WindowedValue<byte[]>> runnerCoder =
         WireCoders.instantiateRunnerWireCoder(fooPC, components);
 
@@ -199,24 +202,23 @@ public class BundleFactoryOutputReceiverFactoryTest {
   @Test
   public void differentPCollectionsIndependent() throws Exception {
     FnDataReceiver<WindowedValue<byte[]>> fooReceiver = factory.create(fooPC.getId());
-    MessageWithComponents fooSdkWireCoder =
-        WireCoders.createSdkWireCoder(fooPC, components, components::containsCoders);
+
+    Components.Builder builder = baseComponents.toBuilder();
+    String sdkWireCoderId = WireCoders.addSdkWireCoder(fooPC, builder);
+    String barSdkWireCoderId =
+        WireCoders.addSdkWireCoder(barPC, builder);
+    Components components = builder.build();
+
     Coder<WindowedValue<String>> fooSdkCoder =
         (Coder<WindowedValue<String>>)
-            CoderTranslation.fromProto(
-                fooSdkWireCoder.getCoder(),
-                RehydratedComponents.forComponents(fooSdkWireCoder.getComponents()));
+            RehydratedComponents.forComponents(components).getCoder(sdkWireCoderId);
     Coder<WindowedValue<byte[]>> fooRunnerCoder =
         WireCoders.instantiateRunnerWireCoder(fooPC, components);
 
     FnDataReceiver<WindowedValue<byte[]>> barReceiver = factory.create(barPC.getId());
-    MessageWithComponents barSdkWireCoder =
-        WireCoders.createSdkWireCoder(barPC, components, components::containsCoders);
     Coder<WindowedValue<Integer>> barSdkCoder =
         (Coder<WindowedValue<Integer>>)
-            CoderTranslation.fromProto(
-                barSdkWireCoder.getCoder(),
-                RehydratedComponents.forComponents(barSdkWireCoder.getComponents()));
+            RehydratedComponents.forComponents(components).getCoder(barSdkWireCoderId);
     Coder<WindowedValue<byte[]>> barRunnerCoder =
         WireCoders.instantiateRunnerWireCoder(barPC, components);
 

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/BundleFactoryOutputReceiverFactoryTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/portable/BundleFactoryOutputReceiverFactoryTest.java
@@ -84,7 +84,8 @@ public class BundleFactoryOutputReceiverFactoryTest {
 
     outputBundles = new ArrayList<>();
     factory =
-        BundleFactoryOutputReceiverFactory.create(bundleFactory, baseComponents, outputBundles::add);
+        BundleFactoryOutputReceiverFactory.create(
+            bundleFactory, baseComponents, outputBundles::add);
   }
 
   @Test

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
@@ -21,12 +21,10 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import java.io.IOException;
-import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.control.DockerJobBundleFactory;
 import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors;
-import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors.ExecutableProcessBundleDescriptor;
 import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
@@ -62,24 +60,12 @@ class BatchFlinkExecutableStageContext implements FlinkExecutableStageContext {
       ExecutableStage executableStage, RuntimeContext runtimeContext) {
     MultimapSideInputHandlerFactory sideInputHandlerFactory =
         FlinkBatchSideInputHandlerFactory.forStage(executableStage, runtimeContext);
-    ExecutableProcessBundleDescriptor processBundleDescriptor;
     try {
-      // NOTE: We require an executable bundle descriptor for the StateRequestHandlers construction
-      // below. This only uses the bundle descriptor for side input specs and effectively ignores
-      // data and state endpoints. We rely on the fact that PCollections and coders are structurally
-      // identical between instantiations here to prevent having to wire the original executable
-      // bundle descriptor here. The correct long-term fix is to move side input logic out of
-      // ExecutableProcessBundleDescriptor and into ExecutableStage.
-      processBundleDescriptor =
-          ProcessBundleDescriptors.fromExecutableStage(
-              "id", executableStage, Endpoints.ApiServiceDescriptor.getDefaultInstance());
+      return StateRequestHandlers.forMultimapSideInputHandlerFactory(
+          ProcessBundleDescriptors.getMultimapSideInputs(executableStage), sideInputHandlerFactory);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
-    StateRequestHandler stateRequestHandler =
-        StateRequestHandlers.forMultimapSideInputHandlerFactory(
-            processBundleDescriptor, sideInputHandlerFactory);
-    return stateRequestHandler;
   }
 
   @Override

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
@@ -25,6 +25,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -32,15 +33,12 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleDescriptor;
-import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleDescriptor.Builder;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
 import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
-import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
-import org.apache.beam.runners.core.construction.SyntheticComponents;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PTransformNode;
@@ -98,39 +96,39 @@ public class ProcessBundleDescriptors {
       ExecutableStage stage,
       ApiServiceDescriptor dataEndpoint,
       @Nullable ApiServiceDescriptor stateEndpoint) throws IOException {
-    Components components = stage.getComponents();
     // Create with all of the processing transforms, and all of the components.
     // TODO: Remove the unreachable subcomponents if the size of the descriptor matters.
+    Map<String, PTransform> stageTransforms =
+        stage
+            .getTransforms()
+            .stream()
+            .collect(Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform));
+
+    Components.Builder components =
+        stage.getComponents().toBuilder().clearTransforms().putAllTransforms(stageTransforms);
+
+    // The order of these 3 does not matter.
+    RemoteInputDestination<WindowedValue<?>> inputDestination =
+        addStageInput(dataEndpoint, stage.getInputPCollection(), components);
+
+    Map<Target, Coder<WindowedValue<?>>> outputTargetCoders =
+        addStageOutputs(dataEndpoint, stage.getOutputPCollections(), components);
+
+    Map<String, Map<String, MultimapSideInputSpec>> multimapSideInputSpecs =
+        addMultimapSideInputs(stage, components);
+
+    // Copy data from components to ProcessBundleDescriptor.
     ProcessBundleDescriptor.Builder bundleDescriptorBuilder =
-        ProcessBundleDescriptor.newBuilder()
-            .setId(id)
-            .putAllCoders(components.getCodersMap())
-            .putAllEnvironments(components.getEnvironmentsMap())
-            .putAllPcollections(components.getPcollectionsMap())
-            .putAllWindowingStrategies(components.getWindowingStrategiesMap())
-            .putAllTransforms(
-                stage
-                    .getTransforms()
-                    .stream()
-                    .collect(
-                        Collectors.toMap(PTransformNode::getId, PTransformNode::getTransform)));
+        ProcessBundleDescriptor.newBuilder().setId(id);
     if (stateEndpoint != null) {
       bundleDescriptorBuilder.setStateApiServiceDescriptor(stateEndpoint);
     }
-
-    RemoteInputDestination<WindowedValue<?>> inputDestination =
-        addStageInput(
-            stage.getInputPCollection(), components, dataEndpoint, bundleDescriptorBuilder);
-
-    Map<BeamFnApi.Target, Coder<WindowedValue<?>>> outputTargetCoders = new LinkedHashMap<>();
-    for (PCollectionNode outputPCollection : stage.getOutputPCollections()) {
-      TargetEncoding targetEncoding =
-          addStageOutput(components, dataEndpoint, bundleDescriptorBuilder, outputPCollection);
-      outputTargetCoders.put(targetEncoding.getTarget(), targetEncoding.getCoder());
-    }
-
-    Map<String, Map<String, MultimapSideInputSpec>> multimapSideInputSpecs =
-        forMultimapSideInputs(stage, components, bundleDescriptorBuilder);
+    bundleDescriptorBuilder
+        .putAllCoders(components.getCodersMap())
+        .putAllEnvironments(components.getEnvironmentsMap())
+        .putAllPcollections(components.getPcollectionsMap())
+        .putAllWindowingStrategies(components.getWindowingStrategiesMap())
+        .putAllTransforms(components.getTransformsMap());
 
     return ExecutableProcessBundleDescriptor.of(
         bundleDescriptorBuilder.build(),
@@ -139,16 +137,26 @@ public class ProcessBundleDescriptors {
         multimapSideInputSpecs);
   }
 
+  private static Map<Target, Coder<WindowedValue<?>>> addStageOutputs(
+      ApiServiceDescriptor dataEndpoint, Collection<PCollectionNode> outputPCollections,
+      Components.Builder components) throws IOException {
+    Map<Target, Coder<WindowedValue<?>>> outputTargetCoders = new LinkedHashMap<>();
+    for (PCollectionNode outputPCollection : outputPCollections) {
+      TargetEncoding targetEncoding =
+          addStageOutput(dataEndpoint, components, outputPCollection);
+      outputTargetCoders.put(targetEncoding.getTarget(), targetEncoding.getCoder());
+    }
+    return outputTargetCoders;
+  }
+
   private static RemoteInputDestination<WindowedValue<?>> addStageInput(
-      PCollectionNode inputPCollection,
-      Components components,
-      ApiServiceDescriptor dataEndpoint,
-      ProcessBundleDescriptor.Builder bundleDescriptorBuilder)
+      ApiServiceDescriptor dataEndpoint, PCollectionNode inputPCollection,
+      Components.Builder components)
       throws IOException {
-    String inputWireCoderId = addWireCoder(inputPCollection, components, bundleDescriptorBuilder);
+    String inputWireCoderId = WireCoders.addSdkWireCoder(inputPCollection, components);
     @SuppressWarnings("unchecked")
     Coder<WindowedValue<?>> wireCoder =
-        (Coder) WireCoders.instantiateRunnerWireCoder(inputPCollection, components);
+        (Coder) WireCoders.instantiateRunnerWireCoder(inputPCollection, components.build());
 
     RemoteGrpcPort inputPort =
         RemoteGrpcPort.newBuilder()
@@ -158,10 +166,10 @@ public class ProcessBundleDescriptors {
     String inputId =
         uniqueId(
             String.format("fn/read/%s", inputPCollection.getId()),
-            bundleDescriptorBuilder::containsTransforms);
+            components::containsTransforms);
     PTransform inputTransform =
         RemoteGrpcPortRead.readFromPort(inputPort, inputPCollection.getId()).toPTransform();
-    bundleDescriptorBuilder.putTransforms(inputId, inputTransform);
+    components.putTransforms(inputId, inputTransform);
     return RemoteInputDestination.of(
         wireCoder,
         Target.newBuilder()
@@ -171,15 +179,14 @@ public class ProcessBundleDescriptors {
   }
 
   private static TargetEncoding addStageOutput(
-      Components components,
       ApiServiceDescriptor dataEndpoint,
-      Builder bundleDescriptorBuilder,
+      Components.Builder components,
       PCollectionNode outputPCollection)
       throws IOException {
-    String outputWireCoderId = addWireCoder(outputPCollection, components, bundleDescriptorBuilder);
+    String outputWireCoderId = WireCoders.addSdkWireCoder(outputPCollection, components);
     @SuppressWarnings("unchecked")
     Coder<WindowedValue<?>> wireCoder =
-        (Coder) WireCoders.instantiateRunnerWireCoder(outputPCollection, components);
+        (Coder) WireCoders.instantiateRunnerWireCoder(outputPCollection, components.build());
     RemoteGrpcPort outputPort =
         RemoteGrpcPort.newBuilder()
             .setApiServiceDescriptor(dataEndpoint)
@@ -190,9 +197,9 @@ public class ProcessBundleDescriptors {
     String outputId =
         uniqueId(
             String.format("fn/write/%s", outputPCollection.getId()),
-            bundleDescriptorBuilder::containsTransforms);
+            components::containsTransforms);
     PTransform outputTransform = outputWrite.toPTransform();
-    bundleDescriptorBuilder.putTransforms(outputId, outputTransform);
+    components.putTransforms(outputId, outputTransform);
     return new AutoValue_ProcessBundleDescriptors_TargetEncoding(
         Target.newBuilder()
             .setPrimitiveTransformReference(outputId)
@@ -201,44 +208,25 @@ public class ProcessBundleDescriptors {
         wireCoder);
   }
 
-  private static Map<String, Map<String, MultimapSideInputSpec>> forMultimapSideInputs(
+  private static Map<String, Map<String, MultimapSideInputSpec>> addMultimapSideInputs(
       ExecutableStage stage,
-      Components components,
-      ProcessBundleDescriptor.Builder bundleDescriptorBuilder) throws IOException {
+      Components.Builder components) throws IOException {
     ImmutableTable.Builder<String, String, MultimapSideInputSpec> idsToSpec =
         ImmutableTable.builder();
     for (SideInputReference sideInputReference : stage.getSideInputs()) {
       // Update the coder specification for side inputs to be length prefixed so that the
       // SDK and Runner agree on how to encode/decode the key, window, and values for multimap
       // side inputs.
-      String pCollectionId = sideInputReference.collection().getId();
-      RunnerApi.MessageWithComponents lengthPrefixedSideInputCoder =
-          LengthPrefixUnknownCoders.forCoder(
-              components.getPcollectionsOrThrow(pCollectionId).getCoderId(),
-              components,
-              false);
-      String lengthPrefixedSideInputCoderId = SyntheticComponents.uniqueId(
-          String.format(
-              "fn/side_input/%s",
-              components.getPcollectionsOrThrow(pCollectionId).getCoderId()),
-          bundleDescriptorBuilder.getCodersMap().keySet()::contains);
-
-      bundleDescriptorBuilder.putCoders(
-          lengthPrefixedSideInputCoderId, lengthPrefixedSideInputCoder.getCoder());
-      bundleDescriptorBuilder.putAllCoders(
-          lengthPrefixedSideInputCoder.getComponents().getCodersMap());
-      bundleDescriptorBuilder.putPcollections(
-          pCollectionId,
-          bundleDescriptorBuilder
-              .getPcollectionsMap()
-              .get(pCollectionId)
-              .toBuilder()
-              .setCoderId(lengthPrefixedSideInputCoderId)
-              .build());
+      PCollectionNode pcNode = sideInputReference.collection();
+      PCollection pc = pcNode.getPCollection();
+      String lengthPrefixedCoderId =
+          LengthPrefixUnknownCoders.addLengthPrefixedCoder(pc.getCoderId(), components, false);
+      components.putPcollections(
+          pcNode.getId(), pc.toBuilder().setCoderId(lengthPrefixedCoderId).build());
 
       FullWindowedValueCoder<KV<?, ?>> coder =
-          (FullWindowedValueCoder) WireCoders.instantiateRunnerWireCoder(
-              sideInputReference.collection(), components);
+          (FullWindowedValueCoder)
+              WireCoders.instantiateRunnerWireCoder(pcNode, components.build());
       idsToSpec.put(
           sideInputReference.transform().getId(),
           sideInputReference.localName(),
@@ -280,26 +268,6 @@ public class ProcessBundleDescriptors {
     public abstract Coder<K> keyCoder();
     public abstract Coder<V> valueCoder();
     public abstract Coder<W> windowCoder();
-  }
-
-  /**
-   * Add a {@link RunnerApi.Coder} suitable for using as the wire coder to the provided {@link
-   * ProcessBundleDescriptor.Builder} and return the ID of that Coder.
-   */
-  private static String addWireCoder(
-      PCollectionNode pCollection,
-      Components components,
-      ProcessBundleDescriptor.Builder bundleDescriptorBuilder) {
-    MessageWithComponents wireCoder =
-        WireCoders.createSdkWireCoder(
-            pCollection, components, bundleDescriptorBuilder::containsCoders);
-    bundleDescriptorBuilder.putAllCoders(wireCoder.getComponents().getCodersMap());
-    String wireCoderId =
-        uniqueId(
-            String.format("fn/wire/%s", pCollection.getId()),
-            bundleDescriptorBuilder::containsCoders);
-    bundleDescriptorBuilder.putCoders(wireCoderId, wireCoder.getCoder());
-    return wireCoderId;
   }
 
   /** */

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
@@ -208,6 +208,11 @@ public class ProcessBundleDescriptors {
         wireCoder);
   }
 
+  public static Map<String, Map<String, MultimapSideInputSpec>> getMultimapSideInputs(
+      ExecutableStage stage) throws IOException {
+    return addMultimapSideInputs(stage, stage.getComponents().toBuilder());
+  }
+
   private static Map<String, Map<String, MultimapSideInputSpec>> addMultimapSideInputs(
       ExecutableStage stage,
       Components.Builder components) throws IOException {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/WireCoders.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/WireCoders.java
@@ -20,9 +20,7 @@ package org.apache.beam.runners.fnexecution.wire;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
-import java.util.function.Predicate;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.runners.core.construction.CoderTranslation;
 import org.apache.beam.runners.core.construction.ModelCoders;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.SyntheticComponents;
@@ -38,11 +36,11 @@ public class WireCoders {
    * unknown to the runner are wrapped with length-prefix coders. The inner element coders are kept
    * intact so that SDK harnesses can reconstruct the original elements.
    *
-   * @return a windowed value coder containing the PCollection's element coder
+   * @return id of a windowed value coder containing the PCollection's element coder
    */
-  public static RunnerApi.MessageWithComponents createSdkWireCoder(
-      PCollectionNode pCollectionNode, RunnerApi.Components components, Predicate<String> idUsed) {
-    return createWireCoder(pCollectionNode, components, idUsed, false);
+  public static String addSdkWireCoder(
+      PCollectionNode pCollectionNode, RunnerApi.Components.Builder components) {
+    return addWireCoder(pCollectionNode, components, false);
   }
 
   /**
@@ -51,9 +49,9 @@ public class WireCoders {
    *
    * @return a windowed value coder containing the PCollection's element coder
    */
-  public static RunnerApi.MessageWithComponents createRunnerWireCoder(
-      PCollectionNode pCollectionNode, RunnerApi.Components components, Predicate<String> idUsed) {
-    return createWireCoder(pCollectionNode, components, idUsed, true);
+  public static String addRunnerWireCoder(
+      PCollectionNode pCollectionNode, RunnerApi.Components.Builder components) {
+    return addWireCoder(pCollectionNode, components, true);
   }
 
   /**
@@ -66,11 +64,9 @@ public class WireCoders {
       PCollectionNode pCollectionNode, RunnerApi.Components components) throws IOException {
     // NOTE: We discard the new set of components so we don't bother to ensure it's consistent with
     // the caller's view.
-    RunnerApi.MessageWithComponents protoCoder =
-        createRunnerWireCoder(pCollectionNode, components, components::containsCoders);
-    Coder<?> javaCoder =
-        CoderTranslation.fromProto(
-            protoCoder.getCoder(), RehydratedComponents.forComponents(protoCoder.getComponents()));
+    RunnerApi.Components.Builder builder = components.toBuilder();
+    String protoCoderId = addRunnerWireCoder(pCollectionNode, builder);
+    Coder<?> javaCoder = RehydratedComponents.forComponents(builder.build()).getCoder(protoCoderId);
     checkArgument(
         javaCoder instanceof WindowedValue.FullWindowedValueCoder,
         "Unexpected Deserialized %s type, expected %s, got %s",
@@ -80,10 +76,9 @@ public class WireCoders {
     return (Coder<WindowedValue<T>>) javaCoder;
   }
 
-  private static RunnerApi.MessageWithComponents createWireCoder(
+  private static String addWireCoder(
       PCollectionNode pCollectionNode,
-      RunnerApi.Components components,
-      Predicate<String> idUsed,
+      RunnerApi.Components.Builder components,
       boolean useByteArrayCoder) {
     String elementCoderId = pCollectionNode.getPCollection().getCoderId();
     String windowingStrategyId = pCollectionNode.getPCollection().getWindowingStrategyId();
@@ -93,11 +88,11 @@ public class WireCoders {
         ModelCoders.windowedValueCoder(elementCoderId, windowCoderId);
     // Add the original WindowedValue<T, W> coder to the components;
     String windowedValueId =
-        SyntheticComponents.uniqueId(String.format("fn/wire/%s", pCollectionNode.getId()), idUsed);
-    return LengthPrefixUnknownCoders.forCoder(
-        windowedValueId,
-        components.toBuilder().putCoders(windowedValueId, windowedValueCoder).build(),
-        useByteArrayCoder);
+        SyntheticComponents.uniqueId(
+            String.format("fn/wire/%s", pCollectionNode.getId()), components::containsCoders);
+    components.putCoders(windowedValueId, windowedValueCoder);
+    return LengthPrefixUnknownCoders.addLengthPrefixedCoder(
+        windowedValueId, components, useByteArrayCoder);
   }
 
   // Not instantiable.

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/WireCoders.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/wire/WireCoders.java
@@ -36,6 +36,8 @@ public class WireCoders {
    * unknown to the runner are wrapped with length-prefix coders. The inner element coders are kept
    * intact so that SDK harnesses can reconstruct the original elements.
    *
+   * <p>Adds all necessary coders to the components builder.
+   *
    * @return id of a windowed value coder containing the PCollection's element coder
    */
   public static String addSdkWireCoder(
@@ -47,7 +49,9 @@ public class WireCoders {
    * Creates a runner-side wire coder for a port read/write for the given PCollection. Unknown
    * coders are replaced with length-prefixed byte arrays.
    *
-   * @return a windowed value coder containing the PCollection's element coder
+   * <p>Adds all necessary coders to the components builder.
+   *
+   * @return id of a windowed value coder containing the PCollection's element coder
    */
   public static String addRunnerWireCoder(
       PCollectionNode pCollectionNode, RunnerApi.Components.Builder components) {

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -324,7 +324,7 @@ public class RemoteExecutionTest implements Serializable {
             CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "C"));
     StateRequestHandler stateRequestHandler =
         StateRequestHandlers.forMultimapSideInputHandlerFactory(
-            descriptor,
+            descriptor.getMultimapSideInputSpecs(),
             new MultimapSideInputHandlerFactory() {
               @Override
               public <K, V, W extends BoundedWindow> MultimapSideInputHandler<K, V, W> forSideInput(

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCodersTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCodersTest.java
@@ -135,13 +135,13 @@ public class LengthPrefixUnknownCodersTest {
   public void test() throws IOException {
     MessageWithComponents originalCoderProto = CoderTranslation.toProto(original);
     Components.Builder builder = originalCoderProto.getComponents().toBuilder();
-    String coderId = LengthPrefixUnknownCoders.generateUniqueId("rootTestId",
-        originalCoderProto.getComponents().getCodersMap().keySet());
+    String coderId =
+        LengthPrefixUnknownCoders.generateUniqueId(
+            "rootTestId", originalCoderProto.getComponents()::containsCoders);
     builder.putCoders(coderId, originalCoderProto.getCoder());
-    MessageWithComponents updatedCoderProto = LengthPrefixUnknownCoders.forCoder(
-        coderId, builder.build(), replaceWithByteArray);
-    assertEquals(expected,
-        CoderTranslation.fromProto(updatedCoderProto.getCoder(),
-            RehydratedComponents.forComponents(updatedCoderProto.getComponents())));
+    String updatedCoderId = LengthPrefixUnknownCoders.addLengthPrefixedCoder(
+        coderId, builder, replaceWithByteArray);
+    assertEquals(
+        expected, RehydratedComponents.forComponents(builder.build()).getCoder(updatedCoderId));
   }
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCodersTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/LengthPrefixUnknownCodersTest.java
@@ -23,9 +23,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.MessageWithComponents;
-import org.apache.beam.runners.core.construction.CoderTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
+import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -133,15 +132,12 @@ public class LengthPrefixUnknownCodersTest {
 
   @Test
   public void test() throws IOException {
-    MessageWithComponents originalCoderProto = CoderTranslation.toProto(original);
-    Components.Builder builder = originalCoderProto.getComponents().toBuilder();
-    String coderId =
-        LengthPrefixUnknownCoders.generateUniqueId(
-            "rootTestId", originalCoderProto.getComponents()::containsCoders);
-    builder.putCoders(coderId, originalCoderProto.getCoder());
+    SdkComponents sdkComponents = SdkComponents.create();
+    String coderId = sdkComponents.registerCoder(original);
+    Components.Builder components = sdkComponents.toComponents().toBuilder();
     String updatedCoderId = LengthPrefixUnknownCoders.addLengthPrefixedCoder(
-        coderId, builder, replaceWithByteArray);
+        coderId, components, replaceWithByteArray);
     assertEquals(
-        expected, RehydratedComponents.forComponents(builder.build()).getCoder(updatedCoderId));
+        expected, RehydratedComponents.forComponents(components.build()).getCoder(updatedCoderId));
   }
 }


### PR DESCRIPTION
Instead of returning MessageWithComponents, they take a Components.Builder directly and add the necessary coders to it. This considerably simplifies both the implementation code and caller code: see ProcessBundleDescriptors.

I had to refactor ProcessBundleDescriptors a bit to make this work: I'm not sure why ProcessBundleDescriptor doesn't just have a Components inside it already, and instead has the same fields - but using Components at least for internal calculations simplifies that code too.

R: @lukecwik (sorry for bombarding you with reviews today: FWIW I'm not blocked on this PR, it can wait a few days if you're busy)