### PR TITLE
[BEAM-4593] Remove refcounts from the Python SDK

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -47,7 +47,6 @@ Typical usage::
 from __future__ import absolute_import
 
 import abc
-import collections
 import logging
 import os
 import re
@@ -529,7 +528,6 @@ class Pipeline(object):
                            'output type-hint was found for the '
                            'PTransform %s' % ptransform_name)
 
-    current.update_input_refcounts()
     self.transforms_stack.pop()
     return pvalueish_result
 
@@ -699,29 +697,9 @@ class AppliedPTransform(object):
     self.outputs = {}
     self.parts = []
 
-    # Per tag refcount dictionary for PValues for which this node is a
-    # root producer.
-    self.refcounts = collections.defaultdict(int)
-
   def __repr__(self):
     return "%s(%s, %s)" % (self.__class__.__name__, self.full_label,
                            type(self.transform).__name__)
-
-  def update_input_refcounts(self):
-    """Increment refcounts for all transforms providing inputs."""
-
-    def real_producer(pv):
-      real = pv.producer
-      while real.parts:
-        real = real.parts[-1]
-      return real
-
-    if not self.is_composite():
-      for main_input in self.inputs:
-        if not isinstance(main_input, pvalue.PBegin):
-          real_producer(main_input).refcounts[main_input.tag] += 1
-      for side_input in self.side_inputs:
-        real_producer(side_input.pvalue).refcounts[side_input.pvalue.tag] += 1
 
   def replace_output(self, output, tag=None):
     """Replaces the output defined by the given tag with the given output.
@@ -885,7 +863,6 @@ class AppliedPTransform(object):
           pc = context.pcollections.get_by_id(pcoll_id)
           pc.producer = result
           pc.tag = None if tag == 'None' else tag
-    result.update_input_refcounts()
     return result
 
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -265,7 +265,6 @@ class DataflowRunner(PipelineRunner):
               new_side_input.pvalue.producer = map_to_void_key
               map_to_void_key.add_output(new_side_input.pvalue)
               parent.add_part(map_to_void_key)
-              transform_node.update_input_refcounts()
             elif access_pattern == common_urns.side_inputs.MULTIMAP.urn:
               # Ensure the input coder is a KV coder and patch up the
               # access pattern to appease Dataflow.
@@ -596,7 +595,6 @@ class DataflowRunner(PipelineRunner):
 
     # Attach side inputs.
     si_dict = {}
-    # We must call self._cache.get_pvalue exactly once due to refcounting.
     si_labels = {}
     full_label_counts = defaultdict(int)
     lookup_label = lambda side_pval: si_labels[side_pval]


### PR DESCRIPTION
This change removes some vestigial code doing PValue refcounting that is no longer used.