### PR TITLE
Make javadoc build more clear

### DIFF
--- a/sdks/java/javadoc/build.gradle
+++ b/sdks/java/javadoc/build.gradle
@@ -16,6 +16,13 @@
  * limitations under the License.
  */
 
+/*
+ * Aggregate Javadoc is not published to Maven Central. Each Java module that is published
+ * to Maven Cental packages its own Javadoc. To generate aggregated javadocs, run:
+ *   ./gradlew :beam-sdks-java-javadoc:aggregateJavadoc
+ * Generated files will be located under beam/sdks/java/javadoc/build/docs/javadoc and are
+ * used as part of the beam-site source tree.
+ */
 description = "Apache Beam :: SDKs :: Java :: Aggregated Javadoc"
 apply plugin: 'java'
 
@@ -91,7 +98,7 @@ task aggregateJavadoc(type: Javadoc) {
 
   options.with {
     failOnError false
-    title "Apache Beam 2.5.0"
+    title "Apache Beam " + project.version
     overview 'overview.html'
     addStringOption('Xdoclint:all', '-quiet')
     addStringOption('Xdoclint:-missing', '-quiet')


### PR DESCRIPTION
1. Changed hardcoded version number into env variable.
2.  Added more comments.

r: @lukecwik 
cc: @pabloem