### PR TITLE
Interactive Beam - enable caching in GCS

### DIFF
--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -690,6 +690,20 @@ class FileSystem(with_metaclass(abc.ABCMeta, BeamPlugin)):
     """
     raise NotImplementedError
 
+  @abc.abstractmethod
+  def last_updated(self, path):
+    """Get UNIX Epoch time in seconds on the FileSystem.
+
+    Args:
+      path: string path of file.
+
+    Returns: float UNIX Epoch time
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    raise NotImplementedError
+
   def checksum(self, path):
     """Fetch checksum metadata of a file on the
     :class:`~apache_beam.io.filesystem.FileSystem`.

--- a/sdks/python/apache_beam/io/filesystem_test.py
+++ b/sdks/python/apache_beam/io/filesystem_test.py
@@ -92,6 +92,9 @@ class TestingFileSystem(FileSystem):
   def size(self, path):
     raise NotImplementedError
 
+  def last_updated(self, path):
+    raise NotImplementedError
+
   def checksum(self, path):
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/io/filesystems.py
+++ b/sdks/python/apache_beam/io/filesystems.py
@@ -248,6 +248,21 @@ class FileSystems(object):
     return filesystem.exists(path)
 
   @staticmethod
+  def last_updated(path):
+    """Get UNIX Epoch time in seconds on the FileSystem.
+
+    Args:
+      path: string path of file.
+
+    Returns: float UNIX Epoch time
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    filesystem = FileSystems.get_filesystem(path)
+    return filesystem.last_updated(path)
+
+  @staticmethod
   def checksum(path):
     """Fetch checksum metadata of a file on the
     :class:`~apache_beam.io.filesystem.FileSystem`.

--- a/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
+++ b/sdks/python/apache_beam/io/gcp/gcsfilesystem.py
@@ -266,6 +266,19 @@ class GCSFileSystem(FileSystem):
     """
     return gcsio.GcsIO().size(path)
 
+  def last_updated(self, path):
+    """Get UNIX Epoch time in seconds on the FileSystem.
+
+    Args:
+      path: string path of file.
+
+    Returns: float UNIX Epoch time
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    return gcsio.GcsIO().last_updated(path)
+
   def checksum(self, path):
     """Fetch checksum metadata of a file on the
     :class:`~apache_beam.io.filesystem.FileSystem`.

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -412,6 +412,23 @@ class GcsIO(object):
 
   @retry.with_exponential_backoff(
       retry_filter=retry.retry_on_server_errors_and_timeout_filter)
+  def last_updated(self, path):
+    """Returns the last updated epoch time of a single GCS object.
+
+    This method does not perform glob expansion. Hence the given path must be
+    for a single GCS object.
+
+    Returns: last updated time of the GCS object in second.
+    """
+    bucket, object_path = parse_gcs_path(path)
+    request = storage.StorageObjectsGetRequest(
+        bucket=bucket, object=object_path)
+    datetime = self.client.objects.Get(request).updated
+    return (time.mktime(datetime.timetuple()) - time.timezone
+            + datetime.microsecond / 1000000.0)
+
+  @retry.with_exponential_backoff(
+      retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def list_prefix(self, path):
     """Lists files matching the prefix.
 

--- a/sdks/python/apache_beam/io/hadoopfilesystem.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem.py
@@ -340,6 +340,9 @@ class HadoopFileSystem(FileSystem):
       raise BeamIOError('File not found: %s' % url)
     return status[_FILE_STATUS_LENGTH]
 
+  def last_updated(self, url):
+    raise NotImplementedError
+
   def checksum(self, url):
     """Fetches a checksum description for a URL.
 

--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -268,6 +268,21 @@ class LocalFileSystem(FileSystem):
     except Exception as e:  # pylint: disable=broad-except
       raise BeamIOError("Size operation failed", {path: e})
 
+  def last_updated(self, path):
+    """Get UNIX Epoch time in seconds on the FileSystem.
+
+    Args:
+      path: string path of file.
+
+    Returns: float UNIX Epoch time
+
+    Raises:
+      ``BeamIOError`` if path doesn't exist.
+    """
+    if not self.exists(path):
+      raise BeamIOError('Path does not exist: %s' % path)
+    return os.path.getmtime(path)
+
   def checksum(self, path):
     """Fetch checksum metadata of a file on the
     :class:`~apache_beam.io.filesystem.FileSystem`.

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -20,9 +20,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
-import glob
 import os
-import shutil
 import tempfile
 import urllib
 
@@ -79,7 +77,7 @@ class CacheManager(object):
     raise NotImplementedError
 
 
-class LocalFileCacheManager(CacheManager):
+class FileBasedCacheManager(CacheManager):
   """Maps PCollections to local temp files for materialization."""
 
   def __init__(self, temp_dir=None):
@@ -88,14 +86,12 @@ class LocalFileCacheManager(CacheManager):
     self._versions = collections.defaultdict(lambda: self._CacheVersion())
 
   def exists(self, *labels):
-    return bool(
-        filesystems.FileSystems.match([self._glob_path(*labels)],
-                                      limits=[1])[0].metadata_list)
+    return bool(self._match(*labels))
 
   def _latest_version(self, *labels):
     timestamp = 0
-    for path in glob.glob(self._glob_path(*labels)):
-      timestamp = max(timestamp, os.path.getmtime(path))
+    for path in self._match(*labels):
+      timestamp = max(timestamp, filesystems.FileSystems.last_updated(path))
     result = self._versions["-".join(labels)].get_version(timestamp)
     return result
 
@@ -105,8 +101,8 @@ class LocalFileCacheManager(CacheManager):
 
     def _read_helper():
       coder = SafeFastPrimitivesCoder()
-      for path in glob.glob(self._glob_path(*labels)):
-        for line in open(path):
+      for path in self._match(*labels):
+        for line in filesystems.FileSystems.open(path):
           yield coder.decode(line.strip())
     result, version = list(_read_helper()), self._latest_version(*labels)
     return result, version
@@ -120,14 +116,19 @@ class LocalFileCacheManager(CacheManager):
                                coder=SafeFastPrimitivesCoder())._sink
 
   def cleanup(self):
-    if os.path.exists(self._temp_dir):
-      shutil.rmtree(self._temp_dir)
+    if filesystems.FileSystems.exists(self._temp_dir):
+      filesystems.FileSystems.delete([self._temp_dir])
 
   def _glob_path(self, *labels):
     return self._path(*labels) + '-*-of-*'
 
   def _path(self, *labels):
     return filesystems.FileSystems.join(self._temp_dir, *labels)
+
+  def _match(self, *labels):
+    match = filesystems.FileSystems.match([self._glob_path(*labels)])
+    assert len(match) == 1
+    return [metadata.path for metadata in match[0].metadata_list]
 
   class _CacheVersion(object):
     """This class keeps track of the timestamp and the corresponding version."""

--- a/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
@@ -29,18 +29,20 @@ from apache_beam.io import filesystems
 from apache_beam.runners.interactive import cache_manager as cache
 
 
-class LocalFileCacheManagerTest(unittest.TestCase):
-  """Unit test for LocalFileCacheManager.
+class FileBasedCacheManagerTest(unittest.TestCase):
+  """Unit test for FileBasedCacheManager.
 
   Note that this set of tests focuses only the the methods that interacts with
-  the local operating system. Those tests that involve interactions with Beam
-  (i.e. source(), sink(), ReadCache, and WriteCache) will be tested with
-  InteractiveRunner as a part of integration tests instead.
+  the LOCAL file system. The idea is that once FileBasedCacheManager works well
+  with the local file system, it should work with any file system with
+  `apache_beam.io.filesystem` interface. Those tests that involve interactions
+  with Beam pipeline (i.e. source(), sink(), ReadCache, and WriteCache) will be
+  tested with InteractiveRunner as a part of integration tests instead.
   """
 
   def setUp(self):
     self.test_dir = tempfile.mkdtemp()
-    self.cache_manager = cache.LocalFileCacheManager(self.test_dir)
+    self.cache_manager = cache.FileBasedCacheManager(self.test_dir)
 
   def tearDown(self):
     # The test_dir might have already been removed by cache_manager.cleanup().

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -45,11 +45,12 @@ class InteractiveRunner(runners.PipelineRunner):
   Allows interactively building and running Beam Python pipelines.
   """
 
-  def __init__(self, underlying_runner=direct_runner.BundleBasedDirectRunner()):
+  def __init__(self, underlying_runner=None, cache_dir=None):
     # TODO(qinyeli, BEAM-4755) remove explicitly overriding underlying runner
     # once interactive_runner works with FnAPI mode
-    self._underlying_runner = underlying_runner
-    self._cache_manager = cache.LocalFileCacheManager()
+    self._underlying_runner = (underlying_runner
+                               or direct_runner.BundleBasedDirectRunner())
+    self._cache_manager = cache.FileBasedCacheManager(cache_dir)
     self._in_session = False
 
   def start_session(self):


### PR DESCRIPTION
Changes made:
* Added last_updated() API to beam.io.filesystem.
    related files in /apache_beam/io

* Generalized LocalFileCacheManager to FileBasedCacheManager. Now
PCollection caches can be kept anywhere as long as it implements
beam.io.filesystem.
    related files in /apache_beam/runners

**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




