### PR TITLE
[BEAM-690] Backoff in the DirectRunner if no work is available

### DIFF
--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/QuiescenceDriver.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/QuiescenceDriver.java
@@ -94,7 +94,7 @@ class QuiescenceDriver implements ExecutionDriver {
 
   @Override
   public DriverState drive() {
-    boolean noWorkOutstanding = outstandingWork.get() == 0L;
+    boolean noWorkOutstanding = noWorkOutstanding();
     ExecutorState startingState = state.get();
     if (startingState == ExecutorState.ACTIVE) {
       // The remainder of this call will add all available work to the Executor, and there will
@@ -126,8 +126,16 @@ class QuiescenceDriver implements ExecutionDriver {
     } else if (evaluationContext.isDone()) {
       return DriverState.SHUTDOWN;
     } else {
-      return DriverState.CONTINUE;
+      if (noWorkOutstanding()) {
+        return DriverState.CONTINUE_THROTTLE;
+      } else {
+        return DriverState.CONTINUE;
+      }
     }
+  }
+
+  private boolean noWorkOutstanding() {
+    return outstandingWork.get() == 0L;
   }
 
   private void applyUpdate(

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ThrottleableTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/ThrottleableTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.direct;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.beam.runners.local.ExecutionDriver;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test the exponential back-off algorithm as provided by {@link
+ * ExecutorServiceParallelExecutor.Throttleable}.
+ */
+public class ThrottleableTest {
+
+  @Test
+  public void testBackoff() {
+    List<ExecutionDriver.DriverState> states =
+        Lists.newArrayList(
+            ExecutionDriver.DriverState.CONTINUE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE,
+            ExecutionDriver.DriverState.CONTINUE_THROTTLE);
+    List<Long> sleeps = new ArrayList<>();
+    ExecutorServiceParallelExecutor.Throttleable throttleable =
+        new ExecutorServiceParallelExecutor.Throttleable() {
+          @Override
+          public void sleep() {
+            sleeps.add(delay);
+          }
+
+          @Override
+          public void run() {
+            throttle(states.remove(0));
+          }
+        };
+    while (!states.isEmpty()) {
+      throttleable.run();
+    }
+    Assert.assertEquals(
+        Lists.newArrayList(
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST * 2,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST * 2,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST * 4,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_FIRST * 8,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_MAX,
+            ExecutorServiceParallelExecutor.Throttleable.DELAY_MAX),
+        sleeps);
+  }
+}

--- a/runners/local-java/src/main/java/org/apache/beam/runners/local/ExecutionDriver.java
+++ b/runners/local-java/src/main/java/org/apache/beam/runners/local/ExecutionDriver.java
@@ -25,6 +25,7 @@ public interface ExecutionDriver {
   /** The state of the driver. If the state is terminal, the driver can no longer make progress. */
   enum DriverState {
     CONTINUE(false),
+    CONTINUE_THROTTLE(false),
     FAILED(true),
     SHUTDOWN(true);
 


### PR DESCRIPTION
Implementing backoff as described in the JIRA ticker for [BEAM-690]. Basically this PR:

1. adds new DriverState (CONTINUE_THROTTLE) that signals that no work was available
2. performs capped exponential backoff in the ExecutorServiceParallelExecutor when CONTINUE_THROTTLE is encountered

@tgroh , you are probably the most suitable reviewer

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




