### PR TITLE
Revert #5878 to unbreak Python postcommit

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -128,7 +128,7 @@ GCP_REQUIREMENTS = [
     'google-cloud-pubsub==0.26.0',
     'proto-google-cloud-pubsub-v1==0.15.4',
     # GCP packages required by tests
-    'google-cloud-bigquery',
+    'google-cloud-bigquery==0.25.0',
 ]
 
 


### PR DESCRIPTION
This change reverts #5878 which caused errors in Python postcommits.  We should reapply that change once we fix some changed BigQuery API semantics.

R: @mariapython 
CC: @logc @pabloem @chamikaramj 