### PR TITLE
[BEAM-5265] Use currentProcessingTime() for onTime with processing time domain

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -256,6 +256,8 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
         break;
 
       case PROCESSING_TIME:
+        effectiveTimestamp = stepContext.timerInternals().currentProcessingTime();
+        break;
       case SYNCHRONIZED_PROCESSING_TIME:
         effectiveTimestamp = stepContext.timerInternals().currentInputWatermarkTime();
         break;

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SimpleDoFnRunnerTest.java
@@ -17,32 +17,41 @@
  */
 package org.apache.beam.runners.core;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import org.apache.beam.runners.core.DoFnRunners.OutputManager;
 import org.apache.beam.runners.core.TimerInternals.TimerData;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.state.Timer;
 import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.joda.time.Duration;
@@ -51,6 +60,7 @@ import org.joda.time.format.PeriodFormat;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -61,6 +71,8 @@ import org.mockito.MockitoAnnotations;
 @RunWith(JUnit4.class)
 public class SimpleDoFnRunnerTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Rule public TestPipeline pipeline = TestPipeline.create();
 
   @Mock StepContext mockStepContext;
 
@@ -124,9 +136,9 @@ public class SimpleDoFnRunnerTest {
    */
   @Test
   public void testTimerSet() {
-    WindowFn<?, ?> windowFn = new GlobalWindows();
-    DoFnWithTimers<GlobalWindow> fn = new DoFnWithTimers(windowFn.windowCoder());
-    DoFnRunner<String, String> runner =
+    WindowFn<?, GlobalWindow> windowFn = new GlobalWindows();
+    DoFnWithTimers<GlobalWindow> fn = new DoFnWithTimers<>(windowFn.windowCoder());
+    DoFnRunner<KV<String, String>, TimerData> runner =
         new SimpleDoFnRunner<>(
             null,
             fn,
@@ -142,15 +154,23 @@ public class SimpleDoFnRunnerTest {
     // Setting the timer needs the current time, as it is set relative
     Instant currentTime = new Instant(42);
     when(mockTimerInternals.currentInputWatermarkTime()).thenReturn(currentTime);
+    when(mockTimerInternals.currentProcessingTime()).thenReturn(currentTime);
 
-    runner.processElement(WindowedValue.valueInGlobalWindow("anyValue"));
+    runner.processElement(WindowedValue.valueInGlobalWindow(KV.of("anyKey", "anyValue")));
 
     verify(mockTimerInternals)
         .setTimer(
             StateNamespaces.window(new GlobalWindows().windowCoder(), GlobalWindow.INSTANCE),
-            DoFnWithTimers.TIMER_ID,
+            DoFnWithTimers.EVENT_TIMER_ID,
             currentTime.plus(DoFnWithTimers.TIMER_OFFSET),
             TimeDomain.EVENT_TIME);
+
+    verify(mockTimerInternals)
+        .setTimer(
+            StateNamespaces.window(new GlobalWindows().windowCoder(), GlobalWindow.INSTANCE),
+            DoFnWithTimers.PROCESSING_TIMER_ID,
+            currentTime.plus(DoFnWithTimers.TIMER_OFFSET),
+            TimeDomain.PROCESSING_TIME);
   }
 
   @Test
@@ -198,44 +218,185 @@ public class SimpleDoFnRunnerTest {
   }
 
   /**
-   * Tests that {@link SimpleDoFnRunner#onTimer} properly dispatches to the underlying {@link DoFn}.
+   * Tests that {@link SimpleDoFnRunner#onTimer} properly dispatches to the underlying {@link DoFn}
+   * on appropriate time domains.
    */
   @Test
-  public void testOnTimerCalled() {
+  @Category(NeedsRunner.class)
+  public void testOnTimerCalledWithGlobalWindow() {
+
+    // TIMESTAMP_MIN_VALUE is initial value for processing time used done by TestClock
+    Instant currentProcessingTime = BoundedWindow.TIMESTAMP_MIN_VALUE;
+    Instant currentEventTime = new Instant(42);
+
+    TestStream<KV<String, String>> testStream =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+            .advanceWatermarkTo(currentEventTime)
+            .addElements(TimestampedValue.of(KV.of("anyKey", "anyValue"), new Instant(99)))
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkToInfinity();
+
     WindowFn<?, GlobalWindow> windowFn = new GlobalWindows();
-    DoFnWithTimers<GlobalWindow> fn = new DoFnWithTimers(windowFn.windowCoder());
-    DoFnRunner<String, String> runner =
-        new SimpleDoFnRunner<>(
-            null,
-            fn,
-            NullSideInputReader.empty(),
-            null,
-            null,
-            Collections.emptyList(),
-            mockStepContext,
-            null,
-            Collections.emptyMap(),
-            WindowingStrategy.of(windowFn));
+    DoFnWithTimers<GlobalWindow> fn = new DoFnWithTimers<>(windowFn.windowCoder());
 
-    Instant currentTime = new Instant(42);
-    Duration offset = Duration.millis(37);
+    PCollection<TimerData> output =
+        pipeline
+            .apply(testStream)
+            .apply(Window.into(new GlobalWindows()))
+            .apply(ParDo.of(fn))
+            .setCoder(TimerInternals.TimerDataCoder.of(windowFn.windowCoder()));
 
-    // Mocking is not easily compatible with annotation analysis, so we manually record
-    // the method call.
-    runner.onTimer(
-        DoFnWithTimers.TIMER_ID,
-        GlobalWindow.INSTANCE,
-        currentTime.plus(offset),
-        TimeDomain.EVENT_TIME);
-
-    assertThat(
-        fn.onTimerInvocations,
-        contains(
+    PAssert.that(output)
+        .containsInAnyOrder(
             TimerData.of(
-                DoFnWithTimers.TIMER_ID,
+                DoFnWithTimers.PROCESSING_TIMER_ID,
                 StateNamespaces.window(windowFn.windowCoder(), GlobalWindow.INSTANCE),
-                currentTime.plus(offset),
-                TimeDomain.EVENT_TIME)));
+                currentProcessingTime.plus(DoFnWithTimers.TIMER_OFFSET).plus(1),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), GlobalWindow.INSTANCE),
+                currentEventTime.plus(DoFnWithTimers.TIMER_OFFSET),
+                TimeDomain.EVENT_TIME));
+
+    pipeline.run();
+  }
+
+  /**
+   * Tests that {@link SimpleDoFnRunner#onTimer} properly dispatches to the underlying {@link DoFn}
+   * on appropriate time domains. With {@link IntervalWindow}, we check behavior of emitted events
+   * when time is inside and outside of window boundaries.
+   */
+  @Test
+  @Category(NeedsRunner.class)
+  public void testOnTimerCalledWithIntervalWindow() {
+
+    // TIMESTAMP_MIN_VALUE is initial value for processing time used done by TestClock
+    Instant baseTime = new Instant(0);
+
+    Duration windowDuration = Duration.standardHours(1);
+    Duration windowLateness = Duration.standardMinutes(1);
+    IntervalWindow window = new IntervalWindow(baseTime, windowDuration);
+    FixedWindows windowFn = FixedWindows.of(windowDuration);
+    DoFnWithTimers<IntervalWindow> fn = new DoFnWithTimers<>(windowFn.windowCoder());
+
+    TimestampedValue<KV<String, String>> event =
+        TimestampedValue.of(KV.of("anyKey", "anyValue"), window.start());
+
+    TestStream<KV<String, String>> testStream =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
+            // watermark in window, processing time far behind
+            .advanceWatermarkTo(window.start())
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkTo(window.start().plus(DoFnWithTimers.TIMER_OFFSET).plus(1))
+
+            // watermark and processing time within window
+            .advanceProcessingTime(
+                Duration.millis(Math.abs(BoundedWindow.TIMESTAMP_MIN_VALUE.getMillis())))
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkTo(
+                window.start().plus(2 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(2))
+
+            // watermark in window, processing time ahead of window.end() but within lateness
+            .advanceProcessingTime(windowDuration)
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkTo(
+                window.start().plus(3 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(3))
+
+            // watermark in window, processing time  is out of window's allowed lateness
+            .advanceProcessingTime(Duration.millis(100 * windowLateness.getMillis()))
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkTo(
+                window.start().plus(4 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(4))
+
+            // watermark is ahead of window.end() but we are not too late
+            .advanceWatermarkTo(window.end().plus(1))
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkTo(window.end().plus(DoFnWithTimers.TIMER_OFFSET).plus(2))
+
+            // all too late => only these 2 onTimer events are dropped, all above gets emitted
+            .advanceWatermarkTo(window.end().plus(windowLateness).plus(1))
+            .addElements(event)
+            .advanceProcessingTime(DoFnWithTimers.TIMER_OFFSET.plus(1))
+            .advanceWatermarkToInfinity();
+
+    PCollection<TimerData> output =
+        pipeline
+            .apply(testStream)
+            .apply(
+                Window.<KV<String, String>>into(windowFn)
+                    .withAllowedLateness(windowLateness)
+                    .discardingFiredPanes())
+            .apply(ParDo.of(fn))
+            .setCoder(TimerInternals.TimerDataCoder.of(windowFn.windowCoder()));
+
+    PAssert.that(output)
+        .containsInAnyOrder(
+            TimerData.of(
+                DoFnWithTimers.PROCESSING_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                BoundedWindow.TIMESTAMP_MIN_VALUE.plus(DoFnWithTimers.TIMER_OFFSET).plus(1),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                baseTime.plus(DoFnWithTimers.TIMER_OFFSET),
+                TimeDomain.EVENT_TIME),
+            TimerData.of(
+                DoFnWithTimers.PROCESSING_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                baseTime.plus(2 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(2),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                baseTime.plus(2 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(1),
+                TimeDomain.EVENT_TIME),
+            TimerData.of(
+                DoFnWithTimers.PROCESSING_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                window.end().plus(3 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(3),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                baseTime.plus(3 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(2),
+                TimeDomain.EVENT_TIME),
+            TimerData.of(
+                DoFnWithTimers.PROCESSING_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                window
+                    .end()
+                    .plus(100 * windowLateness.getMillis())
+                    .plus(4 * DoFnWithTimers.TIMER_OFFSET.getMillis())
+                    .plus(4),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                baseTime.plus(4 * DoFnWithTimers.TIMER_OFFSET.getMillis()).plus(3),
+                TimeDomain.EVENT_TIME),
+            TimerData.of(
+                DoFnWithTimers.PROCESSING_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                window
+                    .end()
+                    .plus(100 * windowLateness.getMillis())
+                    .plus(5 * DoFnWithTimers.TIMER_OFFSET.getMillis())
+                    .plus(5),
+                TimeDomain.PROCESSING_TIME),
+            TimerData.of(
+                DoFnWithTimers.EVENT_TIMER_ID,
+                StateNamespaces.window(windowFn.windowCoder(), window),
+                window.end().plus(DoFnWithTimers.TIMER_OFFSET).plus(1),
+                TimeDomain.EVENT_TIME));
+
+    pipeline.run();
   }
 
   /**
@@ -379,34 +540,49 @@ public class SimpleDoFnRunnerTest {
     }
   }
 
-  private static class DoFnWithTimers<W extends BoundedWindow> extends DoFn<String, String> {
-    static final String TIMER_ID = "testTimerId";
+  private static class DoFnWithTimers<W extends BoundedWindow>
+      extends DoFn<KV<String, String>, TimerData> {
+    static final String EVENT_TIMER_ID = "testEventTimerId";
+    static final String PROCESSING_TIMER_ID = "testProcessingTimerId";
 
     static final Duration TIMER_OFFSET = Duration.millis(100);
 
     private final Coder<W> windowCoder;
 
-    // Mutable
-    List<TimerData> onTimerInvocations;
-
     DoFnWithTimers(Coder<W> windowCoder) {
       this.windowCoder = windowCoder;
-      this.onTimerInvocations = new ArrayList<>();
     }
 
-    @TimerId(TIMER_ID)
-    private static final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+    @TimerId(EVENT_TIMER_ID)
+    private static final TimerSpec eventTimer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+    @TimerId(PROCESSING_TIMER_ID)
+    private static final TimerSpec processingTimer = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
 
     @ProcessElement
-    public void process(ProcessContext context, @TimerId(TIMER_ID) Timer timer) {
-      timer.offset(TIMER_OFFSET).setRelative();
+    public void process(
+        ProcessContext context,
+        @TimerId(EVENT_TIMER_ID) Timer eventTimer,
+        @TimerId(PROCESSING_TIMER_ID) Timer processingTimer) {
+      eventTimer.offset(TIMER_OFFSET).setRelative();
+      processingTimer.offset(TIMER_OFFSET).setRelative();
     }
 
-    @OnTimer(TIMER_ID)
-    public void onTimer(OnTimerContext context) {
-      onTimerInvocations.add(
+    @OnTimer(EVENT_TIMER_ID)
+    public void onEventTimer(OnTimerContext context) {
+      context.output(
           TimerData.of(
-              DoFnWithTimers.TIMER_ID,
+              DoFnWithTimers.EVENT_TIMER_ID,
+              StateNamespaces.window(windowCoder, (W) context.window()),
+              context.timestamp(),
+              context.timeDomain()));
+    }
+
+    @OnTimer(PROCESSING_TIMER_ID)
+    public void onProcessingTimer(OnTimerContext context) {
+      context.output(
+          TimerData.of(
+              DoFnWithTimers.PROCESSING_TIMER_ID,
               StateNamespaces.window(windowCoder, (W) context.window()),
               context.timestamp(),
               context.timeDomain()));


### PR DESCRIPTION

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




