### PR TITLE
[BEAM-5210] Support VARBINARY in BeamSqlPrimitive

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitive.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironment;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.Row;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.NlsString;
 import org.joda.time.ReadableInstant;
@@ -131,6 +132,8 @@ public class BeamSqlPrimitive<T> extends BeamSqlExpression {
       case CHAR:
       case VARCHAR:
         return value instanceof String || value instanceof NlsString;
+      case VARBINARY:
+        return value instanceof byte[] || value instanceof ByteString;
       case TIME:
       case TIMESTAMP:
       case DATE:

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlPrimitiveTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.extensions.sql.impl.interpreter.operator;
 
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironments;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlFnExecutorTestBase;
+import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,6 +33,24 @@ public class BeamSqlPrimitiveTest extends BeamSqlFnExecutorTestBase {
     Assert.assertEquals(
         expInt.getValue(),
         expInt.evaluate(row, null, BeamSqlExpressionEnvironments.empty()).getValue());
+  }
+
+  @Test
+  public void testPrimitiveBytes1() {
+    BeamSqlPrimitive<byte[]> expBytes =
+        BeamSqlPrimitive.of(SqlTypeName.VARBINARY, new byte[] {1, 2, 3});
+    Assert.assertEquals(
+        expBytes.getValue(),
+        expBytes.evaluate(row, null, BeamSqlExpressionEnvironments.empty()).getValue());
+  }
+
+  @Test
+  public void testPrimitiveBytes2() {
+    BeamSqlPrimitive<ByteString> expBytes =
+        BeamSqlPrimitive.of(SqlTypeName.VARBINARY, ByteString.of("123ABC", 16));
+    Assert.assertEquals(
+        expBytes.getValue(),
+        expBytes.evaluate(row, null, BeamSqlExpressionEnvironments.empty()).getValue());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -64,5 +83,13 @@ public class BeamSqlPrimitiveTest extends BeamSqlFnExecutorTestBase {
     Assert.assertEquals(
         expInt.getValue(),
         expInt.evaluate(row, null, BeamSqlExpressionEnvironments.empty()).getValue());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testPrimitiveTypeUnMatch5() {
+    BeamSqlPrimitive expBytes = BeamSqlPrimitive.of(SqlTypeName.VARBINARY, 100L);
+    Assert.assertEquals(
+        expBytes.getValue(),
+        expBytes.evaluate(row, null, BeamSqlExpressionEnvironments.empty()).getValue());
   }
 }


### PR DESCRIPTION
A quick bug fix to support VARBINARY in BeamSqlPrimitive.
------------
R: @apilloud @akedin @xumingming @amaliujia  @vectorijk