### PR TITLE
[BEAM-4556] Enable ErrorProne analysis and -Werror for all Java projects.

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -599,8 +599,12 @@ class BeamModulePlugin implements Plugin<Project> {
         testApt auto_service
 
         // These dependencies are needed to avoid error-prone warnings on package-info.java files,
-        // also to include the annotations to supress warnings.
-        def findbugs_annotations = "com.github.stephenc.findbugs:findbugs-annotations:1.3.9-1"
+        // also to include the annotations to suppress warnings.
+        //
+        // findbugs-annotations artifact is licensed under LGPL and cannot be included in the
+        // Apache Beam distribution, but may be relied on during build.
+        // See: https://www.apache.org/legal/resolved.html#prohibited
+        def findbugs_annotations = "com.google.code.findbugs:annotations:3.0.1"
         compileOnly findbugs_annotations
         apt findbugs_annotations
         testCompileOnly findbugs_annotations

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -56,9 +56,6 @@ class BeamModulePlugin implements Plugin<Project> {
     /** Controls whether the findbugs plugin is enabled and configured. */
     boolean enableFindbugs = true
 
-    /** Controls whether the errorprone plugin is enabled and configured. */
-    boolean enableErrorProne = true
-
     /** Controls whether compiler warnings are treated as errors. */
     boolean failOnWarning = true
 
@@ -546,13 +543,11 @@ class BeamModulePlugin implements Plugin<Project> {
         options.compilerArgs += ['-parameters', '-Xlint:all']+ (
         defaultLintSuppressions + configuration.disableLintWarnings
         ).collect { "-Xlint:-${it}" }
-        if (configuration.enableErrorProne) {
-          options.compilerArgs += [
-            "-XepDisableWarningsInGeneratedCode",
-            "-XepExcludedPaths:(.*/)?(build/generated.*avro-java|build/generated)/.*",
-            "-Xep:MutableConstantField:OFF" // Guava's immutable collections cannot appear on API surface.
-          ]
-        }
+        options.compilerArgs += [
+          "-XepDisableWarningsInGeneratedCode",
+          "-XepExcludedPaths:(.*/)?(build/generated.*avro-java|build/generated)/.*",
+          "-Xep:MutableConstantField:OFF" // Guava's immutable collections cannot appear on API surface.
+        ]
         if (configuration.failOnWarning) {
           options.compilerArgs += "-Werror"
         }
@@ -658,11 +653,9 @@ class BeamModulePlugin implements Plugin<Project> {
         }
       }
 
-      // Enable errorprone, not by default right now
-      if (configuration.enableErrorProne) {
-        project.apply plugin: 'net.ltgt.errorprone'
-        project.tasks.withType(JavaCompile) { options.compilerArgs += "-XepDisableWarningsInGeneratedCode" }
-      }
+      // Enable errorprone static analysis
+      project.apply plugin: 'net.ltgt.errorprone'
+      project.tasks.withType(JavaCompile) { options.compilerArgs += "-XepDisableWarningsInGeneratedCode" }
 
       // Enables a plugin which can perform shading of classes. See the general comments
       // above about dependency management for Java projects and how the shadow plugin

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -56,9 +56,6 @@ class BeamModulePlugin implements Plugin<Project> {
     /** Controls whether the findbugs plugin is enabled and configured. */
     boolean enableFindbugs = true
 
-    /** Controls whether compiler warnings are treated as errors. */
-    boolean failOnWarning = true
-
     /**
      * List of additional lint warnings to disable.
      * In addition, defaultLintSuppressions defined below
@@ -540,17 +537,15 @@ class BeamModulePlugin implements Plugin<Project> {
 
       project.tasks.withType(JavaCompile) {
         options.encoding = "UTF-8"
-        options.compilerArgs += ['-parameters', '-Xlint:all']+ (
-        defaultLintSuppressions + configuration.disableLintWarnings
-        ).collect { "-Xlint:-${it}" }
-        options.compilerArgs += [
-          "-XepDisableWarningsInGeneratedCode",
-          "-XepExcludedPaths:(.*/)?(build/generated.*avro-java|build/generated)/.*",
-          "-Xep:MutableConstantField:OFF" // Guava's immutable collections cannot appear on API surface.
+        options.compilerArgs += ([
+          '-parameters',
+          '-Xlint:all',
+          '-Werror',
+          '-XepDisableWarningsInGeneratedCode',
+          '-XepExcludedPaths:(.*/)?(build/generated.*avro-java|build/generated)/.*',
+          '-Xep:MutableConstantField:OFF' // Guava's immutable collections cannot appear on API surface.
         ]
-        if (configuration.failOnWarning) {
-          options.compilerArgs += "-Werror"
-        }
+        + (defaultLintSuppressions + configuration.disableLintWarnings).collect { "-Xlint:-${it}" })
       }
 
       // Configure the default test tasks set of tests executed

--- a/model/fn-execution/build.gradle
+++ b/model/fn-execution/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(enableFindbugs: false, enableErrorProne: false)
+applyJavaNature(enableFindbugs: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Fn Execution"

--- a/model/job-management/build.gradle
+++ b/model/job-management/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(enableFindbugs: false, enableErrorProne: false)
+applyJavaNature(enableFindbugs: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Job Management"

--- a/model/pipeline/build.gradle
+++ b/model/pipeline/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(enableFindbugs: false, enableErrorProne: false)
+applyJavaNature(enableFindbugs: false)
 applyGrpcNature()
 
 description = "Apache Beam :: Model :: Pipeline"

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -18,7 +18,6 @@
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 applyJavaNature(
-  failOnWarning: true,
   shadowClosure: {
     append "reference.conf"
   },

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -19,7 +19,7 @@
 import groovy.json.JsonOutput
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(failOnWarning: true, publish: false)
+applyJavaNature(publish: false)
 // Evaluate the given project before this one, to allow referencing
 // its sourceSets.test.output directly.
 evaluationDependsOn(":beam-examples-java")

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -19,7 +19,7 @@
 import groovy.json.JsonOutput
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(failOnWarning: true, publish: false)
+applyJavaNature(publish: false)
 // Evaluate the given project before this one, to allow referencing
 // its sourceSets.test.output directly.
 evaluationDependsOn(":beam-examples-java")

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -17,7 +17,7 @@
  */
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
-applyJavaNature(failOnWarning: false, shadowClosure: DEFAULT_SHADOW_CLOSURE << {
+applyJavaNature(shadowClosure: DEFAULT_SHADOW_CLOSURE << {
   dependencies {
     include(dependency(library.java.protobuf_java))
     include(dependency(library.java.byte_buddy))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -582,6 +582,7 @@ public class TextIO {
     abstract ValueProvider<ResourceId> getTempDirectory();
 
     /** The delimiter between string records. */
+    @SuppressWarnings("mutable") // this returns an array that can be mutated by the caller
     abstract char[] getDelimiter();
 
     /** An optional header to add to each file. */


### PR DESCRIPTION
This is the final cleanup in the [long road]() to enabling ErrorProne and warnings-as-errors for all Java projects.

:fireworks: :fireworks: :fireworks: 

Big thanks to everyone who helped out! @iemejia @timrobertson100 @cademarkegard @tengpeng 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




