### PR TITLE
Revert "[BEAM-4752] Add support for newer dill dependency"

### DIFF
--- a/sdks/python/apache_beam/internal/pickler.py
+++ b/sdks/python/apache_beam/internal/pickler.py
@@ -39,12 +39,6 @@ import zlib
 
 import dill
 
-# Dill 0.28.0 renamed dill.dill to dill._dill:
-# https://github.com/uqfoundation/dill/commit/f0972ecc7a41d0b8acada6042d557068cac69baa
-# TODO: Remove this once Beam depends on dill >= 0.2.8
-if not getattr(dill, 'dill', None):
-  dill.dill = dill._dill
-
 
 def _is_nested_class(cls):
   """Returns true if argument is a class object that appears to be nested."""

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -97,7 +97,7 @@ else:
 REQUIRED_PACKAGES = [
     'avro>=1.8.1,<2.0.0',
     'crcmod>=1.7,<2.0',
-    'dill>=0.2.6,<=0.2.8.2',
+    'dill==0.2.6',
     'grpcio>=1.8,<2',
     'hdfs>=2.1.0,<3.0.0',
     'httplib2>=0.8,<=0.11.3',


### PR DESCRIPTION
Reverts apache/beam#5931

R: @alanmyrvold 

Breaks post commit tests: https://builds.apache.org/job/beam_PostCommit_Py_ValCont/228/console