### PR TITLE
[BEAM-5412][BEAM-5408] Fixes a bug that limited the size of TFRecords

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -619,32 +619,39 @@ public class TFRecordIO {
         return null;
       }
       checkState(headerBytes == HEADER_LEN, "Not a valid TFRecord. Fewer than 12 bytes.");
+
       header.rewind();
       long length = header.getLong();
+      long lengthHash = hashLong(length);
       int maskedCrc32OfLength = header.getInt();
-      checkState(hashLong(length) == maskedCrc32OfLength, "Mismatch of length mask");
-
-      ByteBuffer data = ByteBuffer.allocate((int) length);
-      long totalRead = 0;
-      while (true) {
-        long read = inChannel.read(data);
-        if (read == 0) {
-          break;
-        }
-        totalRead += read;
-      }
-      if (totalRead != length) {
+      if (lengthHash != maskedCrc32OfLength) {
         throw new IOException(
             String.format(
-                "Expected a record of length %d but only read %d bytes.", length, totalRead));
+                "Mistmatch of length mask when reading a record. Expected %d but received %d.",
+                maskedCrc32OfLength, lengthHash));
+      }
+
+      ByteBuffer data = ByteBuffer.allocate((int) length);
+      while (data.hasRemaining() && inChannel.read(data) >= 0) {}
+      if (data.hasRemaining()) {
+        throw new IOException(
+            String.format(
+                "EOF while reading record of length %d. Read only %d bytes. Input might be truncated.",
+                length, data.position()));
       }
 
       footer.clear();
       inChannel.read(footer);
       footer.rewind();
-      int maskedCrc32OfData = footer.getInt();
 
-      checkState(hashBytes(data.array()) == maskedCrc32OfData, "Mismatch of data mask");
+      int maskedCrc32OfData = footer.getInt();
+      int dataHash = hashBytes(data.array());
+      if (dataHash != maskedCrc32OfData) {
+        throw new IOException(
+            String.format(
+                "Mistmatch of data mask when reading a record. Expected %d but received %d.",
+                maskedCrc32OfData, dataHash));
+      }
       return data.array();
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -625,7 +625,19 @@ public class TFRecordIO {
       checkState(hashLong(length) == maskedCrc32OfLength, "Mismatch of length mask");
 
       ByteBuffer data = ByteBuffer.allocate((int) length);
-      checkState(inChannel.read(data) == length, "Invalid data");
+      long totalRead = 0;
+      while (true) {
+        long read = inChannel.read(data);
+        if (read == 0) {
+          break;
+        }
+        totalRead += read;
+      }
+      if (totalRead != length) {
+        throw new IOException(
+            String.format(
+                "Expected a record of length %d but only read %d bytes.", length, totalRead));
+      }
 
       footer.clear();
       inChannel.read(footer);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
@@ -84,7 +84,8 @@ public class TFRecordIOTest {
   private static final String[] FOO_BAR_RECORDS = {"foo", "bar"};
 
   private static final Iterable<String> EMPTY = Collections.emptyList();
-  private static final Iterable<String> LARGE = makeLines(1000);
+  private static final Iterable<String> LARGE = makeLines(1000, 4);
+  private static final Iterable<String> LARGE_RECORDS = makeLines(100, 100000);
 
   @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -287,6 +288,18 @@ public class TFRecordIOTest {
     runTestRoundTrip(LARGE, 10, ".tfrecords", DEFLATE, AUTO);
   }
 
+  @Test
+  @Category(NeedsRunner.class)
+  public void runTestRoundTripLargeRecords() throws IOException {
+    runTestRoundTrip(LARGE_RECORDS, 10, ".tfrecords", UNCOMPRESSED, UNCOMPRESSED);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void runTestRoundTripLargeRecordsGzip() throws IOException {
+    runTestRoundTrip(LARGE_RECORDS, 10, ".tfrecords", GZIP, GZIP);
+  }
+
   private void runTestRoundTrip(
       Iterable<String> elems,
       int numShards,
@@ -344,10 +357,15 @@ public class TFRecordIOTest {
     readPipeline.run();
   }
 
-  private static Iterable<String> makeLines(int n) {
+  private static Iterable<String> makeLines(int n, int minRecordSize) {
     List<String> ret = Lists.newArrayList();
+    StringBuilder recordBuilder = new StringBuilder();
+    for (int i = 0; i < minRecordSize; i++) {
+      recordBuilder.append("x");
+    }
+    String record = recordBuilder.toString();
     for (int i = 0; i < n; ++i) {
-      ret.add("word" + i);
+      ret.add(record + " " + i);
     }
     return ret;
   }


### PR DESCRIPTION
Fixes a bug that limited the size of records read from TFRecord files that are GZIP compressed.