### PR TITLE
[BEAM-3971, BEAM-4284] Remove fromProto for Pipeline and PTransform translation.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CombineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CombineTranslation.java
@@ -28,11 +28,8 @@ import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
-import javax.annotation.Nonnull;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.CombinePayload;
-import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
 import org.apache.beam.runners.core.construction.PTransformTranslation.TransformPayloadTranslator;
@@ -59,10 +56,6 @@ public class CombineTranslation {
   /** A {@link TransformPayloadTranslator} for {@link Combine.PerKey}. */
   public static class CombinePayloadTranslator
       implements PTransformTranslation.TransformPayloadTranslator<Combine.PerKey<?, ?, ?>> {
-    public static TransformPayloadTranslator create() {
-      return new CombinePayloadTranslator();
-    }
-
     private CombinePayloadTranslator() {}
 
     @Override
@@ -86,18 +79,6 @@ public class CombineTranslation {
       }
     }
 
-    @Override
-    public PTransformTranslation.RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException {
-      checkArgument(
-          protoTransform.getSpec() != null,
-          "%s received transform with null spec",
-          getClass().getSimpleName());
-      checkArgument(protoTransform.getSpec().getUrn().equals(COMBINE_TRANSFORM_URN));
-      return new RawCombine<>(protoTransform, rehydratedComponents);
-    }
-
     /** Registers {@link CombinePayloadTranslator}. */
     @AutoService(TransformPayloadTranslatorRegistrar.class)
     public static class Registrar implements TransformPayloadTranslatorRegistrar {
@@ -106,33 +87,10 @@ public class CombineTranslation {
           getTransformPayloadTranslators() {
         return Collections.singletonMap(Combine.PerKey.class, new CombinePayloadTranslator());
       }
-
-      @Override
-      public Map<String, ? extends TransformPayloadTranslator> getTransformRehydrators() {
-        return Collections.singletonMap(COMBINE_TRANSFORM_URN, new CombinePayloadTranslator());
-      }
     }
   }
 
-  /**
-   * These methods drive to-proto translation for both Java SDK transforms and rehydrated
-   * transforms.
-   */
-  interface CombineLike {
-    RunnerApi.SdkFunctionSpec getCombineFn();
-
-    Coder<?> getAccumulatorCoder();
-  }
-
-  /** Produces a {@link RunnerApi.CombinePayload} from a portable {@link CombineLike}. */
-  static RunnerApi.CombinePayload payloadForCombineLike(
-      CombineLike combine, SdkComponents components) throws IOException {
-    return RunnerApi.CombinePayload.newBuilder()
-        .setAccumulatorCoderId(components.registerCoder(combine.getAccumulatorCoder()))
-        .setCombineFn(combine.getCombineFn())
-        .build();
-  }
-
+  /** Produces a {@link RunnerApi.CombinePayload} from a {@link Combine}. */
   static <K, InputT, OutputT> CombinePayload payloadForCombine(
       final AppliedPTransform<
               PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>,
@@ -141,96 +99,28 @@ public class CombineTranslation {
       final SdkComponents components)
       throws IOException {
 
-    return payloadForCombineLike(
-        new CombineLike() {
-          @Override
-          public SdkFunctionSpec getCombineFn() {
-            return SdkFunctionSpec.newBuilder()
-                .setEnvironmentId(
-                    components.registerEnvironment(Environments.JAVA_SDK_HARNESS_ENVIRONMENT))
-                .setSpec(
-                    FunctionSpec.newBuilder()
-                        .setUrn(JAVA_SERIALIZED_COMBINE_FN_URN)
-                        .setPayload(
-                            ByteString.copyFrom(
-                                SerializableUtils.serializeToByteArray(
-                                    combine.getTransform().getFn())))
-                        .build())
-                .build();
-          }
-
-          @Override
-          public Coder<?> getAccumulatorCoder() {
-            GlobalCombineFn<?, ?, ?> combineFn = combine.getTransform().getFn();
-            try {
-              return extractAccumulatorCoder(combineFn, (AppliedPTransform) combine);
-            } catch (CannotProvideCoderException e) {
-              throw new IllegalStateException(e);
-            }
-          }
-        },
-        components);
-  }
-
-  private static class RawCombine<K, InputT, AccumT, OutputT>
-      extends PTransformTranslation.RawPTransform<
-          PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>>
-      implements CombineLike {
-
-    private final RunnerApi.PTransform protoTransform;
-    private final transient RehydratedComponents rehydratedComponents;
-    private final FunctionSpec spec;
-    private final CombinePayload payload;
-    private final Coder<AccumT> accumulatorCoder;
-
-    private RawCombine(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException {
-      this.protoTransform = protoTransform;
-      this.rehydratedComponents = rehydratedComponents;
-      this.spec = protoTransform.getSpec();
-      this.payload = CombinePayload.parseFrom(spec.getPayload());
-
-      // Eagerly extract the coder to throw a good exception here
-      try {
-        this.accumulatorCoder =
-            (Coder<AccumT>) rehydratedComponents.getCoder(payload.getAccumulatorCoderId());
-      } catch (IOException exc) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Failure extracting accumulator coder with id '%s' for %s",
-                payload.getAccumulatorCoderId(), Combine.class.getSimpleName()),
-            exc);
-      }
-    }
-
-    @Override
-    public String getUrn() {
-      return COMBINE_TRANSFORM_URN;
-    }
-
-    @Nonnull
-    @Override
-    public FunctionSpec getSpec() {
-      return spec;
-    }
-
-    @Override
-    public RunnerApi.FunctionSpec migrate(SdkComponents sdkComponents) throws IOException {
-      return RunnerApi.FunctionSpec.newBuilder()
-          .setUrn(COMBINE_TRANSFORM_URN)
-          .setPayload(payloadForCombineLike(this, sdkComponents).toByteString())
+    GlobalCombineFn<?, ?, ?> combineFn = combine.getTransform().getFn();
+    try {
+      return RunnerApi.CombinePayload.newBuilder()
+          .setAccumulatorCoderId(
+              components.registerCoder(
+                  extractAccumulatorCoder(combineFn, (AppliedPTransform) combine)))
+          .setCombineFn(
+              SdkFunctionSpec.newBuilder()
+                  .setEnvironmentId(
+                      components.registerEnvironment(Environments.JAVA_SDK_HARNESS_ENVIRONMENT))
+                  .setSpec(
+                      FunctionSpec.newBuilder()
+                          .setUrn(JAVA_SERIALIZED_COMBINE_FN_URN)
+                          .setPayload(
+                              ByteString.copyFrom(
+                                  SerializableUtils.serializeToByteArray(
+                                      combine.getTransform().getFn())))
+                          .build())
+                  .build())
           .build();
-    }
-
-    @Override
-    public SdkFunctionSpec getCombineFn() {
-      return payload.getCombineFn();
-    }
-
-    @Override
-    public Coder<?> getAccumulatorCoder() {
-      return accumulatorCoder;
+    } catch (CannotProvideCoderException e) {
+      throw new IllegalArgumentException(e);
     }
   }
 
@@ -249,7 +139,7 @@ public class CombineTranslation {
           .setCombineFn(toProto(combineFn, sdkComponents))
           .build();
     } catch (CannotProvideCoderException e) {
-      throw new IllegalStateException(e);
+      throw new IllegalArgumentException(e);
     }
   }
 
@@ -282,63 +172,5 @@ public class CombineTranslation {
                 .setPayload(ByteString.copyFrom(SerializableUtils.serializeToByteArray(combineFn)))
                 .build())
         .build();
-  }
-
-  public static Coder<?> getAccumulatorCoder(
-      CombinePayload payload, RehydratedComponents components) throws IOException {
-    String id = payload.getAccumulatorCoderId();
-    return components.getCoder(id);
-  }
-
-  public static Coder<?> getAccumulatorCoder(AppliedPTransform<?, ?, ?> transform)
-      throws IOException {
-    SdkComponents sdkComponents = SdkComponents.create();
-    String id =
-        getCombinePayload(transform, sdkComponents)
-            .map(CombinePayload::getAccumulatorCoderId)
-            .orElseThrow(() -> new IOException("Transform does not contain an AccumulatorCoder"));
-    Components components = sdkComponents.toComponents();
-    return CoderTranslation.fromProto(
-        components.getCodersOrThrow(id), RehydratedComponents.forComponents(components));
-  }
-
-  public static GlobalCombineFn<?, ?, ?> getCombineFn(CombinePayload payload) throws IOException {
-    checkArgument(
-        payload.getCombineFn().getSpec().getUrn().equals(JAVA_SERIALIZED_COMBINE_FN_URN),
-        "Payload URN was \"%s\", should have been \"%s\".",
-        payload.getCombineFn().getSpec().getUrn(),
-        JAVA_SERIALIZED_COMBINE_FN_URN);
-    return (GlobalCombineFn<?, ?, ?>)
-        SerializableUtils.deserializeFromByteArray(
-            payload.getCombineFn().getSpec().getPayload().toByteArray(), "CombineFn");
-  }
-
-  public static Optional<GlobalCombineFn<?, ?, ?>> getCombineFn(
-      AppliedPTransform<?, ?, ?> transform) throws IOException {
-    Optional<CombinePayload> payload = getCombinePayload(transform);
-    if (payload.isPresent()) {
-      return Optional.of(getCombineFn(payload.get()));
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  private static Optional<CombinePayload> getCombinePayload(AppliedPTransform<?, ?, ?> transform)
-      throws IOException {
-    return getCombinePayload(transform, SdkComponents.create());
-  }
-
-  private static Optional<CombinePayload> getCombinePayload(
-      AppliedPTransform<?, ?, ?> transform, SdkComponents components) throws IOException {
-    RunnerApi.PTransform proto =
-        PTransformTranslation.toProto(transform, Collections.emptyList(), components);
-
-    // Even if the proto has no spec, calling getSpec still returns a blank spec, which we want to
-    // avoid. It should be clear to the caller whether or not there was a spec in the transform.
-    if (proto.hasSpec()) {
-      return Optional.of(CombinePayload.parseFrom(proto.getSpec().getPayload()));
-    } else {
-      return Optional.empty();
-    }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/CreatePCollectionViewTranslation.java
@@ -82,7 +82,7 @@ public class CreatePCollectionViewTranslation {
    */
   @Deprecated
   static class CreatePCollectionViewTranslator
-      extends TransformPayloadTranslator.WithDefaultRehydration<View.CreatePCollectionView<?, ?>> {
+      implements TransformPayloadTranslator<View.CreatePCollectionView<?, ?>> {
     @Override
     public String getUrn(View.CreatePCollectionView<?, ?> transform) {
       return PTransformTranslation.CREATE_VIEW_TRANSFORM_URN;
@@ -115,11 +115,6 @@ public class CreatePCollectionViewTranslation {
         getTransformPayloadTranslators() {
       return Collections.singletonMap(
           View.CreatePCollectionView.class, new CreatePCollectionViewTranslator());
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/FlattenTranslator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/FlattenTranslator.java
@@ -32,8 +32,7 @@ import org.apache.beam.sdk.transforms.windowing.Window.Assign;
 /**
  * Utility methods for translating a {@link Assign} to and from {@link RunnerApi} representations.
  */
-public class FlattenTranslator
-    extends TransformPayloadTranslator.WithDefaultRehydration<Flatten.PCollections<?>> {
+public class FlattenTranslator implements TransformPayloadTranslator<Flatten.PCollections<?>> {
 
   public static TransformPayloadTranslator create() {
     return new FlattenTranslator();
@@ -59,11 +58,6 @@ public class FlattenTranslator
     public Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(Flatten.PCollections.class, new FlattenTranslator());
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/GroupByKeyTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/GroupByKeyTranslation.java
@@ -34,8 +34,7 @@ import org.apache.beam.sdk.transforms.PTransform;
  */
 public class GroupByKeyTranslation {
 
-  static class GroupByKeyTranslator
-      extends TransformPayloadTranslator.WithDefaultRehydration<GroupByKey<?, ?>> {
+  static class GroupByKeyTranslator implements TransformPayloadTranslator<GroupByKey<?, ?>> {
     @Override
     public String getUrn(GroupByKey<?, ?> transform) {
       return PTransformTranslation.GROUP_BY_KEY_TRANSFORM_URN;
@@ -55,11 +54,6 @@ public class GroupByKeyTranslation {
     public Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(GroupByKey.class, new GroupByKeyTranslator());
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ImpulseTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ImpulseTranslation.java
@@ -33,8 +33,7 @@ import org.apache.beam.sdk.transforms.PTransform;
  * Utility methods for translating a {@link Impulse} to and from {@link RunnerApi} representations.
  */
 public class ImpulseTranslation {
-  private static class ImpulseTranslator
-      extends TransformPayloadTranslator.WithDefaultRehydration<Impulse> {
+  private static class ImpulseTranslator implements TransformPayloadTranslator<Impulse> {
     @Override
     public String getUrn(Impulse transform) {
       return PTransformTranslation.IMPULSE_TRANSFORM_URN;
@@ -54,11 +53,6 @@ public class ImpulseTranslation {
     public Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(Impulse.class, new ImpulseTranslator());
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -21,9 +21,7 @@ package org.apache.beam.runners.core.construction;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.io.IOException;
@@ -92,12 +90,6 @@ public class PTransformTranslation {
   private static final Map<Class<? extends PTransform>, TransformPayloadTranslator>
       KNOWN_PAYLOAD_TRANSLATORS = loadTransformPayloadTranslators();
 
-  private static final Map<String, TransformPayloadTranslator> KNOWN_REHYDRATORS =
-      loadTransformRehydrators();
-
-  private static final TransformPayloadTranslator<?> DEFAULT_REHYDRATOR =
-      new RawPTransformTranslator();
-
   private static Map<Class<? extends PTransform>, TransformPayloadTranslator>
       loadTransformPayloadTranslators() {
     HashMap<Class<? extends PTransform>, TransformPayloadTranslator> translators = new HashMap<>();
@@ -120,28 +112,6 @@ public class PTransformTranslation {
       translators.putAll(newTranslators);
     }
     return ImmutableMap.copyOf(translators);
-  }
-
-  private static Map<String, TransformPayloadTranslator> loadTransformRehydrators() {
-    HashMap<String, TransformPayloadTranslator> rehydrators = new HashMap<>();
-
-    for (TransformPayloadTranslatorRegistrar registrar :
-        ServiceLoader.load(TransformPayloadTranslatorRegistrar.class)) {
-
-      Map<String, ? extends TransformPayloadTranslator> newRehydrators =
-          registrar.getTransformRehydrators();
-
-      Set<String> alreadyRegistered =
-          Sets.intersection(rehydrators.keySet(), newRehydrators.keySet());
-
-      if (!alreadyRegistered.isEmpty()) {
-        throw new IllegalArgumentException(
-            String.format("URNs already registered: %s", Joiner.on(", ").join(alreadyRegistered)));
-      }
-
-      rehydrators.putAll(newRehydrators);
-    }
-    return ImmutableMap.copyOf(rehydrators);
   }
 
   private PTransformTranslation() {}
@@ -215,26 +185,6 @@ public class PTransformTranslation {
   }
 
   /**
-   * Translates a {@link RunnerApi.PTransform} to a {@link RawPTransform} specialized for the URN
-   * and spec.
-   */
-  static RawPTransform<?, ?> rehydrate(
-      RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-      throws IOException {
-
-    @Nullable
-    TransformPayloadTranslator<?> rehydrator =
-        KNOWN_REHYDRATORS.get(
-            protoTransform.getSpec() == null ? null : protoTransform.getSpec().getUrn());
-
-    if (rehydrator == null) {
-      return DEFAULT_REHYDRATOR.rehydrate(protoTransform, rehydratedComponents);
-    } else {
-      return rehydrator.rehydrate(protoTransform, rehydratedComponents);
-    }
-  }
-
-  /**
    * Translates a composite {@link AppliedPTransform} into a runner API proto with no component
    * transforms.
    *
@@ -303,24 +253,6 @@ public class PTransformTranslation {
     FunctionSpec translate(AppliedPTransform<?, ?, T> application, SdkComponents components)
         throws IOException;
 
-    RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException;
-
-    /**
-     * A {@link TransformPayloadTranslator} for transforms that contain no references to components,
-     * so they do not need a specialized rehydration.
-     */
-    abstract class WithDefaultRehydration<T extends PTransform<?, ?>>
-        implements TransformPayloadTranslator<T> {
-      @Override
-      public final RawPTransform<?, ?> rehydrate(
-          RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-          throws IOException {
-        return UnknownRawPTransform.forSpec(protoTransform.getSpec());
-      }
-    }
-
     /**
      * A {@link TransformPayloadTranslator} for transforms that contain no references to components,
      * so they do not need a specialized rehydration.
@@ -344,16 +276,6 @@ public class PTransformTranslation {
             String.format(
                 "%s should never be translated",
                 transform.getTransform().getClass().getCanonicalName()));
-      }
-
-      @Override
-      public final RawPTransform<?, ?> rehydrate(
-          RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-          throws IOException {
-        throw new UnsupportedOperationException(
-            String.format(
-                "%s.rehydrate should never be called; there is no serialized form",
-                getClass().getCanonicalName()));
       }
     }
   }
@@ -403,66 +325,6 @@ public class PTransformTranslation {
               "%s should never be asked to expand;"
                   + " it is the result of deserializing an already-constructed Pipeline",
               getClass().getSimpleName()));
-    }
-  }
-
-  @AutoValue
-  abstract static class UnknownRawPTransform extends RawPTransform<PInput, POutput> {
-
-    @Override
-    public String getUrn() {
-      return getSpec() == null ? null : getSpec().getUrn();
-    }
-
-    @Nullable
-    @Override
-    public abstract RunnerApi.FunctionSpec getSpec();
-
-    public static UnknownRawPTransform forSpec(RunnerApi.FunctionSpec spec) {
-      return new AutoValue_PTransformTranslation_UnknownRawPTransform(spec);
-    }
-
-    @Override
-    public POutput expand(PInput input) {
-      throw new IllegalStateException(
-          String.format(
-              "%s should never be asked to expand;"
-                  + " it is the result of deserializing an already-constructed Pipeline",
-              getClass().getSimpleName()));
-    }
-
-    @Override
-    public String toString() {
-      return MoreObjects.toStringHelper(this)
-          .add("urn", getUrn())
-          .add("payload", getSpec())
-          .toString();
-    }
-
-    public RunnerApi.FunctionSpec getSpecForComponents(SdkComponents components) {
-      return getSpec();
-    }
-  }
-
-  /** A translator that uses the explicit URN and payload from a {@link RawPTransform}. */
-  public static class RawPTransformTranslator
-      implements TransformPayloadTranslator<RawPTransform<?, ?>> {
-    @Override
-    public String getUrn(RawPTransform<?, ?> transform) {
-      return transform.getUrn();
-    }
-
-    @Override
-    public FunctionSpec translate(
-        AppliedPTransform<?, ?, RawPTransform<?, ?>> transform, SdkComponents components)
-        throws IOException {
-      return transform.getTransform().migrate(components);
-    }
-
-    @Override
-    public RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents) {
-      return UnknownRawPTransform.forSpec(protoTransform.getSpec());
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
@@ -18,34 +18,18 @@
 
 package org.apache.beam.runners.core.construction;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.runners.core.construction.PTransformTranslation.RawPTransform;
 import org.apache.beam.runners.core.construction.graph.PipelineValidator;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.AppliedPTransform;
-import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
-import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.transforms.display.HasDisplayData;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.beam.sdk.values.PCollectionViews;
-import org.apache.beam.sdk.values.PValue;
-import org.apache.beam.sdk.values.TupleTag;
 
 /** Utilities for going to/from Runner API pipelines. */
 public class PipelineTranslation {
@@ -100,105 +84,5 @@ public class PipelineTranslation {
     // Validate that translation didn't produce an invalid pipeline.
     PipelineValidator.validate(res);
     return res;
-  }
-
-  private static DisplayData evaluateDisplayData(HasDisplayData component) {
-    return DisplayData.from(component);
-  }
-
-  public static Pipeline fromProto(final RunnerApi.Pipeline pipelineProto) throws IOException {
-    PipelineValidator.validate(pipelineProto);
-    TransformHierarchy transforms = new TransformHierarchy();
-    Pipeline pipeline = Pipeline.forTransformHierarchy(transforms, PipelineOptionsFactory.create());
-
-    // Keeping the PCollections straight is a semantic necessity, but being careful not to explode
-    // the number of coders and windowing strategies is also nice, and helps testing.
-    RehydratedComponents rehydratedComponents =
-        RehydratedComponents.forComponents(pipelineProto.getComponents()).withPipeline(pipeline);
-
-    for (String rootId : pipelineProto.getRootTransformIdsList()) {
-      addRehydratedTransform(
-          transforms,
-          pipelineProto.getComponents().getTransformsOrThrow(rootId),
-          pipeline,
-          pipelineProto.getComponents().getTransformsMap(),
-          rehydratedComponents);
-    }
-
-    return pipeline;
-  }
-
-  private static void addRehydratedTransform(
-      TransformHierarchy transforms,
-      RunnerApi.PTransform transformProto,
-      Pipeline pipeline,
-      Map<String, RunnerApi.PTransform> transformProtos,
-      RehydratedComponents rehydratedComponents)
-      throws IOException {
-
-    Map<TupleTag<?>, PValue> rehydratedInputs = new HashMap<>();
-    for (Map.Entry<String, String> inputEntry : transformProto.getInputsMap().entrySet()) {
-      rehydratedInputs.put(
-          new TupleTag<>(inputEntry.getKey()),
-          rehydratedComponents.getPCollection(inputEntry.getValue()));
-    }
-
-    Map<TupleTag<?>, PValue> rehydratedOutputs = new HashMap<>();
-    for (Map.Entry<String, String> outputEntry : transformProto.getOutputsMap().entrySet()) {
-      rehydratedOutputs.put(
-          new TupleTag<>(outputEntry.getKey()),
-          rehydratedComponents.getPCollection(outputEntry.getValue()));
-    }
-
-    RawPTransform<?, ?> transform =
-        PTransformTranslation.rehydrate(transformProto, rehydratedComponents);
-
-    if (isPrimitive(transformProto)) {
-      transforms.addFinalizedPrimitiveNode(
-          transformProto.getUniqueName(), rehydratedInputs, transform, rehydratedOutputs);
-    } else {
-      transforms.pushFinalizedNode(
-          transformProto.getUniqueName(), rehydratedInputs, transform, rehydratedOutputs);
-
-      for (String childTransformId : transformProto.getSubtransformsList()) {
-        addRehydratedTransform(
-            transforms,
-            transformProtos.get(childTransformId),
-            pipeline,
-            transformProtos,
-            rehydratedComponents);
-      }
-
-      transforms.popNode();
-    }
-  }
-
-  private static Map<TupleTag<?>, PValue> sideInputMapToAdditionalInputs(
-      RunnerApi.PTransform transformProto,
-      RehydratedComponents rehydratedComponents,
-      Map<TupleTag<?>, PValue> rehydratedInputs,
-      Map<String, RunnerApi.SideInput> sideInputsMap)
-      throws IOException {
-    List<PCollectionView<?>> views = new ArrayList<>();
-    for (Map.Entry<String, RunnerApi.SideInput> sideInputEntry : sideInputsMap.entrySet()) {
-      String localName = sideInputEntry.getKey();
-      RunnerApi.SideInput sideInput = sideInputEntry.getValue();
-      PCollection<?> pCollection =
-          (PCollection<?>) checkNotNull(rehydratedInputs.get(new TupleTag<>(localName)));
-      views.add(
-          PCollectionViewTranslation.viewFromProto(
-              sideInput, localName, pCollection, transformProto, rehydratedComponents));
-    }
-    return PCollectionViews.toAdditionalInputs(views);
-  }
-
-  // A primitive transform is one with outputs that are not in its input and also
-  // not produced by a subtransform.
-  private static boolean isPrimitive(RunnerApi.PTransform transformProto) {
-    return transformProto.getSubtransformsCount() == 0
-        && !transformProto
-            .getInputsMap()
-            .values()
-            .containsAll(transformProto.getOutputsMap().values());
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ReadTranslation.java
@@ -153,8 +153,7 @@ public class ReadTranslation {
 
   /** A {@link TransformPayloadTranslator} for {@link Read.Unbounded}. */
   public static class UnboundedReadPayloadTranslator
-      extends PTransformTranslation.TransformPayloadTranslator.WithDefaultRehydration<
-          Read.Unbounded<?>> {
+      implements PTransformTranslation.TransformPayloadTranslator<Read.Unbounded<?>> {
     public static TransformPayloadTranslator create() {
       return new UnboundedReadPayloadTranslator();
     }
@@ -179,8 +178,7 @@ public class ReadTranslation {
 
   /** A {@link TransformPayloadTranslator} for {@link Read.Bounded}. */
   public static class BoundedReadPayloadTranslator
-      extends PTransformTranslation.TransformPayloadTranslator.WithDefaultRehydration<
-          Read.Bounded<?>> {
+      implements PTransformTranslation.TransformPayloadTranslator<Read.Bounded<?>> {
     public static TransformPayloadTranslator create() {
       return new BoundedReadPayloadTranslator();
     }
@@ -213,11 +211,6 @@ public class ReadTranslation {
           .put(Read.Unbounded.class, new UnboundedReadPayloadTranslator())
           .put(Read.Bounded.class, new BoundedReadPayloadTranslator())
           .build();
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -23,7 +23,6 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -312,17 +311,11 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
           .put(ProcessKeyedElements.class, new ProcessKeyedElementsTranslator())
           .build();
     }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
-    }
   }
 
   /** A translator for {@link ProcessKeyedElements}. */
   public static class ProcessKeyedElementsTranslator
-      extends PTransformTranslation.TransformPayloadTranslator.WithDefaultRehydration<
-          ProcessKeyedElements<?, ?, ?>> {
+      implements PTransformTranslation.TransformPayloadTranslator<ProcessKeyedElements<?, ?, ?>> {
 
     public static TransformPayloadTranslator create() {
       return new ProcessKeyedElementsTranslator();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TestStreamTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TestStreamTranslation.java
@@ -22,14 +22,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.runners.core.construction.PTransformTranslation.TEST_STREAM_TRANSFORM_URN;
 
 import com.google.auto.service.AutoService;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.PTransformTranslation.TransformPayloadTranslator;
 import org.apache.beam.sdk.coders.Coder;
@@ -48,73 +46,6 @@ import org.joda.time.Instant;
  * representations.
  */
 public class TestStreamTranslation {
-
-  private interface TestStreamLike {
-    Coder<?> getValueCoder();
-
-    List<RunnerApi.TestStreamPayload.Event> getEvents();
-  }
-
-  @VisibleForTesting
-  static class RawTestStream<T> extends PTransformTranslation.RawPTransform<PBegin, PCollection<T>>
-      implements TestStreamLike {
-
-    private final transient RehydratedComponents rehydratedComponents;
-    private final RunnerApi.TestStreamPayload payload;
-    private final Coder<T> valueCoder;
-    private final RunnerApi.FunctionSpec spec;
-
-    public RawTestStream(
-        RunnerApi.TestStreamPayload payload, RehydratedComponents rehydratedComponents) {
-      this.payload = payload;
-      this.spec =
-          RunnerApi.FunctionSpec.newBuilder()
-              .setUrn(TEST_STREAM_TRANSFORM_URN)
-              .setPayload(payload.toByteString())
-              .build();
-      this.rehydratedComponents = rehydratedComponents;
-
-      // Eagerly extract the coder to throw a good exception here
-      try {
-        this.valueCoder = (Coder<T>) rehydratedComponents.getCoder(payload.getCoderId());
-      } catch (IOException exc) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Failure extracting coder with id '%s' for %s",
-                payload.getCoderId(), TestStream.class.getSimpleName()),
-            exc);
-      }
-    }
-
-    @Override
-    public String getUrn() {
-      return TEST_STREAM_TRANSFORM_URN;
-    }
-
-    @Nonnull
-    @Override
-    public RunnerApi.FunctionSpec getSpec() {
-      return spec;
-    }
-
-    @Override
-    public RunnerApi.FunctionSpec migrate(SdkComponents components) throws IOException {
-      return RunnerApi.FunctionSpec.newBuilder()
-          .setUrn(TEST_STREAM_TRANSFORM_URN)
-          .setPayload(payloadForTestStreamLike(this, components).toByteString())
-          .build();
-    }
-
-    @Override
-    public Coder<T> getValueCoder() {
-      return valueCoder;
-    }
-
-    @Override
-    public List<RunnerApi.TestStreamPayload.Event> getEvents() {
-      return payload.getEventsList();
-    }
-  }
 
   private static TestStream<?> testStreamFromProtoPayload(
       RunnerApi.TestStreamPayload testStreamPayload, RehydratedComponents components)
@@ -241,20 +172,6 @@ public class TestStreamTranslation {
       return translateTyped(transform.getTransform(), components);
     }
 
-    @Override
-    public PTransformTranslation.RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException {
-      checkArgument(
-          protoTransform.getSpec() != null,
-          "%s received transform with null spec",
-          getClass().getSimpleName());
-      checkArgument(protoTransform.getSpec().getUrn().equals(TEST_STREAM_TRANSFORM_URN));
-      return new RawTestStream<>(
-          RunnerApi.TestStreamPayload.parseFrom(protoTransform.getSpec().getPayload()),
-          rehydratedComponents);
-    }
-
     private <T> RunnerApi.FunctionSpec translateTyped(
         final TestStream<T> testStream, SdkComponents components) throws IOException {
       return RunnerApi.FunctionSpec.newBuilder()
@@ -271,46 +188,24 @@ public class TestStreamTranslation {
           getTransformPayloadTranslators() {
         return Collections.singletonMap(TestStream.class, new TestStreamTranslator());
       }
-
-      @Override
-      public Map<String, ? extends TransformPayloadTranslator> getTransformRehydrators() {
-        return Collections.singletonMap(TEST_STREAM_TRANSFORM_URN, new TestStreamTranslator());
-      }
     }
   }
 
-  /** Produces a {@link RunnerApi.TestStreamPayload} from a portable {@link RawTestStream}. */
-  static RunnerApi.TestStreamPayload payloadForTestStreamLike(
-      TestStreamLike transform, SdkComponents components) throws IOException {
+  /** Produces a {@link RunnerApi.TestStreamPayload} from a {@link TestStream}. */
+  static <T> RunnerApi.TestStreamPayload payloadForTestStream(
+      final TestStream<T> transform, SdkComponents components) throws IOException {
+    List<RunnerApi.TestStreamPayload.Event> protoEvents = new ArrayList<>();
+    try {
+      for (TestStream.Event<T> event : transform.getEvents()) {
+        protoEvents.add(eventToProto(event, transform.getValueCoder()));
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
     return RunnerApi.TestStreamPayload.newBuilder()
         .setCoderId(components.registerCoder(transform.getValueCoder()))
-        .addAllEvents(transform.getEvents())
+        .addAllEvents(protoEvents)
         .build();
-  }
-
-  @VisibleForTesting
-  static <T> RunnerApi.TestStreamPayload payloadForTestStream(
-      final TestStream<T> testStream, SdkComponents components) throws IOException {
-    return payloadForTestStreamLike(
-        new TestStreamLike() {
-          @Override
-          public Coder<T> getValueCoder() {
-            return testStream.getValueCoder();
-          }
-
-          @Override
-          public List<RunnerApi.TestStreamPayload.Event> getEvents() {
-            try {
-              List<RunnerApi.TestStreamPayload.Event> protoEvents = new ArrayList<>();
-              for (TestStream.Event<T> event : testStream.getEvents()) {
-                protoEvents.add(eventToProto(event, testStream.getValueCoder()));
-              }
-              return protoEvents;
-            } catch (IOException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        },
-        components);
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TransformPayloadTranslatorRegistrar.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/TransformPayloadTranslatorRegistrar.java
@@ -26,6 +26,4 @@ import org.apache.beam.sdk.transforms.PTransform;
 public interface TransformPayloadTranslatorRegistrar {
   Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
       getTransformPayloadTranslators();
-
-  Map<String, ? extends TransformPayloadTranslator> getTransformRehydrators();
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowIntoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WindowIntoTranslation.java
@@ -42,8 +42,7 @@ import org.apache.beam.sdk.transforms.windowing.WindowFn;
  */
 public class WindowIntoTranslation {
 
-  static class WindowAssignTranslator
-      extends TransformPayloadTranslator.WithDefaultRehydration<Window.Assign<?>> {
+  static class WindowAssignTranslator implements TransformPayloadTranslator<Window.Assign<?>> {
 
     @Override
     public String getUrn(Assign<?> transform) {
@@ -107,8 +106,7 @@ public class WindowIntoTranslation {
 
   /** A {@link TransformPayloadTranslator} for {@link Window}. */
   public static class WindowIntoPayloadTranslator
-      extends PTransformTranslation.TransformPayloadTranslator.WithDefaultRehydration<
-          Window.Assign<?>> {
+      implements PTransformTranslation.TransformPayloadTranslator<Window.Assign<?>> {
     public static TransformPayloadTranslator create() {
       return new WindowIntoPayloadTranslator();
     }
@@ -138,11 +136,6 @@ public class WindowIntoTranslation {
     public Map<? extends Class<? extends PTransform>, ? extends TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(Window.Assign.class, new WindowIntoPayloadTranslator());
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/WriteFilesTranslation.java
@@ -286,13 +286,6 @@ public class WriteFilesTranslation {
           .setPayload(payloadForWriteFiles(transform.getTransform(), components).toByteString())
           .build();
     }
-
-    @Override
-    public PTransformTranslation.RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException {
-      return new RawWriteFiles(protoTransform, rehydratedComponents);
-    }
   }
 
   /** Registers {@link WriteFilesTranslator}. */
@@ -302,11 +295,6 @@ public class WriteFilesTranslation {
     public Map<Class<? extends PTransform>, TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(WriteFiles.CONCRETE_CLASS, new WriteFilesTranslator());
-    }
-
-    @Override
-    public Map<String, ? extends TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.singletonMap(WRITE_FILES_TRANSFORM_URN, new WriteFilesTranslator());
     }
   }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
@@ -24,15 +24,20 @@ import static org.junit.Assert.assertThat;
 import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.CombinePayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.io.GenerateSequence;
+import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
@@ -109,14 +114,6 @@ public class PipelineTranslationTest {
     pipeline.traverseTopologically(new PipelineProtoVerificationVisitor(pipelineProto));
   }
 
-  @Test
-  public void testProtoAgainstRehydrated() throws Exception {
-    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(pipeline);
-    Pipeline rehydrated = PipelineTranslation.fromProto(pipelineProto);
-
-    rehydrated.traverseTopologically(new PipelineProtoVerificationVisitor(pipelineProto));
-  }
-
   private static class PipelineProtoVerificationVisitor extends PipelineVisitor.Defaults {
 
     private final RunnerApi.Pipeline pipelineProto;
@@ -159,8 +156,7 @@ public class PipelineTranslationTest {
           // Combine translation introduces a coder that is not assigned to any PCollection
           // in the default expansion, and must be explicitly added here.
           try {
-            addCoders(
-                CombineTranslation.getAccumulatorCoder(node.toAppliedPTransform(getPipeline())));
+            addCoders(getAccumulatorCoder(node.toAppliedPTransform(getPipeline())));
           } catch (IOException e) {
             throw new RuntimeException(e);
           }
@@ -191,6 +187,32 @@ public class PipelineTranslationTest {
           addCoders(component);
         }
       }
+    }
+  }
+
+  private static Coder<?> getAccumulatorCoder(AppliedPTransform<?, ?, ?> transform)
+      throws IOException {
+    SdkComponents sdkComponents = SdkComponents.create();
+    String id =
+        getCombinePayload(transform, sdkComponents)
+            .map(CombinePayload::getAccumulatorCoderId)
+            .orElseThrow(() -> new IOException("Transform does not contain an AccumulatorCoder"));
+    Components components = sdkComponents.toComponents();
+    return CoderTranslation.fromProto(
+        components.getCodersOrThrow(id), RehydratedComponents.forComponents(components));
+  }
+
+  private static Optional<CombinePayload> getCombinePayload(
+      AppliedPTransform<?, ?, ?> transform, SdkComponents components) throws IOException {
+    RunnerApi.PTransform proto =
+        PTransformTranslation.toProto(transform, Collections.emptyList(), components);
+
+    // Even if the proto has no spec, calling getSpec still returns a blank spec, which we want to
+    // avoid. It should be clear to the caller whether or not there was a spec in the transform.
+    if (proto.hasSpec()) {
+      return Optional.of(CombinePayload.parseFrom(proto.getSpec().getPayload()));
+    } else {
+      return Optional.empty();
     }
   }
 }

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -96,7 +96,7 @@ task needsRunnerTests(type: Test) {
   group = "Verification"
   description = "Runs tests that require a runner to validate that piplines/transforms work correctly"
 
-  def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false", "--protoTranslation"])
+  def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false"])
   systemProperty "beamTestPipelineOptions", pipelineOptions
 
   classpath = configurations.needsRunner
@@ -118,7 +118,7 @@ task validatesRunner(type: Test) {
   group = "Verification"
   description "Validates Direct runner"
 
-  def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false", "--protoTranslation"])
+  def pipelineOptions = JsonOutput.toJson(["--runner=DirectRunner", "--runnerDeterminedSharding=false"])
   systemProperty "beamTestPipelineOptions", pipelineOptions
 
   classpath = configurations.validatesRunner

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectOptions.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectOptions.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.direct;
 
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
@@ -78,11 +76,4 @@ public interface DirectOptions extends PipelineOptions, ApplicationNameOptions {
       return Math.max(Runtime.getRuntime().availableProcessors(), MIN_PARALLELISM);
     }
   }
-
-  @Experimental(Kind.CORE_RUNNERS_ONLY)
-  @Default.Boolean(false)
-  @Description("Control whether toProto/fromProto translations are applied to original Pipeline")
-  boolean isProtoTranslation();
-
-  void setProtoTranslation(boolean b);
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -36,7 +35,6 @@ import java.util.concurrent.Executors;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
 import org.apache.beam.runners.core.construction.PTransformMatchers;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
-import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.SplittableParDo;
 import org.apache.beam.runners.direct.DirectRunner.DirectPipelineResult;
 import org.apache.beam.runners.direct.TestStreamEvaluatorFactory.DirectTestStreamFactory;
@@ -152,17 +150,7 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
   }
 
   @Override
-  public DirectPipelineResult run(Pipeline originalPipeline) {
-    Pipeline pipeline;
-    if (options.isProtoTranslation()) {
-      try {
-        pipeline = PipelineTranslation.fromProto(PipelineTranslation.toProto(originalPipeline));
-      } catch (IOException exception) {
-        throw new RuntimeException("Error preparing pipeline for direct execution.", exception);
-      }
-    } else {
-      pipeline = originalPipeline;
-    }
+  public DirectPipelineResult run(Pipeline pipeline) {
     pipeline.replaceAll(defaultTransformOverrides());
     MetricsEnvironment.setMetricsSupported(true);
     try {

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/TransformEvaluatorRegistry.java
@@ -36,7 +36,6 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
@@ -129,11 +128,6 @@ class TransformEvaluatorRegistry {
               SplittableParDoViaKeyedWorkItems.ProcessElements.class,
               TransformPayloadTranslator.NotSerializable.forUrn(SPLITTABLE_PROCESS_URN))
           .build();
-    }
-
-    @Override
-    public Map<String, TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -19,8 +19,6 @@ package org.apache.beam.runners.flink;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.IOException;
-import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -74,13 +72,6 @@ class FlinkPipelineExecutionEnvironment {
   public void translate(FlinkRunner flinkRunner, Pipeline pipeline) {
     this.flinkBatchEnv = null;
     this.flinkStreamEnv = null;
-
-    // Serialize and rehydrate pipeline to make sure we only depend serialized transforms.
-    try {
-      pipeline = PipelineTranslation.fromProto(PipelineTranslation.toProto(pipeline));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
 
     PipelineTranslationOptimizer optimizer =
         new PipelineTranslationOptimizer(TranslationMode.BATCH, options);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
@@ -37,7 +37,6 @@ import org.apache.beam.runners.core.construction.ForwardingPTransform;
 import org.apache.beam.runners.core.construction.PTransformReplacements;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.ParDoTranslation;
-import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.core.construction.SingleInputOutputOverrideFactory;
 import org.apache.beam.runners.core.construction.TransformPayloadTranslatorRegistrar;
@@ -149,16 +148,6 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
           .build();
     }
 
-    @Override
-    public PTransformTranslation.RawPTransform<?, ?> rehydrate(
-        RunnerApi.PTransform protoTransform, RehydratedComponents rehydratedComponents)
-        throws IOException {
-      throw new UnsupportedOperationException(
-          String.format(
-              "%s.rehydrate should never be called; the serialized form is that of a ParDo",
-              getClass().getCanonicalName()));
-    }
-
     private static RunnerApi.ParDoPayload payloadForParDoSingle(
         final ParDoSingle<?, ?> parDo, SdkComponents components) throws IOException {
       final DoFn<?, ?> doFn = parDo.getFn();
@@ -238,12 +227,6 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
             ? extends PTransformTranslation.TransformPayloadTranslator>
         getTransformPayloadTranslators() {
       return Collections.singletonMap(ParDoSingle.class, new PayloadTranslator());
-    }
-
-    @Override
-    public Map<String, ? extends PTransformTranslation.TransformPayloadTranslator>
-        getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/SamzaPipelineTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/SamzaPipelineTranslator.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.TransformPayloadTranslatorRegistrar;
@@ -134,11 +133,6 @@ public class SamzaPipelineTranslator {
         getTransformPayloadTranslators() {
       return ImmutableMap.of(
           SamzaPublishView.class, new SamzaPublishView.SamzaPublishViewPayloadTranslator());
-    }
-
-    @Override
-    public Map<String, PTransformTranslation.TransformPayloadTranslator> getTransformRehydrators() {
-      return Collections.emptyMap();
     }
   }
 }


### PR DESCRIPTION
This prevents runners from attempting to convert a pipeline proto into SDK pipeline construct. All runners should use the proto directly and utilities that work on the proto representation since there is no expectation that runners will be able to rehydrate all aspects of SDK constructs.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | ---




