### PR TITLE
[BEAM-4824] Batch BigQueryIO returns job results

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -26,6 +26,7 @@ import com.google.api.services.bigquery.model.TableRow;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
@@ -69,7 +70,6 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.ShardedKey;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.sdk.values.TypeDescriptor;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -283,9 +283,18 @@ class BatchLoads<DestinationT>
                             singlePartitionTag))
                     .withSideInputs(tempFilePrefixView)
                     .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
-    PCollection<KV<TableDestination, String>> tempTables =
+    PCollection<KV<TableDestination, BigQueryWriteResult>> tempTables =
         writeTempTables(partitions.get(multiPartitionsTag), loadJobIdPrefixView);
     tempTables
+        .apply(
+            ParDo.of(
+                new DoFn<
+                    KV<TableDestination, BigQueryWriteResult>, KV<TableDestination, String>>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    c.output(KV.of(c.element().getKey(), c.element().getValue().getTable()));
+                  }
+                }))
         // Now that the load job has happened, we want the rename to happen immediately.
         .apply(
             Window.<KV<TableDestination, String>>into(new GlobalWindows())
@@ -306,8 +315,9 @@ class BatchLoads<DestinationT>
                         createDisposition,
                         maxRetryJobs))
                 .withSideInputs(loadJobIdPrefixView));
-    writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
-    return writeResult(p);
+    PCollection<KV<TableDestination, BigQueryWriteResult>> singlePartitionResults =
+        writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
+    return writeResult(p, PCollectionList.of(Arrays.asList(singlePartitionResults, tempTables)));
   }
 
   // Expand the pipeline when the user has not requested periodically-triggered file writes.
@@ -350,10 +360,19 @@ class BatchLoads<DestinationT>
                             singlePartitionTag))
                     .withSideInputs(tempFilePrefixView)
                     .withOutputTags(multiPartitionsTag, TupleTagList.of(singlePartitionTag)));
-    PCollection<KV<TableDestination, String>> tempTables =
+    PCollection<KV<TableDestination, BigQueryWriteResult>> tempTables =
         writeTempTables(partitions.get(multiPartitionsTag), loadJobIdPrefixView);
 
     tempTables
+        .apply(
+            ParDo.of(
+                new DoFn<
+                    KV<TableDestination, BigQueryWriteResult>, KV<TableDestination, String>>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    c.output(KV.of(c.element().getKey(), c.element().getValue().getTable()));
+                  }
+                }))
         .apply("ReifyRenameInput", new ReifyAsIterable<>())
         .setCoder(IterableCoder.of(KvCoder.of(TableDestinationCoderV2.of(), StringUtf8Coder.of())))
         .apply(
@@ -366,8 +385,9 @@ class BatchLoads<DestinationT>
                         createDisposition,
                         maxRetryJobs))
                 .withSideInputs(loadJobIdPrefixView));
-    writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
-    return writeResult(p);
+    PCollection<KV<TableDestination, BigQueryWriteResult>> singlePartitionResults =
+        writeSinglePartition(partitions.get(singlePartitionTag), loadJobIdPrefixView);
+    return writeResult(p, PCollectionList.of(Arrays.asList(singlePartitionResults, tempTables)));
   }
 
   // Generate the base job id string.
@@ -505,7 +525,7 @@ class BatchLoads<DestinationT>
   }
 
   // Take in a list of files and write them to temporary tables.
-  private PCollection<KV<TableDestination, String>> writeTempTables(
+  private PCollection<KV<TableDestination, BigQueryWriteResult>> writeTempTables(
       PCollection<KV<ShardedKey<DestinationT>, List<String>>> input,
       PCollectionView<String> jobIdTokenView) {
     List<PCollectionView<?>> sideInputs = Lists.newArrayList(jobIdTokenView);
@@ -541,7 +561,7 @@ class BatchLoads<DestinationT>
 
   // In the case where the files fit into a single load job, there's no need to write temporary
   // tables and rename. We can load these files directly into the target BigQuery table.
-  void writeSinglePartition(
+  PCollection<KV<TableDestination, BigQueryWriteResult>> writeSinglePartition(
       PCollection<KV<ShardedKey<DestinationT>, List<String>>> input,
       PCollectionView<String> loadJobIdPrefixView) {
     List<PCollectionView<?>> sideInputs = Lists.newArrayList(loadJobIdPrefixView);
@@ -551,7 +571,7 @@ class BatchLoads<DestinationT>
             ShardedKeyCoder.of(NullableCoder.of(destinationCoder)),
             ListCoder.of(StringUtf8Coder.of()));
     // Write single partition to final table
-    input
+    return input
         .setCoder(partitionsCoder)
         // Reshuffle will distribute this among multiple workers, and also guard against
         // reexecution of the WritePartitions step once WriteTables has begun.
@@ -571,10 +591,10 @@ class BatchLoads<DestinationT>
                 ignoreUnknownValues));
   }
 
-  private WriteResult writeResult(Pipeline p) {
-    PCollection<TableRow> empty =
-        p.apply("CreateEmptyFailedInserts", Create.empty(TypeDescriptor.of(TableRow.class)));
-    return WriteResult.in(p, new TupleTag<>("failedInserts"), empty);
+  private WriteResult writeResult(
+      Pipeline p, PCollectionList<KV<TableDestination, BigQueryWriteResult>> results) {
+    return WriteResult.withLoadResults(
+        p, new TupleTag<>("loadJobResults"), results.apply(Flatten.pCollections()));
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResult.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import java.util.Objects;
+
+/**
+ * Model definition for BigQueryWriteResult.
+ *
+ * <p>This class represents the result of a batch load job against BQ.
+ */
+public class BigQueryWriteResult {
+
+  private final BigQueryHelpers.Status status;
+  private final String table;
+
+  BigQueryWriteResult(BigQueryHelpers.Status status, String table) {
+    this.status = status;
+    this.table = table;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public BigQueryHelpers.Status getStatus() {
+    return status;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    BigQueryWriteResult that = (BigQueryWriteResult) o;
+    return status == that.status && Objects.equals(table, that.table);
+  }
+
+  @Override
+  public int hashCode() {
+
+    return Objects.hash(status, table);
+  }
+
+  @Override
+  public String toString() {
+    return "BigQueryWriteResult{ status: " + status.name() + ", table: " + table + "}.";
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResultCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResultCoder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.sdk.coders.AtomicCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+
+/** A {@link Coder} that encodes BigQuery {@link BigQueryWriteResult} objects. */
+public class BigQueryWriteResultCoder extends AtomicCoder<BigQueryWriteResult> {
+
+  private static final BigQueryWriteResultCoder INSTANCE = new BigQueryWriteResultCoder();
+
+  public static BigQueryWriteResultCoder of() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void encode(BigQueryWriteResult value, OutputStream outStream) throws IOException {
+    StringUtf8Coder.of().encode(value.getStatus().name(), outStream);
+    StringUtf8Coder.of().encode(value.getTable(), outStream);
+  }
+
+  @Override
+  public BigQueryWriteResult decode(InputStream inStream) throws IOException {
+    return new BigQueryWriteResult(
+        BigQueryHelpers.Status.valueOf(StringUtf8Coder.of().decode(inStream)),
+        StringUtf8Coder.of().decode(inStream));
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteTables.java
@@ -88,7 +88,7 @@ import org.slf4j.LoggerFactory;
 class WriteTables<DestinationT>
     extends PTransform<
         PCollection<KV<ShardedKey<DestinationT>, List<String>>>,
-        PCollection<KV<TableDestination, String>>> {
+        PCollection<KV<TableDestination, BigQueryWriteResult>>> {
   private static final Logger LOG = LoggerFactory.getLogger(WriteTables.class);
 
   private final boolean singlePartition;
@@ -98,14 +98,15 @@ class WriteTables<DestinationT>
   private final CreateDisposition firstPaneCreateDisposition;
   private final DynamicDestinations<?, DestinationT> dynamicDestinations;
   private final List<PCollectionView<?>> sideInputs;
-  private final TupleTag<KV<TableDestination, String>> mainOutputTag;
+  private final TupleTag<KV<TableDestination, BigQueryWriteResult>> mainOutputTag;
   private final TupleTag<String> temporaryFilesTag;
   private final ValueProvider<String> loadJobProjectId;
   private final int maxRetryJobs;
   private final boolean ignoreUnknownValues;
 
   private class WriteTablesDoFn
-      extends DoFn<KV<ShardedKey<DestinationT>, List<String>>, KV<TableDestination, String>> {
+      extends DoFn<
+          KV<ShardedKey<DestinationT>, List<String>>, KV<TableDestination, BigQueryWriteResult>> {
     private Map<DestinationT, String> jsonSchemas = Maps.newHashMap();
 
     @StartBundle
@@ -166,19 +167,19 @@ class WriteTables<DestinationT>
           (c.pane().getIndex() == 0) ? firstPaneWriteDisposition : WriteDisposition.WRITE_APPEND;
       CreateDisposition createDisposition =
           (c.pane().getIndex() == 0) ? firstPaneCreateDisposition : CreateDisposition.CREATE_NEVER;
-      load(
-          bqServices.getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
-          bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
-          jobIdPrefix,
-          tableReference,
-          tableDestination.getTimePartitioning(),
-          tableSchema,
-          partitionFiles,
-          writeDisposition,
-          createDisposition,
-          tableDestination.getTableDescription());
-      c.output(
-          mainOutputTag, KV.of(tableDestination, BigQueryHelpers.toJsonString(tableReference)));
+      BigQueryWriteResult result =
+          load(
+              bqServices.getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
+              bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
+              jobIdPrefix,
+              tableReference,
+              tableDestination.getTimePartitioning(),
+              tableSchema,
+              partitionFiles,
+              writeDisposition,
+              createDisposition,
+              tableDestination.getTableDescription());
+      c.output(mainOutputTag, KV.of(tableDestination, result));
       for (String file : partitionFiles) {
         c.output(temporaryFilesTag, file);
       }
@@ -218,7 +219,7 @@ class WriteTables<DestinationT>
   }
 
   @Override
-  public PCollection<KV<TableDestination, String>> expand(
+  public PCollection<KV<TableDestination, BigQueryWriteResult>> expand(
       PCollection<KV<ShardedKey<DestinationT>, List<String>>> input) {
     PCollectionTuple writeTablesOutputs =
         input.apply(
@@ -245,7 +246,9 @@ class WriteTables<DestinationT>
         .apply(Values.create())
         .apply(ParDo.of(new GarbageCollectTemporaryFiles()));
 
-    return writeTablesOutputs.get(mainOutputTag);
+    return writeTablesOutputs
+        .get(mainOutputTag)
+        .setCoder(KvCoder.of(TableDestinationCoderV2.of(), BigQueryWriteResultCoder.of()));
   }
 
   private BigQueryWriteResult load(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -742,26 +742,6 @@ public class BigQueryIOWriteTest implements Serializable {
   }
 
   @Test
-  public void testWriteUnknown() throws Exception {
-    p.apply(
-            Create.of(
-                    new TableRow().set("name", "a").set("number", 1),
-                    new TableRow().set("name", "b").set("number", 2),
-                    new TableRow().set("name", "c").set("number", 3))
-                .withCoder(TableRowJsonCoder.of()))
-        .apply(
-            BigQueryIO.writeTableRows()
-                .to("project-id:dataset-id.table-id")
-                .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_NEVER)
-                .withTestServices(fakeBqServices)
-                .withoutValidation());
-
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Failed to create load job");
-    p.run();
-  }
-
-  @Test
   public void testWriteFailedJobs() throws Exception {
     p.apply(
             Create.of(
@@ -783,6 +763,8 @@ public class BigQueryIOWriteTest implements Serializable {
 
     p.run();
   }
+
+  // TODO add a test for UNKNOWN errors
 
   @Test
   public void testWriteWithMissingSchemaFromView() throws Exception {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResultCoderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryWriteResultCoderTest.java
@@ -1,0 +1,22 @@
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test case for {@link BigQueryWriteResultCoder}. */
+@RunWith(JUnit4.class)
+public class BigQueryWriteResultCoderTest {
+
+  private static final Coder<BigQueryWriteResult> TEST_CODER = BigQueryWriteResultCoder.of();
+
+  @Test
+  public void testDecodeEncodeEqual() throws Exception {
+    BigQueryWriteResult value =
+        new BigQueryWriteResult(BigQueryHelpers.Status.SUCCEEDED, "dummy_table");
+
+    CoderProperties.coderDecodeEncodeEqual(TEST_CODER, value);
+  }
+}


### PR DESCRIPTION
Adds the batch load results to the `WriteResults` returned by BigQueryIO.write

This PR is still WIP, but I wanted to open it ASAP to get feedback. Meanwhile:
* Unify the returned results, so that if a load required many jobs. Only one element is returned on the PCollection, making that "split into many jobs" transparent to the user
* Add the job's error information to the `BigQueryWriteResult` class so that it is also returned and can be actionable.

@reuvenlax @jkff 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




