### PR TITLE
[BEAM-4417] Fix the expected encoding of BigQuery's NUMERIC type when reading from Avro

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryAvroUtils.java
@@ -33,6 +33,9 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.avro.Conversions;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
@@ -54,7 +57,7 @@ class BigQueryAvroUtils {
           .put("BYTES", Type.BYTES)
           .put("INTEGER", Type.LONG)
           .put("FLOAT", Type.DOUBLE)
-          .put("NUMERIC", Type.STRING)
+          .put("NUMERIC", Type.BYTES)
           .put("BOOLEAN", Type.BOOLEAN)
           .put("TIMESTAMP", Type.LONG)
           .put("RECORD", Type.RECORD)
@@ -131,7 +134,7 @@ class BigQueryAvroUtils {
     String mode = firstNonNull(fieldSchema.getMode(), "NULLABLE");
     switch (mode) {
       case "REQUIRED":
-        return convertRequiredField(schema.getType(), fieldSchema, v);
+        return convertRequiredField(schema.getType(), schema.getLogicalType(), fieldSchema, v);
       case "REPEATED":
         return convertRepeatedField(schema, fieldSchema, v);
       case "NULLABLE":
@@ -159,14 +162,15 @@ class BigQueryAvroUtils {
     List<Object> elements = (List<Object>) v;
     ImmutableList.Builder<Object> values = ImmutableList.builder();
     Type elementType = schema.getElementType().getType();
+    LogicalType elementLogicalType = schema.getElementType().getLogicalType();
     for (Object element : elements) {
-      values.add(convertRequiredField(elementType, fieldSchema, element));
+      values.add(convertRequiredField(elementType, elementLogicalType, fieldSchema, element));
     }
     return values.build();
   }
 
   private static Object convertRequiredField(
-      Type avroType, TableFieldSchema fieldSchema, Object v) {
+      Type avroType, LogicalType avroLogicalType, TableFieldSchema fieldSchema, Object v) {
     // REQUIRED fields are represented as the corresponding Avro types. For example, a BigQuery
     // INTEGER type maps to an Avro LONG type.
     checkNotNull(v, "REQUIRED field %s should not be null", fieldSchema.getName());
@@ -182,6 +186,8 @@ class BigQueryAvroUtils {
         avroType,
         bqType,
         fieldSchema.getName());
+    // For historical reasons, don't validate avroLogicalType except for with NUMERIC.
+    // BigQuery represents NUMERIC in Avro format as BYTES with a DECIMAL logical type.
     switch (fieldSchema.getType()) {
       case "STRING":
       case "DATE":
@@ -198,11 +204,15 @@ class BigQueryAvroUtils {
         verify(v instanceof Double, "Expected Double, got %s", v.getClass());
         return v;
       case "NUMERIC":
-        verify(
-            v instanceof CharSequence || v instanceof BigDecimal,
-            "Expected CharSequence (String) or BigDecimal, got %s",
-            v.getClass());
-        return v.toString();
+        // NUMERIC data types are represented as BYTES with the DECIMAL logical type. They are
+        // converted back to Strings with precision and scale determined by the logical type.
+        verify(v instanceof ByteBuffer, "Expected ByteBuffer, got %s", v.getClass());
+        verifyNotNull(avroLogicalType, "Expected Decimal logical type");
+        verify(avroLogicalType instanceof LogicalTypes.Decimal, "Expected Decimal logical type");
+        BigDecimal numericValue =
+            new Conversions.DecimalConversion()
+                .fromBytes((ByteBuffer) v, Schema.create(avroType), avroLogicalType);
+        return numericValue.toString();
       case "BOOLEAN":
         verify(v instanceof Boolean, "Expected Boolean, got %s", v.getClass());
         return v;
@@ -252,9 +262,10 @@ class BigQueryAvroUtils {
 
     Type firstType = unionTypes.get(0).getType();
     if (!firstType.equals(Type.NULL)) {
-      return convertRequiredField(firstType, fieldSchema, v);
+      return convertRequiredField(firstType, unionTypes.get(0).getLogicalType(), fieldSchema, v);
     }
-    return convertRequiredField(unionTypes.get(1).getType(), fieldSchema, v);
+    return convertRequiredField(
+        unionTypes.get(1).getType(), unionTypes.get(1).getLogicalType(), fieldSchema, v);
   }
 
   static Schema toGenericAvroSchema(String schemaName, List<TableFieldSchema> fieldSchemas) {


### PR DESCRIPTION
The NUMERIC data type is represented in Avro using the BYTES type with the DECIMAL logical type.

I verified this change using BigQueryTornadoes.java, which I modified (locally) to write NUMERIC values to BigQuery, then read them back using Dataflow and write them to a new BigQuery table. The test failed as expected without this change, but now passes, and I can see the correct content in the table.

Context: https://github.com/apache/beam/pull/5755#issuecomment-402241675