### PR TITLE
Update whitelists for running beam jobs from pull requests

### DIFF
--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -144,9 +144,8 @@ class CommonJobProperties {
       githubPullRequest {
         admins(['asfbot'])
         useGitHubHooks()
-        orgWhitelist(['apache'])
+        orgWhitelist(['apache', 'googlecloudplatform'])
         allowMembersOfWhitelistedOrgsAsAdmin()
-        permitAll()
         // prTriggerPhrase is the argument which gets set when we want to allow
         // post-commit builds to run against pending pull requests. This block
         // overrides the default trigger phrase with the new one. Setting this

--- a/.test-infra/jenkins/job_00_seed.groovy
+++ b/.test-infra/jenkins/job_00_seed.groovy
@@ -75,9 +75,8 @@ job('beam_SeedJob') {
     githubPullRequest {
       admins(['asfbot'])
       useGitHubHooks()
-      orgWhitelist(['apache'])
+      orgWhitelist(['apache', 'googlecloudplatform'])
       allowMembersOfWhitelistedOrgsAsAdmin()
-      permitAll()
 
       // Also run when manually kicked on a pull request
       triggerPhrase('Run Seed Job')

--- a/.test-infra/jenkins/job_seed_standalone.groovy
+++ b/.test-infra/jenkins/job_seed_standalone.groovy
@@ -75,9 +75,8 @@ job('beam_SeedJob_Standalone') {
     githubPullRequest {
       admins(['asfbot'])
       useGitHubHooks()
-      orgWhitelist(['apache'])
+      orgWhitelist(['apache', 'googlecloudplatform'])
       allowMembersOfWhitelistedOrgsAsAdmin()
-      permitAll()
 
       // Also run when manually kicked on a pull request
       triggerPhrase('Run Standalone Seed Job')


### PR DESCRIPTION
Update whitelists for running beam jobs from pull requests, removing permitAll.
After this change, members of the apache and googlecloudplatform are whitelisted.

From the https://github.com/jenkinsci/ghprb-plugin documentation:
When a new pull request is opened in the project and the author of the pull request isn't whitelisted, builder will ask `Can one of the admins verify this patch?`. One of the admins can comment `ok to test` to accept this pull request for testing, `test this please` for one time test run and `add to whitelist` to add the author to the whitelist.

@ThatRfernand @iemejia @lgajowy 