### PR TITLE
Interactive Beam -- display issue: number of PTransform executed wrongly displayed

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/display/display_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/display/display_manager.py
@@ -50,33 +50,26 @@ except (ImportError, NameError):
 class DisplayManager(object):
   """Manages displaying pipeline graph and execution status on the frontend."""
 
-  def __init__(self, pipeline_info, pipeline_proto, caches_used, cache_manager,
-               referenced_pcollections, required_transforms,
+  def __init__(self, pipeline_proto, pipeline_analyzer, cache_manager,
                pipeline_graph_renderer):
     """Constructor of DisplayManager.
 
     Args:
-      pipeline_info: (interactive_runner.PipelineInfo)
       pipeline_proto: (Pipeline proto)
-      caches_used: (set of str) A set of PCollection IDs of those whose cached
-          results are used in the execution.
+      pipeline_analyzer: (PipelineAnalyzer)
       cache_manager: (interactive_runner.CacheManager) DisplayManager fetches
           the latest status of pipeline execution by querying cache_manager.
-      referenced_pcollections: (dict from str to PCollection proto) PCollection
-          ID mapped to PCollection referenced during pipeline execution.
-      required_transforms: (dict from str to PTransform proto) mapping from
-          transform ID to transforms that leads to visible results.
       pipeline_graph_renderer: (pipeline_graph_renderer.PipelineGraphRenderer)
           decides how a pipeline graph is rendered.
     """
     # Every parameter except cache_manager is expected to remain constant.
+    self._analyzer = pipeline_analyzer
     self._cache_manager = cache_manager
-    self._referenced_pcollections = referenced_pcollections
     self._pipeline_graph = interactive_pipeline_graph.InteractivePipelineGraph(
         pipeline_proto,
-        required_transforms=required_transforms,
-        referenced_pcollections=referenced_pcollections,
-        cached_pcollections=caches_used)
+        required_transforms=self._analyzer.tl_required_trans_ids(),
+        referenced_pcollections=self._analyzer.tl_referenced_pcoll_ids(),
+        cached_pcollections=self._analyzer.caches_used())
     self._renderer = pipeline_graph_renderer
 
     # _text_to_print keeps track of information to be displayed.
@@ -84,20 +77,22 @@ class DisplayManager(object):
     self._text_to_print['summary'] = (
         'Using %s cached PCollections\nExecuting %s of %s '
         'transforms.') % (
-            # TODO(qinyeli): required_transforms includes ReadCache and
-            # WriteCache fix it.
-            len(caches_used), len(required_transforms),
+            len(self._analyzer.caches_used()),
+            (len(self._analyzer.tl_required_trans_ids())
+             - len(self._analyzer.read_cache_ids())
+             - len(self._analyzer.write_cache_ids())),
             len(pipeline_proto.components.transforms[
                 pipeline_proto.root_transform_ids[0]].subtransforms))
-    self._text_to_print.update(
-        {pcoll_id: "" for pcoll_id in referenced_pcollections})
+    self._text_to_print.update({
+        pcoll_id: "" for pcoll_id
+        in self._analyzer.tl_referenced_pcoll_ids()})
 
     # _pcollection_stats maps pcoll_id to
     # { 'cache_label': cache_label, version': version, 'sample': pcoll_in_list }
     self._pcollection_stats = {}
-    for pcoll_id in pipeline_info.all_pcollections():
+    for pcoll_id in self._analyzer.tl_referenced_pcoll_ids():
       self._pcollection_stats[pcoll_id] = {
-          'cache_label': pipeline_info.cache_label(pcoll_id),
+          'cache_label': self._analyzer.pipeline_info().cache_label(pcoll_id),
           'version': -1,
           'sample': []
       }
@@ -137,7 +132,7 @@ class DisplayManager(object):
           stats['version'] = version
           stats_updated = True
 
-          if pcoll_id in self._referenced_pcollections:
+          if pcoll_id in self._analyzer.tl_referenced_pcoll_ids():
             self._text_to_print[pcoll_id] = (str(
                 '%s produced %s' % (
                     self._producers[pcoll_id],

--- a/sdks/python/apache_beam/runners/interactive/display/interactive_pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/interactive_pipeline_graph.py
@@ -61,15 +61,16 @@ class InteractivePipelineGraph(pipeline_graph.PipelineGraph):
 
     Args:
       pipeline: (Pipeline proto) or (Pipeline) pipeline to be rendered.
-      required_transforms: (dict from str to PTransform proto) Mapping from
-          transform ID to transforms that leads to visible results.
-      referenced_pcollections: (dict from str to PCollection proto) PCollection
-          ID mapped to PCollection referenced during pipeline execution.
+      required_transforms: (list/set of str) ID of top level PTransforms that
+          lead to visible results.
+      referenced_pcollections: (list/set of str) ID of PCollections that are
+          referenced by top level PTransforms executed (i.e.
+          required_transforms)
       cached_pcollections: (set of str) a set of PCollection IDs of those whose
           cached results are used in the execution.
     """
-    self._required_transforms = required_transforms or {}
-    self._referenced_pcollections = referenced_pcollections or {}
+    self._required_transforms = required_transforms or set()
+    self._referenced_pcollections = referenced_pcollections or set()
     self._cached_pcollections = cached_pcollections or set()
 
     super(InteractivePipelineGraph, self).__init__(

--- a/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pipeline_graph.py
@@ -49,7 +49,7 @@ class PipelineGraph(object):
       or
 
       graph = pipeline_graph.PipelineGraph(pipeline)
-      graph.display_grapy()
+      graph.display_graph()
 
     Args:
       pipeline: (Pipeline proto) or (Pipeline) pipeline to be rendered.

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -138,8 +138,8 @@ class InteractiveRunner(runners.PipelineRunner):
         pipeline_proto=pipeline_proto,
         caches_used=analyzer.caches_used(),
         cache_manager=self._cache_manager,
-        referenced_pcollections=analyzer.top_level_referenced_pcollection_ids(),
-        required_transforms=analyzer.top_level_required_transforms(),
+        referenced_pcollections=analyzer.tl_referenced_pcoll_ids(),
+        required_transforms=analyzer.tl_required_trans_ids(),
         pipeline_graph_renderer=self._renderer)
     display.start_periodic_update()
     result = pipeline_to_execute.run()

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner.py
@@ -131,23 +131,18 @@ class InteractiveRunner(runners.PipelineRunner):
         self._underlying_runner,
         pipeline._options)
 
-    pipeline_info = pipeline_analyzer.PipelineInfo(pipeline_proto.components)
-
     display = display_manager.DisplayManager(
-        pipeline_info=pipeline_info,
         pipeline_proto=pipeline_proto,
-        caches_used=analyzer.caches_used(),
+        pipeline_analyzer=analyzer,
         cache_manager=self._cache_manager,
-        referenced_pcollections=analyzer.tl_referenced_pcoll_ids(),
-        required_transforms=analyzer.tl_required_trans_ids(),
         pipeline_graph_renderer=self._renderer)
     display.start_periodic_update()
     result = pipeline_to_execute.run()
     result.wait_until_finish()
     display.stop_periodic_update()
 
-    return PipelineResult(result, self, pipeline_info, self._cache_manager,
-                          pcolls_to_pcoll_id)
+    return PipelineResult(result, self, self._analyzer.pipeline_info(),
+                          self._cache_manager, pcolls_to_pcoll_id)
 
   def _pcolls_to_pcoll_id(self, pipeline, original_context):
     """Returns a dict mapping PCollections string to PCollection IDs.

--- a/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
@@ -108,6 +108,8 @@ class PipelineAnalyzerTest(unittest.TestCase):
         7  # Create, Double, Square, CacheSample * 3, CacheFull
     )
     self.assertEqual(len(analyzer.top_level_referenced_pcollection_ids()), 3)
+    self.assertEqual(len(analyzer.read_cache_ids()), 0)
+    self.assertEqual(len(analyzer.write_cache_ids()), 4)
 
     # The second run.
     _ = (pcoll
@@ -126,6 +128,9 @@ class PipelineAnalyzerTest(unittest.TestCase):
         6  # Read, Triple, Cube, CacheSample * 2, CacheFull
     )
     self.assertEqual(len(analyzer.top_level_referenced_pcollection_ids()), 3)
+    self.assertEqual(len(analyzer.read_cache_ids()), 1)
+    self.assertEqual(len(analyzer.write_cache_ids()), 3)
+
     # No need to actually execute the second run.
 
   def test_word_count(self):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
@@ -104,10 +104,10 @@ class PipelineAnalyzerTest(unittest.TestCase):
     )
     pipeline_to_execute.run().wait_until_finish()
     self.assertEqual(
-        len(analyzer.top_level_required_transforms()),
+        len(analyzer.tl_required_trans_ids()),
         7  # Create, Double, Square, CacheSample * 3, CacheFull
     )
-    self.assertEqual(len(analyzer.top_level_referenced_pcollection_ids()), 3)
+    self.assertEqual(len(analyzer.tl_referenced_pcoll_ids()), 3)
     self.assertEqual(len(analyzer.read_cache_ids()), 0)
     self.assertEqual(len(analyzer.write_cache_ids()), 4)
 
@@ -124,10 +124,10 @@ class PipelineAnalyzerTest(unittest.TestCase):
         p._options
     )
     self.assertEqual(
-        len(analyzer.top_level_required_transforms()),
+        len(analyzer.tl_required_trans_ids()),
         6  # Read, Triple, Cube, CacheSample * 2, CacheFull
     )
-    self.assertEqual(len(analyzer.top_level_referenced_pcollection_ids()), 3)
+    self.assertEqual(len(analyzer.tl_referenced_pcoll_ids()), 3)
     self.assertEqual(len(analyzer.read_cache_ids()), 1)
     self.assertEqual(len(analyzer.write_cache_ids()), 3)
 


### PR DESCRIPTION
The main focus of this PR is to fix the display issue -- the number of PTransform executed is wrongly displayed.
<img width="251" alt="screen shot 2018-09-17 at 2 13 24 pm" src="https://user-images.githubusercontent.com/16407701/45650665-e0374200-ba83-11e8-9425-a2b5de9aa455.png">

"Executing 8 of 3 transforms" now becomes "Executing 3 of 3 transforms".


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---




