### PR TITLE
[BEAM-4936] update org.apache.httpcomponents

### DIFF
--- a/sdks/java/io/amazon-web-services/build.gradle
+++ b/sdks/java/io/amazon-web-services/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   shadow library.java.jackson_databind
   shadow library.java.slf4j_api
   runtime 'commons-codec:commons-codec:1.9'
-  runtime "org.apache.httpcomponents:httpclient:4.5.2"
+  runtime "org.apache.httpcomponents:httpclient:4.5.6"
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")
   shadowTest library.java.guava_testlib
   shadowTest library.java.hamcrest_core

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/build.gradle
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/build.gradle
@@ -27,10 +27,10 @@ def log4j_version = "2.6.2"
 
 dependencies {
   testCompile library.java.jackson_databind
-  testCompile "org.apache.httpcomponents:httpasyncclient:4.1.2"
-  testCompile "org.apache.httpcomponents:httpcore-nio:4.4.5"
-  testCompile "org.apache.httpcomponents:httpcore:4.4.5"
-  testCompile "org.apache.httpcomponents:httpclient:4.5.2"
+  testCompile "org.apache.httpcomponents:httpasyncclient:4.1.4"
+  testCompile "org.apache.httpcomponents:httpcore-nio:4.4.10"
+  testCompile "org.apache.httpcomponents:httpcore:4.4.10"
+  testCompile "org.apache.httpcomponents:httpclient:4.5.6"
 
   testCompile project(path: ":beam-sdks-java-core", configuration: "shadow")
   testCompile project(path: ":beam-sdks-java-io-elasticsearch", configuration: "shadow")

--- a/sdks/java/io/elasticsearch/build.gradle
+++ b/sdks/java/io/elasticsearch/build.gradle
@@ -28,9 +28,9 @@ dependencies {
   shadow library.java.jackson_databind
   shadow library.java.jackson_annotations
   shadow "org.elasticsearch.client:elasticsearch-rest-client:5.6.3"
-  shadow "org.apache.httpcomponents:httpasyncclient:4.1.2"
-  shadow "org.apache.httpcomponents:httpcore-nio:4.4.5"
-  shadow "org.apache.httpcomponents:httpcore:4.4.5"
-  shadow "org.apache.httpcomponents:httpclient:4.5.2"
+  shadow "org.apache.httpcomponents:httpasyncclient:4.1.4"
+  shadow "org.apache.httpcomponents:httpcore-nio:4.4.10"
+  shadow "org.apache.httpcomponents:httpcore:4.4.10"
+  shadow "org.apache.httpcomponents:httpclient:4.5.6"
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadow")
 }

--- a/sdks/java/io/solr/build.gradle
+++ b/sdks/java/io/solr/build.gradle
@@ -27,7 +27,7 @@ dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   shadow library.java.commons_compress
   shadow "org.apache.solr:solr-solrj:5.5.4"
-  compileOnly "org.apache.httpcomponents:httpclient:4.4.1"
+  compileOnly "org.apache.httpcomponents:httpclient:4.5.6"
   testCompile project(path: ":beam-sdks-java-core", configuration: "shadowTest")
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadow")
   testCompile project(path: ":beam-runners-direct-java", configuration: "shadow")


### PR DESCRIPTION
Upgrade the httpcomponents to meet the goal "At release time, at least 90% of the Beam dependencies are using a version that is no older than 6 months from the latest version."
Upgrade in patch versions will not break the backwards compatibility.

+R: @chamikaramj 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




