### PR TITLE
[BEAM-4666] Make Go run on Flink again

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactRetrievalService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactRetrievalService.java
@@ -19,8 +19,10 @@
 package org.apache.beam.runners.fnexecution.artifact;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -70,7 +72,12 @@ public class BeamFileSystemArtifactRetrievalService
   public void getManifest(
       ArtifactApi.GetManifestRequest request,
       StreamObserver<ArtifactApi.GetManifestResponse> responseObserver) {
-    String token = request.getRetrievalToken();
+    final String token = request.getRetrievalToken();
+    if (Strings.isNullOrEmpty(token)) {
+      throw new StatusRuntimeException(
+              Status.INVALID_ARGUMENT.withDescription("Empty artifact token"));
+    }
+
     LOG.info("GetManifest for {}", token);
     try {
       ArtifactApi.ProxyManifest proxyManifest = MANIFEST_CACHE.get(token);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClientPoolService.java
@@ -19,6 +19,9 @@ package org.apache.beam.runners.fnexecution.control;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.base.Strings;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -74,7 +77,12 @@ public class FnApiControlClientPoolService extends BeamFnControlGrpc.BeamFnContr
   @Override
   public StreamObserver<BeamFnApi.InstructionResponse> control(
       StreamObserver<BeamFnApi.InstructionRequest> requestObserver) {
-    String workerId = headerAccessor.getSdkWorkerId();
+    final String workerId = headerAccessor.getSdkWorkerId();
+    if (Strings.isNullOrEmpty(workerId)) {
+      throw new StatusRuntimeException(
+              Status.INVALID_ARGUMENT.withDescription("No worker_id header provided"));
+    }
+
     LOGGER.info("Beam Fn Control client connected with id {}", workerId);
     FnApiControlClient newClient = FnApiControlClient.forRequestObserver(workerId, requestObserver);
     try {

--- a/sdks/go/pkg/beam/artifact/stage.go
+++ b/sdks/go/pkg/beam/artifact/stage.go
@@ -163,7 +163,7 @@ func Stage(ctx context.Context, client pb.ArtifactStagingServiceClient, key, fil
 		stream.CloseAndRecv() // ignore error
 		return nil, fmt.Errorf("failed to send chunks for %v: %v", filename, err)
 	}
-	if _, err := stream.CloseAndRecv(); err != nil {
+	if _, err := stream.CloseAndRecv(); err != nil && err != io.EOF {
 		return nil, fmt.Errorf("failed to close stream for %v: %v", filename, err)
 	}
 	if hash != stagedHash {

--- a/sdks/go/pkg/beam/core/runtime/harness/init/init.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/init/init.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/harness"
+	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
 )
 
 var (
@@ -81,7 +82,8 @@ func hook() {
 	// Since Init() is hijacking main, it's appropriate to do as main
 	// does, and establish the background context here.
 
-	if err := harness.Main(context.Background(), *loggingEndpoint, *controlEndpoint); err != nil {
+	ctx := grpcx.WriteWorkerID(context.Background(), *id)
+	if err := harness.Main(ctx, *loggingEndpoint, *controlEndpoint); err != nil {
 		fmt.Fprintf(os.Stderr, "Worker failed: %v", err)
 		os.Exit(1)
 	}

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -49,10 +49,6 @@ var (
 
 	// Async determines whether to wait for job completion.
 	Async = flag.Bool("async", false, "Do not wait for job completion.")
-
-	// InternalJavaRunner is the java class needed at this time for Java runners.
-	// To be removed.
-	InternalJavaRunner = flag.String("internal_java_runner", "", "Internal java runner class.")
 )
 
 // GetEndpoint returns the endpoint, if non empty and exits otherwise. Runners

--- a/sdks/go/pkg/beam/runners/flink/flink.go
+++ b/sdks/go/pkg/beam/runners/flink/flink.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/options/jobopts"
 	"github.com/apache/beam/sdks/go/pkg/beam/runners/universal"
 )
 
@@ -31,8 +30,5 @@ func init() {
 // Execute runs the given pipeline on Flink. Convenience wrapper over the
 // universal runner.
 func Execute(ctx context.Context, p *beam.Pipeline) error {
-	if *jobopts.InternalJavaRunner == "" {
-		*jobopts.InternalJavaRunner = "org.apache.beam.runners.flink.FlinkRunner"
-	}
 	return universal.Execute(ctx, p)
 }

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
@@ -61,7 +61,7 @@ func Execute(ctx context.Context, p *pb.Pipeline, endpoint string, opt *JobOptio
 		log.Infof(ctx, "Using specified worker binary: '%v'", bin)
 	}
 
-	token, err := Stage(ctx, prepID, artifactEndpoint, st, bin)
+	token, err := Stage(ctx, prepID, artifactEndpoint, bin, st)
 	if err != nil {
 		return "", err
 	}

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/job.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/job.go
@@ -41,9 +41,6 @@ type JobOptions struct {
 
 	// Worker is the worker binary override.
 	Worker string
-
-	// InternalJavaRunner is the class of the receiving Java runner. To be removed.
-	InternalJavaRunner string
 }
 
 // Prepare prepares a job to the given job service. It returns the preparation id
@@ -51,7 +48,6 @@ type JobOptions struct {
 func Prepare(ctx context.Context, client jobpb.JobServiceClient, p *pb.Pipeline, opt *JobOptions) (id, endpoint, stagingToken string, err error) {
 	raw := runtime.RawOptionsWrapper{
 		Options:     beam.PipelineOptions.Export(),
-		Runner:      opt.InternalJavaRunner,
 		AppName:     opt.Name,
 		Experiments: append(opt.Experiments, "beam_fn_api"),
 	}

--- a/sdks/go/pkg/beam/runners/universal/universal.go
+++ b/sdks/go/pkg/beam/runners/universal/universal.go
@@ -54,7 +54,6 @@ func Execute(ctx context.Context, p *beam.Pipeline) error {
 		Name:               jobopts.GetJobName(),
 		Experiments:        jobopts.GetExperiments(),
 		Worker:             *jobopts.WorkerBinary,
-		InternalJavaRunner: *jobopts.InternalJavaRunner,
 	}
 	_, err = runnerlib.Execute(ctx, pipeline, endpoint, opt, *jobopts.Async)
 	return err


### PR DESCRIPTION
Fix a handful of minor issues with Go and the portable Flink runner that stem from the differences between master and the old hacking branch. The commits each describe the issues.

Verified that the Go integration tests work.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




