### PR TITLE
[BEAM-4798] Fix IndexOutOfBoundsException in Flink runner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -207,6 +207,10 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
       // parallelism is 2 and number of Kafka topic partitions is 1). In this case, we just fall
       // through to idle this executor.
       LOG.info("Number of readers is 0 for this task executor, idle");
+
+      // set this, so that the later logic will emit a final watermark and then decide whether
+      // to idle or not
+      isRunning = false;
     } else if (localReaders.size() == 1) {
       // the easy case, we just read from one reader
       UnboundedSource.UnboundedReader<OutputT> reader = localReaders.get(0);
@@ -442,13 +446,12 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
   private void setNextWatermarkTimer(StreamingRuntimeContext runtime) {
     if (this.isRunning) {
       long watermarkInterval = runtime.getExecutionConfig().getAutoWatermarkInterval();
-      long timeToNextWatermark = getTimeToNextWatermark(watermarkInterval);
-      runtime.getProcessingTimeService().registerTimer(timeToNextWatermark, this);
+      synchronized (context.getCheckpointLock()) {
+        long timeToNextWatermark =
+            runtime.getProcessingTimeService().getCurrentProcessingTime() + watermarkInterval;
+        runtime.getProcessingTimeService().registerTimer(timeToNextWatermark, this);
+      }
     }
-  }
-
-  private long getTimeToNextWatermark(long watermarkInterval) {
-    return System.currentTimeMillis() + watermarkInterval;
   }
 
   /** Visible so that we can check this in tests. Must not be used for anything else. */

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -202,7 +202,12 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
     ReaderInvocationUtil<OutputT, UnboundedSource.UnboundedReader<OutputT>> readerInvoker =
         new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);
 
-    if (localReaders.size() == 1) {
+    if (localReaders.size() == 0) {
+      // It can happen when value of parallelism is greater than number of IO readers (for example,
+      // parallelism is 2 and number of Kafka topic partitions is 1). In this case, we just fall
+      // through to idle this executor.
+      LOG.info("Number of readers is 0 for this task executor, idle");
+    } else if (localReaders.size() == 1) {
       // the easy case, we just read from one reader
       UnboundedSource.UnboundedReader<OutputT> reader = localReaders.get(0);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/UnboundedSourceWrapperTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.Unbounded
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.ValueWithRecordId;
@@ -59,16 +60,16 @@ public class UnboundedSourceWrapperTest {
 
   /** Parameterized tests. */
   @RunWith(Parameterized.class)
-  public static class UnboundedSourceWrapperTestWithParams {
+  public static class ParameterizedUnboundedSourceWrapperTest {
     private final int numTasks;
     private final int numSplits;
 
-    public UnboundedSourceWrapperTestWithParams(int numTasks, int numSplits) {
+    public ParameterizedUnboundedSourceWrapperTest(int numTasks, int numSplits) {
       this.numTasks = numTasks;
       this.numSplits = numSplits;
     }
 
-    @Parameterized.Parameters
+    @Parameterized.Parameters(name = "numTasks = {0}; numSplits={1}")
     public static Collection<Object[]> data() {
       /*
        * Parameters for initializing the tests:
@@ -89,75 +90,113 @@ public class UnboundedSourceWrapperTest {
      */
     @Test
     public void testValueEmission() throws Exception {
-      final int numElements = 20;
+      final int numElementsPerShard = 20;
       final Object checkpointLock = new Object();
       PipelineOptions options = PipelineOptionsFactory.create();
 
-      // this source will emit exactly NUM_ELEMENTS across all parallel readers,
+      final long[] numElementsReceived = {0L};
+      final int[] numWatermarksReceived = {0};
+
+      // this source will emit exactly NUM_ELEMENTS for each parallel reader,
       // afterwards it will stall. We check whether we also receive NUM_ELEMENTS
       // elements later.
-      TestCountingSource source = new TestCountingSource(numElements);
-      UnboundedSourceWrapper<KV<Integer, Integer>, TestCountingSource.CounterMark> flinkWrapper =
-          new UnboundedSourceWrapper<>("stepName", options, source, numSplits);
+      TestCountingSource source =
+          new TestCountingSource(numElementsPerShard).withFixedNumSplits(numSplits);
 
-      assertEquals(numSplits, flinkWrapper.getSplitSources().size());
+      for (int subtaskIndex = 0; subtaskIndex < numTasks; subtaskIndex++) {
+        UnboundedSourceWrapper<KV<Integer, Integer>, TestCountingSource.CounterMark> flinkWrapper =
+            new UnboundedSourceWrapper<>("stepName", options, source, numTasks);
 
-      StreamSource<
-              WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>,
-              UnboundedSourceWrapper<KV<Integer, Integer>, TestCountingSource.CounterMark>>
-          sourceOperator = new StreamSource<>(flinkWrapper);
+        // the source wrapper will only request as many splits as there are tasks and the source
+        // will create at most numSplits splits
+        assertEquals(numSplits, flinkWrapper.getSplitSources().size());
 
-      AbstractStreamOperatorTestHarness<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>
-          testHarness =
-              new AbstractStreamOperatorTestHarness<>(
-                  sourceOperator,
-                  numTasks /* max parallelism */,
-                  numTasks /* parallelism */,
-                  0 /* subtask index */);
+        StreamSource<
+                WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>,
+                UnboundedSourceWrapper<KV<Integer, Integer>, TestCountingSource.CounterMark>>
+            sourceOperator = new StreamSource<>(flinkWrapper);
 
-      testHarness.setTimeCharacteristic(TimeCharacteristic.EventTime);
+        AbstractStreamOperatorTestHarness<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>
+            testHarness =
+                new AbstractStreamOperatorTestHarness<>(
+                    sourceOperator,
+                    numTasks /* max parallelism */,
+                    numTasks /* parallelism */,
+                    subtaskIndex /* subtask index */);
 
-      try {
-        testHarness.open();
-        sourceOperator.run(
-            checkpointLock,
-            new TestStreamStatusMaintainer(),
-            new Output<StreamRecord<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>>() {
-              private int count = 0;
+        testHarness.setProcessingTime(System.currentTimeMillis());
 
+        // start a thread that advances processing time, so that we eventually get the final
+        // watermark which is only updated via a processing-time trigger
+        Thread processingTimeUpdateThread =
+            new Thread() {
               @Override
-              public void emitWatermark(Watermark watermark) {}
-
-              @Override
-              public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
-                collect((StreamRecord) streamRecord);
-              }
-
-              @Override
-              public void emitLatencyMarker(LatencyMarker latencyMarker) {}
-
-              @Override
-              public void collect(
-                  StreamRecord<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>
-                      windowedValueStreamRecord) {
-
-                count++;
-                if (count >= numElements) {
-                  throw new SuccessException();
+              public void run() {
+                while (true) {
+                  try {
+                    synchronized (testHarness.getCheckpointLock()) {
+                      testHarness.setProcessingTime(System.currentTimeMillis());
+                    }
+                    Thread.sleep(1000);
+                  } catch (Exception e) {
+                    break;
+                  }
                 }
               }
+            };
+        processingTimeUpdateThread.start();
 
-              @Override
-              public void close() {}
-            });
-      } catch (SuccessException e) {
+        testHarness.setTimeCharacteristic(TimeCharacteristic.EventTime);
 
-        assertEquals(Math.max(1, numSplits / numTasks), flinkWrapper.getLocalSplitSources().size());
+        try {
+          testHarness.open();
+          sourceOperator.run(
+              checkpointLock,
+              new TestStreamStatusMaintainer(),
+              new Output<StreamRecord<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>>() {
+                private boolean hasSeenMaxWatermark = false;
 
-        // success
-        return;
+                @Override
+                public void emitWatermark(Watermark watermark) {
+                  // we get this when there is no more data
+                  // it can happen that we get the max watermark several times, so guard against
+                  // this
+                  if (!hasSeenMaxWatermark
+                      && watermark.getTimestamp()
+                          >= BoundedWindow.TIMESTAMP_MAX_VALUE.getMillis()) {
+                    numWatermarksReceived[0]++;
+                    hasSeenMaxWatermark = true;
+                  }
+                }
+
+                @Override
+                public <X> void collect(OutputTag<X> outputTag, StreamRecord<X> streamRecord) {
+                  collect((StreamRecord) streamRecord);
+                }
+
+                @Override
+                public void emitLatencyMarker(LatencyMarker latencyMarker) {}
+
+                @Override
+                public void collect(
+                    StreamRecord<WindowedValue<ValueWithRecordId<KV<Integer, Integer>>>>
+                        windowedValueStreamRecord) {
+                  numElementsReceived[0]++;
+                }
+
+                @Override
+                public void close() {}
+              });
+        } catch (SuccessException e) {
+          processingTimeUpdateThread.interrupt();
+          processingTimeUpdateThread.join();
+          // success, continue for the other subtask indices
+        }
       }
-      fail("Read terminated without producing expected number of outputs");
+      // verify that we get the expected count across all subtasks
+      assertEquals(numElementsPerShard * numSplits, numElementsReceived[0]);
+      // and that we get as many final watermarks as there are subtasks
+      assertEquals(numTasks, numWatermarksReceived[0]);
     }
 
     /**


### PR DESCRIPTION
This is an addition on top of #5996 that fixes the test so that it would have caught the bug that @aromanenko-dev fixed in #5996.

CC @aromanenko-dev 

@tweise Maybe this is relevant to your work on portability but I don't think so. Neverthelesse, doesn't hurt to take a look. 😅 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




