### PR TITLE
[BEAM-5375] KafkaIO : Handle runtime exceptions while fetching from Kafka better. 

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -172,7 +172,6 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     offsetFetcherThread.scheduleAtFixedRate(
         this::updateLatestOffsets, 0, OFFSET_UPDATE_INTERVAL_SECONDS, TimeUnit.SECONDS);
 
-    nextBatch();
     return advance();
   }
 
@@ -376,6 +375,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   // like 100 milliseconds does not work well. This along with large receive buffer for
   // consumer achieved best throughput in tests (see `defaultConsumerProperties`).
   private final ExecutorService consumerPollThread = Executors.newSingleThreadExecutor();
+  private AtomicReference<Exception> consumerPollException = new AtomicReference<>();
   private final SynchronousQueue<ConsumerRecords<byte[], byte[]>> availableRecordsQueue =
       new SynchronousQueue<>();
   private AtomicReference<KafkaCheckpointMark> finalizedCheckpointMark = new AtomicReference<>();
@@ -391,7 +391,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
       Executors.newSingleThreadScheduledExecutor();
   private static final int OFFSET_UPDATE_INTERVAL_SECONDS = 1;
 
-  static final long UNINITIALIZED_OFFSET = -1;
+  private static final long UNINITIALIZED_OFFSET = -1;
 
   //Add SpEL instance to cover the interface difference of Kafka client
   private transient ConsumerSpEL consumerSpEL;
@@ -570,28 +570,33 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   private void consumerPollLoop() {
     // Read in a loop and enqueue the batch of records, if any, to availableRecordsQueue.
 
-    ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
-    while (!closed.get()) {
-      try {
-        if (records.isEmpty()) {
-          records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
-        } else if (availableRecordsQueue.offer(
+    try {
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
+      while (!closed.get()) {
+        try {
+          if (records.isEmpty()) {
+            records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
+          } else if (availableRecordsQueue.offer(
             records, RECORDS_ENQUEUE_POLL_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS)) {
-          records = ConsumerRecords.empty();
+            records = ConsumerRecords.empty();
+          }
+          KafkaCheckpointMark checkpointMark = finalizedCheckpointMark.getAndSet(null);
+          if (checkpointMark != null) {
+            commitCheckpointMark(checkpointMark);
+          }
+        } catch (InterruptedException e) {
+          LOG.warn("{}: consumer thread is interrupted", this, e); // not expected
+          break;
+        } catch (WakeupException e) {
+          break;
         }
-        KafkaCheckpointMark checkpointMark = finalizedCheckpointMark.getAndSet(null);
-        if (checkpointMark != null) {
-          commitCheckpointMark(checkpointMark);
-        }
-      } catch (InterruptedException e) {
-        LOG.warn("{}: consumer thread is interrupted", this, e); // not expected
-        break;
-      } catch (WakeupException e) {
-        break;
       }
+      LOG.info("{}: Returning from consumer pool loop", this);
+    } catch (Exception e) { // mostly an unrecoverable KafkaException.
+      LOG.error("{}: Exception while reading from Kafka", this, e);
+      consumerPollException.set(e);
+      throw e;
     }
-
-    LOG.info("{}: Returning from consumer pool loop", this);
   }
 
   private void commitCheckpointMark(KafkaCheckpointMark checkpointMark) {
@@ -622,9 +627,12 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     checkpointMarkCommitsEnqueued.inc();
   }
 
-  private void nextBatch() {
-    curBatch = Collections.emptyIterator();
+  private void nextBatch() throws IOException {
+    if (consumerPollException.get() != null) {
+      throw new IOException("Exception while reading from Kafka", consumerPollException.get());
+    }
 
+    curBatch = Collections.emptyIterator();
     ConsumerRecords<byte[], byte[]> records;
     try {
       // poll available records, wait (if necessary) up to the specified timeout.
@@ -653,7 +661,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     if (pState.nextOffset != UNINITIALIZED_OFFSET) {
       consumer.seek(pState.topicPartition, pState.nextOffset);
     } else {
-      // nextOffset is unininitialized here, meaning start reading from latest record as of now
+      // nextOffset is uninitialized here, meaning start reading from latest record as of now
       // ('latest' is the default, and is configurable) or 'look up offset by startReadTime.
       // Remember the current position without waiting until the first record is read. This
       // ensures checkpoint is accurate even if the reader is closed before reading any records.

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -19,13 +19,17 @@ package org.apache.beam.sdk.io.kafka;
 
 import static org.apache.beam.sdk.metrics.MetricResultsMatchers.attemptedMetricsResult;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.junit.internal.matchers.ThrowableCauseMatcher.hasCause;
+import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -104,6 +108,7 @@ import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
@@ -274,6 +279,9 @@ public class KafkaIOTest {
               }
             }
             if (recordsAdded == 0) {
+              if (config.get("inject.error.at.eof") != null) {
+                consumer.setException(new KafkaException("Injected error in consumer.poll()"));
+              }
               // MockConsumer.poll(timeout) does not actually wait even when there aren't any records.
               // Add a small wait here in order to avoid busy looping in the reader.
               Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
@@ -638,6 +646,38 @@ public class KafkaIOTest {
         }
       };
     }
+  }
+
+  @Test
+  public void testUnboundedSourceWithExceptionInKafkaFetch() {
+    // Similar testUnboundedSource, but with an injected exception inside Kafk Consumer poll.
+
+    // The reader should throw an IOException:
+    thrown.expectCause(isA(IOException.class));
+    thrown.expectCause(hasMessage(containsString("Exception while reading from Kafka")));
+    // The original exception is from MockConsumer.poll():
+    thrown.expectCause(hasCause(isA(KafkaException.class)));
+    thrown.expectCause(hasCause(hasMessage(containsString("Injected error in consumer.poll()"))));
+
+    int numElements = 1000;
+    String topic = "my_topic";
+
+    KafkaIO.Read<Integer, Long> reader =
+      KafkaIO.<Integer, Long>read()
+        .withBootstrapServers("none")
+        .withTopic("my_topic")
+        .withConsumerFactoryFn(
+          new ConsumerFactoryFn(
+            ImmutableList.of(topic), 10, numElements, OffsetResetStrategy.EARLIEST))
+        .withMaxNumRecords(2 * numElements) // Try to read more messages than available.
+        .updateConsumerProperties(ImmutableMap.of("inject.error.at.eof", true))
+        .withKeyDeserializer(IntegerDeserializer.class)
+        .withValueDeserializer(LongDeserializer.class);
+
+    PCollection<Long> input = p.apply(reader.withoutMetadata()).apply(Values.create());
+
+    addCountingAsserts(input, numElements);
+    p.run();
   }
 
   @Test

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -663,16 +663,16 @@ public class KafkaIOTest {
     String topic = "my_topic";
 
     KafkaIO.Read<Integer, Long> reader =
-      KafkaIO.<Integer, Long>read()
-        .withBootstrapServers("none")
-        .withTopic("my_topic")
-        .withConsumerFactoryFn(
-          new ConsumerFactoryFn(
-            ImmutableList.of(topic), 10, numElements, OffsetResetStrategy.EARLIEST))
-        .withMaxNumRecords(2 * numElements) // Try to read more messages than available.
-        .updateConsumerProperties(ImmutableMap.of("inject.error.at.eof", true))
-        .withKeyDeserializer(IntegerDeserializer.class)
-        .withValueDeserializer(LongDeserializer.class);
+        KafkaIO.<Integer, Long>read()
+            .withBootstrapServers("none")
+            .withTopic("my_topic")
+            .withConsumerFactoryFn(
+                new ConsumerFactoryFn(
+                    ImmutableList.of(topic), 10, numElements, OffsetResetStrategy.EARLIEST))
+            .withMaxNumRecords(2 * numElements) // Try to read more messages than available.
+            .updateConsumerProperties(ImmutableMap.of("inject.error.at.eof", true))
+            .withKeyDeserializer(IntegerDeserializer.class)
+            .withValueDeserializer(LongDeserializer.class);
 
     PCollection<Long> input = p.apply(reader.withoutMetadata()).apply(Values.create());
 


### PR DESCRIPTION
 Unrecoverable exceptions in Kafka fetch should result in IOException in the reader.

KafkaConsumer.poll() could throw unrecoverable exceptions, KafkaIO didn't handle
it well. The poll thread just silently died. It should result in an IOException
thrown inside start()/advance() in unbounded reader.

Fix: The consumer poll thread saves the exception before exiting, and the reader checks for it before checking for more records. Added a unit test to verify.



