### PR TITLE
[BEAM-5105] Better parallelize BigQuery load jobs

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteRename.java
@@ -18,10 +18,6 @@
 
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.google.api.client.util.BackOff;
-import com.google.api.client.util.BackOffUtils;
-import com.google.api.client.util.Sleeper;
-import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationTableCopy;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.TableReference;
@@ -32,21 +28,17 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.RetryJobId;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.RetryJobIdResult;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.PendingJobManager;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.util.BackOffAdapter;
-import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +59,23 @@ class WriteRename extends DoFn<Iterable<KV<TableDestination, String>>, Void> {
   private final CreateDisposition firstPaneCreateDisposition;
   private final int maxRetryJobs;
 
+  private static class PendingJobData {
+    final BigQueryHelpers.PendingJob retryJob;
+    final TableDestination tableDestination;
+    final List<TableReference> tempTables;
+
+    public PendingJobData(
+        BigQueryHelpers.PendingJob retryJob,
+        TableDestination tableDestination,
+        List<TableReference> tempTables) {
+      this.retryJob = retryJob;
+      this.tableDestination = tableDestination;
+      this.tempTables = tempTables;
+    }
+  }
+  // All pending copy jobs.
+  private List<PendingJobData> pendingJobs = Lists.newArrayList();
+
   public WriteRename(
       BigQueryServices bqServices,
       PCollectionView<String> jobIdToken,
@@ -80,6 +89,11 @@ class WriteRename extends DoFn<Iterable<KV<TableDestination, String>>, Void> {
     this.maxRetryJobs = maxRetryJobs;
   }
 
+  @StartBundle
+  public void startBundle(StartBundleContext c) {
+    pendingJobs.clear();
+  }
+
   @ProcessElement
   public void processElement(ProcessContext c) throws Exception {
     Multimap<TableDestination, String> tempTables = ArrayListMultimap.create();
@@ -88,58 +102,78 @@ class WriteRename extends DoFn<Iterable<KV<TableDestination, String>>, Void> {
     }
     for (Map.Entry<TableDestination, Collection<String>> entry : tempTables.asMap().entrySet()) {
       // Process each destination table.
-      writeRename(entry.getKey(), entry.getValue(), c);
+      // Do not copy if no temp tables are provided.
+      if (!entry.getValue().isEmpty()) {
+        pendingJobs.add(startWriteRename(entry.getKey(), entry.getValue(), c));
+      }
     }
   }
 
-  private void writeRename(
+  @FinishBundle
+  public void finishBundle(FinishBundleContext c) throws Exception {
+    DatasetService datasetService =
+        bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class));
+    PendingJobManager jobManager = new PendingJobManager();
+    for (PendingJobData pendingJob : pendingJobs) {
+      jobManager.addPendingJob(
+          pendingJob.retryJob,
+          j -> {
+            try {
+              if (pendingJob.tableDestination.getTableDescription() != null) {
+                TableReference ref = pendingJob.tableDestination.getTableReference();
+                datasetService.patchTableDescription(
+                    ref.clone()
+                        .setTableId(BigQueryHelpers.stripPartitionDecorator(ref.getTableId())),
+                    pendingJob.tableDestination.getTableDescription());
+              }
+              removeTemporaryTables(datasetService, pendingJob.tempTables);
+              return null;
+            } catch (IOException | InterruptedException e) {
+              return e;
+            }
+          });
+    }
+    jobManager.waitForDone();
+  }
+
+  private PendingJobData startWriteRename(
       TableDestination finalTableDestination, Iterable<String> tempTableNames, ProcessContext c)
       throws Exception {
     WriteDisposition writeDisposition =
         (c.pane().getIndex() == 0) ? firstPaneWriteDisposition : WriteDisposition.WRITE_APPEND;
     CreateDisposition createDisposition =
         (c.pane().getIndex() == 0) ? firstPaneCreateDisposition : CreateDisposition.CREATE_NEVER;
-    List<String> tempTablesJson = Lists.newArrayList(tempTableNames);
-    // Do not copy if no temp tables are provided
-    if (tempTablesJson.isEmpty()) {
-      return;
-    }
-
-    List<TableReference> tempTables = Lists.newArrayList();
-    for (String table : tempTablesJson) {
-      tempTables.add(BigQueryHelpers.fromJsonString(table, TableReference.class));
-    }
+    List<TableReference> tempTables =
+        StreamSupport.stream(tempTableNames.spliterator(), false)
+            .map(table -> BigQueryHelpers.fromJsonString(table, TableReference.class))
+            .collect(Collectors.toList());
+    ;
 
     // Make sure each destination table gets a unique job id.
     String jobIdPrefix =
         BigQueryHelpers.createJobId(
             c.sideInput(jobIdToken), finalTableDestination, -1, c.pane().getIndex());
 
-    copy(
-        bqServices.getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
-        bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
-        jobIdPrefix,
-        finalTableDestination.getTableReference(),
-        tempTables,
-        writeDisposition,
-        createDisposition,
-        finalTableDestination.getTableDescription());
-
-    DatasetService tableService =
-        bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class));
-    removeTemporaryTables(tableService, tempTables);
+    BigQueryHelpers.PendingJob retryJob =
+        startCopy(
+            bqServices.getJobService(c.getPipelineOptions().as(BigQueryOptions.class)),
+            bqServices.getDatasetService(c.getPipelineOptions().as(BigQueryOptions.class)),
+            jobIdPrefix,
+            finalTableDestination.getTableReference(),
+            tempTables,
+            writeDisposition,
+            createDisposition);
+    return new PendingJobData(retryJob, finalTableDestination, tempTables);
   }
 
-  private void copy(
+  private BigQueryHelpers.PendingJob startCopy(
       JobService jobService,
       DatasetService datasetService,
       String jobIdPrefix,
       TableReference ref,
       List<TableReference> tempTables,
       WriteDisposition writeDisposition,
-      CreateDisposition createDisposition,
-      @Nullable String tableDescription)
-      throws InterruptedException, IOException {
+      CreateDisposition createDisposition) {
     JobConfigurationTableCopy copyConfig =
         new JobConfigurationTableCopy()
             .setSourceTables(tempTables)
@@ -147,89 +181,60 @@ class WriteRename extends DoFn<Iterable<KV<TableDestination, String>>, Void> {
             .setWriteDisposition(writeDisposition.name())
             .setCreateDisposition(createDisposition.name());
 
-    String projectId = ref.getProjectId();
-    Job lastFailedCopyJob = null;
-    RetryJobId jobId = new RetryJobId(jobIdPrefix, 0);
     String bqLocation =
         BigQueryHelpers.getDatasetLocation(datasetService, ref.getProjectId(), ref.getDatasetId());
-    BackOff backoff =
-        BackOffAdapter.toGcpBackOff(
-            FluentBackoff.DEFAULT
-                .withMaxRetries(maxRetryJobs)
-                .withInitialBackoff(Duration.standardSeconds(1))
-                .withMaxBackoff(Duration.standardMinutes(1))
-                .backoff());
-    Sleeper sleeper = Sleeper.DEFAULT;
-    int i = 0;
-    do {
-      ++i;
-      JobReference jobRef =
-          new JobReference()
-              .setProjectId(projectId)
-              .setJobId(jobId.getJobId())
-              .setLocation(bqLocation);
-      LOG.info("Starting copy job for table {} using  {}, attempt {}", ref, jobRef, i);
-      try {
-        jobService.startCopyJob(jobRef, copyConfig);
-      } catch (IOException e) {
-        LOG.warn("Copy job {} failed with {}", jobRef, e);
-        // It's possible that the job actually made it to BQ even though we got a failure here.
-        // For example, the response from BQ may have timed out returning. getRetryJobId will
-        // return the correct job id to use on retry, or a job id to continue polling (if it turns
-        // out the the job has not actually failed yet).
-        RetryJobIdResult result =
-            BigQueryHelpers.getRetryJobId(jobId, projectId, bqLocation, jobService);
-        jobId = result.jobId;
-        if (result.shouldRetry) {
-          // Try the load again with the new job id.
-          continue;
-        }
-        // Otherwise,the job has reached BigQuery and is in either the PENDING state or has
-        // completed successfully.
-      }
-      Job copyJob = jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
-      Status jobStatus = BigQueryHelpers.parseStatus(copyJob);
-      switch (jobStatus) {
-        case SUCCEEDED:
-          if (tableDescription != null) {
-            datasetService.patchTableDescription(ref, tableDescription);
-          }
-          return;
-        case UNKNOWN:
-          // This might happen if BigQuery's job listing is slow. Retry with the same
-          // job id.
-          LOG.info(
-              "Copy job {} finished in unknown state: {}: {}",
-              jobRef,
-              copyJob.getStatus(),
-              (i < maxRetryJobs - 1) ? "will retry" : "will not retry");
-          lastFailedCopyJob = copyJob;
-          continue;
-        case FAILED:
-          lastFailedCopyJob = copyJob;
-          jobId = BigQueryHelpers.getRetryJobId(jobId, projectId, bqLocation, jobService).jobId;
-          continue;
-        default:
-          throw new IllegalStateException(
-              String.format(
-                  "Unexpected status [%s] of load job: %s.",
-                  jobStatus, BigQueryHelpers.jobToPrettyString(copyJob)));
-      }
-    } while (nextBackOff(sleeper, backoff));
-    throw new RuntimeException(
-        String.format(
-            "Failed to create copy job with id prefix %s, "
-                + "reached max retries: %d, last failed copy job: %s.",
-            jobIdPrefix, maxRetryJobs, BigQueryHelpers.jobToPrettyString(lastFailedCopyJob)));
-  }
 
-  /** Identical to {@link BackOffUtils#next} but without checked IOException. */
-  private static boolean nextBackOff(Sleeper sleeper, BackOff backoff) throws InterruptedException {
-    try {
-      return BackOffUtils.next(sleeper, backoff);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    String projectId = ref.getProjectId();
+    BigQueryHelpers.PendingJob retryJob =
+        new BigQueryHelpers.PendingJob(
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              LOG.info(
+                  "Starting copy job for table {} using  {}, job id iteration {}",
+                  ref,
+                  jobRef,
+                  jobId.getRetryIndex());
+              try {
+                jobService.startCopyJob(jobRef, copyConfig);
+              } catch (IOException | InterruptedException e) {
+                LOG.warn("Copy job {} failed with {}", jobRef, e);
+                throw new RuntimeException(e);
+              }
+              return null;
+            },
+            // Function to poll the result of a load job.
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              try {
+                return jobService.pollJob(jobRef, BatchLoads.LOAD_JOB_POLL_MAX_RETRIES);
+              } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            // Function to lookup a job.
+            jobId -> {
+              JobReference jobRef =
+                  new JobReference()
+                      .setProjectId(projectId)
+                      .setJobId(jobId.getJobId())
+                      .setLocation(bqLocation);
+              try {
+                return jobService.getJob(jobRef);
+              } catch (InterruptedException | IOException e) {
+                throw new RuntimeException(e);
+              }
+            },
+            maxRetryJobs,
+            jobIdPrefix);
+    return retryJob;
   }
 
   static void removeTemporaryTables(DatasetService tableService, List<TableReference> tempTables) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpersTest.java
@@ -20,23 +20,36 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static org.junit.Assert.assertEquals;
 
 import com.google.api.client.util.Data;
+import com.google.api.services.bigquery.model.ErrorProto;
+import com.google.api.services.bigquery.model.Job;
+import com.google.api.services.bigquery.model.JobReference;
+import com.google.api.services.bigquery.model.JobStatus;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.collect.ImmutableSet;
+import java.util.Random;
+import java.util.Set;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.ShardedKeyCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.PendingJob;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.PendingJobManager;
 import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.util.BackOffAdapter;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.testng.collections.Sets;
 
 /** Tests for {@link BigQueryHelpers}. */
 @RunWith(JUnit4.class)
@@ -130,5 +143,64 @@ public class BigQueryHelpersTest {
         WindowedValue.getFullCoder(
             KvCoder.of(ShardedKeyCoder.of(StringUtf8Coder.of()), TableRowInfoCoder.of()),
             IntervalWindow.getCoder()));
+  }
+
+  @Test
+  public void testPendingJobManager() throws Exception {
+    PendingJobManager jobManager =
+        new PendingJobManager(
+            BackOffAdapter.toGcpBackOff(
+                FluentBackoff.DEFAULT
+                    .withMaxRetries(Integer.MAX_VALUE)
+                    .withInitialBackoff(Duration.millis(10))
+                    .withMaxBackoff(Duration.millis(10))
+                    .backoff()));
+
+    Set<String> succeeded = Sets.newHashSet();
+    for (int i = 0; i < 5; i++) {
+      Job currentJob = new Job();
+      currentJob.setKind(" bigquery#job");
+      PendingJob pendingJob =
+          new PendingJob(
+              retryId -> {
+                if (new Random().nextInt(2) == 0) {
+                  throw new RuntimeException("Failing to start.");
+                }
+                currentJob.setJobReference(
+                    new JobReference()
+                        .setProjectId("")
+                        .setLocation("")
+                        .setJobId(retryId.getJobId()));
+                return null;
+              },
+              retryId -> {
+                if (retryId.getRetryIndex() < 5) {
+                  currentJob.setStatus(new JobStatus().setErrorResult(new ErrorProto()));
+                } else {
+                  currentJob.setStatus(new JobStatus().setErrorResult(null));
+                }
+                return currentJob;
+              },
+              retryId -> {
+                if (retryId.getJobId().equals(currentJob.getJobReference().getJobId())) {
+                  return currentJob;
+                } else {
+                  return null;
+                }
+              },
+              100,
+              "JOB_" + i);
+      jobManager.addPendingJob(
+          pendingJob,
+          j -> {
+            succeeded.add(j.currentJobId.getJobId());
+            return null;
+          });
+    }
+
+    jobManager.waitForDone();
+    Set<String> expectedJobs =
+        ImmutableSet.of("JOB_0-5", "JOB_1-5", "JOB_2-5", "JOB_3-5", "JOB_4-5");
+    assertEquals(expectedJobs, succeeded);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -757,7 +757,7 @@ public class BigQueryIOWriteTest implements Serializable {
                 .withoutValidation());
 
     thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Failed to create load job");
+    thrown.expectMessage("Failed to create job");
     p.run();
   }
 
@@ -777,9 +777,9 @@ public class BigQueryIOWriteTest implements Serializable {
                 .withoutValidation());
 
     thrown.expect(RuntimeException.class);
-    thrown.expectMessage("Failed to create load job with id prefix");
+    thrown.expectMessage("Failed to create job with prefix");
     thrown.expectMessage("reached max retries");
-    thrown.expectMessage("last failed load job");
+    thrown.expectMessage("last failed job");
 
     p.run();
   }
@@ -1281,6 +1281,7 @@ public class BigQueryIOWriteTest implements Serializable {
     DoFnTester<Iterable<KV<TableDestination, String>>, Void> tester = DoFnTester.of(writeRename);
     tester.setSideInput(jobIdTokenView, GlobalWindow.INSTANCE, jobIdToken);
     tester.processElement(tempTablesElement);
+    tester.finishBundle();
 
     for (Map.Entry<TableDestination, Collection<String>> entry : tempTables.asMap().entrySet()) {
       TableDestination tableDestination = entry.getKey();


### PR DESCRIPTION
Instead of blocking in every processElement, start the load jobs and wait for all of them in finishBundle.