### PR TITLE
[BEAM-4611] Point gearpump post-commit tests to master

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_ValidatesRunner_Gearpump.groovy
@@ -22,7 +22,8 @@ import JobBuilder
 // This job runs the suite of ValidatesRunner tests against the Gearpump
 // runner.
 JobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle',
-  'Run Gearpump ValidatesRunner', 'Apache Gearpump Runner ValidatesRunner Tests', this) {
+  'Run Gearpump ValidatesRunner', 'Apache Gearpump Runner ValidatesRunner Tests',
+  this) {
   description('Runs the ValidatesRunner suite on the Gearpump runner.')
   previousNames('beam_PostCommit_Java_ValidatesRunner_Gearpump')
   previousNames('beam_PostCommit_Java_RunnableOnService_Gearpump')
@@ -30,7 +31,7 @@ JobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle',
   // Set common parameters.
   common_job_properties.setTopLevelMainJobProperties(
     delegate,
-    'gearpump-runner')
+    'master')
 
   // Publish all test results to Jenkins
   publishers {
@@ -46,3 +47,4 @@ JobBuilder.postCommitJob('beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle',
     }
   }
 }
+


### PR DESCRIPTION
Gearpump post-commit tests configuration was stale and pointing to non-existing branch "gearpump-runner".
Gearpump was merged onto master quite some time ago. So updating post-commit tests configuration.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
