### PR TITLE
[BEAM-5068] switch mobile gaming input file to a public storage

### DIFF
--- a/.test-infra/jenkins/job_PostRelease_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_PostRelease_NightlySnapshot.groovy
@@ -23,9 +23,6 @@ import CommonJobProperties as commonJobProperties
 job('beam_PostRelease_NightlySnapshot') {
   description('Runs post release verification of the nightly snapshot.')
 
-  // Execute concurrent builds if necessary.
-  concurrentBuild()
-
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate)
 

--- a/release/src/main/groovy/MobileGamingCommands.groovy
+++ b/release/src/main/groovy/MobileGamingCommands.groovy
@@ -22,6 +22,8 @@ class MobileGamingCommands {
 
   private TestScripts testScripts
 
+  private static final INPUT_GAMING_DATA = "gs://dataflow-samples/game/5000_gaming_data.csv"
+
   public static final RUNNERS = [DirectRunner: "direct-runner",
     DataflowRunner: "dataflow-runner",
     SparkRunner: "spark-runner",
@@ -104,21 +106,21 @@ class MobileGamingCommands {
 
   private Map getUserScoreArgs(String runner){
     if(runner == "DataflowRunner"){
-      return [input: "gs://${testScripts.gcsBucket()}/5000_gaming_data.csv",
+      return [input: INPUT_GAMING_DATA,
         project: testScripts.gcpProject(),
         output: "gs://${testScripts.gcsBucket()}/${getUserScoreOutputName(runner)}"]
     }
-    return [input: "gs://${testScripts.gcsBucket()}/5000_gaming_data.csv",
+    return [input: INPUT_GAMING_DATA,
       output: "${getUserScoreOutputName(runner)}"]
   }
 
   private Map getHourlyTeamScoreArgs(String runner){
     if(runner == "DataflowRunner"){
-      return [input: "gs://${testScripts.gcsBucket()}/5000_gaming_data.csv",
+      return [input: INPUT_GAMING_DATA,
         project: testScripts.gcpProject(),
         output: "gs://${testScripts.gcsBucket()}/${getHourlyTeamScoreOutputName(runner)}"]
     }
-    return [input: "gs://${testScripts.gcsBucket()}/5000_gaming_data.csv",
+    return [input: INPUT_GAMING_DATA,
       output: "${getHourlyTeamScoreOutputName(runner)}"]
   }
 

--- a/release/src/main/groovy/MobileGamingCommands.groovy
+++ b/release/src/main/groovy/MobileGamingCommands.groovy
@@ -66,10 +66,10 @@ class MobileGamingCommands {
     return "java-hourlyteamscore-result-${RUNNERS[runner]}.txt"
   }
 
-  public String createPipelineCommand(String exampleName, String runner){
+  public String createPipelineCommand(String exampleName, String runner, String jobName=''){
     return """mvn compile exec:java -q \
       -Dexec.mainClass=org.apache.beam.examples.complete.game.${exampleName} \
-      -Dexec.args=\"${getArgs(exampleName, runner)}\" \
+      -Dexec.args=\"${getArgs(exampleName, runner, jobName)}\" \
       -P${RUNNERS[runner]}"""
   }
 
@@ -80,7 +80,7 @@ class MobileGamingCommands {
   }
 
 
-  private String getArgs(String exampleName, String runner){
+  private String getArgs(String exampleName, String runner, String jobName){
     def args
     switch (exampleName) {
       case "UserScore":
@@ -90,10 +90,10 @@ class MobileGamingCommands {
         args = getHourlyTeamScoreArgs(runner)
         break
       case "LeaderBoard":
-        args = getLeaderBoardArgs(runner)
+        args = getLeaderBoardArgs(runner, jobName)
         break
       case "GameStats":
-        args = getGameStatsArgs(runner)
+        args = getGameStatsArgs(runner, jobName)
         break
       default:
         testScripts.error("Cannot find example ${exampleName} in archetypes.")
@@ -124,21 +124,23 @@ class MobileGamingCommands {
       output: "${getHourlyTeamScoreOutputName(runner)}"]
   }
 
-  private Map getLeaderBoardArgs(String runner){
+  private Map getLeaderBoardArgs(String runner, String jobName){
     return [project: testScripts.gcpProject(),
       dataset: testScripts.bqDataset(),
       topic: "projects/${testScripts.gcpProject()}/topics/${testScripts.pubsubTopic()}",
       leaderBoardTableName: "leaderboard_${runner}",
-      teamWindowDuration: 5]
+      teamWindowDuration: 5,
+      jobName: jobName]
   }
 
-  private Map getGameStatsArgs(String runner){
+  private Map getGameStatsArgs(String runner, String jobName){
     return [project: testScripts.gcpProject(),
       dataset: testScripts.bqDataset(),
       topic: "projects/${testScripts.gcpProject()}/topics/${testScripts.pubsubTopic()}",
       fixedWindowDuration: 5,
       userActivityWindowDuration: 5,
       sessionGap: 1,
-      gameStatsTablePrefix: "gamestats_${runner}"]
+      gameStatsTablePrefix: "gamestats_${runner}",
+      jobName: jobName]
   }
 }

--- a/release/src/main/groovy/mobilegaming-java-dataflow.groovy
+++ b/release/src/main/groovy/mobilegaming-java-dataflow.groovy
@@ -76,8 +76,9 @@ def InjectorThread = Thread.start() {
   t.run(mobileGamingCommands.createInjectorCommand())
 }
 
+jobName = "leaderboard-validation-" + new Date().getTime() + "-" + new Random().nextInt(1000)
 def LeaderBoardThread = Thread.start() {
-  t.run(mobileGamingCommands.createPipelineCommand("LeaderBoard", runner))
+  t.run(mobileGamingCommands.createPipelineCommand("LeaderBoard", runner, jobName))
 }
 
 t.run("gcloud dataflow jobs list | grep pyflow-wordstream-candidate | grep Running | cut -d' ' -f1")
@@ -101,7 +102,7 @@ while((System.currentTimeMillis() - startTime)/60000 < mobileGamingCommands.EXEC
 }
 InjectorThread.stop()
 LeaderBoardThread.stop()
-t.run("gcloud dataflow jobs cancel \$(gcloud dataflow jobs list | grep leaderboard-jenkins | grep Running | cut -d' ' -f1)")
+t.run("gcloud dataflow jobs cancel \$(gcloud dataflow jobs list | grep ${jobName} | grep Running | cut -d' ' -f1)")
 
 if(!isSuccess){
   t.error("FAILED: Failed running LeaderBoard on DataflowRunner")

--- a/release/src/main/groovy/mobilegaming-java-direct.groovy
+++ b/release/src/main/groovy/mobilegaming-java-direct.groovy
@@ -74,8 +74,9 @@ def InjectorThread = Thread.start() {
   t.run(mobileGamingCommands.createInjectorCommand())
 }
 
+jobName = "leaderboard-validation-" + new Date().getTime() + "-" + new Random().nextInt(1000)
 def LeaderBoardThread = Thread.start() {
-  t.run(mobileGamingCommands.createPipelineCommand("LeaderBoard", runner))
+  t.run(mobileGamingCommands.createPipelineCommand("LeaderBoard", runner, jobName))
 }
 
 // verify outputs in BQ tables


### PR DESCRIPTION
Switch the mobile-gaming input date "5000_gaming_data.csv" to a public storage:
1. Allows contributors run this test on their local machine;
2. No worries about the life time in the gcs under the apache-beam-testing
+R @pabloem 
cc: @alanmyrvold @boyuanzz  

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




