### PR TITLE
[BEAM-1251] Replace NameError-driven dispatch with ``past``

### DIFF
--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -37,6 +37,9 @@ from __future__ import division
 from builtins import chr
 from builtins import object
 
+from past.builtins import long
+from past.builtins import unicode
+
 from apache_beam.coders import observable
 from apache_beam.utils import windowed_value
 from apache_beam.utils.timestamp import MAX_TIMESTAMP
@@ -60,13 +63,6 @@ except ImportError:
   from .slow_stream import ByteCountingOutputStream
   from .slow_stream import get_varint_size
 # pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
-
-try:                # Python 2
-  long              # pylint: disable=long-builtin
-  unicode           # pylint: disable=unicode-builtin
-except NameError:   # Python 3
-  long = int
-  unicode = str
 
 
 class CoderImpl(object):

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -24,20 +24,14 @@ from __future__ import absolute_import
 import base64
 from builtins import object
 
-import google.protobuf
-from google.protobuf import wrappers_pb2
+import google.protobuf.wrappers_pb2
+from future.moves import pickle
 
 from apache_beam.coders import coder_impl
 from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.utils import proto_utils
-
-# This is for py2/3 compatibility. cPickle was renamed pickle in python 3.
-try:
-  import cPickle as pickle # Python 2
-except ImportError:
-  import pickle # Python 3
 
 # pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
 try:
@@ -277,7 +271,7 @@ class Coder(object):
   def to_runner_api_parameter(self, context):
     return (
         python_urns.PICKLED_CODER,
-        wrappers_pb2.BytesValue(value=serialize_coder(self)),
+        google.protobuf.wrappers_pb2.BytesValue(value=serialize_coder(self)),
         ())
 
   @staticmethod

--- a/sdks/python/apache_beam/coders/typecoders.py
+++ b/sdks/python/apache_beam/coders/typecoders.py
@@ -67,13 +67,10 @@ from __future__ import absolute_import
 
 from builtins import object
 
+from past.builtins import unicode
+
 from apache_beam.coders import coders
 from apache_beam.typehints import typehints
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 __all__ = ['registry']
 

--- a/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
+++ b/sdks/python/apache_beam/examples/cookbook/datastore_wordcount.py
@@ -73,6 +73,7 @@ from google.cloud.proto.datastore.v1 import entity_pb2
 from google.cloud.proto.datastore.v1 import query_pb2
 from googledatastore import helper as datastore_helper
 from googledatastore import PropertyFilter
+from past.builtins import unicode
 
 import apache_beam as beam
 from apache_beam.io import ReadFromText
@@ -82,11 +83,6 @@ from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -36,6 +36,8 @@ import argparse
 from builtins import object
 from builtins import range
 
+from past.builtins import unicode
+
 import apache_beam as beam
 from apache_beam.io import iobase
 from apache_beam.io.range_trackers import OffsetRangeTracker
@@ -54,11 +56,6 @@ from apache_beam.transforms.core import PTransform
 # pylint:disable=reimported
 # pylint:disable=unused-variable
 # pylint:disable=wrong-import-order, wrong-import-position
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class SnippetUtils(object):

--- a/sdks/python/apache_beam/examples/streaming_wordcount.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount.py
@@ -23,17 +23,14 @@ from __future__ import absolute_import
 import argparse
 import logging
 
+from past.builtins import unicode
+
 import apache_beam as beam
 import apache_beam.transforms.window as window
 from apache_beam.examples.wordcount import WordExtractingDoFn
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 def run(argv=None):

--- a/sdks/python/apache_beam/examples/streaming_wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_debugging.py
@@ -38,6 +38,8 @@ import argparse
 import logging
 import re
 
+from past.builtins import unicode
+
 import apache_beam as beam
 import apache_beam.transforms.window as window
 from apache_beam.examples.wordcount import WordExtractingDoFn
@@ -47,11 +49,6 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to_per_window
 from apache_beam.transforms.core import ParDo
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class PrintFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/windowed_wordcount.py
+++ b/sdks/python/apache_beam/examples/windowed_wordcount.py
@@ -26,13 +26,10 @@ from __future__ import absolute_import
 import argparse
 import logging
 
+from past.builtins import unicode
+
 import apache_beam as beam
 import apache_beam.transforms.window as window
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 TABLE_SCHEMA = ('word:STRING, count:INTEGER, '
                 'window_start:TIMESTAMP, window_end:TIMESTAMP')

--- a/sdks/python/apache_beam/examples/wordcount.py
+++ b/sdks/python/apache_beam/examples/wordcount.py
@@ -23,6 +23,8 @@ import argparse
 import logging
 import re
 
+from past.builtins import unicode
+
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
@@ -30,11 +32,6 @@ from apache_beam.metrics import Metrics
 from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/wordcount_debugging.py
+++ b/sdks/python/apache_beam/examples/wordcount_debugging.py
@@ -45,6 +45,8 @@ import argparse
 import logging
 import re
 
+from past.builtins import unicode
+
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
@@ -53,11 +55,6 @@ from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class FilterTextFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/wordcount_fnapi.py
+++ b/sdks/python/apache_beam/examples/wordcount_fnapi.py
@@ -28,6 +28,8 @@ import argparse
 import logging
 import re
 
+from past.builtins import unicode
+
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 # TODO(BEAM-2887): Enable after the issue is fixed.
@@ -37,11 +39,6 @@ from apache_beam.metrics.metric import MetricsFilter
 from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class WordExtractingDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/examples/wordcount_minimal.py
+++ b/sdks/python/apache_beam/examples/wordcount_minimal.py
@@ -50,16 +50,13 @@ import argparse
 import logging
 import re
 
+from past.builtins import unicode
+
 import apache_beam as beam
 from apache_beam.io import ReadFromText
 from apache_beam.io import WriteToText
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import SetupOptions
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 def run(argv=None):

--- a/sdks/python/apache_beam/internal/gcp/json_value.py
+++ b/sdks/python/apache_beam/internal/gcp/json_value.py
@@ -19,6 +19,9 @@
 
 from __future__ import absolute_import
 
+from past.builtins import long
+from past.builtins import unicode
+
 from apache_beam.options.value_provider import ValueProvider
 
 # Protect against environments where apitools library is not available.
@@ -29,12 +32,6 @@ except ImportError:
   extra_types = None
 # pylint: enable=wrong-import-order, wrong-import-position
 
-try:              # Python 2
-  unicode         # pylint: disable=unicode-builtin
-  long            # pylint: disable=long-builtin
-except NameError: # Python 3
-  unicode = str
-  long = int
 
 _MAXINT64 = (1 << 63) - 1
 _MININT64 = - (1 << 63)

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -28,6 +28,7 @@ from builtins import range
 from builtins import zip
 
 from future.utils import iteritems
+from past.builtins import unicode
 
 from apache_beam.internal import util
 from apache_beam.io import iobase
@@ -42,11 +43,6 @@ from apache_beam.transforms.display import DisplayDataItem
 DEFAULT_SHARD_NAME_TEMPLATE = '-SSSSS-of-NNNNN'
 
 __all__ = ['FileBasedSink']
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 
 class FileBasedSink(iobase.Sink):

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -39,6 +39,8 @@ from builtins import zip
 
 from future import standard_library
 from future.utils import with_metaclass
+from past.builtins import long
+from past.builtins import unicode
 
 from apache_beam.utils.plugin import BeamPlugin
 
@@ -50,13 +52,6 @@ DEFAULT_READ_BUFFER_SIZE = 16 * 1024 * 1024
 
 __all__ = ['CompressionTypes', 'CompressedFile', 'FileMetadata', 'FileSystem',
            'MatchResult']
-
-try:
-  unicode       # pylint: disable=unicode-builtin
-  long          # pylint: disable=long-builtin
-except NameError:
-  unicode = str
-  long = int
 
 
 class CompressionTypes(object):

--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 import re
 from builtins import object
 
+from past.builtins import unicode
+
 from apache_beam.io.filesystem import BeamIOError
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileSystem
@@ -48,10 +50,6 @@ try:
 except ImportError:
   pass
 
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 # pylint: enable=wrong-import-position, unused-import
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -124,6 +124,7 @@ from builtins import zip
 
 from future.utils import iteritems
 from future.utils import itervalues
+from past.builtins import unicode
 
 from apache_beam import coders
 from apache_beam.internal.gcp import auth
@@ -146,10 +147,6 @@ except ImportError:
   pass
 # pylint: enable=wrong-import-order, wrong-import-position
 
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 __all__ = [
     'TableRowJsonCoder',

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -24,15 +24,12 @@ import logging
 import math
 import threading
 
+from past.builtins import long
+
 from apache_beam.io import iobase
 
 __all__ = ['OffsetRangeTracker', 'LexicographicKeyRangeTracker',
            'OrderedPositionRangeTracker', 'UnsplittableRangeTracker']
-
-try:
-  long  # pylint: disable=long-builtin
-except NameError:
-  long = int
 
 
 class OffsetRangeTracker(iobase.RangeTracker):

--- a/sdks/python/apache_beam/io/range_trackers_test.py
+++ b/sdks/python/apache_beam/io/range_trackers_test.py
@@ -24,12 +24,9 @@ import logging
 import math
 import unittest
 
-from apache_beam.io import range_trackers
+from past.builtins import long
 
-try:
-  long  # pylint: disable=long-builtin
-except NameError:
-  long = int
+from apache_beam.io import range_trackers
 
 
 class OffsetRangeTrackerTest(unittest.TestCase):

--- a/sdks/python/apache_beam/io/vcfio.py
+++ b/sdks/python/apache_beam/io/vcfio.py
@@ -29,6 +29,7 @@ from builtins import object
 from collections import namedtuple
 
 from future.utils import iteritems
+from past.builtins import unicode
 
 import vcf
 
@@ -38,13 +39,6 @@ from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.iobase import Read
 from apache_beam.io.textio import _TextSource as TextSource
 from apache_beam.transforms import PTransform
-
-try:
-  unicode  # pylint: disable=unicode-builtin
-  int        # Python 2
-except NameError:
-  unicode = str
-  long = int  # Python 3
 
 
 __all__ = ['ReadFromVcf', 'Variant', 'VariantCall', 'VariantInfo',

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -31,17 +31,14 @@ import itertools
 from builtins import hex
 from builtins import object
 
+from past.builtins import unicode
+
 from apache_beam import coders
 from apache_beam import typehints
 from apache_beam.internal import pickler
 from apache_beam.portability import common_urns
 from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
-
-try:
-  unicode           # pylint: disable=unicode-builtin
-except NameError:
-  unicode = str
 
 __all__ = [
     'PCollection',

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 import operator
 import random
 
+from past.builtins import long
+
 from apache_beam.transforms import core
 from apache_beam.transforms import cy_combiners
 from apache_beam.transforms import ptransform
@@ -35,11 +37,6 @@ from apache_beam.typehints import TypeVariable
 from apache_beam.typehints import Union
 from apache_beam.typehints import with_input_types
 from apache_beam.typehints import with_output_types
-
-try:
-  long        # Python 2
-except NameError:
-  long = int  # Python 3
 
 __all__ = [
     'Count',

--- a/sdks/python/apache_beam/typehints/opcodes.py
+++ b/sdks/python/apache_beam/typehints/opcodes.py
@@ -33,6 +33,8 @@ import sys
 import types
 from functools import reduce
 
+from past.builtins import unicode
+
 from . import typehints
 from .trivial_inference import BoundMethod
 from .trivial_inference import Const
@@ -44,11 +46,6 @@ from .typehints import Iterable
 from .typehints import List
 from .typehints import Tuple
 from .typehints import Union
-
-try:                # Python 2
-  unicode           # pylint: disable=unicode-builtin
-except NameError:   # Python 3
-  unicode = str
 
 
 def pop_one(state, unused_arg):

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -27,6 +27,7 @@ import inspect
 import types
 
 from future.utils import raise_with_traceback
+from past.builtins import unicode
 
 from apache_beam import pipeline
 from apache_beam.pvalue import TaggedOutput
@@ -40,11 +41,6 @@ from apache_beam.typehints.decorators import getcallargs_forhints
 from apache_beam.typehints.typehints import CompositeTypeHintError
 from apache_beam.typehints.typehints import SimpleTypeHintError
 from apache_beam.typehints.typehints import check_constraint
-
-try:                # Python 2
-  unicode           # pylint: disable=unicode-builtin
-except NameError:   # Python 3
-  unicode = str
 
 
 class AbstractDoFnWrapper(DoFn):

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -29,11 +29,7 @@ import re
 from builtins import object
 
 import pytz
-
-try:                # Python 2
-  long              # pylint: disable=long-builtin
-except NameError:   # Python 3
-  long = int
+from past.builtins import long
 
 
 @functools.total_ordering


### PR DESCRIPTION
The only leftover is the ``ToStringCoder`` which uses ``NameError`` to detect Python2/3. The logic there looks fishy (it encodes text data on 2.X but not on 3.X), so I'd rather address it in a follow up PR.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




