### PR TITLE
[Do Not Merge] test virtualenv setup

### DIFF
--- a/.test-infra/jenkins/jira_utils/jira_manager.py
+++ b/.test-infra/jenkins/jira_utils/jira_manager.py
@@ -117,7 +117,7 @@ class JiraManager:
       parent_key: only required if the 'is_subtask'is true.
     """
     logging.info("Creating a new JIRA issue to track {0} upgrade process".format(dep_name))
-    assignee, owners = self._find_owners(dep_name)
+    owners = self._find_owners(dep_name)
     summary =  _ISSUE_SUMMARY_PREFIX + dep_name
     if dep_latest_version:
       summary = summary + " " + dep_latest_version
@@ -132,9 +132,9 @@ class JiraManager:
       description += "[~{0}], ".format(owner)
     try:
       if not is_subtask:
-        issue = self.jira.create_issue(summary, [_JIRA_COMPONENT], description, assignee=assignee)
+        issue = self.jira.create_issue(summary, [_JIRA_COMPONENT], description)
       else:
-        issue = self.jira.create_issue(summary, [_JIRA_COMPONENT], description, assignee=assignee, parent_key=parent_key)
+        issue = self.jira.create_issue(summary, [_JIRA_COMPONENT], description, parent_key=parent_key)
     except Exception as e:
       logging.error("Failed creating issue: "+ str(e))
       raise e
@@ -175,7 +175,7 @@ class JiraManager:
         dep_name,
         dep_latest_version
     )
-    _, owners = self._find_owners(dep_name)
+    owners = self._find_owners(dep_name)
     for owner in owners:
       description += "[~{0}], ".format(owner)
     try:
@@ -213,6 +213,4 @@ class JiraManager:
     owners = owners.split(',')
     owners = map(str.strip, owners)
     owners = list(filter(None, owners))
-    primary = owners[0]
-    del owners[0]
-    return primary, owners
+    return owners

--- a/.test-infra/jenkins/jira_utils/jira_manager_test.py
+++ b/.test-infra/jenkins/jira_utils/jira_manager_test.py
@@ -46,76 +46,6 @@ class JiraManagerTest(unittest.TestCase):
     print("\n\nTest : " + self._testMethodName)
 
 
-  def test_find_owners_with_single_owner(self, *args):
-    """
-    Test on _find_owners with single owner
-    Expect: the primary owner is 'owner0', an empty list of other owners.
-    """
-    owners_yaml = """
-                  deps:
-                    dep0:
-                      owners: owner0,
-                  """
-    with patch('__builtin__.open', mock_open(read_data=owners_yaml)):
-      manager = JiraManager('url', 'username', 'password', owners_yaml)
-      primary, owners = manager._find_owners('dep0')
-      self.assertEqual(primary, 'owner0')
-      self.assertEqual(len(owners), 0)
-
-
-  def test_find_owners_with_multi_owners(self, *args):
-    """
-    Test on _find_owners with multiple owners.
-    Expect: the primary owner is 'owner0', a list contains 'owner1' and 'owner2'.
-    """
-    owners_yaml = """
-                  deps:
-                    dep0:
-                      owners: owner0, owner1 , owner2,
-                  """
-    with patch('__builtin__.open', mock_open(read_data=owners_yaml)):
-      manager = JiraManager('url', 'username', 'password', owners_yaml)
-      primary, owners = manager._find_owners('dep0')
-      self.assertEqual(primary, 'owner0')
-      self.assertEqual(len(owners), 2)
-      self.assertIn('owner1', owners)
-      self.assertIn('owner2', owners)
-
-
-  def test_find_owners_with_no_owners_defined(self, *args):
-    """
-    Test on _find_owners without owner.
-    Expect: the primary owner is None, an empty list of other owners.
-    """
-    owners_yaml = """
-                  deps:
-                    dep0:
-                      owners:
-                  """
-    with patch('__builtin__.open', mock_open(read_data=owners_yaml)):
-      manager = JiraManager('url', 'username', 'password', owners_yaml)
-      primary, owners = manager._find_owners('dep0')
-      self.assertIsNone(primary)
-      self.assertEqual(len(owners), 0)
-
-
-  def test_find_owners_with_no_dep_defined(self, *args):
-    """
-    Test on _find_owners with non-defined dep.
-    Expect: through out KeyErrors. The primary owner is None, an empty list of other owners.
-    """
-    owners_yaml = """
-                  deps:
-                    dep0:
-                      owners:
-                  """
-    with patch('__builtin__.open', mock_open(read_data=owners_yaml)):
-      manager = JiraManager('url', 'username', 'password', owners_yaml)
-      primary, owners = manager._find_owners('dep1')
-      self.assertIsNone(primary)
-      self.assertEqual(len(owners), 0)
-
-
   @patch('jira_utils.jira_manager.datetime', Mock(today=Mock(return_value=datetime.strptime('2000-01-01', '%Y-%m-%d'))))
   def test_run_with_creating_new_issue(self, *args):
     """
@@ -132,8 +62,8 @@ class JiraManagerTest(unittest.TestCase):
       manager.run('dep0', '1.0', 'Python')
       manager.jira.create_issue.assert_called_once_with(self._get_experct_summary('dep0', '1.0'),
                                                         ['dependencies'],
-                                                        self._get_expected_description('dep0', '1.0', ['owner1', 'owner2']),
-                                                        assignee='owner0')
+                                                        self._get_expected_description('dep0', '1.0', ['owner0', 'owner1', 'owner2']),
+                                                        )
 
 
   @patch('jira_utils.jira_manager.datetime', Mock(today=Mock(return_value=datetime.strptime('2000-01-01', '%Y-%m-%d'))))
@@ -186,8 +116,7 @@ class JiraManagerTest(unittest.TestCase):
         manager.run(dep_name, dep_latest_version, 'Java', group_id='group0')
         manager.jira.create_issue.assert_called_once_with(self._get_experct_summary(dep_name, dep_latest_version),
                                                           ['dependencies'],
-                                                          self._get_expected_description(dep_name, dep_latest_version, []),
-                                                          assignee='owner0',
+                                                          self._get_expected_description(dep_name, dep_latest_version, ['owner0']),
                                                           parent_key='BEAM-1000',
                                                           )
 

--- a/.test-infra/jenkins/job_PostCommit_Python_PortableValidatesRunner_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Python_PortableValidatesRunner_Flink.groovy
@@ -27,6 +27,12 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Python_PortableValidatesRunn
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate)
 
+
+  commonJobProperties.enablePhraseTriggeringFromPullRequest(
+          delegate,
+          'Python Compatibility Matrix Test',
+          'Run Python Compatibility Matrix Test')
+
   // Execute gradle task to test Python SDK.
   steps {
     gradle {

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -35,7 +35,7 @@ task setupVirtualenv {
     }
     exec {
       executable 'sh'
-      args '-c', ". ${envdir}/bin/activate && pip install --upgrade tox==3.0.0 grpcio-tools==1.3.5"
+      args '-c', ". ${envdir}/bin/activate"
     }
   }
   // Gradle will delete outputs whenever it thinks they are stale. Putting a
@@ -292,12 +292,12 @@ def flinkCompatibilityMatrix = {
   def name = 'flinkCompatibilityMatrix' + type
   tasks.create(name: name) {
     dependsOn 'setupVirtualenv'
-    dependsOn ':beam-sdks-python-container:docker'
-    dependsOn ':beam-runners-flink_2.11-job-server:jar'
+//    dependsOn ':beam-sdks-python-container:docker'
+//    dependsOn ':beam-runners-flink_2.11-job-server:jar'
     doLast {
       exec {
         executable 'sh'
-        args '-c', ". ${envdir}/bin/activate && pip install -e . && python -m apache_beam.runners.portability.flink_runner_test ${project(":beam-runners-flink_2.11-job-server:").shadowJar.archivePath} ${type}"
+        args '-c', "pip --version"
       }
     }
   }


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf). * [new branch]            BEAM-5301/migrate_integration_test_for_datastore_wordcount -> BEAM-5301/migrate_integration_test_for_datastore_wordcount


It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




