### PR TITLE
[BEAM-4275] Implement integration tests for PubSub on DirectRunner

### DIFF
--- a/sdks/python/apache_beam/runners/__init__.py
+++ b/sdks/python/apache_beam/runners/__init__.py
@@ -23,6 +23,7 @@ This package defines runners, which are used to execute a pipeline.
 from __future__ import absolute_import
 
 from apache_beam.runners.direct.direct_runner import DirectRunner
+from apache_beam.runners.direct.test_direct_runner import TestDirectRunner
 from apache_beam.runners.runner import PipelineRunner
 from apache_beam.runners.runner import PipelineState
 from apache_beam.runners.runner import create_runner

--- a/sdks/python/apache_beam/runners/direct/direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner_test.py
@@ -21,6 +21,9 @@ import threading
 import unittest
 
 import apache_beam as beam
+from apache_beam.runners import DirectRunner
+from apache_beam.runners import TestDirectRunner
+from apache_beam.runners import create_runner
 from apache_beam.testing import test_pipeline
 
 
@@ -39,6 +42,14 @@ class DirectPipelineResultTest(unittest.TestCase):
       post_test_threads = set(t.ident for t in threading.enumerate())
       new_threads = post_test_threads - pre_test_threads
       self.assertEqual(len(new_threads), 0)
+
+  def test_create_runner(self):
+    self.assertTrue(
+        isinstance(create_runner('DirectRunner'),
+                   DirectRunner))
+    self.assertTrue(
+        isinstance(create_runner('TestDirectRunner'),
+                   TestDirectRunner))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/direct/executor.py
+++ b/sdks/python/apache_beam/runners/direct/executor.py
@@ -448,6 +448,9 @@ class _ExecutorServiceParallelExecutor(object):
       self.executor_service.shutdown()
       self.executor_service.await_completion()
 
+  def request_shutdown(self):
+    self.executor_service.shutdown()
+
   def schedule_consumers(self, committed_bundle):
     if committed_bundle.pcollection in self.value_to_consumers:
       consumers = self.value_to_consumers[committed_bundle.pcollection]

--- a/sdks/python/apache_beam/runners/direct/test_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/test_direct_runner.py
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Wrapper of Beam runners that's built for running and verifying e2e tests."""
+
+from __future__ import absolute_import
+from __future__ import print_function
+
+from apache_beam.internal import pickler
+from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.options.pipeline_options import TestOptions
+from apache_beam.runners.direct.direct_runner import DirectRunner
+from apache_beam.runners.runner import PipelineState
+
+__all__ = ['TestDirectRunner']
+
+
+class TestDirectRunner(DirectRunner):
+  def run_pipeline(self, pipeline):
+    """Execute test pipeline and verify test matcher"""
+    options = pipeline._options.view_as(TestOptions)
+    on_success_matcher = options.on_success_matcher
+    is_streaming = options.view_as(StandardOptions).streaming
+
+    # [BEAM-1889] Do not send this to remote workers also, there is no need to
+    # send this option to remote executors.
+    options.on_success_matcher = None
+
+    self.result = super(TestDirectRunner, self).run_pipeline(pipeline)
+
+    try:
+      if not is_streaming:
+        self.result.wait_until_finish()
+
+      if on_success_matcher:
+        from hamcrest import assert_that as hc_assert_that
+        hc_assert_that(self.result, pickler.loads(on_success_matcher))
+    finally:
+      if not PipelineState.is_terminal(self.result.state):
+        self.result.cancel()
+
+    return self.result

--- a/sdks/python/apache_beam/runners/direct/transform_evaluator.py
+++ b/sdks/python/apache_beam/runners/direct/transform_evaluator.py
@@ -391,6 +391,9 @@ class _PubSubReadEvaluator(_TransformEvaluator):
         side_inputs)
 
     self.source = self._applied_ptransform.transform._source
+    if self.source.id_label:
+      raise NotImplementedError(
+          'DirectRunner: id_label is not supported for PubSub reads')
     self._subscription = _PubSubReadEvaluator.get_subscription(
         self._applied_ptransform, self.source.project, self.source.topic_name,
         self.source.subscription_name)
@@ -430,11 +433,9 @@ class _PubSubReadEvaluator(_TransformEvaluator):
         max_messages=10) as results:
       def _get_element(message):
         parsed_message = PubsubMessage._from_message(message)
-        if timestamp_attribute:
-          try:
-            rfc3339_or_milli = parsed_message.attributes[timestamp_attribute]
-          except KeyError as e:
-            raise KeyError('Timestamp attribute not found: %s' % e)
+        if (timestamp_attribute and
+            timestamp_attribute in parsed_message.attributes):
+          rfc3339_or_milli = parsed_message.attributes[timestamp_attribute]
           try:
             timestamp = Timestamp.from_rfc3339(rfc3339_or_milli)
           except ValueError:

--- a/sdks/python/apache_beam/runners/runner.py
+++ b/sdks/python/apache_beam/runners/runner.py
@@ -50,7 +50,7 @@ _KNOWN_PYTHON_RPC_DIRECT_RUNNER = ('PythonRPCDirectRunner',)
 _KNOWN_DIRECT_RUNNERS = ('DirectRunner', 'BundleBasedDirectRunner',
                          'SwitchingDirectRunner')
 _KNOWN_DATAFLOW_RUNNERS = ('DataflowRunner',)
-_KNOWN_TEST_RUNNERS = ('TestDataflowRunner',)
+_KNOWN_TEST_RUNNERS = ('TestDataflowRunner', 'TestDirectRunner')
 _KNOWN_PORTABLE_RUNNERS = ('PortableRunner',)
 
 _RUNNER_MAP = {}
@@ -76,8 +76,8 @@ def create_runner(runner_name):
   Creates a runner instance from a runner class name.
 
   Args:
-    runner_name: Name of the pipeline runner. Possible values are:
-      DirectRunner, DataflowRunner and TestDataflowRunner.
+    runner_name: Name of the pipeline runner. Possible values are listed in
+      _RUNNER_MAP above.
 
   Returns:
     A runner object.
@@ -332,6 +332,11 @@ class PipelineState(object):
   PENDING = 'PENDING' # the job has been created but is not yet running.
   CANCELLING = 'CANCELLING' # job has been explicitly cancelled and is
                             # in the process of stopping
+
+  @classmethod
+  def is_terminal(cls, state):
+    return state in [cls.STOPPED, cls.DONE, cls.FAILED, cls.CANCELLED,
+                     cls.UPDATED, cls.DRAINED]
 
 
 class PipelineResult(object):

--- a/sdks/python/apache_beam/runners/test/__init__.py
+++ b/sdks/python/apache_beam/runners/test/__init__.py
@@ -27,6 +27,7 @@ from __future__ import absolute_import
 
 try:
   from apache_beam.runners.dataflow.test_dataflow_runner import TestDataflowRunner
+  from apache_beam.runners.direct.test_direct_runner import TestDirectRunner
 except ImportError:
   pass
 # pylint: enable=wrong-import-order, wrong-import-position

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -187,12 +187,17 @@ task installGcpTest(dependsOn: 'setupVirtualenv') {
   }
 }
 
-task localWordCount(dependsOn: 'installGcpTest') {
+task directRunnerIT(dependsOn: 'installGcpTest') {
   doLast {
     exec {
       executable 'sh'
-      args '-c', ". ${envdir}/bin/activate && python -m apache_beam.examples.wordcount --output /tmp/py-wordcount-direct"
-      // TODO: Check that the output file is generated and runs.
+      args '-c', ". ${envdir}/bin/activate && ./scripts/run_postcommit.sh IT batch TestDirectRunner"
+    }
+  }
+  doLast {
+    exec {
+      executable 'sh'
+      args '-c', ". ${envdir}/bin/activate && ./scripts/run_postcommit.sh IT streaming TestDirectRunner"
     }
   }
 }
@@ -281,7 +286,7 @@ flinkCompatibilityMatrix('Streaming')
 
 task postCommit() {
   dependsOn "preCommit"
-  dependsOn "localWordCount"
+  dependsOn "directRunnerIT"
   dependsOn "hdfsIntegrationTest"
   dependsOn "postCommitITTests"
 }

--- a/sdks/python/container/run_validatescontainer.sh
+++ b/sdks/python/container/run_validatescontainer.sh
@@ -77,7 +77,7 @@ SDK_LOCATION=$(find dist/apache-beam-*.tar.gz)
 echo ">>> RUNNING DATAFLOW RUNNER VALIDATESCONTAINER TEST"
 python setup.py nosetests \
   --attr ValidatesContainer \
-  --nocapture \
+  --nologcapture \
   --processes=1 \
   --process-timeout=900 \
   --test-pipeline-options=" \


### PR DESCRIPTION
Adds PubSub integration test on DirectRunner to postcommit tests.
See commit comments for details.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




