### PR TITLE
[BEAM-3769] Fix broken JIRA links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Beam supports multiple language specific SDKs for writing pipelines against the 
 
 Currently, this repository contains SDKs for Java, Python and Go.
 
-Have ideas for new SDKs or DSLs? See the [JIRA](https://issues.apache.org/jira/browse/BEAM/component/12328909/).
+Have ideas for new SDKs or DSLs? See the [JIRA](https://issues.apache.org/jira/issues/?jql=project%20%3D%20BEAM%20AND%20component%20%3D%20sdk-ideas).
 
 ### Runners
 
@@ -67,7 +67,7 @@ Beam supports executing programs on multiple distributed processing backends thr
 - The `FlinkRunner` runs the pipeline on an Apache Flink cluster. The code has been donated from [dataArtisans/flink-dataflow](https://github.com/dataArtisans/flink-dataflow) and is now part of Beam.
 - The `SparkRunner` runs the pipeline on an Apache Spark cluster. The code has been donated from [cloudera/spark-dataflow](https://github.com/cloudera/spark-dataflow) and is now part of Beam.
 
-Have ideas for new Runners? See the [JIRA](https://issues.apache.org/jira/browse/BEAM/component/12328916/).
+Have ideas for new Runners? See the [JIRA](https://issues.apache.org/jira/issues/?jql=project%20%3D%20BEAM%20AND%20component%20%3D%20runner-ideas).
 
 ## Getting Started
 


### PR DESCRIPTION
This PR fixes two broken JIRA links in the main README.
