### PR TITLE
[BEAM-4283] Fix naming of the BigQuery fields

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -145,10 +145,10 @@ public class Main<OptionT extends NexmarkOptions> {
         new TableSchema()
             .setFields(
                 ImmutableList.of(
-                    new TableFieldSchema().setName("Runtime(sec)").setType("FLOAT"),
-                    new TableFieldSchema().setName("Events(/sec)").setType("FLOAT"),
+                    new TableFieldSchema().setName("runtimeSec").setType("FLOAT"),
+                    new TableFieldSchema().setName("eventsPerSec").setType("FLOAT"),
                     new TableFieldSchema()
-                        .setName("Size of the result collection")
+                        .setName("numResults")
                         .setType("INTEGER")));
 
     String tableSpec =
@@ -163,9 +163,9 @@ public class Main<OptionT extends NexmarkOptions> {
         input -> {
           NexmarkPerf nexmarkPerf = input.getValue();
           TableRow row = new TableRow()
-              .set("Runtime(sec)", nexmarkPerf.runtimeSec)
-              .set("Events(/sec)", nexmarkPerf.eventsPerSec)
-              .set("Size of the result collection", nexmarkPerf.numResults);
+              .set("runtimeSec", nexmarkPerf.runtimeSec)
+              .set("eventsPerSec", nexmarkPerf.eventsPerSec)
+              .set("numResults", nexmarkPerf.numResults);
           return row;
         };
     BigQueryIO.Write io =

--- a/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
+++ b/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
@@ -104,16 +104,16 @@ public class PerfsToBigQueryTest {
     assertEquals("Wrong number of rows inserted", 2, actualRows.size());
     List<TableRow> expectedRows = new ArrayList<>();
     TableRow row1 = new TableRow()
-        .set("Runtime(sec)", nexmarkPerf1.runtimeSec).set("Events(/sec)", nexmarkPerf1.eventsPerSec)
+        .set("runtimeSec", nexmarkPerf1.runtimeSec).set("eventsPerSec", nexmarkPerf1.eventsPerSec)
         // when read using TableRowJsonCoder the row field is boxed into an Integer, cast it to int
         // to for bowing into Integer in the expectedRows.
-        .set("Size of the result collection", (int) nexmarkPerf1.numResults);
+        .set("numResults", (int) nexmarkPerf1.numResults);
     expectedRows.add(row1);
     TableRow row2 = new TableRow()
-        .set("Runtime(sec)", nexmarkPerf2.runtimeSec).set("Events(/sec)", nexmarkPerf2.eventsPerSec)
+        .set("runtimeSec", nexmarkPerf2.runtimeSec).set("eventsPerSec", nexmarkPerf2.eventsPerSec)
         // when read using TableRowJsonCoder the row field is boxed into an Integer, cast it to int
         // to for bowing into Integer in the expectedRows.
-        .set("Size of the result collection", (int) nexmarkPerf2.numResults);
+        .set("numResults", (int) nexmarkPerf2.numResults);
     expectedRows.add(row2);
     assertThat(actualRows, containsInAnyOrder(Iterables.toArray(expectedRows, TableRow.class)));
 


### PR DESCRIPTION
Fix naming of the fields of the added BQ table. Naming error not see in UT (see https://issues.apache.org/jira/browse/BEAM-4607)
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
