### PR TITLE
Use more explicit mounts in Docker invocation

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/ReferenceRunner.java
@@ -30,6 +30,9 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.protobuf.Struct;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -234,7 +237,8 @@ public class ReferenceRunner {
       GrpcFnServer<GrpcLoggingService> logging,
       GrpcFnServer<ArtifactRetrievalService> artifact,
       GrpcFnServer<StaticGrpcProvisionService> provisioning,
-      ControlClientPool.Source controlClientSource) {
+      ControlClientPool.Source controlClientSource)
+      throws IOException {
     switch (environmentType) {
       case DOCKER:
         return DockerEnvironmentFactory.forServices(
@@ -243,6 +247,8 @@ public class ReferenceRunner {
             artifact,
             provisioning,
             controlClientSource,
+            // TODO: Clean up at the appropriate time.
+            Files.createTempDirectory(Paths.get("/tmp"), "worker_persistent_dir"),
             IdGenerators.incrementingLongs());
       case IN_PROCESS:
         return InProcessEnvironmentFactory.create(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
@@ -117,8 +117,6 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
 
     // Prepare docker invocation.
     String containerImage = environment.getUrl();
-    // TODO: https://issues.apache.org/jira/browse/BEAM-4148 The default service address will not
-    // work for Docker for Mac.
     String loggingEndpoint = loggingServiceServer.getApiServiceDescriptor().getUrl();
     String artifactEndpoint = retrievalServiceServer.getApiServiceDescriptor().getUrl();
     String provisionEndpoint = provisioningServiceServer.getApiServiceDescriptor().getUrl();

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
@@ -20,7 +20,10 @@ package org.apache.beam.runners.fnexecution.environment;
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
@@ -56,6 +59,7 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
       GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
       GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
       ControlClientPool.Source clientSource,
+      Path workerTempDir,
       IdGenerator idGenerator) {
     return forServicesWithDocker(
         DockerCommand.getDefault(),
@@ -64,6 +68,7 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
         retrievalServiceServer,
         provisioningServiceServer,
         clientSource,
+        workerTempDir,
         idGenerator);
   }
 
@@ -74,6 +79,7 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
       GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
       GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
       ControlClientPool.Source clientSource,
+      Path workerTempDir,
       IdGenerator idGenerator) {
     return new DockerEnvironmentFactory(
         docker,
@@ -81,8 +87,9 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
         loggingServiceServer,
         retrievalServiceServer,
         provisioningServiceServer,
-        idGenerator,
-        clientSource);
+        clientSource,
+        workerTempDir,
+        idGenerator);
   }
 
   private final DockerCommand docker;
@@ -90,8 +97,9 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
   private final GrpcFnServer<GrpcLoggingService> loggingServiceServer;
   private final GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer;
   private final GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer;
-  private final IdGenerator idGenerator;
   private final ControlClientPool.Source clientSource;
+  private final Path workerTempDir;
+  private final IdGenerator idGenerator;
 
   private DockerEnvironmentFactory(
       DockerCommand docker,
@@ -99,15 +107,17 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
       GrpcFnServer<GrpcLoggingService> loggingServiceServer,
       GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
       GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
-      IdGenerator idGenerator,
-      ControlClientPool.Source clientSource) {
+      ControlClientPool.Source clientSource,
+      Path workerTempDir,
+      IdGenerator idGenerator) {
     this.docker = docker;
     this.controlServiceServer = controlServiceServer;
     this.loggingServiceServer = loggingServiceServer;
     this.retrievalServiceServer = retrievalServiceServer;
     this.provisioningServiceServer = provisioningServiceServer;
-    this.idGenerator = idGenerator;
     this.clientSource = clientSource;
+    this.workerTempDir = workerTempDir;
+    this.idGenerator = idGenerator;
   }
 
   /** Creates a new, active {@link RemoteEnvironment} backed by a local Docker container. */
@@ -116,6 +126,10 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
     String workerId = idGenerator.getId();
 
     // Prepare docker invocation.
+    String pathSafeWorkerId =
+        BaseEncoding.base64Url().encode(workerId.getBytes(StandardCharsets.UTF_8));
+    Path workerPersistentDirectory = workerTempDir.resolve(pathSafeWorkerId);
+    String semiPersistentDirectory = "/var/opt/apache/beam/semi_persistent_dir";
     String containerImage = environment.getUrl();
     String loggingEndpoint = loggingServiceServer.getApiServiceDescriptor().getUrl();
     String artifactEndpoint = retrievalServiceServer.getApiServiceDescriptor().getUrl();
@@ -125,6 +139,11 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
     List<String> volArg =
         ImmutableList.<String>builder()
             .addAll(gcsCredentialArgs())
+            .add(
+                "--mount",
+                String.format(
+                    "type=bind,source=%s,dst=%s",
+                    workerPersistentDirectory, semiPersistentDirectory))
             // NOTE: Host networking does not work on Mac, but the command line flag is accepted.
             .add("--network=host")
             .build();

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactoryTest.java
@@ -45,7 +45,9 @@ import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionServi
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.IdGenerators;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
@@ -54,6 +56,8 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link DockerJobBundleFactory}. */
 @RunWith(JUnit4.class)
 public class DockerJobBundleFactoryTest {
+
+  @Rule public TemporaryFolder workerTempDir = new TemporaryFolder();
 
   @Mock private DockerEnvironmentFactory envFactory;
   @Mock private RemoteEnvironment remoteEnvironment;
@@ -88,7 +92,8 @@ public class DockerJobBundleFactoryTest {
             controlServer,
             loggingServer,
             retrievalServer,
-            provisioningServer)) {
+            provisioningServer,
+            workerTempDir.getRoot().toPath())) {
       bundleFactory.forStage(getExecutableStage(environment));
       verify(envFactory).createEnvironment(environment);
     }
@@ -104,7 +109,8 @@ public class DockerJobBundleFactoryTest {
             controlServer,
             loggingServer,
             retrievalServer,
-            provisioningServer);
+            provisioningServer,
+            workerTempDir.getRoot().toPath());
     try (AutoCloseable unused = bundleFactory) {
       bundleFactory.forStage(getExecutableStage(environment));
     }
@@ -121,7 +127,8 @@ public class DockerJobBundleFactoryTest {
             controlServer,
             loggingServer,
             retrievalServer,
-            provisioningServer)) {
+            provisioningServer,
+            workerTempDir.getRoot().toPath())) {
       StageBundleFactory<?> bf1 = bundleFactory.forStage(getExecutableStage(environment));
       StageBundleFactory<?> bf2 = bundleFactory.forStage(getExecutableStage(environment));
       // NOTE: We hang on to stage bundle references to ensure their underlying environments are not
@@ -153,7 +160,8 @@ public class DockerJobBundleFactoryTest {
             controlServer,
             loggingServer,
             retrievalServer,
-            provisioningServer)) {
+            provisioningServer,
+            workerTempDir.getRoot().toPath())) {
       bundleFactory.forStage(getExecutableStage(environment));
       bundleFactory.forStage(getExecutableStage(envFoo));
       verify(envFactory).createEnvironment(environment);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactoryTest.java
@@ -34,7 +34,9 @@ import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionServi
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.IdGenerators;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
@@ -54,6 +56,8 @@ public class DockerEnvironmentFactoryTest {
       "e4485f0f2b813b63470feacba5fe9cb89699878c095df4124abd320fd5401385";
 
   private static final IdGenerator ID_GENERATOR = IdGenerators.incrementingLongs();
+
+  @Rule public TemporaryFolder workerTempDir = new TemporaryFolder();
 
   @Mock private DockerCommand docker;
 
@@ -81,6 +85,7 @@ public class DockerEnvironmentFactoryTest {
             retrievalServiceServer,
             provisioningServiceServer,
             (workerId, timeout) -> client,
+            workerTempDir.getRoot().toPath(),
             ID_GENERATOR);
   }
 


### PR DESCRIPTION
The shorthand `-v` syntax is error-prone and was not doing what we wanted originally. This switches to use an explicit `--mount` option with source and destination specified.

This also changes temporary directory generation to use `/tmp`, since this is on the Docker-for-Mac whitelist of mount points. Without this explicit prefix, the Docker invocation fails on Mac.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




