### PR TITLE
[BEAM-4800] send PutArtifactResponse in BeamFileSystemArtifactStagingService

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactStagingService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactStagingService.java
@@ -297,6 +297,7 @@ public class BeamFileSystemArtifactStagingService extends ArtifactStagingService
           return;
         }
       }
+      outboundObserver.onNext(PutArtifactResponse.newBuilder().build());
       outboundObserver.onCompleted();
     }
   }


### PR DESCRIPTION
Portable word-count is failing for me at the end of staging the first artifact.

I'm using the usual commands:

```
./gradlew -p sdks/python/container docker
./gradlew :beam-runners-flink_2.11-job-server:runShadow
./gradlew :beam-sdks-python:portableWordCount
```

The relevant output in the job-server terminal is:

```
[grpc-default-executor-4] INFO org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactStagingService - Going to stage artifact pickled_main_session to /tmp/flink-artifacts/job_89b631dc-1b97-419f-8995-f3fb5ea3f9df/artifacts/artifact_ea0d10d07f4601782ed647e8f6ba4a055be13674ab79fa0c6e2fa44917c5264c.
[grpc-default-executor-4] INFO org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactStagingService - Staging artifact completed for /tmp/flink-artifacts/job_89b631dc-1b97-419f-8995-f3fb5ea3f9df/artifacts/artifact_ea0d10d07f4601782ed647e8f6ba4a055be13674ab79fa0c6e2fa44917c5264c
Jul 15, 2018 7:01:25 PM org.apache.beam.vendor.grpc.v1.io.grpc.internal.ServerCallImpl internalClose
WARNING: Cancelling the stream with status Status{code=INTERNAL, description=Completed without a response, cause=null}
```

It seems that a `PutArtifactResponse` needs to be sent in response to a `PutArtifactRequest` in `BeamFileSystemArtifactStagingService`.

I'm not sure when this might have broken; I'm assuming it was allowed to because these code-paths aren't tested yet (cf. #5935)

R: @angoenka 


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




