### PR TITLE
dataflow_runner.py: use the pbegin's pipeline

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -757,9 +757,9 @@ class DataflowRunner(PipelineRunner):
          PropertyNames.OUTPUT_NAME: PropertyNames.OUT})
     step.add_property(PropertyNames.OUTPUT_INFO, outputs)
 
-  def apply_Read(self, transform, unused_pbegin):
+  def apply_Read(self, unused_transform, pbegin):
     # Always consider Read to be a primitive for dataflow.
-    return beam.pvalue.PCollection(transform.pipeline)
+    return beam.pvalue.PCollection(pbegin.pipeline)
 
   def run_Read(self, transform_node):
     transform = transform_node.transform


### PR DESCRIPTION
Sometimes the transform doesn't have a pipeline for a read step.