### PR TITLE
[BEAM-4745] Revert "[BEAM-4016] Invoke Setup and TearDown on SplitRestrictionFn and PairWithRestrictionFn"

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -415,19 +415,12 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
     @Setup
     public void setup() {
       invoker = DoFnInvokers.invokerFor(fn);
-      invoker.invokeSetup();
     }
 
     @ProcessElement
     public void processElement(ProcessContext context) {
       context.output(
           KV.of(context.element(), invoker.invokeGetInitialRestriction(context.element())));
-    }
-
-    @Teardown
-    public void tearDown() {
-      invoker.invokeTeardown();
-      invoker = null;
     }
   }
 
@@ -446,7 +439,6 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
     @Setup
     public void setup() {
       invoker = DoFnInvokers.invokerFor(splittableFn);
-      invoker.invokeSetup();
     }
 
     @ProcessElement
@@ -466,12 +458,6 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
               throw new UnsupportedOperationException();
             }
           });
-    }
-
-    @Teardown
-    public void tearDown() {
-      invoker.invokeTeardown();
-      invoker = null;
     }
   }
 }


### PR DESCRIPTION
Temporarily reverts #5894 .

See https://issues.apache.org/jira/browse/BEAM-4745 for reasoning.