### PR TITLE
[BEAM-5101][SQL] Improve tests of Floor and Ceil functions

### DIFF
--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslSqlStdOperatorsTest.java
@@ -1112,16 +1112,29 @@ public class BeamSqlDslSqlStdOperatorsTest extends BeamSqlBuiltinFunctionsIntegr
   }
 
   @Test
-  // More needed @SqlOperatorTest(name = "FLOOR", kind = "FLOOR")
-  // More needed @SqlOperatorTest(name = "CEIL", kind = "CEIL")
-  public void testFloorAndCeil() {
+  // https://issues.apache.org/jira/browse/BEAM-5128
+  // @SqlOperatorTest(name = "FLOOR", kind = "FLOOR")
+  public void testFloor() {
     ExpressionChecker checker =
         new ExpressionChecker()
             .addExpr("FLOOR(ts TO MONTH)", parseDate("1986-02-01 00:00:00"))
             .addExpr("FLOOR(ts TO YEAR)", parseDate("1986-01-01 00:00:00"))
+            .addExpr("FLOOR(c_double)", 1.0);
+
+    checker.buildRunAndCheck(getFloorCeilingTestPCollection());
+  }
+
+  @Test
+  // https://issues.apache.org/jira/browse/BEAM-5128
+  // @SqlOperatorTest(name = "CEIL", kind = "CEIL")
+  public void testCeil() {
+    ExpressionChecker checker =
+        new ExpressionChecker()
             .addExpr("CEIL(ts TO MONTH)", parseDate("1986-03-01 00:00:00"))
-            .addExpr("CEIL(ts TO YEAR)", parseDate("1987-01-01 00:00:00"));
-    checker.buildRunAndCheck();
+            .addExpr("CEIL(ts TO YEAR)", parseDate("1987-01-01 00:00:00"))
+            .addExpr("CEIL(c_double)", 2.0);
+
+    checker.buildRunAndCheck(getFloorCeilingTestPCollection());
   }
 
   @Test

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -106,6 +106,12 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
           .addNullableField("c_decimal", FieldType.DECIMAL)
           .build();
 
+  private static final Schema ROW_TYPE_THREE =
+      Schema.builder()
+          .addField("ts", FieldType.DATETIME)
+          .addField("c_double", FieldType.DOUBLE)
+          .build();
+
   @Rule public final TestPipeline pipeline = TestPipeline.create();
 
   protected PCollection<Row> getTestPCollection() {
@@ -126,6 +132,17 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
               9223372036854775807L)
           .buildIOReader(pipeline.begin())
           .setRowSchema(ROW_TYPE);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected PCollection<Row> getFloorCeilingTestPCollection() {
+    try {
+      return MockedBoundedTable.of(ROW_TYPE_THREE)
+          .addRows(parseDate("1986-02-15 11:35:26"), 1.4)
+          .buildIOReader(pipeline.begin())
+          .setRowSchema(ROW_TYPE_THREE);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Improve  tests of Floor and Ceil functions. 


There is a bug for Floor and Ceil where Floor and Ceil convert some primitive types (e.g. int) to Double but the code [BeamCalcRel](https://github.com/apache/beam/blob/master/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamCalcRel.java#L127) still generates a ROW with initial schema (e.g. int32), so Row verification will fail because of mismatch between, for example, INT32 type and Double value. Add a `@Ingore` with created [bug JIRA](https://issues.apache.org/jira/browse/BEAM-5128) to the unit test.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




