### PR TITLE
[BEAM-4076] Schema utilities for converting between types

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -120,6 +120,9 @@ public abstract class RowCoderGenerator {
 
   @SuppressWarnings("unchecked")
   public static Coder<Row> generate(Schema schema, UUID coderId) {
+    if (schema.getFieldCount() == 0) {
+      throw new RuntimeException("Cannot generate coder for empty schema.");
+    }
     return generatedCoders.computeIfAbsent(
         coderId,
         h -> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -172,6 +173,7 @@ public class Schema implements Serializable {
     return Schema.builder().addFields(fields).build();
   }
 
+  /** Returns true if two Schemas have the same fields in the same order. */
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof Schema)) {
@@ -180,6 +182,33 @@ public class Schema implements Serializable {
     Schema other = (Schema) o;
     return Objects.equals(fieldIndices, other.fieldIndices)
         && Objects.equals(getFields(), other.getFields());
+  }
+
+  /** Returns true if two Schemas have the same fields, but possibly in different orders. */
+  public boolean equivalent(Schema other) {
+    List<Field> otherFields =
+        other
+            .getFields()
+            .stream()
+            .sorted(Comparator.comparing(Field::getName))
+            .collect(Collectors.toList());
+    List<Field> actualFields =
+        getFields()
+            .stream()
+            .sorted(Comparator.comparing(Field::getName))
+            .collect(Collectors.toList());
+    if (otherFields.size() != actualFields.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < otherFields.size(); ++i) {
+      Field otherField = otherFields.get(i);
+      Field actualField = actualFields.get(i);
+      if (!otherField.equivalent(actualField)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override
@@ -399,6 +428,26 @@ public class Schema implements Serializable {
           && Arrays.equals(getMetadata(), other.getMetadata());
     }
 
+    private boolean equivalent(FieldType other) {
+      if (!other.getTypeName().equals(getTypeName())) {
+        return false;
+      }
+      if (TypeName.ROW.equals(getTypeName()) && !other.getRowSchema().equivalent(getRowSchema())) {
+        return false;
+      } else if (TypeName.ARRAY.equals(getTypeName())
+          && !other.getCollectionElementType().equivalent(getCollectionElementType())) {
+        return false;
+      } else if (TypeName.MAP.equals(getTypeName())) {
+        if (!other.getMapKeyType().equivalent(getMapKeyType())
+            || !other.getMapValueType().equivalent(getMapValueType())) {
+          return false;
+        }
+      } else {
+        return other.equals(this);
+      }
+      return true;
+    }
+
     @Override
     public int hashCode() {
       return Arrays.deepHashCode(
@@ -493,6 +542,12 @@ public class Schema implements Serializable {
           && Objects.equals(getDescription(), other.getDescription())
           && Objects.equals(getType(), other.getType())
           && Objects.equals(getNullable(), other.getNullable());
+    }
+
+    private boolean equivalent(Field otherField) {
+      return otherField.getName().equals(getName())
+          && otherField.getNullable().equals(getNullable())
+          && getType().equivalent(otherField.getType());
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -432,18 +432,25 @@ public class Schema implements Serializable {
       if (!other.getTypeName().equals(getTypeName())) {
         return false;
       }
-      if (TypeName.ROW.equals(getTypeName()) && !other.getRowSchema().equivalent(getRowSchema())) {
-        return false;
-      } else if (TypeName.ARRAY.equals(getTypeName())
-          && !other.getCollectionElementType().equivalent(getCollectionElementType())) {
-        return false;
-      } else if (TypeName.MAP.equals(getTypeName())) {
-        if (!other.getMapKeyType().equivalent(getMapKeyType())
-            || !other.getMapValueType().equivalent(getMapValueType())) {
-          return false;
-        }
-      } else {
-        return other.equals(this);
+      switch (getTypeName()) {
+        case ROW:
+          if (!other.getRowSchema().equivalent(getRowSchema())) {
+            return false;
+          }
+          break;
+        case ARRAY:
+          if (!other.getCollectionElementType().equivalent(getCollectionElementType())) {
+            return false;
+          }
+          break;
+        case MAP:
+          if (!other.getMapKeyType().equivalent(getMapKeyType())
+              || !other.getMapValueType().equivalent(getMapValueType())) {
+            return false;
+          }
+          break;
+        default:
+          return other.equals(this);
       }
       return true;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.schemas;
 
+import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -31,7 +32,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * contacts an external schema-registry service to determine the schema for a type.
  */
 @Experimental(Kind.SCHEMAS)
-public interface SchemaProvider {
+public interface SchemaProvider extends Serializable {
 
   /** Lookup a schema for the given type. If no schema exists, returns null. */
   @Nullable

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
@@ -42,7 +42,7 @@ public class Convert {
    * the same schema as the iput.
    */
   public static <InputT> PTransform<PCollection<InputT>, PCollection<Row>> toRows() {
-    return convert(Row.class);
+    return to(Row.class);
   }
 
   /**
@@ -53,7 +53,7 @@ public class Convert {
    */
   public static <OutputT> PTransform<PCollection<Row>, PCollection<OutputT>> fromRows(
       Class<OutputT> clazz) {
-    return convert(clazz);
+    return to(clazz);
   }
 
   /**
@@ -64,7 +64,7 @@ public class Convert {
    */
   public static <OutputT> PTransform<PCollection<Row>, PCollection<OutputT>> fromRows(
       TypeDescriptor<OutputT> typeDescriptor) {
-    return convert(typeDescriptor);
+    return to(typeDescriptor);
   }
 
   /**
@@ -74,9 +74,9 @@ public class Convert {
    * <i>compatible</i> schemas. Two schemas are said to be <i>compatible</i> if they recursively
    * have fields with the same names, but possibly different orders.
    */
-  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> convert(
+  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> to(
       Class<OutputT> clazz) {
-    return convert(TypeDescriptor.of(clazz));
+    return to(TypeDescriptor.of(clazz));
   }
 
   /**
@@ -86,7 +86,7 @@ public class Convert {
    * <i>compatible</i> schemas. Two schemas are said to be <i>compatible</i> if they recursively
    * have fields with the same names, but possibly different orders.
    */
-  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> convert(
+  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> to(
       TypeDescriptor<OutputT> typeDescriptor) {
     return new ConvertTransform<>(typeDescriptor);
   }
@@ -133,7 +133,11 @@ public class Convert {
           // assert matches input schema.
           if (!outputSchemaCoder.getSchema().equivalent(input.getSchema())) {
             throw new RuntimeException(
-                "Cannot convert between types that don't have equivalent " + "schemas.");
+                "Cannot convert between types that don't have equivalent schemas."
+                    + " input schema: "
+                    + input.getSchema()
+                    + " output schema: "
+                    + outputSchemaCoder.getSchema());
           }
         } catch (NoSuchSchemaException e) {
           throw new RuntimeException("No schema registered for " + outputTypeDescriptor);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Convert.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.schemas.transforms;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/** A set of utilities for converting between different objects supporting schemas. */
+@Experimental(Kind.SCHEMAS)
+public class Convert {
+  /**
+   * Convert a {@link PCollection<InputT>} into a {@link PCollection<Row>}.
+   *
+   * <p>The input {@link PCollection} must have a schema attached. The output collection will have
+   * the same schema as the iput.
+   */
+  public static <InputT> PTransform<PCollection<InputT>, PCollection<Row>> toRows() {
+    return convert(Row.class);
+  }
+
+  /**
+   * Convert a {@link PCollection<Row>} into a {@link PCollection<OutputT>}.
+   *
+   * <p>The output schema will be inferred using the schema registry. A schema must be registered
+   * for this type, or the conversion will fail.
+   */
+  public static <OutputT> PTransform<PCollection<Row>, PCollection<OutputT>> fromRows(
+      Class<OutputT> clazz) {
+    return convert(clazz);
+  }
+
+  /**
+   * Convert a {@link PCollection<Row>} into a {@link PCollection<OutputT>}.
+   *
+   * <p>The output schema will be inferred using the schema registry. A schema must be registered
+   * for this type, or the conversion will fail.
+   */
+  public static <OutputT> PTransform<PCollection<Row>, PCollection<OutputT>> fromRows(
+      TypeDescriptor<OutputT> typeDescriptor) {
+    return convert(typeDescriptor);
+  }
+
+  /**
+   * Convert a {@link PCollection<InputT>} to a {@link PCollection<OutputT>}.
+   *
+   * <p>This function allows converting between two types as long as the two types have
+   * <i>compatible</i> schemas. Two schemas are said to be <i>compatible</i> if they recursively
+   * have fields with the same names, but possibly different orders.
+   */
+  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> convert(
+      Class<OutputT> clazz) {
+    return convert(TypeDescriptor.of(clazz));
+  }
+
+  /**
+   * Convert a {@link PCollection<InputT>} to a {@link PCollection<OutputT>}.
+   *
+   * <p>This function allows converting between two types as long as the two types have
+   * <i>compatible</i> schemas. Two schemas are said to be <i>compatible</i> if they recursively
+   * have fields with the same names, but possibly different orders.
+   */
+  public static <InputT, OutputT> PTransform<PCollection<InputT>, PCollection<OutputT>> convert(
+      TypeDescriptor<OutputT> typeDescriptor) {
+    return new ConvertTransform<>(typeDescriptor);
+  }
+
+  private static class ConvertTransform<InputT, OutputT>
+      extends PTransform<PCollection<InputT>, PCollection<OutputT>> {
+    @Nullable TypeDescriptor<OutputT> outputTypeDescriptor = null;
+    SchemaCoder<OutputT> outputSchemaCoder;
+
+    ConvertTransform(Class<OutputT> outputClass) {
+      this(TypeDescriptor.of(outputClass));
+    }
+
+    ConvertTransform(TypeDescriptor<OutputT> outputTypeDescriptor) {
+      this.outputTypeDescriptor = outputTypeDescriptor;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public PCollection<OutputT> expand(PCollection<InputT> input) {
+      if (!input.hasSchema()) {
+        throw new RuntimeException("Convert requires a schema on the input.");
+      }
+
+      boolean toRow = outputTypeDescriptor.equals(TypeDescriptor.of(Row.class));
+      if (toRow) {
+        // If the output is of type Row, then just forward the schema of the input type to the
+        // output.
+        outputSchemaCoder =
+            (SchemaCoder<OutputT>)
+                SchemaCoder.of(
+                    input.getSchema(),
+                    SerializableFunctions.identity(),
+                    SerializableFunctions.identity());
+      } else {
+        // Otherwise, try to find a schema for the output type in the schema registry.
+        SchemaRegistry registry = input.getPipeline().getSchemaRegistry();
+        try {
+          outputSchemaCoder =
+              SchemaCoder.of(
+                  registry.getSchema(outputTypeDescriptor),
+                  registry.getToRowFunction(outputTypeDescriptor),
+                  registry.getFromRowFunction(outputTypeDescriptor));
+          // assert matches input schema.
+          if (!outputSchemaCoder.getSchema().equivalent(input.getSchema())) {
+            throw new RuntimeException(
+                "Cannot convert between types that don't have equivalent " + "schemas.");
+          }
+        } catch (NoSuchSchemaException e) {
+          throw new RuntimeException("No schema registered for " + outputTypeDescriptor);
+        }
+      }
+
+      return input
+          .apply(
+              ParDo.of(
+                  new DoFn<InputT, OutputT>() {
+                    @ProcessElement
+                    public void processElement(@Element Row row, OutputReceiver<OutputT> o) {
+                      o.output(outputSchemaCoder.getFromRowFunction().apply(row));
+                    }
+                  }))
+          .setSchema(
+              outputSchemaCoder.getSchema(),
+              outputSchemaCoder.getToRowFunction(),
+              outputSchemaCoder.getFromRowFunction());
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/package-info.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/package-info.java
@@ -15,17 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.sdk.schemas.utils;
+/**
+ * Defines transforms that work on PCollections with schemas..
+ *
+ * <p>For further details, see the documentation for each class in this package.
+ */
+@DefaultAnnotation(NonNull.class)
+package org.apache.beam.sdk.schemas.transforms;
 
-import static org.junit.Assert.assertTrue;
-
-import org.apache.beam.sdk.schemas.Schema;
-
-/** Utilities for testing schemas. */
-public class SchemaTestUtils {
-  // Assert that two schemas are equivalent, ignoring field order. This tests that both schemas
-  // (recursively) contain the same fields with the same names, but possibly different orders.
-  public static void assertSchemaEquivalent(Schema expected, Schema actual) {
-    assertTrue(actual.equivalent(expected));
-  }
-}
+import edu.umd.cs.findbugs.annotations.DefaultAnnotation;
+import edu.umd.cs.findbugs.annotations.NonNull;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
@@ -301,6 +301,18 @@ public class PCollection<T> extends PValueBase implements PValue {
     return setCoder(SchemaCoder.of(schema, toRowFunction, fromRowFunction));
   }
 
+  /** Returns whether this {@link PCollection} has an attached schema. */
+  @Experimental(Kind.SCHEMAS)
+  public boolean hasSchema() {
+    return getCoder() instanceof SchemaCoder;
+  }
+
+  /** Returns the attached schema, or null if there is none. */
+  @Experimental(Kind.SCHEMAS)
+  public Schema getSchema() {
+    return hasSchema() ? ((SchemaCoder) getCoder()).getSchema() : null;
+  }
+
   /**
    * of the {@link PTransform}.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueGetter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueGetter.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.values.reflect;
 
+import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Internal;
 
 /**
@@ -28,7 +29,7 @@ import org.apache.beam.sdk.annotations.Internal;
  * <p>Implementations of this interface are generated at runtime to map object fields to Row fields.
  */
 @Internal
-public interface FieldValueGetter<ObjectT, ValueT> {
+public interface FieldValueGetter<ObjectT, ValueT> extends Serializable {
   ValueT get(ObjectT object);
 
   String name();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueGetterFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueGetterFactory.java
@@ -18,11 +18,12 @@
 
 package org.apache.beam.sdk.values.reflect;
 
+import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
 
 /** A factory interface for creating {@link FieldValueGetter} objects corresponding to a class. */
-public interface FieldValueGetterFactory {
+public interface FieldValueGetterFactory extends Serializable {
   /**
    * Returns a list of {@link FieldValueGetter}s for the target class.
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueSetter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueSetter.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.values.reflect;
 
+import java.io.Serializable;
 import java.lang.reflect.Type;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Internal;
@@ -31,7 +32,7 @@ import org.apache.beam.sdk.annotations.Internal;
  * fields.
  */
 @Internal
-public interface FieldValueSetter<ObjectT, ValueT> {
+public interface FieldValueSetter<ObjectT, ValueT> extends Serializable {
   /** Sets the specified field on object to value. */
   void set(ObjectT object, ValueT value);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueSetterFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/reflect/FieldValueSetterFactory.java
@@ -18,11 +18,12 @@
 
 package org.apache.beam.sdk.values.reflect;
 
+import java.io.Serializable;
 import java.util.List;
 import org.apache.beam.sdk.schemas.Schema;
 
 /** A factory interface for creating {@link FieldValueSetter} objects corresponding to a class. */
-public interface FieldValueSetterFactory {
+public interface FieldValueSetterFactory extends Serializable {
   /**
    * Returns a list of {@link FieldValueGetter}s for the target class.
    *

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.schemas;
 
 import static org.apache.beam.sdk.schemas.Schema.toSchema;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.stream.Stream;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -155,5 +156,34 @@ public class SchemaTest {
     assertEquals(FieldType.INT32, schema.getField(0).getType());
     assertEquals("f_string", schema.getField(1).getName());
     assertEquals(FieldType.STRING, schema.getField(1).getType());
+  }
+
+  @Test
+  public void testEquivalent() {
+    final Schema expectedNested1 =
+        Schema.builder().addStringField("yard1").addInt64Field("yard2").build();
+
+    final Schema expectedSchema1 =
+        Schema.builder()
+            .addStringField("field1")
+            .addInt64Field("field2")
+            .addRowField("field3", expectedNested1)
+            .addArrayField("field4", FieldType.row(expectedNested1))
+            .addMapField("field5", FieldType.STRING, FieldType.row(expectedNested1))
+            .build();
+
+    final Schema expectedNested2 =
+        Schema.builder().addInt64Field("yard2").addStringField("yard1").build();
+
+    final Schema expectedSchema2 =
+        Schema.builder()
+            .addMapField("field5", FieldType.STRING, FieldType.row(expectedNested2))
+            .addArrayField("field4", FieldType.row(expectedNested2))
+            .addRowField("field3", expectedNested2)
+            .addInt64Field("field2")
+            .addStringField("field1")
+            .build();
+
+    assertTrue(expectedSchema1.equivalent(expectedSchema2));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/ConvertTest.java
@@ -1,0 +1,199 @@
+package org.apache.beam.sdk.schemas.transforms;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.beam.sdk.schemas.DefaultSchema;
+import org.apache.beam.sdk.schemas.JavaFieldSchema;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.SerializableFunctions;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class ConvertTest {
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class POJO1 {
+    public String field1 = "field1";
+    public long field2 = 42;
+    public POJO1Nested field3 = new POJO1Nested();
+    public POJO1Nested[] field4 = new POJO1Nested[] {new POJO1Nested(), new POJO1Nested()};
+    public Map<String, POJO1Nested> field5 =
+        ImmutableMap.of(
+            "first", new POJO1Nested(),
+            "second", new POJO1Nested());
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      POJO1 pojo1 = (POJO1) o;
+      return field2 == pojo1.field2
+          && Objects.equals(field1, pojo1.field1)
+          && Objects.equals(field3, pojo1.field3)
+          && Arrays.equals(field4, pojo1.field4)
+          && Objects.equals(field5, pojo1.field5);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(field1, field2, field3, field5);
+      result = 31 * result + Arrays.hashCode(field4);
+      return result;
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class POJO1Nested {
+    public String yard1 = "yard2";
+    public long yard2 = 43;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      POJO1Nested that = (POJO1Nested) o;
+      return yard2 == that.yard2 && Objects.equals(yard1, that.yard1);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(yard1, yard2);
+    }
+  }
+
+  public static final Schema EXPECTED_SCHEMA1_NESTED =
+      Schema.builder().addStringField("yard1").addInt64Field("yard2").build();
+
+  public static final Schema EXPECTED_SCHEMA1 =
+      Schema.builder()
+          .addStringField("field1")
+          .addInt64Field("field2")
+          .addRowField("field3", EXPECTED_SCHEMA1_NESTED)
+          .addArrayField("field4", FieldType.row(EXPECTED_SCHEMA1_NESTED))
+          .addMapField("field5", FieldType.STRING, FieldType.row(EXPECTED_SCHEMA1_NESTED))
+          .build();
+
+  public static final Row EXPECTED_ROW1_NESTED =
+      Row.withSchema(EXPECTED_SCHEMA1_NESTED).addValues("yard2", 43L).build();
+  public static final Row EXPECTED_ROW1 =
+      Row.withSchema(EXPECTED_SCHEMA1)
+          .addValue("field1")
+          .addValue(42L)
+          .addValue(EXPECTED_ROW1_NESTED)
+          .addArray(ImmutableList.of(EXPECTED_ROW1_NESTED, EXPECTED_ROW1_NESTED))
+          .addValue(ImmutableMap.of("first", EXPECTED_ROW1_NESTED, "second", EXPECTED_ROW1_NESTED))
+          .build();
+
+  // These classes will have different but equivalent (same fields in different order) schemas.
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class POJO2 {
+    public Map<String, POJO2Nested> field5 =
+        ImmutableMap.of(
+            "first", new POJO2Nested(),
+            "second", new POJO2Nested());
+    public POJO2Nested[] field4 = new POJO2Nested[] {new POJO2Nested(), new POJO2Nested()};
+    public POJO2Nested field3 = new POJO2Nested();
+    public long field2 = 42;
+    public String field1 = "field1";
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      POJO2 pojo2 = (POJO2) o;
+      return field2 == pojo2.field2
+          && Objects.equals(field5, pojo2.field5)
+          && Arrays.equals(field4, pojo2.field4)
+          && Objects.equals(field3, pojo2.field3)
+          && Objects.equals(field1, pojo2.field1);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(field5, field3, field2, field1);
+      result = 31 * result + Arrays.hashCode(field4);
+      return result;
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class POJO2Nested {
+    public long yard2 = 43;
+    public String yard1 = "yard2";
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      POJO2Nested that = (POJO2Nested) o;
+      return yard2 == that.yard2 && Objects.equals(yard1, that.yard1);
+    }
+
+    @Override
+    public int hashCode() {
+
+      return Objects.hash(yard2, yard1);
+    }
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testToRows() {
+    PCollection<Row> rows = pipeline.apply(Create.of(new POJO1())).apply(Convert.toRows());
+    PAssert.that(rows).containsInAnyOrder(EXPECTED_ROW1);
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testFromRows() {
+    PCollection<POJO1> pojos =
+        pipeline
+            .apply(
+                Create.of(EXPECTED_ROW1)
+                    .withSchema(
+                        EXPECTED_SCHEMA1,
+                        SerializableFunctions.identity(),
+                        SerializableFunctions.identity()))
+            .apply(Convert.fromRows(POJO1.class));
+    PAssert.that(pojos).containsInAnyOrder(new POJO1());
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testGeneralConvert() {
+    PCollection<POJO2> pojos =
+        pipeline.apply(Create.of(new POJO1())).apply(Convert.to(POJO2.class));
+    PAssert.that(pojos).containsInAnyOrder(new POJO2());
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
If two types have the same or equivalent schemas, we can automatically convert between them. This PR provides a utility to convert between any schema types.

This is preparatory PR for the one that converts SQL to use Schemas.

R: @apilloud 