### PR TITLE
[BEAM-4814] Add client configuration to aws options

### DIFF
--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.aws.options;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -29,6 +30,9 @@ import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -68,6 +72,7 @@ public class AwsModule extends SimpleModule {
     setMixInAnnotation(AWSCredentialsProvider.class, AWSCredentialsProviderMixin.class);
     setMixInAnnotation(SSECustomerKey.class, SSECustomerKeyMixin.class);
     setMixInAnnotation(SSEAwsKeyManagementParams.class, SSEAwsKeyManagementParamsMixin.class);
+    setMixInAnnotation(ClientConfiguration.class, ClientConfigurationMixin.class);
   }
 
   /** A mixin to add Jackson annotations to {@link AWSCredentialsProvider}. */
@@ -233,5 +238,24 @@ public class AwsModule extends SimpleModule {
       final String awsKmsKeyId = asMap.getOrDefault("awsKmsKeyId", null);
       return new SSEAwsKeyManagementParams(awsKmsKeyId);
     }
+  }
+
+  @JsonAutoDetect(
+    fieldVisibility = Visibility.NONE,
+    getterVisibility = Visibility.NONE,
+    setterVisibility = Visibility.NONE
+  )
+  interface ClientConfigurationMixin {
+    @JsonProperty
+    String getProxyHost();
+
+    @JsonProperty
+    Integer getProxyPort();
+
+    @JsonProperty
+    String getProxyUsername();
+
+    @JsonProperty
+    String getProxyPassword();
   }
 }

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsOptions.java
@@ -18,6 +18,7 @@
 
 package org.apache.beam.sdk.io.aws.options;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import org.apache.beam.sdk.options.Default;
@@ -73,6 +74,42 @@ public interface AwsOptions extends PipelineOptions {
     @Override
     public AWSCredentialsProvider create(PipelineOptions options) {
       return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+  }
+
+  /**
+   * The client configuration instance that should be used to configure AWS service clients. Please
+   * note that the configuration deserialization only allows one to specify proxy settings.
+   *
+   * <p>For example, to specify the proxy host, port, username and password, specify the following:
+   * <code>
+   * --clientConfiguration={
+   *   "proxyHost":"hostname",
+   *   "proxyPort":1234,
+   *   "proxyUsername":"username",
+   *   "proxyPassword":"password"
+   * }
+   * </code>
+   *
+   * @return
+   */
+  @Description(
+      "The client configuration instance that should be used to configure AWS service "
+          + "clients. Please note that the configuration deserialization only allows one to specify "
+          + "proxy settings. For example, to specify the proxy host, port, username and password, "
+          + "specify the following: --clientConfiguration={\"proxyHost\":\"hostname\",\"proxyPort\":1234,"
+          + "\"proxyUsername\":\"username\",\"proxyPassword\":\"password\"}")
+  @Default.InstanceFactory(ClientConfigurationFactory.class)
+  ClientConfiguration getClientConfiguration();
+
+  void setClientConfiguration(ClientConfiguration clientConfiguration);
+
+  /** Default AWS client configuration. */
+  class ClientConfigurationFactory implements DefaultValueFactory<ClientConfiguration> {
+
+    @Override
+    public ClientConfiguration create(PipelineOptions options) {
+      return new ClientConfiguration();
     }
   }
 }

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -118,6 +118,11 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
   private static AmazonS3 buildAmazonS3Client(S3Options options) {
     AmazonS3ClientBuilder builder =
         AmazonS3ClientBuilder.standard().withCredentials(options.getAwsCredentialsProvider());
+
+    if (options.getClientConfiguration() != null) {
+      builder = builder.withClientConfiguration(options.getClientConfiguration());
+    }
+
     if (Strings.isNullOrEmpty(options.getAwsServiceEndpoint())) {
       builder = builder.withRegion(options.getAwsRegion());
     } else {

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/options/AwsModuleTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/options/AwsModuleTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -181,5 +182,22 @@ public class AwsModuleTest {
         objectMapper.readValue(valueAsJson, SSEAwsKeyManagementParams.class);
     assertEquals(awsKmsKeyId, valueDes.getAwsKmsKeyId());
     assertEquals(encryption, valueDes.getEncryption());
+  }
+
+  @Test
+  public void testClientConfigurationSerializationDeserialization() throws Exception {
+    ClientConfiguration clientConfiguration = new ClientConfiguration();
+    clientConfiguration.setProxyHost("localhost");
+    clientConfiguration.setProxyPort(1234);
+    clientConfiguration.setProxyUsername("username");
+    clientConfiguration.setProxyPassword("password");
+
+    final String valueAsJson = objectMapper.writeValueAsString(clientConfiguration);
+    final ClientConfiguration valueDes =
+        objectMapper.readValue(valueAsJson, ClientConfiguration.class);
+    assertEquals("localhost", valueDes.getProxyHost());
+    assertEquals(1234, valueDes.getProxyPort());
+    assertEquals("username", valueDes.getProxyUsername());
+    assertEquals("password", valueDes.getProxyPassword());
   }
 }


### PR DESCRIPTION
I want to run a Beam job in my Spark cluster that uses the S3FileSystem. My Spark cluster is configured to require a proxy server with authentication in order to make outbound connections. A small change is required to enable ClientConfiguration to be added to the configuration to enable this.

This PR adds the ability to specify the four proxy related properties of ClientConfiguration object and passes that when creating an S3 client.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




