### PR TITLE
[BEAM-5270] Finish Python 3 porting for coders subpackage

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -62,12 +62,13 @@ __all__ = ['Coder',
 
 def serialize_coder(coder):
   from apache_beam.internal import pickler
-  return '%s$%s' % (coder.__class__.__name__, pickler.dumps(coder))
+  return b'%s$%s' % (coder.__class__.__name__.encode('utf-8'),
+                     pickler.dumps(coder))
 
 
 def deserialize_coder(serialized):
   from apache_beam.internal import pickler
-  return pickler.loads(serialized.split('$', 1)[1])
+  return pickler.loads(serialized.split(b'$', 1)[1])
 # pylint: enable=wrong-import-order, wrong-import-position
 
 

--- a/sdks/python/apache_beam/coders/coders_test_common.py
+++ b/sdks/python/apache_beam/coders/coders_test_common.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 
 import logging
 import math
+import sys
 import unittest
 from builtins import range
 
@@ -41,7 +42,7 @@ from . import observable
 class CustomCoder(coders.Coder):
 
   def encode(self, x):
-    return str(x+1)
+    return str(x+1).encode('utf-8')
 
   def decode(self, encoded):
     return int(encoded) - 1
@@ -56,6 +57,9 @@ class CodersTest(unittest.TestCase):
   def setUpClass(cls):
     cls.seen = set()
     cls.seen_nested = set()
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   @classmethod
   def tearDownClass(cls):
@@ -272,7 +276,7 @@ class CodersTest(unittest.TestCase):
         yield i
 
     iterable_coder = coders.IterableCoder(coders.VarIntCoder())
-    self.assertItemsEqual(list(iter_generator(count)),
+    self.assertCountEqual(list(iter_generator(count)),
                           iterable_coder.decode(
                               iterable_coder.encode(iter_generator(count))))
 
@@ -374,8 +378,8 @@ class CodersTest(unittest.TestCase):
     self.assertEqual({'@type': 'kind:global_window'},
                      coder.as_cloud_object())
     # Test binary representation
-    self.assertEqual('', coder.encode(value))
-    self.assertEqual(value, coder.decode(''))
+    self.assertEqual(b'', coder.encode(value))
+    self.assertEqual(value, coder.decode(b''))
     # Test unnested
     self.check_coder(coder, value)
     # Test nested

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -67,7 +67,7 @@ class StandardCodersTest(unittest.TestCase):
   }
 
   _urn_to_json_value_parser = {
-      'beam:coder:bytes:v1': lambda x: x,
+      'beam:coder:bytes:v1': lambda x: x.encode('utf-8'),
       'beam:coder:varint:v1': lambda x: x,
       'beam:coder:kv:v1':
           lambda x, key_parser, value_parser: (key_parser(x['key']),

--- a/sdks/python/apache_beam/coders/stream_test.py
+++ b/sdks/python/apache_beam/coders/stream_test.py
@@ -36,20 +36,20 @@ class StreamTest(unittest.TestCase):
 
   def test_read_write(self):
     out_s = self.OutputStream()
-    out_s.write('abc')
-    out_s.write('\0\t\n')
-    out_s.write('xyz', True)
-    out_s.write('', True)
+    out_s.write(b'abc')
+    out_s.write(b'\0\t\n')
+    out_s.write(b'xyz', True)
+    out_s.write(b'', True)
     in_s = self.InputStream(out_s.get())
-    self.assertEquals('abc\0\t\n', in_s.read(6))
-    self.assertEquals('xyz', in_s.read_all(True))
-    self.assertEquals('', in_s.read_all(True))
+    self.assertEquals(b'abc\0\t\n', in_s.read(6))
+    self.assertEquals(b'xyz', in_s.read_all(True))
+    self.assertEquals(b'', in_s.read_all(True))
 
   def test_read_all(self):
     out_s = self.OutputStream()
-    out_s.write('abc')
+    out_s.write(b'abc')
     in_s = self.InputStream(out_s.get())
-    self.assertEquals('abc', in_s.read_all(False))
+    self.assertEquals(b'abc', in_s.read_all(False))
 
   def test_read_write_byte(self):
     out_s = self.OutputStream()
@@ -129,15 +129,15 @@ class StreamTest(unittest.TestCase):
   def test_byte_counting(self):
     bc_s = self.ByteCountingOutputStream()
     self.assertEquals(0, bc_s.get_count())
-    bc_s.write('def')
+    bc_s.write(b'def')
     self.assertEquals(3, bc_s.get_count())
-    bc_s.write('')
+    bc_s.write(b'')
     self.assertEquals(3, bc_s.get_count())
     bc_s.write_byte(10)
     self.assertEquals(4, bc_s.get_count())
     # "nested" also writes the length of the string, which should
     # cause 1 extra byte to be counted.
-    bc_s.write('2345', nested=True)
+    bc_s.write(b'2345', nested=True)
     self.assertEquals(9, bc_s.get_count())
     bc_s.write_var_int64(63)
     self.assertEquals(10, bc_s.get_count())

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -56,11 +56,13 @@ commands =
 [testenv:py3]
 setenv =
   BEAM_EXPERIMENTAL_PY3=1
+modules =
+  apache_beam.coders,apache_beam.tools
 commands =
   python --version
   pip --version
   {toxinidir}/scripts/run_tox_cleanup.sh
-  python setup.py nosetests --tests apache_beam.runners.direct.direct_metrics_test:DirectMetricsTest.test_combiner_functions
+  python setup.py nosetests --tests {[testenv:py3]modules}
   {toxinidir}/scripts/run_tox_cleanup.sh
 
 [testenv:py27-cython]


### PR DESCRIPTION
This PR finishes the porting of the coders subpackage to Python 3 as outlined [here](https://s.apache.org/beam-python-3).

Python 3 tests can be activated per module by extending the module list under the py3 test environment in tox.ini.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




