### PR TITLE
[BEAM-4837] Added '--continue' switches into nightly build

### DIFF
--- a/.test-infra/jenkins/job_Release_Gradle_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_Release_Gradle_NightlySnapshot.groovy
@@ -52,6 +52,7 @@ job('beam_Release_Gradle_NightlySnapshot') {
       tasks('build')
       commonJobProperties.setGradleSwitches(delegate)
       switches('--no-parallel')
+      switches('--continue')
     }
     gradle {
       rootBuildScriptDir(commonJobProperties.checkoutDir)
@@ -62,6 +63,7 @@ job('beam_Release_Gradle_NightlySnapshot') {
       // Don't run tasks in parallel, currently the maven-publish/signing plugins
       // cause build failures when run in parallel with messages like 'error snapshotting'
       switches('--no-parallel')
+      switches('--continue')
     }
   }
 }


### PR DESCRIPTION
We want job_Release_Gradle_NightlySnapshot catch as much errors as possible. Putting '--continue' switches helps make sure all tasks are been build rather than stopping when first error occurs.
r: @alanmyrvold @aaltay 