### PR TITLE
[BEAM-4751] fix missing pylint3 check for io subpackage

### DIFF
--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -78,6 +78,9 @@ class RangeSource(iobase.BoundedSource):
     return (type(self) == type(other)
             and self._start == other._start and self._end == other._end)
 
+  def __hash__(self):
+    return hash((type(self), self._start, self._end))
+
   def __ne__(self, other):
     return not self == other
 

--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -35,6 +35,8 @@ from apache_beam.testing.util import equal_to
 
 class RangeSource(iobase.BoundedSource):
 
+  __hash__ = None
+
   def __init__(self, start, end, split_freq=1):
     assert start <= end
     self._start = start
@@ -79,9 +81,6 @@ class RangeSource(iobase.BoundedSource):
             and self._start == other._start
             and self._end == other._end
             and self._split_freq == other._split_freq)
-
-  def __hash__(self):
-    return hash((type(self), self._start, self._end, self._split_freq))
 
   def __ne__(self, other):
     return not self == other

--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -76,10 +76,12 @@ class RangeSource(iobase.BoundedSource):
   # For testing
   def __eq__(self, other):
     return (type(self) == type(other)
-            and self._start == other._start and self._end == other._end)
+            and self._start == other._start
+            and self._end == other._end
+            and self._split_freq == other._split_freq)
 
   def __hash__(self):
-    return hash((type(self), self._start, self._end))
+    return hash((type(self), self._start, self._end, self._split_freq))
 
   def __ne__(self, other):
     return not self == other

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -60,6 +60,7 @@ class FileBasedSink(iobase.Sink):
 
   # Max number of threads to be used for renaming.
   _MAX_RENAME_THREADS = 64
+  __hash__ = None
 
   def __init__(self,
                file_path_prefix,
@@ -372,9 +373,6 @@ class FileBasedSink(iobase.Sink):
     # TODO: Clean up workitem_test which uses this.
     # pylint: disable=unidiomatic-typecheck
     return type(self) == type(other) and self.__dict__ == other.__dict__
-
-  def __hash__(self):
-    return hash((type(self), frozenset(self.__dict__.items())))
 
 
 class FileBasedSinkWriter(iobase.Writer):

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -374,7 +374,7 @@ class FileBasedSink(iobase.Sink):
     return type(self) == type(other) and self.__dict__ == other.__dict__
 
   def __hash__(self):
-    return hash((type(self), self.__dict__))
+    return hash((type(self), frozenset(self.__dict__.items())))
 
 
 class FileBasedSinkWriter(iobase.Writer):

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -373,6 +373,9 @@ class FileBasedSink(iobase.Sink):
     # pylint: disable=unidiomatic-typecheck
     return type(self) == type(other) and self.__dict__ == other.__dict__
 
+  def __hash__(self):
+    return hash((type(self), self.__dict__))
+
 
 class FileBasedSinkWriter(iobase.Writer):
   """The writer for FileBasedSink.

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -15,6 +15,7 @@
 #
 
 from __future__ import absolute_import
+from __future__ import division
 
 import bz2
 import gzip

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/datastoreio.py
@@ -22,6 +22,7 @@ from __future__ import division
 import logging
 import time
 from builtins import object
+from builtins import round
 
 from apache_beam.io.gcp.datastore.v1 import helper
 from apache_beam.io.gcp.datastore.v1 import query_splitter

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/helper.py
@@ -20,6 +20,8 @@
 For internal use only; no backwards-compatibility guarantees.
 """
 
+from __future__ import absolute_import
+
 import errno
 import logging
 import sys

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/query_splitter.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/query_splitter.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import division
 
 from builtins import range
+from builtins import round
 
 from apache_beam.io.gcp.datastore.v1 import helper
 

--- a/sdks/python/apache_beam/io/gcp/datastore/v1/util_test.py
+++ b/sdks/python/apache_beam/io/gcp/datastore/v1/util_test.py
@@ -16,6 +16,8 @@
 #
 
 """Tests for util.py."""
+from __future__ import absolute_import
+
 import unittest
 
 from apache_beam.io.gcp.datastore.v1 import util

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem_test.py
@@ -18,6 +18,8 @@
 
 """Unit tests for GCS File System."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 from builtins import zip

--- a/sdks/python/apache_beam/io/gcp/gcsio_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 """Tests for Google Cloud Storage client."""
+from __future__ import absolute_import
 from __future__ import division
 
 import errno

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -78,6 +78,9 @@ class PubsubMessage(object):
         self.data == other.data and
         self.attributes == other.attributes)
 
+  def __hash__(self):
+    return hash((type(self), self.payload, self.attributes))
+
   def __repr__(self):
     return 'PubsubMessage(%s, %s)' % (self.data, self.attributes)
 

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -78,9 +78,6 @@ class PubsubMessage(object):
         self.data == other.data and
         self.attributes == other.attributes)
 
-  def __hash__(self):
-    return hash((type(self), self.payload, self.attributes))
-
   def __repr__(self):
     return 'PubsubMessage(%s, %s)' % (self.data, self.attributes)
 

--- a/sdks/python/apache_beam/io/gcp/pubsub_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_integration_test.py
@@ -17,6 +17,7 @@
 """
 Integration test for Google Cloud Pub/Sub.
 """
+from __future__ import absolute_import
 
 import logging
 import unittest

--- a/sdks/python/apache_beam/io/gcp/pubsub_it_pipeline.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_it_pipeline.py
@@ -18,6 +18,8 @@
 Test pipeline for use by pubsub_integration_test.
 """
 
+from __future__ import absolute_import
+
 import argparse
 
 import apache_beam as beam

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
@@ -17,6 +17,8 @@
 
 """Unit test for PubSub verifier."""
 
+from __future__ import absolute_import
+
 import logging
 import unittest
 

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -35,6 +35,7 @@ from apache_beam.options.pipeline_options import PipelineOptions
 
 class FakeFile(io.BytesIO):
   """File object for FakeHdfs"""
+  __hash__ = None
 
   def __init__(self, path, mode='', type='FILE'):
     io.BytesIO.__init__(self)
@@ -48,9 +49,6 @@ class FakeFile(io.BytesIO):
 
   def __eq__(self, other):
     return self.stat == other.stat and self.getvalue() == self.getvalue()
-
-  def __hash__(self):
-    return hash((frozenset(self.stat.items()), self.getvalue()))
 
   def close(self):
     self.saved_data = self.getvalue()

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -49,6 +49,9 @@ class FakeFile(io.BytesIO):
   def __eq__(self, other):
     return self.stat == other.stat and self.getvalue() == self.getvalue()
 
+  def __hash__(self):
+    return hash((self.stat, self.getvalue()))
+
   def close(self):
     self.saved_data = self.getvalue()
     io.BytesIO.close(self)

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -50,7 +50,7 @@ class FakeFile(io.BytesIO):
     return self.stat == other.stat and self.getvalue() == self.getvalue()
 
   def __hash__(self):
-    return hash((self.stat, self.getvalue()))
+    return hash((frozenset(self.stat.items()), self.getvalue()))
 
   def close(self):
     self.saved_data = self.getvalue()

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -20,9 +20,13 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import codecs
 import logging
 import math
 import threading
+from builtins import zip
+
+from past.builtins import long
 
 from past.builtins import long
 
@@ -402,7 +406,7 @@ class LexicographicKeyRangeTracker(OrderedPositionRangeTracker):
       s += '\0' * (prec - len(s))
     else:
       s = s[:prec]
-    return int(s.encode('hex'), 16)
+    return int(codecs.encode(s, 'hex'), 16)
 
   @staticmethod
   def _string_from_int(i, prec):
@@ -410,4 +414,4 @@ class LexicographicKeyRangeTracker(OrderedPositionRangeTracker):
     Inverse of _string_to_int.
     """
     h = '%x' % i
-    return ('0' * (2 * prec - len(h)) + h).decode('hex')
+    return codecs.decode('0' * (2 * prec - len(h)) + h, 'hex')

--- a/sdks/python/apache_beam/io/range_trackers.py
+++ b/sdks/python/apache_beam/io/range_trackers.py
@@ -28,8 +28,6 @@ from builtins import zip
 
 from past.builtins import long
 
-from past.builtins import long
-
 from apache_beam.io import iobase
 
 __all__ = ['OffsetRangeTracker', 'LexicographicKeyRangeTracker',

--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -42,6 +42,9 @@ class OffsetRange(object):
 
     return self.start == other.start and self.stop == other.stop
 
+  def __hash__(self):
+    return hash((type(self), self.start, self.stop))
+
   def split(self, desired_num_offsets_per_split, min_num_offsets_per_split=1):
     current_split_start = self.start
     max_split_size = max(desired_num_offsets_per_split,

--- a/sdks/python/apache_beam/io/tfrecordio.py
+++ b/sdks/python/apache_beam/io/tfrecordio.py
@@ -18,6 +18,7 @@
 
 from __future__ import absolute_import
 
+import codecs
 import logging
 import struct
 from builtins import object
@@ -120,24 +121,24 @@ class _TFRecordUtil(object):
     # Validate all length related payloads.
     if len(buf) != buf_length_expected:
       raise ValueError('Not a valid TFRecord. Fewer than %d bytes: %s' %
-                       (buf_length_expected, buf.encode('hex')))
+                       (buf_length_expected, codecs.encode(buf, 'hex')))
     length, length_mask_expected = struct.unpack('<QI', buf)
     length_mask_actual = cls._masked_crc32c(buf[:8])
     if length_mask_actual != length_mask_expected:
       raise ValueError('Not a valid TFRecord. Mismatch of length mask: %s' %
-                       buf.encode('hex'))
+                       codecs.encode(buf, 'hex'))
 
     # Validate all data related payloads.
     buf_length_expected = length + 4
     buf = file_handle.read(buf_length_expected)
     if len(buf) != buf_length_expected:
       raise ValueError('Not a valid TFRecord. Fewer than %d bytes: %s' %
-                       (buf_length_expected, buf.encode('hex')))
+                       (buf_length_expected, codecs.encode(buf, 'hex')))
     data, data_mask_expected = struct.unpack('<%dsI' % length, buf)
     data_mask_actual = cls._masked_crc32c(data)
     if data_mask_actual != data_mask_expected:
       raise ValueError('Not a valid TFRecord. Mismatch of data mask: %s' %
-                       buf.encode('hex'))
+                       codecs.encode(buf, 'hex'))
 
     # All validation checks passed.
     return data

--- a/sdks/python/apache_beam/io/vcfio.py
+++ b/sdks/python/apache_beam/io/vcfio.py
@@ -220,7 +220,8 @@ class VariantCall(object):
             (other.name, other.genotype, other.phaseset, other.info))
 
   def __hash__(self):
-    return hash((self.name, self.genotype, self.phaseset, self.info))
+    return hash((self.name, self.genotype,
+                 self.phaseset, frozenset(self.info.items())))
 
   def __repr__(self):
     return ', '.join(

--- a/sdks/python/apache_beam/io/vcfio.py
+++ b/sdks/python/apache_beam/io/vcfio.py
@@ -73,6 +73,7 @@ class Variant(object):
 
   Each object corresponds to a single record in a VCF file.
   """
+  __hash__ = None
 
   def __init__(self,
                reference_name=None,
@@ -123,9 +124,6 @@ class Variant(object):
   def __eq__(self, other):
     return (isinstance(other, Variant) and
             vars(self) == vars(other))
-
-  def __hash__(self):
-    return hash((type(self), vars(self)))
 
   def __repr__(self):
     return ', '.join(
@@ -191,6 +189,8 @@ class VariantCall(object):
   variant. It may include associated information such as quality and phasing.
   """
 
+  __hash__ = None
+
   def __init__(self, name=None, genotype=None, phaseset=None, info=None):
     """Initialize the :class:`VariantCall` object.
 
@@ -218,10 +218,6 @@ class VariantCall(object):
   def __eq__(self, other):
     return ((self.name, self.genotype, self.phaseset, self.info) ==
             (other.name, other.genotype, other.phaseset, other.info))
-
-  def __hash__(self):
-    return hash((self.name, self.genotype,
-                 self.phaseset, frozenset(self.info.items())))
 
   def __repr__(self):
     return ', '.join(

--- a/sdks/python/apache_beam/io/vcfio.py
+++ b/sdks/python/apache_beam/io/vcfio.py
@@ -29,6 +29,7 @@ from builtins import object
 from collections import namedtuple
 
 from future.utils import iteritems
+from past.builtins import long
 from past.builtins import unicode
 
 import vcf
@@ -123,6 +124,9 @@ class Variant(object):
     return (isinstance(other, Variant) and
             vars(self) == vars(other))
 
+  def __hash__(self):
+    return hash((type(self), vars(self)))
+
   def __repr__(self):
     return ', '.join(
         [str(s) for s in [self.reference_name,
@@ -214,6 +218,9 @@ class VariantCall(object):
   def __eq__(self, other):
     return ((self.name, self.genotype, self.phaseset, self.info) ==
             (other.name, other.genotype, other.phaseset, other.info))
+
+  def __hash__(self):
+    return hash((self.name, self.genotype, self.phaseset, self.info))
 
   def __repr__(self):
     return ', '.join(
@@ -407,7 +414,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
           # Note: this is already done for INFO fields in PyVCF.
           if (field in formats and
               formats[field].num is None and
-              isinstance(data, (int, float, int, str, unicode, bool))):
+              isinstance(data, (int, float, long, str, unicode, bool))):
             data = [data]
           call.info[field] = data
         variant.calls.append(call)

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -103,6 +103,7 @@ modules =
   apache_beam/runners
   apache_beam/examples
   apache_beam/portability
+  apache_beam/io
   apache_beam/internal
   apache_beam/metrics
   apache_beam/options


### PR DESCRIPTION
This pull request finishes the preparation of the io subpackage for Python 3 support. The work for io was started in #5715, however the py27-lint3 test was missing in tox.ini, resulting in some open issues and missing checks for new PRs.

The PR is part of a series in which all subpackages will be updated using the same approach.
This approach has been documented [here](https://docs.google.com/document/d/1xDG0MWVlDKDPu_IW9gtMvxi2S9I0GB0VDTkPhjXT0nE/edit) and the first pull request in the series (Futurize coders subpackage) demonstrating this approach can be found at #5053.

R: @aaltay @tvalentyn @RobbeSneyders @charlesccychen @superbobry

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




