### PR TITLE
[BEAM-4726] Add a simple benchmark to the ParDo execution node.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
@@ -109,3 +109,39 @@ func (n *FixedRoot) FinishBundle(ctx context.Context) error {
 func (n *FixedRoot) Down(ctx context.Context) error {
 	return nil
 }
+
+// BenchRoot is a test Root that emits elements through a channel for benchmarking purposes.
+type BenchRoot struct {
+	UID      UnitID
+	Elements <-chan MainInput
+	Out      Node
+}
+
+func (n *BenchRoot) ID() UnitID {
+	return n.UID
+}
+
+func (n *BenchRoot) Up(ctx context.Context) error {
+	return nil
+}
+
+func (n *BenchRoot) StartBundle(ctx context.Context, id string, data DataManager) error {
+	return n.Out.StartBundle(ctx, id, data)
+}
+
+func (n *BenchRoot) Process(ctx context.Context) error {
+	for elm := range n.Elements {
+		if err := n.Out.ProcessElement(ctx, elm.Key, elm.Values...); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (n *BenchRoot) FinishBundle(ctx context.Context) error {
+	return n.Out.FinishBundle(ctx)
+}
+
+func (n *BenchRoot) Down(ctx context.Context) error {
+	return nil
+}


### PR DESCRIPTION
Adding a benchmark to get a baseline on ParDo overhead.
Adds a new root construct to accommodate perfered Go Benchmarking style, and allow the testing package to handle benchmark termination appropriately.

$ go test -bench=BenchmarkParDo -benchmem github.com/apache/beam/sdks/go/pkg/beam/core/runtime/exec

On my desktop, this benchmark currently returns in the neighbourhood of
BenchmarkParDo_EmitSumFn-12    	 1000000	      1606 ns/op	     585 B/op	       7 allocs/op


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




