### PR TITLE
Do not email individuals about failures in Jenkins

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -227,25 +227,23 @@ class common_job_properties {
     }
   }
 
-  // Sets common config for jobs which run on a schedule / push
+  // Sets common config for jobs which run on a schedule; optionally on push
   static void setAutoJob(context,
-                            String buildSchedule = '0 */6 * * *',
-                            boolean triggerEveryPush = true,
-                            String notifyAddress = 'commits@beam.apache.org',
-                            boolean emailIndividuals = true) {
+                         String buildSchedule = '0 */6 * * *',
+                         notifyAddress = 'commits@beam.apache.org') {
 
     // Set build triggers
     context.triggers {
       // By default runs every 6 hours.
       cron(buildSchedule)
-      if (triggerEveryPush) {
-        githubPush()
-      }
     }
 
     context.publishers {
       // Notify an email address for each failed build (defaults to commits@).
-      mailer(notifyAddress, false, emailIndividuals)
+      mailer(
+          notifyAddress,
+          /* _do_ notify every unstable build */ false,
+          /* do not email individuals */ false)
     }
   }
 

--- a/.test-infra/jenkins/job_Dependency_Check.groovy
+++ b/.test-infra/jenkins/job_Dependency_Check.groovy
@@ -33,8 +33,7 @@ job('beam_Dependency_Check') {
   // This is a job that runs weekly.
   common_job_properties.setAutoJob(
     delegate,
-    '0 12 * * 1',
-    false)
+    '0 12 * * 1')
 
   steps {
     gradle {

--- a/.test-infra/jenkins/job_PerformanceTests_Dataflow.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Dataflow.groovy
@@ -27,10 +27,7 @@ job('beam_PerformanceTests_Dataflow'){
     // don't email individual committers.
     common_job_properties.setAutoJob(
         delegate,
-        'H */6 * * *',
-        false,
-        'commits@beam.apache.org',
-        false)
+        'H */6 * * *')
 
     def argMap = [
       benchmarks: 'dpb_wordcount_benchmark',

--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
@@ -114,10 +114,7 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
         // don't email individual committers.
         common_job_properties.setAutoJob(
                 delegate,
-                'H */6 * * *',
-                false,
-                'commits@beam.apache.org',
-                false)
+                'H */6 * * *')
 
         def pipelineOptions = [
                 project        : 'apache-beam-testing',

--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
@@ -116,10 +116,7 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
         // don't email individual committers.
         common_job_properties.setAutoJob(
                 delegate,
-                'H */6 * * *',
-                false,
-                'commits@beam.apache.org',
-                false)
+                'H */6 * * *')
 
         def pipelineArgs = [
                 project        : 'apache-beam-testing',

--- a/.test-infra/jenkins/job_PerformanceTests_HadoopInputFormat.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_HadoopInputFormat.groovy
@@ -28,10 +28,7 @@ job(jobName) {
     // don't email individual committers.
     common_job_properties.setAutoJob(
             delegate,
-            'H */6 * * *',
-            false,
-            'commits@beam.apache.org',
-            false)
+            'H */6 * * *')
 
     common_job_properties.enablePhraseTriggeringFromPullRequest(
             delegate,

--- a/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
@@ -28,10 +28,7 @@ job(jobName) {
     // don't email individual committers.
     common_job_properties.setAutoJob(
             delegate,
-            'H */6 * * *',
-            false,
-            'commits@beam.apache.org',
-            false)
+            'H */6 * * *')
 
     common_job_properties.enablePhraseTriggeringFromPullRequest(
             delegate,

--- a/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
@@ -28,10 +28,7 @@ job(jobName) {
     // don't email individual committers.
     common_job_properties.setAutoJob(
             delegate,
-            'H */6 * * *',
-            false,
-            'commits@beam.apache.org',
-            false)
+            'H */6 * * *')
 
     common_job_properties.enablePhraseTriggeringFromPullRequest(
             delegate,

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -26,9 +26,7 @@ job('beam_PerformanceTests_Python'){
   // Run job in postcommit every 6 hours, don't trigger every push.
   common_job_properties.setAutoJob(
       delegate,
-      'H */6 * * *',
-      false,
-      'commits@beam.apache.org')
+      'H */6 * * *')
 
   // Allows triggering this build against pull requests.
   common_job_properties.enablePhraseTriggeringFromPullRequest(

--- a/.test-infra/jenkins/job_PerformanceTests_Spark.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Spark.groovy
@@ -31,10 +31,7 @@ job('beam_PerformanceTests_Spark'){
     // don't email individual committers.
     common_job_properties.setAutoJob(
         delegate,
-        'H */6 * * *',
-        false,
-        'commits@beam.apache.org',
-        false)
+        'H */6 * * *')
 
     def argMap = [
       benchmarks: 'dpb_wordcount_benchmark',

--- a/.test-infra/jenkins/job_PostRelease_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_PostRelease_NightlySnapshot.groovy
@@ -41,8 +41,7 @@ job('beam_PostRelease_NightlySnapshot') {
   // This is a post-commit job that runs once per day, not for every push.
   common_job_properties.setAutoJob(
       delegate,
-      '0 11 * * *',
-      false)
+      '0 11 * * *')
 
 
   // Allows triggering this build against pull requests.

--- a/.test-infra/jenkins/job_Release_Gradle_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_Release_Gradle_NightlySnapshot.groovy
@@ -33,7 +33,6 @@ job('beam_Release_Gradle_NightlySnapshot') {
   common_job_properties.setAutoJob(
       delegate,
       '0 7 * * *',
-      false,
       'dev@beam.apache.org')
 
 

--- a/.test-infra/jenkins/job_beam_PerformanceTests_Analysis.groovy
+++ b/.test-infra/jenkins/job_beam_PerformanceTests_Analysis.groovy
@@ -56,10 +56,7 @@ job(testConfiguration.jobName) {
     // don't email individual committers.
     common_job_properties.setAutoJob(
             delegate,
-            '30 */24 * * *',
-            false,
-            'commits@beam.apache.org',
-            false)
+            '30 */24 * * *')
 
 
     steps {


### PR DESCRIPTION
We have a lot of emails coming from Jenkins. There are some technical reasons why we don't really want to email:

 - new jobs with notifications accidentally email *everyone who has ever contributed* when they start off red
 - merges of web site, feature branches, etc, often end up emailing everyone
 - many commits are not relevant to the particular failure; we shouldn't scrape all commits
 - as job count scales up, email is the wrong way to manage their greenness
 - there are others who are being emailed for no discernable reasons, probably a misconfiguration issue

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




