### PR TITLE
[BEAM-3711] Bug fix and improvements in Dataflow transform override.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPTransformMatchers.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPTransformMatchers.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import java.util.ArrayDeque;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.runners.PTransformMatcher;
+import org.apache.beam.sdk.runners.TransformHierarchy;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.PTransform;
+
+/**
+ * A set of {@link PTransformMatcher PTransformMatchers} that are used in the Dataflow Runner and
+ * not general enough to be shared between runners.
+ */
+class DataflowPTransformMatchers {
+  private DataflowPTransformMatchers() {}
+
+  /**
+   * Matches {@link PTransform}s of class {@link Combine.GroupedValues} that have no side inputs.
+   */
+  static class CombineValuesWithoutSideInputsPTransformMatcher implements PTransformMatcher {
+
+    @Override
+    public boolean matches(AppliedPTransform<?, ?, ?> application) {
+      return application.getTransform().getClass().equals(Combine.GroupedValues.class)
+          && ((Combine.GroupedValues<?, ?, ?>) application.getTransform())
+              .getSideInputs()
+              .isEmpty();
+    }
+
+    @Override
+    public String toString() {
+      return toStringHelper(CombineValuesWithoutSideInputsPTransformMatcher.class).toString();
+    }
+  }
+
+  /**
+   * Matches {@link PTransform}s of class {@link Combine.GroupedValues} that have no side inputs and
+   * are direct subtransforms of a {@link Combine.PerKey}.
+   */
+  static class CombineValuesWithParentCheckPTransformMatcher implements PTransformMatcher {
+
+    @Override
+    public boolean matches(AppliedPTransform<?, ?, ?> application) {
+      return application.getTransform().getClass().equals(Combine.GroupedValues.class)
+          && ((Combine.GroupedValues<?, ?, ?>) application.getTransform()).getSideInputs().isEmpty()
+          && parentIsCombinePerKey(application);
+    }
+
+    private boolean parentIsCombinePerKey(AppliedPTransform<?, ?, ?> application) {
+      // We want the PipelineVisitor below to change the parent, but the parent must be final to
+      // be captured in there. To work around this issue, wrap the parent in a one element array.
+      final TransformHierarchy.Node[] parent = new TransformHierarchy.Node[1];
+
+      // Traverse the pipeline to find the parent transform to application. Do this by maintaining
+      // a stack of each composite transform being entered, and grabbing the top transform of the
+      // stack once the target node is visited.
+      Pipeline pipeline = application.getPipeline();
+      pipeline.traverseTopologically(
+          new Pipeline.PipelineVisitor.Defaults() {
+            private ArrayDeque<TransformHierarchy.Node> parents = new ArrayDeque<>();
+
+            @Override
+            public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
+              CompositeBehavior behavior = CompositeBehavior.ENTER_TRANSFORM;
+
+              // Combine.GroupedValues is a composite transform in the hierarchy, so when entering
+              // a composite first we check if we found our target node.
+              if (!node.isRootNode()
+                  && node.toAppliedPTransform(getPipeline()).equals(application)) {
+                // If we found the target node grab the node's parent.
+                if (parents.isEmpty()) {
+                  parent[0] = null;
+                } else {
+                  parent[0] = parents.peekFirst();
+                }
+                behavior = CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
+              }
+
+              // Even if we found the target node we must add it to the list to maintain parity
+              // with the number of removeFirst calls.
+              parents.addFirst(node);
+              return behavior;
+            }
+
+            @Override
+            public void leaveCompositeTransform(TransformHierarchy.Node node) {
+              if (!node.isRootNode()) {
+                parents.removeFirst();
+              }
+            }
+          });
+
+      if (parent[0] == null) {
+        return false;
+      }
+
+      // If the parent transform cannot be converted to an appliedPTransform it's definitely not
+      // a CombinePerKey.
+      AppliedPTransform<?, ?, ?> appliedParent;
+      try {
+        appliedParent = parent[0].toAppliedPTransform(pipeline);
+      } catch (NullPointerException e) {
+        return false;
+      }
+
+      return appliedParent.getTransform().getClass().equals(Combine.PerKey.class);
+    }
+
+    @Override
+    public String toString() {
+      return toStringHelper(CombineValuesWithParentCheckPTransformMatcher.class).toString();
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -529,13 +529,17 @@ public class DataflowPipelineTranslator {
 
     @Override
     public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
-      parents.addFirst(node);
+      if (!node.isRootNode()) {
+        parents.addFirst(node);
+      }
       return CompositeBehavior.ENTER_TRANSFORM;
     }
 
     @Override
     public void leaveCompositeTransform(TransformHierarchy.Node node) {
-      parents.removeFirst();
+      if (!node.isRootNode()) {
+        parents.removeFirst();
+      }
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.dataflow;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -50,7 +49,6 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.channels.Channels;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -479,7 +477,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         // Order is important. Streaming views almost all use Combine internally.
         .add(
             PTransformOverride.of(
-                combineValuesTranslationMatcher(fnApiEnabled),
+                combineValuesTranslation(fnApiEnabled),
                 new PrimitiveCombineGroupedValuesOverrideFactory()))
         .add(
             PTransformOverride.of(
@@ -630,6 +628,22 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
                   (Class<TransformT>) transform.getTransform().getClass(), transform.getTransform())
               .build();
       return PTransformReplacement.of(PTransformReplacements.getSingletonMainInput(transform), rep);
+    }
+  }
+
+  /**
+   * Returns a {@link PTransformMatcher} that matches {@link PTransform}s of class {@link
+   * Combine.GroupedValues} that will be translated into CombineValues transforms in Dataflow's Job
+   * API and skips those that should be expanded into ParDos.
+   *
+   * @param fnApiEnabled Flag indicating whether this matcher is being retrieved for a fnapi or
+   *     non-fnapi pipeline.
+   */
+  private static PTransformMatcher combineValuesTranslation(boolean fnApiEnabled) {
+    if (fnApiEnabled) {
+      return new DataflowPTransformMatchers.CombineValuesWithParentCheckPTransformMatcher();
+    } else {
+      return new DataflowPTransformMatchers.CombineValuesWithoutSideInputsPTransformMatcher();
     }
   }
 
@@ -1758,115 +1772,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
           String.format(
               "%s does not currently support state or timers with merging windows",
               DataflowRunner.class.getSimpleName()));
-    }
-  }
-
-  /**
-   * Returns a {@link PTransformMatcher} that matches {@link PTransform}s of class {@link
-   * Combine.GroupedValues} that will be translated into CombineValues transforms in Dataflow's Job
-   * API and skips those that should be expanded into ParDos.
-   *
-   * @param fnApiEnabled Flag indicating whether this matcher is being retrieved for a fnapi or
-   *     non-fnapi pipeline.
-   */
-  private static PTransformMatcher combineValuesTranslationMatcher(boolean fnApiEnabled) {
-    if (fnApiEnabled) {
-      return new CombineValuesWithParentCheckPTransformMatcher();
-    } else {
-      return new CombineValuesWithoutSideInputsPTransformMatcher();
-    }
-  }
-
-  /**
-   * Matches {@link PTransform}s of class {@link Combine.GroupedValues} that have no side inputs.
-   */
-  private static class CombineValuesWithoutSideInputsPTransformMatcher
-      implements PTransformMatcher {
-    private CombineValuesWithoutSideInputsPTransformMatcher() {}
-
-    @Override
-    public boolean matches(AppliedPTransform<?, ?, ?> application) {
-      return application.getTransform().getClass().equals(Combine.GroupedValues.class)
-          && ((Combine.GroupedValues<?, ?, ?>) application.getTransform())
-              .getSideInputs()
-              .isEmpty();
-    }
-
-    @Override
-    public String toString() {
-      return toStringHelper(CombineValuesWithoutSideInputsPTransformMatcher.class).toString();
-    }
-  }
-
-  /**
-   * Matches {@link PTransform}s of class {@link Combine.GroupedValues} that have no side inputs and
-   * are direct subtransforms of a {@link Combine.PerKey}.
-   */
-  private static class CombineValuesWithParentCheckPTransformMatcher implements PTransformMatcher {
-    private CombineValuesWithParentCheckPTransformMatcher() {}
-
-    @Override
-    public boolean matches(AppliedPTransform<?, ?, ?> application) {
-      return application.getTransform().getClass().equals(Combine.GroupedValues.class)
-          && ((Combine.GroupedValues<?, ?, ?>) application.getTransform()).getSideInputs().isEmpty()
-          && parentIsCombinePerKey(application);
-    }
-
-    private boolean parentIsCombinePerKey(AppliedPTransform<?, ?, ?> application) {
-      // We want the PipelineVisitor below to change the parent, but the parent must be final to
-      // be captured in there. To work around this issue, wrap the parent in a one element array.
-      final TransformHierarchy.Node[] parent = new TransformHierarchy.Node[1];
-
-      // Traverse the pipeline to find the parent transform to application. Do this by maintaining
-      // a stack of each composite transform being entered, and grabbing the top transform of the
-      // stack once the target node is visited.
-      Pipeline pipeline = application.getPipeline();
-      pipeline.traverseTopologically(
-          new PipelineVisitor.Defaults() {
-            private ArrayDeque<TransformHierarchy.Node> parents = new ArrayDeque<>();
-
-            @Override
-            public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
-              parents.addFirst(node);
-              return CompositeBehavior.ENTER_TRANSFORM;
-            }
-
-            @Override
-            public void leaveCompositeTransform(TransformHierarchy.Node node) {
-              parents.removeFirst();
-            }
-
-            @Override
-            public void visitPrimitiveTransform(TransformHierarchy.Node node) {
-              if (node.toAppliedPTransform(getPipeline()).equals(application)) {
-                if (parents.isEmpty()) {
-                  parent[0] = null;
-                } else {
-                  parent[0] = parents.peekFirst();
-                }
-              }
-            }
-          });
-
-      if (parent[0] == null) {
-        return false;
-      }
-
-      // If the parent transform cannot be converted to an appliedPTransform it's definitely not
-      // a CombinePerKey.
-      AppliedPTransform<?, ?, ?> appliedParent;
-      try {
-        appliedParent = parent[0].toAppliedPTransform(pipeline);
-      } catch (NullPointerException e) {
-        return false;
-      }
-
-      return appliedParent.getTransform().getClass().equals(Combine.PerKey.class);
-    }
-
-    @Override
-    public String toString() {
-      return toStringHelper(CombineValuesWithParentCheckPTransformMatcher.class).toString();
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPTransformMatchersTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPTransformMatchersTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.runners.PTransformMatcher;
+import org.apache.beam.sdk.runners.TransformHierarchy;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.CombineWithContext;
+import org.apache.beam.sdk.transforms.CombineWithContext.Context;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.View;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DataflowPTransformMatchers}. */
+@RunWith(JUnit4.class)
+public class DataflowPTransformMatchersTest {
+
+  /**
+   * Test the cases that the matcher should successfully match against. In this case, it should
+   * match against {@link Combine.GroupedValues} on their own and as part of an expanded {@link
+   * Combine.PerKey} transform.
+   */
+  @Test
+  public void combineValuesWithoutSideInputsSuccessfulMatches() {
+    PTransformMatcher matcher =
+        new DataflowPTransformMatchers.CombineValuesWithoutSideInputsPTransformMatcher();
+    AppliedPTransform<?, ?, ?> groupedValues;
+
+    groupedValues = getCombineGroupedValuesFrom(createCombineGroupedValuesPipeline());
+    assertThat(matcher.matches(groupedValues), is(true));
+
+    groupedValues = getCombineGroupedValuesFrom(createCombinePerKeyPipeline());
+    assertThat(matcher.matches(groupedValues), is(true));
+  }
+
+  /**
+   * Test significant cases that the matcher should not match against. In this case, this explicitly
+   * tests that any {@link Combine.GroupedValues} with side inputs should not match.
+   */
+  @Test
+  public void combineValuesWithoutSideInputsSkipsNonmatching() {
+    PTransformMatcher matcher =
+        new DataflowPTransformMatchers.CombineValuesWithoutSideInputsPTransformMatcher();
+    AppliedPTransform<?, ?, ?> groupedValues;
+
+    groupedValues = getCombineGroupedValuesFrom(createCombineGroupedValuesWithSideInputsPipeline());
+    assertThat(matcher.matches(groupedValues), is(false));
+
+    groupedValues = getCombineGroupedValuesFrom(createCombinePerKeyWithSideInputsPipeline());
+    assertThat(matcher.matches(groupedValues), is(false));
+  }
+
+  /**
+   * Test the cases that the matcher should successfully match against. In this case, it should
+   * match against {@link Combine.GroupedValues} that are part of an expanded {@link Combine.PerKey}
+   * transform.
+   */
+  @Test
+  public void combineValuesWithParentCheckSuccessfulMatches() {
+    PTransformMatcher matcher =
+        new DataflowPTransformMatchers.CombineValuesWithParentCheckPTransformMatcher();
+    AppliedPTransform<?, ?, ?> groupedValues;
+
+    groupedValues = getCombineGroupedValuesFrom(createCombinePerKeyPipeline());
+    assertThat(matcher.matches(groupedValues), is(true));
+  }
+
+  /**
+   * Test significant cases that the matcher should not match against. In this case, this tests that
+   * any {@link Combine.GroupedValues} with side inputs should not match, and that a {@link
+   * Combine.GroupedValues} without an encompassing {@link Combine.PerKey} will not match.
+   */
+  @Test
+  public void combineValuesWithParentCheckSkipsNonmatching() {
+    PTransformMatcher matcher =
+        new DataflowPTransformMatchers.CombineValuesWithParentCheckPTransformMatcher();
+    AppliedPTransform<?, ?, ?> groupedValues;
+
+    groupedValues = getCombineGroupedValuesFrom(createCombineGroupedValuesPipeline());
+    assertThat(matcher.matches(groupedValues), is(false));
+
+    groupedValues = getCombineGroupedValuesFrom(createCombineGroupedValuesWithSideInputsPipeline());
+    assertThat(matcher.matches(groupedValues), is(false));
+
+    groupedValues = getCombineGroupedValuesFrom(createCombinePerKeyWithSideInputsPipeline());
+    assertThat(matcher.matches(groupedValues), is(false));
+  }
+
+  /** Creates a simple pipeline with a {@link Combine.PerKey}. */
+  private static TestPipeline createCombinePerKeyPipeline() {
+    TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+    PCollection<KV<String, Integer>> input =
+        pipeline
+            .apply(Create.of(KV.of("key", 1)))
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+    input.apply(Combine.perKey(new SumCombineFn()));
+
+    return pipeline;
+  }
+
+  /** Creates a simple pipeline with a {@link Combine.PerKey} with side inputs. */
+  private static TestPipeline createCombinePerKeyWithSideInputsPipeline() {
+    TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+    PCollection<KV<String, Integer>> input =
+        pipeline
+            .apply(Create.of(KV.of("key", 1)))
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+    PCollection<String> sideInput = pipeline.apply(Create.of("side input"));
+    PCollectionView<String> sideInputView = sideInput.apply(View.asSingleton());
+
+    input.apply(
+        Combine.<String, Integer, Integer>perKey(new SumCombineFnWithContext())
+            .withSideInputs(sideInputView));
+
+    return pipeline;
+  }
+
+  /** Creates a simple pipeline with a {@link Combine.GroupedValues}. */
+  private static TestPipeline createCombineGroupedValuesPipeline() {
+    TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+    PCollection<KV<String, Integer>> input =
+        pipeline
+            .apply(Create.of(KV.of("key", 1)))
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+    input.apply(GroupByKey.create()).apply(Combine.groupedValues(new SumCombineFn()));
+
+    return pipeline;
+  }
+
+  /** Creates a simple pipeline with a {@link Combine.GroupedValues} with side inputs. */
+  private static TestPipeline createCombineGroupedValuesWithSideInputsPipeline() {
+    TestPipeline pipeline = TestPipeline.create().enableAbandonedNodeEnforcement(false);
+    PCollection<KV<String, Integer>> input =
+        pipeline
+            .apply(Create.of(KV.of("key", 1)))
+            .setCoder(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()));
+    PCollection<String> sideInput = pipeline.apply(Create.of("side input"));
+    PCollectionView<String> sideInputView = sideInput.apply(View.asSingleton());
+
+    input
+        .apply(GroupByKey.create())
+        .apply(
+            Combine.<String, Integer, Integer>groupedValues(new SumCombineFnWithContext())
+                .withSideInputs(sideInputView));
+
+    return pipeline;
+  }
+
+  /** Traverse the pipeline and return the first {@link Combine.GroupedValues} found. */
+  private static AppliedPTransform<?, ?, ?> getCombineGroupedValuesFrom(TestPipeline pipeline) {
+    final AppliedPTransform<?, ?, ?>[] transform = new AppliedPTransform<?, ?, ?>[1];
+    pipeline.traverseTopologically(
+        new Pipeline.PipelineVisitor.Defaults() {
+          @Override
+          public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
+            if (!node.isRootNode()
+                && node.toAppliedPTransform(getPipeline())
+                    .getTransform()
+                    .getClass()
+                    .equals(Combine.GroupedValues.class)) {
+              transform[0] = node.toAppliedPTransform(getPipeline());
+              return CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
+            }
+            return CompositeBehavior.ENTER_TRANSFORM;
+          }
+        });
+    return transform[0];
+  }
+
+  private static class SumCombineFn extends Combine.CombineFn<Integer, Integer, Integer> {
+    @Override
+    public Integer createAccumulator() {
+      return 0;
+    }
+
+    @Override
+    public Integer addInput(Integer accum, Integer input) {
+      return accum + input;
+    }
+
+    @Override
+    public Integer mergeAccumulators(Iterable<Integer> accumulators) {
+      Integer sum = 0;
+      for (Integer accum : accumulators) {
+        sum += accum;
+      }
+      return sum;
+    }
+
+    @Override
+    public Integer extractOutput(Integer accumulator) {
+      return accumulator;
+    }
+  }
+
+  private static class SumCombineFnWithContext
+      extends CombineWithContext.CombineFnWithContext<Integer, Integer, Integer> {
+    SumCombineFn delegate;
+
+    @Override
+    public Integer createAccumulator(Context c) {
+      return delegate.createAccumulator();
+    }
+
+    @Override
+    public Integer addInput(Integer accum, Integer input, Context c) {
+      return delegate.addInput(accum, input);
+    }
+
+    @Override
+    public Integer mergeAccumulators(Iterable<Integer> accumulators, Context c) {
+      return delegate.mergeAccumulators(accumulators);
+    }
+
+    @Override
+    public Integer extractOutput(Integer accumulator, Context c) {
+      return delegate.extractOutput(accumulator);
+    }
+  }
+}


### PR DESCRIPTION
There was a bug occurring when a Pipeline ran with portability enabled
and a Combine.GroupedValues that wasn't wrapped in a Combine.PerKey.
The code for translating the Combine.GroupedValues would attempt to
translate the parent as if it was a Combine.PerKey because it assumed
that all Combine.GroupedValues would be subtransforms.

To avoid that issue I'm adding a clause to the PTransformOverride for
that translation, so the translation will only occur if the parent of
the Combine.GroupedValues is a Combine.PerKey. Essentially, I'm forcing
the assumption to be true.

Along with those changes I'm also bundling in a few code quality,
naming, and comment changes to make the code I touched easier to
understand.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




