### PR TITLE
Infer boundedness for SDF application at application time

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -783,7 +783,7 @@ public class ParDo {
               // TODO
               Collections.emptyMap(),
               input.getWindowingStrategy(),
-              input.isBounded());
+              input.isBounded().and(signature.isBoundedPerElement()));
       @SuppressWarnings("unchecked")
       Coder<InputT> inputCoder = ((PCollection<InputT>) input).getCoder();
       for (PCollection<?> out : outputs.getAll().values()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.coders.SnappyCoder;
 import org.apache.beam.sdk.coders.StructuredCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.transforms.Contextful.Fn;
+import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
@@ -691,6 +692,7 @@ public class Watch {
     }
   }
 
+  @UnboundedPerElement
   private static class WatchGrowthFn<InputT, OutputT, KeyT, TerminationStateT>
       extends DoFn<InputT, KV<InputT, OutputT>> {
     private final Watch.Growth<InputT, OutputT, KeyT> spec;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
@@ -203,6 +203,8 @@ public class FileIOTest implements Serializable {
                     .continuously(
                         Duration.millis(100),
                         Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3))));
+    assertEquals(PCollection.IsBounded.UNBOUNDED, matchMetadata.isBounded());
+    assertEquals(PCollection.IsBounded.UNBOUNDED, matchAllMetadata.isBounded());
 
     Thread writer =
         new Thread(


### PR DESCRIPTION
(as opposed to at the time of applying the SplittableParDo override - the override won't necessarily be applied; and some transforms, such as FileIO.write(), need to know the boundedness of their input collection before overrides are applied)

R: @iemejia 