### PR TITLE
[BEAM-4738] [SQL] Remove decimal support in BigQuery SQL read.

### DIFF
--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.extensions.sql.meta.provider.bigquery;
 
 import static org.apache.beam.sdk.schemas.Schema.FieldType.BOOLEAN;
 import static org.apache.beam.sdk.schemas.Schema.FieldType.BYTE;
-import static org.apache.beam.sdk.schemas.Schema.FieldType.DECIMAL;
 import static org.apache.beam.sdk.schemas.Schema.FieldType.DOUBLE;
 import static org.apache.beam.sdk.schemas.Schema.FieldType.FLOAT;
 import static org.apache.beam.sdk.schemas.Schema.FieldType.INT16;
@@ -32,7 +31,6 @@ import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.Serializable;
-import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
@@ -77,7 +75,6 @@ public class BigQueryReadWriteIT implements Serializable {
           .addNullableField("c_integer", INT32)
           .addNullableField("c_float", FLOAT)
           .addNullableField("c_double", DOUBLE)
-          .addNullableField("c_decimal", DECIMAL)
           .addNullableField("c_boolean", BOOLEAN)
           .addNullableField("c_timestamp", FieldType.DATETIME.withMetadata("TS"))
           .addNullableField("c_varchar", STRING)
@@ -102,7 +99,6 @@ public class BigQueryReadWriteIT implements Serializable {
             + "   c_integer INTEGER, \n"
             + "   c_float FLOAT, \n"
             + "   c_double DOUBLE, \n"
-            + "   c_decimal DECIMAL, \n"
             + "   c_boolean BOOLEAN, \n"
             + "   c_timestamp TIMESTAMP, \n"
             + "   c_varchar VARCHAR, \n "
@@ -123,7 +119,6 @@ public class BigQueryReadWriteIT implements Serializable {
             + "2147483647, "
             + "1.0, "
             + "1.0, "
-            + "123.45, "
             + "TRUE, "
             + "TIMESTAMP '2018-05-28 20:17:40.123', "
             + "'varchar', "
@@ -149,7 +144,6 @@ public class BigQueryReadWriteIT implements Serializable {
                 2147483647,
                 (float) 1.0,
                 1.0,
-                BigDecimal.valueOf(123.45),
                 true,
                 new DateTime(2018, 05, 28, 20, 17, 40, 123, ISOChronology.getInstanceUTC()),
                 "varchar",
@@ -171,7 +165,6 @@ public class BigQueryReadWriteIT implements Serializable {
             + "   c_integer INTEGER, \n"
             + "   c_float FLOAT, \n"
             + "   c_double DOUBLE, \n"
-            + "   c_decimal DECIMAL, \n"
             + "   c_boolean BOOLEAN, \n"
             + "   c_timestamp TIMESTAMP, \n"
             + "   c_varchar VARCHAR, \n "
@@ -192,7 +185,6 @@ public class BigQueryReadWriteIT implements Serializable {
             + "2147483647, "
             + "1.0, "
             + "1.0, "
-            + "123.45, "
             + "TRUE, "
             + "TIMESTAMP '2018-05-28 20:17:40.123', "
             + "'varchar', "
@@ -214,7 +206,6 @@ public class BigQueryReadWriteIT implements Serializable {
                 2147483647,
                 (float) 1.0,
                 1.0,
-                BigDecimal.valueOf(123.45),
                 true,
                 new DateTime(2018, 05, 28, 20, 17, 40, 123, ISOChronology.getInstanceUTC()),
                 "varchar",

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -35,7 +34,6 @@ public class AvroUtils {
       case INT64:
       case FLOAT:
       case DOUBLE:
-      case DECIMAL:
       case BYTE:
       case BOOLEAN:
         ret = convertAvroPrimitiveTypes(beamFieldTypeName, value);
@@ -50,6 +48,8 @@ public class AvroUtils {
       case ARRAY:
         ret = convertAvroArray(beamField, value);
         break;
+      case DECIMAL:
+        throw new RuntimeException("Does not support converting DECIMAL type value");
       case MAP:
         throw new RuntimeException("Does not support converting MAP type value");
       default:
@@ -99,7 +99,7 @@ public class AvroUtils {
       case BOOLEAN:
         return (Boolean) value;
       case DECIMAL:
-        return BigDecimal.valueOf((double) value);
+        throw new RuntimeException("Does not support converting DECIMAL type value");
       case STRING:
         return convertAvroString(value);
       default:


### PR DESCRIPTION
Beam SQL integration tests started to fail recently. It seems like Beam SQL cannot convert decimal value successfully anymore. The root cause is still unknown.

This PR removes decimal support to make java SDK postcommit test green. Future investigation is tracked here: https://issues.apache.org/jira/browse/BEAM-4736.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




