### PR TITLE
[BEAM-4417] Support BigQuery's NUMERIC type using Java

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
@@ -28,6 +28,7 @@ import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.BaseEncoding;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,7 @@ class BigQueryAvroUtils {
           .put("BYTES", Type.BYTES)
           .put("INTEGER", Type.LONG)
           .put("FLOAT", Type.DOUBLE)
+          .put("NUMERIC", Type.STRING)
           .put("BOOLEAN", Type.BOOLEAN)
           .put("TIMESTAMP", Type.LONG)
           .put("RECORD", Type.RECORD)
@@ -60,6 +62,7 @@ class BigQueryAvroUtils {
           .put("DATETIME", Type.STRING)
           .put("TIME", Type.STRING)
           .build();
+
   /**
    * Formats BigQuery seconds-since-epoch into String matching JSON export. Thread-safe and
    * immutable.
@@ -194,6 +197,12 @@ class BigQueryAvroUtils {
       case "FLOAT":
         verify(v instanceof Double, "Expected Double, got %s", v.getClass());
         return v;
+      case "NUMERIC":
+        verify(
+            v instanceof CharSequence || v instanceof BigDecimal,
+            "Expected CharSequence (String) or BigDecimal, got %s",
+            v.getClass());
+        return v.toString();
       case "BOOLEAN":
         verify(v instanceof Boolean, "Expected Boolean, got %s", v.getClass());
         return v;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -70,7 +70,7 @@ public class BigQueryUtils {
           .put(TypeName.INT64, StandardSQLTypeName.INT64)
           .put(TypeName.FLOAT, StandardSQLTypeName.FLOAT64)
           .put(TypeName.DOUBLE, StandardSQLTypeName.FLOAT64)
-          .put(TypeName.DECIMAL, StandardSQLTypeName.FLOAT64)
+          .put(TypeName.DECIMAL, StandardSQLTypeName.NUMERIC)
           .put(TypeName.BOOLEAN, StandardSQLTypeName.BOOL)
           .put(TypeName.ARRAY, StandardSQLTypeName.ARRAY)
           .put(TypeName.ROW, StandardSQLTypeName.STRUCT)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StandardSQLTypeName.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StandardSQLTypeName.java
@@ -31,6 +31,8 @@ enum StandardSQLTypeName {
   INT64,
   /** A 64-bit IEEE binary floating-point value. */
   FLOAT64,
+  /** A decimal value with 38 digits of precision and 9 digits of scale. */
+  NUMERIC,
   /** Variable-length character (Unicode) data. */
   STRING,
   /** Variable-length binary data. */


### PR DESCRIPTION
For comparison, this is the PR that added support in google-cloud-java: https://github.com/GoogleCloudPlatform/google-cloud-java/pull/3110.

I will add Python support separately, unless it's preferable to include that in this PR as well.