### PR TITLE
Publishing plugin now supports signing of all artifacts

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -793,7 +793,6 @@ artifactId=${project.name}
           }
 
           publications {
-            testing(MavenPublication) { from project.components.java }
             mavenJava(MavenPublication) {
               artifact project.shadowJar { // Strip the "shaded" classifier.
                 classifier null }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -751,40 +751,12 @@ artifactId=${project.name}
         }
         project.artifacts.archives project.javadocJar
 
-        // Only sign artifacts if we are performing a release
-        if (isRelease(project)) {
-          project.apply plugin: "signing"
-          project.signing {
-            useGpgCmd()
-            // Drop the unshaded jar because we don't want to publish it.
-            // Otherwise the unshaded one is the only one published since they
-            // both have no classifier and the names conflict.
-            def unshaded = project.configurations.archives.getArtifacts().matching({ artifact ->
-              artifact.classifier == ""
-            }).toList()
-            project.configurations.archives.getArtifacts().removeAll(unshaded)
-            sign project.configurations.archives
-          }
-
-          project.model {
-            tasks.generatePomFileForMavenJavaPublication {
-              destination = project.file("${project.buildDir}/publications/mavenJava/pom.xml")
-            }
-            tasks.publishMavenJavaPublicationToMavenLocal { dependsOn project.tasks.signArchives }
-            tasks.publishMavenJavaPublicationToMavenRepository { dependsOn project.tasks.signArchives }
-          }
-        }
-
-        project.uploadArchives {
-          repositories {
-            mavenDeployer {
-              beforeDeployment { deployment -> isRelease() && signing.signPom(deployment) }
-            }
-          }
-        }
-
         project.publishing {
           repositories {
+            maven {
+              name "testPublicationLocal"
+              url "file://${project.rootProject.projectDir}/testPublication/"
+            }
             maven {
               url(project.properties['distMgmtSnapshotsUrl'] ?: isRelease()
                       ? 'https://repository.apache.org/service/local/staging/deploy/maven2'
@@ -821,6 +793,7 @@ artifactId=${project.name}
           }
 
           publications {
+            testing(MavenPublication) { from project.components.java }
             mavenJava(MavenPublication) {
               artifact project.shadowJar { // Strip the "shaded" classifier.
                 classifier null }
@@ -942,34 +915,16 @@ artifactId=${project.name}
   limitations under the License.
 ''')
                 elem.insertBefore(hdr, elem.getFirstChild())
-
-                // create the sign pom artifact
-                def pomFile = project.file("${project.buildDir}/publications/mavenJava/pom.xml")
-                writeTo(pomFile)
-                if (isRelease()) {
-                  def pomAscFile = signing.sign(pomFile).signatureFiles[0]
-                  artifact(pomAscFile) {
-                    classifier = null
-                    extension = 'pom.asc'
-                  }
-                }
-              }
-
-              // create the signed artifacts
-              if (isRelease(project)) {
-                project.tasks.signArchives.signatureFiles.each {
-                  artifact(it) {
-                    def matcher = it.file =~ /-(tests|sources|test-sources|javadoc)\.jar\.asc$/
-                    if (matcher.find()) {
-                      classifier = matcher.group(1)
-                    } else {
-                      classifier = null
-                    }
-                    extension = 'jar.asc'
-                  }
-                }
               }
             }
+          }
+        }
+        // Only sign artifacts if we are performing a release
+        if (isRelease(project)) {
+          project.apply plugin: "signing"
+          project.signing {
+            useGpgCmd()
+            sign project.publishing.publications
           }
         }
       }


### PR DESCRIPTION
This PR simplifies the signing of pom and jar files that are published.

It also creates a task that allows to review all of the artifacts locally:

` ./gradlew publishTestingPublicationToTestPublicationLocalRepository -PisRelease --no-parallel --no-daemon --info`

Output of this command is: https://pastebin.com/xB0krUDi

r: @lukecwik 

------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




