### PR TITLE
[[BEAM-5092] Row comparison should be faster when both are POJOs.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -31,8 +31,12 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * <p>This provider finds (recursively) all public getters and setters in a Java object, and creates
  * schemas and rows that bind to those fields. The field order in the schema is not guaranteed to
  * match the method order in the class. The Java object is expected to have implemented a correct
- * .equals() method. TODO: Validate equals() method is provided, and if not generate a "slow" equals
- * method based on the schema.
+ * .equals() and .hashCode methods The equals method must be completely determined by the schema
+ * fields. i.e. if the object has hidden fields that are not reflected in the schema but are
+ * compared in equals, then results will be incorrect.
+ *
+ * <p>TODO: Validate equals() method is provided, and if not generate a "slow" equals method based
+ * on the schema.
  */
 @Experimental(Kind.SCHEMAS)
 public class JavaBeanSchema extends GetterBasedSchemaProvider {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -30,9 +30,13 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  *
  * <p>This provider finds all public fields (recursively) in a Java object, and creates schemas and
  * rows that bind to those fields. The field order in the schema is not guaranteed to match the
- * field order in the class. The Java object is expected to have implemented a correct .equals()
- * method. TODO: Validate equals() method is provided, and if not generate a "slow" equals method
- * based on the schema.
+ * field order in the class. The Java object is expected to have implemented a correct .equals() and
+ * .hashCode() methods. The equals method must be completely determined by the schema fields. i.e.
+ * if the object has hidden fields that are not reflected in the schema but are compared in equals,
+ * then results will be incorrect.
+ *
+ * <p>TODO: Validate equals() method is provided, and if not generate a "slow" equals method based
+ * on the schema.
  */
 @Experimental(Kind.SCHEMAS)
 public class JavaFieldSchema extends GetterBasedSchemaProvider {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
@@ -163,7 +163,10 @@ public class SchemaRegistry {
    * Register a POJO type for automatic schema inference.
    *
    * <p>Currently schema field names will match field names in the POJO, and all fields must be
-   * mutable (i.e. no final fields).
+   * mutable (i.e. no final fields). The Java object is expected to have implemented a correct
+   * .equals() and .hashCode methods The equals method must be completely determined by the schema
+   * fields. i.e. if the object has hidden fields that are not reflected in the schema but are
+   * compared in equals, then results will be incorrect.
    */
   public <T> void registerPOJO(TypeDescriptor<T> typeDescriptor) {
     registerSchemaProvider(typeDescriptor, new JavaFieldSchema());
@@ -173,7 +176,10 @@ public class SchemaRegistry {
    * Register a JavaBean type for automatic schema inference.
    *
    * <p>Currently schema field names will match getter names in the bean, and all getters must have
-   * matching setters.
+   * matching setters. The Java object is expected to have implemented a correct .equals() and
+   * .hashCode methods The equals method must be completely determined by the schema fields. i.e. if
+   * the object has hidden fields that are not reflected in the schema but are compared in equals,
+   * then results will be incorrect.
    */
   public <T> void registerJavaBean(Class<T> clazz) {
     registerJavaBean(TypeDescriptor.of(clazz));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -313,7 +313,7 @@ public abstract class Row implements Serializable {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof Row)) {
       return false;
     }
     Row other = (Row) o;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
@@ -122,5 +123,28 @@ public class RowWithGetters extends Row {
 
   public Object getGetterTarget() {
     return getterTarget;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    if (o instanceof RowWithGetters) {
+      RowWithGetters other = (RowWithGetters) o;
+      return Objects.equals(getSchema(), other.getSchema())
+          && Objects.equals(getterTarget, other.getterTarget);
+    } else if ((o instanceof Row)) {
+      return super.equals(o);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getSchema(), getterTarget);
   }
 }


### PR DESCRIPTION
In this case, we can delegate comparison to the target object instead of extracting all values first.