### PR TITLE
[BEAM-4862] Fixes bug in Spanner's MutationGroupEncoder by converting timestamps into Long and not Int.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroupEncoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroupEncoder.java
@@ -478,7 +478,7 @@ class MutationGroupEncoder {
           if (isNull) {
             m.set(fieldName).to((Timestamp) null);
           } else {
-            int seconds = VarInt.decodeInt(bis);
+            long seconds = VarInt.decodeLong(bis);
             int nanoseconds = VarInt.decodeInt(bis);
             m.set(fieldName).to(Timestamp.ofTimeSecondsAndNanos(seconds, nanoseconds));
           }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroupEncoderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationGroupEncoderTest.java
@@ -529,6 +529,36 @@ public class MutationGroupEncoderTest {
   }
 
   @Test
+  public void decodeBasicTimestampMutationGroup() {
+    SpannerSchema spannerSchemaTimestamp =
+        SpannerSchema.builder().addColumn("timestampTest", "timestamp", "TIMESTAMP").build();
+    Timestamp timestamp1 = Timestamp.now();
+    Mutation mutation1 =
+        Mutation.newInsertOrUpdateBuilder("timestampTest").set("timestamp").to(timestamp1).build();
+    encodeAndVerify(g(mutation1), spannerSchemaTimestamp);
+
+    Timestamp timestamp2 = Timestamp.parseTimestamp("2001-01-01T00:00:00Z");
+    Mutation mutation2 =
+        Mutation.newInsertOrUpdateBuilder("timestampTest").set("timestamp").to(timestamp2).build();
+    encodeAndVerify(g(mutation2), spannerSchemaTimestamp);
+  }
+
+  @Test
+  public void decodeMinAndMaxTimestampMutationGroup() {
+    SpannerSchema spannerSchemaTimestamp =
+        SpannerSchema.builder().addColumn("timestampTest", "timestamp", "TIMESTAMP").build();
+    Timestamp timestamp1 = Timestamp.MIN_VALUE;
+    Mutation mutation1 =
+        Mutation.newInsertOrUpdateBuilder("timestampTest").set("timestamp").to(timestamp1).build();
+    encodeAndVerify(g(mutation1), spannerSchemaTimestamp);
+
+    Timestamp timestamp2 = Timestamp.MAX_VALUE;
+    Mutation mutation2 =
+        Mutation.newInsertOrUpdateBuilder("timestampTest").set("timestamp").to(timestamp2).build();
+    encodeAndVerify(g(mutation2), spannerSchemaTimestamp);
+  }
+
+  @Test
   public void timestampKeys() throws Exception {
     SpannerSchema.Builder builder = SpannerSchema.builder();
 


### PR DESCRIPTION
@chamikaramj 

The crux of the bug is that 0001-01-01T00:00:00Z, which is a valid Timestamp per https://cloud.google.com/spanner/docs/data-types#timestamp-type, is too large for an integer. 

So the following stack trace is generated:

```
Caused by: java.io.IOException: varint overflow -62135596800
	at org.apache.beam.sdk.util.VarInt.decodeInt(VarInt.java:65)
	at org.apache.beam.sdk.io.gcp.spanner.MutationGroupEncoder.decodePrimitive(MutationGroupEncoder.java:453)
	at org.apache.beam.sdk.io.gcp.spanner.MutationGroupEncoder.decodeModification(MutationGroupEncoder.java:326)
	at org.apache.beam.sdk.io.gcp.spanner.MutationGroupEncoder.decodeMutation(MutationGroupEncoder.java:280)
	at org.apache.beam.sdk.io.gcp.spanner.MutationGroupEncoder.decode(MutationGroupEncoder.java:264)
	at org.apache.beam.sdk.io.gcp.spanner.SpannerIO$BatchFn.processElement(SpannerIO.java:1030)
	at org.apache.beam.sdk.io.gcp.spanner.SpannerIO$BatchFn$DoFnInvoker.invokeProcessElement(Unknown Source)
	at org.apache.beam.runners.core.SimpleDoFnRunner.invokeProcessElement(SimpleDoFnRunner.java:185)
	at org.apache.beam.runners.core.SimpleDoFnRunner.processElement(SimpleDoFnRunner.java:146)
	at com.google.cloud.dataflow.worker.SimpleParDoFn.processElement(SimpleParDoFn.java:323)
	at com.google.cloud.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:43)
	at com.google.cloud.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:48)
	at com.google.cloud.dataflow.worker.GroupAlsoByWindowsParDoFn$1.output(GroupAlsoByWindowsParDoFn.java:181)
	at com.google.cloud.dataflow.worker.GroupAlsoByWindowFnRunner$1.outputWindowedValue(GroupAlsoByWindowFnRunner.java:102)
	at com.google.cloud.dataflow.worker.util.BatchGroupAlsoByWindowViaIteratorsFn.processElement(BatchGroupAlsoByWindowViaIteratorsFn.java:124)
	at com.google.cloud.dataflow.worker.util.BatchGroupAlsoByWindowViaIteratorsFn.processElement(BatchGroupAlsoByWindowViaIteratorsFn.java:53)
	at com.google.cloud.dataflow.worker.GroupAlsoByWindowFnRunner.invokeProcessElement(GroupAlsoByWindowFnRunner.java:115)
	at com.google.cloud.dataflow.worker.GroupAlsoByWindowFnRunner.processElement(GroupAlsoByWindowFnRunner.java:73)
	at com.google.cloud.dataflow.worker.GroupAlsoByWindowsParDoFn.processElement(GroupAlsoByWindowsParDoFn.java:113)
	at com.google.cloud.dataflow.worker.util.common.worker.ParDoOperation.process(ParDoOperation.java:43)
	at com.google.cloud.dataflow.worker.util.common.worker.OutputReceiver.process(OutputReceiver.java:48)
	at com.google.cloud.dataflow.worker.util.common.worker.ReadOperation.runReadLoop(ReadOperation.java:200)
	at com.google.cloud.dataflow.worker.util.common.worker.ReadOperation.start(ReadOperation.java:158)
	at com.google.cloud.dataflow.worker.util.common.worker.MapTaskExecutor.execute(MapTaskExecutor.java:75)
	at com.google.cloud.dataflow.worker.BatchDataflowWorker.executeWork(BatchDataflowWorker.java:391)
	at com.google.cloud.dataflow.worker.BatchDataflowWorker.doWork(BatchDataflowWorker.java:360)
	at com.google.cloud.dataflow.worker.BatchDataflowWorker.getAndPerformWork(BatchDataflowWorker.java:288)
	at com.google.cloud.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.doWork(DataflowBatchWorkerHarness.java:134)
	at com.google.cloud.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:114)
	at com.google.cloud.dataflow.worker.DataflowBatchWorkerHarness$WorkerThread.call(DataflowBatchWorkerHarness.java:101)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```

The solution is to parse the number of seconds that represent the date as Long and not Int, thereby avoiding the overflow error.