### PR TITLE
Fix backlog bytes reported by CountingSource.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -528,4 +528,3 @@ public class CountingSource {
     public void finalizeCheckpoint() throws IOException {}
    }
 }
-j

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/CountingSource.java
@@ -479,7 +479,8 @@ public class CountingSource {
     @Override
     public long getSplitBacklogBytes() {
       long expected = expectedValue();
-      return Math.max(0L, 8 * (expected - current) / source.stride);
+      long backlogElements = (expected - current) / source.stride;
+      return Math.max(0L, 8 * backlogElements);
     }
   }
 
@@ -527,3 +528,4 @@ public class CountingSource {
     public void finalizeCheckpoint() throws IOException {}
    }
 }
+j


### PR DESCRIPTION
CountingSource reports incorrect backlog when `stride` is > 0. If the source has 10 splits, each split has stride of 10. Intention of existing imlementation is correct : return `8 * backlogElements`, but the missing braces make it return values 1-7 bytes as well. This fixes that.

The main negative effect of such spurious backlog  is that it can cause unnecessary upscaling. 