### PR TITLE
Add PortableRunner service registrars

### DIFF
--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
@@ -145,6 +145,7 @@ public class PortableRunner extends PipelineRunner<PipelineResult> {
             .setPipelineOptions(PipelineOptionsTranslation.toProto(options))
             .build();
 
+    LOG.info("Using job server endpoint: {}", endpoint);
     ManagedChannel jobServiceChannel =
         channelFactory.forDescriptor(
             ApiServiceDescriptor.newBuilder()

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunnerRegistrar.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunnerRegistrar.java
@@ -15,27 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.beam.sdk.options;
+package org.apache.beam.runners.reference;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.PipelineRunner;
+import org.apache.beam.sdk.runners.PipelineRunnerRegistrar;
 
-/**
- * A {@link PipelineOptionsRegistrar} containing the {@link PipelineOptions} subclasses available by
- * default.
- */
-@AutoService(PipelineOptionsRegistrar.class)
-public class DefaultPipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+/** Registrar for the poratble runner. */
+@AutoService(PipelineRunnerRegistrar.class)
+public class PortableRunnerRegistrar implements PipelineRunnerRegistrar {
+
   @Override
-  public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
-    return ImmutableList.<Class<? extends PipelineOptions>>builder()
-        .add(PipelineOptions.class)
-        .add(ApplicationNameOptions.class)
-        .add(StreamingOptions.class)
-        .add(ExperimentalOptions.class)
-        .add(SdkHarnessOptions.class)
-        .add(PortablePipelineOptions.class)
-        .build();
+  public Iterable<Class<? extends PipelineRunner<?>>> getPipelineRunners() {
+    return ImmutableList.of(PortableRunner.class);
   }
 }


### PR DESCRIPTION
This change includes both a registrar for the runner and the runner options. The runner registrar allows users to specify the runner by the short class name by command line (i.e., `PortableRunner`) and the options registrar allows users to specify properties of `PortablePipelineOptions` on the command line. Without the options registrars, users need to explicitly register `PortablePipelineOptions` within their pipelines and recompile in order to use these options.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.
