### PR TITLE
[SQL] Wire up new schema creation DDL statement

### DIFF
--- a/sdks/java/extensions/sql/src/main/codegen/config.fmpp
+++ b/sdks/java/extensions/sql/src/main/codegen/config.fmpp
@@ -27,6 +27,7 @@ data: {
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateTable"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlDdlNodes"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlSetOptionBeam"
+        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlRegisterExternalSchema"
         "org.apache.beam.sdk.schemas.Schema"
         "org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils"
         "org.apache.calcite.sql.type.SqlTypeName"
@@ -38,6 +39,8 @@ data: {
         "IF"
         "LOCATION"
         "TBLPROPERTIES"
+        "REGISTER"
+        "PROPERTIES"
       ]
 
       # List of keywords from "keywords" section that are not reserved.
@@ -46,6 +49,8 @@ data: {
         "IF"
         "LOCATION"
         "TBLPROPERTIES"
+        "REGISTER"
+        "PROPERTIES"
       ]
 
       # List of additional join types. Each is a method with no arguments.
@@ -56,6 +61,7 @@ data: {
       # List of methods for parsing custom SQL statements.
       statementParserMethods: [
         "SqlSetOptionBeam(Span.of(), null)"
+        "SqlRegisterExternalSchema()"
       ]
 
       # List of methods for parsing custom literals.

--- a/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
+++ b/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
@@ -329,4 +329,40 @@ SqlSetOptionBeam SqlSetOptionBeam(Span s, String scope) :
     )
 }
 
+
+SqlRegisterExternalSchema SqlRegisterExternalSchema() :
+{
+    final Span s = Span.of();
+    SqlIdentifier name;
+    final SqlNode type;
+    SqlNode location = null;
+    SqlNode properties = null;
+}
+{
+    <REGISTER> <EXTERNAL> <SCHEMA> {
+        s.add(this);
+    }
+
+    name = CompoundIdentifier()
+
+    <TYPE>
+    (
+        type = StringLiteral()
+    |
+        type = SimpleIdentifier()
+    )
+    [ <LOCATION> location = StringLiteral() ]
+    [ <PROPERTIES> properties = StringLiteral() ]
+
+    {
+        return new SqlRegisterExternalSchema(
+            s.end(this),
+            name,
+            type,
+            location,
+            properties
+        );
+    }
+}
+
 // End parserImpls.ftl

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateTable.java
@@ -149,7 +149,7 @@ public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement 
   private Table toTable() {
     return Table.builder()
         .type(SqlDdlNodes.getString(type))
-        .name(name.getSimple())
+        .name(name.names.get(name.names.size() - 1))
         .schema(columnList.stream().collect(toSchema()))
         .comment(SqlDdlNodes.getString(comment))
         .location(SqlDdlNodes.getString(location))

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlRegisterExternalSchema.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlRegisterExternalSchema.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.sql.impl.parser;
+
+import java.util.List;
+import org.apache.beam.sdk.extensions.sql.impl.BeamCalciteSchemaFactory;
+import org.apache.calcite.jdbc.CalcitePrepare;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlDdl;
+import org.apache.calcite.sql.SqlExecutableStatement;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.Pair;
+
+/** Parse tree for {@code REGISTER EXTERNAL SCHEMA} statement. */
+public class SqlRegisterExternalSchema extends SqlDdl implements SqlExecutableStatement {
+
+  private static final SqlOperator OPERATOR =
+      new SqlSpecialOperator("REGISTER EXTERNAL SCHEMA", SqlKind.OTHER_DDL);
+  private final SqlNode type;
+  private final SqlNode location;
+  private final SqlNode properties;
+
+  private SqlIdentifier name;
+
+  /** Creates a SqlRegisterExternalSchema. */
+  public SqlRegisterExternalSchema(
+      SqlParserPos pos, SqlIdentifier name, SqlNode type, SqlNode location, SqlNode properties) {
+    super(OPERATOR, pos);
+    this.name = name;
+    this.type = type;
+    this.location = location;
+    this.properties = properties;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    throw new UnsupportedOperationException(
+        "Getting operands of REGISTER EXTERNAL SCHEMA is unsupported at the moment");
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("REGISTER");
+    writer.keyword("EXTERNAL");
+    writer.keyword("SCHEMA");
+
+    writer.keyword("TYPE");
+    type.unparse(writer, 0, 0);
+
+    if (location != null) {
+      writer.keyword("LOCATION");
+      location.unparse(writer, 0, 0);
+    }
+
+    if (properties != null) {
+      writer.keyword("PROPERTIES");
+      properties.unparse(writer, 0, 0);
+    }
+  }
+
+  @Override
+  public void execute(CalcitePrepare.Context context) {
+    final Pair<CalciteSchema, String> pair = SqlDdlNodes.schema(context, true, name);
+    final SchemaPlus parentSchema = pair.left.plus();
+    final Schema subSchema =
+        BeamCalciteSchemaFactory.INSTANCE.create(parentSchema, pair.right, null);
+
+    SchemaPlus addedSchema = parentSchema.add(pair.right, subSchema);
+    addedSchema.setCacheEnabled(false);
+  }
+}


### PR DESCRIPTION
Simple `REGISTER EXTERNAL SCHEMA` parser logic.
Decided to do `REGISTER EXTERNAL` for now after discussion in the doc. Can change it to `CREATE FOREIGN` or something else if we want. 

Allows creating new schemas under `"beam"`. Currently doesn't have any actual remote schema providers.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




