### PR TITLE
bugfixs :  pipeleine_option has attribute 'validate' may cause exception

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator.py
@@ -102,7 +102,7 @@ class PipelineOptionsValidator(object):
     """
     errors = []
     for cls in self.OPTIONS:
-      if 'validate' in cls.__dict__:
+      if 'validate' in [k for k, v in cls.__dict__.items() if str(v).startswith("<function")]:
         errors.extend(self.options.view_as(cls).validate(self))
     return errors
 

--- a/sdks/python/apache_beam/options/pipeline_options_validator.py
+++ b/sdks/python/apache_beam/options/pipeline_options_validator.py
@@ -102,7 +102,7 @@ class PipelineOptionsValidator(object):
     """
     errors = []
     for cls in self.OPTIONS:
-      if 'validate' in [k for k, v in cls.__dict__.items() if str(v).startswith("<function")]:
+      if 'validate' in cls.__dict__ and callable(cls.__dict__['validate']):
         errors.extend(self.options.view_as(cls).validate(self))
     return errors
 


### PR DESCRIPTION
If a PipelineOptions implement has attribute named ‘validate’ , it may cause exception