### PR TITLE
[BEAM-3942] Remove mvn leftovers from jenkins IOIT job definitions

### DIFF
--- a/.test-infra/jenkins/common_job_properties.groovy
+++ b/.test-infra/jenkins/common_job_properties.groovy
@@ -265,7 +265,6 @@ class common_job_properties {
     LinkedHashMap<String, String> standardArgs = [
       project: 'apache-beam-testing',
       dpb_log_level: 'INFO',
-      maven_binary: '/home/jenkins/tools/maven/latest/bin/mvn',
       bigquery_table: 'beam_performance.pkb_results',
       k8s_get_retry_count: 36, // wait up to 6 minutes for K8s LoadBalancer
       k8s_get_wait_interval: 10,

--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT.groovy
@@ -129,16 +129,15 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
         }
 
         def argMap = [
-                benchmarks               : 'beam_integration_benchmark',
-                beam_it_timeout          : '1200',
-                beam_it_profile          : 'io-it',
-                beam_prebuilt            : 'false',
-                beam_sdk                 : 'java',
-                beam_it_module           : 'sdks/java/io/file-based-io-tests',
-                beam_it_class            : testConfiguration.itClass,
-                beam_it_options          : common_job_properties.joinPipelineOptions(pipelineOptions),
-                beam_extra_mvn_properties: '["filesystem=gcs"]',
-                bigquery_table           : testConfiguration.bqTable,
+                benchmarks           : 'beam_integration_benchmark',
+                beam_it_timeout      : '1200',
+                beam_prebuilt        : 'false',
+                beam_sdk             : 'java',
+                beam_it_module       : 'sdks/java/io/file-based-io-tests',
+                beam_it_class        : testConfiguration.itClass,
+                beam_it_options      : common_job_properties.joinPipelineOptions(pipelineOptions),
+                beam_extra_properties: '["filesystem=gcs"]',
+                bigquery_table       : testConfiguration.bqTable,
         ]
         common_job_properties.buildPerformanceTest(delegate, argMap)
     }

--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_IT_HDFS.groovy
@@ -139,19 +139,18 @@ private void create_filebasedio_performance_test_job(testConfiguration) {
         String kubeconfig = common_job_properties.getKubeconfigLocationForNamespace(namespace)
 
         def argMap = [
-                kubeconfig               : kubeconfig,
-                benchmarks               : 'beam_integration_benchmark',
-                beam_it_timeout          : '1200',
-                beam_it_profile          : 'io-it',
-                beam_prebuilt            : 'false',
-                beam_sdk                 : 'java',
-                beam_it_module           : 'sdks/java/io/file-based-io-tests',
-                beam_it_class            : testConfiguration.itClass,
-                beam_it_options          : pipelineArgsJoined,
-                beam_extra_mvn_properties: '["filesystem=hdfs"]',
-                bigquery_table           : testConfiguration.bqTable,
-                beam_options_config_file : makePathAbsolute('pkb-config.yml'),
-                beam_kubernetes_scripts  : makePathAbsolute('hdfs-multi-datanode-cluster.yml')
+                kubeconfig              : kubeconfig,
+                benchmarks              : 'beam_integration_benchmark',
+                beam_it_timeout         : '1200',
+                beam_prebuilt           : 'false',
+                beam_sdk                : 'java',
+                beam_it_module          : 'sdks/java/io/file-based-io-tests',
+                beam_it_class           : testConfiguration.itClass,
+                beam_it_options         : pipelineArgsJoined,
+                beam_extra_properties   : '["filesystem=hdfs"]',
+                bigquery_table          : testConfiguration.bqTable,
+                beam_options_config_file: makePathAbsolute('pkb-config.yml'),
+                beam_kubernetes_scripts : makePathAbsolute('hdfs-multi-datanode-cluster.yml')
         ]
         common_job_properties.setupKubernetes(delegate, namespace, kubeconfig)
         common_job_properties.buildPerformanceTest(delegate, argMap)

--- a/.test-infra/jenkins/job_PerformanceTests_HadoopInputFormat.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_HadoopInputFormat.groovy
@@ -52,7 +52,6 @@ job(jobName) {
             kubeconfig              : kubeconfig,
             beam_it_timeout         : '1200',
             benchmarks              : 'beam_integration_benchmark',
-            beam_it_profile         : 'io-it',
             beam_prebuilt           : 'false',
             beam_sdk                : 'java',
             beam_it_module          : 'sdks/java/io/hadoop-input-format',

--- a/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
@@ -52,7 +52,6 @@ job(jobName) {
             kubeconfig              : kubeconfig,
             beam_it_timeout         : '1800',
             benchmarks              : 'beam_integration_benchmark',
-            beam_it_profile         : 'io-it',
             beam_prebuilt           : 'false',
             beam_sdk                : 'java',
             beam_it_module          : 'sdks/java/io/jdbc',

--- a/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_MongoDBIO_IT.groovy
@@ -51,7 +51,6 @@ job(jobName) {
             kubeconfig              : kubeconfig,
             beam_it_timeout         : '1800',
             benchmarks              : 'beam_integration_benchmark',
-            beam_it_profile         : 'io-it',
             beam_prebuilt           : 'false',
             beam_sdk                : 'java',
             beam_it_module          : 'sdks/java/io/mongodb',


### PR DESCRIPTION
This PR removes maven leftovers that weren't removed during migration (to migrate seamlessly).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




