### PR TITLE
[BEAM-4904][BEAM-4905] Upgrade Flapdoodle OSS dependencies

### DIFF
--- a/sdks/java/io/mongodb/build.gradle
+++ b/sdks/java/io/mongodb/build.gradle
@@ -37,6 +37,6 @@ dependencies {
   testCompile library.java.hamcrest_library
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadow")
   testCompile project(path: ":beam-sdks-java-io-common", configuration: "shadowTest")
-  testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo:1.50.1"
-  testCompile "de.flapdoodle.embed:de.flapdoodle.embed.process:1.50.1"
+  testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.1.1"
+  testCompile "de.flapdoodle.embed:de.flapdoodle.embed.process:2.0.5"
 }


### PR DESCRIPTION
Upgrades following dependencies.

de.flapdoodle.embed:de.flapdoodle.embed.mongo from 1.50.1 to 2.1.1
de.flapdoodle.embed:de.flapdoodle.embed.process from 1.50.1 to 2.0.5

Backwards compatibility: This doesn't appear to be changing MongoDbIO API. Also, MongoDbIO is experimental hence we allow backwards incompatible changes (see https://beam.apache.org/contribute/dependencies/).
