### PR TITLE
[BEAM-5144] Fix unstable test by ensuring acks are processed synchronously

### DIFF
--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -54,14 +54,12 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests of {@link JmsIO}. */
-@Ignore("TODO(BEAM-5144): Fix this test before reenabling.")
 @RunWith(JUnit4.class)
 public class JmsIOTest {
 
@@ -74,7 +72,7 @@ public class JmsIOTest {
 
   private BrokerService broker;
   private ConnectionFactory connectionFactory;
-  private ConnectionFactory connectionFactoryWithoutPrefetch;
+  private ConnectionFactory connectionFactoryWithSyncAcksAndWithoutPrefetch;
 
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 
@@ -101,8 +99,8 @@ public class JmsIOTest {
 
     // create JMS connection factory
     connectionFactory = new ActiveMQConnectionFactory(BROKER_URL);
-    connectionFactoryWithoutPrefetch =
-        new ActiveMQConnectionFactory(BROKER_URL + "?jms.prefetchPolicy.all=0");
+    connectionFactoryWithSyncAcksAndWithoutPrefetch =
+        new ActiveMQConnectionFactory(BROKER_URL + "?jms.prefetchPolicy.all=0&jms.sendAcksAsync=false");
   }
 
   @After
@@ -275,7 +273,9 @@ public class JmsIOTest {
     // test, it means that we can have some latency between the receiveNoWait() method used by
     // the consumer and the prefetch buffer populated by the broker. Using a prefetch to 0 means
     // that the consumer will poll for message, which is exactly what we want for the test.
-    Connection connection = connectionFactoryWithoutPrefetch.createConnection(USERNAME, PASSWORD);
+    // We are also sending message acknowledgements synchronously to ensure that they are
+    // processed before any subsequent assertions.
+    Connection connection = connectionFactoryWithSyncAcksAndWithoutPrefetch.createConnection(USERNAME, PASSWORD);
     connection.start();
     Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
     MessageProducer producer = session.createProducer(session.createQueue(QUEUE));
@@ -288,7 +288,7 @@ public class JmsIOTest {
 
     JmsIO.Read spec =
         JmsIO.read()
-            .withConnectionFactory(connectionFactoryWithoutPrefetch)
+            .withConnectionFactory(connectionFactoryWithSyncAcksAndWithoutPrefetch)
             .withUsername(USERNAME)
             .withPassword(PASSWORD)
             .withQueue(QUEUE);

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -91,6 +91,7 @@ public class JmsIOTest {
     // username and password to use to connect to the broker.
     // This user has users privilege (able to browse, consume, produce, list destinations)
     users.add(new AuthenticationUser(USERNAME, PASSWORD, "users"));
+    users.add(new AuthenticationUser(USERNAME, PASSWORD, "users"));
     SimpleAuthenticationPlugin plugin = new SimpleAuthenticationPlugin(users);
     BrokerPlugin[] plugins = new BrokerPlugin[] {plugin};
     broker.setPlugins(plugins);
@@ -100,7 +101,8 @@ public class JmsIOTest {
     // create JMS connection factory
     connectionFactory = new ActiveMQConnectionFactory(BROKER_URL);
     connectionFactoryWithSyncAcksAndWithoutPrefetch =
-        new ActiveMQConnectionFactory(BROKER_URL + "?jms.prefetchPolicy.all=0&jms.sendAcksAsync=false");
+        new ActiveMQConnectionFactory(
+            BROKER_URL + "?jms.prefetchPolicy.all=0&jms.sendAcksAsync=false");
   }
 
   @After
@@ -275,7 +277,8 @@ public class JmsIOTest {
     // that the consumer will poll for message, which is exactly what we want for the test.
     // We are also sending message acknowledgements synchronously to ensure that they are
     // processed before any subsequent assertions.
-    Connection connection = connectionFactoryWithSyncAcksAndWithoutPrefetch.createConnection(USERNAME, PASSWORD);
+    Connection connection =
+        connectionFactoryWithSyncAcksAndWithoutPrefetch.createConnection(USERNAME, PASSWORD);
     connection.start();
     Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
     MessageProducer producer = session.createProducer(session.createQueue(QUEUE));


### PR DESCRIPTION
JmsIOTest was disabled as it was behaving erratically: testCheckpointMark was randomly failing with unexpected queue sizes. 

This would appear to be a consequence of the default ActiveMQ connection factory setting which sees acknowledgement messages sent and processed asynchronously. With this configuration it would be possible that an assertion against queue size could be performed before previous acknowledgements sent via a different connection had been processed.

The fix is a simple change to the connection URL query string, adding sendAcksAsync=false (http://activemq.apache.org/maven/apidocs/org/apache/activemq/ActiveMQConnectionFactory.html#isSendAcksAsync--) in order to ensure that acknowledgements are processed before subsequent test assertions.

@jbonofre 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---



