### PR TITLE
Revert "Revert #5689 to fix build"

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -36,7 +36,7 @@ processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
     'dataflow.legacy_environment_major_version' : '7',
     'dataflow.fnapi_environment_major_version' : '7',
-    'dataflow.container_version' : 'beam-master-20180601'
+    'dataflow.container_version' : 'beam-master-20180619'
   ]
 }
 

--- a/runners/google-cloud-dataflow-java/pom.xml
+++ b/runners/google-cloud-dataflow-java/pom.xml
@@ -33,7 +33,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dataflow.container_version>beam-master-20180601</dataflow.container_version>
+    <dataflow.container_version>beam-master-20180619</dataflow.container_version>
     <dataflow.fnapi_environment_major_version>7</dataflow.fnapi_environment_major_version>
     <dataflow.legacy_environment_major_version>7</dataflow.legacy_environment_major_version>
   </properties>

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -390,6 +390,11 @@ class VarIntCoder(FastCoder):
   def is_deterministic(self):
     return True
 
+  def as_cloud_object(self):
+    return {
+        '@type': 'kind:varint',
+    }
+
   def __eq__(self, other):
     return type(self) == type(other)
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -404,8 +404,11 @@ class DataflowRunner(PipelineRunner):
       for the View transforms introduced to produce side inputs to a ParDo.
     """
     return {
-        '@type': input_encoding['@type'],
-        'component_encodings': [input_encoding]
+        '@type': 'kind:stream',
+        'component_encodings': [input_encoding],
+        'is_stream_like': {
+            'value': True
+        },
     }
 
   def _get_encoded_output_coder(self, transform_node, window_value=True):

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -38,10 +38,10 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 
 # Update this version to the next version whenever there is a change that will
 # require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20180518'
+BEAM_CONTAINER_VERSION = 'beam-master-20180619'
 # Update this version to the next version whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
-BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20180413'
+BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20180619'
 
 # Package names for different distributions
 GOOGLE_PACKAGE_NAME = 'google-cloud-dataflow'

--- a/sdks/python/apache_beam/runners/worker/operation_specs.py
+++ b/sdks/python/apache_beam/runners/worker/operation_specs.py
@@ -337,6 +337,10 @@ def get_coder_from_spec(coder_spec):
     assert ('component_encodings' not in coder_spec
             or not coder_spec['component_encodings'])
     return coders.coders.GlobalWindowCoder()
+  elif coder_spec['@type'] == 'kind:varint':
+    assert ('component_encodings' not in coder_spec
+            or len(coder_spec['component_encodings'] == 0))
+    return coders.coders.VarIntCoder()
   elif coder_spec['@type'] == 'kind:length_prefix':
     assert len(coder_spec['component_encodings']) == 1
     return coders.coders.LengthPrefixCoder(


### PR DESCRIPTION
This reverts commit cf7aa76ba6aa3fcd70637d3acc4b892669948389.

Dataflow Fn API worker image was built which is what was causing the failures.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
