### PR TITLE
[BEAM-4707] Add timestamp field to Nexmark tables and use explicit mode in table name

### DIFF
--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -99,7 +99,7 @@ public class Main<OptionT extends NexmarkOptions> {
         }
       }
       if (options.getExportSummaryToBigQuery()) {
-        savePerfsToBigQuery(options, actual, null);
+        savePerfsToBigQuery(options, actual, null, start);
       }
     } finally {
       if (options.getMonitorJobs()) {
@@ -117,7 +117,8 @@ public class Main<OptionT extends NexmarkOptions> {
   static void savePerfsToBigQuery(
       NexmarkOptions options,
       Map<NexmarkConfiguration, NexmarkPerf> perfs,
-      @Nullable BigQueryServices testBigQueryServices) {
+      @Nullable BigQueryServices testBigQueryServices,
+      Instant start) {
     Pipeline pipeline = Pipeline.create(options);
     PCollection<KV<NexmarkConfiguration, NexmarkPerf>> perfsPCollection =
         pipeline.apply(
@@ -145,6 +146,7 @@ public class Main<OptionT extends NexmarkOptions> {
         new TableSchema()
             .setFields(
                 ImmutableList.of(
+                    new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"),
                     new TableFieldSchema().setName("runtimeSec").setType("FLOAT"),
                     new TableFieldSchema().setName("eventsPerSec").setType("FLOAT"),
                     new TableFieldSchema().setName("numResults").setType("INTEGER")));
@@ -162,6 +164,7 @@ public class Main<OptionT extends NexmarkOptions> {
           NexmarkPerf nexmarkPerf = input.getValue();
           TableRow row =
               new TableRow()
+                  .set("timestamp", start.getMillis())
                   .set("runtimeSec", nexmarkPerf.runtimeSec)
                   .set("eventsPerSec", nexmarkPerf.eventsPerSec)
                   .set("numResults", nexmarkPerf.numResults);

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkUtils.java
@@ -178,7 +178,7 @@ public class NexmarkUtils {
                 baseTableName,
                 queryName,
                 options.getRunner().getSimpleName(),
-                options.isStreaming(),
+                options.isStreaming() ? "streaming" : "batch",
                 version)
             : String.format(
                 "%s:%s.%s_%s_%s_%s",
@@ -187,7 +187,7 @@ public class NexmarkUtils {
                 baseTableName,
                 queryName,
                 options.getRunner().getSimpleName(),
-                options.isStreaming());
+                options.isStreaming() ? "streaming" : "batch");
     }
     throw new RuntimeException("Unrecognized enum " + options.getResourceNameMode());
   }

--- a/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
+++ b/sdks/java/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.FakeBigQueryServices;
 import org.apache.beam.sdk.io.gcp.bigquery.FakeDatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.FakeJobService;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -91,7 +92,8 @@ public class PerfsToBigQueryTest {
     HashMap<NexmarkConfiguration, NexmarkPerf> perfs = new HashMap<>(2);
     perfs.put(nexmarkConfiguration1, nexmarkPerf1);
     perfs.put(nexmarkConfiguration2, nexmarkPerf2);
-    Main.savePerfsToBigQuery(options, perfs, fakeBqServices);
+    Instant start = Instant.now();
+    Main.savePerfsToBigQuery(options, perfs, fakeBqServices, start);
 
     String tableSpec = NexmarkUtils.tableSpec(options, String.valueOf(QUERY), 0L, null);
     List<TableRow> actualRows =
@@ -103,6 +105,7 @@ public class PerfsToBigQueryTest {
     List<TableRow> expectedRows = new ArrayList<>();
     TableRow row1 =
         new TableRow()
+            .set("timestamp", start.getMillis())
             .set("runtimeSec", nexmarkPerf1.runtimeSec)
             .set("eventsPerSec", nexmarkPerf1.eventsPerSec)
             // when read using TableRowJsonCoder the row field is boxed into an Integer, cast it to int
@@ -111,6 +114,7 @@ public class PerfsToBigQueryTest {
     expectedRows.add(row1);
     TableRow row2 =
         new TableRow()
+            .set("timestamp", start.getMillis())
             .set("runtimeSec", nexmarkPerf2.runtimeSec)
             .set("eventsPerSec", nexmarkPerf2.eventsPerSec)
             // when read using TableRowJsonCoder the row field is boxed into an Integer, cast it to int


### PR DESCRIPTION
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




