### PR TITLE
[BEAM-5413] Add PTransform::compose for lambda-based composite transforms

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
@@ -292,4 +292,30 @@ public abstract class PTransform<InputT extends PInput, OutputT extends POutput>
    */
   @Override
   public void populateDisplayData(Builder builder) {}
+
+  /**
+   * For a {@code SerializableFunction<InputT, OutputT>} {@code fn}, returns a {@code PTransform}
+   * given by applying {@code fn.apply(v)} to the input {@code PCollection<InputT>}.
+   *
+   * <p>Allows users to define a concise composite transform using a Java 8 lambda expression.
+   * For example:
+   *
+   * <pre>{@code
+   * PCollection<String> words = wordsAndErrors.apply(
+   *   (PCollectionTuple input) -> {
+   *     input.get(errorsTag).apply(new WriteErrorOutput());
+   *     return input.get(wordsTag);
+   *   });
+   * }</pre>
+   */
+  public static <InputT extends PInput, OutputT extends POutput>
+  PTransform<InputT, OutputT> compose(
+      SerializableFunction<InputT, OutputT> fn) {
+    return new PTransform<InputT, OutputT>() {
+      @Override
+      public OutputT expand(InputT input) {
+        return fn.apply(input);
+      }
+    };
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PTransformTest.java
@@ -17,18 +17,30 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import static org.apache.beam.sdk.values.TypeDescriptors.integers;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
+import java.io.Serializable;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionList;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link PTransform} base class. */
 @RunWith(JUnit4.class)
-public class PTransformTest {
+public class PTransformTest implements Serializable {
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.create();
+
   @Test
   public void testPopulateDisplayDataDefaultBehavior() {
     PTransform<PCollection<String>, PCollection<String>> transform =
@@ -40,5 +52,22 @@ public class PTransformTest {
         };
     DisplayData displayData = DisplayData.from(transform);
     assertThat(displayData.items(), empty());
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testComposeBasicSerializableFunction() throws Exception {
+    PCollection<Integer> output = pipeline
+        .apply(Create.of(1, 2, 3))
+        .apply(PTransform.compose((PCollection<Integer> numbers) -> {
+              PCollection<Integer> inverted = numbers
+                  .apply(MapElements.into(integers()).via(input -> -input));
+              return PCollectionList
+                  .of(numbers).and(inverted)
+                  .apply(Flatten.pCollections());
+            }));
+
+    PAssert.that(output).containsInAnyOrder(-2, -1, -3, 2, 1, 3);
+    pipeline.run();
   }
 }

--- a/website/src/documentation/programming-guide.md
+++ b/website/src/documentation/programming-guide.md
@@ -1572,6 +1572,21 @@ transform's intermediate data changes type multiple times.
   }
 ```
 
+<span class="language-java">If your logic only needs to be used once,
+you may instead define your composite transform as an anonymous Java 8 lambda
+function passed to `PTransform.compose`:
+
+```java
+  input.apply(PTransform.compose((PCollection<String> lines) -> {
+      PCollection<String> words = lines.apply(
+          ParDo.of(new ExtractWordsFn()));
+      PCollection<KV<String, Long>> wordCounts =
+          words.apply(Count.<String>perElement());
+      return wordCounts;
+  }))
+```
+</span>
+
 ```py
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipeline_monitoring_composite
 %}```


### PR DESCRIPTION
This PR adds `PTransform::compose` which takes in a SerializableFunction, intended for use with a Java 8 lambda expression. This method gives users a more compact option for defining simple composite transforms.

cc @lukecwik 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




