### PR TITLE
[BEAM-4176] Tests for running Python on Flink.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import absolute_import
+from __future__ import print_function
+
+import logging
+import sys
+import unittest
+
+import apache_beam as beam
+from apache_beam.options.pipeline_options import DebugOptions
+from apache_beam.options.pipeline_options import SetupOptions
+from apache_beam.runners.portability import portable_runner
+from apache_beam.runners.portability import portable_runner_test
+from apache_beam.testing.util import assert_that
+
+
+if __name__ == '__main__':
+
+  # Run as
+  #
+  # python -m apache_beam.runners.portability.flink_runner_test \
+  #     /path/to/job_server.jar \
+  #     [FlinkRunnerTest.test_method, ...]
+  flinkJobServerJar = sys.argv.pop(1)
+
+  # This is defined here to only be run when we invoke this file explicitly.
+  class FlinkRunnerTest(portable_runner_test.PortableRunnerTest):
+    _use_grpc = True
+    _use_subprocesses = True
+
+    @classmethod
+    def _subprocess_command(cls, port):
+      return [
+          'java',
+          '-jar', flinkJobServerJar,
+          '--artifacts-dir', '/tmp/flink',
+          '--job-host', 'localhost:%s' % port,
+      ]
+
+    @classmethod
+    def get_runner(cls):
+      return portable_runner.PortableRunner()
+
+    def create_options(self):
+      options = super(FlinkRunnerTest, self).create_options()
+      options.view_as(DebugOptions).experiments = ['beam_fn_api']
+      options.view_as(SetupOptions).sdk_location = 'container'
+      return options
+
+    # Can't read host files from within docker, read a "local" file there.
+    def test_read(self):
+      with self.create_pipeline() as p:
+        lines = p | beam.io.ReadFromText('/etc/profile')
+        assert_that(lines, lambda lines: len(lines) > 0)
+
+    def test_no_subtransform_composite(self):
+      raise unittest.SkipTest("BEAM-4781")
+
+    # Inherits all other tests.
+
+
+  # Run the tests.
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -28,9 +28,7 @@ from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability import portable_runner_test
 from apache_beam.testing.util import assert_that
 
-
 if __name__ == '__main__':
-
   # Run as
   #
   # python -m apache_beam.runners.portability.flink_runner_test \
@@ -72,7 +70,6 @@ if __name__ == '__main__':
       raise unittest.SkipTest("BEAM-4781")
 
     # Inherits all other tests.
-
 
   # Run the tests.
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -199,7 +199,9 @@ class FnApiRunnerTest(unittest.TestCase):
   def test_multimap_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
-      side = p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
+      side = (p | 'side' >> beam.Create([('a', 1), ('b', 2), ('a', 3)])
+              # TODO(BEAM-4782): Obviate the need for this map.
+              | beam.Map(lambda kv: (kv[0], kv[1])))
       assert_that(
           main | beam.Map(lambda k, d: (k, sorted(d[k])),
                           beam.pvalue.AsMultiMap(side)),

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -260,6 +260,18 @@ task hdfsIntegrationTest(dependsOn: 'installGcpTest') {
   }
 }
 
+task flinkCompatibilityMatrix() {
+  dependsOn 'setupVirtualenv'
+  dependsOn ':beam-sdks-python-container:docker'
+  dependsOn ':beam-runners-flink_2.11-job-server:jar'
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', ". ${envdir}/bin/activate && pip install -e . && python -m apache_beam.runners.portability.flink_runner_test ${project(":beam-runners-flink_2.11-job-server:").shadowJar.archivePath}"
+    }
+  }
+}
+
 task postCommit() {
   dependsOn "preCommit"
   dependsOn "localWordCount"

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -260,17 +260,24 @@ task hdfsIntegrationTest(dependsOn: 'installGcpTest') {
   }
 }
 
-task flinkCompatibilityMatrix() {
-  dependsOn 'setupVirtualenv'
-  dependsOn ':beam-sdks-python-container:docker'
-  dependsOn ':beam-runners-flink_2.11-job-server:jar'
-  doLast {
-    exec {
-      executable 'sh'
-      args '-c', ". ${envdir}/bin/activate && pip install -e . && python -m apache_beam.runners.portability.flink_runner_test ${project(":beam-runners-flink_2.11-job-server:").shadowJar.archivePath}"
+def flinkCompatibilityMatrix = {
+  def type = it
+  def name = 'flinkCompatibilityMatrix' + type
+  tasks.create(name: name) {
+    dependsOn 'setupVirtualenv'
+    dependsOn ':beam-sdks-python-container:docker'
+    dependsOn ':beam-runners-flink_2.11-job-server:jar'
+    doLast {
+      exec {
+        executable 'sh'
+        args '-c', ". ${envdir}/bin/activate && pip install -e . && python -m apache_beam.runners.portability.flink_runner_test ${project(":beam-runners-flink_2.11-job-server:").shadowJar.archivePath} ${type}"
+      }
     }
   }
 }
+
+flinkCompatibilityMatrix('Batch')
+flinkCompatibilityMatrix('Streaming')
 
 task postCommit() {
   dependsOn "preCommit"


### PR DESCRIPTION
This provides a fairly comprehensive tests of the basic runner compatibility expectations for Python on Flink. Surprisingly, the suite only takes a minute or so to run, so totally feasible to run on presubmit.

Copy of https://github.com/apache/beam/pull/5942
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




