### PR TITLE
[BEAM-4652] Allow PubsubIO to read public data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ task javaPreCommit() {
 task javaPostCommit() {
   dependsOn ":javaPreCommit"
   dependsOn ":beam-runners-google-cloud-dataflow-java:postCommit"
+  dependsOn ":beam-sdks-java-io-google-cloud-platform:postCommit"
   dependsOn ":beam-sdks-java-extensions-sql:postCommit"
 }
 

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -147,6 +147,7 @@ task googleCloudPlatformIntegrationTest(type: Test) {
   ])
 
   include '**/*IT.class'
+  exclude '**/PubsubReadIT.class'
   maxParallelForks 4
   classpath = configurations.googleCloudPlatformIntegrationTest
   testClassesDirs = files(project(":beam-sdks-java-io-google-cloud-platform").sourceSets.test.output.classesDirs)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -234,7 +234,7 @@ public class PubsubJsonIT implements Serializable {
               assertFalse(resultSet.next());
               checked = true;
             } catch (SQLException e) {
-              LOG.warn(e.toString());
+              LOG.warn(e.toString(), e);
             }
           }
         });

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -21,6 +21,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -31,12 +33,14 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchema;
 import org.apache.beam.sdk.extensions.sql.impl.BeamSqlEnv;
 import org.apache.beam.sdk.extensions.sql.impl.JdbcDriver;
@@ -48,8 +52,10 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesCoder;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsub;
 import org.apache.beam.sdk.io.gcp.pubsub.TestPubsubSignal;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.jdbc.CalciteConnection;
@@ -82,6 +88,14 @@ public class PubsubJsonIT implements Serializable {
   @Rule public transient TestPubsub dlqTopic = TestPubsub.create();
   @Rule public transient TestPubsubSignal signal = TestPubsubSignal.create();
   @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  /**
+   * HACK: we need an objectmapper to turn pipelineoptions back into a map. We need to use
+   * ReflectHelpers to get the extra PipelineOptions.
+   */
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
 
   @Test
   public void testSelectsPayloadContent() throws Exception {
@@ -221,7 +235,8 @@ public class PubsubJsonIT implements Serializable {
             message(ts(6), 13, "ba4"),
             message(ts(7), 15, "ba5"));
 
-    CalciteConnection connection = connect(new PubsubJsonTableProvider());
+    // We need the default options on the schema to include the project passed in for the integration test
+    CalciteConnection connection = connect(pipeline.getOptions(), new PubsubJsonTableProvider());
 
     Statement statement = connection.createStatement();
     statement.execute(createTableString);
@@ -247,19 +262,46 @@ public class PubsubJsonIT implements Serializable {
     // wait one minute to allow subscription creation.
     Thread.sleep(60 * 1000);
     eventsTopic.publish(messages);
-    // Wait one minute to allow the thread finishes checks.
     assertThat(queryResult.get().size(), equalTo(3));
     pool.shutdown();
   }
 
-  private CalciteConnection connect(TableProvider... tableProviders) throws SQLException {
+  private static String toArg(Object o) {
+    try {
+      String jsonRepr = MAPPER.writeValueAsString(o);
+
+      // String and enums are expected to be unquoted on the command line
+      if (jsonRepr.startsWith("\"") && jsonRepr.endsWith("\"")) {
+        return jsonRepr.substring(1, jsonRepr.length() - 1);
+      } else {
+        return jsonRepr;
+      }
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private CalciteConnection connect(PipelineOptions options, TableProvider... tableProviders)
+      throws SQLException {
+    // HACK: PipelineOptions should expose a prominent method to do this reliably
+    // The actual options are in the "options" field of the converted map
+    Map<String, Object> optionsMap =
+        (Map<String, Object>) MAPPER.convertValue(pipeline.getOptions(), Map.class).get("options");
+    Map<String, String> argsMap =
+        optionsMap
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(entry -> entry.getKey(), entry -> toArg(entry.getValue())));
+
     InMemoryMetaStore inMemoryMetaStore = new InMemoryMetaStore();
     for (TableProvider tableProvider : tableProviders) {
       inMemoryMetaStore.registerProvider(tableProvider);
     }
 
     Properties info = new Properties();
-    info.put(BEAM_CALCITE_SCHEMA, new BeamCalciteSchema(inMemoryMetaStore));
+    BeamCalciteSchema dbSchema = new BeamCalciteSchema(inMemoryMetaStore);
+    dbSchema.getPipelineOptions().putAll(argsMap);
+    info.put(BEAM_CALCITE_SCHEMA, dbSchema);
     return (CalciteConnection) INSTANCE.connect(CONNECT_STRING_PREFIX, info);
   }
 

--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+import groovy.json.JsonOutput
+
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 applyJavaNature(
   enableFindbugs: false,
@@ -76,4 +78,33 @@ dependencies {
   shadowTest library.java.mockito_core
   shadowTest library.java.junit
   shadowTest library.java.slf4j_jdk14
+}
+
+/**
+ * These are integration tests with the real Pubsub service and the DirectRunner.
+ */
+task integrationTest(type: Test) {
+  group = "Verification"
+  def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
+  def gcpTempRoot = project.findProperty('gcpTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
+  systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+          "--runner=DirectRunner",
+          "--project=${gcpProject}",
+          "--tempRoot=${gcpTempRoot}",
+  ])
+
+  // Disable Gradle cache: these ITs interact with live service that should always be considered "out of date"
+  outputs.upToDateWhen { false }
+
+  include '**/*IT.class'
+  maxParallelForks 4
+  classpath = sourceSets.test.runtimeClasspath
+  testClassesDirs = sourceSets.test.output.classesDirs
+  useJUnit { }
+}
+
+task postCommit {
+  group = "Verification"
+  description = "Integration tests of GCP connectors using the DirectRunner."
+  dependsOn integrationTest
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -309,10 +309,10 @@ public class PubsubIO {
 
   /** Used to build a {@link ValueProvider} for {@link ProjectPath}. */
   private static class ProjectPathTranslator
-      implements SerializableFunction<PubsubTopic, ProjectPath> {
+      implements SerializableFunction<PubsubSubscription, ProjectPath> {
 
     @Override
-    public ProjectPath apply(PubsubTopic from) {
+    public ProjectPath apply(PubsubSubscription from) {
       return PubsubClient.projectPathFromId(from.project);
     }
   }
@@ -692,11 +692,6 @@ public class PubsubIO {
       }
 
       @Nullable
-      ValueProvider<ProjectPath> projectPath =
-          getTopicProvider() == null
-              ? null
-              : NestedValueProvider.of(getTopicProvider(), new ProjectPathTranslator());
-      @Nullable
       ValueProvider<TopicPath> topicPath =
           getTopicProvider() == null
               ? null
@@ -709,7 +704,7 @@ public class PubsubIO {
       PubsubUnboundedSource source =
           new PubsubUnboundedSource(
               FACTORY,
-              projectPath,
+              null /* always get project from runtime PipelineOptions */,
               topicPath,
               subscriptionPath,
               getTimestampAttribute(),

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsubSignal.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsubSignal.java
@@ -50,6 +50,8 @@ import org.joda.time.Duration;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test rule which observes elements of the {@link PCollection} and checks whether they match the
@@ -58,6 +60,7 @@ import org.junit.runners.model.Statement;
  * <p>Uses a random temporary Pubsub topic for synchronization.
  */
 public class TestPubsubSignal implements TestRule {
+  private static final Logger LOG = LoggerFactory.getLogger(TestPubsubSignal.class);
   private static final String TOPIC_FORMAT = "projects/%s/topics/%s-result1";
   private static final String SUBSCRIPTION_FORMAT = "projects/%s/subscriptions/%s";
   private static final String NO_ID_ATTRIBUTE = null;
@@ -192,7 +195,7 @@ public class TestPubsubSignal implements TestRule {
             resultSubscriptionPath, result.stream().map(m -> m.ackId).collect(toList()));
         break;
       } catch (StatusRuntimeException e) {
-        System.out.println("Error while polling for result: " + e.getStatus());
+        LOG.warn("Error while polling for result: %s", e.getStatus());
         sleep(500);
       }
     } while (DateTime.now().isBefore(endPolling));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubReadIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubReadIT.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.common.base.Supplier;
+import org.apache.beam.runners.direct.DirectOptions;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.PCollection;
+import org.joda.time.Duration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Integration test for PubsubIO. */
+@RunWith(JUnit4.class)
+public class PubsubReadIT {
+
+  @Rule public transient TestPubsubSignal signal = TestPubsubSignal.create();
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testReadPublicData() throws Exception {
+    // The pipeline will never terminate on its own
+    pipeline.getOptions().as(DirectOptions.class).setBlockOnRun(false);
+
+    PCollection<String> messages =
+        pipeline.apply(
+            PubsubIO.readStrings()
+                .fromTopic("projects/pubsub-public-data/topics/taxirides-realtime"));
+
+    messages.apply(
+        "waitForAnyMessage", signal.signalSuccessWhen(messages.getCoder(), anyMessages -> true));
+
+    Supplier<Void> start = signal.waitForStart(Duration.standardMinutes(5));
+    pipeline.apply(signal.signalStart());
+    PipelineResult job = pipeline.run();
+    start.get();
+
+    signal.waitForSuccess(Duration.standardSeconds(30));
+    // A runner may not support cancel
+    try {
+      job.cancel();
+    } catch (UnsupportedOperationException exc) {
+      // noop
+    }
+  }
+}


### PR DESCRIPTION
This adds an integration test run for GCP IOs and then adds an integration test for reading a read public data set.

It does not pass, but it also does not fail in the same way that my local testing fails. When I write a pipeline to read this dataset I get a 403 on creating a subscription. The logs that gradle captures are a bit different.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




