### PR TITLE
[BEAM-5071] Replace the bigquery with restful APIs to query dependenc…

### DIFF
--- a/.test-infra/jenkins/dependency_check/dependency_check_report_generator_test.py
+++ b/.test-infra/jenkins/dependency_check/dependency_check_report_generator_test.py
@@ -28,7 +28,7 @@ from dependency_check_report_generator import prioritize_dependencies
 _PROJECT_ID = 'mock-apache-beam-testing'
 _DATASET_ID = 'mock-beam_dependency_states'
 _TABLE_ID = 'mock-java_dependency_states'
-_SDK_TYPE = 'JAVA'
+_SDK_TYPE = 'Java'
 
 # initialize current/latest version release dates for low-priority (LP) and high-priority (HP) dependencies
 _LP_CURR_VERSION_DATE = datetime.strptime('2000-01-01', '%Y-%m-%d')
@@ -40,6 +40,7 @@ _MOCKED_OWNERS_FILE = "deps: "
 @patch('jira_utils.jira_manager.JiraManager')
 @patch('jira_utils.jira_manager.JiraClient')
 @patch('jira_utils.jira_manager.JiraManager.run')
+@patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.clean_stale_records_from_table')
 class DependencyCheckReportGeneratorTest(unittest.TestCase):
   """Tests for `dependency_check_report_generator.py`."""
 
@@ -58,11 +59,11 @@ class DependencyCheckReportGeneratorTest(unittest.TestCase):
       self.assertEqual(len(report), 0)
 
 
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.query_dep_info_by_version',
-         side_effect = [(_LP_CURR_VERSION_DATE, True), (_LATEST_VERSION_DATE, False),
-                        (_LP_CURR_VERSION_DATE, True), (_LATEST_VERSION_DATE, False),
-                        (_HP_CURR_VERSION_DATE, True), (_LATEST_VERSION_DATE, False),
-                        (_LP_CURR_VERSION_DATE, True), (_LATEST_VERSION_DATE, False),])
+  @patch('dependency_check.dependency_check_report_generator.find_release_time_from_maven_central',
+         side_effect = [_LP_CURR_VERSION_DATE, _LATEST_VERSION_DATE,
+                        _LP_CURR_VERSION_DATE, _LATEST_VERSION_DATE,
+                        _HP_CURR_VERSION_DATE, _LATEST_VERSION_DATE,
+                        _LP_CURR_VERSION_DATE, _LATEST_VERSION_DATE,])
   def test_normal_dep_input(self, *args):
     """
     Test on a normal outdated dependencies set.
@@ -82,9 +83,9 @@ class DependencyCheckReportGeneratorTest(unittest.TestCase):
       self.assertIn('group3:artifact3', report[2])
 
 
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.query_dep_info_by_version',
-         side_effect = [(_LP_CURR_VERSION_DATE, True),
-                        (_LATEST_VERSION_DATE, False),])
+  @patch('dependency_check.dependency_check_report_generator.find_release_time_from_maven_central',
+         side_effect = [_LP_CURR_VERSION_DATE,
+                        _LATEST_VERSION_DATE,])
   def test_dep_with_nondigit_major_versions(self, *args):
     """
     Test on a outdated dependency with non-digit major number.
@@ -97,9 +98,9 @@ class DependencyCheckReportGeneratorTest(unittest.TestCase):
       self.assertIn('group1:artifact1', report[0])
 
 
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.query_dep_info_by_version',
-         side_effect = [(_LP_CURR_VERSION_DATE, True),
-                        (_LATEST_VERSION_DATE, False),])
+  @patch('dependency_check.dependency_check_report_generator.find_release_time_from_maven_central',
+         side_effect = [_LP_CURR_VERSION_DATE,
+                        _LATEST_VERSION_DATE,])
   def test_dep_with_nondigit_minor_versions(self, *args):
     """
     Test on a outdated dependency with non-digit minor number.
@@ -112,11 +113,8 @@ class DependencyCheckReportGeneratorTest(unittest.TestCase):
       self.assertIn('group1:artifact1', report[0])
 
 
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.insert_dep_to_table')
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.delete_dep_from_table')
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.query_currently_used_dep_info_in_db', side_effect = [(None, None)])
-  @patch('dependency_check.bigquery_client_utils.BigQueryClientUtils.query_dep_info_by_version',
-         side_effect = [(_HP_CURR_VERSION_DATE, True), (_LATEST_VERSION_DATE, False),])
+  @patch('dependency_check.dependency_check_report_generator.find_release_time_from_maven_central',
+         side_effect = [_HP_CURR_VERSION_DATE,_LATEST_VERSION_DATE,])
   def test_invalid_dep_input(self, *args):
     """
     Test on a invalid outdated dependencies format.


### PR DESCRIPTION
Use maven central REST API to get Java deps release dates.
Use the compatibility checking service to get Python dep release dates.
+R: @chamikaramj 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




