### PR TITLE
[BEAM-3371] Enable running integration tests on Spark

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1109,6 +1109,17 @@ artifactId=${project.name}
           testCompile it.project(path: ":beam-runners-flink_2.11", configuration: 'shadowTest')
         }
 
+        if (runner?.equalsIgnoreCase('spark')) {
+          testCompile it.project(path: ":beam-runners-spark", configuration: 'shadowTest')
+          testCompile project.library.java.spark_core
+          testCompile project.library.java.spark_streaming
+
+          // Testing the Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
+          project.configurations.testRuntimeClasspath {
+            exclude group: "org.slf4j", module: "slf4j-jdk14"
+          }
+        }
+
         /* include dependencies required by filesystems */
         if (filesystem?.equalsIgnoreCase('hdfs')) {
           testCompile it.project(path: ":beam-sdks-java-io-hadoop-file-system", configuration: 'shadowTest')

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineResourcesTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineResourcesTest.java
@@ -17,12 +17,19 @@
  */
 package org.apache.beam.runners.core.construction;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -67,5 +74,44 @@ public class PipelineResourcesTest {
     thrown.expectMessage("Unable to convert url (" + url + ") to file.");
 
     PipelineResources.detectClassPathResourcesToStage(classLoader);
+  }
+
+  @Test
+  public void testRemovingNonexistentFilesFromFilesToStage() throws IOException {
+    String nonexistentFilePath = tmpFolder.getRoot().getPath() + "/nonexistent/file";
+    String existingFilePath = tmpFolder.newFile("existingFile").getAbsolutePath();
+    String temporaryLocation = tmpFolder.newFolder().getAbsolutePath();
+
+    List<String> filesToStage = Arrays.asList(nonexistentFilePath, existingFilePath);
+    List<String> expectedFilesToStage = Arrays.asList(existingFilePath);
+
+    List<String> result = PipelineResources.prepareFilesForStaging(filesToStage, temporaryLocation);
+
+    assertThat(result, is(expectedFilesToStage));
+  }
+
+  @Test
+  public void testPackagingDirectoryResourceToJarFile() throws IOException {
+    String directoryPath = tmpFolder.newFolder().getAbsolutePath();
+    String temporaryLocation = tmpFolder.newFolder().getAbsolutePath();
+
+    List<String> filesToStage = new ArrayList<>();
+    filesToStage.add(directoryPath);
+
+    List<String> result = PipelineResources.prepareFilesForStaging(filesToStage, temporaryLocation);
+
+    assertTrue(new File(result.get(0)).exists());
+    assertTrue(result.get(0).matches(".*\\.jar"));
+  }
+
+  @Test
+  public void testIfThrowsWhenThereIsNoTemporaryFolderForJars() throws IOException {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Please provide temporary location for storing the jar files.");
+
+    List<String> filesToStage = new ArrayList<>();
+    filesToStage.add(tmpFolder.newFolder().getAbsolutePath());
+
+    PipelineResources.prepareFilesForStaging(filesToStage, null);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -18,8 +18,8 @@
 package org.apache.beam.runners.flink;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.beam.runners.core.construction.PipelineResources.prepareFilesForStaging;
 
+import org.apache.beam.runners.core.construction.PipelineResources;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
@@ -83,7 +83,7 @@ class FlinkPipelineExecutionEnvironment {
     pipeline.replaceAll(
         FlinkTransformOverrides.getDefaultOverrides(translationMode == TranslationMode.STREAMING));
 
-    prepareFilesToStageForRemoteClusterExecution();
+    prepareFilesToStageForRemoteClusterExecution(options);
 
     FlinkPipelineTranslator translator;
     if (translationMode == TranslationMode.STREAMING) {
@@ -104,12 +104,13 @@ class FlinkPipelineExecutionEnvironment {
   /**
    * Local configurations work in the same JVM and have no problems with improperly formatted files
    * on classpath (eg. directories with .class files or empty directories). Prepare files for
-   * staging only when using remote cluster.
+   * staging only when using remote cluster (passing the master address explicitly).
    */
-  private void prepareFilesToStageForRemoteClusterExecution() {
-    if (!options.getFlinkMaster().matches("\\[.*\\]")) {
+  private static void prepareFilesToStageForRemoteClusterExecution(FlinkPipelineOptions options) {
+    if (!options.getFlinkMaster().matches("\\[auto\\]|\\[collection\\]|\\[local\\]")) {
       options.setFilesToStage(
-          prepareFilesForStaging(options.getFilesToStage(), options.getTempLocation()));
+          PipelineResources.prepareFilesForStaging(
+              options.getFilesToStage(), options.getTempLocation()));
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -17,22 +17,10 @@
  */
 package org.apache.beam.runners.flink;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.runners.core.construction.PipelineResources.prepareFilesForStaging;
 
-import com.fasterxml.jackson.core.Base64Variants;
-import com.google.common.base.Strings;
-import com.google.common.hash.Funnels;
-import com.google.common.hash.Hasher;
-import com.google.common.hash.Hashing;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.util.ZipFiles;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -95,73 +83,33 @@ class FlinkPipelineExecutionEnvironment {
     pipeline.replaceAll(
         FlinkTransformOverrides.getDefaultOverrides(translationMode == TranslationMode.STREAMING));
 
-    // Local flink configurations work in the same JVM and have no problems with improperly
-    // formatted files on classpath (eg. directories with .class files or empty directories).
-    // prepareFilesToStage() only when using remote flink cluster.
-    List<String> filesToStage;
-    if (!options.getFlinkMaster().matches("\\[.*\\]")) {
-      filesToStage = prepareFilesToStage();
-    } else {
-      filesToStage = options.getFilesToStage();
-    }
+    prepareFilesToStageForRemoteClusterExecution();
 
     FlinkPipelineTranslator translator;
     if (translationMode == TranslationMode.STREAMING) {
       this.flinkStreamEnv =
-          FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, filesToStage);
+          FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+              options, options.getFilesToStage());
       translator = new FlinkStreamingPipelineTranslator(flinkStreamEnv, options);
     } else {
       this.flinkBatchEnv =
-          FlinkExecutionEnvironments.createBatchExecutionEnvironment(options, filesToStage);
+          FlinkExecutionEnvironments.createBatchExecutionEnvironment(
+              options, options.getFilesToStage());
       translator = new FlinkBatchPipelineTranslator(flinkBatchEnv, options);
     }
 
     translator.translate(pipeline);
   }
 
-  private List<String> prepareFilesToStage() {
-    return options
-        .getFilesToStage()
-        .stream()
-        .map(File::new)
-        .filter(File::exists)
-        .map(file -> file.isDirectory() ? packageDirectoriesToStage(file) : file.getAbsolutePath())
-        .collect(Collectors.toList());
-  }
-
-  private String packageDirectoriesToStage(File directoryToStage) {
-    String hash = calculateDirectoryContentHash(directoryToStage);
-    String pathForJar = getUniqueJarPath(hash);
-    zipDirectory(directoryToStage, pathForJar);
-    return pathForJar;
-  }
-
-  private String calculateDirectoryContentHash(File directoryToStage) {
-    Hasher hasher = Hashing.md5().newHasher();
-    try (OutputStream hashStream = Funnels.asOutputStream(hasher)) {
-      ZipFiles.zipDirectory(directoryToStage, hashStream);
-      return Base64Variants.MODIFIED_FOR_URL.encode(hasher.hash().asBytes());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private String getUniqueJarPath(String contentHash) {
-    String tempLocation = options.getTempLocation();
-
-    checkArgument(
-        !Strings.isNullOrEmpty(tempLocation),
-        "Please provide \"tempLocation\" pipeline option. Flink runner needs it to store jars "
-            + "made of directories that were on classpath.");
-
-    return String.format("%s%s.jar", tempLocation, contentHash);
-  }
-
-  private void zipDirectory(File directoryToStage, String uniqueDirectoryPath) {
-    try {
-      ZipFiles.zipDirectory(directoryToStage, new FileOutputStream(uniqueDirectoryPath));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
+  /**
+   * Local configurations work in the same JVM and have no problems with improperly formatted files
+   * on classpath (eg. directories with .class files or empty directories). Prepare files for
+   * staging only when using remote cluster.
+   */
+  private void prepareFilesToStageForRemoteClusterExecution() {
+    if (!options.getFlinkMaster().matches("\\[.*\\]")) {
+      options.setFilesToStage(
+          prepareFilesForStaging(options.getFilesToStage(), options.getTempLocation()));
     }
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
@@ -17,7 +17,17 @@
  */
 package org.apache.beam.runners.flink;
 
+import static java.util.Arrays.asList;
+import static org.apache.beam.sdk.testing.RegexMatcher.matches;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.core.Every.everyItem;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TextIO;
@@ -27,13 +37,17 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.joda.time.Duration;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link FlinkPipelineExecutionEnvironment}. */
 @RunWith(JUnit4.class)
 public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
+
+  @Rule public transient TemporaryFolder tmpFolder = new TemporaryFolder();
 
   @Test
   public void shouldRecognizeAndTranslateStreamingPipeline() {
@@ -49,6 +63,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
         .apply(
             ParDo.of(
                 new DoFn<Long, String>() {
+
                   @ProcessElement
                   public void processElement(ProcessContext c) throws Exception {
                     c.output(Long.toString(c.element()));
@@ -60,5 +75,64 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
     flinkEnv.translate(pipeline);
 
     // no exception should be thrown
+  }
+
+  @Test
+  public void shouldPrepareFilesToStageWhenFlinkMasterIsSetExplicitly() throws IOException {
+    FlinkPipelineOptions options = testPreparingResourcesToStage("localhost:8081");
+
+    assertThat(options.getFilesToStage().size(), is(1));
+    assertThat(options.getFilesToStage().get(0), matches(".*\\.jar"));
+  }
+
+  @Test
+  public void shouldNotPrepareFilesToStageWhenFlinkMasterIsSetToAuto() throws IOException {
+    FlinkPipelineOptions options = testPreparingResourcesToStage("[auto]");
+
+    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
+  }
+
+  @Test
+  public void shouldNotPrepareFilesToStagewhenFlinkMasterIsSetToCollection() throws IOException {
+    FlinkPipelineOptions options = testPreparingResourcesToStage("[collection]");
+
+    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
+  }
+
+  @Test
+  public void shouldNotPrepareFilesToStageWhenFlinkMasterIsSetToLocal() throws IOException {
+    FlinkPipelineOptions options = testPreparingResourcesToStage("[local]");
+
+    assertThat(options.getFilesToStage().size(), is(2));
+    assertThat(options.getFilesToStage(), everyItem(not(matches(".*\\.jar"))));
+  }
+
+  private FlinkPipelineOptions testPreparingResourcesToStage(String flinkMaster)
+      throws IOException {
+    Pipeline pipeline = Pipeline.create();
+    String tempLocation = tmpFolder.newFolder().getAbsolutePath();
+
+    File notEmptyDir = tmpFolder.newFolder();
+    notEmptyDir.createNewFile();
+    String notEmptyDirPath = notEmptyDir.getAbsolutePath();
+    String notExistingPath = "/path/to/not/existing/dir";
+
+    FlinkPipelineOptions options =
+        setPipelineOptions(flinkMaster, tempLocation, asList(notEmptyDirPath, notExistingPath));
+    FlinkPipelineExecutionEnvironment flinkEnv = new FlinkPipelineExecutionEnvironment(options);
+    flinkEnv.translate(pipeline);
+    return options;
+  }
+
+  private FlinkPipelineOptions setPipelineOptions(
+      String flinkMaster, String tempLocation, List<String> filesToStage) {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(TestFlinkRunner.class);
+    options.setFlinkMaster(flinkMaster);
+    options.setTempLocation(tempLocation);
+    options.setFilesToStage(filesToStage);
+    return options;
   }
 }


### PR DESCRIPTION
This PR enables running IOIT on Spark runner. One can do that by setting up remote spark cluster (spark master) and running this command: 

```
./gradlew clean integrationTest -p sdks/java/io/file-based-io-tests/ -DintegrationTestPipelineOptions='["--numberOfRecords=1000", "--filenamePrefix=PREFIX", "--runner=TestSparkRunner", "--sparkMaster=spark://LGs-Mac.local:7077", "--tempLocation=/tmp/"]' -DintegrationTestRunner=spark --tests org.apache.beam.sdk.io.text.TextIOIT --info
```

I experienced some difficulties with TFRecordIOIT, ParquetIOIT and XmlIOIT tests: 
 - XmlIOIT fails on assertion (hashcode of PCollection is different that it should be)
 - ParquetIOIT suffers for dependency missmatch (`java.lang.NoSuchMethodError: org.apache.parquet.hadoop.ParquetWriter$Builder.<init>(Lorg/apache/parquet/io/OutputFile;)V`)
 - TFRecordIOIT cannot find the created file: `java.io.FileNotFoundException: No files found for spec: PREFIX_1534520885787*`

Those issues are of different nature than the one described in BEAM-3371 and have to be tackled separately. 

@iemejia Could you take a look when you're back? There's no need to rush - I'll be off for 2 weeks now. 

CC: @pabloem 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




