### PR TITLE
Parallelize Java precommit integration tests

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -87,6 +87,9 @@ class BeamModulePlugin implements Plugin<Project> {
      * }
      */
     Closure shadowClosure;
+
+    /** Controls whether this project is published to Maven. */
+    boolean publish = true
   }
 
   // A class defining the set of configurable properties for createJavaExamplesArchetypeValidationTask
@@ -711,7 +714,8 @@ class BeamModulePlugin implements Plugin<Project> {
         project.test { classpath = project.configurations.shadowTestRuntimeClasspath }
       }
 
-      if (isRelease(project) || project.hasProperty('publishing')) {
+      if ((isRelease(project) || project.hasProperty('publishing')) &&
+      configuration.publish) {
         project.apply plugin: "maven-publish"
 
         // Create a task which emulates the maven-archiver plugin in generating a

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -26,9 +26,12 @@ ext.summary = """Apache Beam SDK provides a simple, Java-based
 interface for processing virtually any size data. This
 artifact includes all Apache Beam Java SDK examples."""
 
-/** Define the list of runners which execute a precommit test. */
-// https://issues.apache.org/jira/browse/BEAM-3583
-def preCommitRunners = ["dataflowRunner", "dataflowStreamingRunner", "directRunner", "flinkRunner", "sparkRunner"]
+/** Define the list of runners which execute a precommit test.
+ * Some runners are run from separate projects, see the preCommit task below
+ * for details.
+ */
+// TODO: Add apexRunner - https://issues.apache.org/jira/browse/BEAM-3583
+def preCommitRunners = ["directRunner", "flinkRunner", "sparkRunner"]
 for (String runner : preCommitRunners) {
   configurations.create(runner + "PreCommit")
 }
@@ -72,8 +75,6 @@ dependencies {
   }
   // https://issues.apache.org/jira/browse/BEAM-3583
   // apexRunnerPreCommit project(path: ":beam-runners-apex", configuration: "shadow")
-  dataflowRunnerPreCommit project(path: ":beam-runners-google-cloud-dataflow-java", configuration: "shadow")
-  dataflowStreamingRunnerPreCommit project(path: ":beam-runners-google-cloud-dataflow-java", configuration: "shadow")
   directRunnerPreCommit project(path: ":beam-runners-direct-java", configuration: "shadow")
   flinkRunnerPreCommit project(path: ":beam-runners-flink_2.11", configuration: "shadow")
   // TODO: Make the netty version used configurable, we add netty-all 4.1.17.Final so it appears on the classpath
@@ -91,25 +92,20 @@ dependencies {
  */
 def preCommitRunnerClass = [
   apexRunner: "org.apache.beam.runners.apex.TestApexRunner",
-  dataflowRunner: "TestDataflowRunner",
-  dataflowStreamingRunner: "TestDataflowRunner",
   directRunner: "org.apache.beam.runners.direct.DirectRunner",
   flinkRunner: "org.apache.beam.runners.flink.TestFlinkRunner",
   sparkRunner: "org.apache.beam.runners.spark.TestSparkRunner",
 ]
-def preCommitAdditionalFlags = [
-  dataflowStreamingRunner: [ "--streaming=true" ],
-]
-def gcsProject = project.findProperty('gcsProject') ?: 'apache-beam-testing'
+def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
 def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
 
 for (String runner : preCommitRunners) {
   tasks.create(name: runner + "PreCommit", type: Test) {
     def preCommitBeamTestPipelineOptions = [
-       "--project=${gcsProject}",
+       "--project=${gcpProject}",
        "--tempRoot=${gcsTempRoot}",
        "--runner=" + preCommitRunnerClass[runner],
-    ] + preCommitAdditionalFlags[runner]
+    ]
     classpath = configurations."${runner}PreCommit"
     include "**/WordCountIT.class"
     if (!"sparkRunner".equals(runner)) {
@@ -126,5 +122,7 @@ task preCommit() {
   for (String runner : preCommitRunners) {
     dependsOn runner + "PreCommit"
   }
+  dependsOn ":runners:google-cloud-dataflow-java:examples:preCommit"
+  dependsOn ":runners:google-cloud-dataflow-java:examples-streaming:preCommit"
 }
 

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+applyJavaNature(failOnWarning: true, publish: false)
+// Evaluate the given project before this one, to allow referencing
+// its sourceSets.test.output directly.
+evaluationDependsOn(":beam-examples-java")
+
+configurations { dataflowStreamingRunnerPreCommit }
+
+dependencies {
+  testRuntimeOnly project(path: ":beam-examples-java", configuration: "shadow")
+  testRuntimeOnly project(path: ":beam-examples-java", configuration: "shadowTest")
+  testRuntimeOnly project(path: ":beam-runners-google-cloud-dataflow-java", configuration: "shadow")
+}
+def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
+def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
+
+task preCommit(type: Test) {
+  def preCommitBeamTestPipelineOptions = [
+     "--project=${gcpProject}",
+     "--tempRoot=${gcsTempRoot}",
+     "--runner=TestDataflowRunner",
+     "--streaming=true",
+  ]
+  testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)
+  include "**/WordCountIT.class"
+  // Don't include WindowedWordCountIT, since it is already included in
+  // :runners:google-cloud-dataflow-java:examples:preCommit and runs
+  // identically (ignores the --streaming flag).
+  forkEvery 1
+  maxParallelForks 4
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
+}
+

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+applyJavaNature(failOnWarning: true, publish: false)
+// Evaluate the given project before this one, to allow referencing
+// its sourceSets.test.output directly.
+evaluationDependsOn(":beam-examples-java")
+
+configurations { dataflowRunnerPreCommit }
+
+dependencies {
+  testRuntimeOnly project(path: ":beam-examples-java", configuration: "shadow")
+  testRuntimeOnly project(path: ":beam-examples-java", configuration: "shadowTest")
+  testRuntimeOnly project(path: ":beam-runners-google-cloud-dataflow-java", configuration: "shadow")
+}
+def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
+def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
+
+task preCommit(type: Test) {
+  def preCommitBeamTestPipelineOptions = [
+     "--project=${gcpProject}",
+     "--tempRoot=${gcsTempRoot}",
+     "--runner=TestDataflowRunner",
+  ]
+  testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)
+  include "**/WordCountIT.class"
+  include "**/WindowedWordCountIT.class"
+  forkEvery 1
+  maxParallelForks 4
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
+}
+

--- a/settings.gradle
+++ b/settings.gradle
@@ -48,6 +48,10 @@ include "beam-runners-gearpump"
 project(":beam-runners-gearpump").dir = file("runners/gearpump")
 include "beam-runners-google-cloud-dataflow-java"
 project(":beam-runners-google-cloud-dataflow-java").dir = file("runners/google-cloud-dataflow-java")
+// These 2 projects will not be published to Maven so they don't get a special
+// dashed name.
+include ":runners:google-cloud-dataflow-java:examples"
+include ":runners:google-cloud-dataflow-java:examples-streaming"
 include "beam-runners-java-fn-execution"
 project(":beam-runners-java-fn-execution").dir = file("runners/java-fn-execution")
 include "beam-runners-local-java-core"


### PR DESCRIPTION
Splits out slow Dataflow precommit tasks into separate Gradle
subprojects.
Adds a 'publish' flag to JavaNatureConfiguration, that controls Maven
publishing.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

  - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
- [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
