### PR TITLE
BEAM-3026 Adding retrying behavior on ElasticSearchIO for 429: Too Many Requests

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/common/retry/RetryConfiguration.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/common/retry/RetryConfiguration.java
@@ -1,0 +1,79 @@
+package org.apache.beam.sdk.io.common.retry;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.io.Serializable;
+import org.joda.time.Duration;
+
+/**
+ * A POJO encapsulating a configuration for retry behavior when issuing requests. A retry will be
+ * attempted until the maxAttempts or maxDuration is exceeded, whichever comes first, for any of the
+ * following exceptions:
+ */
+public class RetryConfiguration implements Serializable {
+
+  private int maxAttempts;
+  private Duration maxDuration;
+  private RetryPredicate retryPredicate;
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public Duration getMaxDuration() {
+    return maxDuration;
+  }
+
+  public RetryPredicate getRetryPredicate() {
+    return retryPredicate;
+  }
+
+  public static RetryConfiguration create(
+      int maxAttempts, Duration maxDuration, RetryPredicate predicate) {
+    checkArgument(maxAttempts > 0, "maxAttempts must be greater than 0");
+    checkArgument(
+        maxDuration != null && maxDuration.isLongerThan(Duration.ZERO),
+        "maxDuration must be greater than 0");
+    return RetryConfigurationBuilder.create()
+        .withMaxAttempts(maxAttempts)
+        .withMaxDuration(maxDuration)
+        .withRetryPredicate(predicate)
+        .build();
+  }
+
+  public static final class RetryConfigurationBuilder {
+
+    private int maxAttempts;
+    private Duration maxDuration;
+    private RetryPredicate retryPredicate;
+
+    public static RetryConfigurationBuilder create() {
+      return new RetryConfigurationBuilder();
+    }
+
+    private RetryConfigurationBuilder() {}
+
+    public RetryConfigurationBuilder withMaxAttempts(int maxAttempts) {
+      this.maxAttempts = maxAttempts;
+      return this;
+    }
+
+    public RetryConfigurationBuilder withMaxDuration(Duration maxDuration) {
+      this.maxDuration = maxDuration;
+      return this;
+    }
+
+    public RetryConfigurationBuilder withRetryPredicate(RetryPredicate retryPredicate) {
+      this.retryPredicate = retryPredicate;
+      return this;
+    }
+
+    public RetryConfiguration build() {
+      RetryConfiguration retryConfiguration = new RetryConfiguration();
+      retryConfiguration.retryPredicate = this.retryPredicate;
+      retryConfiguration.maxDuration = this.maxDuration;
+      retryConfiguration.maxAttempts = this.maxAttempts;
+      return retryConfiguration;
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/common/retry/RetryPredicate.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/common/retry/RetryPredicate.java
@@ -1,0 +1,11 @@
+package org.apache.beam.sdk.io.common.retry;
+
+import java.io.Serializable;
+import java.util.function.Predicate;
+
+/**
+ * An interface used to control if retry call when a {@link Throwable} occurs. If {@link
+ * RetryPredicate#test(Object)} returns true.
+ */
+@FunctionalInterface
+public interface RetryPredicate extends Predicate<Throwable>, Serializable {}

--- a/sdks/java/io/solr/src/test/java/org/apache/beam/sdk/io/solr/SolrIOTestUtils.java
+++ b/sdks/java/io/solr/src/test/java/org/apache/beam/sdk/io/solr/SolrIOTestUtils.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.apache.beam.sdk.io.common.retry.RetryPredicate;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.request.CollectionAdminRequest;
@@ -122,7 +123,7 @@ public class SolrIOTestUtils {
   }
 
   /** A strategy that will accept to retry on any SolrException. */
-  static class LenientRetryPredicate implements SolrIO.RetryConfiguration.RetryPredicate {
+  static class LenientRetryPredicate implements RetryPredicate {
     @Override
     public boolean test(Throwable throwable) {
       return throwable instanceof SolrException;


### PR DESCRIPTION
@timrobertson100 

Added Retry behavior in ElasticSearchIO for too many  #requests.
Changes made : 
1. moved RetryConfiguration and RetryPredicate to common place
2. Implemented Retry behavior in ESIO and added tests and verified the change.
3. updated SolrIO, and SolrIOTest to use retry configuration from common place.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




