### PR TITLE
[BEAM-3446] Fixes RedisIO non-prefix read operations

### DIFF
--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -353,7 +353,7 @@ public class RedisIO {
       bufferedKeys.add(key);
       this.window = window;
       this.lastMsg = processContext.timestamp();
-      if (bufferedKeys.size() > getBatchSize()) {
+      if (bufferedKeys.size() >= getBatchSize()) {
         List<KV<String, String>> kvs = fetchAndFlush();
         for (KV<String, String> kv : kvs) {
           processContext.output(kv);

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -196,7 +196,7 @@ public class RedisIO {
 
       return input
           .apply(Create.of(keyPattern()))
-          .apply(ParDo.of(new ReadKeywsWithPattern(connectionConfiguration())))
+          .apply(ParDo.of(new ReadKeysWithPattern(connectionConfiguration())))
           .apply(RedisIO.readAll().withConnectionConfiguration(connectionConfiguration()));
     }
   }
@@ -255,12 +255,12 @@ public class RedisIO {
     }
   }
 
-  private abstract static class BaseReadFn<T> extends DoFn<String, T> {
+  abstract static class BaseReadFn<T> extends DoFn<String, T> {
     protected final RedisConnectionConfiguration connectionConfiguration;
 
-    protected transient Jedis jedis;
+    transient Jedis jedis;
 
-    public BaseReadFn(RedisConnectionConfiguration connectionConfiguration) {
+    BaseReadFn(RedisConnectionConfiguration connectionConfiguration) {
       this.connectionConfiguration = connectionConfiguration;
     }
 
@@ -275,9 +275,9 @@ public class RedisIO {
     }
   }
 
-  private static class ReadKeywsWithPattern extends BaseReadFn<String> {
+  private static class ReadKeysWithPattern extends BaseReadFn<String> {
 
-    ReadKeywsWithPattern(RedisConnectionConfiguration connectionConfiguration) {
+    ReadKeysWithPattern(RedisConnectionConfiguration connectionConfiguration) {
       super(connectionConfiguration);
     }
 

--- a/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
+++ b/sdks/java/io/redis/src/main/java/org/apache/beam/sdk/io/redis/RedisIO.java
@@ -196,6 +196,7 @@ public class RedisIO {
 
       return input
           .apply(Create.of(keyPattern()))
+          .apply(ParDo.of(new ReadKeywsWithPattern(connectionConfiguration())))
           .apply(RedisIO.readAll().withConnectionConfiguration(connectionConfiguration()));
     }
   }
@@ -254,20 +255,30 @@ public class RedisIO {
     }
   }
 
-  /** A {@link DoFn} requesting Redis server to get key/value pairs. */
-  private static class ReadFn extends DoFn<String, KV<String, String>> {
+  private abstract static class BaseReadFn<T> extends DoFn<String, T> {
+    protected final RedisConnectionConfiguration connectionConfiguration;
 
-    private final RedisConnectionConfiguration connectionConfiguration;
+    protected transient Jedis jedis;
 
-    private transient Jedis jedis;
-
-    public ReadFn(RedisConnectionConfiguration connectionConfiguration) {
+    public BaseReadFn(RedisConnectionConfiguration connectionConfiguration) {
       this.connectionConfiguration = connectionConfiguration;
     }
 
     @Setup
     public void setup() {
       jedis = connectionConfiguration.connect();
+    }
+
+    @Teardown
+    public void teardown() {
+      jedis.close();
+    }
+  }
+
+  private static class ReadKeywsWithPattern extends BaseReadFn<String> {
+
+    ReadKeywsWithPattern(RedisConnectionConfiguration connectionConfiguration) {
+      super(connectionConfiguration);
     }
 
     @ProcessElement
@@ -280,28 +291,31 @@ public class RedisIO {
       while (!finished) {
         ScanResult<String> scanResult = jedis.scan(cursor, scanParams);
         List<String> keys = scanResult.getResult();
-
-        Pipeline pipeline = jedis.pipelined();
-        if (keys != null) {
-          for (String key : keys) {
-            pipeline.get(key);
-          }
-          List<Object> values = pipeline.syncAndReturnAll();
-          for (int i = 0; i < values.size(); i++) {
-            processContext.output(KV.of(keys.get(i), (String) values.get(i)));
-          }
+        for (String k : keys) {
+          processContext.output(k);
         }
-
         cursor = scanResult.getStringCursor();
         if ("0".equals(cursor)) {
           finished = true;
         }
       }
     }
+  }
+  /** A {@link DoFn} requesting Redis server to get key/value pairs. */
+  private static class ReadFn extends BaseReadFn<KV<String, String>> {
 
-    @Teardown
-    public void teardown() {
-      jedis.close();
+    ReadFn(RedisConnectionConfiguration connectionConfiguration) {
+      super(connectionConfiguration);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext processContext) throws Exception {
+      String key = processContext.element();
+
+      String value = jedis.get(key);
+      if (value != null) {
+        processContext.output(KV.of(key, value));
+      }
     }
   }
 

--- a/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
+++ b/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
@@ -87,6 +87,12 @@ public class RedisIOTest {
 
     readPipeline.run();
   }
+  @Test
+  public void testConfiguration() {
+    RedisIO.Write writeOp = RedisIO.write().withEndpoint("test", 111);
+    Assert.assertEquals(writeOp.connectionConfiguration().port(), 111);
+    Assert.assertEquals(writeOp.connectionConfiguration().host(), "test");
+  }
 
   @Test
   public void testWriteReadUsingSetMethod() throws Exception {

--- a/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
+++ b/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
@@ -87,6 +87,7 @@ public class RedisIOTest {
 
     readPipeline.run();
   }
+
   @Test
   public void testConfiguration() {
     RedisIO.Write writeOp = RedisIO.write().withEndpoint("test", 111);

--- a/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
+++ b/sdks/java/io/redis/src/test/java/org/apache/beam/sdk/io/redis/RedisIOTest.java
@@ -117,8 +117,8 @@ public class RedisIOTest {
   @Test
   public void testConfiguration() {
     RedisIO.Write writeOp = RedisIO.write().withEndpoint("test", 111);
-    Assert.assertEquals(writeOp.connectionConfiguration().port(), 111);
-    Assert.assertEquals(writeOp.connectionConfiguration().host(), "test");
+    Assert.assertEquals(111, writeOp.connectionConfiguration().port());
+    Assert.assertEquals("test", writeOp.connectionConfiguration().host());
   }
 
   @Test


### PR DESCRIPTION
Rebase of https://github.com/apache/beam/pull/4656

BaseReadFn to abstract general jedis operations.
Moved key fetch given prefix to ReadKeywsWithPattern DoFn.
ReadFn is pure fetch from redis given key.
URL: https://issues.apache.org/jira/browse/BEAM-3446
@iemejia  @jbonofre 

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




