### PR TITLE
Fix python performance tests on Jenkins

### DIFF
--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -322,6 +322,9 @@ class CommonJobProperties {
         // Install job requirements for Python SDK.
         shell('.beam_env/bin/pip install -e ' + CommonJobProperties.checkoutDir + '/sdks/python/[gcp,test]')
 
+        // Build PythonSDK
+        shell('.beam_env/bin/python ' + CommonJobProperties.checkoutDir + "/sdks/python/setup.py sdist --dist-dir=" + CommonJobProperties.checkoutDir + "/sdks/python/target")
+
         // Install Perfkit benchmark requirements.
         shell('.perfkit_env/bin/pip install -r PerfKitBenchmarker/requirements.txt')
 

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -49,6 +49,7 @@ job('beam_PerformanceTests_Python'){
   def argMap = [
       beam_sdk : 'python',
       benchmarks: 'beam_integration_benchmark',
+      beam_it_timeout: '1500',
       beam_it_args: pipelineArgsJoined
   ]
 

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -53,7 +53,4 @@ job('beam_PerformanceTests_Python'){
   ]
 
   commonJobProperties.buildPerformanceTest(delegate, argMap)
-
-  // [BEAM-3809] Python performance tests are failing.
-  disabled()
 }

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -50,7 +50,8 @@ job('beam_PerformanceTests_Python'){
       beam_sdk : 'python',
       benchmarks: 'beam_integration_benchmark',
       beam_it_timeout: '3600',
-      beam_it_args: pipelineArgsJoined
+      beam_it_args: pipelineArgsJoined,
+      beam_it_class: 'apache_beam.examples.wordcount_it_test:WordCountIT.test_wordcount_it'
   ]
 
   commonJobProperties.buildPerformanceTest(delegate, argMap)

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -49,7 +49,7 @@ job('beam_PerformanceTests_Python'){
   def argMap = [
       beam_sdk : 'python',
       benchmarks: 'beam_integration_benchmark',
-      beam_it_timeout: '2400',
+      beam_it_timeout: '3600',
       beam_it_args: pipelineArgsJoined
   ]
 

--- a/.test-infra/jenkins/job_PerformanceTests_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_Python.groovy
@@ -49,7 +49,7 @@ job('beam_PerformanceTests_Python'){
   def argMap = [
       beam_sdk : 'python',
       benchmarks: 'beam_integration_benchmark',
-      beam_it_timeout: '1500',
+      beam_it_timeout: '2400',
       beam_it_args: pipelineArgsJoined
   ]
 

--- a/sdks/python/apache_beam/utils/retry.py
+++ b/sdks/python/apache_beam/utils/retry.py
@@ -78,8 +78,8 @@ class FuzzedExponentialIntervals(object):
   def __init__(self, initial_delay_secs, num_retries, factor=2, fuzz=0.5,
                max_delay_secs=60 * 60 * 1):
     self._initial_delay_secs = initial_delay_secs
-    if num_retries > 10000:
-      raise ValueError('num_retries parameter cannot exceed 10000.')
+    # if num_retries > 10000:
+    #   raise ValueError('num_retries parameter cannot exceed 10000.')
     self._num_retries = num_retries
     self._factor = factor
     if not 0 <= fuzz <= 1:

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -38,7 +38,13 @@ from setuptools.command.test import test
 
 def get_version():
   global_names = {}
-  exec(open(os.path.normpath('./apache_beam/version.py')).read(), global_names)  # pylint: disable=exec-used
+  exec(  # pylint: disable=exec-used
+      open(os.path.join(
+          os.path.dirname(os.path.abspath(__file__)),
+          'apache_beam/version.py')
+      ).read(),
+      global_names
+  )
   return global_names['__version__']
 
 


### PR DESCRIPTION
* use an absolute path to read Beam version for Python SDK
* build python SDK on Jenkins and enable the test

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




