### PR TITLE
Fix import order for Python isort test

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -51,8 +51,6 @@ import avro
 from avro import io as avroio
 from avro import datafile
 from avro import schema
-from fastavro.read import block_reader
-from fastavro.write import Writer
 
 import apache_beam as beam
 from apache_beam.io import filebasedsink
@@ -61,6 +59,8 @@ from apache_beam.io import iobase
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.iobase import Read
 from apache_beam.transforms import PTransform
+from fastavro.read import block_reader
+from fastavro.write import Writer
 
 __all__ = ['ReadFromAvro', 'ReadAllFromAvro', 'WriteToAvro']
 


### PR DESCRIPTION
This change fixes the Python isort test, which previously failed with this error (caused by https://github.com/apache/beam/pull/5496):

```
Running isort for module apache_beam  gen_protos.py  setup.py  test_config.py:
ERROR: /home/git/beam/sdks/python/apache_beam/io/avroio.py Imports are incorrectly sorted.
--- /home/git/beam/sdks/python/apache_beam/io/avroio.py:before	2018-07-02 12:57:38.472207
+++ /home/git/beam/sdks/python/apache_beam/io/avroio.py:after	2018-07-02 16:20:40.310009
@@ -51,8 +51,6 @@
 from avro import io as avroio
 from avro import datafile
 from avro import schema
-from fastavro.read import block_reader
-from fastavro.write import Writer
 
 import apache_beam as beam
 from apache_beam.io import filebasedsink
@@ -61,6 +59,8 @@
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.iobase import Read
 from apache_beam.transforms import PTransform
+from fastavro.read import block_reader
+from fastavro.write import Writer
 
 __all__ = ['ReadFromAvro', 'ReadAllFromAvro', 'WriteToAvro']
 
Command exited with non-zero status 1
```