### PR TITLE
[BEAM-5151][SQL] create external table

### DIFF
--- a/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineIT.java
+++ b/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineIT.java
@@ -70,7 +70,7 @@ public class BeamSqlLineIT implements Serializable {
     setProject = String.format("SET project = '%s';", project);
 
     createPubsubTableStatement =
-        "CREATE TABLE taxi_rides (\n"
+        "CREATE EXTERNAL TABLE taxi_rides (\n"
             + "         event_timestamp TIMESTAMP,\n"
             + "         attributes MAP<VARCHAR, VARCHAR>,\n"
             + "         payload ROW<\n"

--- a/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineTest.java
+++ b/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineTest.java
@@ -63,7 +63,7 @@ public class BeamSqlLineTest {
   public void testSqlLine_ddl() throws Exception {
     BeamSqlLine.main(
         new String[] {
-          "-e", "CREATE TABLE test (id INTEGER) TYPE 'text';", "-e", "DROP TABLE test;"
+          "-e", "CREATE EXTERNAL TABLE test (id INTEGER) TYPE 'text';", "-e", "DROP TABLE test;"
         });
   }
 
@@ -74,7 +74,7 @@ public class BeamSqlLineTest {
     BeamSqlLine.main(
         new String[] {
           "-e",
-          "CREATE TABLE test (id INTEGER) TYPE 'text' LOCATION '"
+          "CREATE EXTERNAL TABLE test (id INTEGER) TYPE 'text' LOCATION '"
               + simpleTable.getAbsolutePath()
               + "';",
           "-e",
@@ -102,7 +102,7 @@ public class BeamSqlLineTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     String[] args =
         buildArgs(
-            "CREATE TABLE table_test (col_a VARCHAR, col_b VARCHAR, "
+            "CREATE EXTERNAL TABLE table_test (col_a VARCHAR, col_b VARCHAR, "
                 + "col_c VARCHAR, col_x TINYINT, col_y INT, col_z BIGINT) TYPE 'test';",
             "INSERT INTO table_test VALUES ('a', 'b', 'c', 1, 2, 3);",
             "SELECT * FROM table_test;");
@@ -122,7 +122,7 @@ public class BeamSqlLineTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     String[] args =
         buildArgs(
-            "CREATE TABLE table_test (col_a VARCHAR, col_b VARCHAR) TYPE 'test';",
+            "CREATE EXTERNAL TABLE table_test (col_a VARCHAR, col_b VARCHAR) TYPE 'test';",
             "INSERT INTO table_test SELECT '3', 'hello';",
             "SELECT * FROM table_test;");
 
@@ -138,7 +138,7 @@ public class BeamSqlLineTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     String[] args =
         buildArgs(
-            "CREATE TABLE table_test (col_a VARCHAR, col_b VARCHAR) TYPE 'test';",
+            "CREATE EXTERNAL TABLE table_test (col_a VARCHAR, col_b VARCHAR) TYPE 'test';",
             "INSERT INTO table_test SELECT '3', 'foo';",
             "INSERT INTO table_test SELECT '3', 'bar';",
             "INSERT INTO table_test SELECT '4', 'foo';",
@@ -157,7 +157,7 @@ public class BeamSqlLineTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     String[] args =
         buildArgs(
-            "CREATE TABLE table_test (col_a VARCHAR, col_b TIMESTAMP) TYPE 'test';",
+            "CREATE EXTERNAL TABLE table_test (col_a VARCHAR, col_b TIMESTAMP) TYPE 'test';",
             "INSERT INTO table_test SELECT '3', TIMESTAMP '2018-07-01 21:26:06';",
             "INSERT INTO table_test SELECT '3', TIMESTAMP '2018-07-01 21:26:07';",
             "SELECT TUMBLE_START(col_b, INTERVAL '1' SECOND), count(*) FROM table_test "
@@ -177,7 +177,7 @@ public class BeamSqlLineTest {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     String[] args =
         buildArgs(
-            "CREATE TABLE table_test (col_a VARCHAR, col_b TIMESTAMP) TYPE 'test';",
+            "CREATE EXTERNAL TABLE table_test (col_a VARCHAR, col_b TIMESTAMP) TYPE 'test';",
             "INSERT INTO table_test SELECT '3', TIMESTAMP '2018-07-01 21:26:06';",
             "INSERT INTO table_test SELECT '4', TIMESTAMP '2018-07-01 21:26:07';",
             "INSERT INTO table_test SELECT '6', TIMESTAMP '2018-07-01 21:26:08';",

--- a/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/JdbcJarTest.java
+++ b/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/JdbcJarTest.java
@@ -71,7 +71,7 @@ public class JdbcJarTest {
   public void classLoader_ddl() throws Exception {
     Connection connection = getConnection();
     Statement statement = connection.createStatement();
-    assertEquals(0, statement.executeUpdate("CREATE TABLE test (id INTEGER) TYPE 'text'"));
+    assertEquals(0, statement.executeUpdate("CREATE EXTERNAL TABLE test (id INTEGER) TYPE 'text'"));
     assertEquals(0, statement.executeUpdate("DROP TABLE test"));
   }
 
@@ -84,7 +84,7 @@ public class JdbcJarTest {
     assertEquals(
         0,
         statement.executeUpdate(
-            "CREATE TABLE test (id INTEGER) TYPE 'text' LOCATION '"
+            "CREATE EXTERNAL TABLE test (id INTEGER) TYPE 'text' LOCATION '"
                 + simpleTable.getAbsolutePath()
                 + "'"));
     assertTrue(statement.execute("SELECT * FROM test"));

--- a/sdks/java/extensions/sql/src/main/codegen/config.fmpp
+++ b/sdks/java/extensions/sql/src/main/codegen/config.fmpp
@@ -24,7 +24,7 @@ data: {
         "org.apache.calcite.schema.ColumnStrategy"
         "org.apache.calcite.sql.SqlCreate"
         "org.apache.calcite.sql.SqlDrop"
-        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateTable"
+        "org.apache.beam.sdk.extensions.sql.impl.parser.SqlCreateExternalTable"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlDdlNodes"
         "org.apache.beam.sdk.extensions.sql.impl.parser.SqlSetOptionBeam"
         "org.apache.beam.sdk.schemas.Schema"
@@ -56,6 +56,7 @@ data: {
       # List of methods for parsing custom SQL statements.
       statementParserMethods: [
         "SqlSetOptionBeam(Span.of(), null)"
+        "SqlCreateExternalTable()"
       ]
 
       # List of methods for parsing custom literals.
@@ -76,7 +77,6 @@ data: {
       # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
       # Each must accept arguments "(SqlParserPos pos, boolean replace)".
       createStatementParserMethods: [
-        "SqlCreateTable"
       ]
 
       # List of methods for parsing extensions to "DROP" calls.

--- a/sdks/java/extensions/sql/src/main/codegen/config.fmpp
+++ b/sdks/java/extensions/sql/src/main/codegen/config.fmpp
@@ -77,6 +77,7 @@ data: {
       # List of methods for parsing extensions to "CREATE [OR REPLACE]" calls.
       # Each must accept arguments "(SqlParserPos pos, boolean replace)".
       createStatementParserMethods: [
+        SqlCreateTableNotSupportedMessage
       ]
 
       # List of methods for parsing extensions to "DROP" calls.

--- a/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
+++ b/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
@@ -146,8 +146,10 @@ Schema.Field Field() :
  *   ( LOCATION location_string )?
  *   ( TBLPROPERTIES tbl_properties )?
  */
-SqlCreate SqlCreateTable(Span s, boolean replace) :
+SqlCreate SqlCreateExternalTable() :
 {
+    final Span s = Span.of();
+    final boolean replace = false;
     final boolean ifNotExists;
     final SqlIdentifier id;
     List<Schema.Field> fieldList = null;
@@ -157,7 +159,12 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
     SqlNode tblProperties = null;
 }
 {
-    <TABLE> ifNotExists = IfNotExistsOpt()
+
+    <CREATE> <EXTERNAL> <TABLE> {
+        s.add(this);
+    }
+
+    ifNotExists = IfNotExistsOpt()
     id = CompoundIdentifier()
     fieldList = FieldListParens()
     <TYPE>
@@ -171,7 +178,7 @@ SqlCreate SqlCreateTable(Span s, boolean replace) :
     [ <TBLPROPERTIES> tblProperties = StringLiteral() ]
     {
         return
-            new SqlCreateTable(
+            new SqlCreateExternalTable(
                 s.end(this),
                 replace,
                 ifNotExists,

--- a/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
+++ b/sdks/java/extensions/sql/src/main/codegen/includes/parserImpls.ftl
@@ -191,6 +191,17 @@ SqlCreate SqlCreateExternalTable() :
     }
 }
 
+SqlCreate SqlCreateTableNotSupportedMessage(Span s, boolean replace) :
+{
+}
+{
+  <TABLE>
+  {
+    throw new ParseException("'CREATE TABLE' is not supported in BeamSQL. You can use "
+    + "'CREATE EXTERNAL TABLE' to register an external data source to BeamSQL");
+  }
+}
+
 SqlDrop SqlDropTable(Span s, boolean replace) :
 {
     final boolean ifExists;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
@@ -41,7 +41,7 @@ import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Pair;
 
-/** Parse tree for {@code CREATE TABLE} statement. */
+/** Parse tree for {@code CREATE EXTERNAL TABLE} statement. */
 public class SqlCreateExternalTable extends SqlCreate implements SqlExecutableStatement {
   private final SqlIdentifier name;
   private final List<Schema.Field> columnList;

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/parser/SqlCreateExternalTable.java
@@ -42,7 +42,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.util.Pair;
 
 /** Parse tree for {@code CREATE TABLE} statement. */
-public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement {
+public class SqlCreateExternalTable extends SqlCreate implements SqlExecutableStatement {
   private final SqlIdentifier name;
   private final List<Schema.Field> columnList;
   private final SqlNode type;
@@ -51,10 +51,10 @@ public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement 
   private final SqlNode tblProperties;
 
   private static final SqlOperator OPERATOR =
-      new SqlSpecialOperator("CREATE TABLE", SqlKind.CREATE_TABLE);
+      new SqlSpecialOperator("CREATE EXTERNAL TABLE", SqlKind.OTHER_DDL);
 
-  /** Creates a SqlCreateTable. */
-  public SqlCreateTable(
+  /** Creates a SqlCreateExternalTable. */
+  public SqlCreateExternalTable(
       SqlParserPos pos,
       boolean replace,
       boolean ifNotExists,
@@ -82,6 +82,7 @@ public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement 
   @Override
   public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     writer.keyword("CREATE");
+    writer.keyword("EXTERNAL");
     writer.keyword("TABLE");
     if (ifNotExists) {
       writer.keyword("IF NOT EXISTS");
@@ -161,4 +162,4 @@ public class SqlCreateTable extends SqlCreate implements SqlExecutableStatement 
   }
 }
 
-// End SqlCreateTable.java
+// End SqlCreateExternalTable.java

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlCliTest.java
@@ -45,7 +45,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
@@ -69,7 +69,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age', \n"
@@ -99,7 +99,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age', \n"
@@ -131,7 +131,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age', \n"
@@ -182,7 +182,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
@@ -203,7 +203,7 @@ public class BeamSqlCliTest {
 
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
@@ -221,7 +221,7 @@ public class BeamSqlCliTest {
     BeamSqlCli cli = new BeamSqlCli().metaStore(metaStore);
 
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlExplainTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlExplainTest.java
@@ -39,7 +39,7 @@ public class BeamSqlExplainTest {
     cli = new BeamSqlCli().metaStore(metaStore);
 
     cli.execute(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name', \n"
             + "age int COMMENT 'age') \n"
@@ -47,14 +47,14 @@ public class BeamSqlExplainTest {
             + "COMMENT '' ");
 
     cli.execute(
-        "create table A (\n"
+        "CREATE EXTERNAL TABLE A (\n"
             + "c1 int COMMENT 'c1',\n"
             + "c2 int COMMENT 'c2')\n"
             + "TYPE 'text'\n"
             + "COMMENT '' ");
 
     cli.execute(
-        "create table B (\n"
+        "CREATE EXTERNAL TABLE B (\n"
             + "c1 int COMMENT 'c1',\n"
             + "c2 int COMMENT 'c2')\n"
             + "TYPE 'text'\n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/PubsubToBigqueryIT.java
@@ -59,7 +59,7 @@ public class PubsubToBigqueryIT implements Serializable {
         BeamSqlEnv.inMemory(new PubsubJsonTableProvider(), new BigQueryTableProvider());
 
     String createTableString =
-        "CREATE TABLE pubsub_topic (\n"
+        "CREATE EXTERNAL TABLE pubsub_topic (\n"
             + "event_timestamp TIMESTAMP, \n"
             + "attributes MAP<VARCHAR, VARCHAR>, \n"
             + "payload ROW< \n"
@@ -75,7 +75,7 @@ public class PubsubToBigqueryIT implements Serializable {
     sqlEnv.executeDdl(createTableString);
 
     String createTableStatement =
-        "CREATE TABLE bq_table( \n"
+        "CREATE EXTERNAL TABLE bq_table( \n"
             + "   id BIGINT, \n"
             + "   name VARCHAR \n "
             + ") \n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/JdbcDriverTest.java
@@ -164,9 +164,9 @@ public class JdbcDriverTest {
     ResultSet resultSet = metadata.getTables(null, null, null, new String[] {"TABLE"});
     assertFalse(resultSet.next());
 
-    // Create tables
+    // create external tables
     Statement statement = connection.createStatement();
-    assertEquals(0, statement.executeUpdate("CREATE TABLE test (id INTEGER) TYPE 'text'"));
+    assertEquals(0, statement.executeUpdate("CREATE EXTERNAL TABLE test (id INTEGER) TYPE 'text'"));
 
     // Ensure table test
     resultSet = metadata.getTables(null, null, null, new String[] {"TABLE"});
@@ -174,7 +174,6 @@ public class JdbcDriverTest {
     assertEquals("test", resultSet.getString("TABLE_NAME"));
     assertFalse(resultSet.next());
 
-    // Create tables
     assertEquals(0, statement.executeUpdate("DROP TABLE test"));
 
     // Ensure no tables
@@ -189,7 +188,7 @@ public class JdbcDriverTest {
 
     connection
         .createStatement()
-        .executeUpdate("CREATE TABLE person (id BIGINT, name VARCHAR) TYPE 'test'");
+        .executeUpdate("CREATE EXTERNAL TABLE person (id BIGINT, name VARCHAR) TYPE 'test'");
 
     tableProvider.addRows("person", row(1L, "aaa"), row(2L, "bbb"));
 
@@ -212,7 +211,9 @@ public class JdbcDriverTest {
 
     // A table with one TIMESTAMP column
     Schema schema = Schema.builder().addDateTimeField("ts").build();
-    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+    connection
+        .createStatement()
+        .executeUpdate("CREATE EXTERNAL TABLE test (ts TIMESTAMP) TYPE 'test'");
 
     ReadableInstant july1 =
         ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
@@ -241,7 +242,9 @@ public class JdbcDriverTest {
 
     // A table with one TIMESTAMP column
     Schema schema = Schema.builder().addDateTimeField("ts").build();
-    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+    connection
+        .createStatement()
+        .executeUpdate("CREATE EXTERNAL TABLE test (ts TIMESTAMP) TYPE 'test'");
 
     ReadableInstant july1 =
         ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
@@ -269,7 +272,9 @@ public class JdbcDriverTest {
 
     // A table with one TIMESTAMP column
     Schema schema = Schema.builder().addDateTimeField("ts").build();
-    connection.createStatement().executeUpdate("CREATE TABLE test (ts TIMESTAMP) TYPE 'test'");
+    connection
+        .createStatement()
+        .executeUpdate("CREATE EXTERNAL TABLE test (ts TIMESTAMP) TYPE 'test'");
 
     ReadableInstant july1 =
         ISODateTimeFormat.dateTimeParser().parseDateTime("2018-07-01T01:02:03Z");
@@ -297,7 +302,7 @@ public class JdbcDriverTest {
     connection
         .createStatement()
         .executeUpdate(
-            "CREATE TABLE person ( \n"
+            "CREATE EXTERNAL TABLE person ( \n"
                 + "description VARCHAR, \n"
                 + "nestedRow ROW< \n"
                 + "              id BIGINT, \n"
@@ -331,11 +336,11 @@ public class JdbcDriverTest {
 
     connection
         .createStatement()
-        .executeUpdate("CREATE TABLE person (id BIGINT, name VARCHAR) TYPE 'test'");
+        .executeUpdate("CREATE EXTERNAL TABLE person (id BIGINT, name VARCHAR) TYPE 'test'");
 
     connection
         .createStatement()
-        .executeUpdate("CREATE TABLE person_src (id BIGINT, name VARCHAR) TYPE 'test'");
+        .executeUpdate("CREATE EXTERNAL TABLE person_src (id BIGINT, name VARCHAR) TYPE 'test'");
     tableProvider.addRows("person_src", row(1L, "aaa"), row(2L, "bbb"));
 
     connection.createStatement().execute("INSERT INTO person SELECT id, name FROM person_src");

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLNestedTypesTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLNestedTypesTest.java
@@ -71,7 +71,7 @@ public class BeamDDLNestedTypesTest {
 
   private Table executeCreateTableWith(String fieldType) throws SqlParseException {
     String createTable =
-        "create table tablename ( "
+        "CREATE EXTERNAL TABLE tablename ( "
             + "fieldName "
             + fieldType
             + " ) "

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -49,7 +49,7 @@ public class BeamDDLTest {
     properties.put("hello", hello);
 
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "TYPE 'text' \n"
@@ -66,7 +66,7 @@ public class BeamDDLTest {
   public void testParseCreateTable_withoutType() throws Exception {
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(new TestTableProvider());
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "COMMENT 'person table' \n"
@@ -86,7 +86,7 @@ public class BeamDDLTest {
     properties.put("hello", hello);
 
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "TYPE 'text' \n"
@@ -102,7 +102,7 @@ public class BeamDDLTest {
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "TYPE 'text' \n"
@@ -119,7 +119,7 @@ public class BeamDDLTest {
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "TYPE 'text' \n"
@@ -135,7 +135,7 @@ public class BeamDDLTest {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
-    env.executeDdl("CREATE TABLE person (id INT) TYPE text");
+    env.executeDdl("CREATE EXTERNAL TABLE person (id INT) TYPE text");
 
     assertEquals(
         Table.builder()
@@ -156,7 +156,7 @@ public class BeamDDLTest {
 
     assertNull(tableProvider.getTables().get("person"));
     env.executeDdl(
-        "create table person (\n"
+        "CREATE EXTERNAL TABLE person (\n"
             + "id int COMMENT 'id', \n"
             + "name varchar COMMENT 'name') \n"
             + "TYPE 'text' \n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/parser/BeamDDLTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 public class BeamDDLTest {
 
   @Test
-  public void testParseCreateTable_full() throws Exception {
+  public void testParseCreateExternalTable_full() throws Exception {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
@@ -63,7 +63,7 @@ public class BeamDDLTest {
   }
 
   @Test(expected = ParseException.class)
-  public void testParseCreateTable_withoutType() throws Exception {
+  public void testParseCreateExternalTable_withoutType() throws Exception {
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(new TestTableProvider());
     env.executeDdl(
         "CREATE EXTERNAL TABLE person (\n"
@@ -74,8 +74,21 @@ public class BeamDDLTest {
             + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'");
   }
 
+  @Test(expected = ParseException.class)
+  public void testParseCreateTable() throws Exception {
+    BeamSqlEnv env = BeamSqlEnv.withTableProvider(new TestTableProvider());
+    env.executeDdl(
+        "CREATE TABLE person (\n"
+            + "id int COMMENT 'id', \n"
+            + "name varchar COMMENT 'name') \n"
+            + "TYPE 'text' \n"
+            + "COMMENT 'person table' \n"
+            + "LOCATION '/home/admin/person'\n"
+            + "TBLPROPERTIES '{\"hello\": [\"james\", \"bond\"]}'");
+  }
+
   @Test
-  public void testParseCreateTable_withoutTableComment() throws Exception {
+  public void testParseCreateExternalTable_withoutTableComment() throws Exception {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
@@ -97,7 +110,7 @@ public class BeamDDLTest {
   }
 
   @Test
-  public void testParseCreateTable_withoutTblProperties() throws Exception {
+  public void testParseCreateExternalTable_withoutTblProperties() throws Exception {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
@@ -114,7 +127,7 @@ public class BeamDDLTest {
   }
 
   @Test
-  public void testParseCreateTable_withoutLocation() throws Exception {
+  public void testParseCreateExternalTable_withoutLocation() throws Exception {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 
@@ -131,7 +144,7 @@ public class BeamDDLTest {
   }
 
   @Test
-  public void testParseCreateTable_minimal() throws Exception {
+  public void testParseCreateExternalTable_minimal() throws Exception {
     TestTableProvider tableProvider = new TestTableProvider();
     BeamSqlEnv env = BeamSqlEnv.withTableProvider(tableProvider);
 

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/integrationtest/BeamSqlBuiltinFunctionsIntegrationTestBase.java
@@ -362,7 +362,9 @@ public class BeamSqlBuiltinFunctionsIntegrationTestBase {
       // Here we create a Beam table just to force the calling convention.
       TestTableProvider tableProvider = new TestTableProvider();
       Connection connection = JdbcDriver.connect(tableProvider);
-      connection.createStatement().executeUpdate("CREATE TABLE dummy (dummy BOOLEAN) TYPE 'test'");
+      connection
+          .createStatement()
+          .executeUpdate("CREATE EXTERNAL TABLE dummy (dummy BOOLEAN) TYPE 'test'");
       tableProvider.addRows("dummy", DUMMY_ROW);
 
       for (String expr : exprs) {

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/bigquery/BigQueryReadWriteIT.java
@@ -93,7 +93,7 @@ public class BigQueryReadWriteIT implements Serializable {
     BeamSqlEnv sqlEnv = BeamSqlEnv.inMemory(new BigQueryTableProvider());
 
     String createTableStatement =
-        "CREATE TABLE TEST( \n"
+        "CREATE EXTERNAL TABLE TEST( \n"
             + "   c_bigint BIGINT, \n"
             + "   c_tinyint TINYINT, \n"
             + "   c_smallint SMALLINT, \n"
@@ -159,7 +159,7 @@ public class BigQueryReadWriteIT implements Serializable {
     BeamSqlEnv sqlEnv = BeamSqlEnv.inMemory(new BigQueryTableProvider());
 
     String createTableStatement =
-        "CREATE TABLE TEST( \n"
+        "CREATE EXTERNAL TABLE TEST( \n"
             + "   c_bigint BIGINT, \n"
             + "   c_tinyint TINYINT, \n"
             + "   c_smallint SMALLINT, \n"
@@ -227,7 +227,7 @@ public class BigQueryReadWriteIT implements Serializable {
             new BigQueryTableProvider());
 
     String createTableStatement =
-        "CREATE TABLE ORDERS_BQ( \n"
+        "CREATE EXTERNAL TABLE ORDERS_BQ( \n"
             + "   id BIGINT, \n"
             + "   name VARCHAR, \n "
             + "   arr ARRAY<VARCHAR> \n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -105,7 +105,7 @@ public class PubsubJsonIT implements Serializable {
   @Test
   public void testSelectsPayloadContent() throws Exception {
     String createTableString =
-        "CREATE TABLE message (\n"
+        "CREATE EXTERNAL TABLE message (\n"
             + "event_timestamp TIMESTAMP, \n"
             + "attributes MAP<VARCHAR, VARCHAR>, \n"
             + "payload ROW< \n"
@@ -166,7 +166,7 @@ public class PubsubJsonIT implements Serializable {
   @Test
   public void testUsesDlq() throws Exception {
     String createTableString =
-        "CREATE TABLE message (\n"
+        "CREATE EXTERNAL TABLE message (\n"
             + "event_timestamp TIMESTAMP, \n"
             + "attributes MAP<VARCHAR, VARCHAR>, \n"
             + "payload ROW< \n"
@@ -256,7 +256,7 @@ public class PubsubJsonIT implements Serializable {
   @Test
   public void testSQLLimit() throws Exception {
     String createTableString =
-        "CREATE TABLE message (\n"
+        "CREATE EXTERNAL TABLE message (\n"
             + "event_timestamp TIMESTAMP, \n"
             + "attributes MAP<VARCHAR, VARCHAR>, \n"
             + "payload ROW< \n"

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/text/TextTableProviderTest.java
@@ -68,7 +68,7 @@ public class TextTableProviderTest {
   private static final String SINGLE_STRING_SQL_SCHEMA = "(f_string VARCHAR)";
 
   /**
-   * Tests {@code CREATE TABLE TYPE text} with no format reads a default CSV.
+   * Tests {@code CREATE EXTERNAL TABLE TYPE text} with no format reads a default CSV.
    *
    * <p>The default format ignores empty lines, so that is an important part of this test.
    */
@@ -81,7 +81,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s/*'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s/*'",
             SQL_CSV_SCHEMA, tempFolder.getRoot()));
 
     PCollection<Row> rows =
@@ -95,8 +95,8 @@ public class TextTableProviderTest {
   }
 
   /**
-   * Tests {@code CREATE TABLE TYPE text} with a format other than "csv" or "lines" results in a CSV
-   * read of that format.
+   * Tests {@code CREATE EXTERNAL TABLE TYPE text} with a format other than "csv" or "lines" results
+   * in a CSV read of that format.
    */
   @Test
   public void testLegacyTdfCsv() throws Exception {
@@ -107,7 +107,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"TDF\"}'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"TDF\"}'",
             SQL_CSV_SCHEMA, tempFolder.getRoot()));
 
     PCollection<Row> rows =
@@ -128,7 +128,10 @@ public class TextTableProviderTest {
     pipeline.run();
   }
 
-  /** Tests {@code CREATE TABLE TYPE text TBLPROPERTIES '{"format":"csv"}'} works as expected. */
+  /**
+   * Tests {@code CREATE EXTERNAL TABLE TYPE text TBLPROPERTIES '{"format":"csv"}'} works as
+   * expected.
+   */
   @Test
   public void testExplicitCsv() throws Exception {
     Files.write(
@@ -138,7 +141,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"csv\"}'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"csv\"}'",
             SQL_CSV_SCHEMA, tempFolder.getRoot()));
 
     PCollection<Row> rows =
@@ -152,8 +155,8 @@ public class TextTableProviderTest {
   }
 
   /**
-   * Tests {@code CREATE TABLE TYPE text TBLPROPERTIES '{"format":"csv", "csvFormat": "Excel"}'}
-   * works as expected.
+   * Tests {@code CREATE EXTERNAL TABLE TYPE text TBLPROPERTIES '{"format":"csv", "csvFormat":
+   * "Excel"}'} works as expected.
    *
    * <p>Not that the different with "Excel" format is that blank lines are not ignored but have a
    * single string field.
@@ -166,7 +169,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s/*' "
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s/*' "
                 + "TBLPROPERTIES '{\"format\":\"csv\", \"csvFormat\":\"Excel\"}'",
             SINGLE_STRING_SQL_SCHEMA, tempFolder.getRoot()));
 
@@ -180,7 +183,10 @@ public class TextTableProviderTest {
     pipeline.run();
   }
 
-  /** Tests {@code CREATE TABLE TYPE text TBLPROPERTIES '{"format":"lines"}'} works as expected. */
+  /**
+   * Tests {@code CREATE EXTERNAL TABLE TYPE text TBLPROPERTIES '{"format":"lines"}'} works as
+   * expected.
+   */
   @Test
   public void testLines() throws Exception {
     // Data that looks like CSV but isn't parsed as it
@@ -190,7 +196,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"lines\"}'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s/*' TBLPROPERTIES '{\"format\":\"lines\"}'",
             SQL_LINES_SCHEMA, tempFolder.getRoot()));
 
     PCollection<Row> rows =
@@ -209,7 +215,7 @@ public class TextTableProviderTest {
     BeamSqlEnv env = BeamSqlEnv.inMemory(new TextTableProvider());
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s' TBLPROPERTIES '{\"format\":\"lines\"}'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s' TBLPROPERTIES '{\"format\":\"lines\"}'",
             SQL_LINES_SCHEMA, destinationFile.getAbsolutePath()));
 
     BeamSqlRelUtils.toPCollection(
@@ -230,7 +236,7 @@ public class TextTableProviderTest {
     // NumberedShardedFile
     env.executeDdl(
         String.format(
-            "CREATE TABLE test %s TYPE text LOCATION '%s' TBLPROPERTIES '{\"format\":\"csv\"}'",
+            "CREATE EXTERNAL TABLE test %s TYPE text LOCATION '%s' TBLPROPERTIES '{\"format\":\"csv\"}'",
             SQL_CSV_SCHEMA, destinationFile.getAbsolutePath()));
 
     BeamSqlRelUtils.toPCollection(


### PR DESCRIPTION
Use `CREATE EXTERNAL TABLE` to replace `CREATE TABLE`

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




