### PR TITLE
[BEAM-5056] [SQL] Fix nullability in output schema

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamAggregationRel.java
@@ -125,7 +125,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
                   "combineBy",
                   Combine.perKey(
                       new BeamAggregationTransforms.AggregationAdaptor(
-                          getNamedAggCalls(), CalciteUtils.toBeamSchema(input.getRowType()))))
+                          getNamedAggCalls(), CalciteUtils.toSchema(input.getRowType()))))
               .setCoder(KvCoder.of(keyCoder, aggCoder));
 
       PCollection<Row> mergedStream =
@@ -133,8 +133,8 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
               "mergeRecord",
               ParDo.of(
                   new BeamAggregationTransforms.MergeAggregationRecord(
-                      CalciteUtils.toBeamSchema(getRowType()), windowFieldIndex)));
-      mergedStream.setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+                      CalciteUtils.toSchema(getRowType()), windowFieldIndex)));
+      mergedStream.setRowSchema(CalciteUtils.toSchema(getRowType()));
 
       return mergedStream;
     }
@@ -164,7 +164,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
 
     /** Type of sub-rowrecord used as Group-By keys. */
     private Schema exKeyFieldsSchema(RelDataType relDataType) {
-      Schema inputSchema = CalciteUtils.toBeamSchema(relDataType);
+      Schema inputSchema = CalciteUtils.toSchema(relDataType);
       return groupSet
           .asList()
           .stream()
@@ -183,9 +183,7 @@ public class BeamAggregationRel extends Aggregate implements BeamRelNode {
     }
 
     private Schema.Field newRowField(Pair<AggregateCall, String> namedAggCall) {
-      return Schema.Field.of(
-              namedAggCall.right, CalciteUtils.toFieldType(namedAggCall.left.getType()))
-          .withNullable(namedAggCall.left.getType().isNullable());
+      return CalciteUtils.toField(namedAggCall.right, namedAggCall.left.getType());
     }
   }
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java
@@ -72,12 +72,12 @@ public class BeamCalcRel extends Calc implements BeamRelNode {
 
       BeamSqlExpressionExecutor executor = new BeamSqlFnExecutor(BeamCalcRel.this.getProgram());
 
-      Schema schema = CalciteUtils.toBeamSchema(rowType);
+      Schema schema = CalciteUtils.toSchema(rowType);
       PCollection<Row> projectStream =
           upstream
-              .apply(ParDo.of(new CalcFn(executor, CalciteUtils.toBeamSchema(rowType))))
+              .apply(ParDo.of(new CalcFn(executor, CalciteUtils.toSchema(rowType))))
               .setRowSchema(schema);
-      projectStream.setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+      projectStream.setRowSchema(CalciteUtils.toSchema(getRowType()));
 
       return projectStream;
     }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRel.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.extensions.sql.BeamSqlSeekableTable;
 import org.apache.beam.sdk.extensions.sql.BeamSqlTable;
@@ -146,10 +148,12 @@ public class BeamJoinRel extends Join implements BeamRelNode {
       if (isSideInputJoin()) {
         checkArgument(pinput.size() == 1, "More than one input received for side input join");
         return joinAsLookup(leftRelNode, rightRelNode, pinput.get(0))
-            .setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+            .setRowSchema(CalciteUtils.toSchema(getRowType()));
       }
 
-      Schema leftSchema = CalciteUtils.toBeamSchema(left.getRowType());
+      Schema leftSchema = CalciteUtils.toSchema(left.getRowType());
+      Schema rightSchema = CalciteUtils.toSchema(right.getRowType());
+
       assert pinput.size() == 2;
       PCollection<Row> leftRows = pinput.get(0);
       PCollection<Row> rightRows = pinput.get(1);
@@ -186,10 +190,6 @@ public class BeamJoinRel extends Join implements BeamRelNode {
                   MapElements.via(new BeamJoinTransforms.ExtractJoinFields(false, pairs)))
               .setCoder(KvCoder.of(extractKeyRowCoder, rightRows.getCoder()));
 
-      // prepare the NullRows
-      Row leftNullRow = buildNullRow(leftRelNode);
-      Row rightNullRow = buildNullRow(rightRelNode);
-
       // a regular join
       if ((leftRows.isBounded() == PCollection.IsBounded.BOUNDED
               && rightRows.isBounded() == PCollection.IsBounded.BOUNDED)
@@ -201,7 +201,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
               "WindowFns must match for a bounded-vs-bounded/unbounded-vs-unbounded join.", e);
         }
 
-        return standardJoin(extractedLeftRows, extractedRightRows, leftNullRow, rightNullRow);
+        return standardJoin(extractedLeftRows, extractedRightRows, leftSchema, rightSchema);
       } else if ((leftRows.isBounded() == PCollection.IsBounded.BOUNDED
               && rightRows.isBounded() == UNBOUNDED)
           || (leftRows.isBounded() == UNBOUNDED
@@ -224,7 +224,7 @@ public class BeamJoinRel extends Join implements BeamRelNode {
               "LEFT side of an OUTER JOIN must be Unbounded table.");
         }
 
-        return sideInputJoin(extractedLeftRows, extractedRightRows, leftNullRow, rightNullRow);
+        return sideInputJoin(extractedLeftRows, extractedRightRows, leftSchema, rightSchema);
       } else {
         throw new UnsupportedOperationException(
             "The inputs to the JOIN have un-joinnable windowFns: " + leftWinFn + ", " + rightWinFn);
@@ -257,25 +257,52 @@ public class BeamJoinRel extends Join implements BeamRelNode {
   private PCollection<Row> standardJoin(
       PCollection<KV<Row, Row>> extractedLeftRows,
       PCollection<KV<Row, Row>> extractedRightRows,
-      Row leftNullRow,
-      Row rightNullRow) {
+      Schema leftSchema,
+      Schema rightSchema) {
     PCollection<KV<Row, KV<Row, Row>>> joinedRows = null;
+
     switch (joinType) {
       case LEFT:
-        joinedRows =
-            org.apache.beam.sdk.extensions.joinlibrary.Join.leftOuterJoin(
-                extractedLeftRows, extractedRightRows, rightNullRow);
-        break;
+        {
+          Schema rigthNullSchema = buildNullSchema(rightSchema);
+          Row rightNullRow = Row.nullRow(rigthNullSchema);
+
+          extractedRightRows = setValueCoder(extractedRightRows, SchemaCoder.of(rigthNullSchema));
+
+          joinedRows =
+              org.apache.beam.sdk.extensions.joinlibrary.Join.leftOuterJoin(
+                  extractedLeftRows, extractedRightRows, rightNullRow);
+
+          break;
+        }
       case RIGHT:
-        joinedRows =
-            org.apache.beam.sdk.extensions.joinlibrary.Join.rightOuterJoin(
-                extractedLeftRows, extractedRightRows, leftNullRow);
-        break;
+        {
+          Schema leftNullSchema = buildNullSchema(leftSchema);
+          Row leftNullRow = Row.nullRow(leftNullSchema);
+
+          extractedLeftRows = setValueCoder(extractedLeftRows, SchemaCoder.of(leftNullSchema));
+
+          joinedRows =
+              org.apache.beam.sdk.extensions.joinlibrary.Join.rightOuterJoin(
+                  extractedLeftRows, extractedRightRows, leftNullRow);
+          break;
+        }
       case FULL:
-        joinedRows =
-            org.apache.beam.sdk.extensions.joinlibrary.Join.fullOuterJoin(
-                extractedLeftRows, extractedRightRows, leftNullRow, rightNullRow);
-        break;
+        {
+          Schema leftNullSchema = buildNullSchema(leftSchema);
+          Schema rightNullSchema = buildNullSchema(rightSchema);
+
+          Row leftNullRow = Row.nullRow(leftNullSchema);
+          Row rightNullRow = Row.nullRow(rightNullSchema);
+
+          extractedLeftRows = setValueCoder(extractedLeftRows, SchemaCoder.of(leftNullSchema));
+          extractedRightRows = setValueCoder(extractedRightRows, SchemaCoder.of(rightNullSchema));
+
+          joinedRows =
+              org.apache.beam.sdk.extensions.joinlibrary.Join.fullOuterJoin(
+                  extractedLeftRows, extractedRightRows, leftNullRow, rightNullRow);
+          break;
+        }
       case INNER:
       default:
         joinedRows =
@@ -288,15 +315,15 @@ public class BeamJoinRel extends Join implements BeamRelNode {
         joinedRows
             .apply(
                 "JoinParts2WholeRow", MapElements.via(new BeamJoinTransforms.JoinParts2WholeRow()))
-            .setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+            .setRowSchema(CalciteUtils.toSchema(getRowType()));
     return ret;
   }
 
   public PCollection<Row> sideInputJoin(
       PCollection<KV<Row, Row>> extractedLeftRows,
       PCollection<KV<Row, Row>> extractedRightRows,
-      Row leftNullRow,
-      Row rightNullRow) {
+      Schema leftSchema,
+      Schema rightSchema) {
     // we always make the Unbounded table on the left to do the sideInput join
     // (will convert the result accordingly before return)
     boolean swapped = (extractedLeftRows.isBounded() == PCollection.IsBounded.BOUNDED);
@@ -305,7 +332,19 @@ public class BeamJoinRel extends Join implements BeamRelNode {
 
     PCollection<KV<Row, Row>> realLeftRows = swapped ? extractedRightRows : extractedLeftRows;
     PCollection<KV<Row, Row>> realRightRows = swapped ? extractedLeftRows : extractedRightRows;
-    Row realRightNullRow = swapped ? leftNullRow : rightNullRow;
+
+    Row realRightNullRow;
+    if (swapped) {
+      Schema leftNullSchema = buildNullSchema(leftSchema);
+
+      realRightRows = setValueCoder(realRightRows, SchemaCoder.of(leftNullSchema));
+      realRightNullRow = Row.nullRow(leftNullSchema);
+    } else {
+      Schema rightNullSchema = buildNullSchema(rightSchema);
+
+      realRightRows = setValueCoder(realRightRows, SchemaCoder.of(rightNullSchema));
+      realRightNullRow = Row.nullRow(rightNullSchema);
+    }
 
     // swapped still need to pass down because, we need to swap the result back.
     return sideInputJoinHelper(
@@ -327,14 +366,26 @@ public class BeamJoinRel extends Join implements BeamRelNode {
                         new BeamJoinTransforms.SideInputJoinDoFn(
                             joinType, rightNullRow, rowsView, swapped))
                     .withSideInputs(rowsView))
-            .setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+            .setRowSchema(CalciteUtils.toSchema(getRowType()));
 
     return ret;
   }
 
-  private Row buildNullRow(BeamRelNode relNode) {
-    Schema leftType = CalciteUtils.toBeamSchema(relNode.getRowType());
-    return Row.nullRow(leftType);
+  private Schema buildNullSchema(Schema schema) {
+    Schema.Builder builder = Schema.builder();
+
+    builder.addFields(
+        schema.getFields().stream().map(f -> f.withNullable(true)).collect(Collectors.toList()));
+
+    return builder.build();
+  }
+
+  private static <K, V> PCollection<KV<K, V>> setValueCoder(
+      PCollection<KV<K, V>> kvs, Coder<V> valueCoder) {
+    // safe case because PCollection of KV always has KvCoder
+    KvCoder<K, V> coder = (KvCoder<K, V>) kvs.getCoder();
+
+    return kvs.setCoder(KvCoder.of(coder.getKeyCoder(), valueCoder));
   }
 
   private List<Pair<Integer, Integer>> extractJoinColumns(int leftRowColumnCount) {
@@ -386,8 +437,8 @@ public class BeamJoinRel extends Join implements BeamRelNode {
         new BeamJoinTransforms.JoinAsLookup(
             condition,
             seekableTable,
-            CalciteUtils.toBeamSchema(rightRelNode.getRowType()),
-            CalciteUtils.toBeamSchema(leftRelNode.getRowType()).getFieldCount()));
+            CalciteUtils.toSchema(rightRelNode.getRowType()),
+            CalciteUtils.toSchema(leftRelNode.getRowType()).getFieldCount()));
   }
 
   /** check if {@code BeamRelNode} implements {@code BeamSeekableTable}. */

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRel.java
@@ -167,7 +167,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
         return upstream
             .apply(Window.into(new GlobalWindows()))
             .apply(new LimitTransform<>())
-            .setRowSchema(CalciteUtils.toBeamSchema(getRowType()));
+            .setRowSchema(CalciteUtils.toSchema(getRowType()));
       } else {
 
         WindowingStrategy<?, ?> windowingStrategy = upstream.getWindowingStrategy();
@@ -202,7 +202,7 @@ public class BeamSortRel extends Sort implements BeamRelNode {
         return rawStream
             .apply("flatten", Flatten.iterables())
             .setSchema(
-                CalciteUtils.toBeamSchema(getRowType()),
+                CalciteUtils.toSchema(getRowType()),
                 SerializableFunctions.identity(),
                 SerializableFunctions.identity());
       }

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUncollectRel.java
@@ -63,7 +63,7 @@ public class BeamUncollectRel extends Uncollect implements BeamRelNode {
 
       // Each row of the input contains a single array of things to be emitted; Calcite knows
       // what the row looks like
-      Schema outputSchema = CalciteUtils.toBeamSchema(getRowType());
+      Schema outputSchema = CalciteUtils.toSchema(getRowType());
 
       PCollection<Row> uncollected =
           upstream.apply(ParDo.of(new UncollectDoFn(outputSchema))).setRowSchema(outputSchema);

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamUnnestRel.java
@@ -93,7 +93,7 @@ public class BeamUnnestRel extends Correlate implements BeamRelNode {
 
       // The correlated subquery
       BeamUncollectRel uncollect = (BeamUncollectRel) BeamSqlRelUtils.getBeamRelInput(right);
-      Schema innerSchema = CalciteUtils.toBeamSchema(uncollect.getRowType());
+      Schema innerSchema = CalciteUtils.toSchema(uncollect.getRowType());
       checkArgument(
           innerSchema.getFieldCount() == 1, "Can only UNNEST a single column", getClass());
 
@@ -101,7 +101,7 @@ public class BeamUnnestRel extends Correlate implements BeamRelNode {
           new BeamSqlFnExecutor(
               ((BeamCalcRel) BeamSqlRelUtils.getBeamRelInput(uncollect.getInput())).getProgram());
 
-      Schema joinedSchema = CalciteUtils.toBeamSchema(rowType);
+      Schema joinedSchema = CalciteUtils.toSchema(rowType);
 
       return outer
           .apply(

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamValuesRel.java
@@ -78,7 +78,7 @@ public class BeamValuesRel extends Values implements BeamRelNode {
         throw new IllegalStateException("Values with empty tuples!");
       }
 
-      Schema schema = CalciteUtils.toBeamSchema(getRowType());
+      Schema schema = CalciteUtils.toSchema(getRowType());
 
       List<Row> rows = tuples.stream().map(tuple -> tupleToRow(schema, tuple)).collect(toList());
 

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
@@ -146,7 +146,7 @@ public class BeamAggregationTransforms implements Serializable {
         String aggName = aggCall.right;
 
         if (call.getArgList().size() == 2) {
-          /**
+          /*
            * handle the case of aggregation function has two parameters and use KV pair to bundle
            * two corresponding expressions.
            */
@@ -171,8 +171,9 @@ public class BeamAggregationTransforms implements Serializable {
           sourceFieldExps.add(sourceExp);
         }
 
-        FieldType typeDescriptor = CalciteUtils.toFieldType(call.type);
-        fields.add(Schema.Field.of(aggName, typeDescriptor));
+        Schema.Field field = CalciteUtils.toField(aggName, call.type);
+        Schema.TypeName fieldTypeName = field.getType().getTypeName();
+        fields.add(field);
 
         switch (call.getAggregation().getName()) {
           case "COUNT":
@@ -193,22 +194,17 @@ public class BeamAggregationTransforms implements Serializable {
             break;
           case "VAR_POP":
             aggregators.add(
-                VarianceFn.newPopulation(
-                    BigDecimalConverter.forSqlType(typeDescriptor.getTypeName())));
+                VarianceFn.newPopulation(BigDecimalConverter.forSqlType(fieldTypeName)));
             break;
           case "VAR_SAMP":
-            aggregators.add(
-                VarianceFn.newSample(BigDecimalConverter.forSqlType(typeDescriptor.getTypeName())));
+            aggregators.add(VarianceFn.newSample(BigDecimalConverter.forSqlType(fieldTypeName)));
             break;
           case "COVAR_POP":
             aggregators.add(
-                CovarianceFn.newPopulation(
-                    BigDecimalConverter.forSqlType(typeDescriptor.getTypeName())));
+                CovarianceFn.newPopulation(BigDecimalConverter.forSqlType(fieldTypeName)));
             break;
           case "COVAR_SAMP":
-            aggregators.add(
-                CovarianceFn.newSample(
-                    BigDecimalConverter.forSqlType(typeDescriptor.getTypeName())));
+            aggregators.add(CovarianceFn.newSample(BigDecimalConverter.forSqlType(fieldTypeName)));
             break;
           default:
             if (call.getAggregation() instanceof SqlUserDefinedAggFunction) {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtils.java
@@ -18,8 +18,6 @@
 
 package org.apache.beam.sdk.extensions.sql.impl.utils;
 
-import static org.apache.beam.sdk.schemas.Schema.toSchema;
-
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableMap;
@@ -90,12 +88,8 @@ public class CalciteUtils {
           FieldType.STRING, SqlTypeName.VARCHAR);
 
   /** Generate {@link Schema} from {@code RelDataType} which is used to create table. */
-  public static Schema toBeamSchema(RelDataType tableInfo) {
-    return tableInfo
-        .getFieldList()
-        .stream()
-        .map(CalciteUtils::toBeamSchemaField)
-        .collect(toSchema());
+  public static Schema toSchema(RelDataType tableInfo) {
+    return tableInfo.getFieldList().stream().map(CalciteUtils::toField).collect(Schema.toSchema());
   }
 
   public static SqlTypeName toSqlTypeName(FieldType type) {
@@ -134,6 +128,14 @@ public class CalciteUtils {
     }
   }
 
+  public static Schema.Field toField(RelDataTypeField calciteField) {
+    return toField(calciteField.getName(), calciteField.getType());
+  }
+
+  public static Schema.Field toField(String name, RelDataType calciteType) {
+    return Schema.Field.of(name, toFieldType(calciteType)).withNullable(calciteType.isNullable());
+  }
+
   public static FieldType toFieldType(RelDataType calciteType) {
     switch (calciteType.getSqlTypeName()) {
       case ARRAY:
@@ -143,17 +145,11 @@ public class CalciteUtils {
         return FieldType.map(
             toFieldType(calciteType.getKeyType()), toFieldType(calciteType.getValueType()));
       case ROW:
-        return FieldType.row(toBeamSchema(calciteType));
+        return FieldType.row(toSchema(calciteType));
 
       default:
         return toFieldType(calciteType.getSqlTypeName());
     }
-  }
-
-  public static Schema.Field toBeamSchemaField(RelDataTypeField calciteField) {
-    FieldType fieldType = toFieldType(calciteField.getType());
-    // TODO: We should support Calcite's nullable annotations.
-    return Schema.Field.of(calciteField.getName(), fieldType).withNullable(true);
   }
 
   /** Create an instance of {@code RelDataType} so it can be used to create a table. */

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
@@ -245,9 +245,8 @@ public class TestUtils {
   }
 
   // TODO: support nested.
-  // TODO: support nullable.
   private static Schema.Field toRecordField(Object[] args, int i) {
-    return Schema.Field.of((String) args[i + 1], (FieldType) args[i]).withNullable(true);
+    return Schema.Field.of((String) args[i + 1], (FieldType) args[i]);
   }
 
   /**

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/BeamSqlFnExecutorTestBase.java
@@ -65,7 +65,7 @@ public class BeamSqlFnExecutorTestBase {
             .build();
 
     row =
-        Row.withSchema(CalciteUtils.toBeamSchema(relDataType))
+        Row.withSchema(CalciteUtils.toSchema(relDataType))
             .addValues(1234567L, 0, 8.9, 1234567L, "This is an order.")
             .build();
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelBoundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelBoundedVsBoundedTest.java
@@ -66,12 +66,14 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
     PAssert.that(rows)
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.INT32, "price",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "site_id0",
-                    Schema.FieldType.INT32, "price0")
+                    Schema.builder()
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("site_id", Schema.FieldType.INT32)
+                        .addField("price", Schema.FieldType.INT32)
+                        .addField("order_id0", Schema.FieldType.INT32)
+                        .addField("site_id0", Schema.FieldType.INT32)
+                        .addField("price0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(2, 3, 3, 1, 2, 3)
                 .getRows());
     pipeline.run();
@@ -91,12 +93,14 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
     PAssert.that(rows)
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.INT32, "price",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "site_id0",
-                    Schema.FieldType.INT32, "price0")
+                    Schema.builder()
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("site_id", Schema.FieldType.INT32)
+                        .addField("price", Schema.FieldType.INT32)
+                        .addNullableField("order_id0", Schema.FieldType.INT32)
+                        .addNullableField("site_id0", Schema.FieldType.INT32)
+                        .addNullableField("price0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(1, 2, 3, null, null, null, 2, 3, 3, 1, 2, 3, 3, 4, 5, null, null, null)
                 .getRows());
     pipeline.run();
@@ -115,12 +119,14 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
     PAssert.that(rows)
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.INT32, "price",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "site_id0",
-                    Schema.FieldType.INT32, "price0")
+                    Schema.builder()
+                        .addNullableField("order_id", Schema.FieldType.INT32)
+                        .addNullableField("site_id", Schema.FieldType.INT32)
+                        .addNullableField("price", Schema.FieldType.INT32)
+                        .addField("order_id0", Schema.FieldType.INT32)
+                        .addField("site_id0", Schema.FieldType.INT32)
+                        .addField("price0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(2, 3, 3, 1, 2, 3, null, null, null, 2, 3, 3, null, null, null, 3, 4, 5)
                 .getRows());
     pipeline.run();
@@ -139,12 +145,14 @@ public class BeamJoinRelBoundedVsBoundedTest extends BaseRelTest {
     PAssert.that(rows)
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.INT32, "price",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "site_id0",
-                    Schema.FieldType.INT32, "price0")
+                    Schema.builder()
+                        .addNullableField("order_id", Schema.FieldType.INT32)
+                        .addNullableField("site_id", Schema.FieldType.INT32)
+                        .addNullableField("price", Schema.FieldType.INT32)
+                        .addNullableField("order_id0", Schema.FieldType.INT32)
+                        .addNullableField("site_id0", Schema.FieldType.INT32)
+                        .addNullableField("price0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(
                     2, 3, 3, 1, 2, 3, 1, 2, 3, null, null, null, 3, 4, 5, null, null, null, null,
                     null, null, 2, 3, 3, null, null, null, 3, 4, 5)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsBoundedTest.java
@@ -184,13 +184,17 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
             + " o1.order_id=o2.order_id";
 
     PCollection<Row> rows = compilePipeline(sql, pipeline);
+
     rows.apply(ParDo.of(new BeamSqlOutputToConsoleFn("helloworld")));
+
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.STRING, "buyer")
+                    Schema.builder()
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("sum_site_id", Schema.FieldType.INT32)
+                        .addNullableField("buyer", Schema.FieldType.STRING)
+                        .build())
                 .addRows(1, 3, "james", 2, 5, "bond", 3, 3, null)
                 .getStringRows());
     pipeline.run();
@@ -225,9 +229,11 @@ public class BeamJoinRelUnboundedVsBoundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.STRING, "buyer")
+                    Schema.builder()
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("sum_site_id", Schema.FieldType.INT32)
+                        .addNullableField("buyer", Schema.FieldType.STRING)
+                        .build())
                 .addRows(1, 3, "james", 2, 5, "bond", 3, 3, null)
                 .getStringRows());
     pipeline.run();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsUnboundedTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamJoinRelUnboundedVsUnboundedTest.java
@@ -92,10 +92,12 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "sum_site_id0")
+                    Schema.builder()
+                        .addField("order_id1", Schema.FieldType.INT32)
+                        .addField("sum_site_id", Schema.FieldType.INT32)
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("sum_site_id0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(1, 3, 1, 3, 2, 5, 2, 5)
                 .getStringRows());
     pipeline.run();
@@ -123,10 +125,12 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "sum_site_id0")
+                    Schema.builder()
+                        .addField("order_id1", Schema.FieldType.INT32)
+                        .addField("sum_site_id", Schema.FieldType.INT32)
+                        .addNullableField("order_id", Schema.FieldType.INT32)
+                        .addNullableField("sum_site_id0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(1, 1, 1, 3, 2, 2, null, null, 2, 2, 2, 5, 3, 3, null, null)
                 .getStringRows());
     pipeline.run();
@@ -148,10 +152,12 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.INT32, "order_id0",
-                    Schema.FieldType.INT32, "sum_site_id0")
+                    Schema.builder()
+                        .addNullableField("order_id1", Schema.FieldType.INT32)
+                        .addNullableField("sum_site_id", Schema.FieldType.INT32)
+                        .addField("order_id", Schema.FieldType.INT32)
+                        .addField("sum_site_id0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(1, 3, 1, 1, null, null, 2, 2, 2, 5, 2, 2, null, null, 3, 3)
                 .getStringRows());
     pipeline.run();
@@ -174,10 +180,12 @@ public class BeamJoinRelUnboundedVsUnboundedTest extends BaseRelTest {
     PAssert.that(rows.apply(ParDo.of(new TestUtils.BeamSqlRow2StringDoFn())))
         .containsInAnyOrder(
             TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT32, "order_id1",
-                    Schema.FieldType.INT32, "sum_site_id",
-                    Schema.FieldType.INT32, "order_id",
-                    Schema.FieldType.INT32, "sum_site_id0")
+                    Schema.builder()
+                        .addNullableField("order_id1", Schema.FieldType.INT32)
+                        .addNullableField("sum_site_id", Schema.FieldType.INT32)
+                        .addNullableField("order_id", Schema.FieldType.INT32)
+                        .addNullableField("sum_site_id0", Schema.FieldType.INT32)
+                        .build())
                 .addRows(
                     1, 1, 1, 3, 6, 2, null, null, 7, 2, null, null, 8, 3, null, null, null, null, 2,
                     5)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamSortRelTest.java
@@ -90,9 +90,11 @@ public class BeamSortRelTest extends BaseRelTest {
     registerTable(
         "SUB_ORDER_RAM",
         MockedBoundedTable.of(
-            Schema.FieldType.INT64, "order_id",
-            Schema.FieldType.INT32, "site_id",
-            Schema.FieldType.DOUBLE, "price"));
+            Schema.builder()
+                .addField("order_id", Schema.FieldType.INT64)
+                .addField("site_id", Schema.FieldType.INT32)
+                .addNullableField("price", Schema.FieldType.DOUBLE)
+                .build()));
   }
 
   @Test
@@ -153,19 +155,18 @@ public class BeamSortRelTest extends BaseRelTest {
 
   @Test
   public void testOrderBy_nullsFirst() throws Exception {
+    Schema schema =
+        Schema.builder()
+            .addField("order_id", Schema.FieldType.INT64)
+            .addNullableField("site_id", Schema.FieldType.INT32)
+            .addField("price", Schema.FieldType.DOUBLE)
+            .build();
+
     registerTable(
         "ORDER_DETAILS",
-        MockedBoundedTable.of(
-                Schema.FieldType.INT64, "order_id",
-                Schema.FieldType.INT32, "site_id",
-                Schema.FieldType.DOUBLE, "price")
+        MockedBoundedTable.of(schema)
             .addRows(1L, 2, 1.0, 1L, null, 2.0, 2L, 1, 3.0, 2L, null, 4.0, 5L, 5, 5.0));
-    registerTable(
-        "SUB_ORDER_RAM",
-        MockedBoundedTable.of(
-            Schema.FieldType.INT64, "order_id",
-            Schema.FieldType.INT32, "site_id",
-            Schema.FieldType.DOUBLE, "price"));
+    registerTable("SUB_ORDER_RAM", MockedBoundedTable.of(schema));
 
     String sql =
         "INSERT INTO SUB_ORDER_RAM(order_id, site_id, price)  SELECT "
@@ -176,10 +177,7 @@ public class BeamSortRelTest extends BaseRelTest {
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows)
         .containsInAnyOrder(
-            TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT64, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.DOUBLE, "price")
+            TestUtils.RowsBuilder.of(schema)
                 .addRows(1L, null, 2.0, 1L, 2, 1.0, 2L, null, 4.0, 2L, 1, 3.0)
                 .getRows());
     pipeline.run().waitUntilFinish();
@@ -187,19 +185,18 @@ public class BeamSortRelTest extends BaseRelTest {
 
   @Test
   public void testOrderBy_nullsLast() throws Exception {
+    Schema schema =
+        Schema.builder()
+            .addField("order_id", Schema.FieldType.INT64)
+            .addNullableField("site_id", Schema.FieldType.INT32)
+            .addField("price", Schema.FieldType.DOUBLE)
+            .build();
+
     registerTable(
         "ORDER_DETAILS",
-        MockedBoundedTable.of(
-                Schema.FieldType.INT64, "order_id",
-                Schema.FieldType.INT32, "site_id",
-                Schema.FieldType.DOUBLE, "price")
+        MockedBoundedTable.of(schema)
             .addRows(1L, 2, 1.0, 1L, null, 2.0, 2L, 1, 3.0, 2L, null, 4.0, 5L, 5, 5.0));
-    registerTable(
-        "SUB_ORDER_RAM",
-        MockedBoundedTable.of(
-            Schema.FieldType.INT64, "order_id",
-            Schema.FieldType.INT32, "site_id",
-            Schema.FieldType.DOUBLE, "price"));
+    registerTable("SUB_ORDER_RAM", MockedBoundedTable.of(schema));
 
     String sql =
         "INSERT INTO SUB_ORDER_RAM(order_id, site_id, price)  SELECT "
@@ -210,10 +207,7 @@ public class BeamSortRelTest extends BaseRelTest {
     PCollection<Row> rows = compilePipeline(sql, pipeline);
     PAssert.that(rows)
         .containsInAnyOrder(
-            TestUtils.RowsBuilder.of(
-                    Schema.FieldType.INT64, "order_id",
-                    Schema.FieldType.INT32, "site_id",
-                    Schema.FieldType.DOUBLE, "price")
+            TestUtils.RowsBuilder.of(schema)
                 .addRows(1L, 2, 1.0, 1L, null, 2.0, 2L, 1, 3.0, 2L, null, 4.0)
                 .getRows());
     pipeline.run().waitUntilFinish();

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/schema/BeamSqlRowCoderTest.java
@@ -54,7 +54,7 @@ public class BeamSqlRowCoderTest {
             .add("col_boolean", SqlTypeName.BOOLEAN)
             .build();
 
-    Schema beamSchema = CalciteUtils.toBeamSchema(relDataType);
+    Schema beamSchema = CalciteUtils.toSchema(relDataType);
 
     Row row =
         Row.withSchema(beamSchema)

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/utils/CalciteUtilsTest.java
@@ -124,4 +124,48 @@ public class CalciteUtilsTest {
     assertEquals(SqlTypeName.VARBINARY, fields.get("f9").getSqlTypeName());
     assertEquals(SqlTypeName.VARCHAR, fields.get("f10").getSqlTypeName());
   }
+
+  @Test
+  public void testRoundTripBeamSchema() {
+    final Schema schema =
+        Schema.builder()
+            .addField("f1", Schema.FieldType.BYTE)
+            .addField("f2", Schema.FieldType.INT16)
+            .addField("f3", Schema.FieldType.INT32)
+            .addField("f4", Schema.FieldType.INT64)
+            .addField("f5", Schema.FieldType.FLOAT)
+            .addField("f6", Schema.FieldType.DOUBLE)
+            .addField("f7", Schema.FieldType.DECIMAL)
+            .addField("f8", Schema.FieldType.BOOLEAN)
+            .addField("f9", Schema.FieldType.BYTES)
+            .addField("f10", Schema.FieldType.STRING)
+            .build();
+
+    final Schema out =
+        CalciteUtils.toSchema(CalciteUtils.toCalciteRowType(schema, dataTypeFactory));
+
+    assertEquals(schema, out);
+  }
+
+  @Test
+  public void testRoundTripBeamNullableSchema() {
+    final Schema schema =
+        Schema.builder()
+            .addNullableField("f1", Schema.FieldType.BYTE)
+            .addNullableField("f2", Schema.FieldType.INT16)
+            .addNullableField("f3", Schema.FieldType.INT32)
+            .addNullableField("f4", Schema.FieldType.INT64)
+            .addNullableField("f5", Schema.FieldType.FLOAT)
+            .addNullableField("f6", Schema.FieldType.DOUBLE)
+            .addNullableField("f7", Schema.FieldType.DECIMAL)
+            .addNullableField("f8", Schema.FieldType.BOOLEAN)
+            .addNullableField("f9", Schema.FieldType.BYTES)
+            .addNullableField("f10", Schema.FieldType.STRING)
+            .build();
+
+    final Schema out =
+        CalciteUtils.toSchema(CalciteUtils.toCalciteRowType(schema, dataTypeFactory));
+
+    assertEquals(schema, out);
+  }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/kafka/BeamKafkaCSVTableTest.java
@@ -75,7 +75,7 @@ public class BeamKafkaCSVTableTest {
 
   private static Schema genSchema() {
     JavaTypeFactory typeFactory = new JavaTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
-    return CalciteUtils.toBeamSchema(
+    return CalciteUtils.toSchema(
         typeFactory
             .builder()
             .add("order_id", SqlTypeName.BIGINT)


### PR DESCRIPTION
Before we didn't properly propagate nullability from Calcite to
`Schema.Field`.

In the case of "group by", aggregate expressions were always non-nullable.
It isn't true if the bucketing key and aggregated expression are nullable.

```
> SELECT SUM(EXPR$0), EXPR$0 FROM UNNEST (ARRAY [1, NULL]) GROUP BY EXPR$0;
+------------+------------+
|   EXPR$0   |   EXPR$0   |
+------------+------------+
| null       | null       |
| 1          | 1          |
+------------+------------+
```

In the case of "join", every field was nullable. It true for outer joins,
but isn't precise for left, right or inner joins.

The code is based on https://github.com/apache/beam/pull/6108. One suggestion would be to check output schema in tests, along with output.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




