### PR TITLE
[BEAM-4654] Treat timers as PCollections within proto representation in the Java SDK.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -23,9 +23,13 @@ import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,10 +40,12 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.SplittableParDoComponents;
+import org.apache.beam.runners.core.construction.ParDoTranslation.ParDoTranslator;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.util.common.ReflectHelpers.ObjectsClassComparator;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
@@ -47,8 +53,8 @@ import org.apache.beam.sdk.values.PValue;
 import org.apache.beam.sdk.values.TupleTag;
 
 /**
- * Utilities for converting {@link PTransform PTransforms} to and from {@link RunnerApi Runner API
- * protocol buffers}.
+ * Utilities for converting {@link PTransform PTransforms} to {@link RunnerApi Runner API protocol
+ * buffers}.
  */
 public class PTransformTranslation {
 
@@ -87,31 +93,16 @@ public class PTransformTranslation {
   public static final String MULTIMAP_SIDE_INPUT =
       getUrn(RunnerApi.StandardSideInputTypes.Enum.MULTIMAP);
 
-  private static final Map<Class<? extends PTransform>, TransformPayloadTranslator>
-      KNOWN_PAYLOAD_TRANSLATORS = loadTransformPayloadTranslators();
+  private static final Collection<TransformTranslator<?>> KNOWN_TRANSLATORS =
+      loadKnownTranslators();
 
-  private static Map<Class<? extends PTransform>, TransformPayloadTranslator>
-      loadTransformPayloadTranslators() {
-    HashMap<Class<? extends PTransform>, TransformPayloadTranslator> translators = new HashMap<>();
-
-    for (TransformPayloadTranslatorRegistrar registrar :
-        ServiceLoader.load(TransformPayloadTranslatorRegistrar.class)) {
-
-      Map<Class<? extends PTransform>, TransformPayloadTranslator> newTranslators =
-          (Map) registrar.getTransformPayloadTranslators();
-
-      Set<Class<? extends PTransform>> alreadyRegistered =
-          Sets.intersection(translators.keySet(), newTranslators.keySet());
-
-      if (!alreadyRegistered.isEmpty()) {
-        throw new IllegalArgumentException(
-            String.format(
-                "Classes already registered: %s", Joiner.on(", ").join(alreadyRegistered)));
-      }
-
-      translators.putAll(newTranslators);
-    }
-    return ImmutableMap.copyOf(translators);
+  private static Collection<TransformTranslator<?>> loadKnownTranslators() {
+    return ImmutableSortedSet.<TransformTranslator<?>>orderedBy(
+            (Comparator) ObjectsClassComparator.INSTANCE)
+        .add(new RawPTransformTranslator())
+        .add(new KnownTransformPayloadTranslator())
+        .add(ParDoTranslator.create())
+        .build();
   }
 
   private PTransformTranslation() {}
@@ -126,7 +117,224 @@ public class PTransformTranslation {
       List<AppliedPTransform<?, ?, ?>> subtransforms,
       SdkComponents components)
       throws IOException {
-    // TODO include DisplayData https://issues.apache.org/jira/browse/BEAM-2645
+
+    TransformTranslator<?> transformTranslator =
+        Iterables.find(
+            KNOWN_TRANSLATORS,
+            (translator) -> translator.canTranslate(appliedPTransform.getTransform()),
+            DefaultUnknownTransformTranslator.INSTANCE);
+    return transformTranslator.translate(appliedPTransform, subtransforms, components);
+  }
+
+  /**
+   * Translates a composite {@link AppliedPTransform} into a runner API proto with no component
+   * transforms.
+   *
+   * <p>This should not be used when translating a {@link Pipeline}.
+   *
+   * <p>Does not register the {@code appliedPTransform} within the provided {@link SdkComponents}.
+   */
+  static RunnerApi.PTransform toProto(
+      AppliedPTransform<?, ?, ?> appliedPTransform, SdkComponents components) throws IOException {
+    return toProto(appliedPTransform, Collections.emptyList(), components);
+  }
+
+  private static String toProto(TupleTag<?> tag) {
+    return tag.getId();
+  }
+
+  /** Returns the URN for the transform if it is known, otherwise {@code null}. */
+  @Nullable
+  public static String urnForTransformOrNull(PTransform<?, ?> transform) {
+    TransformTranslator<?> transformTranslator =
+        Iterables.find(
+            KNOWN_TRANSLATORS,
+            (translator) -> translator.canTranslate(transform),
+            DefaultUnknownTransformTranslator.INSTANCE);
+    return ((TransformTranslator) transformTranslator).getUrn(transform);
+  }
+
+  /** Returns the URN for the transform if it is known, otherwise throws. */
+  public static String urnForTransform(PTransform<?, ?> transform) {
+    String urn = urnForTransformOrNull(transform);
+    if (urn == null) {
+      throw new IllegalStateException(
+          String.format("No translator known for %s", transform.getClass().getName()));
+    }
+    return urn;
+  }
+
+  /** Returns the URN for the transform if it is known, otherwise {@code null}. */
+  @Nullable
+  public static String urnForTransformOrNull(RunnerApi.PTransform transform) {
+    return transform.getSpec() == null ? null : transform.getSpec().getUrn();
+  }
+
+  /**
+   * A translator between a Java-based {@link PTransform} and a protobuf for that transform.
+   *
+   * <p>When going to a protocol buffer message, the translator produces a payload corresponding to
+   * the Java representation while registering components that transform references.
+   */
+  public interface TransformTranslator<T extends PTransform<?, ?>> {
+    @Nullable
+    String getUrn(T transform);
+
+    boolean canTranslate(PTransform<?, ?> pTransform);
+
+    RunnerApi.PTransform translate(
+        AppliedPTransform<?, ?, ?> appliedPTransform,
+        List<AppliedPTransform<?, ?, ?>> subtransforms,
+        SdkComponents components)
+        throws IOException;
+  }
+
+  /** Translates all unknown transforms to have an empty {@link FunctionSpec} and unset URN. */
+  private static class DefaultUnknownTransformTranslator
+      implements TransformTranslator<PTransform<?, ?>> {
+    private static final TransformTranslator<?> INSTANCE = new DefaultUnknownTransformTranslator();
+
+    @Override
+    public String getUrn(PTransform<?, ?> transform) {
+      return null;
+    }
+
+    @Override
+    public boolean canTranslate(PTransform<?, ?> pTransform) {
+      return true;
+    }
+
+    @Override
+    public RunnerApi.PTransform translate(
+        AppliedPTransform<?, ?, ?> appliedPTransform,
+        List<AppliedPTransform<?, ?, ?>> subtransforms,
+        SdkComponents components)
+        throws IOException {
+      return translateAppliedPTransform(appliedPTransform, subtransforms, components).build();
+    }
+  }
+
+  /**
+   * Translates {@link RawPTransform} by extracting the {@link FunctionSpec} and migrating over all
+   * referenced components.
+   */
+  private static class RawPTransformTranslator implements TransformTranslator<RawPTransform<?, ?>> {
+    @Override
+    public String getUrn(RawPTransform transform) {
+      return transform.getUrn();
+    }
+
+    @Override
+    public boolean canTranslate(PTransform<?, ?> pTransform) {
+      return pTransform instanceof RawPTransform;
+    }
+
+    @Override
+    public RunnerApi.PTransform translate(
+        AppliedPTransform<?, ?, ?> appliedPTransform,
+        List<AppliedPTransform<?, ?, ?>> subtransforms,
+        SdkComponents components)
+        throws IOException {
+      RunnerApi.PTransform.Builder transformBuilder =
+          translateAppliedPTransform(appliedPTransform, subtransforms, components);
+
+      PTransform<?, ?> transform = appliedPTransform.getTransform();
+
+      // The raw transform was parsed in the context of other components; this puts it in the
+      // context of our current serialization
+      FunctionSpec spec = ((RawPTransform<?, ?>) transform).migrate(components);
+
+      // A composite transform is permitted to have a null spec. There are also some pseudo-
+      // primitives not yet supported by the portability framework that have null specs
+      if (spec != null) {
+        transformBuilder.setSpec(spec);
+      }
+
+      return transformBuilder.build();
+    }
+  }
+
+  /**
+   * Translates a set of registered transforms whose content only differs based by differences in
+   * their {@link FunctionSpec}s and URNs.
+   */
+  private static class KnownTransformPayloadTranslator<T extends PTransform<?, ?>>
+      implements TransformTranslator<T> {
+    private static final Map<Class<? extends PTransform>, TransformPayloadTranslator>
+        KNOWN_PAYLOAD_TRANSLATORS = loadTransformPayloadTranslators();
+
+    private static Map<Class<? extends PTransform>, TransformPayloadTranslator>
+        loadTransformPayloadTranslators() {
+      HashMap<Class<? extends PTransform>, TransformPayloadTranslator> translators =
+          new HashMap<>();
+
+      for (TransformPayloadTranslatorRegistrar registrar :
+          ServiceLoader.load(TransformPayloadTranslatorRegistrar.class)) {
+
+        Map<Class<? extends PTransform>, TransformPayloadTranslator> newTranslators =
+            (Map) registrar.getTransformPayloadTranslators();
+
+        Set<Class<? extends PTransform>> alreadyRegistered =
+            Sets.intersection(translators.keySet(), newTranslators.keySet());
+
+        if (!alreadyRegistered.isEmpty()) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Classes already registered: %s", Joiner.on(", ").join(alreadyRegistered)));
+        }
+
+        translators.putAll(newTranslators);
+      }
+      return ImmutableMap.copyOf(translators);
+    }
+
+    @Override
+    public boolean canTranslate(PTransform pTransform) {
+      return KNOWN_PAYLOAD_TRANSLATORS.containsKey(pTransform.getClass());
+    }
+
+    @Override
+    public String getUrn(PTransform transform) {
+      return KNOWN_PAYLOAD_TRANSLATORS.get(transform.getClass()).getUrn(transform);
+    }
+
+    @Override
+    public RunnerApi.PTransform translate(
+        AppliedPTransform<?, ?, ?> appliedPTransform,
+        List<AppliedPTransform<?, ?, ?>> subtransforms,
+        SdkComponents components)
+        throws IOException {
+      RunnerApi.PTransform.Builder transformBuilder =
+          translateAppliedPTransform(appliedPTransform, subtransforms, components);
+
+      FunctionSpec spec =
+          KNOWN_PAYLOAD_TRANSLATORS
+              .get(appliedPTransform.getTransform().getClass())
+              .translate(appliedPTransform, components);
+      if (spec != null) {
+        transformBuilder.setSpec(spec);
+      }
+      return transformBuilder.build();
+    }
+  }
+
+  /**
+   * Translates an {@link AppliedPTransform} by:
+   *
+   * <ul>
+   *   <li>adding an input to the PTransform for each {@link AppliedPTransform#getInputs()}.
+   *   <li>adding an output to the PTransform for each {@link AppliedPTransform#getOutputs()}.
+   *   <li>adding a PCollection for each {@link AppliedPTransform#getOutputs()}.
+   *   <li>adding a reference to each subtransform.
+   *   <li>set the unique name.
+   *   <li>set the display data.
+   * </ul>
+   */
+  static RunnerApi.PTransform.Builder translateAppliedPTransform(
+      AppliedPTransform<?, ?, ?> appliedPTransform,
+      List<AppliedPTransform<?, ?, ?>> subtransforms,
+      SdkComponents components)
+      throws IOException {
     RunnerApi.PTransform.Builder transformBuilder = RunnerApi.PTransform.newBuilder();
     for (Map.Entry<TupleTag<?>, PValue> taggedInput : appliedPTransform.getInputs().entrySet()) {
       checkArgument(
@@ -156,95 +364,14 @@ public class PTransformTranslation {
     transformBuilder.setUniqueName(appliedPTransform.getFullName());
     transformBuilder.setDisplayData(
         DisplayDataTranslation.toProto(DisplayData.from(appliedPTransform.getTransform())));
-
-    PTransform<?, ?> transform = appliedPTransform.getTransform();
-
-    // A RawPTransform directly vends its payload. Because it will generally be
-    // a subclass, we cannot do dictionary lookup in KNOWN_PAYLOAD_TRANSLATORS.
-    if (transform instanceof RawPTransform) {
-      // The raw transform was parsed in the context of other components; this puts it in the
-      // context of our current serialization
-      FunctionSpec spec = ((RawPTransform<?, ?>) transform).migrate(components);
-
-      // A composite transform is permitted to have a null spec. There are also some pseudo-
-      // primitives not yet supported by the portability framework that have null specs
-      if (spec != null) {
-        transformBuilder.setSpec(spec);
-      }
-    } else if (KNOWN_PAYLOAD_TRANSLATORS.containsKey(transform.getClass())) {
-      FunctionSpec spec =
-          KNOWN_PAYLOAD_TRANSLATORS
-              .get(transform.getClass())
-              .translate(appliedPTransform, components);
-      if (spec != null) {
-        transformBuilder.setSpec(spec);
-      }
-    }
-
-    return transformBuilder.build();
+    return transformBuilder;
   }
 
   /**
-   * Translates a composite {@link AppliedPTransform} into a runner API proto with no component
-   * transforms.
-   *
-   * <p>This should not be used when translating a {@link Pipeline}.
-   *
-   * <p>Does not register the {@code appliedPTransform} within the provided {@link SdkComponents}.
-   */
-  static RunnerApi.PTransform toProto(
-      AppliedPTransform<?, ?, ?> appliedPTransform, SdkComponents components) throws IOException {
-    return toProto(appliedPTransform, Collections.emptyList(), components);
-  }
-
-  private static String toProto(TupleTag<?> tag) {
-    return tag.getId();
-  }
-
-  /** Returns the URN for the transform if it is known, otherwise {@code null}. */
-  @Nullable
-  public static String urnForTransformOrNull(PTransform<?, ?> transform) {
-
-    // A RawPTransform directly vends its URN. Because it will generally be
-    // a subclass, we cannot do dictionary lookup in KNOWN_PAYLOAD_TRANSLATORS.
-    if (transform instanceof RawPTransform) {
-      return ((RawPTransform) transform).getUrn();
-    }
-
-    TransformPayloadTranslator translator = KNOWN_PAYLOAD_TRANSLATORS.get(transform.getClass());
-    if (translator == null) {
-      return null;
-    }
-    return translator.getUrn(transform);
-  }
-
-  /** Returns the URN for the transform if it is known, otherwise throws. */
-  public static String urnForTransform(PTransform<?, ?> transform) {
-    String urn = urnForTransformOrNull(transform);
-    if (urn == null) {
-      throw new IllegalStateException(
-          String.format("No translator known for %s", transform.getClass().getName()));
-    }
-    return urn;
-  }
-
-  /** Returns the URN for the transform if it is known, otherwise {@code null}. */
-  @Nullable
-  public static String urnForTransformOrNull(RunnerApi.PTransform transform) {
-    return transform.getSpec() == null ? null : transform.getSpec().getUrn();
-  }
-
-  /**
-   * A bi-directional translator between a Java-based {@link PTransform} and a protobuf payload for
-   * that transform.
+   * A translator between a Java-based {@link PTransform} and a protobuf payload for that transform.
    *
    * <p>When going to a protocol buffer message, the translator produces a payload corresponding to
    * the Java representation while registering components that payload references.
-   *
-   * <p>When "rehydrating" a protocol buffer message, the translator returns a {@link RawPTransform}
-   * - because the transform may not be Java-based, it is not possible to rebuild a Java-based
-   * {@link PTransform}. The resulting {@link RawPTransform} subclass encapsulates the knowledge of
-   * which components are referenced in the payload.
    */
   public interface TransformPayloadTranslator<T extends PTransform<?, ?>> {
     String getUrn(T transform);


### PR DESCRIPTION
I abstracted away PTransform translation so that timers can be translated to PCollections since the existing translation mechanism required could only modify the FunctionSpec.
Note that I took this approach because changing the AppliedPTransform implementation to treat timers as an additional input and output would require updating all the non portable runners which did not seem worth the effort.
Once portability lands, we can go back and clean up several user and Runner facing interfaces which contain both user and Runner specific bindings.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




