### PR TITLE
[BEAM-4619] Fix Gearpump validatesRunner gradle config

### DIFF
--- a/runners/gearpump/build.gradle
+++ b/runners/gearpump/build.gradle
@@ -56,6 +56,7 @@ dependencies {
   shadowTest library.java.jackson_dataformat_yaml
   shadowTest library.java.mockito_core
   validatesRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  validatesRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
   validatesRunner project(path: project.path, configuration: "shadow")
 }
 


### PR DESCRIPTION
Throwing `ClassNotFound` for Hamcrest. Same as the fix in #5666 and #5671. We just missed it because the Jenkins job was not pointed at the `master` branch.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
