### PR TITLE
[BEAM-4130] Bring up Job Server container for Python jobs

### DIFF
--- a/runners/flink/job-server-container/Dockerfile
+++ b/runners/flink/job-server-container/Dockerfile
@@ -19,7 +19,7 @@
 FROM openjdk:8
 MAINTAINER "Apache Beam <dev@beam.apache.org>"
 
-ADD target/beam-runners-flink_2.11-job-server.jar /opt/apache/beam/jars/
+ADD target/beam-runners-flink-job-server.jar /opt/apache/beam/jars/
 ADD target/flink-job-server.sh /opt/apache/beam/
 
 WORKDIR /opt/apache/beam

--- a/runners/flink/job-server-container/build.gradle
+++ b/runners/flink/job-server-container/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 task copyDockerfileDependencies(type: Copy) {
   // Required Jars
   from configurations.dockerDependency
-  rename 'beam-runners-flink_2.11-job-server.*.jar', 'beam-runners-flink_2.11-job-server.jar'
+  rename 'beam-runners-flink_2.11-job-server.*.jar', 'beam-runners-flink-job-server.jar'
   into "build/target"
   // Entry script
   from file("./flink-job-server.sh")

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/ServerFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/ServerFactory.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.util.function.Supplier;
+
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.sdk.fn.channel.SocketAddressFactory;
 import org.apache.beam.vendor.grpc.v1.io.grpc.BindableService;
@@ -39,9 +41,9 @@ public abstract class ServerFactory {
     return new InetSocketAddressServerFactory(UrlFactory.createDefault());
   }
 
-  /** Create a {@link ServerFactory} that uses the given url factory. */
-  public static ServerFactory createWithUrlFactory(UrlFactory urlFactory) {
-    return new InetSocketAddressServerFactory(urlFactory);
+  /** Create a {@link ServerFactory} that uses the given url factory and a given port. */
+  public static ServerFactory createWithUrlFactory(UrlFactory urlFactory, Supplier<Integer> portSupplier) {
+    return new InetSocketAddressServerFactory(urlFactory, portSupplier);
   }
 
   /**
@@ -68,16 +70,22 @@ public abstract class ServerFactory {
    */
   public static class InetSocketAddressServerFactory extends ServerFactory {
     private final UrlFactory urlFactory;
+    private final Supplier<Integer> portSupplier;
 
     private InetSocketAddressServerFactory(UrlFactory urlFactory) {
+      this(urlFactory, () -> 0);
+    }
+
+    private InetSocketAddressServerFactory(UrlFactory urlFactory, Supplier<Integer> portSupplier) {
       this.urlFactory = urlFactory;
+      this.portSupplier = portSupplier;
     }
 
     @Override
     public Server allocatePortAndCreate(
         BindableService service, Endpoints.ApiServiceDescriptor.Builder apiServiceDescriptor)
         throws IOException {
-      InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+      InetSocketAddress address = new InetSocketAddress(InetAddress.getLoopbackAddress(), portSupplier.get());
       Server server = createServer(service, address);
       apiServiceDescriptor.setUrl(urlFactory.createUrl(address.getHostName(), server.getPort()));
       return server;

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/DockerEnvironmentFactory.java
@@ -129,6 +129,8 @@ public class DockerEnvironmentFactory implements EnvironmentFactory {
             .addAll(gcsCredentialArgs())
             // NOTE: Host networking does not work on Mac, but the command line flag is accepted.
             .add("--network=host")
+            // We need to pass on the information about Docker-on-Mac environment (due to missing host networking on Mac)
+            .add("--env=DOCKER_MAC_CONTAINER=" + System.getenv("DOCKER_MAC_CONTAINER"))
             .build();
 
     List<String> args =

--- a/sdks/python/apache_beam/runners/portability/job_server.py
+++ b/sdks/python/apache_beam/runners/portability/job_server.py
@@ -1,0 +1,98 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import atexit
+import logging
+import os
+from subprocess import Popen
+from threading import Lock
+
+import signal
+import sys
+import time
+
+
+class DockerizedJobServer:
+  """
+   Spins up the JobServer in a docker container for local execution
+  """
+
+  def __init__(self, job_host = "localhost",
+               job_port=8099,
+               artifact_port=8098,
+               harness_port_range=(8100, 8200),
+               max_connection_retries=5):
+      self.job_host = job_host
+      self.job_port = job_port
+      self.artifact_port = artifact_port
+      self.harness_port_range = harness_port_range
+      self.max_connection_retries = max_connection_retries
+      self.docker_process = None
+      self.process_lock = Lock()
+
+  def start(self):
+    # TODO This is hardcoded to Flink at the moment but should be changed
+    job_server_image_name = os.environ['USER'] + "-docker-apache.bintray.io/beam/flink-job-server:latest"
+    cmd = ["docker", "run",
+      # We mount the docker binary and socket to be able to spin up "sibling" containers
+      # for the SDK harness.
+      "-v", "/usr/local/bin/docker:/bin/docker",
+      "-v", "/var/run/docker.sock:/var/run/docker.sock"]
+    args = ["--job-host", self.job_host, "--job-port", str(self.job_port)]
+
+    if sys.platform == "darwin":
+      # Docker-for-Mac doesn't support host networking, so we need to explictly publish ports
+      # from the Docker container to be able to connect to it.
+      # Also, all other containers need to be aware that they run Docker-on-Mac to connect
+      # against the internal Docker-for-Mac address.
+      cmd += ["-e", "DOCKER_MAC_CONTAINER=1"]
+      cmd += ["-p", "{}:{}".format(self.job_port, self.job_port)]
+      cmd += ["-p", "{}:{}".format(self.artifact_port, self.artifact_port)]
+      cmd += ["-p", "{0}-{1}:{0}-{1}".format(self.harness_port_range[0], self.harness_port_range[1])]
+      args += ["--artifact-port", "{}".format(self.artifact_port)]
+    else:
+      # This shouldn't be set for MacOS because it detroys port forwardings,
+      # even though host networking is not supported on MacOS.
+      cmd.append("--network=host")
+
+    cmd.append(job_server_image_name)
+    cmd += args
+
+    logging.debug("Starting container with {}".format(cmd))
+    try:
+      self.docker_process = Popen(cmd)
+      atexit.register(self.stop)
+      signal.signal(signal.SIGINT, self.stop)
+    except:
+      logging.exception("Error bringing up container")
+      self.stop()
+
+    return "{}:{}".format(self.job_host, self.job_port)
+
+  def stop(self):
+    with self.process_lock:
+      if not self.docker_process:
+        return
+      num_retries = 0
+      while self.docker_process.poll() is None and num_retries < self.max_connection_retries:
+        logging.debug("Sending SIGINT to job_server container")
+        self.docker_process.send_signal(signal.SIGINT)
+        num_retries += 1
+        time.sleep(1)
+      if self.docker_process.poll is None:
+        self.docker_process.kill()
+

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -204,14 +204,10 @@ task directRunnerIT(dependsOn: 'installGcpTest') {
 
 // Before running this, you need to:
 //
-// 1. build the SDK container:
+// Build the SDK container:
 //
 //    ./gradlew -p sdks/python/container docker
 //
-// 2. start a local JobService, for example, the Portable Flink runner
-//    (in a separate shell since it continues to run):
-//
-//    ./gradlew :beam-runners-flink_2.11-job-server:runShadow
 //
 // Then you can run this example:
 //
@@ -222,7 +218,7 @@ task portableWordCount(dependsOn: 'installGcpTest') {
     exec {
       executable 'sh'
       // TODO: Figure out GCS credentials and use real GCS input and output.
-      args '-c', ". ${envdir}/bin/activate && python -m apache_beam.examples.wordcount --input /etc/profile --output /tmp/py-wordcount-direct --experiments=beam_fn_api --runner=PortableRunner --job_endpoint=localhost:8099 --sdk_location=container"
+      args '-c', ". ${envdir}/bin/activate && python -m apache_beam.examples.wordcount --input /etc/profile --output /tmp/py-wordcount-direct --experiments=beam_fn_api --runner=PortableRunner --sdk_location=container"
       // TODO: Check that the output file is generated and runs.
     }
   }


### PR DESCRIPTION
This starts the Job Server in a container when Python pipelines are run and no
Job Server endpoint has been specified. The Job Server has the docker binaries
and socket mounted from the host to bring up SDK harness containers directly on
the host. This feature is currently only is available for Flink.

Due to host networking not being available on MacOs, we need to explicitly map
ports from the host system to the container. On Linux this is not necessary
because host networking works as expected. Generally, getting Docker support to
work on MacOs proved to be a bit tricky.

You can test this via:

```
 gradle :beam-sdks-python:portableWordCount
```

Some rough edges on MacOS:

- At times, the JobService socket is not available, even though `grpc.channel_ready_future(channel).result()` in the portable_runner returns.
- The port range for the SDK harness is restricted to be between 8100 and 8200 (configurable) due to the necessary explicit port forwarding

Potentially problematic on Linux:

- The Docker binary might not be statically compiled and depend on shared
  libraries, though this needs to be tested

CC @angoenka 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




