### PR TITLE
Test expressions and values via JDBC

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriver.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.extensions.sql.impl;
 import static org.codehaus.commons.compiler.CompilerFactoryFactory.getDefaultCompilerFactory;
 
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
@@ -133,7 +134,8 @@ public class JdbcDriver extends Driver {
     }
   }
 
-  static CalciteConnection connect(TableProvider tableProvider) {
+  @VisibleForTesting
+  public static CalciteConnection connect(TableProvider tableProvider) {
     try {
       Properties info = new Properties();
       info.put(BEAM_CALCITE_SCHEMA, new BeamCalciteSchema(tableProvider));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
@@ -425,34 +425,36 @@ public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegr
   @SqlOperatorTest(name = "SUBSTRING", kind = "OTHER_FUNCTION")
   @SqlOperatorTest(name = "TRIM", kind = "TRIM")
   @SqlOperatorTest(name = "UPPER", kind = "OTHER_FUNCTION")
-  public void testStringFunctions() {
-    ExpressionChecker checker =
-        new ExpressionChecker()
-            .addExpr("'hello' || ' world'", "hello world")
-            .addExpr("CHAR_LENGTH('hello')", 5)
-            .addExpr("CHARACTER_LENGTH('hello')", 5)
-            .addExpr("INITCAP('hello world')", "Hello World")
-            .addExpr("LOWER('HELLO')", "hello")
-            .addExpr("POSITION('world' IN 'helloworld')", 6)
-            .addExpr("POSITION('world' IN 'helloworldworld' FROM 7)", 11)
-            .addExpr("POSITION('world' IN 'hello')", 0)
-            .addExpr("TRIM(' hello ')", "hello")
-            .addExpr("TRIM(LEADING 'eh' FROM 'hehe__hehe')", "__hehe")
-            .addExpr("TRIM(TRAILING 'eh' FROM 'hehe__hehe')", "hehe__")
-            .addExpr("TRIM(BOTH 'eh' FROM 'hehe__hehe')", "__")
-            .addExpr("TRIM(BOTH ' ' FROM ' hello ')", "hello")
-            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3)", "w3resou3rce")
-            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 4)", "w3resou33rce")
-            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 5)", "w3resou3rce")
-            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 7)", "w3resouce")
-            .addExpr("SUBSTRING('hello' FROM 2)", "ello")
-            .addExpr("SUBSTRING('hello' FROM -1)", "o")
-            .addExpr("SUBSTRING('hello' FROM 2 FOR 2)", "el")
-            .addExpr("SUBSTRING('hello' FROM 2 FOR 100)", "ello")
-            .addExpr("SUBSTRING('hello' FROM -3 for 2)", "ll")
-            .addExpr("UPPER('hello')", "HELLO");
+  public void testStringFunctions() throws Exception {
+    SqlExpressionChecker checker =
+        new SqlExpressionChecker()
+            .addExpr("'hello' || ' world' = 'hello world'")
+            .addExpr("CHAR_LENGTH('hello') = 5")
+            .addExpr("CHARACTER_LENGTH('hello') = 5")
+            .addExpr("INITCAP('hello world') = 'Hello World'")
+            .addExpr("LOWER('HELLO') = 'hello'")
+            .addExpr("POSITION('world' IN 'helloworld') = 6")
+            .addExpr("POSITION('world' IN 'helloworldworld' FROM 7) = 11")
+            .addExpr("POSITION('world' IN 'hello') = 0")
+            .addExpr("TRIM(' hello ') = 'hello'")
+            // https://issues.apache.org/jira/browse/BEAM-4704
+            .addExpr("TRIM(LEADING 'eh' FROM 'hehe__hehe') = '__hehe'")
+            .addExpr("TRIM(TRAILING 'eh' FROM 'hehe__hehe') = 'hehe__'")
+            .addExpr("TRIM(BOTH 'eh' FROM 'hehe__hehe') = '__'")
+            .addExpr("TRIM(BOTH ' ' FROM ' hello ') = 'hello'")
+            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3) = 'w3resou3rce'")
+            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 4) = 'w3resou33rce'")
+            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 5) = 'w3resou3rce'")
+            .addExpr("OVERLAY('w3333333rce' PLACING 'resou' FROM 3 FOR 7) = 'w3resouce'")
+            .addExpr("SUBSTRING('hello' FROM 2) = 'ello'")
+            .addExpr("SUBSTRING('hello' FROM -1) = 'o'")
+            .addExpr("SUBSTRING('hello' FROM 2 FOR 2) = 'el'")
+            .addExpr("SUBSTRING('hello' FROM 2 FOR 100) = 'ello'")
+            .addExpr("SUBSTRING('hello' FROM -3 for 2) = 'll'")
+            .addExpr("UPPER('hello') = 'HELLO'");
 
-    checker.buildRunAndCheck();
+    checker.check(pipeline);
+    pipeline.run();
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
@@ -34,9 +34,13 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.extensions.sql.impl.parser.TestTableProvider;
 import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
@@ -49,7 +53,10 @@ import org.apache.calcite.jdbc.CalciteSchema;
 import org.apache.calcite.schema.SchemaPlus;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.joda.time.ReadableInstant;
+import org.joda.time.format.ISODateTimeFormat;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -196,6 +203,91 @@ public class JdbcDriverTest {
             .collect(Collectors.toList());
 
     assertThat(resultRows, containsInAnyOrder(row(1L, "aaa"), row(2L, "bbb")));
+  }
+
+  @Test
+  @Ignore("https://issues.apache.org/jira/browse/CALCITE-2394")
+  public void testTimestampWithDefaultTimezone() throws Exception {
+    TestTableProvider tableProvider = new TestTableProvider();
+    Connection connection = JdbcDriver.connect(tableProvider);
+
+    // A table with one TIMESTAMP column
+    Schema schema = Schema.builder().addDateTimeField("ts").build();
+    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+
+    ReadableInstant july1 =
+        ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
+    tableProvider.addRows("test", Row.withSchema(schema).addValue(july1).build());
+
+    ResultSet selectResult =
+        connection.createStatement().executeQuery(String.format("SELECT ts FROM test"));
+    selectResult.next();
+    Timestamp ts = selectResult.getTimestamp(1);
+
+    assertThat(
+        String.format(
+            "Wrote %s to a table, but got back %s",
+            ISODateTimeFormat.basicDateTime().print(july1),
+            ISODateTimeFormat.basicDateTime().print(ts.getTime())),
+        ts.getTime(),
+        equalTo(july1.getMillis()));
+  }
+
+  @Test
+  @Ignore("https://issues.apache.org/jira/browse/CALCITE-2394")
+  public void testTimestampWithNonzeroTimezone() throws Exception {
+    Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("Asia/Tokyo"), Locale.ROOT);
+    TestTableProvider tableProvider = new TestTableProvider();
+    Connection connection = JdbcDriver.connect(tableProvider);
+
+    // A table with one TIMESTAMP column
+    Schema schema = Schema.builder().addDateTimeField("ts").build();
+    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+
+    ReadableInstant july1 =
+        ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
+    tableProvider.addRows("test", Row.withSchema(schema).addValue(july1).build());
+
+    ResultSet selectResult =
+        connection.createStatement().executeQuery(String.format("SELECT ts FROM test"));
+    selectResult.next();
+    Timestamp ts = selectResult.getTimestamp(1, cal);
+
+    assertThat(
+        String.format(
+            "Wrote %s to a table, but got back %s",
+            ISODateTimeFormat.basicDateTime().print(july1),
+            ISODateTimeFormat.basicDateTime().print(ts.getTime())),
+        ts.getTime(),
+        equalTo(july1.getMillis()));
+  }
+
+  @Test
+  public void testTimestampWithZeroTimezone() throws Exception {
+    Calendar cal = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
+    TestTableProvider tableProvider = new TestTableProvider();
+    Connection connection = JdbcDriver.connect(tableProvider);
+
+    // A table with one TIMESTAMP column
+    Schema schema = Schema.builder().addDateTimeField("ts").build();
+    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+
+    ReadableInstant july1 =
+        ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
+    tableProvider.addRows("test", Row.withSchema(schema).addValue(july1).build());
+
+    ResultSet selectResult =
+        connection.createStatement().executeQuery(String.format("SELECT ts FROM test"));
+    selectResult.next();
+    Timestamp ts = selectResult.getTimestamp(1, cal);
+
+    assertThat(
+        String.format(
+            "Wrote %s to a table, but got back %s",
+            ISODateTimeFormat.basicDateTime().print(july1),
+            ISODateTimeFormat.basicDateTime().print(ts.getTime())),
+        ts.getTime(),
+        equalTo(july1.getMillis()));
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/TestTableProvider.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/TestTableProvider.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.sql.impl.parser;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -91,6 +93,7 @@ public class TestTableProvider implements TableProvider {
   }
 
   public void addRows(String tableName, Row... rows) {
+    checkArgument(tables().containsKey(tableName), "Table not found: " + tableName);
     tables().get(tableName).rows.addAll(Arrays.asList(rows));
   }
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -19,23 +19,38 @@
 package org.apache.beam.sdk.extensions.sql.integrationtest;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static org.junit.Assert.assertTrue;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.extensions.sql.SqlTransform;
 import org.apache.beam.sdk.extensions.sql.TestUtils;
+import org.apache.beam.sdk.extensions.sql.impl.JdbcDriver;
+import org.apache.beam.sdk.extensions.sql.impl.parser.TestTableProvider;
+import org.apache.beam.sdk.extensions.sql.meta.provider.ReadOnlyTableProvider;
 import org.apache.beam.sdk.extensions.sql.mock.MockedBoundedTable;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.junit.Rule;
@@ -119,7 +134,7 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
   }
 
   /**
-   * Helper class to make write integration test for built-in functions easier.
+   * Helper class to write tests for built-in functions.
    *
    * <p>example usage:
    *
@@ -171,6 +186,118 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
       }
 
       inputCollection.getPipeline().run();
+    }
+  }
+
+  /**
+   * Helper class to write tests for SQL Expressions.
+   *
+   * <p>Differs from {@link ExpressionChecker}:
+   *
+   * <ul>
+   *   <li>Tests a SQL expression is SQL true, not against a Java return type. Correctness relies on
+   *       bootstrapped testing of literals and whatever operators, like {@code =} and {@code <} are
+   *       used in the expression.
+   *   <li>There is no implicit table to reference columns from, just literals.
+   *   <li>Runs tests both via QueryTransform and also via JDBC driver.
+   *   <li>Requires a pipeline to be provided where it will attach transforms.
+   * </ul>
+   *
+   * <p>example usage:
+   *
+   * <pre>{@code
+   * SqlExpressionChecker checker = new ExpressionChecker()
+   *   .addExpr("1 + 1 = 2")
+   *   .addExpr("1.0 + 1 = 2.0")
+   *   .addExpr("1 + 1.0 = 2.0")
+   *   .addExpr("1.0 + 1.0 = 2.0")
+   *   .addExpr("CAST(1 AS TINYINT) + CAST(1 AS TINYINT) = CAST(1 AS TINYINT)");
+   * checker.check(pipeline);
+   * }</pre>
+   */
+  public static class SqlExpressionChecker {
+
+    private transient List<String> exprs = new ArrayList<>();
+
+    public SqlExpressionChecker addExpr(String expr) {
+      exprs.add(expr);
+      return this;
+    }
+
+    /**
+     * Tests the cases set up via a PTransform in the given pipeline as well as via the JDBC driver.
+     */
+    public void check(Pipeline pipeline) throws Exception {
+      checkPTransform(pipeline);
+      checkJdbc();
+    }
+
+    private static final Schema DUMMY_SCHEMA = Schema.builder().addBooleanField("dummy").build();
+    private static final Row DUMMY_ROW = Row.withSchema(DUMMY_SCHEMA).addValue(true).build();
+
+    private void checkPTransform(Pipeline pipeline) {
+      for (String expr : exprs) {
+        pipeline.apply(expr, new CheckPTransform(expr));
+      }
+    }
+
+    private static final ReadOnlyTableProvider BOUNDED_TABLE =
+        new ReadOnlyTableProvider(
+            "test",
+            ImmutableMap.of(
+                "test",
+                MockedBoundedTable.of(
+                        Schema.FieldType.INT32, "id",
+                        Schema.FieldType.STRING, "name")
+                    .addRows(1, "first")));
+
+    private void checkJdbc() throws Exception {
+      // Beam SQL code is only invoked when the calling convention insists on it, so we
+      // have to express this as selecting from a Beam table, even though the contents are
+      // irrelevant.
+      //
+      // Sometimes this means the results are incorrect, because other calling conventions
+      // are incorrect: https://issues.apache.org/jira/browse/BEAM-4704
+      //
+      // Here we create a Beam table just to force the calling convention.
+      TestTableProvider tableProvider = new TestTableProvider();
+      Connection connection = JdbcDriver.connect(tableProvider);
+      connection.createStatement().executeUpdate("CREATE TABLE dummy (dummy BOOLEAN) TYPE 'test'");
+      tableProvider.addRows("dummy", DUMMY_ROW);
+
+      for (String expr : exprs) {
+        ResultSet exprResult =
+            connection.createStatement().executeQuery(String.format("SELECT %s FROM dummy", expr));
+        exprResult.next();
+        exprResult.getBoolean(1);
+        assertTrue("Test expression is false: " + expr, exprResult.getBoolean(1));
+      }
+    }
+
+    private static class CheckPTransform extends PTransform<PBegin, PDone> {
+
+      private final String expr;
+
+      private CheckPTransform(String expr) {
+        this.expr = expr;
+      }
+
+      @Override
+      public PDone expand(PBegin begin) {
+        PCollection<Boolean> result =
+            begin
+                .apply(Create.of(DUMMY_ROW).withCoder(RowCoder.of(DUMMY_SCHEMA)))
+                .apply(SqlTransform.query("SELECT " + expr))
+                .apply(MapElements.into(TypeDescriptors.booleans()).via(row -> row.getBoolean(0)));
+
+        PAssert.that(result)
+            .satisfies(
+                input -> {
+                  assertTrue("Test expression is false: " + expr, Iterables.getOnlyElement(input));
+                  return null;
+                });
+        return PDone.in(begin.getPipeline());
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a testing path for expressions via JDBC as well as testing that retrieving a TIMESTAMP works.

Currently, there is a failure that looks due to timezone confusion.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




