### PR TITLE
[BEAM-5114] Create example uber jars

### DIFF
--- a/examples/java/direct/build.gradle
+++ b/examples/java/direct/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+// Disable default shadow jar closure and include all class files and resources.
+applyJavaNature(shadowClosure: {})
+
+dependencies {
+    compile project(path: ":beam-examples-java", configuration: "shadow")
+    compile project(path: ":beam-examples-java", configuration: "directRunnerPreCommit")
+}

--- a/examples/java/flink/build.gradle
+++ b/examples/java/flink/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+// Disable default shadow jar closure and include all class files and resources.
+applyJavaNature(shadowClosure: {})
+
+dependencies {
+    compile project(path: ":beam-examples-java", configuration: "shadow")
+    compile project(path: ":beam-examples-java", configuration: "flinkRunnerPreCommit")
+}

--- a/examples/java/portable/build.gradle
+++ b/examples/java/portable/build.gradle
@@ -20,15 +20,7 @@ import groovy.json.JsonOutput
 
 apply plugin: org.apache.beam.gradle.BeamModulePlugin
 // Disable default shadow jar closure and include all class files and resources.
-applyJavaNature(shadowClosure: {
-    dependencies {
-        include {
-            compile project(path: ":beam-examples-java", configuration: "shadow")
-            compile project(path: ":beam-runners-reference-java", configuration: "shadow")
-        }
-    }
-} << DEFAULT_BLAH)
-//applyJavaNature(shadowClosure: {})
+applyJavaNature(shadowClosure: {})
 
 dependencies {
     compile project(path: ":beam-examples-java", configuration: "shadow")

--- a/examples/java/portable/build.gradle
+++ b/examples/java/portable/build.gradle
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+// Disable default shadow jar closure and include all class files and resources.
+applyJavaNature(shadowClosure: {
+    dependencies {
+        include {
+            compile project(path: ":beam-examples-java", configuration: "shadow")
+            compile project(path: ":beam-runners-reference-java", configuration: "shadow")
+        }
+    }
+} << DEFAULT_BLAH)
+//applyJavaNature(shadowClosure: {})
+
+dependencies {
+    compile project(path: ":beam-examples-java", configuration: "shadow")
+    compile project(path: ":beam-runners-reference-java", configuration: "shadow")
+}

--- a/examples/java/spark/build.gradle
+++ b/examples/java/spark/build.gradle
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * License); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import groovy.json.JsonOutput
+
+apply plugin: org.apache.beam.gradle.BeamModulePlugin
+// Disable default shadow jar closure and include all class files and resources.
+applyJavaNature(shadowClosure: {})
+
+dependencies {
+    compile project(path: ":beam-examples-java", configuration: "shadow")
+    compile project(path: ":beam-examples-java", configuration: "sparkRunnerPreCommit")
+}

--- a/runners/reference/java/build.gradle
+++ b/runners/reference/java/build.gradle
@@ -29,6 +29,7 @@ configurations {
 }
 
 dependencies {
+  compile library.java.guava
   compile library.java.hamcrest_library
   shadow project(path: ":beam-model-pipeline", configuration: "shadow")
   shadow project(path: ":beam-runners-core-construction-java", configuration: "shadow")

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,14 @@ include ":release"
 
 include "beam-examples-java"
 project(":beam-examples-java").dir = file("examples/java")
+include "beam-examples-java-direct"
+project(":beam-examples-java-direct").dir = file("examples/java/direct")
+include "beam-examples-java-flink"
+project(":beam-examples-java-flink").dir = file("examples/java/flink")
+include "beam-examples-java-portable"
+project(":beam-examples-java-portable").dir = file("examples/java/portable")
+include "beam-examples-java-spark"
+project(":beam-examples-java-spark").dir = file("examples/java/spark")
 include "beam-model-fn-execution"
 project(":beam-model-fn-execution").dir = file("model/fn-execution")
 include "beam-model-job-management"


### PR DESCRIPTION
This adds uber jars for the Java examples for each precommit runner (as well as the portable runner).

While trying to run the examples against the portable runner, I noticed a runtime issue due to a missing guava dependency in the reference runner. Piggy-backed a fix here.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




