### PR TITLE
[BEAM-4451] Schemas default provider and serviceloader

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/DefaultSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/DefaultSchema.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.schemas;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * The {@link DefaultSchema} annotation specifies a {@link SchemaProvider} class to handle obtaining
+ * a schema and row for the specified class.
+ *
+ * <p>For example, if your class is JavaBean, the JavaBeanSchema provider class knows how to vend
+ * schemas for this class. You can annotate it as follows:
+ *
+ * <pre><code>
+ *   {@literal @}DefaultSchema(JavaBeanSchema.class)
+ *   class MyClass {
+ *     public String getFoo();
+ *     void setFoo(String foo);
+ *           ....
+ *   }
+ * </code></pre>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@SuppressWarnings("rawtypes")
+@Experimental(Kind.SCHEMAS)
+public @interface DefaultSchema {
+  @CheckForNull
+  Class<? extends SchemaProvider> value();
+
+  /**
+   * {@link SchemaProvider} for default schemas. Looks up the provider annotated for a type, and
+   * delegates to that provider.
+   */
+  class DefaultSchemaProvider extends SchemaProvider {
+    Map<TypeDescriptor, SchemaProvider> cachedProviders = Maps.newConcurrentMap();
+
+    @Nullable
+    private SchemaProvider getSchemaProvider(TypeDescriptor<?> typeDescriptor) {
+      return cachedProviders.computeIfAbsent(
+          typeDescriptor,
+          type -> {
+            Class<?> clazz = type.getRawType();
+            DefaultSchema annotation = clazz.getAnnotation(DefaultSchema.class);
+            if (annotation == null) {
+              return null;
+            }
+            Class<? extends SchemaProvider> providerClass = annotation.value();
+            checkArgument(
+                providerClass != null,
+                "Type "
+                    + type
+                    + " has a @DefaultSchemaProvider annotation "
+                    + " with a null argument.");
+
+            try {
+              return providerClass.getDeclaredConstructor().newInstance();
+            } catch (NoSuchMethodException
+                | InstantiationException
+                | IllegalAccessException
+                | InvocationTargetException e) {
+              throw new IllegalStateException(
+                  "Failed to create SchemaProvider "
+                      + providerClass.getSimpleName()
+                      + " which was"
+                      + " specified as the default SchemaProvider for type "
+                      + type
+                      + ". Make "
+                      + " sure that this class has a default constructor.",
+                  e);
+            }
+          });
+    }
+
+    @Override
+    public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+      SchemaProvider schemaProvider = getSchemaProvider(typeDescriptor);
+      return (schemaProvider != null) ? schemaProvider.schemaFor(typeDescriptor) : null;
+    }
+
+    /**
+     * Given a type, return a function that converts that type to a {@link Row} object If no schema
+     * exists, returns null.
+     */
+    @Override
+    public <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor) {
+      SchemaProvider schemaProvider = getSchemaProvider(typeDescriptor);
+      return (schemaProvider != null) ? schemaProvider.toRowFunction(typeDescriptor) : null;
+    }
+
+    /**
+     * Given a type, returns a function that converts from a {@link Row} object to that type. If no
+     * schema exists, returns null.
+     */
+    @Override
+    public <T> SerializableFunction<Row, T> fromRowFunction(TypeDescriptor<T> typeDescriptor) {
+      SchemaProvider schemaProvider = getSchemaProvider(typeDescriptor);
+      return (schemaProvider != null) ? schemaProvider.fromRowFunction(typeDescriptor) : null;
+    }
+  }
+
+  /** Registrar for default schemas. */
+  class DefaultSchemaProviderRegistrar implements SchemaProviderRegistrar {
+    @Override
+    public List<SchemaProvider> getSchemaProviders() {
+      return ImmutableList.of(new DefaultSchemaProvider());
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/DefaultSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/DefaultSchema.java
@@ -68,7 +68,7 @@ public @interface DefaultSchema {
    * delegates to that provider.
    */
   class DefaultSchemaProvider extends SchemaProvider {
-    Map<TypeDescriptor, SchemaProvider> cachedProviders = Maps.newConcurrentMap();
+    final Map<TypeDescriptor, SchemaProvider> cachedProviders = Maps.newConcurrentMap();
 
     @Nullable
     private SchemaProvider getSchemaProvider(TypeDescriptor<?> typeDescriptor) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.schemas;
 
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -33,18 +34,21 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 public abstract class SchemaProvider {
 
   /** Lookup a schema for the given type. If no schema exists, returns null. */
+  @Nullable
   public abstract <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor);
 
   /**
    * Given a type, return a function that converts that type to a {@link Row} object If no schema
    * exists, returns null.
    */
+  @Nullable
   public abstract <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor);
 
   /**
    * Given a type, returns a function that converts from a {@link Row} object to that type. If no
    * schema exists, returns null.
    */
+  @Nullable
   public abstract <T> SerializableFunction<Row, T> fromRowFunction(
       TypeDescriptor<T> typeDescriptor);
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProviderRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProviderRegistrar.java
@@ -1,0 +1,42 @@
+package org.apache.beam.sdk.schemas;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.auto.service.AutoService;
+import java.util.List;
+import java.util.ServiceLoader;
+import org.apache.beam.sdk.annotations.Experimental;
+
+/**
+ * {@link SchemaProvider} creators have the ability to automatically have their
+ * {@link SchemaProvider schemaProvider} registered with this SDK by creating a
+ * {@link ServiceLoader} entry and a concrete implementation of this interface.
+ *
+ * <p>It is optional but recommended to use one of the many build time tools such as
+ * {@link AutoService} to generate the necessary META-INF files automatically.
+ */
+@Experimental
+public interface SchemaProviderRegistrar {
+  /**
+   * Returns a list of {@link SchemaProvider schema providers} which
+   * will be registered by default within each {@link SchemaRegistry schema registry} instance.
+   *
+   */
+  List<SchemaProvider> getSchemaProviders();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProviderRegistrar.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProviderRegistrar.java
@@ -22,21 +22,21 @@ import com.google.auto.service.AutoService;
 import java.util.List;
 import java.util.ServiceLoader;
 import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
- * {@link SchemaProvider} creators have the ability to automatically have their
- * {@link SchemaProvider schemaProvider} registered with this SDK by creating a
- * {@link ServiceLoader} entry and a concrete implementation of this interface.
+ * {@link SchemaProvider} creators have the ability to automatically have their {@link
+ * SchemaProvider schemaProvider} registered with this SDK by creating a {@link ServiceLoader} entry
+ * and a concrete implementation of this interface.
  *
- * <p>It is optional but recommended to use one of the many build time tools such as
- * {@link AutoService} to generate the necessary META-INF files automatically.
+ * <p>It is optional but recommended to use one of the many build time tools such as {@link
+ * AutoService} to generate the necessary META-INF files automatically.
  */
-@Experimental
+@Experimental(Kind.SCHEMAS)
 public interface SchemaProviderRegistrar {
   /**
-   * Returns a list of {@link SchemaProvider schema providers} which
-   * will be registered by default within each {@link SchemaRegistry schema registry} instance.
-   *
+   * Returns a list of {@link SchemaProvider schema providers} which will be registered by default
+   * within each {@link SchemaRegistry schema registry} instance.
    */
   List<SchemaProvider> getSchemaProviders();
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
@@ -64,8 +64,8 @@ public class SchemaRegistry {
     }
   }
 
-  Map<TypeDescriptor, SchemaEntry> entries = Maps.newHashMap();
-  ArrayDeque<SchemaProvider> providers;
+  private final Map<TypeDescriptor, SchemaEntry> entries = Maps.newHashMap();
+  private final ArrayDeque<SchemaProvider> providers;
 
   private SchemaRegistry() {
     providers = new ArrayDeque<>(REGISTERED_SCHEMA_PROVIDERS);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
@@ -18,14 +18,21 @@
 
 package org.apache.beam.sdk.schemas;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.function.Function;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.apache.beam.sdk.util.common.ReflectHelpers.ObjectsClassComparator;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
 
@@ -42,6 +49,8 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  */
 @Experimental(Kind.SCHEMAS)
 public class SchemaRegistry {
+  private static final List<SchemaProvider> REGISTERED_SCHEMA_PROVIDERS;
+
   private static class SchemaEntry<T> {
     private final Schema schema;
     private final SerializableFunction<T, Row> toRow;
@@ -55,8 +64,12 @@ public class SchemaRegistry {
     }
   }
 
-  private final Map<TypeDescriptor, SchemaEntry> entries = Maps.newHashMap();
-  private final List<SchemaProvider> providers = Lists.newArrayList();
+  Map<TypeDescriptor, SchemaEntry> entries = Maps.newHashMap();
+  ArrayDeque<SchemaProvider> providers;
+
+  private SchemaRegistry() {
+    providers = new ArrayDeque<>(REGISTERED_SCHEMA_PROVIDERS);
+  }
 
   public static SchemaRegistry createDefault() {
     return new SchemaRegistry();
@@ -88,7 +101,7 @@ public class SchemaRegistry {
    * the external service and return the correct {@link Schema}.
    */
   public void registerSchemaProvider(SchemaProvider schemaProvider) {
-    providers.add(schemaProvider);
+    providers.addFirst(schemaProvider);
   }
 
   /**
@@ -152,5 +165,23 @@ public class SchemaRegistry {
       return entry.fromRow;
     }
     return getProviderResult((SchemaProvider p) -> p.fromRowFunction(typeDescriptor));
+  }
+
+  static {
+    // find all statically-registered SchemaProviders.
+    List<SchemaProvider> providersToRegister = Lists.newArrayList();
+    Set<SchemaProviderRegistrar> registrars = Sets.newTreeSet(ObjectsClassComparator.INSTANCE);
+    // Find all SchemaProviderRegistrar classes that are registered as service loaders
+    // (usually using the @AutoService annotation).
+    registrars.addAll(
+        Lists.newArrayList(
+            ServiceLoader.load(SchemaProviderRegistrar.class, ReflectHelpers.findClassLoader())));
+    // Load all SchemaProviders that are registered using the @DefaultSchema annotation.
+    providersToRegister.addAll(
+        new DefaultSchema.DefaultSchemaProviderRegistrar().getSchemaProviders());
+    for (SchemaProviderRegistrar registrar : registrars) {
+      providersToRegister.addAll(registrar.getSchemaProviders());
+    }
+    REGISTERED_SCHEMA_PROVIDERS = ImmutableList.copyOf(providersToRegister);
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaRegistryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaRegistryTest.java
@@ -20,6 +20,9 @@ package org.apache.beam.sdk.schemas;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -30,6 +33,7 @@ import org.junit.rules.ExpectedException;
 
 /** Unit tests for {@link SchemaRegistry}. */
 public class SchemaRegistryTest {
+  static final Schema EMPTY_SCHEMA = Schema.builder().build();
   static final Schema STRING_SCHEMA = Schema.builder().addStringField("string").build();
   static final Schema INTEGER_SCHEMA = Schema.builder().addInt32Field("integer").build();
   @Rule public ExpectedException thrown = ExpectedException.none();
@@ -117,5 +121,83 @@ public class SchemaRegistryTest {
     SchemaRegistry registry = SchemaRegistry.createDefault();
     registry.registerSchemaProvider(new Provider());
     tryGetters(registry);
+  }
+
+  static class TestSchemaClass {}
+
+  static final class TestAutoProvider extends SchemaProvider {
+    @Override
+    public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestSchemaClass.class))) {
+        return EMPTY_SCHEMA;
+      }
+      return null;
+    }
+
+    @Override
+    public <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestSchemaClass.class))) {
+        return v -> Row.withSchema(EMPTY_SCHEMA).build();
+      }
+      return null;
+    }
+
+    @Override
+    public <T> SerializableFunction<Row, T> fromRowFunction(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestSchemaClass.class))) {
+        return r -> (T) new TestSchemaClass();
+      }
+      return null;
+    }
+  }
+
+  /** A @link SchemaProviderRegistrar} for testing. */
+  @AutoService(SchemaProviderRegistrar.class)
+  public static class TestSchemaProviderRegistrar implements SchemaProviderRegistrar {
+    @Override
+    public List<SchemaProvider> getSchemaProviders() {
+      return ImmutableList.of(new TestAutoProvider());
+    }
+  }
+
+  @Test
+  public void testAutoSchemaProvider() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    assertEquals(EMPTY_SCHEMA, registry.getSchema(TestSchemaClass.class));
+  }
+
+  @DefaultSchema(TestDefaultSchemaProvider.class)
+  static class TestDefaultSchemaClass {}
+
+  static final class TestDefaultSchemaProvider extends SchemaProvider {
+    @Override
+    public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestDefaultSchemaClass.class))) {
+        return EMPTY_SCHEMA;
+      }
+      return null;
+    }
+
+    @Override
+    public <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestDefaultSchemaClass.class))) {
+        return v -> Row.withSchema(EMPTY_SCHEMA).build();
+      }
+      return null;
+    }
+
+    @Override
+    public <T> SerializableFunction<Row, T> fromRowFunction(TypeDescriptor<T> typeDescriptor) {
+      if (typeDescriptor.equals(TypeDescriptor.of(TestDefaultSchemaClass.class))) {
+        return r -> (T) new TestSchemaClass();
+      }
+      return null;
+    }
+  }
+
+  @Test
+  public void testDefaultSchemaProvider() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    assertEquals(EMPTY_SCHEMA, registry.getSchema(TestDefaultSchemaClass.class));
   }
 }


### PR DESCRIPTION
Adds a ServiceLoader interface for SchemaProvider. This allows external modules to define SchemaProviders that provide schemas for types.

Also adds a DefaultSchema provider. Tagging any Java type with @DefaultSchema(SomeSchemaProvider.class) will cause that schema provider to be used to vend schemas for the Java type.

R: @apilloud