### PR TITLE
[BEAM-5062] Add ability to provide custom S3ClientOptions

### DIFF
--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3ClientBuilderFactory.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3ClientBuilderFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.options;
+
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+/** Construct AmazonS3ClientBuilder from S3 pipeline options. */
+public interface S3ClientBuilderFactory {
+  AmazonS3ClientBuilder createBuilder(S3Options s3Options);
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3Options.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/S3Options.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.aws.options;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.aws.s3.DefaultS3ClientBuilderFactory;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
@@ -71,6 +72,14 @@ public interface S3Options extends AwsOptions {
   SSEAwsKeyManagementParams getSSEAwsKeyManagementParams();
 
   void setSSEAwsKeyManagementParams(SSEAwsKeyManagementParams value);
+
+  @Description(
+      "Factory class that should be created and used to create a builder of AmazonS3 client."
+          + "Override the default value if you need a S3 client with custom properties, like path style access, etc.")
+  @Default.Class(DefaultS3ClientBuilderFactory.class)
+  Class<? extends S3ClientBuilderFactory> getS3ClientFactoryClass();
+
+  void setS3ClientFactoryClass(Class<? extends S3ClientBuilderFactory> s3ClientFactoryClass);
 
   /**
    * Provide the default s3 upload buffer size in bytes: 64MB if more than 512MB in RAM are

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/DefaultS3ClientBuilderFactory.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/DefaultS3ClientBuilderFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.aws.s3;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.google.common.base.Strings;
+import org.apache.beam.sdk.io.aws.options.S3ClientBuilderFactory;
+import org.apache.beam.sdk.io.aws.options.S3Options;
+
+/**
+ * Construct AmazonS3ClientBuilder with default values of S3 client properties like path style
+ * access, accelerated mode, etc.
+ */
+public class DefaultS3ClientBuilderFactory implements S3ClientBuilderFactory {
+
+  @Override
+  public AmazonS3ClientBuilder createBuilder(S3Options s3Options) {
+    AmazonS3ClientBuilder builder =
+        AmazonS3ClientBuilder.standard().withCredentials(s3Options.getAwsCredentialsProvider());
+
+    if (s3Options.getClientConfiguration() != null) {
+      builder = builder.withClientConfiguration(s3Options.getClientConfiguration());
+    }
+
+    if (Strings.isNullOrEmpty(s3Options.getAwsServiceEndpoint())) {
+      builder = builder.withRegion(s3Options.getAwsRegion());
+    } else {
+      builder =
+          builder.withEndpointConfiguration(
+              new AwsClientBuilder.EndpointConfiguration(
+                  s3Options.getAwsServiceEndpoint(), s3Options.getAwsRegion()));
+    }
+    return builder;
+  }
+}

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -22,9 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
@@ -72,9 +70,11 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.io.FileSystem;
+import org.apache.beam.sdk.io.aws.options.S3ClientBuilderFactory;
 import org.apache.beam.sdk.io.aws.options.S3Options;
 import org.apache.beam.sdk.io.fs.CreateOptions;
 import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.util.InstanceBuilder;
 import org.apache.beam.sdk.util.MoreFutures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +105,12 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
           "The AWS S3 Beam extension was included in this build, but the awsRegion flag "
               + "was not specified. If you don't plan to use S3, then ignore this message.");
     }
-    this.amazonS3 = buildAmazonS3Client(options);
+    this.amazonS3 =
+        InstanceBuilder.ofType(S3ClientBuilderFactory.class)
+            .fromClass(options.getS3ClientFactoryClass())
+            .build()
+            .createBuilder(options)
+            .build();
 
     checkNotNull(options.getS3StorageClass(), "storageClass");
     checkArgument(options.getS3ThreadPoolSize() > 0, "threadPoolSize");
@@ -113,24 +118,6 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
         MoreExecutors.listeningDecorator(
             Executors.newFixedThreadPool(
                 options.getS3ThreadPoolSize(), new ThreadFactoryBuilder().setDaemon(true).build()));
-  }
-
-  private static AmazonS3 buildAmazonS3Client(S3Options options) {
-    AmazonS3ClientBuilder builder =
-        AmazonS3ClientBuilder.standard().withCredentials(options.getAwsCredentialsProvider());
-
-    if (options.getClientConfiguration() != null) {
-      builder = builder.withClientConfiguration(options.getClientConfiguration());
-    }
-
-    if (Strings.isNullOrEmpty(options.getAwsServiceEndpoint())) {
-      builder = builder.withRegion(options.getAwsRegion());
-    } else {
-      builder =
-          builder.withEndpointConfiguration(
-              new EndpointConfiguration(options.getAwsServiceEndpoint(), options.getAwsRegion()));
-    }
-    return builder.build();
   }
 
   @Override

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemTest.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3FileSystemTest.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.sdk.io.aws.s3.S3TestUtils.buildMockedS3FileSystem;
 import static org.apache.beam.sdk.io.aws.s3.S3TestUtils.getSSECustomerKeyMd5;
 import static org.apache.beam.sdk.io.aws.s3.S3TestUtils.s3Options;
+import static org.apache.beam.sdk.io.aws.s3.S3TestUtils.s3OptionsWithCustomEndpointAndPathStyleAccessEnabled;
 import static org.apache.beam.sdk.io.aws.s3.S3TestUtils.s3OptionsWithSSECustomerKey;
 import static org.apache.beam.sdk.io.fs.CreateOptions.StandardCreateOptions.builder;
 import static org.hamcrest.Matchers.contains;
@@ -61,6 +62,8 @@ import com.google.common.collect.ImmutableList;
 import io.findify.s3mock.S3Mock;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -122,6 +125,14 @@ public class S3FileSystemTest {
   public void testGetScheme() {
     S3FileSystem s3FileSystem = new S3FileSystem(s3Options());
     assertEquals("s3", s3FileSystem.getScheme());
+  }
+
+  @Test
+  public void testGetPathStyleAccessEnabled() throws URISyntaxException {
+    S3FileSystem s3FileSystem =
+        new S3FileSystem(s3OptionsWithCustomEndpointAndPathStyleAccessEnabled());
+    URL s3Url = s3FileSystem.getAmazonS3Client().getUrl("bucket", "file");
+    assertEquals("https://s3.custom.dns/bucket/file", s3Url.toURI().toString());
   }
 
   @Test

--- a/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3TestUtils.java
+++ b/sdks/java/io/amazon-web-services/src/test/java/org/apache/beam/sdk/io/aws/s3/S3TestUtils.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.aws.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.SSECustomerKey;
@@ -34,6 +35,15 @@ class S3TestUtils {
     S3Options options = PipelineOptionsFactory.as(S3Options.class);
     options.setAwsRegion("us-west-1");
     options.setS3UploadBufferSizeBytes(5_242_880);
+    return options;
+  }
+
+  static S3Options s3OptionsWithCustomEndpointAndPathStyleAccessEnabled() {
+    S3Options options = PipelineOptionsFactory.as(S3Options.class);
+    options.setAwsServiceEndpoint("https://s3.custom.dns");
+    options.setAwsRegion("no-matter");
+    options.setS3UploadBufferSizeBytes(5_242_880);
+    options.setS3ClientFactoryClass(PathStyleAcccessS3ClientBuilderFactory.class);
     return options;
   }
 
@@ -82,5 +92,13 @@ class S3TestUtils {
       return Base64.encodeAsString(DigestUtils.md5(Base64.decode(sseCostumerKey.getKey())));
     }
     return null;
+  }
+
+  private static class PathStyleAcccessS3ClientBuilderFactory
+      extends DefaultS3ClientBuilderFactory {
+    @Override
+    public AmazonS3ClientBuilder createBuilder(S3Options s3Options) {
+      return super.createBuilder(s3Options).withPathStyleAccessEnabled(true);
+    }
   }
 }


### PR DESCRIPTION
This PR adds an ability to provide custom S3ClientOptions for creating required amazon s3 client.

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




