### PR TITLE
[BEAM-5414] Latest grpcio-tools incompatible with latest protobuf 3.6.1

### DIFF
--- a/sdks/python/gen_protos.py
+++ b/sdks/python/gen_protos.py
@@ -32,7 +32,8 @@ import warnings
 
 import pkg_resources
 
-GRPC_TOOLS = 'grpcio-tools>=1.3.5,<2'
+# TODO(BEAM-5414): latest grpcio-tools incompatible with latest protobuf 3.6.1.
+GRPC_TOOLS = 'grpcio-tools>=1.3.5,<=1.14.2'
 
 BEAM_PROTO_PATHS = [
     os.path.join('..', '..', 'model', 'pipeline', 'src', 'main', 'proto'),


### PR DESCRIPTION
R: @chamikaramj 