### PR TITLE
[BEAM-2277] Do not drop empty authority

### DIFF
--- a/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
+++ b/sdks/java/io/hadoop-file-system/src/main/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystem.java
@@ -88,7 +88,7 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
         List<Metadata> metadata = new ArrayList<>();
         for (FileStatus fileStatus : fileStatuses) {
           if (fileStatus.isFile()) {
-            URI uri = dropEmptyAuthority(fileStatus.getPath().toUri().toString());
+            URI uri = fileStatus.getPath().toUri();
             metadata.add(
                 Metadata.builder()
                     .setResourceId(new HadoopResourceId(uri))
@@ -163,8 +163,8 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
           String.format("Expected file path but received directory path %s", singleResourceSpec));
     }
     return !singleResourceSpec.endsWith("/") && isDirectory
-        ? new HadoopResourceId(dropEmptyAuthority(singleResourceSpec + "/"))
-        : new HadoopResourceId(dropEmptyAuthority(singleResourceSpec));
+        ? new HadoopResourceId(URI.create(singleResourceSpec + "/"))
+        : new HadoopResourceId(URI.create(singleResourceSpec));
   }
 
   @Override
@@ -254,16 +254,6 @@ class HadoopFileSystem extends FileSystem<HadoopResourceId> {
     public void close() throws IOException {
       closed = true;
       inputStream.close();
-    }
-  }
-
-  private static URI dropEmptyAuthority(String uriStr) {
-    URI uri = URI.create(uriStr);
-    String prefix = uri.getScheme() + ":///";
-    if (uriStr.startsWith(prefix)) {
-      return URI.create(uri.getScheme() + ":/" + uriStr.substring(prefix.length()));
-    } else {
-      return uri;
     }
   }
 }

--- a/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
+++ b/sdks/java/io/hadoop-file-system/src/test/java/org/apache/beam/sdk/io/hdfs/HadoopFileSystemTest.java
@@ -264,6 +264,11 @@ public class HadoopFileSystemTest {
     // match dir spec with '/'
     assertEquals(testPath("dir/"), fileSystem.matchNewResource(testPath("dir/").toString(), true));
 
+    // match should preserve empty authority
+    assertEquals(
+        "hdfs:///dir/file", fileSystem.matchNewResource("hdfs:///dir/file", false).toString());
+    assertEquals("hdfs:///dir/", fileSystem.matchNewResource("hdfs:///dir", true).toString());
+
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Expected file path but received directory path");
     fileSystem.matchNewResource(testPath("dir/").toString(), false);


### PR DESCRIPTION
When empty authority is dropped, resource `"hdfs:///path/file"` becomes `"hdfs:/path/file"` which is then, from it's string form not parseable back via `FileSystem.matchNewResource()` to `hdfs` scheme `ResourceId`, but `file`. This was introduced by stricter scheme parsing as described in `BEAM-5180`