### PR TITLE
Support @RequiresStableInput on Dataflow runner in Java SDK

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -108,6 +108,64 @@ public class PTransformMatchers {
 
   /**
    * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} containing a {@link DoFn}
+   * that requires stable input, as signified by {@link ProcessElementMethod#requiresStableInput()}.
+   */
+  public static PTransformMatcher requiresStableInputParDoSingle() {
+    return new PTransformMatcher() {
+      @Override
+      public boolean matches(AppliedPTransform<?, ?, ?> application) {
+        PTransform<?, ?> transform = application.getTransform();
+        if (transform instanceof ParDo.SingleOutput) {
+          DoFn<?, ?> fn = ((ParDo.SingleOutput<?, ?>) transform).getFn();
+          DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
+          return signature.processElement().requiresStableInput();
+        }
+        return false;
+      }
+
+      @Override
+      public boolean matchesDuringValidation(AppliedPTransform<?, ?, ?> application) {
+        return false;
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper("RequiresStableInputParDoSingleMatcher").toString();
+      }
+    };
+  }
+
+  /**
+   * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutput} containing a {@link DoFn}
+   * that requires stable input, as signified by {@link ProcessElementMethod#requiresStableInput()}.
+   */
+  public static PTransformMatcher requiresStableInputParDoMulti() {
+    return new PTransformMatcher() {
+      @Override
+      public boolean matches(AppliedPTransform<?, ?, ?> application) {
+        PTransform<?, ?> transform = application.getTransform();
+        if (transform instanceof ParDo.MultiOutput) {
+          DoFn<?, ?> fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
+          DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
+          return signature.processElement().requiresStableInput();
+        }
+        return false;
+      }
+
+      @Override
+      public boolean matchesDuringValidation(AppliedPTransform<?, ?, ?> application) {
+        return false;
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper("RequiresStableInputParDoMultiMatcher").toString();
+      }
+    };
+  }
+
+  /**
+   * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} containing a {@link DoFn}
    * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */
   public static PTransformMatcher splittableParDoSingle() {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -330,6 +330,32 @@ public class PTransformMatchersTest implements Serializable {
   }
 
   @Test
+  public void parDoRequiresStableInput() {
+    DoFn<Object, Object> doFnRSI = new DoFn<Object, Object>() {
+      @RequiresStableInput
+      @ProcessElement
+      public void process(ProcessContext ctxt) {
+      }
+    };
+
+    AppliedPTransform<?, ?, ?> single = getAppliedTransform(ParDo.of(doFn));
+    AppliedPTransform<?, ?, ?> singleRSI = getAppliedTransform(ParDo.of(doFnRSI));
+    AppliedPTransform<?, ?, ?> multi = getAppliedTransform(ParDo.of(doFn)
+        .withOutputTags(new TupleTag<>(), TupleTagList.empty()));
+    AppliedPTransform<?, ?, ?> multiRSI = getAppliedTransform(ParDo.of(doFnRSI)
+        .withOutputTags(new TupleTag<>(), TupleTagList.empty()));
+
+    assertThat(PTransformMatchers.requiresStableInputParDoSingle().matches(single), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoSingle().matches(singleRSI), is(true));
+    assertThat(PTransformMatchers.requiresStableInputParDoSingle().matches(multi), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoSingle().matches(multiRSI), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoMulti().matches(single), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoMulti().matches(singleRSI), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoMulti().matches(multi), is(false));
+    assertThat(PTransformMatchers.requiresStableInputParDoMulti().matches(multiRSI), is(true));
+  }
+
+  @Test
   public void parDoWithFnTypeWithMatchingType() {
     DoFn<Object, Object> fn = new DoFn<Object, Object>() {
       @ProcessElement

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -439,6 +439,18 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
                       BatchViewOverrides.BatchViewAsIterable.class, this)));
       }
     }
+    // Uses Reshuffle, so has to be before the Reshuffle override
+    overridesBuilder
+        .add(
+            PTransformOverride.of(
+                PTransformMatchers.requiresStableInputParDoSingle(),
+                RequiresStableInputParDoOverrides.singleOutputOverrideFactory()));
+    // Uses Reshuffle, so has to be before the Reshuffle override
+    overridesBuilder
+        .add(
+            PTransformOverride.of(
+                PTransformMatchers.requiresStableInputParDoMulti(),
+                RequiresStableInputParDoOverrides.multiOutputOverrideFactory()));
     // Expands into Reshuffle and single-output ParDo, so has to be before the overrides below.
     if (hasExperiment(options, "beam_fn_api")) {
       overridesBuilder.add(

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/RequiresStableInputParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/RequiresStableInputParDoOverrides.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow;
+
+import java.util.Map;
+import org.apache.beam.runners.core.construction.PTransformReplacements;
+import org.apache.beam.runners.core.construction.ReplacementOutputs;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.runners.PTransformOverrideFactory;
+import org.apache.beam.sdk.transforms.DoFn.RequiresStableInput;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.PValue;
+import org.apache.beam.sdk.values.TupleTag;
+
+/** Transform overrides for supporting {@link RequiresStableInput} in the Dataflow runner. */
+class RequiresStableInputParDoOverrides {
+
+  /**
+   * Returns a {@link PTransformOverrideFactory} that inserts a {@link Reshuffle.ViaRandomKey}
+   * before a {@link ParDo.SingleOutput} that uses the {@link RequiresStableInput} annotation.
+   */
+  static <InputT, OutputT> PTransformOverrideFactory<
+      PCollection<InputT>,
+      PCollection<OutputT>,
+      ParDo.SingleOutput<InputT, OutputT>>
+          singleOutputOverrideFactory() {
+    return new SingleOutputOverrideFactory<>();
+  }
+
+  /**
+   * Returns a {@link PTransformOverrideFactory} that inserts a {@link Reshuffle.ViaRandomKey}
+   * before a {@link ParDo.MultiOutput} that uses the {@link RequiresStableInput} annotation.
+   */
+  static <InputT, OutputT> PTransformOverrideFactory<
+      PCollection<InputT>,
+      PCollectionTuple,
+      ParDo.MultiOutput<InputT, OutputT>>
+          multiOutputOverrideFactory() {
+    return new MultiOutputOverrideFactory<>();
+  }
+
+  private static class SingleOutputOverrideFactory<InputT, OutputT>
+      implements PTransformOverrideFactory<
+          PCollection<InputT>,
+          PCollection<OutputT>,
+          ParDo.SingleOutput<InputT, OutputT>> {
+
+    @Override
+    public PTransformReplacement<PCollection<InputT>, PCollection<OutputT>> getReplacementTransform(
+        AppliedPTransform<
+            PCollection<InputT>,
+            PCollection<OutputT>,
+            ParDo.SingleOutput<InputT, OutputT>>
+                appliedTransform) {
+      return PTransformReplacement.of(
+          PTransformReplacements.getSingletonMainInput(appliedTransform),
+          new PTransform<PCollection<InputT>, PCollection<OutputT>>() {
+            @Override
+            public PCollection<OutputT> expand(PCollection<InputT> input) {
+              return input.apply(Reshuffle.viaRandomKey()).apply(appliedTransform.getTransform());
+            }
+          });
+    }
+
+    @Override
+    public Map<PValue, ReplacementOutput> mapOutputs(
+        Map<TupleTag<?>, PValue> outputs, PCollection<OutputT> newOutput) {
+      return ReplacementOutputs.singleton(outputs, newOutput);
+    }
+  }
+
+  private static class MultiOutputOverrideFactory<InputT, OutputT>
+      implements PTransformOverrideFactory<
+          PCollection<InputT>,
+          PCollectionTuple,
+          ParDo.MultiOutput<InputT, OutputT>> {
+
+    @Override
+    public PTransformReplacement<PCollection<InputT>, PCollectionTuple> getReplacementTransform(
+        AppliedPTransform<
+            PCollection<InputT>,
+            PCollectionTuple,
+            ParDo.MultiOutput<InputT, OutputT>>
+                appliedTransform) {
+      return PTransformReplacement.of(
+          PTransformReplacements.getSingletonMainInput(appliedTransform),
+          new PTransform<PCollection<InputT>, PCollectionTuple>() {
+            @Override
+            public PCollectionTuple expand(PCollection<InputT> input) {
+              return input.apply(Reshuffle.viaRandomKey()).apply(appliedTransform.getTransform());
+            }
+          });
+    }
+
+    @Override
+    public Map<PValue, ReplacementOutput> mapOutputs(
+        Map<TupleTag<?>, PValue> outputs, PCollectionTuple newOutput) {
+      return ReplacementOutputs.tagged(outputs, newOutput);
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -219,16 +219,13 @@ public class Pipeline {
           @Override
           public CompositeBehavior enterCompositeTransform(Node node) {
             if (!node.isRootNode()) {
-              for (PTransformOverride override : overrides) {
-                if (override.getMatcher().matches(node.toAppliedPTransform(getPipeline()))) {
-                  matched.put(node, override);
-                }
-              }
+              checkForMatches(node);
             }
-            if (!matched.containsKey(node)) {
+            if (matched.containsKey(node)) {
+              return CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
+            } else {
               return CompositeBehavior.ENTER_TRANSFORM;
             }
-            return CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
           }
 
           @Override
@@ -241,8 +238,12 @@ public class Pipeline {
 
           @Override
           public void visitPrimitiveTransform(Node node) {
+            checkForMatches(node);
+          }
+
+          private void checkForMatches(Node node) {
             for (PTransformOverride override : overrides) {
-              if (override.getMatcher().matches(node.toAppliedPTransform(getPipeline()))) {
+              if (override.getMatcher().matchesDuringValidation(node.toAppliedPTransform(getPipeline()))) {
                 matched.put(node, override);
               }
             }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/Pipeline.java
@@ -243,7 +243,8 @@ public class Pipeline {
 
           private void checkForMatches(Node node) {
             for (PTransformOverride override : overrides) {
-              if (override.getMatcher().matchesDuringValidation(node.toAppliedPTransform(getPipeline()))) {
+              if (override.getMatcher()
+                  .matchesDuringValidation(node.toAppliedPTransform(getPipeline()))) {
                 matched.put(node, override);
               }
             }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/PTransformMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/runners/PTransformMatcher.java
@@ -33,6 +33,10 @@ import org.apache.beam.sdk.transforms.PTransform;
 public interface PTransformMatcher {
   boolean matches(AppliedPTransform<?, ?, ?> application);
 
+  default boolean matchesDuringValidation(AppliedPTransform<?, ?, ?> application) {
+    return matches(application);
+  }
+
   default PTransformMatcher and(PTransformMatcher matcher) {
     return application -> this.matches(application) && matcher.matches(application);
   }


### PR DESCRIPTION
During pipeline surgery, DataflowRunner will replace a transform T with (Reshuffle + T), if T is a ParDo.SingleOutput or ParDo.MultiOutput transform with a DoFn whose ProcessElement method is annotated with @RequiresStableInput.
r: @kennknowles 