### PR TITLE
[BEAM-4094] Removing ScopedMetricsContainer from Python SDK

### DIFF
--- a/sdks/python/apache_beam/metrics/execution.pxd
+++ b/sdks/python/apache_beam/metrics/execution.pxd
@@ -23,10 +23,3 @@ cdef class MetricsContainer(object):
   cdef public object counters
   cdef public object distributions
   cdef public object gauges
-
-
-cdef class ScopedMetricsContainer(object):
-  cpdef enter(self)
-  cpdef exit(self)
-  cdef list _stack
-  cdef MetricsContainer _container

--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -122,38 +122,16 @@ class _MetricsEnvironment(object):
   def __init__(self):
     self.METRICS_SUPPORTED = False
     self._METRICS_SUPPORTED_LOCK = threading.Lock()
-    self.PER_THREAD = threading.local()
-    self.set_container_stack()
-
-  def set_container_stack(self):
-    if not hasattr(self.PER_THREAD, 'container'):
-      self.PER_THREAD.container = []
-
-  def container_stack(self):
-    self.set_container_stack()
-    return self.PER_THREAD.container
 
   def set_metrics_supported(self, supported):
-    self.set_container_stack()
     with self._METRICS_SUPPORTED_LOCK:
       self.METRICS_SUPPORTED = supported
-
-  def _old_style_container(self):
-    """Gets the current MetricsContainer based on the container stack.
-
-    The container stack is the old method, and will be deprecated. Should
-    rely on StateSampler instead."""
-    self.set_container_stack()
-    index = len(self.PER_THREAD.container) - 1
-    if index < 0:
-      return None
-    return self.PER_THREAD.container[index]
 
   def current_container(self):
     """Returns the current MetricsContainer."""
     sampler = statesampler.get_current_tracker()
     if sampler is None:
-      return self._old_style_container()
+      return None
     return sampler.current_state().metrics_container
 
 

--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -234,27 +234,6 @@ class MetricsContainer(object):
     )
 
 
-class ScopedMetricsContainer(object):
-
-  def __init__(self, container=None):
-    self._stack = MetricsEnvironment.container_stack()
-    self._container = container
-
-  def enter(self):
-    if self._container:
-      self._stack.append(self._container)
-
-  def exit(self):
-    if self._container:
-      self._stack.pop()
-
-  def __enter__(self):
-    self.enter()
-
-  def __exit__(self, type, value, traceback):
-    self.exit()
-
-
 class MetricUpdates(object):
   """Contains updates for several metrics.
 

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -18,7 +18,6 @@
 cimport cython
 
 from apache_beam.utils.windowed_value cimport WindowedValue
-from apache_beam.metrics.execution cimport ScopedMetricsContainer
 from apache_beam.transforms.cy_dataflow_distribution_counter cimport DataflowDistributionCounter
 
 from libc.stdint cimport int64_t

--- a/sdks/python/apache_beam/runners/worker/operations.pxd
+++ b/sdks/python/apache_beam/runners/worker/operations.pxd
@@ -20,7 +20,6 @@ cimport cython
 from apache_beam.runners.common cimport Receiver
 from apache_beam.runners.worker cimport opcounters
 from apache_beam.utils.windowed_value cimport WindowedValue
-from apache_beam.metrics.execution cimport ScopedMetricsContainer
 
 
 cdef WindowedValue _globally_windowed_value
@@ -46,7 +45,6 @@ cdef class Operation(object):
   cdef object consumers
   cdef readonly counter_factory
   cdef public metrics_container
-  cdef public ScopedMetricsContainer scoped_metrics_container
   # Public for access by Fn harness operations.
   # TODO(robertwb): Cythonize FnHarness.
   cdef public list receivers

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -32,7 +32,6 @@ from apache_beam import pvalue
 from apache_beam.internal import pickler
 from apache_beam.io import iobase
 from apache_beam.metrics.execution import MetricsContainer
-from apache_beam.metrics.execution import ScopedMetricsContainer
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.runners import common
 from apache_beam.runners.common import Receiver
@@ -131,9 +130,6 @@ class Operation(object):
 
     # These are overwritten in the legacy harness.
     self.metrics_container = MetricsContainer(self.name_context.metrics_name())
-    # TODO(BEAM-4094): Remove ScopedMetricsContainer after Dataflow no longer
-    # depends on it.
-    self.scoped_metrics_container = ScopedMetricsContainer()
 
     self.state_sampler = state_sampler
     self.scoped_start_state = self.state_sampler.scoped_state(


### PR DESCRIPTION
As StateSampler is now the main context manager, ScopedMetricsContainer is no longer useful.