### PR TITLE
Makes FileIO.match watermark advance even without new files

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -645,8 +645,10 @@ public class FileIO {
       @Override
       public Watch.Growth.PollResult<MatchResult.Metadata> apply(String element, Context c)
           throws Exception {
+        Instant now = Instant.now();
         return Watch.Growth.PollResult.incomplete(
-            Instant.now(), FileSystems.match(element, EmptyMatchTreatment.ALLOW).metadata());
+                now, FileSystems.match(element, EmptyMatchTreatment.ALLOW).metadata())
+            .withWatermark(now);
       }
     }
 


### PR DESCRIPTION
R: @rangadi 