### PR TITLE
Removing debug string from UserScore.java

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
@@ -128,7 +128,6 @@ public class UserScore {
 
     @ProcessElement
     public void processElement(ProcessContext c) {
-      System.out.println("GOT " + c.element());
       String[] components = c.element().split(",", -1);
       try {
         String user = components[0].trim();


### PR DESCRIPTION
This breaks the pipeline when using large datasets on Dataflow runner due to too much logging.
r: @aaltay 