### PR TITLE
[BEAM-4733] Pass pipeline options from Python portable runner to job server.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslation.java
@@ -18,14 +18,27 @@
 
 package org.apache.beam.runners.core.construction;
 
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
 import com.google.protobuf.Struct;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 
-/** Utilities for going to/from Runner API pipeline options. */
+/**
+ * Utilities for going to/from Runner API pipeline options.
+ *
+ * <p>TODO: Make this the default to/from translation for PipelineOptions.
+ */
 public class PipelineOptionsTranslation {
   private static final ObjectMapper MAPPER =
       new ObjectMapper()
@@ -34,10 +47,24 @@ public class PipelineOptionsTranslation {
   /** Converts the provided {@link PipelineOptions} to a {@link Struct}. */
   public static Struct toProto(PipelineOptions options) {
     Struct.Builder builder = Struct.newBuilder();
+
     try {
+      // TODO: Officially define URNs for options and their scheme.
+      TreeNode treeNode = MAPPER.valueToTree(options);
+      TreeNode rootOptions = treeNode.get("options");
+      Iterator<String> optionsKeys = rootOptions.fieldNames();
+      Map<String, TreeNode> optionsUsingUrns = new HashMap<String, TreeNode>();
+      while (optionsKeys.hasNext()) {
+        String optionKey = optionsKeys.next();
+        TreeNode optionValue = rootOptions.get(optionKey);
+        optionsUsingUrns.put(
+            "beam:option:" + CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, optionKey) + ":v1",
+            optionValue);
+      }
+
       // The JSON format of a Protobuf Struct is the JSON object that is equivalent to that struct
       // (with values encoded in a standard json-codeable manner). See Beam PR 3719 for more.
-      JsonFormat.parser().merge(MAPPER.writeValueAsString(options), builder);
+      JsonFormat.parser().merge(MAPPER.writeValueAsString(optionsUsingUrns), builder);
       return builder.build();
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -46,6 +73,21 @@ public class PipelineOptionsTranslation {
 
   /** Converts the provided {@link Struct} into {@link PipelineOptions}. */
   public static PipelineOptions fromProto(Struct protoOptions) throws IOException {
-    return MAPPER.readValue(JsonFormat.printer().print(protoOptions), PipelineOptions.class);
+    Map<String, TreeNode> mapWithoutUrns = new HashMap<String, TreeNode>();
+    TreeNode rootOptions = MAPPER.readTree(
+        JsonFormat.printer().print(protoOptions));
+    Iterator<String> optionsKeys = rootOptions.fieldNames();
+    while (optionsKeys.hasNext()) {
+      String optionKey = optionsKeys.next();
+      TreeNode optionValue = rootOptions.get(optionKey);
+      mapWithoutUrns.put(
+          CaseFormat.LOWER_UNDERSCORE.to(
+              CaseFormat.LOWER_CAMEL,
+              optionKey.substring("beam:option:".length(), optionKey.length() - ":v1".length())),
+          optionValue);
+    }
+    return MAPPER.readValue(
+        MAPPER.writeValueAsString(ImmutableMap.of("options", mapWithoutUrns)),
+        PipelineOptions.class);
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslation.java
@@ -18,13 +18,10 @@
 
 package org.apache.beam.runners.core.construction;
 
-import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableMap;
-import com.google.gson.JsonObject;
 import com.google.protobuf.Struct;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
@@ -53,12 +50,14 @@ public class PipelineOptionsTranslation {
       TreeNode treeNode = MAPPER.valueToTree(options);
       TreeNode rootOptions = treeNode.get("options");
       Iterator<String> optionsKeys = rootOptions.fieldNames();
-      Map<String, TreeNode> optionsUsingUrns = new HashMap<String, TreeNode>();
+      Map<String, TreeNode> optionsUsingUrns = new HashMap<>();
       while (optionsKeys.hasNext()) {
         String optionKey = optionsKeys.next();
         TreeNode optionValue = rootOptions.get(optionKey);
         optionsUsingUrns.put(
-            "beam:option:" + CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, optionKey) + ":v1",
+            "beam:option:"
+                + CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, optionKey)
+                + ":v1",
             optionValue);
       }
 
@@ -73,9 +72,8 @@ public class PipelineOptionsTranslation {
 
   /** Converts the provided {@link Struct} into {@link PipelineOptions}. */
   public static PipelineOptions fromProto(Struct protoOptions) throws IOException {
-    Map<String, TreeNode> mapWithoutUrns = new HashMap<String, TreeNode>();
-    TreeNode rootOptions = MAPPER.readTree(
-        JsonFormat.printer().print(protoOptions));
+    Map<String, TreeNode> mapWithoutUrns = new HashMap<>();
+    TreeNode rootOptions = MAPPER.readTree(JsonFormat.printer().print(protoOptions));
     Iterator<String> optionsKeys = rootOptions.fieldNames();
     while (optionsKeys.hasNext()) {
       String optionKey = optionsKeys.next();

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineOptionsTranslationTest.java
@@ -130,7 +130,9 @@ public class PipelineOptionsTranslationTest {
     public void structWithNullOptionsDeserializes() throws Exception {
       Struct serialized =
           Struct.newBuilder()
-              .putFields("options", Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
+              .putFields(
+                  "beam:option:option_key:v1",
+                  Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build())
               .build();
       PipelineOptions deserialized = PipelineOptionsTranslation.fromProto(serialized);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming;
 import static org.apache.flink.util.Preconditions.checkState;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
@@ -84,7 +83,8 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
       PipelineOptions options,
       RunnerApi.ExecutableStagePayload payload,
       JobInfo jobInfo,
-      FlinkExecutableStageContext.Factory contextFactory) {
+      FlinkExecutableStageContext.Factory contextFactory,
+      Map<String, TupleTag<?>> outputMap) {
     super(
         new NoOpDoFn(),
         stepName,
@@ -101,19 +101,7 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
     this.payload = payload;
     this.jobInfo = jobInfo;
     this.contextFactory = contextFactory;
-    this.outputMap = createOutputMap(mainOutputTag, additionalOutputTags);
-  }
-
-  private static Map<String, TupleTag<?>> createOutputMap(
-      TupleTag mainOutput, List<TupleTag<?>> additionalOutputs) {
-    Map<String, TupleTag<?>> outputMap = new HashMap<>(additionalOutputs.size() + 1);
-    if (mainOutput != null) {
-      outputMap.put(mainOutput.getId(), mainOutput);
-    }
-    for (TupleTag<?> additionalTag : additionalOutputs) {
-      outputMap.put(additionalTag.getId(), additionalTag);
-    }
-    return outputMap;
+    this.outputMap = outputMap;
   }
 
   @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/ExecutableStageDoFnOperatorTest.java
@@ -32,7 +32,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Struct;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
@@ -325,7 +327,8 @@ public class ExecutableStageDoFnOperatorTest {
             PipelineOptionsFactory.as(FlinkPipelineOptions.class),
             stagePayload,
             jobInfo,
-            FlinkExecutableStageContext.batchFactory());
+            FlinkExecutableStageContext.batchFactory(),
+            createOutputMap(mainOutput, ImmutableList.of(additionalOutput)));
 
     ExecutableStageDoFnOperator<Integer, Integer> clone = SerializationUtils.clone(operator);
     assertNotNull(clone);
@@ -358,8 +361,21 @@ public class ExecutableStageDoFnOperatorTest {
             PipelineOptionsFactory.as(FlinkPipelineOptions.class),
             stagePayload,
             jobInfo,
-            contextFactory);
+            contextFactory,
+            createOutputMap(mainOutput, additionalOutputs));
 
     return operator;
+  }
+
+  private static Map<String, TupleTag<?>> createOutputMap(
+      TupleTag mainOutput, List<TupleTag<?>> additionalOutputs) {
+    Map<String, TupleTag<?>> outputMap = new HashMap<>(additionalOutputs.size() + 1);
+    if (mainOutput != null) {
+      outputMap.put(mainOutput.getId(), mainOutput);
+    }
+    for (TupleTag<?> additionalTag : additionalOutputs) {
+      outputMap.put(additionalTag.getId(), additionalTag);
+    }
+    return outputMap;
   }
 }

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -30,6 +30,7 @@ from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import beam_job_api_pb2_grpc
 from apache_beam.runners import pipeline_context
 from apache_beam.runners import runner
+from apache_beam.runners.job import utils as job_utils
 from apache_beam.runners.portability import portable_stager
 
 __all__ = ['PortableRunner']
@@ -100,11 +101,17 @@ class PortableRunner(runner.PipelineRunner):
           del proto_pipeline.components.transforms[sub_transform]
         del transform_proto.subtransforms[:]
 
+    # TODO: Define URNs for options.
+    options = {'beam:option:' + k + ':v1': v
+               for k, v in pipeline._options.get_all_options().iteritems()
+               if v is not None}
+
     job_service = beam_job_api_pb2_grpc.JobServiceStub(
         grpc.insecure_channel(job_endpoint))
     prepare_response = job_service.Prepare(
         beam_job_api_pb2.PrepareJobRequest(
-            job_name='job', pipeline=proto_pipeline))
+            job_name='job', pipeline=proto_pipeline,
+            pipeline_options=job_utils.dict_to_struct(options)))
     if prepare_response.artifact_staging_endpoint.url:
       stager = portable_stager.PortableStager(
           grpc.insecure_channel(prepare_response.artifact_staging_endpoint.url),


### PR DESCRIPTION
The Python portable runner client doesn't pass the pipeline options to the job service. Backport of  [change from prototype](https://github.com/bsidhom/beam/commit/ce8a79122b98a7cbcf6fea7db4a5fe31b6e8248a#diff-f2f54a3d6ae6ef6a22e5d52621a133ed) from @lukecwik fixes this. Is a similar change needed for Go @herohde ?

Added extra commit to fix Flink runner executable stage streaming translation. 
