### PR TITLE
[BEAM-4745, BEAM-4016] Reintroduces Setup and TearDown on SplitRestrictionFn and PairWithRestrictionFn

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -415,12 +415,19 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
     @Setup
     public void setup() {
       invoker = DoFnInvokers.invokerFor(fn);
+      invoker.invokeSetup();
     }
 
     @ProcessElement
     public void processElement(ProcessContext context) {
       context.output(
           KV.of(context.element(), invoker.invokeGetInitialRestriction(context.element())));
+    }
+
+    @Teardown
+    public void tearDown() {
+      invoker.invokeTeardown();
+      invoker = null;
     }
   }
 
@@ -439,6 +446,7 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
     @Setup
     public void setup() {
       invoker = DoFnInvokers.invokerFor(splittableFn);
+      invoker.invokeSetup();
     }
 
     @ProcessElement
@@ -458,6 +466,12 @@ public class SplittableParDo<InputT, OutputT, RestrictionT>
               throw new UnsupportedOperationException();
             }
           });
+    }
+
+    @Teardown
+    public void tearDown() {
+      invoker.invokeTeardown();
+      invoker = null;
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -36,7 +36,7 @@ processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
     'dataflow.legacy_environment_major_version' : '7',
     'dataflow.fnapi_environment_major_version' : '7',
-    'dataflow.container_version' : 'beam-master-20180619'
+    'dataflow.container_version' : 'beam-master-20180710'
   ]
 }
 


### PR DESCRIPTION
This should be safe now, after a Dataflow worker release that is more correctly shaded and picks up fresh versions of this code.