### PR TITLE
[BEAM-4176] Initial implementation for running portable runner tests

### DIFF
--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   validatesRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
   validatesRunner project(path: ":beam-runners-reference-java", configuration: "shadowTest")
   compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
-//  TODO: Enable AWS and HDPS file system.
+//  TODO: Enable AWS and HDFS file system.
 }
 
 // NOTE: runShadow must be used in order to run the job server. The standard run

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -75,7 +75,7 @@ class PortableValidatesRunnerConfig {
 }
 
 def createPortableValidatesRunnerTask = {
-  def config = it as PortableValidatesRunnerConfig
+  def config = it ? it as PortableValidatesRunnerConfig : new PortableValidatesRunnerConfig()
   tasks.create(name: config.name, type: Test) {
     group = "Verification"
     description = "Validates the PortableRunner with JobServer ${config.jobServerDriver}"

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -29,7 +29,8 @@ applyJavaNature(
  * the following projects are evaluated before we evaluate this project. This is because
  * we are attempting to reference the "sourceSets.test.output" directly.
  */
-evaluationDependsOn(":beam-runners-flink_2.11")
+evaluationDependsOn(":beam-sdks-java-core")
+evaluationDependsOn(":beam-runners-core-java")
 
 description = "Apache Beam :: Runners :: Flink :: Job Server"
 
@@ -44,6 +45,8 @@ configurations {
 dependencies {
   compile project(path: ":beam-runners-flink_2.11", configuration: "shadow")
   validatesRunner project(path: ":beam-runners-flink_2.11", configuration: "shadowTest")
+  validatesRunner project(path: ":beam-sdks-java-core", configuration: "shadowTest")
+  validatesRunner project(path: ":beam-runners-core-java", configuration: "shadowTest")
   validatesRunner project(path: ":beam-runners-reference-java", configuration: "shadowTest")
   compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
 //  TODO: Enable AWS and HDPS file system.
@@ -61,21 +64,25 @@ runShadow {
 }
 
 class PortableValidatesRunnerConfig {
+  // Task name for validate runner case.
   String name
+  // Fully qualified JobServerClass name to use.
   String jobServerDriver
+  // A string representing the jobServer Configuration.
   String jobServerConfig
+  // Flag to include tests for streaming or batch.
   boolean streaming
 }
 
-def createPortableValidatesRunnerTask(Map m) {
-  def config = m as PortableValidatesRunnerConfig
+def createPortableValidatesRunnerTask = {
+  def config = it as PortableValidatesRunnerConfig
   tasks.create(name: config.name, type: Test) {
     group = "Verification"
     description = "Validates the PortableRunner with JobServer ${config.jobServerDriver}"
     systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
             "--runner=org.apache.beam.runners.reference.testing.TestPortableRunner",
             "--jobServerDriver=${config.jobServerDriver}",
-            "--jobServerConfig=${config.jobServerConfig}",
+            config.jobServerConfig ? "--jobServerConfig=${config.jobServerConfig}" : "",
     ])
     classpath = configurations.validatesRunner
     testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs, project(":beam-runners-core-java").sourceSets.test.output.classesDirs)
@@ -104,7 +111,7 @@ def createPortableValidatesRunnerTask(Map m) {
   }
 }
 
-createPortableValidatesRunnerTask(name: "validatesPortableRunner", jobServerDriver: "org.apache.beam.runners.flink.FlinkJobServerDriver", jobServerConfig: "[]", streaming: false)
+createPortableValidatesRunnerTask(name: "validatesPortableRunner", jobServerDriver: "org.apache.beam.runners.flink.FlinkJobServerDriver", jobServerConfig: "", streaming: false)
 
 task validatesRunner {
   group = "Verification"

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import groovy.json.JsonOutput
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 applyJavaNature(
@@ -23,14 +24,27 @@ applyJavaNature(
   },
 )
 
+/*
+ * We need to rely on manually specifying these evaluationDependsOn to ensure that
+ * the following projects are evaluated before we evaluate this project. This is because
+ * we are attempting to reference the "sourceSets.test.output" directly.
+ */
+evaluationDependsOn(":beam-runners-flink_2.11")
+
 description = "Apache Beam :: Runners :: Flink :: Job Server"
 
 apply plugin: "application"
 
 mainClassName = "org.apache.beam.runners.flink.FlinkJobServerDriver"
 
+configurations {
+  validatesRunner
+}
+
 dependencies {
   compile project(path: ":beam-runners-flink_2.11", configuration: "shadow")
+  validatesRunner project(path: ":beam-runners-flink_2.11", configuration: "shadowTest")
+  validatesRunner project(path: ":beam-runners-reference-java", configuration: "shadowTest")
   compile project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
 //  TODO: Enable AWS and HDPS file system.
 }
@@ -44,4 +58,56 @@ runShadow {
   args = ["--job-host=${jobHost}", "--artifacts-dir=${artifactsDir}"]
   // Enable remote debugging.
   jvmArgs = ["-Xdebug", "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005"]
+}
+
+class PortableValidatesRunnerConfig {
+  String name
+  String jobServerDriver
+  String jobServerConfig
+  boolean streaming
+}
+
+def createPortableValidatesRunnerTask(Map m) {
+  def config = m as PortableValidatesRunnerConfig
+  tasks.create(name: config.name, type: Test) {
+    group = "Verification"
+    description = "Validates the PortableRunner with JobServer ${config.jobServerDriver}"
+    systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
+            "--runner=org.apache.beam.runners.reference.testing.TestPortableRunner",
+            "--jobServerDriver=${config.jobServerDriver}",
+            "--jobServerConfig=${config.jobServerConfig}",
+    ])
+    classpath = configurations.validatesRunner
+    testClassesDirs = files(project(":beam-sdks-java-core").sourceSets.test.output.classesDirs, project(":beam-runners-core-java").sourceSets.test.output.classesDirs)
+    maxParallelForks 1
+    if (config.streaming) {
+      useJUnit {
+        includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+        excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+        excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSchema'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+      }
+    } else {
+      useJUnit {
+        includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+        excludeCategories 'org.apache.beam.sdk.testing.FlattenWithHeterogeneousCoders'
+        excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSchema'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDo'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
+      }
+    }
+  }
+}
+
+createPortableValidatesRunnerTask(name: "validatesPortableRunner", jobServerDriver: "org.apache.beam.runners.flink.FlinkJobServerDriver", jobServerConfig: "[]", streaming: false)
+
+task validatesRunner {
+  group = "Verification"
+  description "Validates Portable Flink runner"
+  dependsOn validatesPortableRunner
 }

--- a/runners/flink/job-server/build.gradle
+++ b/runners/flink/job-server/build.gradle
@@ -97,7 +97,7 @@ def createPortableValidatesRunnerTask(Map m) {
         excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
         excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
         excludeCategories 'org.apache.beam.sdk.testing.UsesSchema'
-        excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDo'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
       }
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobInvocation.java
@@ -89,7 +89,7 @@ public class FlinkJobInvocation implements JobInvocation {
   }
 
   private PipelineResult runPipeline() throws Exception {
-    MetricsEnvironment.setMetricsSupported(true);
+    MetricsEnvironment.setMetricsSupported(false);
 
     LOG.info("Translating pipeline to Flink program.");
     // Fused pipeline proto.

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -75,7 +75,7 @@ public class FlinkJobServerDriver implements Runnable {
     System.err.println();
   }
 
-  private static ServerConfiguration parseServerConfiguration(String[] args) {
+  public static FlinkJobServerDriver fromParams(String[] args) {
     ServerConfiguration configuration = new ServerConfiguration();
     CmdLineParser parser = new CmdLineParser(configuration);
     try {
@@ -85,11 +85,8 @@ public class FlinkJobServerDriver implements Runnable {
       printUsage(parser);
       throw new IllegalArgumentException("Unable to parse command line arguments.", e);
     }
-    return configuration;
-  }
 
-  public static FlinkJobServerDriver fromParams(String[] args) {
-    return fromConfig(parseServerConfiguration(args));
+    return fromConfig(configuration);
   }
 
   public static FlinkJobServerDriver fromConfig(ServerConfiguration configuration) {
@@ -143,7 +140,7 @@ public class FlinkJobServerDriver implements Runnable {
         LOG.info("JobServer stopped on {}", jobServer.getApiServiceDescriptor().getUrl());
         jobServer = null;
       } catch (Exception e) {
-        LOG.error("Error while closing the jobServer.");
+        LOG.error("Error while closing the jobServer.", e);
       }
     }
     if (artifactStagingServer != null) {
@@ -153,7 +150,7 @@ public class FlinkJobServerDriver implements Runnable {
             "ArtifactStagingServer stopped on {}", jobServer.getApiServiceDescriptor().getUrl());
         artifactStagingServer = null;
       } catch (Exception e) {
-        LOG.error("Error while closing the artifactStagingServer.");
+        LOG.error("Error while closing the artifactStagingServer.", e);
       }
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -147,7 +147,8 @@ public class FlinkJobServerDriver implements Runnable {
       try {
         artifactStagingServer.close();
         LOG.info(
-            "ArtifactStagingServer stopped on {}", jobServer.getApiServiceDescriptor().getUrl());
+            "ArtifactStagingServer stopped on {}",
+            artifactStagingServer.getApiServiceDescriptor().getUrl());
         artifactStagingServer = null;
       } catch (Exception e) {
         LOG.error("Error while closing the artifactStagingServer.", e);

--- a/runners/reference/java/build.gradle
+++ b/runners/reference/java/build.gradle
@@ -24,7 +24,12 @@ ext.summary = """A Java implementation of the Beam Model which utilizes the port
 framework to execute user-definied functions."""
 
 
+configurations {
+  validatesRunner
+}
+
 dependencies {
+  compile library.java.hamcrest_library
   shadow project(path: ":beam-model-pipeline", configuration: "shadow")
   shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")
   shadow project(path: ":beam-sdks-java-fn-execution", configuration: "shadow")

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
@@ -19,6 +19,8 @@ package org.apache.beam.runners.reference.testing;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.options.Default;
+import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsRegistrar;
@@ -32,14 +34,23 @@ public interface TestPortablePipelineOptions extends TestPipelineOptions, Portab
   @Required
   @Description(
       "Fully qualified class name of TestJobServiceDriver capable of managing the JobService.")
-  String getJobServerDriver();
+  Class getJobServerDriver();
 
-  void setJobServerDriver(String jobServerDriver);
+  void setJobServerDriver(Class jobServerDriver);
 
   @Description("String containing comma separated arguments for the JobServer.")
-  String getJobServerConfig();
+  @Default.InstanceFactory(DefaultJobServerConfigFactory.class)
+  String[] getJobServerConfig();
 
-  void setJobServerConfig(String jobServerConfig);
+  void setJobServerConfig(String[] jobServerConfig);
+
+  class DefaultJobServerConfigFactory implements DefaultValueFactory<String[]> {
+
+    @Override
+    public String[] create(PipelineOptions options) {
+      return new String[0];
+    }
+  }
 
   /** Register {@link TestPortablePipelineOptions}. */
   @AutoService(PipelineOptionsRegistrar.class)

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
@@ -44,6 +44,7 @@ public interface TestPortablePipelineOptions extends TestPipelineOptions, Portab
 
   void setJobServerConfig(String[] jobServerConfig);
 
+  /** Factory for default config. */
   class DefaultJobServerConfigFactory implements DefaultValueFactory<String[]> {
 
     @Override

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
@@ -41,8 +41,8 @@ public interface TestPortablePipelineOptions extends TestPipelineOptions, Portab
 
   void setJobServerConfig(String jobServerConfig);
 
-  @AutoService(PipelineOptionsRegistrar.class)
   /** Register {@link TestPortablePipelineOptions}. */
+  @AutoService(PipelineOptionsRegistrar.class)
   class TestPortablePipelineOptionsRegistrar implements PipelineOptionsRegistrar {
 
     @Override

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.reference.testing;
+
+import com.google.auto.service.AutoService;
+import com.google.common.collect.ImmutableList;
+import org.apache.beam.sdk.options.Description;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsRegistrar;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.options.Validation.Required;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+
+/** Options for {@link TestPortableRunner}. */
+public interface TestPortablePipelineOptions extends TestPipelineOptions, PortablePipelineOptions {
+
+  @Required
+  @Description(
+      "Fully qualified class name of TestJobServiceDriver capable of managing the JobService.")
+  String getJobServerDriver();
+
+  void setJobServerDriver(String jobServerDriver);
+
+  @Description("String containing comma separated arguments for the JobServer.")
+  String getJobServerConfig();
+
+  void setJobServerConfig(String jobServerConfig);
+
+  @AutoService(PipelineOptionsRegistrar.class)
+  /** Register {@link TestPortablePipelineOptions}. */
+  class TestPortablePipelineOptionsRegistrar implements PipelineOptionsRegistrar {
+
+    @Override
+    public Iterable<Class<? extends PipelineOptions>> getPipelineOptions() {
+      return ImmutableList.of(TestPortablePipelineOptions.class);
+    }
+  }
+}

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortablePipelineOptions.java
@@ -42,7 +42,7 @@ public interface TestPortablePipelineOptions extends TestPipelineOptions, Portab
   @Default.InstanceFactory(DefaultJobServerConfigFactory.class)
   String[] getJobServerConfig();
 
-  void setJobServerConfig(String[] jobServerConfig);
+  void setJobServerConfig(String... jobServerConfig);
 
   /** Factory for default config. */
   class DefaultJobServerConfigFactory implements DefaultValueFactory<String[]> {

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.reference.testing;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import org.apache.beam.runners.reference.PortableRunner;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineRunner;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link TestPortableRunner} is a pipeline runner that wraps a {@link PortableRunner} when running
+ * tests against the {@link TestPipeline}.
+ *
+ * @see TestPipeline
+ */
+public class TestPortableRunner extends PipelineRunner<PipelineResult> {
+  private static final Logger LOG = LoggerFactory.getLogger(TestPortableRunner.class);
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper()
+          .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
+  private final PortablePipelineOptions options;
+
+  private TestPortableRunner(PortablePipelineOptions options) {
+    this.options = options;
+  }
+
+  public static TestPortableRunner fromOptions(PipelineOptions options) {
+    return new TestPortableRunner(options.as(PortablePipelineOptions.class));
+  }
+
+  @Override
+  public PipelineResult run(Pipeline pipeline) {
+    TestPortablePipelineOptions testPortablePipelineOptions =
+        options.as(TestPortablePipelineOptions.class);
+    String jobServerHost = "localhost:8099";
+    Object jobServerDriver;
+    Class<?> jobServerDriverClass;
+    try {
+      jobServerDriverClass =
+          Class.forName(
+              testPortablePipelineOptions.getJobServerDriver(),
+              true,
+              ReflectHelpers.findClassLoader());
+      String[] parameters;
+      try {
+        parameters =
+            MAPPER.readValue(testPortablePipelineOptions.getJobServerConfig(), String[].class);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Arguments to jobServers should be a comma separated list of strings. Provided %s",
+                testPortablePipelineOptions.getJobServerDriver()));
+      }
+      try {
+        jobServerDriver =
+            jobServerDriverClass
+                .getMethod("fromHostAndParams", String.class, String[].class)
+                .invoke(null, jobServerHost, parameters);
+        jobServerDriverClass.getMethod("start").invoke(jobServerDriver);
+      } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+        throw new IllegalArgumentException(e);
+      }
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Unknown 'TestJobServerDriver' specified '%s'",
+              testPortablePipelineOptions.getJobServerDriver()),
+          e);
+    }
+    try {
+      PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
+      portableOptions.setRunner(PortableRunner.class);
+      portableOptions.setJobEndpoint(jobServerHost);
+      PortableRunner runner = PortableRunner.fromOptions(portableOptions);
+      PipelineResult result = runner.run(pipeline);
+      result.waitUntilFinish();
+      return result;
+    } finally {
+      try {
+        jobServerDriverClass.getMethod("stop").invoke(jobServerDriver);
+      } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        LOG.error(
+            String.format(
+                "Provided JobServiceDriver %s does not implement stop().", jobServerDriverClass),
+            e);
+      }
+    }
+  }
+}

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
@@ -35,11 +35,13 @@ import org.slf4j.LoggerFactory;
  * {@link TestPortableRunner} is a pipeline runner that wraps a {@link PortableRunner} when running
  * tests against the {@link TestPipeline}.
  *
- * This runner requires a JobServerDriver with following methods.
+ * <p>This runner requires a JobServerDriver with following methods.
  *
- * public static Object fromParams(String... params)
- * public String start() // Start JobServer and returns the JobServer host and port.
- * public void start() // Stop the JobServer and free all resources.
+ * <ul>
+ *   <li>public static Object fromParams(String... params)
+ *   <li>public String start() // Start JobServer and returns the JobServer host and port.
+ *   <li>public void start() // Stop the JobServer and free all resources.
+ * </ul>
  *
  * @see TestPipeline
  */

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/testing/TestPortableRunner.java
@@ -17,17 +17,21 @@
  */
 package org.apache.beam.runners.reference.testing;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import org.apache.beam.runners.reference.PortableRunner;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineResult.State;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.hamcrest.Matchers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +110,7 @@ public class TestPortableRunner extends PipelineRunner<PipelineResult> {
       portableOptions.setJobEndpoint(jobServerHostPort);
       PortableRunner runner = PortableRunner.fromOptions(portableOptions);
       PipelineResult result = runner.run(pipeline);
-      result.waitUntilFinish();
+      assertThat("Pipeline did not succeed.", result.waitUntilFinish(), Matchers.is(State.DONE));
       return result;
     } finally {
       try {


### PR DESCRIPTION
Basic idea is to start a job server using a JobServerDriver which can be initialized with provided parameters.
TestPortableRunner will start a new instance of JobServer for every test and then run the test on it.

I have kept the maxParallelForks to 1 for now as i want to first make sure that all the tests pass with no concurrency.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




