### PR TITLE
Flink upload jobserver jar to flink remote environment

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -115,7 +115,8 @@ public class FlinkBatchPortablePipelineTranslator
    * Creates a batch translation context. The resulting Flink execution dag will live in a new
    * {@link ExecutionEnvironment}.
    */
-  public static BatchTranslationContext createTranslationContext(JobInfo jobInfo) {
+  public static BatchTranslationContext createTranslationContext(JobInfo jobInfo,
+      List<String> filesToStage) {
     PipelineOptions pipelineOptions;
     try {
       pipelineOptions = PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());
@@ -124,7 +125,7 @@ public class FlinkBatchPortablePipelineTranslator
     }
     ExecutionEnvironment executionEnvironment =
         FlinkExecutionEnvironments.createBatchExecutionEnvironment(
-            pipelineOptions.as(FlinkPipelineOptions.class));
+            pipelineOptions.as(FlinkPipelineOptions.class), filesToStage);
     return new BatchTranslationContext(jobInfo, executionEnvironment);
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -115,8 +115,8 @@ public class FlinkBatchPortablePipelineTranslator
    * Creates a batch translation context. The resulting Flink execution dag will live in a new
    * {@link ExecutionEnvironment}.
    */
-  public static BatchTranslationContext createTranslationContext(JobInfo jobInfo,
-      List<String> filesToStage) {
+  public static BatchTranslationContext createTranslationContext(
+      JobInfo jobInfo, List<String> filesToStage) {
     PipelineOptions pipelineOptions;
     try {
       pipelineOptions = PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -37,8 +37,8 @@ public class FlinkExecutionEnvironments {
    * If the submitted job is a batch processing job, this method creates the adequate Flink {@link
    * org.apache.flink.api.java.ExecutionEnvironment} depending on the user-specified options.
    */
-  public static ExecutionEnvironment createBatchExecutionEnvironment(FlinkPipelineOptions options,
-      List<String> filesToStage) {
+  public static ExecutionEnvironment createBatchExecutionEnvironment(
+      FlinkPipelineOptions options, List<String> filesToStage) {
 
     LOG.info("Creating a Batch Execution Environment.");
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -37,7 +37,8 @@ public class FlinkExecutionEnvironments {
    * If the submitted job is a batch processing job, this method creates the adequate Flink {@link
    * org.apache.flink.api.java.ExecutionEnvironment} depending on the user-specified options.
    */
-  public static ExecutionEnvironment createBatchExecutionEnvironment(FlinkPipelineOptions options) {
+  public static ExecutionEnvironment createBatchExecutionEnvironment(FlinkPipelineOptions options,
+      List<String> filesToStage) {
 
     LOG.info("Creating a Batch Execution Environment.");
 
@@ -53,12 +54,11 @@ public class FlinkExecutionEnvironments {
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
       List<String> parts = Splitter.on(':').splitToList(masterUrl);
-      List<String> stagingFiles = options.getFilesToStage();
       flinkBatchEnv =
           ExecutionEnvironment.createRemoteEnvironment(
               parts.get(0),
               Integer.parseInt(parts.get(1)),
-              stagingFiles.toArray(new String[stagingFiles.size()]));
+              filesToStage.toArray(new String[filesToStage.size()]));
     } else {
       LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);
       flinkBatchEnv = ExecutionEnvironment.getExecutionEnvironment();
@@ -87,7 +87,7 @@ public class FlinkExecutionEnvironments {
    * user-specified options.
    */
   public static StreamExecutionEnvironment createStreamExecutionEnvironment(
-      FlinkPipelineOptions options) {
+      FlinkPipelineOptions options, List<String> filesToStage) {
 
     LOG.info("Creating a Streaming Environment.");
 
@@ -101,12 +101,11 @@ public class FlinkExecutionEnvironments {
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     } else if (masterUrl.matches(".*:\\d*")) {
       List<String> parts = Splitter.on(':').splitToList(masterUrl);
-      List<String> stagingFiles = options.getFilesToStage();
       flinkStreamEnv =
           StreamExecutionEnvironment.createRemoteEnvironment(
               parts.get(0),
               Integer.parseInt(parts.get(1)),
-              stagingFiles.toArray(new String[stagingFiles.size()]));
+              filesToStage.toArray(new String[filesToStage.size()]));
     } else {
       LOG.warn("Unrecognized Flink Master URL {}. Defaulting to [auto].", masterUrl);
       flinkStreamEnv = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
@@ -55,8 +55,8 @@ public class FlinkJobInvocation implements JobInvocation {
       Pipeline pipeline,
       FlinkPipelineOptions pipelineOptions,
       List<String> filesToStage) {
-    return new FlinkJobInvocation(id, retrievalToken, executorService, pipeline, pipelineOptions,
-        filesToStage);
+    return new FlinkJobInvocation(
+        id, retrievalToken, executorService, pipeline, pipelineOptions, filesToStage);
   }
 
   private final String id;
@@ -75,7 +75,8 @@ public class FlinkJobInvocation implements JobInvocation {
       String retrievalToken,
       ListeningExecutorService executorService,
       Pipeline pipeline,
-      FlinkPipelineOptions pipelineOptions, List<String> filesToStage) {
+      FlinkPipelineOptions pipelineOptions,
+      List<String> filesToStage) {
     this.id = id;
     this.retrievalToken = retrievalToken;
     this.executorService = executorService;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvoker.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvoker.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static org.apache.beam.runners.core.construction.PipelineResources.detectClassPathResourcesToStage;
 
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.protobuf.Struct;
@@ -62,6 +63,8 @@ public class FlinkJobInvoker implements JobInvoker {
     LOG.info("Invoking job {}", invocationId);
 
     flinkOptions.setFlinkMaster(firstNonNull(flinkOptions.getFlinkMaster(), flinkMasterUrl));
+    flinkOptions
+        .setFilesToStage(detectClassPathResourcesToStage(FlinkJobInvoker.class.getClassLoader()));
 
     flinkOptions.setRunner(null);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvoker.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvoker.java
@@ -63,12 +63,15 @@ public class FlinkJobInvoker implements JobInvoker {
     LOG.info("Invoking job {}", invocationId);
 
     flinkOptions.setFlinkMaster(firstNonNull(flinkOptions.getFlinkMaster(), flinkMasterUrl));
-    flinkOptions
-        .setFilesToStage(detectClassPathResourcesToStage(FlinkJobInvoker.class.getClassLoader()));
 
     flinkOptions.setRunner(null);
 
     return FlinkJobInvocation.create(
-        invocationId, retrievalToken, executorService, pipeline, flinkOptions);
+        invocationId,
+        retrievalToken,
+        executorService,
+        pipeline,
+        flinkOptions,
+        detectClassPathResourcesToStage(FlinkJobInvoker.class.getClassLoader()));
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -93,10 +93,12 @@ class FlinkPipelineExecutionEnvironment {
 
     FlinkPipelineTranslator translator;
     if (translationMode == TranslationMode.STREAMING) {
-      this.flinkStreamEnv = FlinkExecutionEnvironments.createStreamExecutionEnvironment(options);
+      this.flinkStreamEnv = FlinkExecutionEnvironments
+          .createStreamExecutionEnvironment(options, options.getFilesToStage());
       translator = new FlinkStreamingPipelineTranslator(flinkRunner, flinkStreamEnv, options);
     } else {
-      this.flinkBatchEnv = FlinkExecutionEnvironments.createBatchExecutionEnvironment(options);
+      this.flinkBatchEnv = FlinkExecutionEnvironments
+          .createBatchExecutionEnvironment(options, options.getFilesToStage());
       translator = new FlinkBatchPipelineTranslator(flinkBatchEnv, options);
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -93,12 +93,14 @@ class FlinkPipelineExecutionEnvironment {
 
     FlinkPipelineTranslator translator;
     if (translationMode == TranslationMode.STREAMING) {
-      this.flinkStreamEnv = FlinkExecutionEnvironments
-          .createStreamExecutionEnvironment(options, options.getFilesToStage());
+      this.flinkStreamEnv =
+          FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+              options, options.getFilesToStage());
       translator = new FlinkStreamingPipelineTranslator(flinkRunner, flinkStreamEnv, options);
     } else {
-      this.flinkBatchEnv = FlinkExecutionEnvironments
-          .createBatchExecutionEnvironment(options, options.getFilesToStage());
+      this.flinkBatchEnv =
+          FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+              options, options.getFilesToStage());
       translator = new FlinkBatchPipelineTranslator(flinkBatchEnv, options);
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -87,7 +88,8 @@ public class FlinkStreamingPortablePipelineTranslator
    * Creates a streaming translation context. The resulting Flink execution dag will live in a new
    * {@link StreamExecutionEnvironment}.
    */
-  public static StreamingTranslationContext createTranslationContext(JobInfo jobInfo) {
+  public static StreamingTranslationContext createTranslationContext(JobInfo jobInfo,
+      List<String> filesToStage) {
     PipelineOptions pipelineOptions;
     try {
       pipelineOptions = PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());
@@ -95,8 +97,8 @@ public class FlinkStreamingPortablePipelineTranslator
       throw new RuntimeException(e);
     }
     StreamExecutionEnvironment executionEnvironment =
-        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
-            pipelineOptions.as(FlinkPipelineOptions.class));
+            FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+                    pipelineOptions.as(FlinkPipelineOptions.class), filesToStage);
     return new StreamingTranslationContext(jobInfo, pipelineOptions, executionEnvironment);
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -88,8 +88,8 @@ public class FlinkStreamingPortablePipelineTranslator
    * Creates a streaming translation context. The resulting Flink execution dag will live in a new
    * {@link StreamExecutionEnvironment}.
    */
-  public static StreamingTranslationContext createTranslationContext(JobInfo jobInfo,
-      List<String> filesToStage) {
+  public static StreamingTranslationContext createTranslationContext(
+      JobInfo jobInfo, List<String> filesToStage) {
     PipelineOptions pipelineOptions;
     try {
       pipelineOptions = PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions());
@@ -97,8 +97,8 @@ public class FlinkStreamingPortablePipelineTranslator
       throw new RuntimeException(e);
     }
     StreamExecutionEnvironment executionEnvironment =
-            FlinkExecutionEnvironments.createStreamExecutionEnvironment(
-                    pipelineOptions.as(FlinkPipelineOptions.class), filesToStage);
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            pipelineOptions.as(FlinkPipelineOptions.class), filesToStage);
     return new StreamingTranslationContext(jobInfo, pipelineOptions, executionEnvironment);
   }
 


### PR DESCRIPTION
Flink job server jar is needed to run beam job on flink at execution time.
Uploading the class path which should contain the job server jar if started with command
"java -jar jobserver.jar ....."

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




