### PR TITLE
[BEAM-4642] Pipeline options in JDBC URI; default userAgent=BeamSQL

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
@@ -22,22 +22,42 @@ import static org.codehaus.commons.compiler.CompilerFactoryFactory.getDefaultCom
 import com.google.auto.service.AutoService;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.beam.sdk.extensions.sql.impl.parser.impl.BeamSqlParserImpl;
 import org.apache.beam.sdk.extensions.sql.impl.planner.BeamRelDataTypeSystem;
 import org.apache.beam.sdk.extensions.sql.meta.provider.TableProvider;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.util.ReleaseInfo;
+import org.apache.calcite.avatica.ConnectStringParser;
 import org.apache.calcite.avatica.ConnectionProperty;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.jdbc.CalciteConnection;
+import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.jdbc.Driver;
 import org.apache.calcite.schema.SchemaPlus;
 
-/** Calcite JDBC driver with Beam defaults. */
+/**
+ * Calcite JDBC driver with Beam defaults.
+ *
+ * <p>Connection URLs have this form:
+ *
+ * <p><code>jdbc:beam:param1=value1;param2=value2;param3=value3</code>
+ *
+ * <p>The querystring-style parameters are parsed as {@link PipelineOptions}.
+ */
 @AutoService(java.sql.Driver.class)
 public class JdbcDriver extends Driver {
   public static final JdbcDriver INSTANCE = new JdbcDriver();
   public static final String CONNECT_STRING_PREFIX = "jdbc:beam:";
+
+  /**
+   * Querystring parameters that begin with {@code "beam."} will be interpreted as {@link
+   * PipelineOptions}.
+   */
+  public static final String BEAM_QUERYSTRING_PREFIX = "beam.";
+
   private static final String BEAM_CALCITE_SCHEMA = "beamCalciteSchema";
 
   static {
@@ -87,6 +107,22 @@ public class JdbcDriver extends Driver {
 
     // Beam schema may change without notifying Calcite
     defaultSchema.setCacheEnabled(false);
+
+    // Set default PipelineOptions to which we apply the querystring
+    Map<String, String> pipelineOptionsMap =
+        ((BeamCalciteSchema) CalciteSchema.from(defaultSchema).schema).getPipelineOptions();
+    ReleaseInfo releaseInfo = ReleaseInfo.getReleaseInfo();
+    pipelineOptionsMap.put("userAgent", String.format("BeamSQL/%s", releaseInfo.getVersion()));
+
+    String querystring = url.substring(CONNECT_STRING_PREFIX.length());
+    for (Map.Entry<Object, Object> propertyValue :
+        ConnectStringParser.parse(querystring).entrySet()) {
+      String name = (String) propertyValue.getKey();
+      if (name.startsWith(BEAM_QUERYSTRING_PREFIX)) {
+        pipelineOptionsMap.put(
+            name.substring(BEAM_QUERYSTRING_PREFIX.length()), (String) propertyValue.getValue());
+      }
+    }
     return connection;
   }
 


### PR DESCRIPTION
Currently you can only `SET` pipeline options. It is convenient to provide them by default in the JDBC URI.

Alternatives considered: JVM system properties in a reserved namespace like:

```
beamsql.jdbc.pipelineoptions.key1=value1
beamsql.jdbc.pipelineoptions.key2=value2
```

But that is global to JDBC. We could also support it or other `Properties` based approaches but I don't see a pressing need.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




