### PR TITLE
[BEAM-4602][BEAM-4598] Datetime type comparison

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlCompareExpression.java
@@ -24,6 +24,7 @@ import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimi
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.joda.time.DateTime;
 
 /**
  * {@link BeamSqlCompareExpression} is used for compare operations.
@@ -70,6 +71,9 @@ public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
       case VARCHAR:
         return BeamSqlPrimitive.of(
             SqlTypeName.BOOLEAN, compare((CharSequence) leftValue, (CharSequence) rightValue));
+      case DATE:
+        return BeamSqlPrimitive.of(
+            SqlTypeName.BOOLEAN, compare((DateTime) leftValue, (DateTime) rightValue));
       default:
         throw new UnsupportedOperationException(toString());
     }
@@ -87,4 +91,7 @@ public abstract class BeamSqlCompareExpression extends BeamSqlExpression {
    * SqlTypeName#INTEGER}, {@link SqlTypeName#SMALLINT} and {@link SqlTypeName#TINYINT}.
    */
   public abstract Boolean compare(Number leftValue, Number rightValue);
+
+  /** Compare between DateTime values, mapping to {@link SqlTypeName#DATETIME_TYPES}. */
+  public abstract Boolean compare(DateTime leftValue, DateTime rightValue);
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlEqualsExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code =} operation. */
 public class BeamSqlEqualsExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlEqualsExpression extends BeamSqlCompareExpression {
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() == (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return leftValue.isEqual(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code >} operation. */
 public class BeamSqlGreaterThanExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlGreaterThanExpression extends BeamSqlCompareExpression {
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() > (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return leftValue.isAfter(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanOrEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlGreaterThanOrEqualsExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code >=} operation. */
 public class BeamSqlGreaterThanOrEqualsExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlGreaterThanOrEqualsExpression extends BeamSqlCompareExpressi
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() >= (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return leftValue.isAfter(rightValue) || leftValue.isEqual(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code <} operation. */
 public class BeamSqlLessThanExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlLessThanExpression extends BeamSqlCompareExpression {
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() < (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return leftValue.isBefore(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanOrEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLessThanOrEqualsExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code <=} operation. */
 public class BeamSqlLessThanOrEqualsExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlLessThanOrEqualsExpression extends BeamSqlCompareExpression 
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() <= (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return leftValue.isBefore(rightValue) || leftValue.isEqual(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlLikeExpression.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.calcite.runtime.SqlFunctions;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for 'LIKE' operation. */
 public class BeamSqlLikeExpression extends BeamSqlCompareExpression {
@@ -41,5 +42,10 @@ public class BeamSqlLikeExpression extends BeamSqlCompareExpression {
   @Override
   public Boolean compare(Number leftValue, Number rightValue) {
     throw new IllegalArgumentException("LIKE is not supported for Number.");
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    throw new IllegalArgumentException("LIKE is not supported for DateTime.");
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlNotEqualsExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/comparison/BeamSqlNotEqualsExpression.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.comparison;
 
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
+import org.joda.time.DateTime;
 
 /** {@code BeamSqlExpression} for {@code <>} operation. */
 public class BeamSqlNotEqualsExpression extends BeamSqlCompareExpression {
@@ -43,5 +44,10 @@ public class BeamSqlNotEqualsExpression extends BeamSqlCompareExpression {
         || (leftValue != null
             && rightValue != null
             && leftValue.floatValue() != (rightValue).floatValue());
+  }
+
+  @Override
+  public Boolean compare(DateTime leftValue, DateTime rightValue) {
+    return !leftValue.isEqual(rightValue);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamTableUtils.java
@@ -35,6 +35,7 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.csv.CSVRecord;
+import org.joda.time.DateTime;
 
 /**
  * Utility methods for working with {@code BeamTable}.
@@ -105,6 +106,8 @@ public final class BeamTableUtils {
       } else {
         return rawObj;
       }
+    } else if (type.isDateType()) {
+      return DateTime.parse(rawObj.toString());
     } else if (type.isNumericType()
         && ((rawObj instanceof String)
             || (rawObj instanceof BigDecimal && type != TypeName.DECIMAL))) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
@@ -401,7 +401,16 @@ public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegr
             .addExpr("1 IS NOT DISTINCT FROM 2", false)
             .addExpr("1.0 IS NOT DISTINCT FROM 2.0", false)
             .addExpr("'a' IS NOT DISTINCT FROM 'b'", false)
-            .addExpr("true IS NOT DISTINCT FROM false", false);
+            .addExpr("true IS NOT DISTINCT FROM false", false)
+            .addExpr("date '2018-01-01' > DATE '2017-12-31' ", true)
+            .addExpr("date '2018-01-01' >= DATE '2017-12-31' ", true)
+            .addExpr("date '2018-01-01' < DATE '2017-12-31' ", false)
+            .addExpr("date '2018-01-01' <= DATE '2017-12-31' ", false)
+            .addExpr("date '2018-06-24' = DATE '2018-06-24' ", true)
+            .addExpr("Date '2018-06-24' <> DATE '2018-06-24' ", false)
+            .addExpr("TIME '20:17:40' < Time '15:05:57' ", false)
+            .addExpr("TIME '00:00:01' >= time '00:00:01' ", true)
+            .addExpr("TIMESTAMP '2017-12-31 23:59:59' < TIMESTAMP '2018-01-01 00:00:00' ", true);
 
     checker.buildRunAndCheck();
   }


### PR DESCRIPTION
Support datetime type in comparison expression
Test datetime type comparison at the DSL level

R: @kennknowles @XuMingmin
cc: @akedin @apilloud @amaliujia 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




