### PR TITLE
[BEAM-4615] Flink job server wrapper and shadow jar

### DIFF
--- a/runners/flink/build.gradle
+++ b/runners/flink/build.gradle
@@ -134,5 +134,31 @@ task validatesRunner {
   dependsOn validatesRunnerStreaming
 }
 
+task runJobServer(type: JavaExec) {
+  classpath = sourceSets.main.runtimeClasspath
+  main = "org.apache.beam.runners.flink.FlinkJobServerDriver"
+  def jobHost = project.hasProperty("jobHost") ? project.property("jobHost") : "localhost:8099"
+  def artifactsDir = project.hasProperty("artifactsDir") ?  project.property("artifactsDir") : "/tmp/flink-artifacts"
+  args = ["--job-host=${jobHost}", "--artifacts-dir=${artifactsDir}"]
+  // Enable remote debugging.
+  jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
+}
+
+task jobServerShadowJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  archiveName = "flink-job-server.jar"
+  mergeServiceFiles()
+  append "reference.conf"
+  from sourceSets.main.output
+  configurations = [project.configurations.runtime]
+  // Use the same canonical relocations as used in the core shadow jar.
+  relocate("com.google.common", getJavaRelocatedPath("com.google.common")) {
+    // com.google.common is too generic, need to exclude guava-testlib
+    exclude "com.google.common.collect.testing.**"
+    exclude "com.google.common.escape.testing.**"
+    exclude "com.google.common.testing.**"
+    exclude "com.google.common.util.concurrent.testing.**"
+  }
+}
+
 // Generates :beam-runners-flink_2.11:runQuickstartJavaFlinkLocal
 createJavaExamplesArchetypeValidationTask(type: 'Quickstart', runner: 'FlinkLocal')


### PR DESCRIPTION
Adds a `JavaExec` target that can be remotely debugged and a runnable uber jar that packages the Flink job server.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
