### PR TITLE
[BEAM-5063] Fix Watermark does not progress for low traffic streams

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MovingFunction.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/MovingFunction.java
@@ -69,25 +69,21 @@ public class MovingFunction {
     numSamples = new int[n];
     Arrays.fill(numSamples, 0);
     currentMsSinceEpoch = -1;
-    currentIndex = -1;
+    currentIndex = 0;
   }
 
   /** Flush stale values. */
   private void flush(long nowMsSinceEpoch) {
     checkArgument(nowMsSinceEpoch >= 0, "Only positive timestamps supported");
-    if (currentIndex < 0) {
-      currentMsSinceEpoch = nowMsSinceEpoch - (nowMsSinceEpoch % sampleUpdateMs);
-      currentIndex = 0;
-    }
     checkArgument(nowMsSinceEpoch >= currentMsSinceEpoch, "Attempting to move backwards");
     int newBuckets =
         Math.min((int) ((nowMsSinceEpoch - currentMsSinceEpoch) / sampleUpdateMs), buckets.length);
+    currentMsSinceEpoch = nowMsSinceEpoch - (nowMsSinceEpoch % sampleUpdateMs);
     while (newBuckets > 0) {
       currentIndex = (currentIndex + 1) % buckets.length;
       buckets[currentIndex] = function.identity();
       numSamples[currentIndex] = 0;
       newBuckets--;
-      currentMsSinceEpoch += sampleUpdateMs;
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MovingFunctionTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/MovingFunctionTest.java
@@ -107,4 +107,12 @@ public class MovingFunctionTest {
     assertEquals(1, f.get(SAMPLE_PERIOD + 3 * SAMPLE_UPDATE));
     assertEquals(0, f.get(SAMPLE_PERIOD * 2));
   }
+
+  @Test
+  public void properlyFlushStaleValues() {
+    MovingFunction f = newFunc();
+    f.add(0, 1);
+    f.add(SAMPLE_PERIOD * 3, 1);
+    assertEquals(1, f.get(SAMPLE_PERIOD * 3));
+  }
 }

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisWatermark.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/KinesisWatermark.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import java.util.function.BooleanSupplier;
+import org.apache.beam.sdk.transforms.Min;
+import org.apache.beam.sdk.util.MovingFunction;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/**
+ * Keeps track of current watermark using {@link MovingFunction}. If the pipeline is up to date with
+ * the processing, watermark would be around 'now - {@link KinesisWatermark#SAMPLE_PERIOD}' for a
+ * stream with steady traffic, and around 'now - {@link KinesisWatermark#UPDATE_THRESHOLD}' for a
+ * stream with low traffic.
+ */
+class KinesisWatermark {
+  /** Period of updates to determine watermark. */
+  private static final Duration SAMPLE_UPDATE = Duration.standardSeconds(5);
+
+  /** Period of samples to determine watermark. */
+  static final Duration SAMPLE_PERIOD = Duration.standardMinutes(1);
+
+  /**
+   * Period after which watermark should be updated regardless of number of samples. It has to be
+   * longer than {@link KinesisWatermark#SAMPLE_PERIOD}, so that for most of the cases value
+   * returned from {@link MovingFunction#isSignificant()} is sufficient to decide about watermark
+   * update.
+   */
+  static final Duration UPDATE_THRESHOLD = SAMPLE_PERIOD.multipliedBy(2);
+
+  /** Constant representing the maximum Kinesis stream retention period. */
+  static final Duration MAX_KINESIS_STREAM_RETENTION_PERIOD = Duration.standardDays(7);
+
+  /** Minimum number of unread messages required before considering updating watermark. */
+  static final int MIN_MESSAGES = 10;
+
+  /**
+   * Minimum number of SAMPLE_UPDATE periods over which unread messages should be spread before
+   * considering updating watermark.
+   */
+  private static final int MIN_SPREAD = 2;
+
+  private Instant lastWatermark = Instant.now().minus(MAX_KINESIS_STREAM_RETENTION_PERIOD);
+  private Instant lastUpdate = new Instant(0L);
+  private final MovingFunction minReadTimestampMsSinceEpoch =
+      new MovingFunction(
+          SAMPLE_PERIOD.getMillis(),
+          SAMPLE_UPDATE.getMillis(),
+          MIN_SPREAD,
+          MIN_MESSAGES,
+          Min.ofLongs());
+
+  public Instant getCurrent(BooleanSupplier shardsUpToDate) {
+    Instant now = Instant.now();
+    Instant readMin = getMinReadTimestamp(now);
+    if (readMin == null) {
+      if (shardsUpToDate.getAsBoolean()) {
+        updateLastWatermark(now.minus(SAMPLE_PERIOD), now);
+      }
+    } else if (shouldUpdate(now)) {
+      updateLastWatermark(readMin, now);
+    }
+    return lastWatermark;
+  }
+
+  public void update(Instant recordArrivalTime) {
+    minReadTimestampMsSinceEpoch.add(Instant.now().getMillis(), recordArrivalTime.getMillis());
+  }
+
+  private Instant getMinReadTimestamp(Instant now) {
+    long readMin = minReadTimestampMsSinceEpoch.get(now.getMillis());
+    if (readMin == Min.ofLongs().identity()) {
+      return null;
+    } else {
+      return new Instant(readMin);
+    }
+  }
+
+  /**
+   * In case of streams with low traffic, {@link MovingFunction} could never get enough samples in
+   * {@link KinesisWatermark#SAMPLE_PERIOD} to move watermark. To prevent this situation, we need to
+   * check if watermark is stale (it was not updated during {@link
+   * KinesisWatermark#UPDATE_THRESHOLD}) and force its update if it is.
+   *
+   * @param now - current timestamp
+   * @return should the watermark be updated
+   */
+  private boolean shouldUpdate(Instant now) {
+    boolean hasEnoughSamples = minReadTimestampMsSinceEpoch.isSignificant();
+    boolean isStale = lastUpdate.isBefore(now.minus(UPDATE_THRESHOLD));
+    return hasEnoughSamples || isStale;
+  }
+
+  private void updateLastWatermark(Instant newWatermark, Instant now) {
+    if (newWatermark.isAfter(lastWatermark)) {
+      lastWatermark = newWatermark;
+      lastUpdate = now;
+    }
+  }
+}

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisWatermarkTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/KinesisWatermarkTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kinesis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.function.BooleanSupplier;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+/** Tests {@link KinesisWatermark}. */
+@RunWith(MockitoJUnitRunner.class)
+public class KinesisWatermarkTest {
+  private static final BooleanSupplier SHARDS_UP_TO_DATE = () -> true;
+  private static final BooleanSupplier SHARDS_NOT_UP_TO_DATE = () -> false;
+  private static final BooleanSupplier SHARDS_IRRELEVANT =
+      () -> {
+        throw new AssertionError("Shard status should not be queried");
+      };
+  private final Instant now = Instant.now();
+  private KinesisWatermark watermark;
+
+  @Before
+  public void setUp() {
+    setCurrentTimeTo(now);
+    watermark = new KinesisWatermark();
+  }
+
+  @After
+  public void tearDown() {
+    DateTimeUtils.setCurrentMillisSystem();
+  }
+
+  @Test
+  public void watermarkStartsAtSamplePeriodBehindNowIfShardsUpToDate() {
+    assertThat(watermark.getCurrent(SHARDS_UP_TO_DATE))
+        .isEqualTo(now.minus(KinesisWatermark.SAMPLE_PERIOD));
+  }
+
+  @Test
+  public void watermarkStartsWithMinIfShardsNotUpToDate() {
+    Instant minKinesisWatermark = now.minus(KinesisWatermark.MAX_KINESIS_STREAM_RETENTION_PERIOD);
+
+    assertThat(watermark.getCurrent(SHARDS_NOT_UP_TO_DATE)).isEqualTo(minKinesisWatermark);
+  }
+
+  @Test
+  public void watermarkIsUpdatedToFirstRecordTimestamp() {
+    Instant firstTimestamp = now.minus(Duration.standardHours(1));
+
+    watermark.update(firstTimestamp);
+
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+  }
+
+  @Test
+  public void watermarkIsUpdatedToRecentRecordTimestampIfItIsOlderThanUpdateThreshold() {
+    Instant firstTimestamp = now.minus(Duration.standardHours(1));
+    watermark.update(firstTimestamp);
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+
+    Instant timeAfterWatermarkUpdateThreshold =
+        now.plus(KinesisWatermark.UPDATE_THRESHOLD.plus(Duration.millis(1)));
+    setCurrentTimeTo(timeAfterWatermarkUpdateThreshold);
+    Instant nextTimestamp = timeAfterWatermarkUpdateThreshold.plus(Duration.millis(1));
+    watermark.update(nextTimestamp);
+
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(nextTimestamp);
+  }
+
+  @Test
+  public void watermarkDoesNotChangeWhenTooFewSampleRecordsInSamplePeriod() {
+    Instant firstTimestamp = now.minus(Duration.standardHours(1));
+    watermark.update(firstTimestamp);
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+
+    setCurrentTimeTo(now.plus(KinesisWatermark.SAMPLE_PERIOD));
+    watermark.update(firstTimestamp);
+    for (int i = 1; i <= KinesisWatermark.MIN_MESSAGES / 2; ++i) {
+      Instant plus = firstTimestamp.plus(Duration.millis(i));
+      watermark.update(plus);
+    }
+
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+  }
+
+  @Test
+  public void watermarkAdvancesWhenEnoughRecordsReadRecently() {
+    Instant firstTimestamp = now.minus(Duration.standardHours(1));
+    watermark.update(firstTimestamp);
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+
+    Instant newTimestamp = firstTimestamp.plus(Duration.millis(1));
+    setCurrentTimeTo(now.plus(KinesisWatermark.SAMPLE_PERIOD));
+
+    for (int i = 0; i < KinesisWatermark.MIN_MESSAGES - 1; ++i) {
+      watermark.update(newTimestamp.plus(Duration.millis(i)));
+      assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(firstTimestamp);
+    }
+
+    watermark.update(newTimestamp.plus(Duration.millis(KinesisWatermark.MIN_MESSAGES - 1)));
+    assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(newTimestamp);
+  }
+
+  @Test
+  public void watermarkDoesNotGoBackward() {
+    watermark.update(now);
+    for (int i = 0; i <= KinesisWatermark.MIN_MESSAGES * 2; ++i) {
+      watermark.update(now.minus(Duration.millis(i)));
+      assertThat(watermark.getCurrent(SHARDS_IRRELEVANT)).isEqualTo(now);
+    }
+  }
+
+  private static void setCurrentTimeTo(Instant time) {
+    DateTimeUtils.setCurrentMillisFixed(time.getMillis());
+  }
+}


### PR DESCRIPTION
Kinesis watermark was extracted to separate class (`KinesisWatermark`) to encapsulate its logic. Watermark calculation was changed to mitigate the problem with too low traffic on the corresponding stream. In new implementation, when watermark was not updated within some period of time, it's updated to the recent min from the `MovingFunction`, regardless of the number of samples.

@pawel-kaczmarczyk, @rtshadow, @kennknowles could you please take a look at the changes?

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




