### PR TITLE
FileSystems should throw exception if filesystem for schema is not found

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -69,7 +69,7 @@ public class FileSystems {
 
   public static final String DEFAULT_SCHEME = "file";
   private static final Pattern FILE_SCHEME_PATTERN =
-      Pattern.compile("(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*):.*");
+      Pattern.compile("(?<scheme>[a-zA-Z][-a-zA-Z0-9+.]*)://.*");
   private static final Pattern GLOB_PATTERN = Pattern.compile("[*?{}]");
 
   private static final AtomicReference<Map<String, FileSystem>> SCHEME_TO_FILESYSTEM =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -455,10 +455,10 @@ public class FileSystems {
     String lowerCaseScheme = scheme.toLowerCase();
     Map<String, FileSystem> schemeToFileSystem = SCHEME_TO_FILESYSTEM.get();
     FileSystem rval = schemeToFileSystem.get(lowerCaseScheme);
-    if (rval != null) {
-      return rval;
+    if (rval == null) {
+      throw new IllegalArgumentException("No filesystem found for scheme " + scheme);
     }
-    return schemeToFileSystem.get(DEFAULT_SCHEME);
+    return rval;
   }
 
   /** ******************************** METHODS FOR REGISTRATION ********************************* */

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -183,6 +184,18 @@ public class FileSystemsTest {
     assertThat(
         Files.readLines(destPath3.toFile(), StandardCharsets.UTF_8),
         containsInAnyOrder("content3"));
+  }
+
+  @Test
+  public void testValidMatchNewResourceForLocalFileSystem() {
+    assertEquals("file", FileSystems.matchNewResource("/tmp/f1", false).getScheme());
+    assertEquals("file", FileSystems.matchNewResource("tmp/f1", false).getScheme());
+    assertEquals("file", FileSystems.matchNewResource("c:\\tmp\\f1", false).getScheme());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSchemaMatchNewResource() {
+    assertEquals("file", FileSystems.matchNewResource("invalidschema://tmp/f1", false));
   }
 
   private List<ResourceId> toResourceIds(List<Path> paths, final boolean isDirectory) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileSystemsTest.java
@@ -68,6 +68,11 @@ public class FileSystemsTest {
     assertTrue(
         FileSystems.getFileSystemInternal(toLocalResourceId("File://home").getScheme())
             instanceof LocalFileSystem);
+    if (SystemUtils.IS_OS_WINDOWS) {
+      assertTrue(
+          FileSystems.getFileSystemInternal(toLocalResourceId("c:\\home\\").getScheme())
+              instanceof LocalFileSystem);
+    }
   }
 
   @Test


### PR DESCRIPTION
Not failing and falling back to LocalFileSystem creates hard to find bug and delayed failure.

Example:
File path: gs://my_bucker/my_folder
Running the program from /root/
If GCS is not added then in the current code we create a local file "/root/gs://my_bucker/my_folder" without any exception or message.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




