### PR TITLE
[BEAM-5190] Fixing Python SDK thread count for Portable Runners

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import argparse
+from builtins import list
 from builtins import object
 
 from apache_beam.options.value_provider import RuntimeValueProvider
@@ -182,6 +183,9 @@ class PipelineOptions(HasDisplayData):
       if isinstance(v, bool):
         if v:
           flags.append('--%s' % k)
+      elif isinstance(v, list):
+        for i in v:
+          flags.append('--%s=%s' % (k, i))
       else:
         flags.append('--%s=%s' % (k, v))
 

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -38,14 +38,18 @@ class PipelineOptionsTest(unittest.TestCase):
 
   TEST_CASES = [
       {'flags': ['--num_workers', '5'],
-       'expected': {'num_workers': 5, 'mock_flag': False, 'mock_option': None},
+       'expected': {'num_workers': 5,
+                    'mock_flag': False,
+                    'mock_option': None,
+                    'mock_multi_option': None},
        'display_data': [DisplayDataItemMatcher('num_workers', 5)]},
       {
           'flags': [
               '--profile_cpu', '--profile_location', 'gs://bucket/', 'ignored'],
           'expected': {
               'profile_cpu': True, 'profile_location': 'gs://bucket/',
-              'mock_flag': False, 'mock_option': None},
+              'mock_flag': False, 'mock_option': None,
+              'mock_multi_option': None},
           'display_data': [
               DisplayDataItemMatcher('profile_cpu',
                                      True),
@@ -53,32 +57,52 @@ class PipelineOptionsTest(unittest.TestCase):
                                      'gs://bucket/')]
       },
       {'flags': ['--num_workers', '5', '--mock_flag'],
-       'expected': {'num_workers': 5, 'mock_flag': True, 'mock_option': None},
+       'expected': {'num_workers': 5,
+                    'mock_flag': True,
+                    'mock_option': None,
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('num_workers', 5),
            DisplayDataItemMatcher('mock_flag', True)]
       },
       {'flags': ['--mock_option', 'abc'],
-       'expected': {'mock_flag': False, 'mock_option': 'abc'},
+       'expected': {'mock_flag': False,
+                    'mock_option': 'abc',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', 'abc')]
       },
       {'flags': ['--mock_option', ' abc def '],
-       'expected': {'mock_flag': False, 'mock_option': ' abc def '},
+       'expected': {'mock_flag': False,
+                    'mock_option': ' abc def ',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', ' abc def ')]
       },
       {'flags': ['--mock_option= abc xyz '],
-       'expected': {'mock_flag': False, 'mock_option': ' abc xyz '},
+       'expected': {'mock_flag': False,
+                    'mock_option': ' abc xyz ',
+                    'mock_multi_option': None},
        'display_data': [
            DisplayDataItemMatcher('mock_option', ' abc xyz ')]
       },
-      {'flags': ['--mock_option=gs://my bucket/my folder/my file'],
+      {'flags': ['--mock_option=gs://my bucket/my folder/my file',
+                 '--mock_multi_option=op1',
+                 '--mock_multi_option=op2'],
        'expected': {'mock_flag': False,
-                    'mock_option': 'gs://my bucket/my folder/my file'},
+                    'mock_option': 'gs://my bucket/my folder/my file',
+                    'mock_multi_option': ['op1', 'op2']},
        'display_data': [
            DisplayDataItemMatcher(
-               'mock_option', 'gs://my bucket/my folder/my file')]
+               'mock_option', 'gs://my bucket/my folder/my file'),
+           DisplayDataItemMatcher('mock_multi_option', ['op1', 'op2'])]
+      },
+      {'flags': ['--mock_multi_option=op1', '--mock_multi_option=op2'],
+       'expected': {'mock_flag': False,
+                    'mock_option': None,
+                    'mock_multi_option': ['op1', 'op2']},
+       'display_data': [
+           DisplayDataItemMatcher('mock_multi_option', ['op1', 'op2'])]
       },
   ]
 
@@ -89,6 +113,8 @@ class PipelineOptionsTest(unittest.TestCase):
     def _add_argparse_args(cls, parser):
       parser.add_argument('--mock_flag', action='store_true', help='mock flag')
       parser.add_argument('--mock_option', help='mock option')
+      parser.add_argument(
+          '--mock_multi_option', action='append', help='mock multi option')
       parser.add_argument('--option with space', help='mock option with space')
 
   def test_display_data(self):
@@ -107,6 +133,9 @@ class PipelineOptionsTest(unittest.TestCase):
       self.assertEqual(options.view_as(
           PipelineOptionsTest.MockOptions).mock_option,
                        case['expected']['mock_option'])
+      self.assertEqual(options.view_as(
+          PipelineOptionsTest.MockOptions).mock_multi_option,
+                       case['expected']['mock_multi_option'])
 
   def test_from_dictionary(self):
     for case in PipelineOptionsTest.TEST_CASES:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -24,10 +24,24 @@ import json
 import logging
 import unittest
 
+from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.runners.worker import sdk_worker_main
 
 
 class SdkWorkerMainTest(unittest.TestCase):
+
+  # Used for testing newly added flags.
+  class MockOptions(PipelineOptions):
+
+    @classmethod
+    def _add_argparse_args(cls, parser):
+      parser.add_argument('--eam:option:mock_option:v', help='mock option')
+      parser.add_argument('--eam:option:mock_option:v1', help='mock option')
+      parser.add_argument('--beam:option:mock_option:v', help='mock option')
+      parser.add_argument('--mock_flag', action='store_true', help='mock flag')
+      parser.add_argument('--mock_option', help='mock option')
+      parser.add_argument(
+          '--mock_multi_option', action='append', help='mock multi option')
 
   def test_status_server(self):
 
@@ -42,29 +56,75 @@ class SdkWorkerMainTest(unittest.TestCase):
   def test_work_count_default_value(self):
     self._check_worker_count('{}', 12)
 
+  def test_parse_pipeine_options(self):
+    expected_options = PipelineOptions()
+    expected_options.view_as(
+        SdkWorkerMainTest.MockOptions).mock_multi_option = [
+            'worker_threads=1', 'beam_fn_api'
+        ]
+    expected_options.view_as(
+        SdkWorkerMainTest.MockOptions).mock_option = '/tmp/requirements.txt'
+    self.assertEqual(
+        {'mock_multi_option': ['worker_threads=1']},
+        sdk_worker_main._parse_pipeline_options(
+            '{"options": {"mock_multi_option":["worker_threads=1"]}}')
+        .get_all_options(drop_default=True))
+    self.assertEqual(
+        expected_options.get_all_options(),
+        sdk_worker_main._parse_pipeline_options(
+            '{"options": {' +
+            '"mock_option": "/tmp/requirements.txt", ' +
+            '"mock_multi_option":["worker_threads=1", "beam_fn_api"]' +
+            '}}').get_all_options())
+    self.assertEqual(
+        {'mock_multi_option': ['worker_threads=1']},
+        sdk_worker_main._parse_pipeline_options(
+            '{"beam:option:mock_multi_option:v1":["worker_threads=1"]}')
+        .get_all_options(drop_default=True))
+    self.assertEqual(
+        expected_options.get_all_options(),
+        sdk_worker_main._parse_pipeline_options(
+            '{"beam:option:mock_option:v1": "/tmp/requirements.txt", ' +
+            '"beam:option:mock_multi_option:v1":["worker_threads=1", ' +
+            '"beam_fn_api"]}').get_all_options())
+    self.assertEqual(
+        {'beam:option:mock_option:v': 'mock_val'},
+        sdk_worker_main._parse_pipeline_options(
+            '{"options": {"beam:option:mock_option:v":"mock_val"}}')
+        .get_all_options(drop_default=True))
+    self.assertEqual(
+        {'eam:option:mock_option:v1': 'mock_val'},
+        sdk_worker_main._parse_pipeline_options(
+            '{"options": {"eam:option:mock_option:v1":"mock_val"}}')
+        .get_all_options(drop_default=True))
+    self.assertEqual(
+        {'eam:option:mock_option:v': 'mock_val'},
+        sdk_worker_main._parse_pipeline_options(
+            '{"options": {"eam:option:mock_option:v":"mock_val"}}')
+        .get_all_options(drop_default=True))
+
   def test_work_count_custom_value(self):
-    self._check_worker_count(
-        '{"options": {"experiments":["worker_threads=1"]}}', 1)
-    self._check_worker_count(
-        '{"options": {"experiments":["worker_threads=4"]}}', 4)
-    self._check_worker_count(
-        '{"options": {"experiments":["worker_threads=12"]}}', 12)
+    self._check_worker_count('{"experiments":["worker_threads=1"]}', 1)
+    self._check_worker_count('{"experiments":["worker_threads=4"]}', 4)
+    self._check_worker_count('{"experiments":["worker_threads=12"]}', 12)
 
   def test_work_count_wrong_format(self):
     self._check_worker_count(
-        '{"options": {"experiments":["worker_threads="]}}', exception=True)
+        '{"experiments":["worker_threads="]}', exception=True)
     self._check_worker_count(
-        '{"options": {"experiments":["worker_threads=a"]}}', exception=True)
+        '{"experiments":["worker_threads=a"]}', exception=True)
     self._check_worker_count(
-        '{"options": {"experiments":["worker_threads=1a"]}}', exception=True)
+        '{"experiments":["worker_threads=1a"]}', exception=True)
 
   def _check_worker_count(self, pipeline_options, expected=0, exception=False):
     if exception:
-      self.assertRaises(Exception, sdk_worker_main._get_worker_count,
-                        json.loads(pipeline_options))
+      self.assertRaises(
+          Exception, sdk_worker_main._get_worker_count,
+          PipelineOptions.from_dictionary(json.loads(pipeline_options)))
     else:
       self.assertEquals(
-          sdk_worker_main._get_worker_count(json.loads(pipeline_options)),
+          sdk_worker_main._get_worker_count(
+              PipelineOptions.from_dictionary(json.loads(pipeline_options))),
           expected)
 
 


### PR DESCRIPTION
Portable pipeline options have a different structure than the legacy runners. Correctly parsing the pipeline options and using it to get the worker_threads

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




