### PR TITLE
Interactive Beam -- introduced version into CacheManager

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -1,0 +1,193 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import collections
+import glob
+import os
+import shutil
+import tempfile
+import urllib
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam.io import filesystems
+from apache_beam.transforms import combiners
+
+
+class CacheManager(object):
+  """Abstract class for caching PCollections.
+
+  A PCollection cache is identified by labels, which consist of a prefix (either
+  'full' or 'sample') and a cache_label which is a hash of the PCollection
+  derivation.
+  """
+
+  def exists(self, *labels):
+    """Returns if the PCollection cache exists."""
+    raise NotImplementedError
+
+  def is_latest_version(self, version, *labels):
+    """Returns if the given version number is the latest."""
+    return version == self._latest_version(*labels)
+
+  def _latest_version(self, *labels):
+    """Returns the latest version number of the PCollection cache."""
+    raise NotImplementedError
+
+  def read(self, *labels):
+    """Return the PCollection as a list as well as the version number.
+
+    Returns:
+      (List[PCollection])
+      (int) the version number
+
+    It is possible that the version numbers from read() and_latest_version()
+    are different. This usually means that the cache's been evicted (thus
+    unavailable => read() returns version = -1), but it had reached version n
+    before eviction.
+    """
+    raise NotImplementedError
+
+  def source(self, *labels):
+    """Returns a beam.io.Source that reads the PCollection cache."""
+    raise NotImplementedError
+
+  def sink(self, *labels):
+    """Returns a beam.io.Sink that writes the PCollection cache."""
+    raise NotImplementedError
+
+  def cleanup(self):
+    """Cleans up all the PCollection caches."""
+    raise NotImplementedError
+
+
+class LocalFileCacheManager(CacheManager):
+  """Maps PCollections to local temp files for materialization."""
+
+  def __init__(self, temp_dir=None):
+    self._temp_dir = temp_dir or tempfile.mkdtemp(
+        prefix='interactive-temp-', dir=os.environ.get('TEST_TMPDIR', None))
+    self._versions = collections.defaultdict(lambda: self._CacheVersion())
+
+  def exists(self, *labels):
+    return bool(
+        filesystems.FileSystems.match([self._glob_path(*labels)],
+                                      limits=[1])[0].metadata_list)
+
+  def _latest_version(self, *labels):
+    timestamp = 0
+    for path in glob.glob(self._glob_path(*labels)):
+      timestamp = max(timestamp, os.path.getmtime(path))
+    result = self._versions["-".join(labels)].get_version(timestamp)
+    return result
+
+  def read(self, *labels):
+    if not self.exists(*labels):
+      return [], -1
+
+    def _read_helper():
+      coder = SafeFastPrimitivesCoder()
+      for path in glob.glob(self._glob_path(*labels)):
+        for line in open(path):
+          yield coder.decode(line.strip())
+    result, version = list(_read_helper()), self._latest_version(*labels)
+    return result, version
+
+  def source(self, *labels):
+    return beam.io.ReadFromText(self._glob_path(*labels),
+                                coder=SafeFastPrimitivesCoder())._source
+
+  def sink(self, *labels):
+    return beam.io.WriteToText(self._path(*labels),
+                               coder=SafeFastPrimitivesCoder())._sink
+
+  def cleanup(self):
+    if os.path.exists(self._temp_dir):
+      shutil.rmtree(self._temp_dir)
+
+  def _glob_path(self, *labels):
+    return self._path(*labels) + '-*-of-*'
+
+  def _path(self, *labels):
+    return filesystems.FileSystems.join(self._temp_dir, *labels)
+
+  class _CacheVersion(object):
+    """This class keeps track of the timestamp and the corresponding version."""
+
+    def __init__(self):
+      self.current_version = -1
+      self.current_timestamp = 0
+
+    def get_version(self, timestamp):
+      """Updates version if necessary and returns the version number.
+
+      Args:
+        timestamp: (int) unix timestamp when the cache is updated. This value is
+            zero if the cache has been evicted or doesn't exist.
+      """
+      # Do not update timestamp if the cache's been evicted.
+      if timestamp != 0 and timestamp != self.current_timestamp:
+        assert timestamp > self.current_timestamp
+        self.current_version = self.current_version + 1
+        self.current_timestamp = timestamp
+      return self.current_version
+
+
+class ReadCache(beam.PTransform):
+  """A PTransform that reads the PCollections from the cache."""
+  def __init__(self, cache_manager, label):
+    self._cache_manager = cache_manager
+    self._label = label
+
+  def expand(self, pbegin):
+    # pylint: disable=expression-not-assigned
+    return pbegin | 'Load%s' % self._label >> beam.io.Read(
+        self._cache_manager.source('full', self._label))
+
+
+class WriteCache(beam.PTransform):
+  """A PTransform that writes the PCollections to the cache."""
+  def __init__(self, cache_manager, sample=False, sample_size=0):
+    self._cache_manager = cache_manager
+    self._sample = sample
+    self._sample_size = sample_size
+
+  def expand(self, pcolls_to_write):
+    for label, pcoll in pcolls_to_write.items():
+      prefix = 'sample' if self._sample else 'full'
+      if not self._cache_manager.exists(prefix, label):
+        if self._sample:
+          pcoll |= 'Sample%s' % label >> (
+              combiners.Sample.FixedSizeGlobally(self._sample_size)
+              | beam.FlatMap(lambda sample: sample))
+        # pylint: disable=expression-not-assigned
+        pcoll | 'Cache%s' % label >> beam.io.Write(
+            self._cache_manager.sink(prefix, label))
+
+
+class SafeFastPrimitivesCoder(coders.Coder):
+  """This class add an quote/unquote step to escape special characters."""
+
+  def encode(self, value):
+    return urllib.quote(coders.coders.FastPrimitivesCoder().encode(value))
+
+  def decode(self, value):
+    return coders.coders.FastPrimitivesCoder().decode(urllib.unquote(value))

--- a/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
@@ -1,0 +1,164 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+from apache_beam.io import filesystems
+from apache_beam.runners.interactive import cache_manager as cache
+
+
+class LocalFileCacheManagerTest(unittest.TestCase):
+  """Unit test for LocalFileCacheManager.
+
+  Note that this set of tests focuses only the the methods that interacts with
+  the local operating system. Those tests that involve interactions with Beam
+  (i.e. source(), sink(), ReadCache, and WriteCache) will be tested with
+  InteractiveRunner as a part of integration tests instead.
+  """
+
+  def setUp(self):
+    self.test_dir = tempfile.mkdtemp()
+    self.cache_manager = cache.LocalFileCacheManager(self.test_dir)
+
+  def tearDown(self):
+    # The test_dir might have already been removed by cache_manager.cleanup().
+    if os.path.exists(self.test_dir):
+      shutil.rmtree(self.test_dir)
+
+  def mock_write_cache(self, pcoll_list, prefix, cache_label):
+    """Cache the PCollection where cache.WriteCache would write to."""
+    cache_path = filesystems.FileSystems.join(self.test_dir, prefix)
+    if not filesystems.FileSystems.exists(cache_path):
+      filesystems.FileSystems.mkdirs(cache_path)
+
+    # Pause for 0.1 sec, because the Jenkins test runs so fast that the file
+    # writes happen at the same timestamp.
+    time.sleep(0.1)
+
+    cache_file = cache_label + '-1-of-2'
+    with open(self.cache_manager._path(prefix, cache_file), 'w') as f:
+      for line in pcoll_list:
+        f.write(cache.SafeFastPrimitivesCoder().encode(line))
+        f.write('\n')
+
+  def test_exists(self):
+    """Test that CacheManager can correctly tell if the cache exists or not."""
+    prefix = 'full'
+    cache_label = 'some-cache-label'
+    cache_version_one = ['cache', 'version', 'one']
+
+    self.assertFalse(self.cache_manager.exists(prefix, cache_label))
+    self.mock_write_cache(cache_version_one, prefix, cache_label)
+    self.assertTrue(self.cache_manager.exists(prefix, cache_label))
+    self.cache_manager.cleanup()
+    self.assertFalse(self.cache_manager.exists(prefix, cache_label))
+    self.mock_write_cache(cache_version_one, prefix, cache_label)
+    self.assertTrue(self.cache_manager.exists(prefix, cache_label))
+
+  def test_read_basic(self):
+    """Test the condition where the cache is read once after written once."""
+    prefix = 'full'
+    cache_label = 'some-cache-label'
+    cache_version_one = ['cache', 'version', 'one']
+
+    self.mock_write_cache(cache_version_one, prefix, cache_label)
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    self.assertListEqual(pcoll_list, cache_version_one)
+    self.assertEqual(version, 0)
+    self.assertTrue(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+  def test_read_version_update(self):
+    """Tests if the version is properly updated after the files are updated."""
+    prefix = 'full'
+    cache_label = 'some-cache-label'
+    cache_version_one = ['cache', 'version', 'one']
+    cache_version_two = ['cache', 'version', 'two']
+
+    self.mock_write_cache(cache_version_one, prefix, cache_label)
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+
+    self.mock_write_cache(cache_version_two, prefix, cache_label)
+    self.assertFalse(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    self.assertListEqual(pcoll_list, cache_version_two)
+    self.assertEqual(version, 1)
+    self.assertTrue(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+  def test_read_before_write(self):
+    """Test the behavior when read() is called before WriteCache completes."""
+    prefix = 'full'
+    cache_label = 'some-cache-label'
+
+    self.assertFalse(self.cache_manager.exists(prefix, cache_label))
+
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    self.assertListEqual(pcoll_list, [])
+    self.assertEqual(version, -1)
+    self.assertTrue(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+  def test_read_over_cleanup(self):
+    """Test the behavior of read() over cache cleanup."""
+    prefix = 'full'
+    cache_label = 'some-cache-label'
+    cache_version_one = ['cache', 'version', 'one']
+    cache_version_two = ['cache', 'version', 'two']
+
+    # The initial write and read.
+    self.mock_write_cache(cache_version_one, prefix, cache_label)
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+
+    # Cache cleanup.
+    self.cache_manager.cleanup()
+    # Check that even if cache is evicted, the latest version stays the same.
+    self.assertTrue(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    self.assertListEqual(pcoll_list, [])
+    self.assertEqual(version, -1)
+    self.assertFalse(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+    # PCollection brought back to cache.
+    self.mock_write_cache(cache_version_two, prefix, cache_label)
+    self.assertFalse(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+    pcoll_list, version = self.cache_manager.read(prefix, cache_label)
+    self.assertListEqual(pcoll_list, cache_version_two)
+    # Check that version continues from the previous value instead of starting
+    # from 0 again.
+    self.assertEqual(version, 1)
+    self.assertTrue(
+        self.cache_manager.is_latest_version(version, prefix, cache_label))
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
* Moved CacheManager out of interactive_runner.py
* Introduced version into CacheManager
* Designed the abstract interaface of CacheManager. The overriding class
can choose to keep cache anywhere.
* Logics of the original CacheManager moved into LocalFileCacheManager

**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




