### PR TITLE
[BEAM-3711] Enabling combiner lifting in Dataflow Runner.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -44,6 +44,7 @@ import com.google.api.services.dataflow.model.WorkerPool;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Iterables;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -294,6 +295,9 @@ public class DataflowPipelineTranslator {
     /** The transform currently being applied. */
     private AppliedPTransform<?, ?, ?> currentTransform;
 
+    /** A stack of all composite PTransforms encompassing the current transform. */
+    private ArrayDeque<TransformHierarchy.Node> parents = new ArrayDeque<>();
+
     /** Constructs a Translator that will translate the specified Pipeline into Dataflow objects. */
     public Translator(Pipeline pipeline, DataflowRunner runner, SdkComponents sdkComponents) {
       this.pipeline = pipeline;
@@ -522,6 +526,26 @@ public class DataflowPipelineTranslator {
         throw new IllegalArgumentException("output " + value + " already has a name specified");
       }
     }
+
+    @Override
+    public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
+      parents.addFirst(node);
+      return CompositeBehavior.ENTER_TRANSFORM;
+    }
+
+    @Override
+    public void leaveCompositeTransform(TransformHierarchy.Node node) {
+      parents.removeFirst();
+    }
+
+    @Override
+    public AppliedPTransform<?, ?, ?> getCurrentParent() {
+      if (parents.isEmpty()) {
+        return null;
+      } else {
+        return parents.peekFirst().toAppliedPTransform(getPipeline());
+      }
+    }
   }
 
   static class StepTranslator implements StepTranslationContext {
@@ -747,8 +771,19 @@ public class DataflowPipelineTranslator {
                     context.getInput(primitiveTransform).getWindowingStrategy());
 
             stepContext.addEncodingInput(fn.getAccumulatorCoder());
-            stepContext.addInput(
-                PropertyNames.SERIALIZED_FN, byteArrayToJsonString(serializeToByteArray(fn)));
+
+            List<String> experiments = context.getPipelineOptions().getExperiments();
+            boolean isFnApi = experiments != null && experiments.contains("beam_fn_api");
+
+            if (isFnApi) {
+              String ptransformId =
+                  context.getSdkComponents().getPTransformIdOrThrow(context.getCurrentParent());
+              stepContext.addInput(PropertyNames.SERIALIZED_FN, ptransformId);
+            } else {
+              stepContext.addInput(
+                  PropertyNames.SERIALIZED_FN, byteArrayToJsonString(serializeToByteArray(fn)));
+            }
+
             stepContext.addOutput(PropertyNames.OUTPUT, context.getOutput(primitiveTransform));
           }
         });

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -1760,7 +1760,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
   /**
    * Returns a {@link PTransformMatcher} that matches a {@link PTransform} if the class of the
-   * {@link PTransform} is equal to the {@link Class} provided ot this matcher and it has no side
+   * {@link PTransform} is equal to the {@link Class} provided to this matcher and it has no side
    * inputs.
    */
   private static PTransformMatcher combineValuesWithoutSideInputs() {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -83,6 +83,12 @@ public interface TransformTranslator<TransformT extends PTransform> {
 
     /** Get the {@link AppliedPTransform} that produced the provided {@link PValue}. */
     AppliedPTransform<?, ?, ?> getProducer(PValue value);
+
+    /**
+     * Gets the parent composite transform to the current transform, if one exists. Otherwise
+     * returns one null.
+     */
+    AppliedPTransform<?, ?, ?> getCurrentParent();
   }
 
   /** The interface for a {@link TransformTranslator} to build a Dataflow step. */


### PR DESCRIPTION
This change does two things:

1. It modifies the way that the Dataflow Runner transmits combines to
Dataflow so that it can support combiner lifting. This is done by, when
translating CombineGroupedValues transforms, encoding the ID of the
parent Combine Per Key transform as a Serialized Fn.

2. This change also preemptively fixes an issue that occurs that would
cause CombineGroupedValues with side inputs to get translated that way
for Combiner lifting, despite the parent transform being an anonymous
composite transform, indicating that the CombineGroupedValues should
be translated as a ParDo. This is fixed by adjusting the PTransform
Overrides in DataflowRunner slightly.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




