### PR TITLE
[BEAM-3218] Added Quota checks for PubsubMessage in PubsubBoundedWriter

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StringUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/StringUtils.java
@@ -19,7 +19,9 @@ package org.apache.beam.sdk.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /** Utilities for working with JSON and other human-readable string formats. */
@@ -140,5 +142,17 @@ public class StringUtils {
     }
 
     return v1[t.length()];
+  }
+
+  public static int getTotalSizeInBytes(Collection<String> list) {
+    int out = 0;
+    for (String s : list) {
+      out += getStringByteSize(s);
+    }
+    return out;
+  }
+
+  public static int getStringByteSize(String s) {
+    return s.getBytes(StandardCharsets.UTF_8).length;
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/StringUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/StringUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.util;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -53,5 +54,15 @@ public class StringUtilsTest {
     assertEquals(1, StringUtils.getLevenshteinDistance("abc", "ac")); // deletion
     assertEquals(1, StringUtils.getLevenshteinDistance("abc", "ab1c")); // insertion
     assertEquals(1, StringUtils.getLevenshteinDistance("abc", "a1c")); // modification
+  }
+
+  @Test
+  public void testTotalSizeInBytes() {
+    assertEquals(0, StringUtils.getTotalSizeInBytes(Arrays.asList("")));
+    assertEquals(1, StringUtils.getTotalSizeInBytes(Arrays.asList("a")));
+    assertEquals(2, StringUtils.getTotalSizeInBytes(Arrays.asList("ab")));
+    assertEquals(2, StringUtils.getTotalSizeInBytes(Arrays.asList("a", "b")));
+    assertEquals(3, StringUtils.getTotalSizeInBytes(Arrays.asList("abc")));
+    assertEquals(3, StringUtils.getTotalSizeInBytes(Arrays.asList("a", "b", "c")));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessage.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io.gcp.pubsub;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.sdk.util.StringUtils.getTotalSizeInBytes;
 
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -51,5 +52,13 @@ public class PubsubMessage {
   /** Returns the full map of attributes. This is an unmodifiable map. */
   public Map<String, String> getAttributeMap() {
     return attributes;
+  }
+
+  public int getMessageByteSize() {
+    return message.length + getAttributeMapByteSize();
+  }
+
+  int getAttributeMapByteSize() {
+    return getTotalSizeInBytes(attributes.values()) + getTotalSizeInBytes(attributes.keySet());
   }
 }


### PR DESCRIPTION
[BEAM-3218] Added Quota checks for PubsubMessage in PubsubBoundedWriter

@nguyent @kennknowles @reuvenlax @chamikaramj

Please note this is a port of https://github.com/apache/beam/pull/4275.  I ran into issues rebasing the old change so I copied the PR changes here
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




