### PR TITLE
[BEAM-4003] Fix missing iteritems import

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -32,6 +32,7 @@ from collections import defaultdict
 
 from future.moves.urllib.parse import quote
 from future.moves.urllib.parse import unquote
+from future.utils import iteritems
 
 import apache_beam as beam
 from apache_beam import coders


### PR DESCRIPTION
This change adds an `iteritems` import that was missing in #5373 and caused issues in postcommits (https://builds.apache.org/job/beam_PostCommit_Python_Verify/5527/consoleFull).

R: @Fematich