### PR TITLE
[BEAM-4723] Support all datetime types plus interval

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
@@ -132,7 +132,6 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
       case VARCHAR:
         return value instanceof String || value instanceof NlsString;
       case TIME:
-        return value instanceof ReadableInstant;
       case TIMESTAMP:
       case DATE:
         return value instanceof ReadableInstant;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
@@ -58,7 +58,7 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
   @Override
   public boolean accept() {
     return operands.size() == 2
-        && SqlTypeName.TIMESTAMP.equals(operands.get(0).getOutputType())
+        && SqlTypeName.DATETIME_TYPES.contains(operands.get(0).getOutputType())
         && SUPPORTED_INTERVAL_TYPES.contains(operands.get(1).getOutputType());
   }
 
@@ -103,12 +103,13 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
   private DateTime getTimestampOperand(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
     BeamSqlPrimitive timestampOperandPrimitive =
-        findExpressionOfType(operands, SqlTypeName.TIMESTAMP).get().evaluate(inputRow, window, env);
+        findExpressionOfType(operands, SqlTypeName.DATETIME_TYPES)
+            .get()
+            .evaluate(inputRow, window, env);
     return new DateTime(timestampOperandPrimitive.getDate());
   }
 
   private DateTime addInterval(DateTime dateTime, SqlTypeName intervalType, int numberOfIntervals) {
-
     switch (intervalType) {
       case INTERVAL_SECOND:
         return dateTime.plusSeconds(numberOfIntervals);

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateExpressionTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDateExpressionTestBase.java
@@ -29,4 +29,9 @@ public class BeamSqlDateExpressionTestBase extends BeamSqlFnExecutorTestBase {
     DateTimeFormatter format = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss").withZoneUTC();
     return format.parseDateTime(dateStr);
   }
+
+  static DateTime str2Date(String dateStr) {
+    DateTimeFormatter format = DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC();
+    return format.parseDateTime(dateStr);
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpressionTest.java
@@ -43,7 +43,15 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
 
   private static final Row NULL_INPUT_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
-  private static final DateTime DATE = str2DateTime("1984-04-19 01:02:03");
+  private static final DateTime DATETIME = str2DateTime("1984-04-19 01:02:03");
+  private static final DateTime DATE = str2Date("2018-07-01");
+
+  private static final DateTime DATETIME_PLUS_15_SECONDS = DATETIME.plusSeconds(15);
+  private static final DateTime DATETIME_PLUS_10_MINUTES = DATETIME.plusMinutes(10);
+  private static final DateTime DATETIME_PLUS_7_HOURS = DATETIME.plusHours(7);
+  private static final DateTime DATETIME_PLUS_3_DAYS = DATETIME.plusDays(3);
+  private static final DateTime DATETIME_PLUS_2_MONTHS = DATETIME.plusMonths(2);
+  private static final DateTime DATETIME_PLUS_11_YEARS = DATETIME.plusYears(11);
 
   private static final DateTime DATE_PLUS_15_SECONDS = DATE.plusSeconds(15);
   private static final DateTime DATE_PLUS_10_MINUTES = DATE.plusMinutes(10);
@@ -68,11 +76,21 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
       interval(SqlTypeName.INTERVAL_YEAR, 11);
 
   private static final BeamSqlExpression SQL_TIMESTAMP =
-      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
+      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATETIME);
+
+  private static final BeamSqlExpression SQL_DATE = BeamSqlPrimitive.of(SqlTypeName.DATE, DATE);
 
   @Test
   public void testHappyPath_outputTypeAndAccept() {
     BeamSqlExpression plusExpression = dateTimePlus(SQL_TIMESTAMP, SQL_INTERVAL_3_DAYS);
+
+    assertEquals(SqlTypeName.TIMESTAMP, plusExpression.getOutputType());
+    assertTrue(plusExpression.accept());
+  }
+
+  @Test
+  public void testDateAndInterval_outputTypeAndAccept() {
+    BeamSqlExpression plusExpression = dateTimePlus(SQL_DATE, SQL_INTERVAL_3_DAYS);
 
     assertEquals(SqlTypeName.TIMESTAMP, plusExpression.getOutputType());
     assertTrue(plusExpression.accept());
@@ -106,12 +124,21 @@ public class BeamSqlDatetimePlusExpressionTest extends BeamSqlDateExpressionTest
 
   @Test
   public void testEvaluate() {
-    assertEquals(DATE_PLUS_15_SECONDS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_15_SECONDS));
-    assertEquals(DATE_PLUS_10_MINUTES, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_10_MINUTES));
-    assertEquals(DATE_PLUS_7_HOURS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_7_HOURS));
-    assertEquals(DATE_PLUS_3_DAYS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_3_DAYS));
-    assertEquals(DATE_PLUS_2_MONTHS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_2_MONTHS));
-    assertEquals(DATE_PLUS_11_YEARS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_11_YEARS));
+    assertEquals(
+        DATETIME_PLUS_15_SECONDS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_15_SECONDS));
+    assertEquals(
+        DATETIME_PLUS_10_MINUTES, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_10_MINUTES));
+    assertEquals(DATETIME_PLUS_7_HOURS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_7_HOURS));
+    assertEquals(DATETIME_PLUS_3_DAYS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_3_DAYS));
+    assertEquals(DATETIME_PLUS_2_MONTHS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_2_MONTHS));
+    assertEquals(DATETIME_PLUS_11_YEARS, evalDatetimePlus(SQL_TIMESTAMP, SQL_INTERVAL_11_YEARS));
+
+    assertEquals(DATE_PLUS_15_SECONDS, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_15_SECONDS));
+    assertEquals(DATE_PLUS_10_MINUTES, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_10_MINUTES));
+    assertEquals(DATE_PLUS_7_HOURS, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_7_HOURS));
+    assertEquals(DATE_PLUS_3_DAYS, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_3_DAYS));
+    assertEquals(DATE_PLUS_2_MONTHS, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_2_MONTHS));
+    assertEquals(DATE_PLUS_11_YEARS, evalDatetimePlus(SQL_DATE, SQL_INTERVAL_11_YEARS));
   }
 
   @Test


### PR DESCRIPTION
DatetimePlusExpression should accept all datetime types as its first operand.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




