### PR TITLE
[Do not review] Add JiraTestResultReporter plugin config.

### DIFF
--- a/.test-infra/jenkins/NoPhraseTriggeringPostCommitBuilder.groovy
+++ b/.test-infra/jenkins/NoPhraseTriggeringPostCommitBuilder.groovy
@@ -26,6 +26,6 @@ class NoPhraseTriggeringPostCommitBuilder extends PostcommitJobBuilder{
                             scope,
                             jobDefinition = {}) {
     PostcommitJobBuilder jb = new PostcommitJobBuilder(scope, jobDefinition)
-    jb.defineAutoPostCommitJob(nameBase)
+    jb.defineAutoPostCommitJob(nameBase, "dummy phraze that must never occur alllsood", "dummy description")
   }
 }

--- a/.test-infra/jenkins/PostcommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PostcommitJobBuilder.groovy
@@ -43,14 +43,19 @@ class PostcommitJobBuilder {
                             scope,
                             jobDefinition = {}) {
     PostcommitJobBuilder jb = new PostcommitJobBuilder(scope, jobDefinition)
-    jb.defineAutoPostCommitJob(nameBase)
+    jb.defineAutoPostCommitJob(nameBase, triggerPhrase + " temp", githubUiHint + " temp")
     jb.defineGhprbTriggeredJob(nameBase + "_PR", triggerPhrase, githubUiHint, false)
   }
 
-  void defineAutoPostCommitJob(name) {
+  void defineAutoPostCommitJob(name, triggerPhrase, githubUiHint) {
     def autoBuilds = scope.job(name) {
       commonJobProperties.setAutoJob delegate, '0 */6 * * *', 'commits@beam.apache.org', true
 
+      cjp.setPullRequestBuildTrigger(
+        delegate,
+        githubUiHint,
+        triggerPhrase,
+        true)
     }
 
     autoBuilds.with(jobDefinition)

--- a/.test-infra/jenkins/PostcommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PostcommitJobBuilder.groovy
@@ -51,7 +51,7 @@ class PostcommitJobBuilder {
     def autoBuilds = scope.job(name) {
       commonJobProperties.setAutoJob delegate, '0 */6 * * *', 'commits@beam.apache.org', true
 
-      cjp.setPullRequestBuildTrigger(
+      commonJobProperties.setPullRequestBuildTrigger(
         delegate,
         githubUiHint,
         triggerPhrase,

--- a/.test-infra/jenkins/PostcommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PostcommitJobBuilder.groovy
@@ -18,6 +18,8 @@
 
 import CommonJobProperties as commonJobProperties
 
+
+
 /**
  * This class is to be used for defining jobs for post- and pre-commit tests.
  *
@@ -48,6 +50,7 @@ class PostcommitJobBuilder {
   void defineAutoPostCommitJob(name) {
     def autoBuilds = scope.job(name) {
       commonJobProperties.setAutoJob delegate, '0 */6 * * *', 'commits@beam.apache.org', true
+
     }
 
     autoBuilds.with(jobDefinition)


### PR DESCRIPTION
Configure JiraTestResultReporter plugin for java post-commit job.

Config should be valid. Requires infra team ticket 16767.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




