### PR TITLE
 [BEAM-4285] Extend side input handlers to handle multiple access patterns.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -84,6 +84,11 @@ public class PTransformTranslation {
   public static final String SPLITTABLE_PROCESS_ELEMENTS_URN =
       getUrn(SplittableParDoComponents.PROCESS_ELEMENTS);
 
+  public static final String ITERABLE_SIDE_INPUT =
+      getUrn(RunnerApi.StandardSideInputTypes.Enum.ITERABLE);
+  public static final String MULTIMAP_SIDE_INPUT =
+      getUrn(RunnerApi.StandardSideInputTypes.Enum.MULTIMAP);
+
   private static final Map<Class<? extends PTransform>, TransformPayloadTranslator>
       KNOWN_PAYLOAD_TRANSLATORS = loadTransformPayloadTranslators();
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/BatchFlinkExecutableStageContext.java
@@ -29,7 +29,7 @@ import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
-import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandlerFactory;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.SideInputHandlerFactory;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,11 +58,11 @@ class BatchFlinkExecutableStageContext implements FlinkExecutableStageContext {
   @Override
   public StateRequestHandler getStateRequestHandler(
       ExecutableStage executableStage, RuntimeContext runtimeContext) {
-    MultimapSideInputHandlerFactory sideInputHandlerFactory =
+    SideInputHandlerFactory sideInputHandlerFactory =
         FlinkBatchSideInputHandlerFactory.forStage(executableStage, runtimeContext);
     try {
-      return StateRequestHandlers.forMultimapSideInputHandlerFactory(
-          ProcessBundleDescriptors.getMultimapSideInputs(executableStage), sideInputHandlerFactory);
+      return StateRequestHandlers.forSideInputHandlerFactory(
+          ProcessBundleDescriptors.getSideInputs(executableStage), sideInputHandlerFactory);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactory.java
@@ -23,10 +23,14 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload.SideInputId;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.SideInputReference;
@@ -34,6 +38,7 @@ import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandlerFactory;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
@@ -74,19 +79,67 @@ class FlinkBatchSideInputHandlerFactory implements MultimapSideInputHandlerFacto
   }
 
   @Override
-  public <K, V, W extends BoundedWindow> MultimapSideInputHandler<K, V, W> forSideInput(
+  public <T, V, W extends BoundedWindow> MultimapSideInputHandler<V, W> forSideInput(
       String transformId,
       String sideInputId,
-      Coder<K> keyCoder,
-      Coder<V> valueCoder,
+      RunnerApi.FunctionSpec accessPattern,
+      Coder<T> elementCoder,
       Coder<W> windowCoder) {
+
     PCollectionNode collectionNode =
         sideInputToCollection.get(
             SideInputId.newBuilder().setTransformId(transformId).setLocalName(sideInputId).build());
     checkArgument(collectionNode != null, "No side input for %s/%s", transformId, sideInputId);
-    List<WindowedValue<KV<K, V>>> broadcastVariable =
-        runtimeContext.getBroadcastVariable(collectionNode.getId());
 
+    if (PTransformTranslation.ITERABLE_SIDE_INPUT.equals(accessPattern.getUrn())) {
+      @SuppressWarnings("unchecked") // T == V
+      Coder<V> outputCoder = (Coder<V>) elementCoder;
+      return forIterableSideInput(
+          runtimeContext.getBroadcastVariable(collectionNode.getId()), outputCoder, windowCoder);
+    } else if (PTransformTranslation.MULTIMAP_SIDE_INPUT.equals(accessPattern.getUrn())) {
+      @SuppressWarnings("unchecked") // T == KV<?, V>
+      KvCoder<?, V> kvCoder = (KvCoder<?, V>) elementCoder;
+      return forMultimapSideInput(
+          runtimeContext.getBroadcastVariable(collectionNode.getId()),
+          kvCoder.getKeyCoder(),
+          kvCoder.getValueCoder(),
+          windowCoder);
+    } else {
+      throw new IllegalArgumentException(
+          String.format("Unknown side input access pattern: %s", accessPattern));
+    }
+  }
+
+  private <T, W extends BoundedWindow> MultimapSideInputHandler<T, W> forIterableSideInput(
+      List<WindowedValue<T>> broadcastVariable, Coder<T> elementCoder, Coder<W> windowCoder) {
+    ImmutableMultimap.Builder<Object, T> multimapBuilder = ImmutableMultimap.builder();
+    for (WindowedValue<T> windowedValue : broadcastVariable) {
+      for (BoundedWindow boundedWindow : windowedValue.getWindows()) {
+        @SuppressWarnings("unchecked")
+        W window = (W) boundedWindow;
+        multimapBuilder.put(windowCoder.structuralValue(window), windowedValue.getValue());
+      }
+    }
+    ImmutableMultimap<Object, T> multimap = multimapBuilder.build();
+
+    return new MultimapSideInputHandler<T, W>() {
+      @Override
+      public Iterable<T> get(byte[] key, W window) {
+        return multimap.get(windowCoder.structuralValue(window));
+      }
+
+      @Override
+      public Coder<T> resultCoder() {
+        return elementCoder;
+      }
+    };
+  }
+
+  private <K, V, W extends BoundedWindow> MultimapSideInputHandler<V, W> forMultimapSideInput(
+      List<WindowedValue<KV<K, V>>> broadcastVariable,
+      Coder<K> keyCoder,
+      Coder<V> valueCoder,
+      Coder<W> windowCoder) {
     ImmutableMultimap.Builder<SideInputKey, V> multimap = ImmutableMultimap.builder();
     for (WindowedValue<KV<K, V>> windowedValue : broadcastVariable) {
       K key = windowedValue.getValue().getKey();
@@ -101,27 +154,52 @@ class FlinkBatchSideInputHandlerFactory implements MultimapSideInputHandlerFacto
       }
     }
 
-    return new SideInputHandler<>(multimap.build(), keyCoder, windowCoder);
+    return new SideInputHandler<>(multimap.build(), keyCoder, valueCoder, windowCoder);
+  }
+
+  private <T> List<WindowedValue<T>> getBroadcastVariable(String transformId, String sideInputId) {
+    PCollectionNode collectionNode =
+        sideInputToCollection.get(
+            SideInputId.newBuilder().setTransformId(transformId).setLocalName(sideInputId).build());
+    checkArgument(collectionNode != null, "No side input for %s/%s", transformId, sideInputId);
+    return runtimeContext.getBroadcastVariable(collectionNode.getId());
   }
 
   private static class SideInputHandler<K, V, W extends BoundedWindow>
-      implements MultimapSideInputHandler<K, V, W> {
+      implements MultimapSideInputHandler<V, W> {
 
     private final Multimap<SideInputKey, V> collection;
     private final Coder<K> keyCoder;
+    private final Coder<V> valueCoder;
     private final Coder<W> windowCoder;
 
     private SideInputHandler(
-        Multimap<SideInputKey, V> collection, Coder<K> keyCoder, Coder<W> windowCoder) {
+        Multimap<SideInputKey, V> collection,
+        Coder<K> keyCoder,
+        Coder<V> valueCoder,
+        Coder<W> windowCoder) {
       this.collection = collection;
       this.keyCoder = keyCoder;
+      this.valueCoder = valueCoder;
       this.windowCoder = windowCoder;
     }
 
     @Override
-    public Iterable<V> get(K key, W window) {
+    public Iterable<V> get(byte[] keyBytes, W window) {
+      K key;
+      try {
+        // TODO: We could skip decoding and just compare encoded values for deterministic keyCoders.
+        key = keyCoder.decode(new ByteArrayInputStream(keyBytes));
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
       return collection.get(
           SideInputKey.of(keyCoder.structuralValue(key), windowCoder.structuralValue(window)));
+    }
+
+    @Override
+    public Coder<V> resultCoder() {
+      return valueCoder;
     }
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactoryTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactoryTest.java
@@ -38,7 +38,7 @@ import org.apache.beam.runners.core.construction.graph.ImmutableExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.SideInputReference;
-import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandler;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.SideInputHandler;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -112,7 +112,7 @@ public class FlinkBatchSideInputHandlerFactoryTest {
   public void emptyResultForEmptyCollection() {
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Integer, GlobalWindow> handler =
+    SideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
@@ -133,7 +133,7 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Integer, GlobalWindow> handler =
+    SideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
@@ -155,7 +155,7 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Integer, GlobalWindow> handler =
+    SideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
@@ -185,7 +185,7 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Integer, IntervalWindow> handler =
+    SideInputHandler<Integer, IntervalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactoryTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactoryTest.java
@@ -24,18 +24,23 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.Mockito.when;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.ImmutableExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
 import org.apache.beam.runners.core.construction.graph.PipelineNode.PCollectionNode;
 import org.apache.beam.runners.core.construction.graph.SideInputReference;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandler;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
@@ -65,6 +70,10 @@ public class FlinkBatchSideInputHandlerFactoryTest {
   private static final String TRANSFORM_ID = "transform-id";
   private static final String SIDE_INPUT_NAME = "side-input";
   private static final String COLLECTION_ID = "collection";
+  private static final RunnerApi.FunctionSpec MULTIMAP_ACCESS =
+      RunnerApi.FunctionSpec.newBuilder().setUrn(PTransformTranslation.MULTIMAP_SIDE_INPUT).build();
+  private static final RunnerApi.FunctionSpec ITERABLE_ACCESS =
+      RunnerApi.FunctionSpec.newBuilder().setUrn(PTransformTranslation.ITERABLE_SIDE_INPUT).build();
   private static final ExecutableStage EXECUTABLE_STAGE =
       createExecutableStage(
           Arrays.asList(
@@ -73,6 +82,8 @@ public class FlinkBatchSideInputHandlerFactoryTest {
                   SIDE_INPUT_NAME,
                   PipelineNode.pCollection(
                       COLLECTION_ID, RunnerApi.PCollection.getDefaultInstance()))));
+  private static final byte[] ENCODED_NULL = encode(null, VoidCoder.of());
+  private static final byte[] ENCODED_FOO = encode("foo", StringUtf8Coder.of());
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -90,23 +101,27 @@ public class FlinkBatchSideInputHandlerFactoryTest {
         FlinkBatchSideInputHandlerFactory.forStage(stage, context);
     thrown.expect(instanceOf(IllegalArgumentException.class));
     factory.forSideInput(
-        "transform-id", "side-input", VoidCoder.of(), VoidCoder.of(), GlobalWindow.Coder.INSTANCE);
+        "transform-id",
+        "side-input",
+        MULTIMAP_ACCESS,
+        KvCoder.of(VoidCoder.of(), VoidCoder.of()),
+        GlobalWindow.Coder.INSTANCE);
   }
 
   @Test
   public void emptyResultForEmptyCollection() {
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Void, Integer, GlobalWindow> handler =
+    MultimapSideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
-            VoidCoder.of(),
-            VarIntCoder.of(),
+            MULTIMAP_ACCESS,
+            KvCoder.of(VoidCoder.of(), VarIntCoder.of()),
             GlobalWindow.Coder.INSTANCE);
     // We never populated the broadcast variable for "side-input", so the mock will return an empty
     // list.
-    Iterable<Integer> result = handler.get(null, GlobalWindow.INSTANCE);
+    Iterable<Integer> result = handler.get(ENCODED_NULL, GlobalWindow.INSTANCE);
     assertThat(result, emptyIterable());
   }
 
@@ -118,14 +133,14 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<Void, Integer, GlobalWindow> handler =
+    MultimapSideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
-            VoidCoder.of(),
-            VarIntCoder.of(),
+            MULTIMAP_ACCESS,
+            KvCoder.of(VoidCoder.of(), VarIntCoder.of()),
             GlobalWindow.Coder.INSTANCE);
-    Iterable<Integer> result = handler.get(null, GlobalWindow.INSTANCE);
+    Iterable<Integer> result = handler.get(ENCODED_NULL, GlobalWindow.INSTANCE);
     assertThat(result, contains(3));
   }
 
@@ -140,14 +155,14 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<String, Integer, GlobalWindow> handler =
+    MultimapSideInputHandler<Integer, GlobalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
-            StringUtf8Coder.of(),
-            VarIntCoder.of(),
+            MULTIMAP_ACCESS,
+            KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()),
             GlobalWindow.Coder.INSTANCE);
-    Iterable<Integer> result = handler.get("foo", GlobalWindow.INSTANCE);
+    Iterable<Integer> result = handler.get(ENCODED_FOO, GlobalWindow.INSTANCE);
     assertThat(result, containsInAnyOrder(2, 5));
   }
 
@@ -170,17 +185,47 @@ public class FlinkBatchSideInputHandlerFactoryTest {
 
     FlinkBatchSideInputHandlerFactory factory =
         FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
-    MultimapSideInputHandler<String, Integer, IntervalWindow> handler =
+    MultimapSideInputHandler<Integer, IntervalWindow> handler =
         factory.forSideInput(
             TRANSFORM_ID,
             SIDE_INPUT_NAME,
-            StringUtf8Coder.of(),
-            VarIntCoder.of(),
+            MULTIMAP_ACCESS,
+            KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()),
             IntervalWindowCoder.of());
-    Iterable<Integer> resultA = handler.get("foo", windowA);
-    Iterable<Integer> resultB = handler.get("foo", windowB);
+    Iterable<Integer> resultA = handler.get(ENCODED_FOO, windowA);
+    Iterable<Integer> resultB = handler.get(ENCODED_FOO, windowB);
     assertThat(resultA, containsInAnyOrder(1, 3));
     assertThat(resultB, containsInAnyOrder(4, 6));
+  }
+
+  @Test
+  public void iterableAccessPattern() {
+    Instant instantA = new DateTime(2018, 1, 1, 1, 1, DateTimeZone.UTC).toInstant();
+    Instant instantB = new DateTime(2018, 1, 1, 1, 2, DateTimeZone.UTC).toInstant();
+    Instant instantC = new DateTime(2018, 1, 1, 1, 3, DateTimeZone.UTC).toInstant();
+    IntervalWindow windowA = new IntervalWindow(instantA, instantB);
+    IntervalWindow windowB = new IntervalWindow(instantB, instantC);
+    when(context.getBroadcastVariable(COLLECTION_ID))
+        .thenReturn(
+            Arrays.asList(
+                WindowedValue.of(1, instantA, windowA, PaneInfo.NO_FIRING),
+                WindowedValue.of(2, instantA, windowA, PaneInfo.NO_FIRING),
+                WindowedValue.of(3, instantB, windowB, PaneInfo.NO_FIRING),
+                WindowedValue.of(4, instantB, windowB, PaneInfo.NO_FIRING)));
+
+    FlinkBatchSideInputHandlerFactory factory =
+        FlinkBatchSideInputHandlerFactory.forStage(EXECUTABLE_STAGE, context);
+    SideInputHandler<Integer, IntervalWindow> handler =
+        factory.forSideInput(
+            TRANSFORM_ID,
+            SIDE_INPUT_NAME,
+            ITERABLE_ACCESS,
+            VarIntCoder.of(),
+            IntervalWindowCoder.of());
+    Iterable<Integer> resultA = handler.get(null, windowA);
+    Iterable<Integer> resultB = handler.get(null, windowB);
+    assertThat(resultA, containsInAnyOrder(1, 2));
+    assertThat(resultB, containsInAnyOrder(3, 4));
   }
 
   private static ExecutableStage createExecutableStage(Collection<SideInputReference> sideInputs) {
@@ -195,5 +240,15 @@ public class FlinkBatchSideInputHandlerFactoryTest {
         sideInputs,
         Collections.emptyList(),
         Collections.emptyList());
+  }
+
+  private static <T> byte[] encode(T value, Coder<T> coder) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      coder.encode(value, out);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return out.toByteArray();
   }
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -328,16 +328,21 @@ public class RemoteExecutionTest implements Serializable {
             descriptor.getMultimapSideInputSpecs(),
             new MultimapSideInputHandlerFactory() {
               @Override
-              public <K, V, W extends BoundedWindow> MultimapSideInputHandler<K, V, W> forSideInput(
+              public <T, V, W extends BoundedWindow> MultimapSideInputHandler<V, W> forSideInput(
                   String pTransformId,
                   String sideInputId,
-                  Coder<K> keyCoder,
-                  Coder<V> valueCoder,
+                  RunnerApi.FunctionSpec accessPattern,
+                  Coder<T> elementCoder,
                   Coder<W> windowCoder) {
-                return new MultimapSideInputHandler<K, V, W>() {
+                return new MultimapSideInputHandler<V, W>() {
                   @Override
-                  public Iterable<V> get(K key, W window) {
+                  public Iterable<V> get(byte[] key, W window) {
                     return (Iterable) sideInputData;
+                  }
+
+                  @Override
+                  public Coder<V> resultCoder() {
+                    return ((KvCoder) elementCoder).getValueCoder();
                   }
                 };
               }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -60,8 +60,8 @@ import org.apache.beam.runners.fnexecution.logging.Slf4jLogWriter;
 import org.apache.beam.runners.fnexecution.state.GrpcStateService;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
-import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandler;
-import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.MultimapSideInputHandlerFactory;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.SideInputHandler;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandlers.SideInputHandlerFactory;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
 import org.apache.beam.sdk.coders.Coder;
@@ -324,17 +324,17 @@ public class RemoteExecutionTest implements Serializable {
             CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "B"),
             CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "C"));
     StateRequestHandler stateRequestHandler =
-        StateRequestHandlers.forMultimapSideInputHandlerFactory(
-            descriptor.getMultimapSideInputSpecs(),
-            new MultimapSideInputHandlerFactory() {
+        StateRequestHandlers.forSideInputHandlerFactory(
+            descriptor.getSideInputSpecs(),
+            new SideInputHandlerFactory() {
               @Override
-              public <T, V, W extends BoundedWindow> MultimapSideInputHandler<V, W> forSideInput(
+              public <T, V, W extends BoundedWindow> SideInputHandler<V, W> forSideInput(
                   String pTransformId,
                   String sideInputId,
                   RunnerApi.FunctionSpec accessPattern,
                   Coder<T> elementCoder,
                   Coder<W> windowCoder) {
-                return new MultimapSideInputHandler<V, W>() {
+                return new SideInputHandler<V, W>() {
                   @Override
                   public Iterable<V> get(byte[] key, W window) {
                     return (Iterable) sideInputData;


### PR DESCRIPTION
Python side inputs now work.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




