### PR TITLE
[BEAM-4727] Re-use metric context throughout bundle

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -69,14 +69,53 @@ type ctxKey string
 const bundleKey ctxKey = "beam:bundle"
 const ptransformKey ctxKey = "beam:ptransform"
 
+// beamCtx is a caching context for IDs necessary to place metric updates.
+//  Allocating contexts and searching for PTransformIDs for every element
+// is expensive, so we avoid it if possible.
+type beamCtx struct {
+	context.Context
+	bundleID, ptransformID string
+}
+
+// Value lifts the beam contLift the keys value for faster lookups when not available.
+func (ctx *beamCtx) Value(key interface{}) interface{} {
+	switch key {
+	case bundleKey:
+		if ctx.bundleID == "" {
+			if id := ctx.Value(key); id != nil {
+				ctx.bundleID = id.(string)
+			}
+		}
+		return ctx.bundleID
+	case ptransformKey:
+		if ctx.ptransformID == "" {
+			if id := ctx.Value(key); id != nil {
+				ctx.ptransformID = id.(string)
+			}
+		}
+		return ctx.ptransformID
+	}
+	return ctx.Context.Value(key)
+}
+
 // SetBundleID sets the id of the current Bundle.
 func SetBundleID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, bundleKey, id)
+	// Checking for *beamCtx is an optimization, so we don't dig deeply
+	// for ids if not necessary.
+	if bctx, ok := ctx.(*beamCtx); ok {
+		return &beamCtx{Context: bctx.Context, bundleID: id, ptransformID: bctx.ptransformID}
+	}
+	return &beamCtx{Context: ctx, bundleID: id}
 }
 
 // SetPTransformID sets the id of the current PTransform.
 func SetPTransformID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, ptransformKey, id)
+	// Checking for *beamCtx is an optimization, so we don't dig deeply
+	// for ids if not necessary.
+	if bctx, ok := ctx.(*beamCtx); ok {
+		return &beamCtx{Context: bctx.Context, bundleID: bctx.bundleID, ptransformID: id}
+	}
+	return &beamCtx{Context: ctx, ptransformID: id}
 }
 
 func getContextKey(ctx context.Context, n name) key {

--- a/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/pardo_test.go
@@ -104,7 +104,7 @@ func emitSumFn(n int, emit func(int)) {
 // BenchmarkParDo_EmitSumFn measures the overhead of invoking a ParDo in a plan.
 //
 // On @lostluck's desktop:
-// BenchmarkParDo_EmitSumFn-12    	 1000000	      1202 ns/op	     529 B/op	       4 allocs/op
+// BenchmarkParDo_EmitSumFn-12    	 1000000	      1070 ns/op	     481 B/op	       3 allocs/op
 func BenchmarkParDo_EmitSumFn(b *testing.B) {
 	fn, err := graph.NewDoFn(emitSumFn)
 	if err != nil {


### PR DESCRIPTION
There's overhead in re-allocating a context for every element, and since the Go SDK doesn't modify contexts at present, except to assign identifiers for metrics collection, avoiding the re-allocation costs this way seems reasonable.

Builds off of #5882

Before:
BenchmarkParDo_EmitSumFn-12    	 1000000	      1202 ns/op	     529 B/op
After:
BenchmarkParDo_EmitSumFn-12    	 1000000	      1030 ns/op	     481 B/op	       3 allocs/op

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




