### PR TITLE
[BEAM-5194] Fix Pipeline options with multi value deserialization from map

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import argparse
+from builtins import list
 from builtins import object
 
 from apache_beam.options.value_provider import RuntimeValueProvider
@@ -182,6 +183,9 @@ class PipelineOptions(HasDisplayData):
       if isinstance(v, bool):
         if v:
           flags.append('--%s' % k)
+      elif isinstance(v, list):
+        for i in v:
+          flags.append('--%s=%s' % (k, i))
       else:
         flags.append('--%s=%s' % (k, v))
 

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -38,14 +38,18 @@ class PipelineOptionsTest(unittest.TestCase):
 
   TEST_CASES = [
       {'flags': ['--num_workers', '5'],
-       'expected': {'num_workers': 5, 'mock_flag': False, 'mock_option': None},
+       'expected': {'num_workers': 5,
+                    'mock_flag': False,
+                    'mock_option': None,
+                    'mock_multi_option': None},
        'display_data': [DisplayDataItemMatcher('num_workers', 5)]},
       {
           'flags': [
               '--profile_cpu', '--profile_location', 'gs://bucket/', 'ignored'],
           'expected': {
               'profile_cpu': True, 'profile_location': 'gs://bucket/',
-              'mock_flag': False, 'mock_option': None},
+              'mock_flag': False, 'mock_option': None,
+              'mock_multi_option': None},
           'display_data': [
               DisplayDataItemMatcher('profile_cpu',
                                      True),
@@ -53,32 +57,52 @@ class PipelineOptionsTest(unittest.TestCase):
                                      'gs://bucket/')]
       },
       {'flags': ['--num_workers', '5', '--mock_flag'],
-       'expected': {'num_workers': 5, 'mock_flag': True, 'mock_option': None},
+       'expected': {'num_workers': 5,
+                    'mock_flag': True,
+                    'mock_option': None,
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('num_workers', 5),
            DisplayDataItemMatcher('mock_flag', True)]
       },
       {'flags': ['--mock_option', 'abc'],
-       'expected': {'mock_flag': False, 'mock_option': 'abc'},
+       'expected': {'mock_flag': False,
+                    'mock_option': 'abc',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', 'abc')]
       },
       {'flags': ['--mock_option', ' abc def '],
-       'expected': {'mock_flag': False, 'mock_option': ' abc def '},
+       'expected': {'mock_flag': False,
+                    'mock_option': ' abc def ',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', ' abc def ')]
       },
       {'flags': ['--mock_option= abc xyz '],
-       'expected': {'mock_flag': False, 'mock_option': ' abc xyz '},
+       'expected': {'mock_flag': False,
+                    'mock_option': ' abc xyz ',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', ' abc xyz ')]
       },
-      {'flags': ['--mock_option=gs://my bucket/my folder/my file'],
+      {'flags': ['--mock_option=gs://my bucket/my folder/my file',
+                 '--mock_multi_option=op1',
+                 '--mock_multi_option=op2'],
        'expected': {'mock_flag': False,
-                    'mock_option': 'gs://my bucket/my folder/my file'},
+                    'mock_option': 'gs://my bucket/my folder/my file',
+                    'mock_multi_option': ['op1', 'op2']},
        'display_data': [
            DisplayDataItemMatcher(
-               'mock_option', 'gs://my bucket/my folder/my file')]
+               'mock_option', 'gs://my bucket/my folder/my file'),
+           DisplayDataItemMatcher('mock_multi_option', ['op1', 'op2'])]
+      },
+      {'flags': ['--mock_multi_option=op1', '--mock_multi_option=op2'],
+       'expected': {'mock_flag': False,
+                    'mock_option': None,
+                    'mock_multi_option': ['op1', 'op2']},
+       'display_data': [
+           DisplayDataItemMatcher('mock_multi_option', ['op1', 'op2'])]
       },
   ]
 
@@ -89,6 +113,8 @@ class PipelineOptionsTest(unittest.TestCase):
     def _add_argparse_args(cls, parser):
       parser.add_argument('--mock_flag', action='store_true', help='mock flag')
       parser.add_argument('--mock_option', help='mock option')
+      parser.add_argument(
+          '--mock_multi_option', action='append', help='mock multi option')
       parser.add_argument('--option with space', help='mock option with space')
 
   def test_display_data(self):
@@ -107,6 +133,9 @@ class PipelineOptionsTest(unittest.TestCase):
       self.assertEqual(options.view_as(
           PipelineOptionsTest.MockOptions).mock_option,
                        case['expected']['mock_option'])
+      self.assertEqual(options.view_as(
+          PipelineOptionsTest.MockOptions).mock_multi_option,
+                       case['expected']['mock_multi_option'])
 
   def test_from_dictionary(self):
     for case in PipelineOptionsTest.TEST_CASES:


### PR DESCRIPTION
Multiple options are converted to strings and added to flags which causes wrong deserialization.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




