### PR TITLE
[BEAM-4863] Implement consistentWithEquals/structuralValue on FullWindowedValueCoder

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ListCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ListCoder.java
@@ -32,6 +32,17 @@ public class ListCoder<T> extends IterableLikeCoder<T, List<T>> {
     return new ListCoder<>(elemCoder);
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>List coders are consistent with equals if and only if the element coder is consistent with
+   * equals.
+   */
+  @Override
+  public boolean consistentWithEquals() {
+    return getElemCoder().consistentWithEquals();
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Internal operations below here.
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SetCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SetCoder.java
@@ -54,6 +54,17 @@ public class SetCoder<T> extends IterableLikeCoder<T, Set<T>> {
         new TypeParameter<T>() {}, getElemCoder().getEncodedTypeDescriptor());
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Set coders are consistent with equals if and only if the element coder is consistent with
+   * equals.
+   */
+  @Override
+  public boolean consistentWithEquals() {
+    return getElemCoder().consistentWithEquals();
+  }
+
   /////////////////////////////////////////////////////////////////////////////
   // Internal operations below here.
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ListCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ListCoderTest.java
@@ -18,8 +18,11 @@
 package org.apache.beam.sdk.coders;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +53,24 @@ public class ListCoderTest {
   @Test
   public void testCoderIsSerializableWithWellKnownCoderType() throws Exception {
     CoderProperties.coderSerializable(ListCoder.of(GlobalWindow.Coder.INSTANCE));
+  }
+
+  @Test
+  public void testConsistentWithEquals() throws Exception {
+    assertFalse(CollectionCoder.of(ByteArrayCoder.of()).consistentWithEquals());
+    assertTrue(TEST_CODER.consistentWithEquals());
+    for (List<Integer> value : TEST_VALUES) {
+      CoderProperties.coderConsistentWithEquals(TEST_CODER, value, ImmutableList.copyOf(value));
+    }
+  }
+
+  @Test
+  public void testStructuralValue() throws Exception {
+    for (List<Integer> value : TEST_VALUES) {
+      CoderProperties.structuralValueDecodeEncodeEqual(TEST_CODER, value);
+      CoderProperties.structuralValueConsistentWithEquals(
+          TEST_CODER, value, ImmutableList.copyOf(value));
+    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SetCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/SetCoderTest.java
@@ -18,8 +18,11 @@
 package org.apache.beam.sdk.coders;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +53,24 @@ public class SetCoderTest {
   @Test
   public void testCoderIsSerializableWithWellKnownCoderType() throws Exception {
     CoderProperties.coderSerializable(SetCoder.of(GlobalWindow.Coder.INSTANCE));
+  }
+
+  @Test
+  public void testConsistentWithEquals() throws Exception {
+    assertFalse(CollectionCoder.of(ByteArrayCoder.of()).consistentWithEquals());
+    assertTrue(TEST_CODER.consistentWithEquals());
+    for (Set<Integer> value : TEST_VALUES) {
+      CoderProperties.coderConsistentWithEquals(TEST_CODER, value, ImmutableSet.copyOf(value));
+    }
+  }
+
+  @Test
+  public void testStructuralValue() throws Exception {
+    for (Set<Integer> value : TEST_VALUES) {
+      CoderProperties.structuralValueDecodeEncodeEqual(TEST_CODER, value);
+      CoderProperties.structuralValueConsistentWithEquals(
+          TEST_CODER, value, ImmutableSet.copyOf(value));
+    }
   }
 
   @Test


### PR DESCRIPTION
Note that I also implemented it on the iterable like coder since it is a dependency of the
FullWindowedValueCoder.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




