### PR TITLE
[BEAM-4726] Cache fixed per function Invoke values

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/fn.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn.go
@@ -40,29 +40,83 @@ func Invoke(ctx context.Context, ws []typex.Window, ts typex.EventTime, fn *func
 	if fn == nil {
 		return nil, nil // ok: nothing to Invoke
 	}
+	inv := newInvoker(fn)
+	return inv.Invoke(ctx, ws, ts, opt, extra...)
+}
 
-	// (1) Populate contexts
+// InvokeWithoutEventTime runs the given function at time 0 in the global window.
+func InvokeWithoutEventTime(ctx context.Context, fn *funcx.Fn, opt *MainInput, extra ...interface{}) (*FullValue, error) {
+	return Invoke(ctx, window.SingleGlobalWindow, mtime.ZeroTimestamp, fn, opt, extra...)
+}
 
-	args := make([]interface{}, len(fn.Param))
+// invoker is a container struct for hot path invocations of DoFns, to avoid
+// repeating fixed set up per element.
+type invoker struct {
+	fn   *funcx.Fn
+	args []interface{}
+	// TODO(lostluck):  2018/07/06 consider replacing with a slice of functions to run over the args slice, as an improvement.
+	ctxIdx, wndIdx, etIdx int   // specialized input indexes
+	outEtIdx, errIdx      int   // specialized output indexes
+	in, out               []int // general indexes
+}
 
-	if index, ok := fn.Context(); ok {
-		args[index] = ctx
+func newInvoker(fn *funcx.Fn) *invoker {
+	n := &invoker{
+		fn:   fn,
+		args: make([]interface{}, len(fn.Param)),
+		in:   fn.Params(funcx.FnValue | funcx.FnIter | funcx.FnReIter | funcx.FnEmit),
+		out:  fn.Returns(funcx.RetValue),
 	}
-	if index, ok := fn.Window(); ok {
+	var ok bool
+	if n.ctxIdx, ok = fn.Context(); !ok {
+		n.ctxIdx = -1
+	}
+	if n.wndIdx, ok = fn.Window(); !ok {
+		n.wndIdx = -1
+	}
+	if n.etIdx, ok = fn.EventTime(); !ok {
+		n.etIdx = -1
+	}
+	if n.outEtIdx, ok = fn.OutEventTime(); !ok {
+		n.outEtIdx = -1
+	}
+	if n.errIdx, ok = fn.Error(); !ok {
+		n.errIdx = -1
+	}
+	return n
+}
+
+// Reset zeroes argument entries in the cached slice to allow values to be garbage collected after the bundle ends.
+func (n *invoker) Reset() {
+	for i := range n.args {
+		n.args[i] = nil
+	}
+}
+
+// Invoke invokes the fn with the given values. The extra values must match the non-main
+// side input and emitters. It returns the direct output, if any.
+func (n *invoker) Invoke(ctx context.Context, ws []typex.Window, ts typex.EventTime, opt *MainInput, extra ...interface{}) (*FullValue, error) {
+	// (1) Populate contexts
+	// extract these to make things easier to read.
+	args := n.args
+	fn := n.fn
+	in := n.in
+
+	if n.ctxIdx >= 0 {
+		args[n.ctxIdx] = ctx
+	}
+	if n.wndIdx >= 0 {
 		if len(ws) != 1 {
 			return nil, fmt.Errorf("DoFns that observe windows must be invoked with single window: %v", opt.Key.Windows)
 		}
-		args[index] = ws[0]
+		args[n.wndIdx] = ws[0]
 	}
-	if index, ok := fn.EventTime(); ok {
-		args[index] = ts
+	if n.etIdx >= 0 {
+		args[n.etIdx] = ts
 	}
 
 	// (2) Main input from value, if any.
-
-	in := fn.Params(funcx.FnValue | funcx.FnIter | funcx.FnReIter | funcx.FnEmit)
 	i := 0
-
 	if opt != nil {
 		args[in[i]] = Convert(opt.Key.Elm, fn.Param[in[i]].T)
 		i++
@@ -88,30 +142,30 @@ func Invoke(ctx context.Context, ws []typex.Window, ts typex.EventTime, fn *func
 	}
 
 	// (3) Precomputed side input and emitters (or other output).
-
+	// TODO(lostluck): 2018/07/10 extras (emitters and side inputs), are constant so we could
+	// initialize them once at construction time, and not clear them in Reset.
 	for _, arg := range extra {
 		args[in[i]] = arg
 		i++
 	}
 
 	// (4) Invoke
-
 	ret, err := reflectx.CallNoPanic(fn.Fn, args)
 	if err != nil {
 		return nil, err
 	}
-	if index, ok := fn.Error(); ok && ret[index] != nil {
-		return nil, ret[index].(error)
+	if n.errIdx >= 0 && ret[n.errIdx] != nil {
+		return nil, ret[n.errIdx].(error)
 	}
 
 	// (5) Return direct output, if any. Input timestamp and windows are implicitly
 	// propagated.
 
-	out := fn.Returns(funcx.RetValue)
+	out := n.out
 	if len(out) > 0 {
 		value := &FullValue{Windows: ws, Timestamp: ts}
-		if index, ok := fn.OutEventTime(); ok {
-			value.Timestamp = ret[index].(typex.EventTime)
+		if n.outEtIdx >= 0 {
+			value.Timestamp = ret[n.outEtIdx].(typex.EventTime)
 		}
 		// TODO(herohde) 4/16/2018: apply windowing function to elements with explicit timestamp?
 
@@ -123,10 +177,6 @@ func Invoke(ctx context.Context, ws []typex.Window, ts typex.EventTime, fn *func
 	}
 
 	return nil, nil
-}
-
-func InvokeWithoutEventTime(ctx context.Context, fn *funcx.Fn, opt *MainInput, extra ...interface{}) (*FullValue, error) {
-	return Invoke(ctx, window.SingleGlobalWindow, mtime.ZeroTimestamp, fn, opt, extra...)
 }
 
 func makeSideInputs(fn *funcx.Fn, in []*graph.Inbound, side []ReStream) ([]ReusableInput, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
@@ -150,6 +150,7 @@ func BenchmarkDirectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = inc(n)
 	}
+	b.Log(n)
 }
 
 func BenchmarkIndirectCall(b *testing.B) {
@@ -162,6 +163,7 @@ func BenchmarkIndirectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn(n)
 	}
+	b.Log(n)
 }
 
 func BenchmarkReflectedAndBackCall(b *testing.B) {
@@ -170,6 +172,7 @@ func BenchmarkReflectedAndBackCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn(n)
 	}
+	b.Log(n)
 }
 
 func BenchmarkReflectCall(b *testing.B) {
@@ -178,6 +181,7 @@ func BenchmarkReflectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
+	b.Log(n)
 }
 
 func BenchmarkReflectCallNewArgs(b *testing.B) {
@@ -188,6 +192,7 @@ func BenchmarkReflectCallNewArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
+	b.Log(n)
 }
 
 func BenchmarkReflectCallReuseArgs(b *testing.B) {
@@ -198,6 +203,7 @@ func BenchmarkReflectCallReuseArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
+	b.Log(n)
 }
 
 func BenchmarkInvokeCall(b *testing.B) {
@@ -208,6 +214,7 @@ func BenchmarkInvokeCall(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, &MainInput{Key: FullValue{Elm: n}})
 		n = ret.Elm.(int)
 	}
+	b.Log(n)
 }
 
 func BenchmarkInvokeCallExtra(b *testing.B) {
@@ -218,6 +225,7 @@ func BenchmarkInvokeCallExtra(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, nil, n)
 		n = ret.Elm.(int)
 	}
+	b.Log(n)
 }
 
 // The below take the additional overhead of MakeFunc.
@@ -232,6 +240,7 @@ func BenchmarkReflectFnCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
+	b.Log(n)
 }
 
 func BenchmarkInvokeFnCall(b *testing.B) {
@@ -242,6 +251,7 @@ func BenchmarkInvokeFnCall(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, &MainInput{Key: FullValue{Elm: n}})
 		n = ret.Elm.(int)
 	}
+	b.Log(n)
 }
 
 func BenchmarkInvokeFnCallExtra(b *testing.B) {
@@ -252,4 +262,5 @@ func BenchmarkInvokeFnCallExtra(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, nil, n)
 		n = ret.Elm.(int)
 	}
+	b.Log(n)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
@@ -181,7 +181,7 @@ func BenchmarkReflectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
-	b.Log(n)
+	b.Log(n.Interface())
 }
 
 func BenchmarkReflectCallNewArgs(b *testing.B) {
@@ -192,7 +192,7 @@ func BenchmarkReflectCallNewArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
-	b.Log(n)
+	b.Log(n.Interface())
 }
 
 func BenchmarkReflectCallReuseArgs(b *testing.B) {
@@ -203,7 +203,7 @@ func BenchmarkReflectCallReuseArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
-	b.Log(n)
+	b.Log(n.Interface())
 }
 
 func BenchmarkInvokeCall(b *testing.B) {
@@ -240,7 +240,7 @@ func BenchmarkReflectFnCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
-	b.Log(n)
+	b.Log(n.Interface())
 }
 
 func BenchmarkInvokeFnCall(b *testing.B) {

--- a/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
@@ -150,7 +150,6 @@ func BenchmarkDirectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = inc(n)
 	}
-	b.Log(n)
 }
 
 func BenchmarkIndirectCall(b *testing.B) {
@@ -163,7 +162,6 @@ func BenchmarkIndirectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn(n)
 	}
-	b.Log(n)
 }
 
 func BenchmarkReflectedAndBackCall(b *testing.B) {
@@ -172,7 +170,6 @@ func BenchmarkReflectedAndBackCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn(n)
 	}
-	b.Log(n)
 }
 
 func BenchmarkReflectCall(b *testing.B) {
@@ -181,7 +178,6 @@ func BenchmarkReflectCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
-	b.Log(n.Interface())
 }
 
 func BenchmarkReflectCallNewArgs(b *testing.B) {
@@ -192,7 +188,6 @@ func BenchmarkReflectCallNewArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
-	b.Log(n.Interface())
 }
 
 func BenchmarkReflectCallReuseArgs(b *testing.B) {
@@ -203,7 +198,6 @@ func BenchmarkReflectCallReuseArgs(b *testing.B) {
 		args[0] = n
 		n = fn.Call(args)[0]
 	}
-	b.Log(n.Interface())
 }
 
 func BenchmarkInvokeCall(b *testing.B) {
@@ -214,7 +208,6 @@ func BenchmarkInvokeCall(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, &MainInput{Key: FullValue{Elm: n}})
 		n = ret.Elm.(int)
 	}
-	b.Log(n)
 }
 
 func BenchmarkInvokeCallExtra(b *testing.B) {
@@ -225,7 +218,6 @@ func BenchmarkInvokeCallExtra(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, nil, n)
 		n = ret.Elm.(int)
 	}
-	b.Log(n)
 }
 
 // The below take the additional overhead of MakeFunc.
@@ -240,7 +232,6 @@ func BenchmarkReflectFnCall(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		n = fn.Call([]reflect.Value{n})[0]
 	}
-	b.Log(n.Interface())
 }
 
 func BenchmarkInvokeFnCall(b *testing.B) {
@@ -251,7 +242,6 @@ func BenchmarkInvokeFnCall(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, &MainInput{Key: FullValue{Elm: n}})
 		n = ret.Elm.(int)
 	}
-	b.Log(n)
 }
 
 func BenchmarkInvokeFnCallExtra(b *testing.B) {
@@ -262,5 +252,4 @@ func BenchmarkInvokeFnCallExtra(b *testing.B) {
 		ret, _ := InvokeWithoutEventTime(ctx, fn, nil, n)
 		n = ret.Elm.(int)
 	}
-	b.Log(n)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo.go
@@ -45,6 +45,8 @@ type ParDo struct {
 
 	status Status
 	err    errorx.GuardedError
+
+	inv *invoker
 }
 
 func (n *ParDo) ID() UnitID {
@@ -56,6 +58,7 @@ func (n *ParDo) Up(ctx context.Context) error {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Initializing", n.UID, n.status)
 	}
 	n.status = Up
+	n.inv = newInvoker(n.Fn.ProcessElementFn())
 
 	if _, err := InvokeWithoutEventTime(ctx, n.Fn.SetupFn(), nil); err != nil {
 		return n.fail(err)
@@ -96,13 +99,12 @@ func (n *ParDo) ProcessElement(ctx context.Context, elm FullValue, values ...ReS
 	}
 
 	ctx = metrics.SetPTransformID(ctx, n.PID)
-	fn := n.Fn.ProcessElementFn()
 
 	// If the function observes windows, we must invoke it for each window. The expected fast path
 	// is that either there is a single window or the function doesn't observes windows.
 
-	if !mustExplodeWindows(fn, elm) {
-		val, err := n.invokeDataFn(ctx, elm.Windows, elm.Timestamp, fn, &MainInput{Key: elm, Values: values})
+	if !mustExplodeWindows(n.inv.fn, elm) {
+		val, err := n.invokeProcessFn(ctx, elm.Windows, elm.Timestamp, &MainInput{Key: elm, Values: values})
 		if err != nil {
 			return n.fail(err)
 		}
@@ -115,7 +117,7 @@ func (n *ParDo) ProcessElement(ctx context.Context, elm FullValue, values ...ReS
 		for _, w := range elm.Windows {
 			wElm := FullValue{Elm: elm.Elm, Elm2: elm.Elm2, Timestamp: elm.Timestamp, Windows: []typex.Window{w}}
 
-			val, err := n.invokeDataFn(ctx, wElm.Windows, wElm.Timestamp, fn, &MainInput{Key: wElm, Values: values})
+			val, err := n.invokeProcessFn(ctx, wElm.Windows, wElm.Timestamp, &MainInput{Key: wElm, Values: values})
 			if err != nil {
 				return n.fail(err)
 			}
@@ -144,6 +146,7 @@ func (n *ParDo) FinishBundle(ctx context.Context) error {
 		return fmt.Errorf("invalid status for pardo %v: %v, want Active", n.UID, n.status)
 	}
 	n.status = Up
+	n.inv.Reset()
 
 	if _, err := n.invokeDataFn(ctx, window.SingleGlobalWindow, mtime.ZeroTimestamp, n.Fn.FinishBundleFn(), nil); err != nil {
 		return n.fail(err)
@@ -193,6 +196,7 @@ func (n *ParDo) initIfNeeded() error {
 	return err
 }
 
+// invokeDataFn handle non-per element invocations.
 func (n *ParDo) invokeDataFn(ctx context.Context, ws []typex.Window, ts typex.EventTime, fn *funcx.Fn, opt *MainInput) (*FullValue, error) {
 	if fn == nil {
 		return nil, nil
@@ -209,6 +213,27 @@ func (n *ParDo) invokeDataFn(ctx context.Context, ws []typex.Window, ts typex.Ev
 		}
 	}
 	val, err := Invoke(ctx, ws, ts, fn, opt, n.extra...)
+	for _, s := range n.sideinput {
+		if err := s.Reset(); err != nil {
+			return nil, err
+		}
+	}
+	return val, err
+}
+
+// invokeProcessFn handles the per element invocations
+func (n *ParDo) invokeProcessFn(ctx context.Context, ws []typex.Window, ts typex.EventTime, opt *MainInput) (*FullValue, error) {
+	for _, e := range n.emitters {
+		if err := e.Init(ctx, ws, ts); err != nil {
+			return nil, err
+		}
+	}
+	for _, s := range n.sideinput {
+		if err := s.Init(); err != nil {
+			return nil, err
+		}
+	}
+	val, err := n.inv.Invoke(ctx, ws, ts, opt, n.extra...)
 	for _, s := range n.sideinput {
 		if err := s.Reset(); err != nil {
 			return nil, err

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
@@ -104,7 +104,7 @@ func emitSumFn(n int, emit func(int)) {
 // BenchmarkParDo_EmitSumFn measures the overhead of invoking a ParDo in a plan.
 //
 // On @lostluck's desktop:
-// BenchmarkParDo_EmitSumFn-12    	 1000000	      1606 ns/op	     585 B/op	       7 allocs/op
+// BenchmarkParDo_EmitSumFn-12    	 1000000	      1202 ns/op	     529 B/op	       4 allocs/op
 func BenchmarkParDo_EmitSumFn(b *testing.B) {
 	fn, err := graph.NewDoFn(emitSumFn)
 	if err != nil {


### PR DESCRIPTION
Reduce recomputing and reallocating for ProcessElement functions in ParDos.
There's likely more opportunity here, but this is significant enough on it's own.

Before:
BenchmarkParDo_EmitSumFn-12 1000000	1606 ns/op	585 B/op	7 allocs/op
After:
BenchmarkParDo_EmitSumFn-12 1000000	 1202 ns/op	 529 B/op	  4 allocs/op


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




