### PR TITLE
[BEAM-5110] Explicitly count the references for BatchFlinkExecutableStageContext …

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchExecutableStageContext.java
@@ -17,10 +17,16 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.control.DockerJobBundleFactory;
 import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
@@ -35,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Implementation of a {@link FlinkExecutableStageContext} for batch jobs. */
-class FlinkBatchExecutableStageContext implements FlinkExecutableStageContext {
+class FlinkBatchExecutableStageContext implements FlinkExecutableStageContext, AutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(FlinkBatchExecutableStageContext.class);
 
   private final JobBundleFactory jobBundleFactory;
@@ -68,32 +74,132 @@ class FlinkBatchExecutableStageContext implements FlinkExecutableStageContext {
   }
 
   @Override
-  protected void finalize() throws Exception {
+  public void close() throws Exception {
     jobBundleFactory.close();
   }
 
   enum BatchFactory implements Factory {
-    INSTANCE;
+    REFERENCE_COUNTING {
+      private static final int TTL_IN_SECONDS = 30;
+      int MAX_RETRY = 3;
 
-    @SuppressWarnings("Immutable") // observably immutable
-    private final LoadingCache<JobInfo, FlinkBatchExecutableStageContext> cachedContexts;
+      @SuppressWarnings("Immutable") // observably immutable
+      private final ScheduledExecutorService executor =
+          Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
 
-    BatchFactory() {
-      cachedContexts =
-          CacheBuilder.newBuilder()
-              .weakValues()
-              .build(
-                  new CacheLoader<JobInfo, FlinkBatchExecutableStageContext>() {
-                    @Override
-                    public FlinkBatchExecutableStageContext load(JobInfo jobInfo) throws Exception {
-                      return create(jobInfo);
+      @SuppressWarnings("Immutable") // observably immutable
+      private final ConcurrentHashMap<String, ContextWrapper> keyRegistry =
+          new ConcurrentHashMap<>();
+
+      @Override
+      public FlinkExecutableStageContext get(JobInfo jobInfo) {
+        // Retry is needed in case where an existing wrapper is picked from the keyRegistry but by
+        // the time we accessed wrapper.referenceCount, the wrapper was tombstoned by a pending
+        // release task.
+        // This race condition is highly unlikely to happen as there is no systematic coding
+        // practice which can cause this error because of TTL. However, even in very unlikely case
+        // when it happen we have the retry which get a valid context.
+        // Note: There is no leak in this logic as the cleanup is only done in release.
+        // In case of usage error where release is called before corresponding get finishes,
+        // release might throw an error. If release did not throw an error than we can be sure that
+        // the state of the system remains valid and appropriate cleanup will be done at TTL.
+        for (int retry = 0; retry < MAX_RETRY; retry++) {
+          // ConcurrentHashMap will handle the thread safety at the creation time.
+          ContextWrapper wrapper =
+              keyRegistry.computeIfAbsent(
+                  jobInfo.jobId(),
+                  jobId -> {
+                    try {
+                      return new ContextWrapper(jobInfo.jobId(), create(jobInfo));
+                    } catch (Exception e) {
+                      throw new RuntimeException(
+                          "Unable to create context for job " + jobInfo.jobId(), e);
                     }
                   });
-    }
+          // Take a lock on wrapper before modifying reference count.
+          // Use null referenceCount == null as a tombstone for the wrapper.
+          synchronized (wrapper) {
+            if (wrapper.referenceCount != null) {
+              // The wrapper is still valid.
+              // Release has not yet got the lock and has not yet removed the wrapper.
+              wrapper.referenceCount.incrementAndGet();
+              return wrapper.context;
+            }
+          }
+        }
 
-    @Override
-    public FlinkExecutableStageContext get(JobInfo jobInfo) {
-      return cachedContexts.getUnchecked(jobInfo);
+        throw new RuntimeException(
+            String.format(
+                "Max retry %s exhausted while creating Context for job %s",
+                MAX_RETRY, jobInfo.jobId()));
+      }
+
+      @Override
+      public void release(JobInfo jobInfo) {
+        ContextWrapper wrapper = keyRegistry.get(jobInfo.jobId());
+        Preconditions.checkState(
+            wrapper != null, "Releasing context for unknown job: " + jobInfo.jobId());
+        // Schedule task to clean the container later.
+        @SuppressWarnings("FutureReturnValueIgnored")
+        ScheduledFuture unused =
+            executor.schedule(
+                () -> {
+                  synchronized (wrapper) {
+                    if (wrapper.referenceCount.decrementAndGet() == 0) {
+                      // Tombstone wrapper.
+                      wrapper.referenceCount = null;
+                      if (keyRegistry.remove(wrapper.jobId, wrapper)) {
+                        try (AutoCloseable context = wrapper.context) {
+                        } catch (Exception e) {
+                          LOG.error("Unable to close.", e);
+                        }
+                      }
+                    }
+                  }
+                },
+                TTL_IN_SECONDS,
+                TimeUnit.SECONDS);
+      }
+
+      class ContextWrapper {
+        private String jobId;
+        private AtomicInteger referenceCount;
+        private FlinkBatchExecutableStageContext context;
+
+        ContextWrapper(String jobId, FlinkBatchExecutableStageContext context) {
+          this.jobId = jobId;
+          this.context = context;
+          this.referenceCount = new AtomicInteger(0);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+          if (this == o) {
+            return true;
+          }
+          if (o == null || getClass() != o.getClass()) {
+            return false;
+          }
+          ContextWrapper that = (ContextWrapper) o;
+          return Objects.equals(jobId, that.jobId);
+        }
+
+        @Override
+        public int hashCode() {
+          return Objects.hash(jobId);
+        }
+
+        @Override
+        public String toString() {
+          return "ContextWrapper{"
+              + "jobId='"
+              + jobId
+              + '\''
+              + ", referenceCount="
+              + referenceCount
+              + '}';
+        }
+      }
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchExecutableStageContext.java
@@ -17,16 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
-import com.google.common.base.Preconditions;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.IOException;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.control.DockerJobBundleFactory;
 import org.apache.beam.runners.fnexecution.control.JobBundleFactory;
@@ -79,127 +70,15 @@ class FlinkBatchExecutableStageContext implements FlinkExecutableStageContext, A
   }
 
   enum BatchFactory implements Factory {
-    REFERENCE_COUNTING {
-      private static final int TTL_IN_SECONDS = 30;
-      int MAX_RETRY = 3;
+    REFERENCE_COUNTING;
 
-      @SuppressWarnings("Immutable") // observably immutable
-      private final ScheduledExecutorService executor =
-          Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
+    private static final ReferenceCountingFlinkExecutableStageContextFactory actualFactory =
+        ReferenceCountingFlinkExecutableStageContextFactory.create(
+            FlinkBatchExecutableStageContext::create);
 
-      @SuppressWarnings("Immutable") // observably immutable
-      private final ConcurrentHashMap<String, ContextWrapper> keyRegistry =
-          new ConcurrentHashMap<>();
-
-      @Override
-      public FlinkExecutableStageContext get(JobInfo jobInfo) {
-        // Retry is needed in case where an existing wrapper is picked from the keyRegistry but by
-        // the time we accessed wrapper.referenceCount, the wrapper was tombstoned by a pending
-        // release task.
-        // This race condition is highly unlikely to happen as there is no systematic coding
-        // practice which can cause this error because of TTL. However, even in very unlikely case
-        // when it happen we have the retry which get a valid context.
-        // Note: There is no leak in this logic as the cleanup is only done in release.
-        // In case of usage error where release is called before corresponding get finishes,
-        // release might throw an error. If release did not throw an error than we can be sure that
-        // the state of the system remains valid and appropriate cleanup will be done at TTL.
-        for (int retry = 0; retry < MAX_RETRY; retry++) {
-          // ConcurrentHashMap will handle the thread safety at the creation time.
-          ContextWrapper wrapper =
-              keyRegistry.computeIfAbsent(
-                  jobInfo.jobId(),
-                  jobId -> {
-                    try {
-                      return new ContextWrapper(jobInfo.jobId(), create(jobInfo));
-                    } catch (Exception e) {
-                      throw new RuntimeException(
-                          "Unable to create context for job " + jobInfo.jobId(), e);
-                    }
-                  });
-          // Take a lock on wrapper before modifying reference count.
-          // Use null referenceCount == null as a tombstone for the wrapper.
-          synchronized (wrapper) {
-            if (wrapper.referenceCount != null) {
-              // The wrapper is still valid.
-              // Release has not yet got the lock and has not yet removed the wrapper.
-              wrapper.referenceCount.incrementAndGet();
-              return wrapper.context;
-            }
-          }
-        }
-
-        throw new RuntimeException(
-            String.format(
-                "Max retry %s exhausted while creating Context for job %s",
-                MAX_RETRY, jobInfo.jobId()));
-      }
-
-      @Override
-      public void release(JobInfo jobInfo) {
-        ContextWrapper wrapper = keyRegistry.get(jobInfo.jobId());
-        Preconditions.checkState(
-            wrapper != null, "Releasing context for unknown job: " + jobInfo.jobId());
-        // Schedule task to clean the container later.
-        @SuppressWarnings("FutureReturnValueIgnored")
-        ScheduledFuture unused =
-            executor.schedule(
-                () -> {
-                  synchronized (wrapper) {
-                    if (wrapper.referenceCount.decrementAndGet() == 0) {
-                      // Tombstone wrapper.
-                      wrapper.referenceCount = null;
-                      if (keyRegistry.remove(wrapper.jobId, wrapper)) {
-                        try (AutoCloseable context = wrapper.context) {
-                        } catch (Exception e) {
-                          LOG.error("Unable to close.", e);
-                        }
-                      }
-                    }
-                  }
-                },
-                TTL_IN_SECONDS,
-                TimeUnit.SECONDS);
-      }
-
-      class ContextWrapper {
-        private String jobId;
-        private AtomicInteger referenceCount;
-        private FlinkBatchExecutableStageContext context;
-
-        ContextWrapper(String jobId, FlinkBatchExecutableStageContext context) {
-          this.jobId = jobId;
-          this.context = context;
-          this.referenceCount = new AtomicInteger(0);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-          if (this == o) {
-            return true;
-          }
-          if (o == null || getClass() != o.getClass()) {
-            return false;
-          }
-          ContextWrapper that = (ContextWrapper) o;
-          return Objects.equals(jobId, that.jobId);
-        }
-
-        @Override
-        public int hashCode() {
-          return Objects.hash(jobId);
-        }
-
-        @Override
-        public String toString() {
-          return "ContextWrapper{"
-              + "jobId='"
-              + jobId
-              + '\''
-              + ", referenceCount="
-              + referenceCount
-              + '}';
-        }
-      }
+    @Override
+    public FlinkExecutableStageContext get(JobInfo jobInfo) {
+      return actualFactory.get(jobInfo);
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -25,7 +25,7 @@ import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.flink.api.common.functions.RuntimeContext;
 
 /** The Flink context required in order to execute {@link ExecutableStage stages}. */
-public interface FlinkExecutableStageContext {
+public interface FlinkExecutableStageContext extends AutoCloseable {
 
   /**
    * Creates {@link FlinkExecutableStageContext} instances. Serializable so that factories can be
@@ -33,18 +33,8 @@ public interface FlinkExecutableStageContext {
    */
   interface Factory extends Serializable {
 
-    /**
-     * Get or create {@link FlinkExecutableStageContext} for given {@link JobInfo}. {@link
-     * Factory#release(JobInfo)} should be called for each get request for the jobInfo.
-     */
+    /** Get or create {@link FlinkExecutableStageContext} for given {@link JobInfo}. */
     FlinkExecutableStageContext get(JobInfo jobInfo);
-
-    /**
-     * Release the context for the jobInfo. This method should be called for each call to {@link
-     * Factory#get(JobInfo)}. This method should always be called after the call to {@link
-     * Factory#get(JobInfo)} is completed.
-     */
-    void release(JobInfo jobInfo);
   }
 
   static Factory batchFactory() {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -32,11 +32,23 @@ public interface FlinkExecutableStageContext {
    * defined at translation time and distributed to TaskManagers.
    */
   interface Factory extends Serializable {
+
+    /**
+     * Get or create {@link FlinkExecutableStageContext} for given {@link JobInfo}. {@link
+     * Factory#release(JobInfo)} should be called for each get request for the jobInfo.
+     */
     FlinkExecutableStageContext get(JobInfo jobInfo);
+
+    /**
+     * Release the context for the jobInfo. This method should be called for each call to {@link
+     * Factory#get(JobInfo)}. This method should always be called after the call to {@link
+     * Factory#get(JobInfo)} is completed.
+     */
+    void release(JobInfo jobInfo);
   }
 
   static Factory batchFactory() {
-    return FlinkBatchExecutableStageContext.BatchFactory.INSTANCE;
+    return FlinkBatchExecutableStageContext.BatchFactory.REFERENCE_COUNTING;
   }
 
   StageBundleFactory getStageBundleFactory(ExecutableStage executableStage);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
+import org.apache.beam.sdk.fn.function.ThrowingFunction;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * {@link FlinkExecutableStageContext.Factory} which counts FlinkExecutableStageContext reference
+ * for book keeping.
+ */
+public class ReferenceCountingFlinkExecutableStageContextFactory
+    implements FlinkExecutableStageContext.Factory {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ReferenceCountingFlinkExecutableStageContextFactory.class);
+  private static final int TTL_IN_SECONDS = 30;
+  private static final int MAX_RETRY = 3;
+
+  private final ScheduledExecutorService executor =
+      Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
+
+  private final ConcurrentHashMap<String, WrappedContext> keyRegistry = new ConcurrentHashMap<>();
+  private final ThrowingFunction<JobInfo, FlinkExecutableStageContext> creator;
+
+  public static ReferenceCountingFlinkExecutableStageContextFactory create(
+      ThrowingFunction<JobInfo, FlinkExecutableStageContext> creator) {
+    return new ReferenceCountingFlinkExecutableStageContextFactory(creator);
+  }
+
+  private ReferenceCountingFlinkExecutableStageContextFactory(
+      ThrowingFunction<JobInfo, FlinkExecutableStageContext> creator) {
+    this.creator = creator;
+  }
+
+  @Override
+  public FlinkExecutableStageContext get(JobInfo jobInfo) {
+    // Retry is needed in case where an existing wrapper is picked from the keyRegistry but by
+    // the time we accessed wrapper.referenceCount, the wrapper was tombstoned by a pending
+    // release task.
+    // This race condition is highly unlikely to happen as there is no systematic coding
+    // practice which can cause this error because of TTL. However, even in very unlikely case
+    // when it happen we have the retry which get a valid context.
+    // Note: There is no leak in this logic as the cleanup is only done in release.
+    // In case of usage error where release is called before corresponding get finishes,
+    // release might throw an error. If release did not throw an error than we can be sure that
+    // the state of the system remains valid and appropriate cleanup will be done at TTL.
+    for (int retry = 0; retry < MAX_RETRY; retry++) {
+      // ConcurrentHashMap will handle the thread safety at the creation time.
+      WrappedContext wrapper =
+          keyRegistry.computeIfAbsent(
+              jobInfo.jobId(),
+              jobId -> {
+                try {
+                  return new WrappedContext(jobInfo, creator.apply(jobInfo));
+                } catch (Exception e) {
+                  throw new RuntimeException(
+                      "Unable to create context for job " + jobInfo.jobId(), e);
+                }
+              });
+      // Take a lock on wrapper before modifying reference count.
+      // Use null referenceCount == null as a tombstone for the wrapper.
+      synchronized (wrapper) {
+        if (wrapper.referenceCount != null) {
+          // The wrapper is still valid.
+          // Release has not yet got the lock and has not yet removed the wrapper.
+          wrapper.referenceCount.incrementAndGet();
+          return wrapper;
+        }
+      }
+    }
+
+    throw new RuntimeException(
+        String.format(
+            "Max retry %s exhausted while creating Context for job %s",
+            MAX_RETRY, jobInfo.jobId()));
+  }
+
+  private void scheduleRelease(JobInfo jobInfo) {
+    WrappedContext wrapper = keyRegistry.get(jobInfo.jobId());
+    Preconditions.checkState(
+        wrapper != null, "Releasing context for unknown job: " + jobInfo.jobId());
+    // Schedule task to clean the container later.
+    @SuppressWarnings("FutureReturnValueIgnored")
+    ScheduledFuture unused =
+        executor.schedule(() -> release(wrapper), TTL_IN_SECONDS, TimeUnit.SECONDS);
+  }
+
+  @VisibleForTesting
+  void release(FlinkExecutableStageContext context) {
+    @SuppressWarnings({"unchecked", "Not exected to be called from outside."})
+    WrappedContext wrapper = (WrappedContext) context;
+    synchronized (wrapper) {
+      if (wrapper.referenceCount.decrementAndGet() == 0) {
+        // Tombstone wrapper.
+        wrapper.referenceCount = null;
+        if (keyRegistry.remove(wrapper.jobInfo.jobId(), wrapper)) {
+          try {
+            wrapper.closeActual();
+          } catch (Exception e) {
+            LOG.error("Unable to close.", e);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * {@link WrappedContext} does not expose equals of actual {@link FlinkExecutableStageContext}.
+   */
+  private class WrappedContext implements FlinkExecutableStageContext {
+    private JobInfo jobInfo;
+    private AtomicInteger referenceCount;
+    private FlinkExecutableStageContext context;
+
+    /** {@link WrappedContext#equals(Object)} is only based on {@link JobInfo#jobId()}. */
+    WrappedContext(JobInfo jobInfo, FlinkExecutableStageContext context) {
+      this.jobInfo = jobInfo;
+      this.context = context;
+      this.referenceCount = new AtomicInteger(0);
+    }
+
+    @Override
+    public StageBundleFactory getStageBundleFactory(ExecutableStage executableStage) {
+      return context.getStageBundleFactory(executableStage);
+    }
+
+    @Override
+    public StateRequestHandler getStateRequestHandler(
+        ExecutableStage executableStage, RuntimeContext runtimeContext) {
+      return context.getStateRequestHandler(executableStage, runtimeContext);
+    }
+
+    @Override
+    public void close() {
+      // Just schedule the context as we want to reuse it if possible.
+      scheduleRelease(jobInfo);
+    }
+
+    private void closeActual() throws Exception {
+      context.close();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      WrappedContext that = (WrappedContext) o;
+      return Objects.equals(jobInfo.jobId(), that.jobInfo.jobId());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(jobInfo);
+    }
+
+    @Override
+    public String toString() {
+      return "ContextWrapper{"
+          + "jobId='"
+          + jobInfo
+          + '\''
+          + ", referenceCount="
+          + referenceCount
+          + '}';
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -151,6 +151,7 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
     try (AutoCloseable bundleFactoryCloser = stageBundleFactory) {}
     // Remove the reference to stageContext and make stageContext available for garbage collection.
     stageContext = null;
+    contextFactory.release(jobInfo);
     super.close();
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -150,8 +150,8 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
   public void close() throws Exception {
     try (AutoCloseable bundleFactoryCloser = stageBundleFactory) {}
     // Remove the reference to stageContext and make stageContext available for garbage collection.
+    try (AutoCloseable closable = stageContext) {}
     stageContext = null;
-    contextFactory.release(jobInfo);
     super.close();
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactoryTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactoryTest.java
@@ -21,8 +21,8 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.beam.runners.flink.translation.functions.ReferenceCountingFlinkExecutableStageContextFactory.Creator;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
-import org.apache.beam.sdk.fn.function.ThrowingFunction;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +35,7 @@ public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
   @Test
   public void testCreateReuseReleaseCreate() throws Exception {
 
-    ThrowingFunction<JobInfo, FlinkExecutableStageContext> creator = mock(ThrowingFunction.class);
+    Creator creator = mock(Creator.class);
     FlinkExecutableStageContext c1 = mock(FlinkExecutableStageContext.class);
     FlinkExecutableStageContext c2 = mock(FlinkExecutableStageContext.class);
     FlinkExecutableStageContext c3 = mock(FlinkExecutableStageContext.class);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactoryTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactoryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.fn.function.ThrowingFunction;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ReferenceCountingFlinkExecutableStageContextFactory}. */
+@RunWith(JUnit4.class)
+public class ReferenceCountingFlinkExecutableStageContextFactoryTest {
+
+  @Test
+  public void testCreateReuseReleaseCreate() throws Exception {
+
+    ThrowingFunction<JobInfo, FlinkExecutableStageContext> creator = mock(ThrowingFunction.class);
+    FlinkExecutableStageContext c1 = mock(FlinkExecutableStageContext.class);
+    FlinkExecutableStageContext c2 = mock(FlinkExecutableStageContext.class);
+    FlinkExecutableStageContext c3 = mock(FlinkExecutableStageContext.class);
+    FlinkExecutableStageContext c4 = mock(FlinkExecutableStageContext.class);
+    when(creator.apply(any(JobInfo.class)))
+        .thenReturn(c1)
+        .thenReturn(c2)
+        .thenReturn(c3)
+        .thenReturn(c4);
+    ReferenceCountingFlinkExecutableStageContextFactory factory =
+        ReferenceCountingFlinkExecutableStageContextFactory.create(creator);
+    JobInfo jobA = mock(JobInfo.class);
+    when(jobA.jobId()).thenReturn("jobA");
+    JobInfo jobB = mock(JobInfo.class);
+    when(jobB.jobId()).thenReturn("jobB");
+    FlinkExecutableStageContext ac1A = factory.get(jobA); // 1 open jobA
+    FlinkExecutableStageContext ac2B = factory.get(jobB); // 1 open jobB
+    Assert.assertSame(
+        "Context should be cached and reused.", ac1A, factory.get(jobA)); // 2 open jobA
+    Assert.assertSame(
+        "Context should be cached and reused.", ac2B, factory.get(jobB)); // 2 open jobB
+    factory.release(ac1A); // 1 open jobA
+    Assert.assertSame(
+        "Context should be cached and reused.", ac1A, factory.get(jobA)); // 2 open jobA
+    factory.release(ac1A); // 1 open jobA
+    factory.release(ac1A); // 0 open jobA
+    FlinkExecutableStageContext ac3A = factory.get(jobA); // 1 open jobA
+    Assert.assertNotSame("We should get a new instance.", ac1A, ac3A);
+    Assert.assertSame(
+        "Context should be cached and reused.", ac3A, factory.get(jobA)); // 2 open jobA
+    factory.release(ac3A); // 1 open jobA
+    factory.release(ac3A); // 0 open jobA
+    Assert.assertSame(
+        "Context should be cached and reused.", ac2B, factory.get(jobB)); // 3 open jobB
+    factory.release(ac2B); // 2 open jobB
+    factory.release(ac2B); // 1 open jobB
+    factory.release(ac2B); // 0 open jobB
+    FlinkExecutableStageContext ac4B = factory.get(jobB); // 1 open jobB
+    Assert.assertNotSame("We should get a new instance.", ac2B, ac4B);
+    factory.release(ac4B); // 0 open jobB
+  }
+}


### PR DESCRIPTION
…and clean them after TTL

We relied on weak reference and finalize to keep track of active BatchFlinkExecutableStageContext for each job. This is error prone and sub optimal and has been on our radar for cleanup.
Introducing explicit reference counting and cleanup of BatchFlinkExecutableStageContext for each job.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




