### PR TITLE
[BEAM-5187] Add a ProcessJobBundleFactory for process-based execution

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
@@ -50,7 +50,7 @@ public class DockerJobBundleFactory extends JobBundleFactoryBase {
 
   /** Factory that creates {@link JobBundleFactory} for the given {@link JobInfo}. */
   public interface JobBundleFactoryFactory {
-    DockerJobBundleFactory create(JobInfo jobInfo) throws Exception;
+    JobBundleFactory create(JobInfo jobInfo) throws Exception;
   }
   // TODO (BEAM-4819): a hacky way to override the factory for testing.
   // Should be replaced with mechanism that let's users configure their own factory
@@ -58,7 +58,7 @@ public class DockerJobBundleFactory extends JobBundleFactoryBase {
       new AtomicReference(
           new JobBundleFactoryFactory() {
             @Override
-            public DockerJobBundleFactory create(JobInfo jobInfo) throws Exception {
+            public JobBundleFactory create(JobInfo jobInfo) throws Exception {
               return new DockerJobBundleFactory(jobInfo);
             }
           });
@@ -67,7 +67,7 @@ public class DockerJobBundleFactory extends JobBundleFactoryBase {
   // or attempt to document the supported Docker version(s)?
   private static final String DOCKER_FOR_MAC_HOST = "host.docker.internal";
 
-  public static DockerJobBundleFactory create(JobInfo jobInfo) throws Exception {
+  public static JobBundleFactory create(JobInfo jobInfo) throws Exception {
     return FACTORY.get().create(jobInfo);
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
@@ -18,48 +18,19 @@
 package org.apache.beam.runners.fnexecution.control;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalNotification;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.net.HostAndPort;
-import java.io.IOException;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
-import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
-import org.apache.beam.runners.core.construction.graph.ExecutableStage;
-import org.apache.beam.runners.fnexecution.GrpcContextHeaderAccessorProvider;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.ServerFactory;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
-import org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactRetrievalService;
-import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors.ExecutableProcessBundleDescriptor;
-import org.apache.beam.runners.fnexecution.control.SdkHarnessClient.BundleProcessor;
-import org.apache.beam.runners.fnexecution.data.GrpcDataService;
 import org.apache.beam.runners.fnexecution.environment.DockerEnvironmentFactory;
 import org.apache.beam.runners.fnexecution.environment.EnvironmentFactory;
-import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
 import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
-import org.apache.beam.runners.fnexecution.logging.Slf4jLogWriter;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
-import org.apache.beam.runners.fnexecution.state.GrpcStateService;
-import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
-import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.IdGenerator;
-import org.apache.beam.sdk.fn.IdGenerators;
-import org.apache.beam.sdk.fn.data.FnDataReceiver;
-import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
-import org.apache.beam.sdk.util.WindowedValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A {@link JobBundleFactory} that uses a {@link DockerEnvironmentFactory} for environment
@@ -67,9 +38,7 @@ import org.slf4j.LoggerFactory;
  * thread-safe. Instead, a new stage factory should be created for each client.
  */
 @ThreadSafe
-public class DockerJobBundleFactory implements JobBundleFactory {
-  private static final Logger LOG = LoggerFactory.getLogger(DockerJobBundleFactory.class);
-
+public class DockerJobBundleFactory extends JobBundleFactoryBase {
   // Port offset for MacOS since we don't have host networking and need to use published ports
   private static final int MAC_PORT_START = 8100;
   private static final int MAC_PORT_END = 8200;
@@ -94,51 +63,12 @@ public class DockerJobBundleFactory implements JobBundleFactory {
   // or attempt to document the supported Docker version(s)?
   private static final String DOCKER_FOR_MAC_HOST = "host.docker.internal";
 
-  private final IdGenerator stageIdGenerator;
-  private final GrpcFnServer<FnApiControlClientPoolService> controlServer;
-  private final GrpcFnServer<GrpcLoggingService> loggingServer;
-  private final GrpcFnServer<ArtifactRetrievalService> retrievalServer;
-  private final GrpcFnServer<StaticGrpcProvisionService> provisioningServer;
-
-  private final LoadingCache<Environment, WrappedSdkHarnessClient> environmentCache;
-
   public static DockerJobBundleFactory create(JobInfo jobInfo) throws Exception {
     return FACTORY.get().create(jobInfo);
   }
 
   protected DockerJobBundleFactory(JobInfo jobInfo) throws Exception {
-    ServerFactory serverFactory = getServerFactory();
-    IdGenerator stageIdGenerator = IdGenerators.incrementingLongs();
-    ControlClientPool clientPool = MapControlClientPool.create();
-
-    GrpcFnServer<FnApiControlClientPoolService> controlServer =
-        GrpcFnServer.allocatePortAndCreateFor(
-            FnApiControlClientPoolService.offeringClientsToPool(
-                clientPool.getSink(), GrpcContextHeaderAccessorProvider.getHeaderAccessor()),
-            serverFactory);
-    GrpcFnServer<GrpcLoggingService> loggingServer =
-        GrpcFnServer.allocatePortAndCreateFor(
-            GrpcLoggingService.forWriter(Slf4jLogWriter.getDefault()), serverFactory);
-    GrpcFnServer<ArtifactRetrievalService> retrievalServer =
-        GrpcFnServer.allocatePortAndCreateFor(
-            BeamFileSystemArtifactRetrievalService.create(), serverFactory);
-    GrpcFnServer<StaticGrpcProvisionService> provisioningServer =
-        GrpcFnServer.allocatePortAndCreateFor(
-            StaticGrpcProvisionService.create(jobInfo.toProvisionInfo()), serverFactory);
-    EnvironmentFactory environmentFactory =
-        getEnvironmentFactory(
-            controlServer,
-            loggingServer,
-            retrievalServer,
-            provisioningServer,
-            clientPool.getSource(),
-            IdGenerators.incrementingLongs());
-    this.stageIdGenerator = stageIdGenerator;
-    this.controlServer = controlServer;
-    this.loggingServer = loggingServer;
-    this.retrievalServer = retrievalServer;
-    this.provisioningServer = provisioningServer;
-    this.environmentCache = createEnvironmentCache(environmentFactory, serverFactory);
+    super(jobInfo);
   }
 
   @VisibleForTesting
@@ -150,54 +80,14 @@ public class DockerJobBundleFactory implements JobBundleFactory {
       GrpcFnServer<GrpcLoggingService> loggingServer,
       GrpcFnServer<ArtifactRetrievalService> retrievalServer,
       GrpcFnServer<StaticGrpcProvisionService> provisioningServer) {
-    this.stageIdGenerator = stageIdGenerator;
-    this.controlServer = controlServer;
-    this.loggingServer = loggingServer;
-    this.retrievalServer = retrievalServer;
-    this.provisioningServer = provisioningServer;
-    this.environmentCache = createEnvironmentCache(environmentFactory, serverFactory);
-  }
-
-  private LoadingCache<Environment, WrappedSdkHarnessClient> createEnvironmentCache(
-      EnvironmentFactory environmentFactory, ServerFactory serverFactory) {
-    return CacheBuilder.newBuilder()
-        .removalListener(
-            ((RemovalNotification<Environment, WrappedSdkHarnessClient> notification) -> {
-              LOG.debug("Cleaning up for environment {}", notification.getKey().getUrl());
-              try {
-                notification.getValue().close();
-              } catch (Exception e) {
-                LOG.warn(
-                    String.format("Error cleaning up environment %s", notification.getKey()), e);
-              }
-            }))
-        .build(
-            new CacheLoader<Environment, WrappedSdkHarnessClient>() {
-              @Override
-              public WrappedSdkHarnessClient load(Environment environment) throws Exception {
-                RemoteEnvironment remoteEnvironment =
-                    environmentFactory.createEnvironment(environment);
-                return WrappedSdkHarnessClient.wrapping(remoteEnvironment, serverFactory);
-              }
-            });
-  }
-
-  @Override
-  public StageBundleFactory forStage(ExecutableStage executableStage) {
-    WrappedSdkHarnessClient wrappedClient =
-        environmentCache.getUnchecked(executableStage.getEnvironment());
-    ExecutableProcessBundleDescriptor processBundleDescriptor;
-    try {
-      processBundleDescriptor =
-          ProcessBundleDescriptors.fromExecutableStage(
-              stageIdGenerator.getId(),
-              executableStage,
-              wrappedClient.getDataServer().getApiServiceDescriptor(),
-              wrappedClient.getStateServer().getApiServiceDescriptor());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    return SimpleStageBundleFactory.create(wrappedClient, processBundleDescriptor);
+    super(
+        environmentFactory,
+        serverFactory,
+        stageIdGenerator,
+        controlServer,
+        loggingServer,
+        retrievalServer,
+        provisioningServer);
   }
 
   @Override
@@ -213,6 +103,7 @@ public class DockerJobBundleFactory implements JobBundleFactory {
     provisioningServer.close();
   }
 
+  @Override
   protected ServerFactory getServerFactory() {
     switch (getPlatform()) {
       case LINUX:
@@ -234,7 +125,7 @@ public class DockerJobBundleFactory implements JobBundleFactory {
             // We only use the published Docker ports 8100-8200 in a round-robin fashion
             () -> MAC_PORT.getAndUpdate(val -> val == MAC_PORT_END ? MAC_PORT_START : val + 1));
       default:
-        LOG.warn("Unknown Docker platform. Falling back to default server factory");
+        logger.warn("Unknown Docker platform. Falling back to default server factory");
         return ServerFactory.createDefault();
     }
   }
@@ -253,138 +144,6 @@ public class DockerJobBundleFactory implements JobBundleFactory {
     return Platform.OTHER;
   }
 
-  private static class SimpleStageBundleFactory implements StageBundleFactory {
-
-    private final BundleProcessor processor;
-    private final ExecutableProcessBundleDescriptor processBundleDescriptor;
-
-    // Store the wrapped client in order to keep a live reference into the cache.
-    private WrappedSdkHarnessClient wrappedClient;
-
-    static SimpleStageBundleFactory create(
-        WrappedSdkHarnessClient wrappedClient,
-        ExecutableProcessBundleDescriptor processBundleDescriptor) {
-      @SuppressWarnings("unchecked")
-      BundleProcessor processor =
-          wrappedClient
-              .getClient()
-              .getProcessor(
-                  processBundleDescriptor.getProcessBundleDescriptor(),
-                  processBundleDescriptor.getRemoteInputDestinations(),
-                  wrappedClient.getStateServer().getService());
-      return new SimpleStageBundleFactory(processBundleDescriptor, processor, wrappedClient);
-    }
-
-    SimpleStageBundleFactory(
-        ExecutableProcessBundleDescriptor processBundleDescriptor,
-        BundleProcessor processor,
-        WrappedSdkHarnessClient wrappedClient) {
-      this.processBundleDescriptor = processBundleDescriptor;
-      this.processor = processor;
-      this.wrappedClient = wrappedClient;
-    }
-
-    @Override
-    public RemoteBundle getBundle(
-        OutputReceiverFactory outputReceiverFactory,
-        StateRequestHandler stateRequestHandler,
-        BundleProgressHandler progressHandler)
-        throws Exception {
-      // TODO: Consider having BundleProcessor#newBundle take in an OutputReceiverFactory rather
-      // than constructing the receiver map here. Every bundle factory will need this.
-      ImmutableMap.Builder<Target, RemoteOutputReceiver<?>> outputReceivers =
-          ImmutableMap.builder();
-      for (Map.Entry<Target, Coder<WindowedValue<?>>> targetCoder :
-          processBundleDescriptor.getOutputTargetCoders().entrySet()) {
-        Target target = targetCoder.getKey();
-        Coder<WindowedValue<?>> coder = targetCoder.getValue();
-        String bundleOutputPCollection =
-            Iterables.getOnlyElement(
-                processBundleDescriptor
-                    .getProcessBundleDescriptor()
-                    .getTransformsOrThrow(target.getPrimitiveTransformReference())
-                    .getInputsMap()
-                    .values());
-        FnDataReceiver<WindowedValue<?>> outputReceiver =
-            outputReceiverFactory.create(bundleOutputPCollection);
-        outputReceivers.put(target, RemoteOutputReceiver.of(coder, outputReceiver));
-      }
-      return processor.newBundle(outputReceivers.build(), stateRequestHandler, progressHandler);
-    }
-
-    @Override
-    public void close() throws Exception {
-      // Clear reference to encourage cache eviction. Values are weakly referenced.
-      wrappedClient = null;
-    }
-  }
-
-  /**
-   * Holder for an {@link SdkHarnessClient} along with its associated state and data servers. As of
-   * now, there is a 1:1 relationship between data services and harness clients. The servers are
-   * packaged here to tie server lifetimes to harness client lifetimes.
-   */
-  private static class WrappedSdkHarnessClient implements AutoCloseable {
-    private final RemoteEnvironment environment;
-    private final ExecutorService executor;
-    // TODO: How should data server lifetime be scoped? It is necessary here for now because
-    // SdkHarnessClient requires one at construction.
-    private final GrpcFnServer<GrpcDataService> dataServer;
-    private final GrpcFnServer<GrpcStateService> stateServer;
-    private final SdkHarnessClient client;
-
-    static WrappedSdkHarnessClient wrapping(
-        RemoteEnvironment environment, ServerFactory serverFactory) throws Exception {
-      ExecutorService executor = Executors.newCachedThreadPool();
-      GrpcFnServer<GrpcDataService> dataServer =
-          GrpcFnServer.allocatePortAndCreateFor(
-              GrpcDataService.create(executor, OutboundObserverFactory.serverDirect()),
-              serverFactory);
-      GrpcFnServer<GrpcStateService> stateServer =
-          GrpcFnServer.allocatePortAndCreateFor(GrpcStateService.create(), serverFactory);
-      SdkHarnessClient client =
-          SdkHarnessClient.usingFnApiClient(
-              environment.getInstructionRequestHandler(), dataServer.getService());
-      return new WrappedSdkHarnessClient(environment, executor, dataServer, stateServer, client);
-    }
-
-    private WrappedSdkHarnessClient(
-        RemoteEnvironment environment,
-        ExecutorService executor,
-        GrpcFnServer<GrpcDataService> dataServer,
-        GrpcFnServer<GrpcStateService> stateServer,
-        SdkHarnessClient client) {
-      this.executor = executor;
-      this.environment = environment;
-      this.dataServer = dataServer;
-      this.stateServer = stateServer;
-      this.client = client;
-    }
-
-    SdkHarnessClient getClient() {
-      return client;
-    }
-
-    GrpcFnServer<GrpcStateService> getStateServer() {
-      return stateServer;
-    }
-
-    GrpcFnServer<GrpcDataService> getDataServer() {
-      return dataServer;
-    }
-
-    @Override
-    public void close() throws Exception {
-      try (AutoCloseable stateServerCloser = stateServer;
-          AutoCloseable dataServerCloser = dataServer;
-          AutoCloseable envCloser = environment;
-          AutoCloseable executorCloser = executor::shutdown) {
-        // Wrap resources in try-with-resources to ensure all are cleaned up.
-      }
-      // TODO: Wait for executor shutdown?
-    }
-  }
-
   private enum Platform {
     MAC,
     LINUX,
@@ -392,6 +151,7 @@ public class DockerJobBundleFactory implements JobBundleFactory {
   }
 
   /** Create {@link EnvironmentFactory} for the given services. */
+  @Override
   protected EnvironmentFactory getEnvironmentFactory(
       GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
       GrpcFnServer<GrpcLoggingService> loggingServiceServer,

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DockerJobBundleFactory.java
@@ -31,6 +31,8 @@ import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
 import org.apache.beam.sdk.fn.IdGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link JobBundleFactory} that uses a {@link DockerEnvironmentFactory} for environment
@@ -39,6 +41,8 @@ import org.apache.beam.sdk.fn.IdGenerator;
  */
 @ThreadSafe
 public class DockerJobBundleFactory extends JobBundleFactoryBase {
+  private static final Logger LOG = LoggerFactory.getLogger(DockerJobBundleFactory.class);
+
   // Port offset for MacOS since we don't have host networking and need to use published ports
   private static final int MAC_PORT_START = 8100;
   private static final int MAC_PORT_END = 8200;
@@ -125,7 +129,7 @@ public class DockerJobBundleFactory extends JobBundleFactoryBase {
             // We only use the published Docker ports 8100-8200 in a round-robin fashion
             () -> MAC_PORT.getAndUpdate(val -> val == MAC_PORT_END ? MAC_PORT_START : val + 1));
       default:
-        logger.warn("Unknown Docker platform. Falling back to default server factory");
+        LOG.warn("Unknown Docker platform. Falling back to default server factory");
         return ServerFactory.createDefault();
     }
   }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
@@ -66,7 +66,7 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public abstract class JobBundleFactoryBase implements JobBundleFactory {
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
+  private static final Logger LOG = LoggerFactory.getLogger(JobBundleFactoryBase.class);
 
   final IdGenerator stageIdGenerator;
   final GrpcFnServer<FnApiControlClientPoolService> controlServer;
@@ -142,11 +142,11 @@ public abstract class JobBundleFactoryBase implements JobBundleFactory {
     return CacheBuilder.newBuilder()
         .removalListener(
             ((RemovalNotification<Environment, WrappedSdkHarnessClient> notification) -> {
-              logger.debug("Cleaning up for environment {}", notification.getKey().getUrl());
+              LOG.debug("Cleaning up for environment {}", notification.getKey().getUrl());
               try {
                 notification.getValue().close();
               } catch (Exception e) {
-                logger.warn(
+                LOG.warn(
                     String.format("Error cleaning up environment %s", notification.getKey()), e);
               }
             }))

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.fnexecution.control;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.fnexecution.GrpcContextHeaderAccessorProvider;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.ServerFactory;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors.ExecutableProcessBundleDescriptor;
+import org.apache.beam.runners.fnexecution.control.SdkHarnessClient.BundleProcessor;
+import org.apache.beam.runners.fnexecution.data.GrpcDataService;
+import org.apache.beam.runners.fnexecution.environment.DockerEnvironmentFactory;
+import org.apache.beam.runners.fnexecution.environment.EnvironmentFactory;
+import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.logging.Slf4jLogWriter;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.runners.fnexecution.state.GrpcStateService;
+import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.fn.IdGenerator;
+import org.apache.beam.sdk.fn.IdGenerators;
+import org.apache.beam.sdk.fn.data.FnDataReceiver;
+import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link JobBundleFactory} that uses a {@link DockerEnvironmentFactory} for environment
+ * management. Note that returned {@link StageBundleFactory stage bundle factories} are not
+ * thread-safe. Instead, a new stage factory should be created for each client.
+ */
+@ThreadSafe
+public abstract class JobBundleFactoryBase implements JobBundleFactory {
+  protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+  final IdGenerator stageIdGenerator;
+  final GrpcFnServer<FnApiControlClientPoolService> controlServer;
+  final GrpcFnServer<GrpcLoggingService> loggingServer;
+  final GrpcFnServer<ArtifactRetrievalService> retrievalServer;
+  final GrpcFnServer<StaticGrpcProvisionService> provisioningServer;
+
+  final LoadingCache<Environment, WrappedSdkHarnessClient> environmentCache;
+
+  JobBundleFactoryBase(JobInfo jobInfo) throws Exception {
+    ServerFactory serverFactory = getServerFactory();
+    IdGenerator stageIdGenerator = IdGenerators.incrementingLongs();
+    ControlClientPool clientPool = MapControlClientPool.create();
+
+    GrpcFnServer<FnApiControlClientPoolService> controlServer =
+        GrpcFnServer.allocatePortAndCreateFor(
+            FnApiControlClientPoolService.offeringClientsToPool(
+                clientPool.getSink(), GrpcContextHeaderAccessorProvider.getHeaderAccessor()),
+            serverFactory);
+    GrpcFnServer<GrpcLoggingService> loggingServer =
+        GrpcFnServer.allocatePortAndCreateFor(
+            GrpcLoggingService.forWriter(Slf4jLogWriter.getDefault()), serverFactory);
+    GrpcFnServer<ArtifactRetrievalService> retrievalServer =
+        GrpcFnServer.allocatePortAndCreateFor(
+            BeamFileSystemArtifactRetrievalService.create(), serverFactory);
+    GrpcFnServer<StaticGrpcProvisionService> provisioningServer =
+        GrpcFnServer.allocatePortAndCreateFor(
+            StaticGrpcProvisionService.create(jobInfo.toProvisionInfo()), serverFactory);
+    EnvironmentFactory environmentFactory =
+        getEnvironmentFactory(
+            controlServer,
+            loggingServer,
+            retrievalServer,
+            provisioningServer,
+            clientPool.getSource(),
+            IdGenerators.incrementingLongs());
+    this.stageIdGenerator = stageIdGenerator;
+    this.controlServer = controlServer;
+    this.loggingServer = loggingServer;
+    this.retrievalServer = retrievalServer;
+    this.provisioningServer = provisioningServer;
+    this.environmentCache = createEnvironmentCache(environmentFactory, serverFactory);
+  }
+
+  @VisibleForTesting
+  JobBundleFactoryBase(
+      EnvironmentFactory environmentFactory,
+      ServerFactory serverFactory,
+      IdGenerator stageIdGenerator,
+      GrpcFnServer<FnApiControlClientPoolService> controlServer,
+      GrpcFnServer<GrpcLoggingService> loggingServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServer) {
+    this.stageIdGenerator = stageIdGenerator;
+    this.controlServer = controlServer;
+    this.loggingServer = loggingServer;
+    this.retrievalServer = retrievalServer;
+    this.provisioningServer = provisioningServer;
+    this.environmentCache = createEnvironmentCache(environmentFactory, serverFactory);
+  }
+
+  /** Create {@link EnvironmentFactory} for the given services. */
+  abstract EnvironmentFactory getEnvironmentFactory(
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      ControlClientPool.Source clientSource,
+      IdGenerator idGenerator);
+
+  private LoadingCache<Environment, WrappedSdkHarnessClient> createEnvironmentCache(
+      EnvironmentFactory environmentFactory, ServerFactory serverFactory) {
+    return CacheBuilder.newBuilder()
+        .removalListener(
+            ((RemovalNotification<Environment, WrappedSdkHarnessClient> notification) -> {
+              logger.debug("Cleaning up for environment {}", notification.getKey().getUrl());
+              try {
+                notification.getValue().close();
+              } catch (Exception e) {
+                logger.warn(
+                    String.format("Error cleaning up environment %s", notification.getKey()), e);
+              }
+            }))
+        .build(
+            new CacheLoader<Environment, WrappedSdkHarnessClient>() {
+              @Override
+              public WrappedSdkHarnessClient load(Environment environment) throws Exception {
+                RemoteEnvironment remoteEnvironment =
+                    environmentFactory.createEnvironment(environment);
+                return WrappedSdkHarnessClient.wrapping(remoteEnvironment, serverFactory);
+              }
+            });
+  }
+
+  @Override
+  public StageBundleFactory forStage(ExecutableStage executableStage) {
+    WrappedSdkHarnessClient wrappedClient =
+        environmentCache.getUnchecked(executableStage.getEnvironment());
+    ExecutableProcessBundleDescriptor processBundleDescriptor;
+    try {
+      processBundleDescriptor =
+          ProcessBundleDescriptors.fromExecutableStage(
+              stageIdGenerator.getId(),
+              executableStage,
+              wrappedClient.getDataServer().getApiServiceDescriptor(),
+              wrappedClient.getStateServer().getApiServiceDescriptor());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return SimpleStageBundleFactory.create(wrappedClient, processBundleDescriptor);
+  }
+
+  @Override
+  public void close() throws Exception {
+    // Clear the cache. This closes all active environments.
+    environmentCache.invalidateAll();
+    environmentCache.cleanUp();
+
+    // Tear down common servers.
+    controlServer.close();
+    loggingServer.close();
+    retrievalServer.close();
+    provisioningServer.close();
+  }
+
+  protected ServerFactory getServerFactory() {
+    return ServerFactory.createDefault();
+  }
+
+  /** A simple stage bundle factory for remotely processing bundles. */
+  protected static class SimpleStageBundleFactory implements StageBundleFactory {
+
+    private final BundleProcessor processor;
+    private final ExecutableProcessBundleDescriptor processBundleDescriptor;
+
+    // Store the wrapped client in order to keep a live reference into the cache.
+    @SuppressFBWarnings private WrappedSdkHarnessClient wrappedClient;
+
+    static SimpleStageBundleFactory create(
+        WrappedSdkHarnessClient wrappedClient,
+        ExecutableProcessBundleDescriptor processBundleDescriptor) {
+      @SuppressWarnings("unchecked")
+      BundleProcessor processor =
+          wrappedClient
+              .getClient()
+              .getProcessor(
+                  processBundleDescriptor.getProcessBundleDescriptor(),
+                  processBundleDescriptor.getRemoteInputDestinations(),
+                  wrappedClient.getStateServer().getService());
+      return new SimpleStageBundleFactory(processBundleDescriptor, processor, wrappedClient);
+    }
+
+    SimpleStageBundleFactory(
+        ExecutableProcessBundleDescriptor processBundleDescriptor,
+        BundleProcessor processor,
+        WrappedSdkHarnessClient wrappedClient) {
+      this.processBundleDescriptor = processBundleDescriptor;
+      this.processor = processor;
+      this.wrappedClient = wrappedClient;
+    }
+
+    @Override
+    public RemoteBundle getBundle(
+        OutputReceiverFactory outputReceiverFactory,
+        StateRequestHandler stateRequestHandler,
+        BundleProgressHandler progressHandler)
+        throws Exception {
+      // TODO: Consider having BundleProcessor#newBundle take in an OutputReceiverFactory rather
+      // than constructing the receiver map here. Every bundle factory will need this.
+      ImmutableMap.Builder<Target, RemoteOutputReceiver<?>> outputReceivers =
+          ImmutableMap.builder();
+      for (Map.Entry<Target, Coder<WindowedValue<?>>> targetCoder :
+          processBundleDescriptor.getOutputTargetCoders().entrySet()) {
+        Target target = targetCoder.getKey();
+        Coder<WindowedValue<?>> coder = targetCoder.getValue();
+        String bundleOutputPCollection =
+            Iterables.getOnlyElement(
+                processBundleDescriptor
+                    .getProcessBundleDescriptor()
+                    .getTransformsOrThrow(target.getPrimitiveTransformReference())
+                    .getInputsMap()
+                    .values());
+        FnDataReceiver<WindowedValue<?>> outputReceiver =
+            outputReceiverFactory.create(bundleOutputPCollection);
+        outputReceivers.put(target, RemoteOutputReceiver.of(coder, outputReceiver));
+      }
+      return processor.newBundle(outputReceivers.build(), stateRequestHandler, progressHandler);
+    }
+
+    @Override
+    public void close() throws Exception {
+      // Clear reference to encourage cache eviction. Values are weakly referenced.
+      wrappedClient = null;
+    }
+  }
+
+  /**
+   * Holder for an {@link SdkHarnessClient} along with its associated state and data servers. As of
+   * now, there is a 1:1 relationship between data services and harness clients. The servers are
+   * packaged here to tie server lifetimes to harness client lifetimes.
+   */
+  protected static class WrappedSdkHarnessClient implements AutoCloseable {
+    private final RemoteEnvironment environment;
+    private final ExecutorService executor;
+    // TODO: How should data server lifetime be scoped? It is necessary here for now because
+    // SdkHarnessClient requires one at construction.
+    private final GrpcFnServer<GrpcDataService> dataServer;
+    private final GrpcFnServer<GrpcStateService> stateServer;
+    private final SdkHarnessClient client;
+
+    static WrappedSdkHarnessClient wrapping(
+        RemoteEnvironment environment, ServerFactory serverFactory) throws Exception {
+      ExecutorService executor = Executors.newCachedThreadPool();
+      GrpcFnServer<GrpcDataService> dataServer =
+          GrpcFnServer.allocatePortAndCreateFor(
+              GrpcDataService.create(executor, OutboundObserverFactory.serverDirect()),
+              serverFactory);
+      GrpcFnServer<GrpcStateService> stateServer =
+          GrpcFnServer.allocatePortAndCreateFor(GrpcStateService.create(), serverFactory);
+      SdkHarnessClient client =
+          SdkHarnessClient.usingFnApiClient(
+              environment.getInstructionRequestHandler(), dataServer.getService());
+      return new WrappedSdkHarnessClient(environment, executor, dataServer, stateServer, client);
+    }
+
+    private WrappedSdkHarnessClient(
+        RemoteEnvironment environment,
+        ExecutorService executor,
+        GrpcFnServer<GrpcDataService> dataServer,
+        GrpcFnServer<GrpcStateService> stateServer,
+        SdkHarnessClient client) {
+      this.executor = executor;
+      this.environment = environment;
+      this.dataServer = dataServer;
+      this.stateServer = stateServer;
+      this.client = client;
+    }
+
+    SdkHarnessClient getClient() {
+      return client;
+    }
+
+    GrpcFnServer<GrpcStateService> getStateServer() {
+      return stateServer;
+    }
+
+    GrpcFnServer<GrpcDataService> getDataServer() {
+      return dataServer;
+    }
+
+    @Override
+    public void close() throws Exception {
+      try (AutoCloseable stateServerCloser = stateServer;
+          AutoCloseable dataServerCloser = dataServer;
+          AutoCloseable envCloser = environment;
+          AutoCloseable executorCloser = executor::shutdown) {
+        // Wrap resources in try-with-resources to ensure all are cleaned up.
+      }
+      // TODO: Wait for executor shutdown?
+    }
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/JobBundleFactoryBase.java
@@ -41,7 +41,6 @@ import org.apache.beam.runners.fnexecution.artifact.BeamFileSystemArtifactRetrie
 import org.apache.beam.runners.fnexecution.control.ProcessBundleDescriptors.ExecutableProcessBundleDescriptor;
 import org.apache.beam.runners.fnexecution.control.SdkHarnessClient.BundleProcessor;
 import org.apache.beam.runners.fnexecution.data.GrpcDataService;
-import org.apache.beam.runners.fnexecution.environment.DockerEnvironmentFactory;
 import org.apache.beam.runners.fnexecution.environment.EnvironmentFactory;
 import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
 import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
@@ -60,9 +59,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A {@link JobBundleFactory} that uses a {@link DockerEnvironmentFactory} for environment
- * management. Note that returned {@link StageBundleFactory stage bundle factories} are not
- * thread-safe. Instead, a new stage factory should be created for each client.
+ * A base for a {@link JobBundleFactory} for which the implementation can specify a custom {@link
+ * EnvironmentFactory} for environment management. Note that returned {@link StageBundleFactory
+ * stage bundle factories} are not thread-safe. Instead, a new stage factory should be created for
+ * each client.
  */
 @ThreadSafe
 public abstract class JobBundleFactoryBase implements JobBundleFactory {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
@@ -42,7 +42,7 @@ public class ProcessJobBundleFactory extends JobBundleFactoryBase {
     return new ProcessJobBundleFactory(jobInfo);
   }
 
-  private ProcessJobBundleFactory(JobInfo jobInfo) throws Exception {
+  protected ProcessJobBundleFactory(JobInfo jobInfo) throws Exception {
     super(jobInfo);
   }
 
@@ -66,7 +66,7 @@ public class ProcessJobBundleFactory extends JobBundleFactoryBase {
   }
 
   @Override
-  EnvironmentFactory getEnvironmentFactory(
+  protected EnvironmentFactory getEnvironmentFactory(
       GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
       GrpcFnServer<GrpcLoggingService> loggingServiceServer,
       GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
@@ -28,12 +28,15 @@ import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
 import org.apache.beam.sdk.fn.IdGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link JobBundleFactoryBase} which uses a {@link ProcessEnvironmentFactory} to run the SDK
  * harness in an external process.
  */
 public class ProcessJobBundleFactory extends JobBundleFactoryBase {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessJobBundleFactory.class);
 
   public static ProcessJobBundleFactory create(JobInfo jobInfo) throws Exception {
     return new ProcessJobBundleFactory(jobInfo);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.control;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.ServerFactory;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.environment.EnvironmentFactory;
+import org.apache.beam.runners.fnexecution.environment.ProcessEnvironmentFactory;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.sdk.fn.IdGenerator;
+
+/**
+ * A {@link JobBundleFactoryBase} which uses a {@link ProcessEnvironmentFactory} to run the SDK
+ * harness in an external process.
+ */
+public class ProcessJobBundleFactory extends JobBundleFactoryBase {
+
+  public static ProcessJobBundleFactory create(JobInfo jobInfo) throws Exception {
+    return new ProcessJobBundleFactory(jobInfo);
+  }
+
+  private ProcessJobBundleFactory(JobInfo jobInfo) throws Exception {
+    super(jobInfo);
+  }
+
+  @VisibleForTesting
+  ProcessJobBundleFactory(
+      ProcessEnvironmentFactory envFactory,
+      ServerFactory serverFactory,
+      IdGenerator stageIdGenerator,
+      GrpcFnServer<FnApiControlClientPoolService> controlServer,
+      GrpcFnServer<GrpcLoggingService> loggingServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServer) {
+    super(
+        envFactory,
+        serverFactory,
+        stageIdGenerator,
+        controlServer,
+        loggingServer,
+        retrievalServer,
+        provisioningServer);
+  }
+
+  @Override
+  EnvironmentFactory getEnvironmentFactory(
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      ControlClientPool.Source clientSource,
+      IdGenerator idGenerator) {
+    return ProcessEnvironmentFactory.create(
+        controlServiceServer,
+        loggingServiceServer,
+        retrievalServiceServer,
+        provisioningServiceServer,
+        clientSource,
+        idGenerator);
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironment.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironment.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.environment;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.fnexecution.control.InstructionRequestHandler;
+
+/**
+ * Environment for process-based execution. The environment is responsible for stopping the process.
+ */
+public class ProcessEnvironment implements RemoteEnvironment {
+
+  private final ProcessManager processManager;
+  private final RunnerApi.Environment environment;
+  private final String workerId;
+  private final InstructionRequestHandler instructionHandler;
+  private final Object lock = new Object();
+
+  private boolean isClosed;
+
+  public static RemoteEnvironment create(
+      ProcessManager processManager,
+      RunnerApi.Environment environment,
+      String workerId,
+      InstructionRequestHandler instructionHandler) {
+    return new ProcessEnvironment(processManager, environment, workerId, instructionHandler);
+  }
+
+  private ProcessEnvironment(
+      ProcessManager processManager,
+      RunnerApi.Environment environment,
+      String workerId,
+      InstructionRequestHandler instructionHandler) {
+
+    this.processManager = processManager;
+    this.environment = environment;
+    this.workerId = workerId;
+    this.instructionHandler = instructionHandler;
+  }
+
+  @Override
+  public RunnerApi.Environment getEnvironment() {
+    return environment;
+  }
+
+  @Override
+  public InstructionRequestHandler getInstructionRequestHandler() {
+    return instructionHandler;
+  }
+
+  @Override
+  public void close() throws Exception {
+    synchronized (lock) {
+      if (!isClosed) {
+        instructionHandler.close();
+        processManager.stopProcess(workerId);
+        isClosed = true;
+      }
+    }
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -127,7 +127,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
     InstructionRequestHandler instructionHandler = null;
     try {
       ProcessManager.RunningProcess process =
-          processManager.runCommand(workerId, executable, args, Collections.emptyMap());
+          processManager.startProcess(workerId, executable, args, Collections.emptyMap());
       // Wait on a client from the gRPC server.
       while (instructionHandler == null) {
         try {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.fnexecution.environment;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
@@ -125,7 +126,8 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
     // Wrap the blocking call to clientSource.get in case an exception is thrown.
     InstructionRequestHandler instructionHandler = null;
     try {
-      ProcessManager.RunningProcess process = processManager.runCommand(workerId, executable, args);
+      ProcessManager.RunningProcess process =
+          processManager.runCommand(workerId, executable, args, Collections.emptyMap());
       // Wait on a client from the gRPC server.
       while (instructionHandler == null) {
         try {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -50,7 +50,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
       ControlClientPool.Source clientSource,
       IdGenerator idGenerator) {
     return create(
-        ProcessManager.getInstance(),
+        ProcessManager.create(),
         controlServiceServer,
         loggingServiceServer,
         retrievalServiceServer,

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -59,7 +59,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
         idGenerator);
   }
 
-  static ProcessEnvironmentFactory create(
+  public static ProcessEnvironmentFactory create(
       ProcessManager processManager,
       GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
       GrpcFnServer<GrpcLoggingService> loggingServiceServer,

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -125,10 +125,12 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
     // Wrap the blocking call to clientSource.get in case an exception is thrown.
     InstructionRequestHandler instructionHandler = null;
     try {
-      processManager.runCommand(workerId, executable, args);
+      ProcessManager.RunningProcess process = processManager.runCommand(workerId, executable, args);
       // Wait on a client from the gRPC server.
       while (instructionHandler == null) {
         try {
+          // If the process is not alive anymore, we abort.
+          process.isAliveOrThrow();
           instructionHandler = clientSource.take(workerId, Duration.ofMinutes(2));
         } catch (TimeoutException timeoutEx) {
           LOG.info(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.fnexecution.environment;
 
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
@@ -127,7 +126,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
     InstructionRequestHandler instructionHandler = null;
     try {
       ProcessManager.RunningProcess process =
-          processManager.startProcess(workerId, executable, args, Collections.emptyMap());
+          processManager.startProcess(workerId, executable, args);
       // Wait on a client from the gRPC server.
       while (instructionHandler == null) {
         try {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -49,7 +49,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
       ControlClientPool.Source clientSource,
       IdGenerator idGenerator) {
     return create(
-        ProcessManager.getDefault(),
+        ProcessManager.getInstance(),
         controlServiceServer,
         loggingServiceServer,
         retrievalServiceServer,
@@ -121,7 +121,7 @@ public class ProcessEnvironmentFactory implements EnvironmentFactory {
             String.format("--provision_endpoint=%s", provisionEndpoint),
             String.format("--control_endpoint=%s", controlEndpoint));
 
-    LOG.debug("Creating Process with ID {}", workerId);
+    LOG.debug("Creating Process for worker ID {}", workerId);
     // Wrap the blocking call to clientSource.get in case an exception is thrown.
     InstructionRequestHandler instructionHandler = null;
     try {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactory.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.fnexecution.environment;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.control.ControlClientPool;
+import org.apache.beam.runners.fnexecution.control.FnApiControlClientPoolService;
+import org.apache.beam.runners.fnexecution.control.InstructionRequestHandler;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.sdk.fn.IdGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An {@link EnvironmentFactory} which forks processes based on the given URL in the Environment.
+ * The returned {@link ProcessEnvironment} has to make sure to stop the processes.
+ */
+public class ProcessEnvironmentFactory implements EnvironmentFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessEnvironmentFactory.class);
+
+  public static ProcessEnvironmentFactory create(
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      ControlClientPool.Source clientSource,
+      IdGenerator idGenerator) {
+    return create(
+        ProcessManager.getDefault(),
+        controlServiceServer,
+        loggingServiceServer,
+        retrievalServiceServer,
+        provisioningServiceServer,
+        clientSource,
+        idGenerator);
+  }
+
+  static ProcessEnvironmentFactory create(
+      ProcessManager processManager,
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      ControlClientPool.Source clientSource,
+      IdGenerator idGenerator) {
+    return new ProcessEnvironmentFactory(
+        processManager,
+        controlServiceServer,
+        loggingServiceServer,
+        retrievalServiceServer,
+        provisioningServiceServer,
+        idGenerator,
+        clientSource);
+  }
+
+  private final ProcessManager processManager;
+  private final GrpcFnServer<FnApiControlClientPoolService> controlServiceServer;
+  private final GrpcFnServer<GrpcLoggingService> loggingServiceServer;
+  private final GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer;
+  private final GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer;
+  private final IdGenerator idGenerator;
+  private final ControlClientPool.Source clientSource;
+
+  private ProcessEnvironmentFactory(
+      ProcessManager processManager,
+      GrpcFnServer<FnApiControlClientPoolService> controlServiceServer,
+      GrpcFnServer<GrpcLoggingService> loggingServiceServer,
+      GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer,
+      GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer,
+      IdGenerator idGenerator,
+      ControlClientPool.Source clientSource) {
+    this.processManager = processManager;
+    this.controlServiceServer = controlServiceServer;
+    this.loggingServiceServer = loggingServiceServer;
+    this.retrievalServiceServer = retrievalServiceServer;
+    this.provisioningServiceServer = provisioningServiceServer;
+    this.idGenerator = idGenerator;
+    this.clientSource = clientSource;
+  }
+
+  /** Creates a new, active {@link RemoteEnvironment} backed by a forked process. */
+  @Override
+  public RemoteEnvironment createEnvironment(Environment environment) throws Exception {
+    String workerId = idGenerator.getId();
+
+    // TODO The Environment Protobuf message needs to be changed for process environment
+    String executable = environment.getUrl();
+    String loggingEndpoint = loggingServiceServer.getApiServiceDescriptor().getUrl();
+    String artifactEndpoint = retrievalServiceServer.getApiServiceDescriptor().getUrl();
+    String provisionEndpoint = provisioningServiceServer.getApiServiceDescriptor().getUrl();
+    String controlEndpoint = controlServiceServer.getApiServiceDescriptor().getUrl();
+
+    List<String> args =
+        ImmutableList.of(
+            String.format("--id=%s", workerId),
+            String.format("--logging_endpoint=%s", loggingEndpoint),
+            String.format("--artifact_endpoint=%s", artifactEndpoint),
+            String.format("--provision_endpoint=%s", provisionEndpoint),
+            String.format("--control_endpoint=%s", controlEndpoint));
+
+    LOG.debug("Creating Process with ID {}", workerId);
+    // Wrap the blocking call to clientSource.get in case an exception is thrown.
+    InstructionRequestHandler instructionHandler = null;
+    try {
+      processManager.runCommand(workerId, executable, args);
+      // Wait on a client from the gRPC server.
+      while (instructionHandler == null) {
+        try {
+          instructionHandler = clientSource.take(workerId, Duration.ofMinutes(2));
+        } catch (TimeoutException timeoutEx) {
+          LOG.info(
+              "Still waiting for startup of environment '{}' for worker id {}",
+              environment.getUrl(),
+              workerId);
+        } catch (InterruptedException interruptEx) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(interruptEx);
+        }
+      }
+    } catch (Exception e) {
+      try {
+        processManager.stopProcess(workerId);
+      } catch (Exception processKillException) {
+        e.addSuppressed(processKillException);
+      }
+      throw e;
+    }
+
+    return ProcessEnvironment.create(processManager, environment, workerId, instructionHandler);
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -102,7 +102,6 @@ class ProcessManager {
     pb.environment().putAll(env);
 
     LOG.debug("Attempting to start process with command: " + pb.command());
-    Process newProcess = pb.start();
     // Pipe stdout and stderr to /dev/null to avoid blocking the process due to filled PIPE buffer
     pb.redirectErrorStream(true);
     if (System.getProperty("os.name", "").startsWith("Windows")) {
@@ -111,6 +110,7 @@ class ProcessManager {
       pb.redirectOutput(new File("/dev/null"));
     }
 
+    Process newProcess = pb.start();
     Process oldProcess = processes.put(id, newProcess);
     if (oldProcess != null) {
       oldProcess.destroy();

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -121,8 +121,9 @@ class ProcessManager {
         new ProcessBuilder(ImmutableList.<String>builder().add(command).addAll(args).build());
     pb.environment().putAll(env);
 
-    LOG.debug("Attempting to start process with command: {}", pb.command());
     if (INHERIT_IO) {
+      LOG.debug(
+          "==> DEBUG enabled: Inheriting stdout/stderr of process (adjustable in ProcessManager)");
       pb.inheritIO();
     } else {
       pb.redirectErrorStream(true);
@@ -134,6 +135,7 @@ class ProcessManager {
       }
     }
 
+    LOG.debug("Attempting to start process with command: {}", pb.command());
     Process newProcess = pb.start();
     Process oldProcess = processes.put(id, newProcess);
     if (oldProcess != null) {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -22,6 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,10 +39,10 @@ import org.slf4j.LoggerFactory;
 public class ProcessManager {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessManager.class);
 
-  /** For debugging purposes, we inherit I/O of processes */
+  /** For debugging purposes, we inherit I/O of processes. */
   private static final boolean INHERIT_IO = LOG.isDebugEnabled();
 
-  /** A list of all managers to ensure all processes shutdown on JVM exit */
+  /** A list of all managers to ensure all processes shutdown on JVM exit . */
   private static final List<ProcessManager> ALL_PROCESS_MANAGERS = new ArrayList<>();
 
   static {
@@ -191,6 +192,7 @@ public class ProcessManager {
     private ShutdownHook() {}
 
     @Override
+    @SuppressFBWarnings("SWL_SLEEP_WITH_LOCK_HELD")
     public void run() {
       synchronized (ALL_PROCESS_MANAGERS) {
         ALL_PROCESS_MANAGERS.forEach(ProcessManager::stopAllProcesses);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -72,14 +72,30 @@ class ProcessManager {
    * @return A RunningProcess which can be checked for liveness
    */
   RunningProcess runCommand(String id, String command, List<String> args) throws IOException {
+    return runCommand(id, command, args, Collections.emptyMap());
+  }
+
+  /**
+   * Forks a process with the given command, arguments, and additional environment variables.
+   *
+   * @param id A unique id for the process
+   * @param command The name of the executable to run
+   * @param args Arguments to provide to the executable
+   * @param env Additional environment variables for the process to be forked
+   * @return A RunningProcess which can be checked for liveness
+   */
+  RunningProcess runCommand(String id, String command, List<String> args, Map<String, String> env)
+      throws IOException {
     checkNotNull(id, "Process id must not be null");
     checkNotNull(command, "Command must not be null");
     checkNotNull(args, "Process args must not be null");
+    checkNotNull(env, "Environment map must not be null");
 
     ProcessBuilder pb =
         new ProcessBuilder(ImmutableList.<String>builder().add(command).addAll(args).build());
+    pb.environment().putAll(env);
 
-    LOG.debug("Attempting to start SDK harness with command: " + pb.command());
+    LOG.debug("Attempting to start process with command: " + pb.command());
     Process newProcess = pb.start();
     // Pipe stdout and stderr to /dev/null to avoid blocking the process due to filled PIPE buffer
     pb.redirectErrorStream(true);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -37,12 +37,10 @@ import org.slf4j.LoggerFactory;
 class ProcessManager {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessManager.class);
 
-  private static final ProcessManager INSTANCE = new ProcessManager();
-
   private final Map<String, Process> processes;
 
-  public static ProcessManager getInstance() {
-    return INSTANCE;
+  public static ProcessManager create() {
+    return new ProcessManager();
   }
 
   private ProcessManager() {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -39,7 +39,7 @@ class ProcessManager {
 
   private final Map<String, Process> processes;
 
-  public static ProcessManager getDefault() {
+  public static ProcessManager getInstance() {
     return INSTANCE;
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.environment;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A simple process manager which forks processes and kills them if necessary. */
+@ThreadSafe
+class ProcessManager {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessManager.class);
+
+  private static final ProcessManager INSTANCE = new ProcessManager();
+
+  private final Map<String, Process> processes;
+
+  public static ProcessManager getDefault() {
+    return INSTANCE;
+  }
+
+  private ProcessManager() {
+    this.processes = Collections.synchronizedMap(new HashMap<>());
+  }
+
+  /**
+   * Forks a process with the given command and arguments.
+   *
+   * @param id A unique id for the process
+   * @param command the name of the executable to run
+   * @param args arguments to provide to the executable
+   */
+  void runCommand(String id, String command, List<String> args) throws IOException {
+    checkNotNull(id, "Process id must not be null");
+    checkNotNull(command, "Command must not be null");
+    checkNotNull(args, "Process args must not be null");
+
+    ProcessBuilder pb =
+        new ProcessBuilder(ImmutableList.<String>builder().add(command).addAll(args).build());
+
+    LOG.debug("Attempting to start SDK harness with command: " + pb.command());
+    Process newProcess = pb.start();
+    Process oldProcess = processes.put(id, newProcess);
+    if (oldProcess != null) {
+      oldProcess.destroy();
+      newProcess.destroy();
+      throw new IllegalStateException("There was already a process running with id " + id);
+    }
+  }
+
+  /** Stops a previously started process identified by its unique id. */
+  void stopProcess(String id) {
+    checkNotNull(id, "Process id must not be null");
+    Process process = checkNotNull(processes.remove(id), "Process for id does not exist: " + id);
+    if (process.isAlive()) {
+      process.destroy();
+    }
+  }
+}

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -99,7 +99,7 @@ class ProcessManager {
         new ProcessBuilder(ImmutableList.<String>builder().add(command).addAll(args).build());
     pb.environment().putAll(env);
 
-    LOG.debug("Attempting to start process with command: " + pb.command());
+    LOG.debug("Attempting to start process with command: {}", pb.command());
     // Pipe stdout and stderr to /dev/null to avoid blocking the process due to filled PIPE buffer
     pb.redirectErrorStream(true);
     if (System.getProperty("os.name", "").startsWith("Windows")) {

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 
 /** A simple process manager which forks processes and kills them if necessary. */
 @ThreadSafe
-class ProcessManager {
+public class ProcessManager {
   private static final Logger LOG = LoggerFactory.getLogger(ProcessManager.class);
 
   /** For debugging purposes, we inherit I/O of processes */
@@ -110,8 +110,8 @@ class ProcessManager {
    * @param env Additional environment variables for the process to be forked
    * @return A RunningProcess which can be checked for liveness
    */
-  RunningProcess startProcess(String id, String command, List<String> args, Map<String, String> env)
-      throws IOException {
+  public RunningProcess startProcess(
+      String id, String command, List<String> args, Map<String, String> env) throws IOException {
     checkNotNull(id, "Process id must not be null");
     checkNotNull(command, "Command must not be null");
     checkNotNull(args, "Process args must not be null");
@@ -148,7 +148,7 @@ class ProcessManager {
   }
 
   /** Stops a previously started process identified by its unique id. */
-  void stopProcess(String id) {
+  public void stopProcess(String id) {
     checkNotNull(id, "Process id must not be null");
     Process process = checkNotNull(processes.remove(id), "Process for id does not exist: " + id);
     stopProcess(id, process);

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.fnexecution.environment;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
@@ -60,6 +61,11 @@ class ProcessManager {
       if (!process.isAlive()) {
         throw new IllegalStateException("Process died with exit code " + process.exitValue());
       }
+    }
+
+    @VisibleForTesting
+    Process getUnderlyingProcess() {
+      return process;
     }
   }
 

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -190,6 +190,7 @@ public class ProcessManager {
 
     private ShutdownHook() {}
 
+    @Override
     public void run() {
       synchronized (ALL_PROCESS_MANAGERS) {
         ALL_PROCESS_MANAGERS.forEach(ProcessManager::stopAllProcesses);
@@ -210,16 +211,12 @@ public class ProcessManager {
     }
   }
 
-  /**
-   * Stop all remaining processes gracefully, i.e. upon JVM shutdown
-   */
+  /** Stop all remaining processes gracefully, i.e. upon JVM shutdown */
   private void stopAllProcesses() {
     processes.forEach((id, process) -> process.destroy());
   }
 
-  /**
-   * Kill all remaining processes forcibly, i.e. upon JVM shutdown
-   */
+  /** Kill all remaining processes forcibly, i.e. upon JVM shutdown */
   private void killAllProcesses() {
     processes.forEach((id, process) -> process.destroyForcibly());
   }

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/environment/ProcessManager.java
@@ -71,8 +71,8 @@ class ProcessManager {
    * @param args arguments to provide to the executable
    * @return A RunningProcess which can be checked for liveness
    */
-  RunningProcess runCommand(String id, String command, List<String> args) throws IOException {
-    return runCommand(id, command, args, Collections.emptyMap());
+  RunningProcess startProcess(String id, String command, List<String> args) throws IOException {
+    return startProcess(id, command, args, Collections.emptyMap());
   }
 
   /**
@@ -84,7 +84,7 @@ class ProcessManager {
    * @param env Additional environment variables for the process to be forked
    * @return A RunningProcess which can be checked for liveness
    */
-  RunningProcess runCommand(String id, String command, List<String> args, Map<String, String> env)
+  RunningProcess startProcess(String id, String command, List<String> args, Map<String, String> env)
       throws IOException {
     checkNotNull(id, "Process id must not be null");
     checkNotNull(command, "Command must not be null");

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactoryTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.fnexecution.control;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionResponse;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ExecutableStagePayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
+import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
+import org.apache.beam.model.pipeline.v1.RunnerApi.WindowingStrategy;
+import org.apache.beam.runners.core.construction.ModelCoders;
+import org.apache.beam.runners.core.construction.graph.ExecutableStage;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.ServerFactory;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.environment.ProcessEnvironmentFactory;
+import org.apache.beam.runners.fnexecution.environment.RemoteEnvironment;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.sdk.fn.IdGenerator;
+import org.apache.beam.sdk.fn.IdGenerators;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class ProcessJobBundleFactoryTest {
+
+  @Mock private ProcessEnvironmentFactory envFactory;
+  @Mock private RemoteEnvironment remoteEnvironment;
+  @Mock private InstructionRequestHandler instructionHandler;
+  @Mock private ServerFactory serverFactory;
+  @Mock GrpcFnServer<FnApiControlClientPoolService> controlServer;
+  @Mock GrpcFnServer<GrpcLoggingService> loggingServer;
+  @Mock GrpcFnServer<ArtifactRetrievalService> retrievalServer;
+  @Mock GrpcFnServer<StaticGrpcProvisionService> provisioningServer;
+
+  private final Environment environment = Environment.newBuilder().setUrl("env-url").build();
+  private final IdGenerator stageIdGenerator = IdGenerators.incrementingLongs();
+  private final InstructionResponse instructionResponse =
+      InstructionResponse.newBuilder().setInstructionId("instruction-id").build();
+
+  @Before
+  public void setUpMocks() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    when(envFactory.createEnvironment(environment)).thenReturn(remoteEnvironment);
+    when(remoteEnvironment.getInstructionRequestHandler()).thenReturn(instructionHandler);
+    when(instructionHandler.handle(any()))
+        .thenReturn(CompletableFuture.completedFuture(instructionResponse));
+  }
+
+  @Test
+  public void createsCorrectEnvironment() throws Exception {
+    try (ProcessJobBundleFactory bundleFactory =
+        new ProcessJobBundleFactory(
+            envFactory,
+            serverFactory,
+            stageIdGenerator,
+            controlServer,
+            loggingServer,
+            retrievalServer,
+            provisioningServer)) {
+      bundleFactory.forStage(getExecutableStage(environment));
+      verify(envFactory).createEnvironment(environment);
+    }
+  }
+
+  @Test
+  public void closesEnvironmentOnCleanup() throws Exception {
+    ProcessJobBundleFactory bundleFactory =
+        new ProcessJobBundleFactory(
+            envFactory,
+            serverFactory,
+            stageIdGenerator,
+            controlServer,
+            loggingServer,
+            retrievalServer,
+            provisioningServer);
+    try (AutoCloseable unused = bundleFactory) {
+      bundleFactory.forStage(getExecutableStage(environment));
+    }
+    verify(remoteEnvironment).close();
+  }
+
+  @Test
+  public void cachesEnvironment() throws Exception {
+    try (ProcessJobBundleFactory bundleFactory =
+        new ProcessJobBundleFactory(
+            envFactory,
+            serverFactory,
+            stageIdGenerator,
+            controlServer,
+            loggingServer,
+            retrievalServer,
+            provisioningServer)) {
+      StageBundleFactory bf1 = bundleFactory.forStage(getExecutableStage(environment));
+      StageBundleFactory bf2 = bundleFactory.forStage(getExecutableStage(environment));
+      // NOTE: We hang on to stage bundle references to ensure their underlying environments are not
+      // garbage collected. For additional safety, we print the factories to ensure the referernces
+      // are not optimized away.
+      System.out.println("bundle factory 1:" + bf1);
+      System.out.println("bundle factory 1:" + bf2);
+      verify(envFactory).createEnvironment(environment);
+      verifyNoMoreInteractions(envFactory);
+    }
+  }
+
+  @Test
+  public void doesNotCacheDifferentEnvironments() throws Exception {
+    Environment envFoo = Environment.newBuilder().setUrl("foo-env-url").build();
+    RemoteEnvironment remoteEnvFoo = mock(RemoteEnvironment.class);
+    InstructionRequestHandler fooInstructionHandler = mock(InstructionRequestHandler.class);
+    when(envFactory.createEnvironment(envFoo)).thenReturn(remoteEnvFoo);
+    when(remoteEnvFoo.getInstructionRequestHandler()).thenReturn(fooInstructionHandler);
+    // Don't bother creating a distinct instruction response because we don't use it here.
+    when(fooInstructionHandler.handle(any()))
+        .thenReturn(CompletableFuture.completedFuture(instructionResponse));
+
+    try (ProcessJobBundleFactory bundleFactory =
+        new ProcessJobBundleFactory(
+            envFactory,
+            serverFactory,
+            stageIdGenerator,
+            controlServer,
+            loggingServer,
+            retrievalServer,
+            provisioningServer)) {
+      bundleFactory.forStage(getExecutableStage(environment));
+      bundleFactory.forStage(getExecutableStage(envFoo));
+      verify(envFactory).createEnvironment(environment);
+      verify(envFactory).createEnvironment(envFoo);
+      verifyNoMoreInteractions(envFactory);
+    }
+  }
+
+  private static ExecutableStage getExecutableStage(Environment environment) {
+    return ExecutableStage.fromPayload(
+        ExecutableStagePayload.newBuilder()
+            .setInput("input-pc")
+            .setEnvironment(environment)
+            .setComponents(
+                Components.newBuilder()
+                    .putPcollections(
+                        "input-pc",
+                        PCollection.newBuilder()
+                            .setWindowingStrategyId("windowing-strategy")
+                            .setCoderId("coder-id")
+                            .build())
+                    .putWindowingStrategies(
+                        "windowing-strategy",
+                        WindowingStrategy.newBuilder().setWindowCoderId("coder-id").build())
+                    .putCoders(
+                        "coder-id",
+                        Coder.newBuilder()
+                            .setSpec(
+                                SdkFunctionSpec.newBuilder()
+                                    .setSpec(
+                                        FunctionSpec.newBuilder()
+                                            .setUrn(ModelCoders.INTERVAL_WINDOW_CODER_URN)
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .build());
+  }
+}

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/ProcessJobBundleFactoryTest.java
@@ -51,6 +51,7 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+/** Tests for {@link ProcessEnvironmentFactory}. */
 @RunWith(JUnit4.class)
 public class ProcessJobBundleFactoryTest {
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
@@ -88,7 +88,7 @@ public class ProcessEnvironmentFactoryTest {
     RemoteEnvironment handle = factory.createEnvironment(ENVIRONMENT);
     assertThat(handle.getInstructionRequestHandler(), is(client));
     assertThat(handle.getEnvironment(), equalTo(ENVIRONMENT));
-    Mockito.verify(processManager).runCommand(eq(ID_GENERATOR.currentId), anyString(), anyList());
+    Mockito.verify(processManager).startProcess(eq(ID_GENERATOR.currentId), anyString(), anyList());
   }
 
   @Test

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
@@ -44,6 +45,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+/** Tests for {@link ProcessEnvironmentFactory}. */
 @RunWith(JUnit4.class)
 public class ProcessEnvironmentFactoryTest {
 
@@ -65,9 +67,11 @@ public class ProcessEnvironmentFactoryTest {
   private ProcessEnvironmentFactory factory;
 
   @Before
-  public void initMocks() {
+  public void initMocks() throws IOException {
     MockitoAnnotations.initMocks(this);
 
+    when(processManager.startProcess(anyString(), anyString(), anyList()))
+        .thenReturn(Mockito.mock(ProcessManager.RunningProcess.class));
     when(controlServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
     when(loggingServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
     when(retrievalServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentFactoryTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.fnexecution.environment;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.fnexecution.GrpcFnServer;
+import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
+import org.apache.beam.runners.fnexecution.control.FnApiControlClientPoolService;
+import org.apache.beam.runners.fnexecution.control.InstructionRequestHandler;
+import org.apache.beam.runners.fnexecution.logging.GrpcLoggingService;
+import org.apache.beam.runners.fnexecution.provisioning.StaticGrpcProvisionService;
+import org.apache.beam.sdk.fn.IdGenerator;
+import org.apache.beam.sdk.fn.IdGenerators;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+@RunWith(JUnit4.class)
+public class ProcessEnvironmentFactoryTest {
+
+  private static final ApiServiceDescriptor SERVICE_DESCRIPTOR =
+      ApiServiceDescriptor.newBuilder().setUrl("service-url").build();
+  private static final String COMMAND = "my-command";
+  private static final Environment ENVIRONMENT = Environment.newBuilder().setUrl(COMMAND).build();
+
+  private static final InspectibleIdGenerator ID_GENERATOR = new InspectibleIdGenerator();
+
+  @Mock private ProcessManager processManager;
+
+  @Mock private GrpcFnServer<FnApiControlClientPoolService> controlServiceServer;
+  @Mock private GrpcFnServer<GrpcLoggingService> loggingServiceServer;
+  @Mock private GrpcFnServer<ArtifactRetrievalService> retrievalServiceServer;
+  @Mock private GrpcFnServer<StaticGrpcProvisionService> provisioningServiceServer;
+
+  @Mock private InstructionRequestHandler client;
+  private ProcessEnvironmentFactory factory;
+
+  @Before
+  public void initMocks() {
+    MockitoAnnotations.initMocks(this);
+
+    when(controlServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
+    when(loggingServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
+    when(retrievalServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
+    when(provisioningServiceServer.getApiServiceDescriptor()).thenReturn(SERVICE_DESCRIPTOR);
+    factory =
+        ProcessEnvironmentFactory.create(
+            processManager,
+            controlServiceServer,
+            loggingServiceServer,
+            retrievalServiceServer,
+            provisioningServiceServer,
+            (workerId, timeout) -> client,
+            ID_GENERATOR);
+  }
+
+  @Test
+  public void createsCorrectEnvironment() throws Exception {
+    RemoteEnvironment handle = factory.createEnvironment(ENVIRONMENT);
+    assertThat(handle.getInstructionRequestHandler(), is(client));
+    assertThat(handle.getEnvironment(), equalTo(ENVIRONMENT));
+    Mockito.verify(processManager).runCommand(eq(ID_GENERATOR.currentId), anyString(), anyList());
+  }
+
+  @Test
+  public void destroysCorrectContainer() throws Exception {
+    RemoteEnvironment handle = factory.createEnvironment(ENVIRONMENT);
+    handle.close();
+    verify(processManager).stopProcess(ID_GENERATOR.currentId);
+  }
+
+  @Test
+  public void createsMultipleEnvironments() throws Exception {
+    Environment fooEnv = Environment.newBuilder().setUrl("foo").build();
+    RemoteEnvironment fooHandle = factory.createEnvironment(fooEnv);
+    assertThat(fooHandle.getEnvironment(), is(equalTo(fooEnv)));
+
+    Environment barEnv = Environment.newBuilder().setUrl("bar").build();
+    RemoteEnvironment barHandle = factory.createEnvironment(barEnv);
+    assertThat(barHandle.getEnvironment(), is(equalTo(barEnv)));
+  }
+
+  private static class InspectibleIdGenerator implements IdGenerator {
+
+    private IdGenerator generator = IdGenerators.incrementingLongs();
+    String currentId;
+
+    @Override
+    public String getId() {
+      currentId = generator.getId();
+      return currentId;
+    }
+  }
+}

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.environment;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
+import org.apache.beam.runners.fnexecution.control.InstructionRequestHandler;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProcessEnvironmentTest {
+
+  @Test
+  public void closeClosesInstructionRequestHandler() throws Exception {
+    InstructionRequestHandler handler = mock(InstructionRequestHandler.class);
+    RemoteEnvironment env =
+        ProcessEnvironment.create(
+            mock(ProcessManager.class), Environment.getDefaultInstance(), "1", handler);
+
+    env.close();
+    verify(handler).close();
+  }
+}

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessEnvironmentTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Tests for {@link ProcessEnvironment}. */
 @RunWith(JUnit4.class)
 public class ProcessEnvironmentTest {
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -35,11 +35,11 @@ public class ProcessManagerTest {
   @Test
   public void testRunSimpleCommand() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
-    processManager.runCommand("1", "ls", Collections.emptyList());
+    processManager.startProcess("1", "ls", Collections.emptyList());
     processManager.stopProcess("1");
-    processManager.runCommand("2", "ls", Collections.singletonList("-l"));
+    processManager.startProcess("2", "ls", Collections.singletonList("-l"));
     processManager.stopProcess("2");
-    processManager.runCommand("1", "ls", Arrays.asList("-l", "-a"));
+    processManager.startProcess("1", "ls", Arrays.asList("-l", "-a"));
     processManager.stopProcess("1");
   }
 
@@ -47,7 +47,7 @@ public class ProcessManagerTest {
   public void testRunInvalidExecutable() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
     try {
-      processManager.runCommand("1", "asfasfls", Collections.emptyList());
+      processManager.startProcess("1", "asfasfls", Collections.emptyList());
       fail();
     } catch (IOException e) {
       assertThat(e.getMessage(), containsString("Cannot run program \"asfasfls\""));
@@ -57,9 +57,9 @@ public class ProcessManagerTest {
   @Test
   public void testDuplicateId() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
-    processManager.runCommand("1", "ls", Collections.emptyList());
+    processManager.startProcess("1", "ls", Collections.emptyList());
     try {
-      processManager.runCommand("1", "ls", Collections.emptyList());
+      processManager.startProcess("1", "ls", Collections.emptyList());
       fail();
     } catch (IllegalStateException e) {
       // this is what we want
@@ -72,7 +72,7 @@ public class ProcessManagerTest {
   public void testLivenessCheck() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
     ProcessManager.RunningProcess process =
-        processManager.runCommand("1", "sleep", Collections.singletonList("1000"));
+        processManager.startProcess("1", "sleep", Collections.singletonList("1000"));
     process.isAliveOrThrow();
     processManager.stopProcess("1");
     try {
@@ -87,7 +87,9 @@ public class ProcessManagerTest {
   public void testEnvironmentVariables() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
     ProcessManager.RunningProcess process =
-        processManager.runCommand("1", "/bin/bash",
+        processManager.startProcess(
+            "1",
+            "/bin/bash",
             Arrays.asList("-c", "'echo $WAIT_FOR > /tmp/bla'"),
             Collections.singletonMap("WAIT_FOR", "1000"));
     process.isAliveOrThrow();

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -67,4 +67,19 @@ public class ProcessManagerTest {
       processManager.stopProcess("1");
     }
   }
+
+  @Test
+  public void testLivenessCheck() throws IOException {
+    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager.RunningProcess process =
+        processManager.runCommand("1", "sleep", Arrays.asList("1000"));
+    process.isAliveOrThrow();
+    processManager.stopProcess("1");
+    try {
+      process.isAliveOrThrow();
+      fail();
+    } catch (IllegalStateException e) {
+      // this is what we want
+    }
+  }
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -35,7 +35,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testRunSimpleCommand() throws IOException {
-    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager processManager = ProcessManager.create();
     processManager.startProcess("1", "bash", Collections.emptyList());
     processManager.stopProcess("1");
     processManager.startProcess("2", "bash", Arrays.asList("-c", "ls"));
@@ -46,7 +46,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testRunInvalidExecutable() throws IOException {
-    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager processManager = ProcessManager.create();
     try {
       processManager.startProcess("1", "asfasfls", Collections.emptyList());
       fail();
@@ -57,7 +57,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testDuplicateId() throws IOException {
-    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager processManager = ProcessManager.create();
     processManager.startProcess("1", "bash", Arrays.asList("-c", "ls"));
     try {
       processManager.startProcess("1", "bash", Arrays.asList("-c", "ls"));
@@ -71,7 +71,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testLivenessCheck() throws IOException {
-    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager processManager = ProcessManager.create();
     ProcessManager.RunningProcess process =
         processManager.startProcess("1", "bash", Arrays.asList("-c", "sleep", "1000"));
     process.isAliveOrThrow();
@@ -86,7 +86,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testEnvironmentVariables() throws IOException, InterruptedException {
-    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager processManager = ProcessManager.create();
     ProcessManager.RunningProcess process =
         processManager.startProcess(
             "1",

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -72,7 +72,7 @@ public class ProcessManagerTest {
   public void testLivenessCheck() throws IOException {
     ProcessManager processManager = ProcessManager.getInstance();
     ProcessManager.RunningProcess process =
-        processManager.runCommand("1", "sleep", Arrays.asList("1000"));
+        processManager.runCommand("1", "sleep", Collections.singletonList("1000"));
     process.isAliveOrThrow();
     processManager.stopProcess("1");
     try {
@@ -81,5 +81,16 @@ public class ProcessManagerTest {
     } catch (IllegalStateException e) {
       // this is what we want
     }
+  }
+
+  @Test
+  public void testEnvironmentVariables() throws IOException {
+    ProcessManager processManager = ProcessManager.getInstance();
+    ProcessManager.RunningProcess process =
+        processManager.runCommand("1", "/bin/bash",
+            Arrays.asList("-c", "'echo $WAIT_FOR > /tmp/bla'"),
+            Collections.singletonMap("WAIT_FOR", "1000"));
+    process.isAliveOrThrow();
+    processManager.stopProcess("1");
   }
 }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+/** Tests for {@link ProcessManager}. */
 @RunWith(JUnit4.class)
 public class ProcessManagerTest {
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.fnexecution.environment;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ProcessManagerTest {
+
+  @Test
+  public void testRunSimpleCommand() throws IOException {
+    ProcessManager processManager = ProcessManager.getDefault();
+    processManager.runCommand("1", "ls", Collections.emptyList());
+    processManager.stopProcess("1");
+    processManager.runCommand("2", "ls", Collections.singletonList("-l"));
+    processManager.stopProcess("2");
+    processManager.runCommand("1", "ls", Arrays.asList("-l", "-a"));
+    processManager.stopProcess("1");
+  }
+
+  @Test
+  public void testRunInvalidExecutable() throws IOException {
+    ProcessManager processManager = ProcessManager.getDefault();
+    try {
+      processManager.runCommand("1", "asfasfls", Collections.emptyList());
+      fail();
+    } catch (IOException e) {
+      assertThat(e.getMessage(), containsString("Cannot run program \"asfasfls\""));
+    }
+  }
+
+  @Test
+  public void testDuplicateId() throws IOException {
+    ProcessManager processManager = ProcessManager.getDefault();
+    processManager.runCommand("1", "ls", Collections.emptyList());
+    try {
+      processManager.runCommand("1", "ls", Collections.emptyList());
+      fail();
+    } catch (IllegalStateException e) {
+      // this is what we want
+    } finally {
+      processManager.stopProcess("1");
+    }
+  }
+}

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/environment/ProcessManagerTest.java
@@ -34,7 +34,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testRunSimpleCommand() throws IOException {
-    ProcessManager processManager = ProcessManager.getDefault();
+    ProcessManager processManager = ProcessManager.getInstance();
     processManager.runCommand("1", "ls", Collections.emptyList());
     processManager.stopProcess("1");
     processManager.runCommand("2", "ls", Collections.singletonList("-l"));
@@ -45,7 +45,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testRunInvalidExecutable() throws IOException {
-    ProcessManager processManager = ProcessManager.getDefault();
+    ProcessManager processManager = ProcessManager.getInstance();
     try {
       processManager.runCommand("1", "asfasfls", Collections.emptyList());
       fail();
@@ -56,7 +56,7 @@ public class ProcessManagerTest {
 
   @Test
   public void testDuplicateId() throws IOException {
-    ProcessManager processManager = ProcessManager.getDefault();
+    ProcessManager processManager = ProcessManager.getInstance();
     processManager.runCommand("1", "ls", Collections.emptyList());
     try {
       processManager.runCommand("1", "ls", Collections.emptyList());


### PR DESCRIPTION
This adds a ProcessJobBundleFactory for process-based execution which currently
takes the Environment URL String and executes it with the regular parameters
which are part of the container contract.

As of now, the factory needs to be wired manually. This will change when the
Runner API's Environment supports process-based execution.

The next steps are:

- Modifying the Environment Proto to explicitly support process-based execution
  alongside with other parameters (e.g. target platform, OS).

- Introduce artifact staging

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




