### PR TITLE
[SQL] Simplify unbounded limit

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.extensions.sql.impl.rel;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -33,7 +32,6 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
-import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.MetricNameFilter;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
@@ -44,12 +42,8 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.state.StateSpec;
-import org.apache.beam.sdk.state.StateSpecs;
-import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.PValue;
@@ -139,36 +133,16 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     }
   }
 
-  enum LimitState {
-    REACHED,
-    NOT_REACHED
-  }
-
-  private static class LimitStateVar implements Serializable {
-    private LimitState state;
-
-    public LimitStateVar() {
-      state = LimitState.NOT_REACHED;
-    }
-
-    public void setReached() {
-      state = LimitState.REACHED;
-    }
-
-    public boolean isReached() {
-      return state == LimitState.REACHED;
-    }
-  }
-
   private static PipelineResult limitRun(
       PipelineOptions options,
       BeamRelNode node,
-      DoFn<KV<String, Row>, Void> limitCounterDoFn,
-      LimitStateVar limitStateVar) {
+      DoFn<Row, Void> doFn,
+      Queue<Object> values,
+      int limitCount) {
     options.as(DirectOptions.class).setBlockOnRun(false);
     Pipeline pipeline = Pipeline.create(options);
     PCollection<Row> resultCollection = BeamSqlRelUtils.toPCollection(pipeline, node);
-    resultCollection.apply(ParDo.of(new LimitCollector())).apply(ParDo.of(limitCounterDoFn));
+    resultCollection.apply(ParDo.of(doFn));
 
     PipelineResult result = pipeline.run();
 
@@ -179,10 +153,9 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
       if (state != null && state.isTerminal()) {
         break;
       }
-      // If state is null, or state is not null and indicates pipeline is not terminated
-      // yet, check continue checking the limit var.
+
       try {
-        if (limitStateVar.isReached()) {
+        if (values.size() >= limitCount) {
           result.cancel();
           break;
         }
@@ -191,6 +164,7 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
         break;
       }
     }
+
     return result;
   }
 
@@ -229,78 +203,18 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
             .equals("org.apache.beam.runners.direct.DirectRunner"),
         "SELECT without INSERT is only supported in DirectRunner in SQL Shell.");
 
-    LimitStateVar limitStateVar = new LimitStateVar();
     int limitCount = getLimitCount(node);
 
-    LimitCanceller.globalLimitArguments.put(id, limitCount);
-    LimitCanceller.globalStates.put(id, limitStateVar);
-    LimitCollector.globalValues.put(id, values);
-    limitRun(options, node, new LimitCanceller(), limitStateVar);
-    LimitCanceller.globalLimitArguments.remove(id);
-    LimitCanceller.globalStates.remove(id);
-    LimitCollector.globalValues.remove(id);
+    Collector.globalValues.put(id, values);
+    limitRun(options, node, new Collector(), values, limitCount);
+    Collector.globalValues.remove(id);
+
+    // remove extra retrieved values
+    while (values.size() > limitCount) {
+      values.remove();
+    }
 
     return Linq4j.asEnumerable(values);
-  }
-
-  private static class LimitCanceller extends DoFn<KV<String, Row>, Void> {
-    private static final Map<Long, Integer> globalLimitArguments =
-        new ConcurrentHashMap<Long, Integer>();
-    private static final Map<Long, LimitStateVar> globalStates =
-        new ConcurrentHashMap<Long, LimitStateVar>();
-
-    @Nullable private volatile Integer count;
-    @Nullable private volatile LimitStateVar limitStateVar;
-
-    @StateId("counter")
-    private final StateSpec<ValueState<Integer>> counter = StateSpecs.value(VarIntCoder.of());
-
-    @StartBundle
-    public void startBundle(StartBundleContext context) {
-      long id = context.getPipelineOptions().getOptionsId();
-      count = globalLimitArguments.get(id);
-      limitStateVar = globalStates.get(id);
-    }
-
-    @ProcessElement
-    public void processElement(
-        ProcessContext context, @StateId("counter") ValueState<Integer> counter) {
-      int current = (counter.read() != null ? counter.read() : 0);
-      current += 1;
-      if (current >= count && !limitStateVar.isReached()) {
-        // if current count reaches the limit count but limitStateVar has not been set, flip
-        // the var.
-        limitStateVar.setReached();
-      }
-
-      counter.write(current);
-    }
-  }
-
-  private static class LimitCollector extends DoFn<Row, KV<String, Row>> {
-
-    // This will only work on the direct runner.
-    private static final Map<Long, Queue<Object>> globalValues =
-        new ConcurrentHashMap<Long, Queue<Object>>();
-
-    @Nullable private volatile Queue<Object> values;
-
-    @StartBundle
-    public void startBundle(StartBundleContext context) {
-      long id = context.getPipelineOptions().getOptionsId();
-      values = globalValues.get(id);
-    }
-
-    @ProcessElement
-    public void processElement(ProcessContext context) {
-      Object[] avaticaRow = rowToAvatica(context.element());
-      if (avaticaRow.length == 1) {
-        values.add(avaticaRow[0]);
-      } else {
-        values.add(avaticaRow);
-      }
-      context.output(KV.of("DummyKey", context.element()));
-    }
   }
 
   private static class Collector extends DoFn<Row, Void> {


### PR DESCRIPTION
1. Simplify unbounded limit by reusing code with best of effort. Remove extra defined DoFn, class and enum, and reuse `Collector`. 
2. Make unbounded limit more compatible with distributed runners. In distributed runners, the shared in-memory queue will be replaced by a shared message queue (e.g. Google Cloud Pubsub). Therefore, it makes more sense to monitor the size of in-memory queue and in the future the size of shared message queue when running in distributed runner.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




