### PR TITLE
Add python-snappy to setup.py dependencies

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -106,6 +106,7 @@ REQUIRED_PACKAGES = [
     'oauth2client>=2.0.1,<5',
     # grpcio 1.8.1 and above requires protobuf 3.5.0.post1.
     'protobuf>=3.5.0.post1,<4',
+    'python-snappy>=0.5.3,<1.0',
     'pytz>=2018.3,<=2018.4',
     'pyyaml>=3.12,<4.0.0',
     'pyvcf>=0.6.8,<0.7.0',


### PR DESCRIPTION
This change fixes an issue in postcommits caused by https://github.com/apache/beam/pull/5887, which depends on a newer version of `python-snappy` (which is a dependency of fastavro package), but did not update the setup.py file.