### PR TITLE
[BEAM-1251] Upgrade snappy and use a memoryview

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -341,8 +341,8 @@ class _AvroBlock(object):
 
       # Compressed data includes a 4-byte CRC32 checksum which we verify.
       # We take care to avoid extra copies of data while slicing large objects
-      # by use of a buffer.
-      result = snappy.decompress(buffer(data)[:-4])
+      # by use of a memoryview.
+      result = snappy.decompress(memoryview(data)[:-4])
       avroio.BinaryDecoder(io.BytesIO(data[-4:])).check_crc32(result)
       return result
     else:

--- a/sdks/python/apache_beam/io/tfrecordio.py
+++ b/sdks/python/apache_beam/io/tfrecordio.py
@@ -43,7 +43,7 @@ def _default_crc32c_fn(value):
   if not _default_crc32c_fn.fn:
     try:
       import snappy  # pylint: disable=import-error
-      _default_crc32c_fn.fn = snappy._crc32c  # pylint: disable=protected-access
+      _default_crc32c_fn.fn = snappy._snappy._crc32c  # pylint: disable=protected-access
     except ImportError:
       logging.warning('Couldn\'t find python-snappy so the implementation of '
                       '_TFRecordUtil._masked_crc32c is not as fast as it could '

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -42,7 +42,7 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 
 # Update this version to the next version whenever there is a change that will
 # require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20180619'
+BEAM_CONTAINER_VERSION = 'beam-master-20180709'
 # Update this version to the next version whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
 BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20180619'

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -70,7 +70,7 @@ RUN \
     # Optional packages
     pip install "cython == 0.28.1" && \
     pip install "guppy == 0.1.10" && \
-    pip install "python-snappy == 0.5.1" && \
+    pip install "python-snappy == 0.5.3" && \
     # These are additional packages likely to be used by customers.
     pip install "numpy == 1.13.3" --no-binary=:all: && \
     pip install "pandas == 0.18.1" && \


### PR DESCRIPTION
This change undoes the rollback of #5887 (done in #5908) and incorporates appropriate fixes.