### PR TITLE
[BEAM-5141] Improve error message when SET unregistered options

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionUnexpectedPropertyException.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionUnexpectedPropertyException.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.options;
+
+import com.google.common.collect.Iterables;
+import java.util.SortedSet;
+
+/** An exception used when encounter unexpected properties. */
+public class PipelineOptionUnexpectedPropertyException extends IllegalArgumentException {
+  private static final long serialVersionUID = 3265630128856068164L;
+
+  private final String propertyName;
+  private final SortedSet<String> closestMatches;
+
+  public static PipelineOptionUnexpectedPropertyException create(
+      Class optionClass, String propertyName, SortedSet<String> closestMatches) {
+    String errorMessage = createErrorMessage(optionClass, propertyName, closestMatches);
+    PipelineOptionUnexpectedPropertyException exception =
+        new PipelineOptionUnexpectedPropertyException(errorMessage, propertyName, closestMatches);
+    return exception;
+  }
+
+  private static String createErrorMessage(
+      Class optionClass, String propertyName, SortedSet<String> closestMatches) {
+    String ret;
+
+    switch (closestMatches.size()) {
+      case 0:
+        ret = String.format("Class %s missing a property named '%s'.", optionClass, propertyName);
+        break;
+      case 1:
+        ret =
+            String.format(
+                "Class %s missing a property named '%s'. Did you mean '%s'?",
+                optionClass, propertyName, Iterables.getOnlyElement(closestMatches));
+        break;
+      default:
+        ret =
+            String.format(
+                "Class %s missing a property named '%s'. Did you mean one of %s?",
+                optionClass, propertyName, closestMatches);
+        break;
+    }
+
+    return ret;
+  }
+
+  private PipelineOptionUnexpectedPropertyException(
+      String errorMessage, String propertyName, SortedSet<String> closestMatches) {
+    super(errorMessage);
+    this.propertyName = propertyName;
+    this.closestMatches = closestMatches;
+  }
+
+  public String getPropertyName() {
+    return propertyName;
+  }
+
+  public SortedSet<String> getClosestMatches() {
+    return closestMatches;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1512,21 +1512,9 @@ public class PipelineOptionsFactory {
                   Sets.filter(
                       propertyNamesToGetters.keySet(),
                       input -> StringUtils.getLevenshteinDistance(entry.getKey(), input) <= 2));
-          switch (closestMatches.size()) {
-            case 0:
-              throw new IllegalArgumentException(
-                  String.format("Class %s missing a property named '%s'.", klass, entry.getKey()));
-            case 1:
-              throw new IllegalArgumentException(
-                  String.format(
-                      "Class %s missing a property named '%s'. Did you mean '%s'?",
-                      klass, entry.getKey(), Iterables.getOnlyElement(closestMatches)));
-            default:
-              throw new IllegalArgumentException(
-                  String.format(
-                      "Class %s missing a property named '%s'. Did you mean one of %s?",
-                      klass, entry.getKey(), closestMatches));
-          }
+
+          throw PipelineOptionUnexpectedPropertyException.create(
+              klass, entry.getKey(), closestMatches);
         }
         Method method = propertyNamesToGetters.get(entry.getKey());
         // Only allow empty argument values for String, String Array, and Collection<String>.

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.direct.DirectOptions;
@@ -118,7 +120,25 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     for (Map.Entry<String, String> entry : map.entrySet()) {
       args[i++] = "--" + entry.getKey() + "=" + entry.getValue();
     }
-    PipelineOptions options = PipelineOptionsFactory.fromArgs(args).withValidation().create();
+
+    PipelineOptions options = null;
+    try {
+      options = PipelineOptionsFactory.fromArgs(args).withValidation().create();
+    } catch (IllegalArgumentException e) {
+      Matcher matcher =
+          Pattern.compile("Class (.+) missing a property named \\'(.+)\\'\\.(.*)")
+              .matcher(e.getMessage());
+      if (matcher.matches()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "You may have SET an unregistered option '%s', which could have failed current "
+                    + "query. You could run 'RESET %s' in Shell to reset the option.",
+                matcher.group(2), matcher.group(2)));
+      } else {
+        throw e;
+      }
+    }
+
     options.as(ApplicationNameOptions.class).setAppName("BeamSql");
     return options;
   }


### PR DESCRIPTION
Improve error message when SET unregistered options by SET command in SQL Shell.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




