### PR TITLE
[BEAM-5050] [SQL] Fix aggregation of nulls

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
@@ -244,33 +244,43 @@ public class BeamAggregationTransforms implements Serializable {
     public AggregationAccumulator addInput(AggregationAccumulator accumulator, Row input) {
       AggregationAccumulator deltaAcc = new AggregationAccumulator();
       for (int idx = 0; idx < aggregators.size(); ++idx) {
+        CombineFn aggregator = aggregators.get(idx);
+        Object element = accumulator.accumulatorElements.get(idx);
+
         if (sourceFieldExps.get(idx) instanceof BeamSqlInputRefExpression) {
           BeamSqlInputRefExpression exp = (BeamSqlInputRefExpression) sourceFieldExps.get(idx);
-          deltaAcc.accumulatorElements.add(
-              aggregators
-                  .get(idx)
-                  .addInput(
-                      accumulator.accumulatorElements.get(idx),
-                      exp.evaluate(input, null, BeamSqlExpressionEnvironments.empty()).getValue()));
+          Object value =
+              exp.evaluate(input, null, BeamSqlExpressionEnvironments.empty()).getValue();
+
+          // every aggregator ignores null values, e.g., COUNT(NULL) is always zero
+          if (value != null) {
+            Object delta = aggregator.addInput(element, value);
+            deltaAcc.accumulatorElements.add(delta);
+          } else {
+            deltaAcc.accumulatorElements.add(element);
+          }
         } else if (sourceFieldExps.get(idx) instanceof KV) {
-          /**
+          /*
            * If source expression is type of KV pair, we bundle the value of two expressions into KV
            * pair and pass it to aggregator's addInput method.
            */
           KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression> exp =
               (KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression>) sourceFieldExps.get(idx);
-          deltaAcc.accumulatorElements.add(
-              aggregators
-                  .get(idx)
-                  .addInput(
-                      accumulator.accumulatorElements.get(idx),
-                      KV.of(
-                          exp.getKey()
-                              .evaluate(input, null, BeamSqlExpressionEnvironments.empty())
-                              .getValue(),
-                          exp.getValue()
-                              .evaluate(input, null, BeamSqlExpressionEnvironments.empty())
-                              .getValue())));
+
+          Object key =
+              exp.getKey().evaluate(input, null, BeamSqlExpressionEnvironments.empty()).getValue();
+
+          Object value =
+              exp.getValue()
+                  .evaluate(input, null, BeamSqlExpressionEnvironments.empty())
+                  .getValue();
+
+          // ignore aggregator if either key or value is null, e.g., COVAR_SAMP(x, NULL) is null
+          if (key != null && value != null) {
+            deltaAcc.accumulatorElements.add(aggregator.addInput(element, KV.of(key, value)));
+          } else {
+            deltaAcc.accumulatorElements.add(element);
+          }
         }
       }
       return deltaAcc;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -190,6 +190,8 @@ public class CalciteUtils {
   private static RelDataType toRelDataType(
       RelDataTypeFactory dataTypeFactory, Schema schema, int fieldIndex) {
     Schema.Field field = schema.getField(fieldIndex);
-    return toRelDataType(dataTypeFactory, field.getType());
+    RelDataType type = toRelDataType(dataTypeFactory, field.getType());
+
+    return dataTypeFactory.createTypeWithNullability(type, field.getNullable());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationNullableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationNullableTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql;
+
+import static org.apache.beam.sdk.extensions.sql.utils.RowAsserts.matchesScalar;
+import static org.apache.beam.sdk.transforms.SerializableFunctions.identity;
+
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Integration tests for aggregation nullable columns. */
+public class BeamSqlDslAggregationNullableTest {
+
+  @Rule public TestPipeline pipeline = TestPipeline.create();
+
+  private PCollection<Row> boundedInput;
+
+  @Before
+  public void setUp() {
+    Schema schema =
+        Schema.builder()
+            .addNullableField("f_int1", Schema.FieldType.INT32)
+            .addNullableField("f_int2", Schema.FieldType.INT32)
+            .addInt32Field("f_int3")
+            .build();
+
+    List<Row> rows =
+        TestUtils.RowsBuilder.of(schema)
+            .addRows(1, 5, 1)
+            .addRows(null, 1, 1)
+            .addRows(2, 1, 1)
+            .addRows(null, 1, 1)
+            .addRows(null, null, 1)
+            .addRows(null, null, 1)
+            .addRows(3, 2, 1)
+            .getRows();
+
+    boundedInput =
+        PBegin.in(pipeline).apply(Create.of(rows).withSchema(schema, identity(), identity()));
+  }
+
+  @Test
+  public void testCount() {
+    String sql = "SELECT COUNT(f_int1) FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(3L));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testCountStar() {
+    String sql = "SELECT COUNT(*) FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(7L));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testCountThroughSum() {
+    String sql =
+        "SELECT SUM(CASE f_int1 IS NOT NULL WHEN TRUE THEN 1 ELSE 0 END) "
+            + "FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(3));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testCountNulls() {
+    String sql =
+        "SELECT SUM(CASE f_int1 IS NULL WHEN TRUE THEN 1 ELSE 0 END) "
+            + "FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(4));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testSum() {
+    String sql = "SELECT SUM(f_int1) FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(6));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testAvg() {
+    String sql = "SELECT AVG(f_int1) FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(2));
+
+    pipeline.run();
+  }
+
+  @Ignore
+  // FIXME [BEAM-5056] [SQL] Nullability of aggregation expressions isn't inferred properly
+  public void testAvgGroupByNullable() {
+    String sql = "SELECT AVG(f_int1) FROM PCOLLECTION GROUP BY f_int2";
+
+    boundedInput.apply(SqlTransform.query(sql));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testSampleVariance() {
+    // a special case of aggregator with two parameters
+    String sql = "SELECT COVAR_SAMP(f_int1, f_int2) FROM PCOLLECTION GROUP BY f_int3";
+
+    // COVAR_SAMP(f_int1, f_int2) =
+    //   (SUM(f_int1 * f_int2) - SUM(f_int1) * SUM(f_int2) / n) / (n-1) =
+    //   (SUM([1 * 5, 2 * 1, 3 * 2]) - SUM([1, 2, 3]) * SUM([5, 1, 2]) / 3) / 2 =
+    //   -1.5
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(-1));
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testSampleVarianceReverse() {
+    String sql = "SELECT COVAR_SAMP(f_int2, f_int1) FROM PCOLLECTION GROUP BY f_int3";
+
+    PAssert.that(boundedInput.apply(SqlTransform.query(sql))).satisfies(matchesScalar(-1));
+
+    pipeline.run();
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
@@ -19,7 +19,6 @@
 package org.apache.beam.sdk.extensions.sql.impl.rel;
 
 import org.apache.beam.sdk.extensions.sql.TestUtils;
-import org.apache.beam.sdk.extensions.sql.impl.ParseException;
 import org.apache.beam.sdk.extensions.sql.mock.MockedBoundedTable;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.testing.PAssert;
@@ -30,10 +29,13 @@ import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 /** Test for {@code BeamSortRel}. */
 public class BeamSortRelTest extends BaseRelTest {
   @Rule public final TestPipeline pipeline = TestPipeline.create();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Before
   public void prepare() {
@@ -259,8 +261,11 @@ public class BeamSortRelTest extends BaseRelTest {
     pipeline.run().waitUntilFinish();
   }
 
-  @Test(expected = ParseException.class)
-  public void testOrderBy_exception() throws Exception {
+  @Test
+  public void testOrderBy_exception() {
+    thrown.expect(UnsupportedOperationException.class);
+    thrown.expectMessage("`ORDER BY` is only supported for GlobalWindows");
+
     String sql =
         "INSERT INTO SUB_ORDER_RAM(order_id, site_id)  SELECT "
             + " order_id, COUNT(*) "

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rel.type.RelDataTypeSystem;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for conversion from Beam schema to Calcite data type. */
+public class CalciteUtilsTest {
+
+  RelDataTypeFactory dataTypeFactory;
+
+  @Before
+  public void setUp() {
+    dataTypeFactory = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
+  }
+
+  Map<String, RelDataType> calciteRowTypeFields(Schema schema) {
+    final RelDataType dataType = CalciteUtils.toCalciteRowType(schema, dataTypeFactory);
+
+    return dataType
+        .getFieldNames()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                x -> x,
+                x ->
+                    dataType
+                        .getField(x, /*caseSensitive=*/ true, /*elideRecord=*/ false)
+                        .getType()));
+  }
+
+  @Test
+  public void testToCalciteRowType() {
+    final Schema schema =
+        Schema.builder()
+            .addField("f1", Schema.FieldType.BYTE)
+            .addField("f2", Schema.FieldType.INT16)
+            .addField("f3", Schema.FieldType.INT32)
+            .addField("f4", Schema.FieldType.INT64)
+            .addField("f5", Schema.FieldType.FLOAT)
+            .addField("f6", Schema.FieldType.DOUBLE)
+            .addField("f7", Schema.FieldType.DECIMAL)
+            .addField("f8", Schema.FieldType.BOOLEAN)
+            .addField("f9", Schema.FieldType.BYTES)
+            .addField("f10", Schema.FieldType.STRING)
+            .build();
+
+    final Map<String, RelDataType> fields = calciteRowTypeFields(schema);
+
+    assertEquals(10, fields.size());
+
+    fields.values().forEach(x -> assertFalse(x.isNullable()));
+
+    assertEquals(SqlTypeName.TINYINT, fields.get("f1").getSqlTypeName());
+    assertEquals(SqlTypeName.SMALLINT, fields.get("f2").getSqlTypeName());
+    assertEquals(SqlTypeName.INTEGER, fields.get("f3").getSqlTypeName());
+    assertEquals(SqlTypeName.BIGINT, fields.get("f4").getSqlTypeName());
+    assertEquals(SqlTypeName.FLOAT, fields.get("f5").getSqlTypeName());
+    assertEquals(SqlTypeName.DOUBLE, fields.get("f6").getSqlTypeName());
+    assertEquals(SqlTypeName.DECIMAL, fields.get("f7").getSqlTypeName());
+    assertEquals(SqlTypeName.BOOLEAN, fields.get("f8").getSqlTypeName());
+    assertEquals(SqlTypeName.VARBINARY, fields.get("f9").getSqlTypeName());
+    assertEquals(SqlTypeName.VARCHAR, fields.get("f10").getSqlTypeName());
+  }
+
+  @Test
+  public void testToCalciteRowTypeNullable() {
+    final Schema schema =
+        Schema.builder()
+            .addNullableField("f1", Schema.FieldType.BYTE)
+            .addNullableField("f2", Schema.FieldType.INT16)
+            .addNullableField("f3", Schema.FieldType.INT32)
+            .addNullableField("f4", Schema.FieldType.INT64)
+            .addNullableField("f5", Schema.FieldType.FLOAT)
+            .addNullableField("f6", Schema.FieldType.DOUBLE)
+            .addNullableField("f7", Schema.FieldType.DECIMAL)
+            .addNullableField("f8", Schema.FieldType.BOOLEAN)
+            .addNullableField("f9", Schema.FieldType.BYTES)
+            .addNullableField("f10", Schema.FieldType.STRING)
+            .build();
+
+    final Map<String, RelDataType> fields = calciteRowTypeFields(schema);
+
+    assertEquals(10, fields.size());
+
+    fields.values().forEach(x -> assertTrue(x.isNullable()));
+
+    assertEquals(SqlTypeName.TINYINT, fields.get("f1").getSqlTypeName());
+    assertEquals(SqlTypeName.SMALLINT, fields.get("f2").getSqlTypeName());
+    assertEquals(SqlTypeName.INTEGER, fields.get("f3").getSqlTypeName());
+    assertEquals(SqlTypeName.BIGINT, fields.get("f4").getSqlTypeName());
+    assertEquals(SqlTypeName.FLOAT, fields.get("f5").getSqlTypeName());
+    assertEquals(SqlTypeName.DOUBLE, fields.get("f6").getSqlTypeName());
+    assertEquals(SqlTypeName.DECIMAL, fields.get("f7").getSqlTypeName());
+    assertEquals(SqlTypeName.BOOLEAN, fields.get("f8").getSqlTypeName());
+    assertEquals(SqlTypeName.VARBINARY, fields.get("f9").getSqlTypeName());
+    assertEquals(SqlTypeName.VARCHAR, fields.get("f10").getSqlTypeName());
+  }
+}

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/RowAsserts.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/utils/RowAsserts.java
@@ -38,6 +38,16 @@ public class RowAsserts {
     };
   }
 
+  /** Asserts result contains single row with an long field. */
+  public static SerializableFunction<Iterable<Row>, Void> matchesScalar(long expected) {
+    return records -> {
+      Row row = Iterables.getOnlyElement(records);
+      assertNotNull(row);
+      assertEquals(expected, (long) row.getInt64(0));
+      return null;
+    };
+  }
+
   /** Asserts result contains single row with a double field. */
   public static SerializableFunction<Iterable<Row>, Void> matchesScalar(
       double expected, double delta) {


### PR DESCRIPTION
Before Beam SQL didn't aggregate nulls properly, e.g.,

```
-- [{x: null, y: 1}, {x: 1, y: 1}, {x: 2, y: 1}]
SELECT COUNT(x) FROM PCOLLECTION GROUP BY y
-- got: 3
-- expected: 2
```

There are two reasons:
- it didn't pass the value of `Schema.Field#getNullable` to Calcite data type, and Calcite optimized `COUNT(x)` to `COUNT()`
- it didn't handle nulls in `BeamAggregationTransforms`, that is relevant for `AVG`, `SUM`, etc.

You can find more examples of broken queries in `BeamSqlDslAggregationNullableTest`.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




