### PR TITLE
Interactive Beam -- keep alive

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -67,13 +67,21 @@ class InteractiveRunner(runners.PipelineRunner):
   def run_pipeline(self, pipeline):
     if not hasattr(self, '_desired_cache_labels'):
       self._desired_cache_labels = set()
-    print('Running...')
+
+    # Invoke a round trip through the runner API. This makes sure the Pipeline
+    # proto is stable.
+    pipeline = beam.pipeline.Pipeline.from_runner_api(
+        pipeline.to_runner_api(),
+        pipeline.runner,
+        pipeline._options)
 
     # Snapshot the pipeline in a portable proto before mutating it.
     pipeline_proto, original_context = pipeline.to_runner_api(
         return_context=True)
-
     pcolls_to_pcoll_id = self._pcolls_to_pcoll_id(pipeline, original_context)
+
+    # TODO(qinyeli): Refactor the rest of this function into
+    # def manipulate_pipeline(pipeline_proto) -> pipeline_proto_to_run:
 
     # Make a copy of the original pipeline to avoid accidental manipulation
     pipeline, context = beam.pipeline.Pipeline.from_runner_api(

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 import collections
 import copy
 import glob
+import logging
 import os
 import shutil
 import tempfile
@@ -56,6 +57,29 @@ class InteractiveRunner(runners.PipelineRunner):
     # once interactive_runner works with FnAPI mode
     self._underlying_runner = underlying_runner
     self._cache_manager = CacheManager()
+    self._in_session = False
+
+  def start_session(self):
+    if self._in_session:
+      return
+
+    enter = getattr(self._underlying_runner, '__enter__', None)
+    if enter is not None:
+      logging.info('Starting session.')
+      self._in_session = True
+      enter()
+    else:
+      logging.error('Keep alive not supported.')
+
+  def end_session(self):
+    if not self._in_session:
+      return
+
+    exit = getattr(self._underlying_runner, '__exit__', None)
+    if exit is not None:
+      self._in_session = False
+      logging.info('Ending session.')
+      exit(None, None, None)
 
   def cleanup(self):
     self._cache_manager.cleanup()

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -99,6 +99,24 @@ class InteractiveRunnerTest(unittest.TestCase):
             'question': 1
         })
 
+  def test_session(self):
+    class MockPipelineRunner(object):
+      def __init__(self):
+        self._in_session = False
+
+      def __enter__(self):
+        self._in_session = True
+
+      def __exit__(self, exc_type, exc_val, exc_tb):
+        self._in_session = False
+
+    underlying_runner = MockPipelineRunner()
+    runner = interactive_runner.InteractiveRunner(underlying_runner)
+    runner.start_session()
+    self.assertTrue(underlying_runner._in_session)
+    runner.end_session()
+    self.assertFalse(underlying_runner._in_session)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Main changes:
* Added start_session() and end_session() for keeping pipeline backend alive
* Added a round trip to Pipeline proto to resolve inconsistent proto serialization issue.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




