### PR TITLE
[BEAM-4834] Identify loops before doing topological sort of pipeline network

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/Networks.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/Networks.java
@@ -189,7 +189,7 @@ public class Networks {
   private static <NodeT, EdgeT> void dfs(
       Network<NodeT, EdgeT> network, NodeT node, ArrayDeque<NodeT> parents, Set<NodeT> parentsSet) {
     if (parentsSet.contains(node)) {
-      checkArgument(!parents.contains(node), "Network has a cycle %s on node %s", node);
+      checkArgument(!parents.contains(node), "Network has a cycle %s on node %s", parents, node);
     }
     parents.addLast(node);
     parentsSet.add(node);

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/Networks.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/Networks.java
@@ -177,6 +177,28 @@ public class Networks {
   }
 
   /**
+   * Do a simple DFS traversal to find cycle in the graph. Not using Graphs.hasCycle as it does not
+   * provide the found cycle.
+   */
+  private static <NodeT, EdgeT> void checkCycle(Network<NodeT, EdgeT> network) {
+    ArrayDeque<NodeT> parents = new ArrayDeque<>();
+    HashSet<NodeT> parentsSet = new HashSet<>();
+    network.nodes().forEach(node -> dfs(network, node, parents, parentsSet));
+  }
+
+  private static <NodeT, EdgeT> void dfs(
+      Network<NodeT, EdgeT> network, NodeT node, ArrayDeque<NodeT> parents, Set<NodeT> parentsSet) {
+    if (parentsSet.contains(node)) {
+      checkArgument(!parents.contains(node), "Network has a cycle %s on node %s", node);
+    }
+    parents.addLast(node);
+    parentsSet.add(node);
+    network.successors(node).forEach(successor -> dfs(network, successor, parents, parentsSet));
+    parentsSet.remove(node);
+    parents.removeLast();
+  }
+
+  /**
    * Compute the topological order for a {@link Network}.
    *
    * <p>Nodes must be considered in the order specified by the {@link Network Network's} {@link
@@ -193,6 +215,7 @@ public class Networks {
         "Only networks without self loops are supported, given %s",
         network);
 
+    checkCycle(network);
     // Linked hashset will prevent duplicates from appearing and will maintain insertion order.
     LinkedHashSet<NodeT> nodes = new LinkedHashSet<>(network.nodes().size());
     Queue<NodeT> processingOrder = new ArrayDeque<>();


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




