### PR TITLE
[BEAM-4723] [SQL] Support datetime type minus time interval

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
@@ -51,6 +51,37 @@ public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
     this.delegateExpression = createDelegateExpression(operands, outputType);
   }
 
+  private BeamSqlExpression createDelegateExpression(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+    if (isTimestampMinusTimestamp(operands, outputType)) {
+      return new BeamSqlTimestampMinusTimestampExpression(operands, outputType);
+    } else if (isTimestampMinusInterval(operands, outputType)) {
+      return new BeamSqlTimestampMinusIntervalExpression(operands, outputType);
+    } else if (isDatetimeMinusInterval(operands, outputType)) {
+      return new BeamSqlDatetimeMinusIntervalExpression(operands, outputType);
+    }
+
+    return null;
+  }
+
+  private boolean isTimestampMinusTimestamp(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+
+    return BeamSqlTimestampMinusTimestampExpression.accept(operands, outputType);
+  }
+
+  private boolean isTimestampMinusInterval(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+
+    return BeamSqlTimestampMinusIntervalExpression.accept(operands, outputType);
+  }
+
+  private boolean isDatetimeMinusInterval(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+
+    return BeamSqlDatetimeMinusIntervalExpression.accept(operands, outputType);
+  }
+
   @Override
   public boolean accept() {
     return delegateExpression != null && delegateExpression.accept();
@@ -64,26 +95,5 @@ public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
     }
 
     return delegateExpression.evaluate(inputRow, window, env);
-  }
-
-  private BeamSqlExpression createDelegateExpression(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-    if (isTimestampMinusTimestamp(operands, outputType)) {
-      return new BeamSqlTimestampMinusTimestampExpression(operands, outputType);
-    } else if (isTimestampMinusInterval(operands, outputType)) {
-      return new BeamSqlTimestampMinusIntervalExpression(operands, outputType);
-    }
-
-    return null;
-  }
-
-  private boolean isTimestampMinusTimestamp(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-    return BeamSqlTimestampMinusTimestampExpression.accept(operands, outputType);
-  }
-
-  private boolean isTimestampMinusInterval(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-    return BeamSqlTimestampMinusIntervalExpression.accept(operands, outputType);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpression.java
@@ -18,16 +18,13 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
 import org.apache.calcite.sql.type.SqlTypeName;
-import org.joda.time.DurationFieldType;
 
 /**
  * Infix '-' operation for timestamps.
@@ -46,47 +43,12 @@ import org.joda.time.DurationFieldType;
  * yet.
  */
 public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
-
-  static final Map<SqlTypeName, DurationFieldType> INTERVALS_DURATIONS_TYPES =
-      ImmutableMap.<SqlTypeName, DurationFieldType>builder()
-          .put(SqlTypeName.INTERVAL_SECOND, DurationFieldType.seconds())
-          .put(SqlTypeName.INTERVAL_MINUTE, DurationFieldType.minutes())
-          .put(SqlTypeName.INTERVAL_HOUR, DurationFieldType.hours())
-          .put(SqlTypeName.INTERVAL_DAY, DurationFieldType.days())
-          .put(SqlTypeName.INTERVAL_MONTH, DurationFieldType.months())
-          .put(SqlTypeName.INTERVAL_YEAR, DurationFieldType.years())
-          .build();
-
   private BeamSqlExpression delegateExpression;
 
   public BeamSqlDatetimeMinusExpression(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
 
     this.delegateExpression = createDelegateExpression(operands, outputType);
-  }
-
-  private BeamSqlExpression createDelegateExpression(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-
-    if (isTimestampMinusTimestamp(operands, outputType)) {
-      return new BeamSqlTimestampMinusTimestampExpression(operands, outputType);
-    } else if (isTimestampMinusInterval(operands, outputType)) {
-      return new BeamSqlTimestampMinusIntervalExpression(operands, outputType);
-    }
-
-    return null;
-  }
-
-  private boolean isTimestampMinusTimestamp(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-
-    return BeamSqlTimestampMinusTimestampExpression.accept(operands, outputType);
-  }
-
-  private boolean isTimestampMinusInterval(
-      List<BeamSqlExpression> operands, SqlTypeName outputType) {
-
-    return BeamSqlTimestampMinusIntervalExpression.accept(operands, outputType);
   }
 
   @Override
@@ -102,5 +64,26 @@ public class BeamSqlDatetimeMinusExpression extends BeamSqlExpression {
     }
 
     return delegateExpression.evaluate(inputRow, window, env);
+  }
+
+  private BeamSqlExpression createDelegateExpression(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+    if (isTimestampMinusTimestamp(operands, outputType)) {
+      return new BeamSqlTimestampMinusTimestampExpression(operands, outputType);
+    } else if (isTimestampMinusInterval(operands, outputType)) {
+      return new BeamSqlTimestampMinusIntervalExpression(operands, outputType);
+    }
+
+    return null;
+  }
+
+  private boolean isTimestampMinusTimestamp(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+    return BeamSqlTimestampMinusTimestampExpression.accept(operands, outputType);
+  }
+
+  private boolean isTimestampMinusInterval(
+      List<BeamSqlExpression> operands, SqlTypeName outputType) {
+    return BeamSqlTimestampMinusIntervalExpression.accept(operands, outputType);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpression.java
@@ -30,13 +30,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DurationFieldType;
 import org.joda.time.Period;
 
-/**
- * '-' operator for 'timestamp - interval' expressions.
- *
- * <p>See {@link BeamSqlDatetimeMinusExpression} for other kinds of datetime types subtraction.
- */
-public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
-  public BeamSqlTimestampMinusIntervalExpression(
+/** minus ('-') operator for 'datetime - interval' expressions. */
+public class BeamSqlDatetimeMinusIntervalExpression extends BeamSqlExpression {
+  public BeamSqlDatetimeMinusIntervalExpression(
       List<BeamSqlExpression> operands, SqlTypeName outputType) {
     super(operands, outputType);
   }
@@ -49,7 +45,7 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
   static boolean accept(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     return operands.size() == 2
         && SqlTypeName.TIMESTAMP.equals(outputType)
-        && SqlTypeName.TIMESTAMP.equals(operands.get(0).getOutputType())
+        && SqlTypeName.DATETIME_TYPES.contains(operands.get(0).getOutputType())
         && TimeUnitUtils.INTERVALS_DURATIONS_TYPES.containsKey(operands.get(1).getOutputType());
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimePlusExpression.java
@@ -21,10 +21,8 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.TimeUnitUtils.timeUnitInternalMultiplier;
 import static org.apache.beam.sdk.extensions.sql.impl.utils.SqlTypeUtils.findExpressionOfType;
 
-import com.google.common.collect.ImmutableSet;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Set;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlPrimitive;
@@ -40,16 +38,6 @@ import org.joda.time.DateTime;
  * <p>Input and output are expected to be of type TIMESTAMP.
  */
 public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
-
-  private static final Set<SqlTypeName> SUPPORTED_INTERVAL_TYPES =
-      ImmutableSet.of(
-          SqlTypeName.INTERVAL_SECOND,
-          SqlTypeName.INTERVAL_MINUTE,
-          SqlTypeName.INTERVAL_HOUR,
-          SqlTypeName.INTERVAL_DAY,
-          SqlTypeName.INTERVAL_MONTH,
-          SqlTypeName.INTERVAL_YEAR);
-
   public BeamSqlDatetimePlusExpression(List<BeamSqlExpression> operands) {
     super(operands, SqlTypeName.TIMESTAMP);
   }
@@ -59,7 +47,7 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
   public boolean accept() {
     return operands.size() == 2
         && SqlTypeName.DATETIME_TYPES.contains(operands.get(0).getOutputType())
-        && SUPPORTED_INTERVAL_TYPES.contains(operands.get(1).getOutputType());
+        && TimeUnitUtils.INTERVALS_DURATIONS_TYPES.containsKey(operands.get(1).getOutputType());
   }
 
   /**
@@ -95,7 +83,7 @@ public class BeamSqlDatetimePlusExpression extends BeamSqlExpression {
 
   private BeamSqlPrimitive getIntervalOperand(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    return findExpressionOfType(operands, SUPPORTED_INTERVAL_TYPES)
+    return findExpressionOfType(operands, TimeUnitUtils.INTERVALS_DURATIONS_TYPES.keySet())
         .get()
         .evaluate(inputRow, window, env);
   }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpression.java
@@ -18,8 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
-import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlDatetimeMinusExpression.INTERVALS_DURATIONS_TYPES;
-
 import java.math.BigDecimal;
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
@@ -41,7 +39,7 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
 
   public BeamSqlTimestampMinusIntervalExpression(
       List<BeamSqlExpression> operands, SqlTypeName outputType) {
-    super(operands, outputType);
+    super(operands, SqlTypeName.TIMESTAMP);
   }
 
   @Override
@@ -52,8 +50,8 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
   static boolean accept(List<BeamSqlExpression> operands, SqlTypeName outputType) {
     return operands.size() == 2
         && SqlTypeName.TIMESTAMP.equals(outputType)
-        && SqlTypeName.TIMESTAMP.equals(operands.get(0).getOutputType())
-        && INTERVALS_DURATIONS_TYPES.containsKey(operands.get(1).getOutputType());
+        && SqlTypeName.DATETIME_TYPES.contains(operands.get(0).getOutputType())
+        && TimeUnitUtils.INTERVALS_DURATIONS_TYPES.containsKey(operands.get(1).getOutputType());
   }
 
   @Override
@@ -78,6 +76,6 @@ public class BeamSqlTimestampMinusIntervalExpression extends BeamSqlExpression {
   }
 
   private static DurationFieldType durationFieldType(SqlTypeName intervalTypeToCount) {
-    return INTERVALS_DURATIONS_TYPES.get(intervalTypeToCount);
+    return TimeUnitUtils.INTERVALS_DURATIONS_TYPES.get(intervalTypeToCount);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusTimestampExpression.java
@@ -18,8 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
-import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlDatetimeMinusExpression.INTERVALS_DURATIONS_TYPES;
-
 import java.util.List;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlExpression;
@@ -57,7 +55,7 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
   }
 
   static boolean accept(List<BeamSqlExpression> operands, SqlTypeName intervalType) {
-    return INTERVALS_DURATIONS_TYPES.containsKey(intervalType)
+    return TimeUnitUtils.INTERVALS_DURATIONS_TYPES.containsKey(intervalType)
         && operands.size() == 2
         && SqlTypeName.TIMESTAMP.equals(operands.get(0).getOutputType())
         && SqlTypeName.TIMESTAMP.equals(operands.get(1).getOutputType());
@@ -90,11 +88,11 @@ public class BeamSqlTimestampMinusTimestampExpression extends BeamSqlExpression 
   }
 
   private static DurationFieldType durationFieldType(SqlTypeName intervalTypeToCount) {
-    if (!INTERVALS_DURATIONS_TYPES.containsKey(intervalTypeToCount)) {
+    if (!TimeUnitUtils.INTERVALS_DURATIONS_TYPES.containsKey(intervalTypeToCount)) {
       throw new IllegalArgumentException(
           "Counting " + intervalTypeToCount.getName() + "s between dates is not supported");
     }
 
-    return INTERVALS_DURATIONS_TYPES.get(intervalTypeToCount);
+    return TimeUnitUtils.INTERVALS_DURATIONS_TYPES.get(intervalTypeToCount);
   }
 }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/TimeUnitUtils.java
@@ -18,12 +18,25 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
+import com.google.common.collect.ImmutableMap;
 import java.math.BigDecimal;
+import java.util.Map;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.joda.time.DurationFieldType;
 
 /** Utils to convert between Calcite's TimeUnit and Sql intervals. */
 public abstract class TimeUnitUtils {
+  /** supported interval and duration type. */
+  public static final Map<SqlTypeName, DurationFieldType> INTERVALS_DURATIONS_TYPES =
+      ImmutableMap.<SqlTypeName, DurationFieldType>builder()
+          .put(SqlTypeName.INTERVAL_SECOND, DurationFieldType.seconds())
+          .put(SqlTypeName.INTERVAL_MINUTE, DurationFieldType.minutes())
+          .put(SqlTypeName.INTERVAL_HOUR, DurationFieldType.hours())
+          .put(SqlTypeName.INTERVAL_DAY, DurationFieldType.days())
+          .put(SqlTypeName.INTERVAL_MONTH, DurationFieldType.months())
+          .put(SqlTypeName.INTERVAL_YEAR, DurationFieldType.years())
+          .build();
 
   /**
    * @return internal multiplier of a TimeUnit, e.g. YEAR is 12, MINUTE is 60000

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusExpressionTest.java
@@ -46,6 +46,8 @@ public class BeamSqlDatetimeMinusExpressionTest {
   private static final BeamSqlPrimitive TIMESTAMP =
       BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
 
+  private static final BeamSqlPrimitive DATE1 = BeamSqlPrimitive.of(SqlTypeName.DATE, DATE);
+
   private static final BeamSqlPrimitive TIMESTAMP_MINUS_2_SEC =
       BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE_MINUS_2_SEC);
 
@@ -122,6 +124,18 @@ public class BeamSqlDatetimeMinusExpressionTest {
   public void testEvaluateTimestampMinusInteval() {
     BeamSqlDatetimeMinusExpression minusExpression =
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
+
+    BeamSqlPrimitive subtractionResult =
+        minusExpression.evaluate(NULL_ROW, NULL_WINDOW, BeamSqlExpressionEnvironments.empty());
+
+    assertEquals(SqlTypeName.TIMESTAMP, subtractionResult.getOutputType());
+    assertEquals(DATE_MINUS_2_SEC, subtractionResult.getDate());
+  }
+
+  @Test
+  public void testEvaluateDateMinusInteval() {
+    BeamSqlDatetimeMinusExpression minusExpression =
+        minusExpression(SqlTypeName.TIMESTAMP, DATE1, INTERVAL_2_SEC);
 
     BeamSqlPrimitive subtractionResult =
         minusExpression.evaluate(NULL_ROW, NULL_WINDOW, BeamSqlExpressionEnvironments.empty());

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpressionTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlDatetimeMinusIntervalExpressionTest.java
@@ -1,21 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
 import static org.junit.Assert.assertEquals;
@@ -40,58 +22,28 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-/** Unit tests for {@link BeamSqlTimestampMinusIntervalExpression}. */
-public class BeamSqlTimestampMinusIntervalExpressionTest {
+/** Unit tests for {@link BeamSqlDatetimeMinusIntervalExpression}. */
+public class BeamSqlDatetimeMinusIntervalExpressionTest {
   private static final Row NULL_ROW = null;
   private static final BoundedWindow NULL_WINDOW = null;
 
   private static final DateTime DATE = new DateTime(329281L);
   private static final DateTime DATE_MINUS_2_SEC = DATE.minusSeconds(2);
 
-  private static final BeamSqlPrimitive TIMESTAMP =
-      BeamSqlPrimitive.of(SqlTypeName.TIMESTAMP, DATE);
+  private static final BeamSqlPrimitive DATETIME = BeamSqlPrimitive.of(SqlTypeName.DATE, DATE);
 
   private static final BeamSqlPrimitive INTERVAL_2_SEC =
       BeamSqlPrimitive.of(
           SqlTypeName.INTERVAL_SECOND, TimeUnit.SECOND.multiplier.multiply(new BigDecimal(2)));
 
-  private static final BeamSqlPrimitive INTERVAL_3_MONTHS =
-      BeamSqlPrimitive.of(
-          SqlTypeName.INTERVAL_MONTH, TimeUnit.MONTH.multiplier.multiply(new BigDecimal(3)));
-
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testBasicProperties() {
-    BeamSqlTimestampMinusIntervalExpression minusExpression =
-        minusExpression(SqlTypeName.INTERVAL_DAY_MINUTE, TIMESTAMP, INTERVAL_3_MONTHS);
-
-    assertEquals(SqlTypeName.INTERVAL_DAY_MINUTE, minusExpression.getOutputType());
-    assertEquals(Arrays.asList(TIMESTAMP, INTERVAL_3_MONTHS), minusExpression.getOperands());
-  }
-
-  @Test
   public void testAcceptsHappyPath() {
-    BeamSqlTimestampMinusIntervalExpression minusExpression =
-        minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
+    BeamSqlDatetimeMinusIntervalExpression minusExpression =
+        minusExpression(SqlTypeName.TIMESTAMP, DATETIME, INTERVAL_2_SEC);
 
     assertTrue(minusExpression.accept());
-  }
-
-  @Test
-  public void testDoesNotAcceptOneOperand() {
-    BeamSqlTimestampMinusIntervalExpression minusExpression =
-        minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP);
-
-    assertFalse(minusExpression.accept());
-  }
-
-  @Test
-  public void testDoesNotAcceptThreeOperands() {
-    BeamSqlTimestampMinusIntervalExpression minusExpression =
-        minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC, INTERVAL_3_MONTHS);
-
-    assertFalse(minusExpression.accept());
   }
 
   @Test
@@ -100,8 +52,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
 
     for (SqlTypeName unsupportedType : unsupportedTypes) {
-      BeamSqlTimestampMinusIntervalExpression minusExpression =
-          minusExpression(unsupportedType, TIMESTAMP, INTERVAL_2_SEC);
+      BeamSqlDatetimeMinusIntervalExpression minusExpression =
+          minusExpression(unsupportedType, DATETIME, INTERVAL_2_SEC);
 
       assertFalse(minusExpression.accept());
     }
@@ -110,13 +62,13 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
   @Test
   public void testDoesNotAcceptWrongFirstOperand() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
-    unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
+    unsupportedTypes.removeAll(SqlTypeName.DATETIME_TYPES);
 
     for (SqlTypeName unsupportedType : unsupportedTypes) {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
       doReturn(unsupportedType).when(unsupportedOperand).getOutputType();
 
-      BeamSqlTimestampMinusIntervalExpression minusExpression =
+      BeamSqlDatetimeMinusIntervalExpression minusExpression =
           minusExpression(SqlTypeName.TIMESTAMP, unsupportedOperand, INTERVAL_2_SEC);
 
       assertFalse(minusExpression.accept());
@@ -132,8 +84,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
       doReturn(unsupportedType).when(unsupportedOperand).getOutputType();
 
-      BeamSqlTimestampMinusIntervalExpression minusExpression =
-          minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, unsupportedOperand);
+      BeamSqlDatetimeMinusIntervalExpression minusExpression =
+          minusExpression(SqlTypeName.TIMESTAMP, DATETIME, unsupportedOperand);
 
       assertFalse(minusExpression.accept());
     }
@@ -145,8 +97,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
       doReturn(unsupportedType).when(unsupportedOperand).getOutputType();
 
-      BeamSqlTimestampMinusIntervalExpression minusExpression =
-          minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, unsupportedOperand);
+      BeamSqlDatetimeMinusIntervalExpression minusExpression =
+          minusExpression(SqlTypeName.TIMESTAMP, DATETIME, unsupportedOperand);
 
       assertTrue(minusExpression.accept());
     }
@@ -154,8 +106,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
 
   @Test
   public void testEvaluateHappyPath() {
-    BeamSqlTimestampMinusIntervalExpression minusExpression =
-        minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC);
+    BeamSqlDatetimeMinusIntervalExpression minusExpression =
+        minusExpression(SqlTypeName.TIMESTAMP, DATETIME, INTERVAL_2_SEC);
 
     BeamSqlPrimitive subtractionResult =
         minusExpression.evaluate(NULL_ROW, NULL_WINDOW, BeamSqlExpressionEnvironments.empty());
@@ -164,8 +116,8 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     assertEquals(DATE_MINUS_2_SEC, subtractionResult.getDate());
   }
 
-  private static BeamSqlTimestampMinusIntervalExpression minusExpression(
+  private static BeamSqlDatetimeMinusIntervalExpression minusExpression(
       SqlTypeName intervalsToCount, BeamSqlExpression... operands) {
-    return new BeamSqlTimestampMinusIntervalExpression(Arrays.asList(operands), intervalsToCount);
+    return new BeamSqlDatetimeMinusIntervalExpression(Arrays.asList(operands), intervalsToCount);
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date;
 
-import static org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.date.BeamSqlDatetimeMinusExpression.INTERVALS_DURATIONS_TYPES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -67,7 +66,7 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_DAY_MINUTE, TIMESTAMP, INTERVAL_3_MONTHS);
 
-    assertEquals(SqlTypeName.INTERVAL_DAY_MINUTE, minusExpression.getOutputType());
+    assertEquals(SqlTypeName.TIMESTAMP, minusExpression.getOutputType());
     assertEquals(Arrays.asList(TIMESTAMP, INTERVAL_3_MONTHS), minusExpression.getOperands());
   }
 
@@ -96,22 +95,9 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
   }
 
   @Test
-  public void testDoesNotAcceptWrongOutputType() {
-    Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
-    unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
-
-    for (SqlTypeName unsupportedType : unsupportedTypes) {
-      BeamSqlTimestampMinusIntervalExpression minusExpression =
-          minusExpression(unsupportedType, TIMESTAMP, INTERVAL_2_SEC);
-
-      assertFalse(minusExpression.accept());
-    }
-  }
-
-  @Test
   public void testDoesNotAcceptWrongFirstOperand() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
-    unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
+    unsupportedTypes.removeAll(SqlTypeName.DATETIME_TYPES);
 
     for (SqlTypeName unsupportedType : unsupportedTypes) {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
@@ -127,7 +113,7 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
   @Test
   public void testDoesNotAcceptWrongSecondOperand() {
     Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
-    unsupportedTypes.removeAll(INTERVALS_DURATIONS_TYPES.keySet());
+    unsupportedTypes.removeAll(TimeUnitUtils.INTERVALS_DURATIONS_TYPES.keySet());
 
     for (SqlTypeName unsupportedType : unsupportedTypes) {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
@@ -142,7 +128,7 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
 
   @Test
   public void testAcceptsAllSupportedIntervalTypes() {
-    for (SqlTypeName unsupportedType : INTERVALS_DURATIONS_TYPES.keySet()) {
+    for (SqlTypeName unsupportedType : TimeUnitUtils.INTERVALS_DURATIONS_TYPES.keySet()) {
       BeamSqlPrimitive unsupportedOperand = mock(BeamSqlPrimitive.class);
       doReturn(unsupportedType).when(unsupportedOperand).getOutputType();
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/date/BeamSqlTimestampMinusIntervalExpressionTest.java
@@ -66,7 +66,7 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
     BeamSqlTimestampMinusIntervalExpression minusExpression =
         minusExpression(SqlTypeName.INTERVAL_DAY_MINUTE, TIMESTAMP, INTERVAL_3_MONTHS);
 
-    assertEquals(SqlTypeName.TIMESTAMP, minusExpression.getOutputType());
+    assertEquals(SqlTypeName.INTERVAL_DAY_MINUTE, minusExpression.getOutputType());
     assertEquals(Arrays.asList(TIMESTAMP, INTERVAL_3_MONTHS), minusExpression.getOperands());
   }
 
@@ -92,6 +92,19 @@ public class BeamSqlTimestampMinusIntervalExpressionTest {
         minusExpression(SqlTypeName.TIMESTAMP, TIMESTAMP, INTERVAL_2_SEC, INTERVAL_3_MONTHS);
 
     assertFalse(minusExpression.accept());
+  }
+
+  @Test
+  public void testDoesNotAcceptWrongOutputType() {
+    Set<SqlTypeName> unsupportedTypes = new HashSet<>(SqlTypeName.ALL_TYPES);
+    unsupportedTypes.remove(SqlTypeName.TIMESTAMP);
+
+    for (SqlTypeName unsupportedType : unsupportedTypes) {
+      BeamSqlTimestampMinusIntervalExpression minusExpression =
+          minusExpression(unsupportedType, TIMESTAMP, INTERVAL_2_SEC);
+
+      assertFalse(minusExpression.accept());
+    }
   }
 
   @Test


### PR DESCRIPTION
DatetimeMinusExpression should accept all datetime types as its first operand.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




