### PR TITLE
Adds build timer to precommits

### DIFF
--- a/.test-infra/jenkins/PrecommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PrecommitJobBuilder.groovy
@@ -76,6 +76,7 @@ class PrecommitJobBuilder {
         '',
         false,
         triggerPathPatterns)
+      steps.gradle.switches("-PbuildTimer=30")
     }
     job.with additionalCustomization
   }
@@ -86,6 +87,7 @@ class PrecommitJobBuilder {
       description buildDescription("on trigger phrase '${buildTriggerPhrase()}'.")
       concurrentBuild()
       commonJobProperties.setPullRequestBuildTrigger delegate, githubUiHint(), buildTriggerPhrase()
+      steps.gradle.switches("-PbuildTimer=30")
     }
     job.with additionalCustomization
   }

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@
 // that can be applied to configure a project for certain common
 // tasks.
 
+import org.apache.beam.gradle.BuildTimer
+
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 
 // Add performanceTest task to this build.gradle file
@@ -168,6 +170,13 @@ rat {
   excludes = exclusions
 }
 check.dependsOn rat
+
+// Add a timer that will fail this build if it takes longer than buildTimer
+// minutes.
+if (project.hasProperty('buildTimer')) {
+  BuildTimer timer = new BuildTimer(Long.parseLong(project.buildTimer, 10));
+  gradle.addBuildListener(timer);
+}
 
 // Define root pre/post commit tasks simplifying what is needed
 // to be specified on the commandline when executing locally.

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BuildTimer.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BuildTimer.groovy
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.gradle
+
+import java.time.Duration
+import java.time.Instant
+import org.gradle.BuildAdapter
+import org.gradle.BuildResult
+import org.gradle.api.GradleException
+import org.gradle.api.invocation.Gradle
+
+
+/**
+ * BuildListener that throws an exception if the build was successful but took
+ * longer than a given number of minutes to complete.
+ */
+class BuildTimer extends BuildAdapter {
+  private Instant buildBegin;
+  private long maxMinutes;
+
+  public BuildTimer(long maxMinutes) {
+    this.maxMinutes = maxMinutes;
+    // BuildStarted is never called for user-defined listeners, so start the timer now.
+    // https://github.com/gradle/gradle/issues/4315
+    buildBegin = Instant.now();
+  }
+
+  @Override
+  void buildFinished(BuildResult result) {
+    Duration duration = Duration.between(buildBegin, Instant.now());
+    float minutes = duration.toSeconds() / 60;
+    if (result.failure != null) {
+      return
+    }
+    if (minutes > maxMinutes) {
+      throw new GradleException("Build took longer than $maxMinutes minutes: $minutes");
+    }
+  }
+}


### PR DESCRIPTION
Timer is started for Commit and Phrase invocations of precommits.
If timer elapses (build takes >30m) the build is failed.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




