### PR TITLE
[BEAM-4761] Run Nexmark in thread pool

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow.groovy
@@ -39,6 +39,7 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=DataflowRunner',
+              '--nexmarkParallel=16',
               '--streaming=false',
               '--suite=STRESS',
               '--manageResources=false',
@@ -55,6 +56,7 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=DataflowRunner',
+              '--nexmarkParallel=16',
               '--streaming=true',
               '--suite=STRESS',
               '--manageResources=false',
@@ -71,6 +73,7 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=DataflowRunner',
+              '--nexmarkParallel=16',
               '--queryLanguage=sql',
               '--streaming=false',
               '--suite=STRESS',
@@ -88,6 +91,7 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
               ' -Pnexmark.args="' +
               [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
               '--runner=DataflowRunner',
+              '--nexmarkParallel=16',
               '--queryLanguage=sql',
               '--streaming=true',
               '--suite=STRESS',

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -33,6 +33,13 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.CoderException;
@@ -74,30 +81,81 @@ import org.joda.time.Instant;
  * <p>See <a href="http://datalab.cs.pdx.edu/niagaraST/NEXMark/">
  * http://datalab.cs.pdx.edu/niagaraST/NEXMark/</a>
  */
-public class Main<OptionT extends NexmarkOptions> {
+public class Main {
+
+  private static class Result {
+    private final NexmarkConfiguration configuration;
+    private final NexmarkPerf perf;
+
+    private Result(NexmarkConfiguration configuration, NexmarkPerf perf) {
+      this.configuration = configuration;
+      this.perf = perf;
+    }
+  }
+
+  private static class Run implements Callable<Result> {
+    private final NexmarkLauncher<NexmarkOptions> nexmarkLauncher;
+    private final NexmarkConfiguration configuration;
+
+    private Run(String[] args, NexmarkConfiguration configuration) {
+      NexmarkOptions options = PipelineOptionsFactory.fromArgs(args).as(NexmarkOptions.class);
+      this.nexmarkLauncher = new NexmarkLauncher<>(options);
+      this.configuration = configuration;
+    }
+
+    @Override
+    public Result call() throws IOException {
+      NexmarkPerf perf = nexmarkLauncher.run(configuration);
+      return new Result(configuration, perf);
+    }
+  }
 
   /** Entry point. */
-  void runAll(OptionT options, NexmarkLauncher nexmarkLauncher) throws IOException {
+  void runAll(String[] args) throws IOException {
     Instant start = Instant.now();
+    NexmarkOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(NexmarkOptions.class);
     Map<NexmarkConfiguration, NexmarkPerf> baseline = loadBaseline(options.getBaselineFilename());
     Map<NexmarkConfiguration, NexmarkPerf> actual = new LinkedHashMap<>();
-    Iterable<NexmarkConfiguration> configurations = options.getSuite().getConfigurations(options);
+    Set<NexmarkConfiguration> configurations = options.getSuite().getConfigurations(options);
+    int nThreads = Math.min(options.getNexmarkParallel(), configurations.size());
+    ExecutorService executor = Executors.newFixedThreadPool(nThreads);
+    CompletionService<Result> completion = new ExecutorCompletionService(executor);
 
     boolean successful = true;
     try {
-      // Run all the configurations.
+      // Schedule all the configurations.
       for (NexmarkConfiguration configuration : configurations) {
-        NexmarkPerf perf = nexmarkLauncher.run(configuration);
-        if (perf != null) {
-          if (perf.errors == null || perf.errors.size() > 0) {
-            successful = false;
-          }
-          appendPerf(options.getPerfFilename(), configuration, perf);
-          actual.put(configuration, perf);
-          // Summarize what we've run so far.
-          saveSummary(null, configurations, actual, baseline, start, options);
-        }
+        completion.submit(new Run(args, configuration));
       }
+
+      // Collect all the results.
+      for (int scheduled = configurations.size(); scheduled > 0; scheduled--) {
+        Result result;
+        try {
+          result = completion.take().get();
+        } catch (InterruptedException e) {
+          break;
+        } catch (ExecutionException e) {
+          Throwable t = e.getCause();
+          if (t instanceof IOException) {
+            throw new IOException(t);
+          } else {
+            throw new RuntimeException(t);
+          }
+        }
+
+        NexmarkConfiguration configuration = result.configuration;
+        NexmarkPerf perf = result.perf;
+        if (perf.errors == null || perf.errors.size() > 0) {
+          successful = false;
+        }
+        appendPerf(options.getPerfFilename(), configuration, perf);
+        actual.put(configuration, perf);
+        // Summarize what we've run so far.
+        saveSummary(null, configurations, actual, baseline, start, options);
+      }
+
       if (options.getExportSummaryToBigQuery()) {
         savePerfsToBigQuery(options, actual, null, start);
       }
@@ -107,6 +165,8 @@ public class Main<OptionT extends NexmarkOptions> {
         saveSummary(options.getSummaryFilename(), configurations, actual, baseline, start, options);
         saveJavascript(options.getJavascriptFilename(), configurations, actual, baseline, start);
       }
+
+      executor.shutdown();
     }
     if (!successful) {
       throw new RuntimeException("Execution was not successful");
@@ -412,9 +472,6 @@ public class Main<OptionT extends NexmarkOptions> {
   }
 
   public static void main(String[] args) throws IOException {
-    NexmarkOptions options =
-        PipelineOptionsFactory.fromArgs(args).withValidation().as(NexmarkOptions.class);
-    NexmarkLauncher<NexmarkOptions> nexmarkLauncher = new NexmarkLauncher<>(options);
-    new Main<>().runAll(options, nexmarkLauncher);
+    new Main().runAll(args);
   }
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
@@ -452,4 +452,10 @@ public interface NexmarkOptions
   int getMaxNumWorkers();
 
   void setMaxNumWorkers(int value);
+
+  @Description("Number of queries to run in parallel.")
+  @Default.Integer(1)
+  int getNexmarkParallel();
+
+  void setNexmarkParallel(int value);
 }

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkSuite.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkSuite.java
@@ -120,7 +120,7 @@ public enum NexmarkSuite {
    * any set command line flags, except for --isStreaming which is only respected for the {@link
    * #DEFAULT} suite.
    */
-  public Iterable<NexmarkConfiguration> getConfigurations(NexmarkOptions options) {
+  public Set<NexmarkConfiguration> getConfigurations(NexmarkOptions options) {
     Set<NexmarkConfiguration> results = new LinkedHashSet<>();
     for (NexmarkConfiguration configuration : configurations) {
       NexmarkConfiguration result = configuration.copy();


### PR DESCRIPTION
Dataflow runs jobs remotely and they are slow to spin up, so we should run multiple at the same time. This should fix the timeouts in the Nexmark Dataflow postcommit.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




