### PR TITLE
[BEAM-4643] Allow to check early panes of a window

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -257,7 +257,7 @@ public class PAssert {
      * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
      *     specified window.
      */
-    IterableAssert<T> inEarlyPanes(BoundedWindow window);
+    IterableAssert<T> inEarlyPane(BoundedWindow window);
 
     /**
      * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
@@ -352,7 +352,7 @@ public class PAssert {
      * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
      *     the specified window.
      */
-    SingletonAssert<T> inEarlyPanes(BoundedWindow window);
+    SingletonAssert<T> inEarlyPane(BoundedWindow window);
 
     /**
      * Asserts that the value in question is equal to the provided value, according to {@link
@@ -532,7 +532,7 @@ public class PAssert {
     }
 
     @Override
-    public PCollectionContentsAssert<T> inEarlyPanes(BoundedWindow window) {
+    public PCollectionContentsAssert<T> inEarlyPane(BoundedWindow window) {
       return withPane(window, PaneExtractors.earlyPanes());
     }
 
@@ -724,7 +724,7 @@ public class PAssert {
     }
 
     @Override
-    public PCollectionSingletonIterableAssert<T> inEarlyPanes(BoundedWindow window) {
+    public PCollectionSingletonIterableAssert<T> inEarlyPane(BoundedWindow window) {
       return withPanes(window, PaneExtractors.earlyPanes());
     }
 
@@ -834,7 +834,7 @@ public class PAssert {
     }
 
     @Override
-    public PCollectionViewAssert<ElemT, ViewT> inEarlyPanes(BoundedWindow window) {
+    public PCollectionViewAssert<ElemT, ViewT> inEarlyPane(BoundedWindow window) {
       return inPane(window, PaneExtractors.earlyPanes());
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -255,7 +255,7 @@ public class PAssert {
      * run on the provided window across all panes that were produced by the arrival of early data.
      *
      * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
-     * specified window.
+     *     specified window.
      */
     IterableAssert<T> inEarlyPanes(BoundedWindow window);
 
@@ -350,13 +350,13 @@ public class PAssert {
      * only run on the provided window, running the checker only on early panes for each key.
      *
      * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
-     * the specified window.
+     *     the specified window.
      */
     SingletonAssert<T> inEarlyPanes(BoundedWindow window);
 
     /**
-     * Asserts that the value in question is equal to the provided value, according to
-     * {@link Object#equals}.
+     * Asserts that the value in question is equal to the provided value, according to {@link
+     * Object#equals}.
      *
      * @return the same {@link SingletonAssert} builder for further assertions
      */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/PAssert.java
@@ -252,6 +252,15 @@ public class PAssert {
 
     /**
      * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
+     * run on the provided window across all panes that were produced by the arrival of early data.
+     *
+     * @return a new {@link IterableAssert} like this one but with the assertion only applied to the
+     * specified window.
+     */
+    IterableAssert<T> inEarlyPanes(BoundedWindow window);
+
+    /**
+     * Creates a new {@link IterableAssert} like this one, but with the assertion restricted to only
      * run on the provided window across all panes that were not produced by the arrival of late
      * data.
      *
@@ -337,8 +346,17 @@ public class PAssert {
     SingletonAssert<T> inOnTimePane(BoundedWindow window);
 
     /**
-     * Asserts that the value in question is equal to the provided value, according to {@link
-     * Object#equals}.
+     * Creates a new {@link SingletonAssert} like this one, but with the assertion restricted to
+     * only run on the provided window, running the checker only on early panes for each key.
+     *
+     * @return a new {@link SingletonAssert} like this one but with the assertion only applied to
+     * the specified window.
+     */
+    SingletonAssert<T> inEarlyPanes(BoundedWindow window);
+
+    /**
+     * Asserts that the value in question is equal to the provided value, according to
+     * {@link Object#equals}.
      *
      * @return the same {@link SingletonAssert} builder for further assertions
      */
@@ -511,6 +529,11 @@ public class PAssert {
     @Override
     public PCollectionContentsAssert<T> inOnTimePane(BoundedWindow window) {
       return withPane(window, PaneExtractors.onTimePane());
+    }
+
+    @Override
+    public PCollectionContentsAssert<T> inEarlyPanes(BoundedWindow window) {
+      return withPane(window, PaneExtractors.earlyPanes());
     }
 
     @Override
@@ -701,6 +724,11 @@ public class PAssert {
     }
 
     @Override
+    public PCollectionSingletonIterableAssert<T> inEarlyPanes(BoundedWindow window) {
+      return withPanes(window, PaneExtractors.earlyPanes());
+    }
+
+    @Override
     public PCollectionSingletonIterableAssert<T> inCombinedNonLatePanes(BoundedWindow window) {
       return withPanes(window, PaneExtractors.nonLatePanes());
     }
@@ -803,6 +831,11 @@ public class PAssert {
     @Override
     public PCollectionViewAssert<ElemT, ViewT> inOnTimePane(BoundedWindow window) {
       return inPane(window, PaneExtractors.onTimePane());
+    }
+
+    @Override
+    public PCollectionViewAssert<ElemT, ViewT> inEarlyPanes(BoundedWindow window) {
+      return inPane(window, PaneExtractors.earlyPanes());
     }
 
     private PCollectionViewAssert<ElemT, ViewT> inPane(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -368,7 +368,7 @@ public class TestStreamTest implements Serializable {
         new IntervalWindow(new Instant(0L), new Instant(0L).plus(Duration.standardMinutes(30)));
 
     PAssert.that(sum)
-        .inEarlyPanes(window)
+        .inEarlyPane(window)
         .satisfies(
             input -> {
               assertThat(StreamSupport.stream(input.spliterator(), false).count(), is(3L));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -20,10 +20,12 @@ package org.apache.beam.sdk.testing;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertThat;
 
 import java.io.Serializable;
+import java.util.stream.StreamSupport;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
@@ -32,6 +34,7 @@ import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Flatten;
 import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.WithKeys;
@@ -46,8 +49,10 @@ import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Never;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.Window.ClosingBehavior;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Rule;
@@ -327,5 +332,55 @@ public class TestStreamTest implements Serializable {
             .advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE.minus(1L));
     thrown.expect(IllegalArgumentException.class);
     stream.advanceWatermarkTo(BoundedWindow.TIMESTAMP_MAX_VALUE);
+  }
+
+  @Test
+  @Category({NeedsRunner.class, UsesTestStream.class})
+  public void testEarlyPanesOfWindow() {
+    TestStream<Long> source = TestStream.create(VarLongCoder.of())
+        .addElements(TimestampedValue.of(1L, new Instant(1000L)))
+        .advanceProcessingTime(Duration.standardMinutes(6)) // Fire early pane
+        .addElements(TimestampedValue.of(2L, new Instant(2000L)))
+        .advanceProcessingTime(Duration.standardMinutes(6)) // Fire early pane
+        .addElements(TimestampedValue.of(3L, new Instant(3000L)))
+        .advanceProcessingTime(Duration.standardMinutes(6)) // Fire early pane
+        .advanceWatermarkToInfinity(); // Fire on-time pane
+
+    PCollection<KV<String, Long>> sum = p.apply(source)
+        .apply(Window.<Long>into(FixedWindows.of(Duration.standardMinutes(30)))
+            .triggering(AfterWatermark.pastEndOfWindow()
+                .withEarlyFirings(AfterProcessingTime.pastFirstElementInPane()
+                    .plusDelayOf(Duration.standardMinutes(5)))).accumulatingFiredPanes()
+            .withAllowedLateness(Duration.ZERO))
+        .apply(
+            MapElements.into(
+                TypeDescriptors.kvs(TypeDescriptors.strings(), TypeDescriptors.longs()))
+                    .via(v -> KV.of("key", v))
+        )
+        .apply(Sum.longsPerKey());
+
+    IntervalWindow window = new IntervalWindow(
+        new Instant(0L),
+        new Instant(0L).plus(Duration.standardMinutes(30))
+    );
+
+    PAssert.that(sum)
+        .inEarlyPanes(window)
+        .satisfies(input -> {
+          assertThat(StreamSupport.stream(input.spliterator(), false).count(), is(3L));
+          return null;
+        })
+        .containsInAnyOrder(
+            KV.of("key", 1L),
+            KV.of("key", 3L),
+            KV.of("key", 6L))
+        .inOnTimePane(window)
+        .satisfies(input -> {
+            assertThat(StreamSupport.stream(input.spliterator(), false).count(), is(1L));
+            return null;
+        })
+        .containsInAnyOrder(KV.of("key", 6L));
+
+    p.run().waitUntilFinish();
   }
 }


### PR DESCRIPTION
Just adding the ability to check the early panes of a specific window (not only the global window).

Just by adding `inEarlyPanes(BoundedWindow window)` method in `PAssert` and its `implementations`, we are now capable of doing:
```java
PAssert.that(teamScores)
    .inEarlyPanes(intervalWindow(05, 20))
        .containsInAnyOrder(
            KV.of("black", 1),  // First item (Black, 1)
            KV.of("black", 2))  // Second item (Black, 1) cumulated with the first one
    .inOnTimePane(intervalWindow(05, 20))
        .containsInAnyOrder(
            KV.of("black", 2))  // No new items since the last early element
    .inFinalPane(intervalWindow(05, 20))
        .containsInAnyOrder(
            KV.of("black", 10)); // New late data (black, 8)
```
**NB**: `intervalWindow(05, 20)` returns an new `IntervalWindow` from 00:05:00 to 00:20:00

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---
