### PR TITLE
[BEAM-4556] Update Findbugs annotations dependency to version with SuppressFBWarnings

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -599,8 +599,12 @@ class BeamModulePlugin implements Plugin<Project> {
         testApt auto_service
 
         // These dependencies are needed to avoid error-prone warnings on package-info.java files,
-        // also to include the annotations to supress warnings.
-        def findbugs_annotations = "com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1"
+        // also to include the annotations to suppress warnings.
+        //
+        // findbugs-annotations artifact is licensed under LGPL and cannot be included in the
+        // Apache Beam distribution, but may be relied on during build.
+        // See: https://www.apache.org/legal/resolved.html#prohibited
+        def findbugs_annotations = "com.google.code.findbugs:annotations:3.0.1"
         compileOnly findbugs_annotations
         apt findbugs_annotations
         testCompileOnly findbugs_annotations

--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -130,6 +130,12 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="format" value="com\.google\.api\.client\.util\.(ByteStreams|Charsets|Collections2|Joiner|Lists|Maps|Objects|Preconditions|Sets|Strings|Throwables)"/>
     </module>
 
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="SuppressFBWarnings" />
+      <property name="ignoreComments" value="true" />
+      <property name="message" value="SuppressFBWarnings annotation is distributed under LGPL and should not appear in Apache Beam. See: https://github.com/apache/beam/pull/5772" />
+    </module>
+
     <!--
          Require static importing from Preconditions.
     -->


### PR DESCRIPTION
FindBugs annotations are a mess. We want to eventually deprecate our own
usage of FindBugs, but we still need to deal with the annotations
because our dependencies (notable byte-buddy) use the annotations
without providing the dependency. This causes compile warnings such as:

  byte-buddy-1.8.11.jar(/net/bytebuddy/description/type/TypeList.class):
  warning: Cannot find annotation method 'value()' in type 'SuppressFBWarnings':
  class file for edu.umd.cs.findbugs.annotations.SuppressFBWarnings not found

To fix these warnings, we need to include a findbugs-annotations
dependency during compile which includes the SuppressFBWarnings
annotation. The dependency options we currently have are:

 * com.google.code.findbugs:annotations:3.0.1
   * Includes @SuppressFBWarnings, but licensed under LGPL
 * com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1
   * Licensed under Apache 2.0, but doesn't include @SuppressFBWarnings

It is ok to use LGPL components during the build, as long as
they don't make it into the distribution. See:
 * https://www.apache.org/legal/resolved.html#prohibited
 * https://www.apache.org/legal/resolved.html#optional

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




