### PR TITLE
[BEAM-3761] Define cmp() in Python 3

### DIFF
--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -53,6 +53,7 @@ import abc
 
 from google.protobuf import duration_pb2
 from google.protobuf import timestamp_pb2
+from past.builtins import cmp
 
 from apache_beam.coders import coders
 from apache_beam.portability import common_urns

--- a/sdks/python/scripts/run_mini_py3lint.sh
+++ b/sdks/python/scripts/run_mini_py3lint.sh
@@ -48,5 +48,4 @@ if test $# -gt 0; then
 fi
 
 echo "Running flake8 for module $MODULE:"
-# TODO(BEAM-3959): Add F821 (undefined names) as soon as that test passes
-flake8 $MODULE --count --select=E9,F822,F823 --show-source --statistics
+flake8 $MODULE --count --select=E9,F821,F822,F823 --show-source --statistics


### PR DESCRIPTION
Signed-off-by: cclauss <cclauss@bluewin.ch>

**Please** add a meaningful description for your change here
Define __cmp()__ function that was removed in Python 3.  A more straight ahead approach to #4774 that should be easier to review.  Fixes the following issues:

flake8 testing of https://github.com/apache/beam on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sdks/python/apache_beam/io/vcfio_test.py:77:14: F821 undefined name 'cmp'
      return cmp(v1.end, v2.end)
             ^
./sdks/python/apache_beam/io/vcfio_test.py:78:12: F821 undefined name 'cmp'
    return cmp(v1.start, v2.start)
           ^
./sdks/python/apache_beam/io/vcfio_test.py:79:10: F821 undefined name 'cmp'
  return cmp(v1.reference_name, v2.reference_name)
         ^
./sdks/python/apache_beam/io/gcp/datastore/v1/helper.py:93:12: F821 undefined name 'cmp'
  result = cmp(p1.kind, p2.kind)
           ^
./sdks/python/apache_beam/io/gcp/datastore/v1/helper.py:101:12: F821 undefined name 'cmp'
    return cmp(p1.id, p2.id)
           ^
./sdks/python/apache_beam/io/gcp/datastore/v1/helper.py:106:10: F821 undefined name 'cmp'
  return cmp(p1.name, p2.name)
         ^
./sdks/python/apache_beam/transforms/window.py:195:12: F821 undefined name 'cmp'
    return cmp(self.end, other.end) or cmp(hash(self), hash(other))
           ^
./sdks/python/apache_beam/transforms/window.py:195:40: F821 undefined name 'cmp'
    return cmp(self.end, other.end) or cmp(hash(self), hash(other))
                                       ^
./sdks/python/apache_beam/transforms/window.py:250:14: F821 undefined name 'cmp'
      return cmp(type(self), type(other))
             ^
./sdks/python/apache_beam/transforms/window.py:251:12: F821 undefined name 'cmp'
    return cmp((self.value, self.timestamp), (other.value, other.timestamp))
           ^
```

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




