### PR TITLE
Interactive Beam -- enable setting render option

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/__init__.py
+++ b/sdks/python/apache_beam/runners/interactive/display/__init__.py
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/sdks/python/apache_beam/runners/interactive/display/interactive_pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/interactive_pipeline_graph.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 
 import re
 
-from apache_beam.runners.interactive import pipeline_graph
+from apache_beam.runners.interactive.display import pipeline_graph
 
 
 def nice_str(o):

--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
@@ -93,15 +93,7 @@ class PipelineGraph(object):
                           default_edge_attrs)
 
   def get_dot(self):
-    return str(self._get_graph())
-
-  def display_graph(self):
-    """Displays graph via IPython or prints DOT if not possible."""
-    try:
-      from IPython.core import display  # pylint: disable=import-error
-      display.display(display.HTML(self._get_graph().create_svg()))  # pylint: disable=protected-access
-    except ImportError:
-      print(str(self._get_graph()))
+    return self._get_graph().to_string()
 
   def _top_level_transforms(self):
     """Yields all top level PTransforms (subtransforms of the root PTransform).

--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph_renderer.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph_renderer.py
@@ -1,0 +1,125 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""For rendering pipeline graph in HTML-compatible format.
+
+This module is experimental. No backwards-compatibility guarantees.
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import abc
+import os
+import subprocess
+
+from future.utils import with_metaclass
+
+from apache_beam.utils.plugin import BeamPlugin
+
+
+class PipelineGraphRenderer(with_metaclass(abc.ABCMeta, BeamPlugin)):
+  """Abstract class for renderers, who decide how pipeline graphs are rendered.
+  """
+
+  @classmethod
+  @abc.abstractmethod
+  def option(cls):
+    """The corresponding rendering option for the renderer.
+    """
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def render_pipeline_graph(self, pipeline_graph):
+    """Renders the pipeline graph in HTML-compatible format.
+
+    Args:
+      pipeline_graph: (pipeline_graph.PipelineGraph) the graph to be rendererd.
+    """
+    raise NotImplementedError
+
+
+class MuteRenderer(PipelineGraphRenderer):
+  """Use this renderer to mute the pipeline display.
+  """
+
+  @classmethod
+  def option(cls):
+    return 'mute'
+
+  def render_pipeline_graph(self, pipeline_graph):
+    return ''
+
+
+class TextRenderer(PipelineGraphRenderer):
+  """This renderer simply returns the dot representation in text format.
+  """
+
+  @classmethod
+  def option(cls):
+    return 'text'
+
+  def render_pipeline_graph(self, pipeline_graph):
+    return pipeline_graph.get_dot()
+
+
+class PydotRenderer(PipelineGraphRenderer):
+  """This renderer renders the graph using pydot.
+
+  It depends on
+    1. The software Graphviz: https://www.graphviz.org/
+    2. The python module pydot: https://pypi.org/project/pydot/
+  """
+
+  @classmethod
+  def option(cls):
+    return 'graph'
+
+  def render_pipeline_graph(self, pipeline_graph):
+    return pipeline_graph._get_graph().create_svg()  # pylint: disable=protected-access
+
+
+def get_renderer(option=None):
+  """Get an instance of PipelineGraphRenderer given rendering option.
+
+  Args:
+    option: (str) the rendering option.
+
+  Returns:
+    (PipelineGraphRenderer)
+  """
+  if option is None:
+    if os.name == 'nt':
+      exists = subprocess.call(['where', 'dot.exe']) == 0
+    else:
+      exists = subprocess.call(['which', 'dot']) == 0
+
+    if exists:
+      option = 'graph'
+    else:
+      option = 'text'
+
+  renderer = [r for r in PipelineGraphRenderer.get_all_subclasses()
+              if option == r.option()]
+  if len(renderer) == 0:
+    raise ValueError()
+  elif len(renderer) == 1:
+    return renderer[0]()
+  else:
+    raise ValueError('Found more than one renderer for option: %s',
+                     option)

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -30,8 +30,9 @@ import apache_beam as beam
 from apache_beam import runners
 from apache_beam.runners.direct import direct_runner
 from apache_beam.runners.interactive import cache_manager as cache
-from apache_beam.runners.interactive import display_manager
 from apache_beam.runners.interactive import pipeline_analyzer
+from apache_beam.runners.interactive.display import display_manager
+from apache_beam.runners.interactive.display import pipeline_graph_renderer
 
 # size of PCollection samples cached.
 SAMPLE_SIZE = 8
@@ -43,11 +44,30 @@ class InteractiveRunner(runners.PipelineRunner):
   Allows interactively building and running Beam Python pipelines.
   """
 
-  def __init__(self, underlying_runner=None, cache_dir=None):
+  def __init__(self, underlying_runner=None, cache_dir=None,
+               render_option=None):
+    """Constructor of InteractiveRunner.
+
+    Args:
+      underlying_runner: (runner.PipelineRunner)
+      cache_dir: (str) the directory where PCollection caches are kept
+      render_option: (str) this parameter decides how the pipeline graph is
+          rendered. See display.pipeline_graph_renderer for available options.
+    """
     self._underlying_runner = (underlying_runner
                                or direct_runner.DirectRunner())
     self._cache_manager = cache.FileBasedCacheManager(cache_dir)
+    self._renderer = pipeline_graph_renderer.get_renderer(render_option)
     self._in_session = False
+
+  def set_render_option(self, render_option):
+    """Sets the rendering option.
+
+    Args:
+      render_option: (str) this parameter decides how the pipeline graph is
+          rendered. See display.pipeline_graph_renderer for available options.
+    """
+    self._renderer = pipeline_graph_renderer.get_renderer(render_option)
 
   def start_session(self):
     """Start the session that keeps back-end managers and workers alive.
@@ -119,7 +139,8 @@ class InteractiveRunner(runners.PipelineRunner):
         caches_used=analyzer.caches_used(),
         cache_manager=self._cache_manager,
         referenced_pcollections=analyzer.top_level_referenced_pcollection_ids(),
-        required_transforms=analyzer.top_level_required_transforms())
+        required_transforms=analyzer.top_level_required_transforms(),
+        pipeline_graph_renderer=self._renderer)
     display.start_periodic_update()
     result = pipeline_to_execute.run()
     result.wait_until_finish()


### PR DESCRIPTION
Main changes in this commit:
  * Decoupled rendering from pipeline_graph into pipeline_graph_renderer
  * Enabled setting render options when instantiating an interactive_runner.

The options include
  * mute: not render anything
  * text: render the pipeline graph as text
  * graph: render the pipeline graph using pydot. This option is
dependent on  graphviz

The default behavior prior to this commit is to use the third option
(graph), which is problematic when the users are running the IPython
kernel in an environment without graphviz.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




