### PR TITLE
[BEAM-1251] Revert #5887 to unbreak Python PostCommit

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -341,8 +341,8 @@ class _AvroBlock(object):
 
       # Compressed data includes a 4-byte CRC32 checksum which we verify.
       # We take care to avoid extra copies of data while slicing large objects
-      # by use of a memoryview.
-      result = snappy.decompress(memoryview(data)[:-4])
+      # by use of a buffer.
+      result = snappy.decompress(buffer(data)[:-4])
       avroio.BinaryDecoder(io.BytesIO(data[-4:])).check_crc32(result)
       return result
     else:

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -70,7 +70,7 @@ RUN \
     # Optional packages
     pip install "cython == 0.28.1" && \
     pip install "guppy == 0.1.10" && \
-    pip install "python-snappy == 0.5.3" && \
+    pip install "python-snappy == 0.5.1" && \
     # These are additional packages likely to be used by customers.
     pip install "numpy == 1.13.3" --no-binary=:all: && \
     pip install "pandas == 0.18.1" && \


### PR DESCRIPTION
This change reverts #5887 to fix issues with the Python PostCommit.  I will take care of undoing this rollback after an appropriate fix.