### PR TITLE
[BEAM-4727] Improve metric lookup overhead for predeclared metrics

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -130,12 +130,12 @@ var (
 	// simplifies code understanding, since each only contains a single type of
 	// cell.
 
-	// counters is a map[key]*counter
-	counters = sync.Map{}
-	// distributions is a map[key]*distribution
-	distributions = sync.Map{}
-	// gauges is a map[key]*gauge
-	gauges = sync.Map{}
+	countersMu      sync.RWMutex
+	counters        = make(map[key]*counter)
+	distributionsMu sync.RWMutex
+	distributions   = make(map[key]*distribution)
+	gaugesMu        sync.RWMutex
+	gauges          = make(map[key]*gauge)
 )
 
 // TODO(lostluck): 2018/03/05 Use a common internal beam now() instead, once that exists.
@@ -144,37 +144,54 @@ var now = time.Now
 // Counter is a simple counter for incrementing and decrementing a value.
 type Counter struct {
 	name name
+	// The following are a fast cache of the key and storage
+	mu sync.Mutex
+	k  key
+	c  *counter
 }
 
-func (m Counter) String() string {
+func (m *Counter) String() string {
 	return fmt.Sprintf("Counter metric %s", m.name)
 }
 
 // NewCounter returns the Counter with the given namespace and name.
-func NewCounter(ns, n string) Counter {
+func NewCounter(ns, n string) *Counter {
 	mn := newName(ns, n)
-	return Counter{
+	return &Counter{
 		name: mn,
 	}
 }
 
 // Inc increments the counter within the given PTransform context by v.
-func (m Counter) Inc(ctx context.Context, v int64) {
+func (m *Counter) Inc(ctx context.Context, v int64) {
 	key := getContextKey(ctx, m.name)
 	cs := &counter{
 		value: v,
 	}
-	if m, loaded := counters.LoadOrStore(key, cs); loaded {
-		c := m.(*counter)
-		c.inc(v)
-	} else {
-		c := m.(*counter)
-		storeMetric(key, c)
+	m.mu.Lock()
+	if m.k == key {
+		m.c.inc(v)
+		m.mu.Unlock()
+		return
 	}
+	m.k = key
+	countersMu.Lock()
+	if c, loaded := counters[key]; loaded {
+		m.c = c
+		countersMu.Unlock()
+		m.mu.Unlock()
+		c.inc(v)
+		return
+	}
+	m.c = cs
+	counters[key] = cs
+	countersMu.Unlock()
+	m.mu.Unlock()
+	storeMetric(key, cs)
 }
 
 // Dec decrements the counter within the given PTransform context by v.
-func (m Counter) Dec(ctx context.Context, v int64) {
+func (m *Counter) Dec(ctx context.Context, v int64) {
 	m.Inc(ctx, -v)
 }
 
@@ -211,22 +228,27 @@ func (m *counter) toProto() *fnexecution_v1.Metrics_User {
 // Distribution is a simple distribution of values.
 type Distribution struct {
 	name name
+
+	// The following are a fast cache of the key and storage
+	mu sync.Mutex
+	k  key
+	d  *distribution
 }
 
-func (m Distribution) String() string {
+func (m *Distribution) String() string {
 	return fmt.Sprintf("Distribution metric %s", m.name)
 }
 
 // NewDistribution returns the Distribution with the given namespace and name.
-func NewDistribution(ns, n string) Distribution {
+func NewDistribution(ns, n string) *Distribution {
 	mn := newName(ns, n)
-	return Distribution{
+	return &Distribution{
 		name: mn,
 	}
 }
 
 // Update updates the distribution within the given PTransform context with v.
-func (m Distribution) Update(ctx context.Context, v int64) {
+func (m *Distribution) Update(ctx context.Context, v int64) {
 	key := getContextKey(ctx, m.name)
 	ds := &distribution{
 		count: 1,
@@ -234,13 +256,26 @@ func (m Distribution) Update(ctx context.Context, v int64) {
 		min:   v,
 		max:   v,
 	}
-	if m, loaded := distributions.LoadOrStore(key, ds); loaded {
-		d := m.(*distribution)
-		d.update(v)
-	} else {
-		d := m.(*distribution)
-		storeMetric(key, d)
+	m.mu.Lock()
+	if m.k == key {
+		m.d.update(v)
+		m.mu.Unlock()
+		return
 	}
+	m.k = key
+	distributionsMu.Lock()
+	if d, loaded := distributions[key]; loaded {
+		m.d = d
+		distributionsMu.Unlock()
+		m.mu.Unlock()
+		d.update(v)
+		return
+	}
+	m.d = ds
+	distributions[key] = ds
+	distributionsMu.Unlock()
+	m.mu.Unlock()
+	storeMetric(key, ds)
 }
 
 // distribution is a metric cell for distribution values.
@@ -286,37 +321,57 @@ func (m *distribution) toProto() *fnexecution_v1.Metrics_User {
 // Gauge is a time, value pair metric.
 type Gauge struct {
 	name name
+
+	// The following are a fast cache of the key and storage
+	mu sync.Mutex
+	k  key
+	g  *gauge
 }
 
-func (m Gauge) String() string {
+func (m *Gauge) String() string {
 	return fmt.Sprintf("Guage metric %s", m.name)
 }
 
 // NewGauge returns the Gauge with the given namespace and name.
-func NewGauge(ns, n string) Gauge {
+func NewGauge(ns, n string) *Gauge {
 	mn := newName(ns, n)
-	return Gauge{
+	return &Gauge{
 		name: mn,
 	}
 }
 
 // Set sets the gauge to the given value, and associates it with the current time on the clock.
-func (m Gauge) Set(ctx context.Context, v int64) {
+func (m *Gauge) Set(ctx context.Context, v int64) {
 	key := getContextKey(ctx, m.name)
 	gs := &gauge{
 		t: now(),
 		v: v,
 	}
-	if m, loaded := gauges.LoadOrStore(key, gs); loaded {
-		g := m.(*gauge)
-		g.set(v)
-	} else {
-		g := m.(*gauge)
-		storeMetric(key, g)
+	m.mu.Lock()
+	if m.k == key {
+		m.g.set(v)
+		m.mu.Unlock()
+		return
 	}
+	m.k = key
+	gaugesMu.Lock()
+	if g, loaded := gauges[key]; loaded {
+		m.g = g
+		gaugesMu.Unlock()
+		m.mu.Unlock()
+		g.set(v)
+		return
+	}
+	m.g = gs
+	gauges[key] = gs
+	gaugesMu.Unlock()
+	m.mu.Unlock()
+	storeMetric(key, gs)
 }
 
 // storeMetric stores a metric away on its first use so it may be retrieved later on.
+// In the event of a name collision, storeMetric can panic, so it's prudent to release
+// locks if they are no longer required.
 func storeMetric(key key, m userMetric) {
 	mu.Lock()
 	defer mu.Unlock()
@@ -402,6 +457,12 @@ func DumpToOut() {
 func dumpTo(p func(format string, args ...interface{})) {
 	mu.RLock()
 	defer mu.RUnlock()
+	countersMu.RLock()
+	defer countersMu.RUnlock()
+	distributionsMu.RLock()
+	defer distributionsMu.RUnlock()
+	gaugesMu.RLock()
+	defer gaugesMu.RUnlock()
 	var bs []string
 	for b := range store {
 		bs = append(bs, b)
@@ -430,13 +491,13 @@ func dumpTo(p func(format string, args ...interface{})) {
 			p("Bundle: %q - PTransformID: %q", b, pt)
 			for _, n := range ns {
 				key := key{name: n, bundle: b, ptransform: pt}
-				if m, ok := counters.Load(key); ok {
+				if m, ok := counters[key]; ok {
 					p("\t%s - %s", key.name, m)
 				}
-				if m, ok := distributions.Load(key); ok {
+				if m, ok := distributions[key]; ok {
 					p("\t%s - %s", key.name, m)
 				}
-				if m, ok := gauges.Load(key); ok {
+				if m, ok := gauges[key]; ok {
 					p("\t%s - %s", key.name, m)
 				}
 			}
@@ -449,9 +510,9 @@ func dumpTo(p func(format string, args ...interface{})) {
 func Clear() {
 	mu.Lock()
 	store = make(map[string]map[string]map[name]userMetric)
-	counters = sync.Map{}
-	distributions = sync.Map{}
-	gauges = sync.Map{}
+	counters = make(map[key]*counter)
+	distributions = make(map[key]*distribution)
+	gauges = make(map[key]*gauge)
 	mu.Unlock()
 }
 
@@ -462,14 +523,20 @@ func ClearBundleData(b string) {
 	// and the metric cell sync.Maps are goroutine safe.
 	mu.Lock()
 	pts := store[b]
+	countersMu.Lock()
+	distributionsMu.Lock()
+	gaugesMu.Lock()
 	for pt, m := range pts {
 		for n := range m {
 			key := key{name: n, bundle: b, ptransform: pt}
-			counters.Delete(key)
-			distributions.Delete(key)
-			gauges.Delete(key)
+			delete(counters, key)
+			delete(distributions, key)
+			delete(gauges, key)
 		}
 	}
+	countersMu.Unlock()
+	distributionsMu.Unlock()
+	gaugesMu.Unlock()
 	delete(store, b)
 	mu.Unlock()
 }

--- a/sdks/go/pkg/beam/metrics.go
+++ b/sdks/go/pkg/beam/metrics.go
@@ -24,7 +24,7 @@ import (
 // Counter is a metric that can be incremented and decremented,
 // and is aggregated by the sum.
 type Counter struct {
-	metrics.Counter
+	*metrics.Counter
 }
 
 // Inc increments the counter within by the given amount.
@@ -45,7 +45,7 @@ func NewCounter(namespace, name string) Counter {
 // Distribution is a metric that records various statistics about the distribution
 // of reported values.
 type Distribution struct {
-	metrics.Distribution
+	*metrics.Distribution
 }
 
 // Update adds an observation to this distribution.
@@ -61,7 +61,7 @@ func NewDistribution(namespace, name string) Distribution {
 // Gauge is a metric that can have its new value set, and is aggregated by taking
 // the last reported value.
 type Gauge struct {
-	metrics.Gauge
+	*metrics.Gauge
 }
 
 // Set sets the current value for this gauge.


### PR DESCRIPTION
Introduces a performance for predeclared metrics when they're used within a single ptransform by caching the storage unit associated with them.
Switched away from using sync.Map in favour of maps with locks. sync.Map doesn't handle high contention very well.

Experimented with changing from a struct key to a string key, but string construction time was worse than directly using the struct. It remains unchanged.

Builds on #5884

Run on @lostluck's desktop:

Before:
BenchmarkMetrics/counter_inplace-12         	10000000	       226 ns/op	      80 B/op	       2 allocs/op
BenchmarkMetrics/distribution_inplace-12    	10000000	       231 ns/op	     112 B/op	       2 allocs/op
BenchmarkMetrics/gauge_inplace-12           	 5000000	       252 ns/op	     112 B/op	       2 allocs/op
BenchmarkMetrics/counter_predeclared-12     	10000000	       222 ns/op	      80 B/op	       2 allocs/op
BenchmarkMetrics/distribution_predeclared-12         	10000000	       228 ns/op	     112 B/op	       2 allocs/op
BenchmarkMetrics/gauge_predeclared-12                	 5000000	       247 ns/op	     112 B/op	       2 allocs/op

After:
 BenchmarkMetrics/counter_inplace-12         	 5000000	       243 ns/op	     128 B/op	       2 allocs/op
 BenchmarkMetrics/distribution_inplace-12    	 5000000	       252 ns/op	     160 B/op	       2 allocs/op
 BenchmarkMetrics/gauge_inplace-12           	 5000000	       266 ns/op	     160 B/op	       2 allocs/op
 BenchmarkMetrics/counter_predeclared-12     	20000000	        74.3 ns/op	      16 B/op	       1 allocs/op
 BenchmarkMetrics/distribution_predeclared-12         	20000000	        79.6 ns/op	      48 B/op	       1 allocs/op
 BenchmarkMetrics/gauge_predeclared-12                	20000000	        92.9 ns/op	      48 B/op	       1 allocs/op


Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




