### PR TITLE
[BEAM-4675] Reduces the size of pretty string of BigQuery jobs

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -117,6 +117,14 @@ public class BigQueryHelpers {
   }
 
   static String jobToPrettyString(@Nullable Job job) throws IOException {
+    if (job != null && job.getConfiguration().getLoad() != null) {
+      // Removing schema and sourceUris from error messages for load jobs since these fields can be
+      // quite long and error message might not be displayed properly in runner specific logs.
+      job = job.clone();
+      job.getConfiguration().getLoad().setSchema(null);
+      job.getConfiguration().getLoad().setSourceUris(null);
+    }
+
     return job == null ? "null" : job.toPrettyString();
   }
 


### PR DESCRIPTION
Some of the error logs that contain BQ load jobs can be extremely large and drop the actual error message. Usually this happens due to 'schema' and/or ''sourceUris' of the job configuration of load jobs being very large. I think these properties are not that useful for debugging so we should consider dropping them from error messages.

