### PR TITLE
Split pre-commit tests into separate jobs based on trigger condition.

### DIFF
--- a/.test-infra/jenkins/PrecommitBuilder.groovy
+++ b/.test-infra/jenkins/PrecommitBuilder.groovy
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import common_job_properties as cjp
+
+/** This class defines PreCommitBuilder.build() helper for defining pre-comit jobs. */
+class PrecommitBuilder {
+  /** scope 'this' parameter from top-level script; used for binding Job DSL methods. */
+  Object scope
+
+  /** Base name for each post-commit suite job, i.e. 'Go'. */
+  String nameBase
+
+  /**  The Gradle task to execute. */
+  String gradleTask
+
+  /** Overall job timeout. */
+  int timeoutMins = 90
+
+  /**
+   * Define a set of pre-commit jobs.
+   *
+   * @param additionalCustomization Job DSL closure with additional customization to apply to the job.
+   */
+  void build(Closure additionalCustomization = {}) {
+    defineCronJob additionalCustomization
+    defineCommitJob additionalCustomization
+    definePhraseJob additionalCustomization
+  }
+
+  /** Create a pre-commit job which runs on a daily schedule. */
+  private void defineCronJob(Closure additionalCustomization) {
+    def job = createBaseJob 'Cron'
+    job.with {
+      description buildDescription('on a daily schedule.')
+      cjp.setPostCommit delegate // TODO: Rename method as only defines cron
+    }
+    job.with additionalCustomization
+  }
+
+  /** Create a pre-commit job which runs on every commit to a PR. */
+  private void defineCommitJob(Closure additionalCustomization) {
+    def job = createBaseJob 'Commit'
+    job.with {
+      description buildDescription('for each commit push.')
+      concurrentBuild()
+      common_job_properties.setPullRequestBuildTrigger delegate, githubUiHint()
+      // TODO: Define filters
+    }
+    job.with additionalCustomization
+  }
+
+  private void definePhraseJob(Closure additionalCustomization) {
+    def job = createBaseJob 'Phrase'
+    job.with {
+      description buildDescription("on trigger phrase '${buildTriggerPhrase()}.)")
+      concurrentBuild()
+      common_job_properties.setPullRequestBuildTrigger delegate, githubUiHint(), buildTriggerPhrase()
+    }
+    job.with additionalCustomization
+  }
+
+  private Object createBaseJob(nameSuffix) {
+    return scope.job("beam_PreCommit_${nameBase}_${nameSuffix}") {
+      // TODO: Update branch
+      common_job_properties.setTopLevelMainJobProperties(delegate, 'pretr', timeoutMins)
+      steps {
+        gradle {
+          rootBuildScriptDir(common_job_properties.checkoutDir)
+          tasks(gradleTask)
+          common_job_properties.setGradleSwitches(delegate)
+        }
+      }
+    }
+  }
+
+  /** The magic phrase used to trigger the job when posted as a PR comment. */
+  private String buildTriggerPhrase() {
+    return "Run ${nameBase} PreCommit"
+  }
+
+  /** A human-readable description which will be used as the base of all suite jobs. */
+  private buildDescription(String triggerDescription) {
+    return "Runs ${nameBase} PreCommit tests ${triggerDescription}"
+  }
+
+  /** The Jenkins job name to display in GitHub. */
+  private String githubUiHint() {
+    "${nameBase} PreCommit (\"${buildTriggerPhrase()}\")"
+  }
+}

--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -194,6 +194,7 @@ class common_job_properties {
   }
 
   // Sets common config for PreCommit jobs.
+  // TODO: Remove
   static void setPreCommit(context,
                            String commitStatusName,
                            String prTriggerPhrase = '',

--- a/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Go_GradleBuild.groovy
@@ -16,29 +16,12 @@
  * limitations under the License.
  */
 
-import common_job_properties
+import PrecommitBuilder
 
-// This is the Go precommit which runs a gradle build, and the current set
-// of precommit tests.
-job('beam_PreCommit_Go_GradleBuild') {
-  description('Runs Go PreCommit tests for the current GitHub Pull Request.')
-
-  // Execute concurrent builds if necessary.
-  concurrentBuild()
-
-  // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(
-    delegate,
-    'master',
-    150)
-
-  // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :goPreCommit', 'Run Go PreCommit')
-  steps {
-    gradle {
-      rootBuildScriptDir(common_job_properties.checkoutDir)
-      tasks(':goPreCommit')
-      common_job_properties.setGradleSwitches(delegate)
-    }
-  }
-}
+PrecommitBuilder builder = new PrecommitBuilder(
+    scope: this,
+    nameBase: 'Go',
+    gradleTask: ':goPreCommit',
+    timeoutMins: 150
+)
+builder.build()

--- a/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Java_GradleBuild.groovy
@@ -16,34 +16,15 @@
  * limitations under the License.
  */
 
-import common_job_properties
+import PrecommitBuilder
 
-// This is the Java precommit which runs a Gradle build, and the current set
-// of precommit tests.
-job('beam_PreCommit_Java_GradleBuild') {
-  description('Runs Java PreCommit tests for the current GitHub Pull Request.')
-
-  // Execute concurrent builds if necessary.
-  concurrentBuild()
-
-  // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(
-    delegate,
-    'master',
-    90)
-
-  // Publish all test results to Jenkins
+PrecommitBuilder builder = new PrecommitBuilder(
+    scope: this,
+    nameBase: 'Java',
+    gradleTask: ':javaPreCommit',
+)
+builder.build {
   publishers {
     archiveJunit('**/build/test-results/**/*.xml')
-  }
-
-  // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :javaPreCommit', 'Run Java PreCommit')
-  steps {
-    gradle {
-      rootBuildScriptDir(common_job_properties.checkoutDir)
-      tasks(':javaPreCommit')
-      common_job_properties.setGradleSwitches(delegate)
-    }
   }
 }

--- a/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python_GradleBuild.groovy
@@ -16,35 +16,17 @@
  * limitations under the License.
  */
 
-import common_job_properties
+import PrecommitBuilder
 
-// This is the Python precommit which runs a Gradle build, and the current set
-// of precommit tests.
-job('beam_PreCommit_Python_GradleBuild') {
-  description('Runs Python PreCommit tests for the current GitHub Pull Request.')
-
-  // Execute concurrent builds if necessary.
-  concurrentBuild()
-
-  // Set common parameters.
-  common_job_properties.setTopLevelMainJobProperties(
-    delegate,
-    'master',
-    90)
-
+PrecommitBuilder builder = new PrecommitBuilder(
+    scope: this,
+    nameBase: 'Python',
+    gradleTask: ':pythonPreCommit',
+)
+builder.build {
   // Publish all test results to Jenkins. Note that Nose documentation
   // specifically mentions that it produces JUnit compatible test results.
   publishers {
     archiveJunit('**/nosetests.xml')
-  }
-
-  // Sets that this is a PreCommit job.
-  common_job_properties.setPreCommit(delegate, './gradlew :pythonPreCommit', 'Run Python PreCommit')
-  steps {
-    gradle {
-      rootBuildScriptDir(common_job_properties.checkoutDir)
-      tasks(':pythonPreCommit')
-      common_job_properties.setGradleSwitches(delegate)
-    }
   }
 }


### PR DESCRIPTION
This is necessary in order to use filtering based on touched files. In
the ghprb plugin all trigger criteria is evaluated together, which means
that include filters are also applied to phrase triggering.
See: https://github.com/jenkinsci/ghprb-plugin/issues/678

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




