### PR TITLE
[BEAM-4749] Install fastavro only in linux

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -53,8 +53,6 @@ import avro
 from avro import io as avroio
 from avro import datafile
 from avro import schema
-from fastavro.read import block_reader
-from fastavro.write import Writer
 
 import apache_beam as beam
 from apache_beam.io import filebasedsink
@@ -443,6 +441,9 @@ class _FastAvroSource(filebasedsource.FileBasedSource):
       start_offset = 0
 
     with self.open_file(file_name) as f:
+      # TODO(BEAM-4749): fastavro fails to install in MacOS.
+      from fastavro.read import block_reader  # pylint: disable=wrong-import-position
+
       blocks = block_reader(f)
       sync_marker = blocks._header['sync']
 
@@ -596,6 +597,9 @@ class _AvroSink(filebasedsink.FileBasedSink):
 class _FastAvroSink(_AvroSink):
   """A sink for avro files that uses the `fastavro` library"""
   def open(self, temp_path):
+    # TODO(BEAM-4749): fastavro fails to install in MacOS.
+    from fastavro.write import Writer  # pylint: disable=wrong-import-position
+
     file_handle = super(_AvroSink, self).open(temp_path)
     return Writer(file_handle, self._schema.to_json(), self._codec)
 

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -453,6 +453,13 @@ class TestFastAvro(TestAvro):
     super(TestFastAvro, self).__init__(methodName)
     self.use_fastavro = True
 
+  def setUp(self):
+    super(TestFastAvro, self).setUp()
+    try:
+      from fastavro.read import block_reader  # pylint: disable=unused-variable
+    except ImportError:
+      self.skipTest("fastavro is not installed.")
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -98,7 +98,6 @@ REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0',
     'crcmod>=1.7,<2.0',
     'dill==0.2.6',
-    'fastavro==0.19.7',
     'grpcio>=1.8,<2',
     'hdfs>=2.1.0,<3.0.0',
     'httplib2>=0.8,<=0.11.3',
@@ -115,6 +114,14 @@ REQUIRED_PACKAGES = [
     'futures>=3.1.1,<4.0.0',
     'future>=0.16.0,<1.0.0',
     ]
+
+REQUIRED_PACKAGES_LINUX_ONLY = [
+    'fastavro==0.19.7',
+]
+
+# TODO(BEAM-4749): fastavro fails to install in MacOS.
+if 'Linux' in platform.system():
+  REQUIRED_PACKAGES.extend(REQUIRED_PACKAGES_LINUX_ONLY)
 
 REQUIRED_TEST_PACKAGES = [
     'nose>=1.3.7',


### PR DESCRIPTION
Installing fastavro breaks in MacOS at compilation time. This in turn prevents SDK from being installed. Until we have tests and know that fastavro installs cleanly in other OSes I will limit it to linux only.

R: @udim 
cc: @ryan-williams 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




