### PR TITLE
[BEAM-5319] Partially port runners

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -89,9 +89,9 @@ def write_data(
   all_data = []
   with tempfile.NamedTemporaryFile(
       delete=False, dir=directory, prefix=prefix) as f:
-    sep_values = ['\n', '\r\n']
+    sep_values = [b'\n', b'\r\n']
     for i in range(num_lines):
-      data = '' if no_data else 'line' + str(i)
+      data = b'' if no_data else b'line' + str(i).encode()
       all_data.append(data)
 
       if eol == EOL.LF:
@@ -101,7 +101,7 @@ def write_data(
       elif eol == EOL.MIXED:
         sep = sep_values[i % len(sep_values)]
       elif eol == EOL.LF_WITH_NOTHING_AT_LAST_LINE:
-        sep = '' if i == (num_lines - 1) else sep_values[0]
+        sep = b'' if i == (num_lines - 1) else sep_values[0]
       else:
         raise ValueError('Received unknown value %s for eol.' % eol)
 

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -37,14 +37,11 @@ import zlib
 from builtins import object
 from builtins import zip
 
-from future import standard_library
 from future.utils import with_metaclass
 from past.builtins import long
 from past.builtins import unicode
 
 from apache_beam.utils.plugin import BeamPlugin
-
-standard_library.install_aliases()
 
 logger = logging.getLogger(__name__)
 

--- a/sdks/python/apache_beam/io/filesystem_test.py
+++ b/sdks/python/apache_beam/io/filesystem_test.py
@@ -29,15 +29,12 @@ import unittest
 from builtins import range
 from io import BytesIO
 
-from future import standard_library
 from future.utils import iteritems
 
 from apache_beam.io.filesystem import CompressedFile
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystem import FileMetadata
 from apache_beam.io.filesystem import FileSystem
-
-standard_library.install_aliases()
 
 
 class TestingFileSystem(FileSystem):

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -147,7 +147,7 @@ class _TextSource(filebasedsource.FileBasedSource):
 
   def read_records(self, file_name, range_tracker):
     start_offset = range_tracker.start_position()
-    read_buffer = _TextSource.ReadBuffer('', 0)
+    read_buffer = _TextSource.ReadBuffer(b'', 0)
 
     next_record_start_position = -1
 
@@ -251,9 +251,9 @@ class _TextSource(filebasedsource.FileBasedSource):
 
       # Using find() here is more efficient than a linear scan of the byte
       # array.
-      next_lf = read_buffer.data.find('\n', current_pos)
+      next_lf = read_buffer.data.find(b'\n', current_pos)
       if next_lf >= 0:
-        if next_lf > 0 and read_buffer.data[next_lf - 1] == '\r':
+        if next_lf > 0 and read_buffer.data[next_lf - 1] == b'\r':
           # Found a '\r\n'. Accepting that as the next separator.
           return (next_lf - 1, next_lf + 1)
         else:

--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -83,7 +83,7 @@ class _TextSource(filebasedsource.FileBasedSource):
       self._position = value
 
     def reset(self):
-      self.data = ''
+      self.data = b''
       self.position = 0
 
   def __init__(self,

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -30,7 +30,6 @@ import unittest
 from builtins import range
 
 import crcmod
-from future import standard_library
 
 import apache_beam as beam
 from apache_beam import Create
@@ -45,8 +44,6 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_utils import TempDir
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-
-standard_library.install_aliases()
 
 try:
   import tensorflow as tf  # pylint: disable=import-error

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -24,13 +24,12 @@ For internal use only; no backwards-compatibility guarantees.
 
 from __future__ import absolute_import
 
-import sys
 import traceback
 from builtins import next
 from builtins import object
 from builtins import zip
 
-from future.utils import raise_
+from future.utils import raise_with_traceback
 from past.builtins import unicode
 
 from apache_beam.internal import util
@@ -703,7 +702,6 @@ class DoFnRunner(Receiver):
       raise
     step_annotation = " [while running '%s']" % self.step_name
     # To emulate exception chaining (not available in Python 2).
-    original_traceback = sys.exc_info()[2]
     try:
       # Attempt to construct the same kind of exception
       # with an augmented message.
@@ -716,7 +714,7 @@ class DoFnRunner(Receiver):
           traceback.format_exception_only(type(exn), exn)[-1].strip()
           + step_annotation)
       new_exn._tagged_with_step = True
-    raise_(type(new_exn), new_exn, original_traceback)
+    raise_with_traceback(new_exn)
 
 
 class OutputProcessor(object):

--- a/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
+++ b/sdks/python/apache_beam/runners/direct/consumer_tracking_pipeline_visitor_test.py
@@ -45,6 +45,10 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
   def setUp(self):
     self.pipeline = Pipeline(DirectRunner())
     self.visitor = ConsumerTrackingPipelineVisitor()
+    try:                    # Python 2
+      self.assertCountEqual = self.assertItemsEqual
+    except AttributeError:  # Python 3
+      pass
 
   def test_root_transforms(self):
     class DummySource(iobase.BoundedSource):
@@ -60,15 +64,13 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
     self.pipeline.visit(self.visitor)
 
-    root_transforms = sorted(
-        [t.transform for t in self.visitor.root_transforms])
+    root_transforms = [t.transform for t in self.visitor.root_transforms]
 
-    self.assertEqual(root_transforms, sorted(
-        [root_read, root_flatten]))
+    self.assertCountEqual(root_transforms, [root_read, root_flatten])
 
-    pbegin_consumers = sorted(
-        [c.transform for c in self.visitor.value_to_consumers[pbegin]])
-    self.assertEqual(pbegin_consumers, sorted([root_read]))
+    pbegin_consumers = [c.transform
+                        for c in self.visitor.value_to_consumers[pbegin]]
+    self.assertCountEqual(pbegin_consumers, [root_read])
     self.assertEqual(len(self.visitor.step_names), 3)
 
   def test_side_inputs(self):
@@ -100,9 +102,8 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
     self.pipeline.visit(self.visitor)
 
-    root_transforms = sorted(
-        [t.transform for t in self.visitor.root_transforms])
-    self.assertEqual(root_transforms, sorted([root_read]))
+    root_transforms = [t.transform for t in self.visitor.root_transforms]
+    self.assertEqual(root_transforms, [root_read])
     self.assertEqual(len(self.visitor.step_names), 3)
     self.assertEqual(len(self.visitor.views), 1)
     self.assertTrue(isinstance(self.visitor.views[0],
@@ -115,8 +116,7 @@ class ConsumerTrackingPipelineVisitorTest(unittest.TestCase):
 
     self.pipeline.visit(self.visitor)
 
-    root_transforms = sorted(
-        [t.transform for t in self.visitor.root_transforms])
+    root_transforms = [t.transform for t in self.visitor.root_transforms]
     self.assertEqual(len(root_transforms), 2)
     self.assertGreater(
         len(self.visitor.step_names), 3)  # 2 creates + expanded CoGBK

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -34,6 +34,7 @@ try:                    # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes
   quote = urllib.parse.quote
 except AttributeError:  # Python 2
+  # pylint: disable=deprecated-urllib-function
   unquote_to_bytes = urllib.unquote
   quote = urllib.quote
 

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -31,6 +31,14 @@ from apache_beam.io import filesystems
 from apache_beam.transforms import combiners
 
 
+try:                    # Python 3
+  unquote_to_bytes = urllib.parse.unquote_to_bytes
+  quote = urllib.parse.quote
+except AttributeError:  # Python 2
+  unquote_to_bytes = urllib.unquote
+  quote = urllib.quote
+
+
 class CacheManager(object):
   """Abstract class for caching PCollections.
 
@@ -193,7 +201,7 @@ class SafeFastPrimitivesCoder(coders.Coder):
   """This class add an quote/unquote step to escape special characters."""
 
   def encode(self, value):
-    return urllib.quote(coders.coders.FastPrimitivesCoder().encode(value))
+    return quote(coders.coders.FastPrimitivesCoder().encode(value))
 
   def decode(self, value):
-    return coders.coders.FastPrimitivesCoder().decode(urllib.unquote(value))
+    return coders.coders.FastPrimitivesCoder().decode(unquote_to_bytes(value))

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -30,7 +30,6 @@ from apache_beam import coders
 from apache_beam.io import filesystems
 from apache_beam.transforms import combiners
 
-
 try:                    # Python 3
   unquote_to_bytes = urllib.parse.unquote_to_bytes
   quote = urllib.parse.quote

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 import unittest
 
 import apache_beam as beam
@@ -42,6 +43,8 @@ def print_with_message(msg):
 
 class InteractiveRunnerTest(unittest.TestCase):
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_basic(self):
     p = beam.Pipeline(
         runner=interactive_runner.InteractiveRunner(
@@ -57,6 +60,8 @@ class InteractiveRunnerTest(unittest.TestCase):
     _ = pc0 | 'Print3' >> beam.Map(print_with_message('Run3'))
     p.run().wait_until_finish()
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_wordcount(self):
 
     class WordExtractingDoFn(beam.DoFn):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_analyzer_test.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import sys
 import unittest
 
 import apache_beam as beam
@@ -86,6 +87,8 @@ class PipelineAnalyzerTest(unittest.TestCase):
     self.assertSetEqual(set(transform_proto1.outputs),
                         set(transform_proto2.outputs))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_basic(self):
     p = beam.Pipeline(runner=self.runner)
 
@@ -128,6 +131,8 @@ class PipelineAnalyzerTest(unittest.TestCase):
     self.assertEqual(len(analyzer.top_level_referenced_pcollection_ids()), 3)
     # No need to actually execute the second run.
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_word_count(self):
     p = beam.Pipeline(runner=self.runner)
 
@@ -210,6 +215,8 @@ class PipelineAnalyzerTest(unittest.TestCase):
     self.assertPipelineEqual(analyzer.pipeline_proto_to_execute(),
                              expected_pipeline_proto)
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_read_cache_expansion(self):
     p = beam.Pipeline(runner=self.runner)
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -1061,7 +1061,7 @@ class FnApiRunner(runner.PipelineRunner):
 
     def blocking_get(self, state_key):
       with self._lock:
-        return ''.join(self._state[self._to_key(state_key)])
+        return b''.join(self._state[self._to_key(state_key)])
 
     def blocking_append(self, state_key, data):
       with self._lock:

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner.py
@@ -30,7 +30,6 @@ from builtins import object
 from concurrent import futures
 
 import grpc
-from future import standard_library
 
 import apache_beam as beam  # pylint: disable=ungrouped-imports
 from apache_beam import coders
@@ -57,7 +56,6 @@ from apache_beam.transforms import trigger
 from apache_beam.transforms.window import GlobalWindows
 from apache_beam.utils import proto_utils
 
-standard_library.install_aliases()
 # This module is experimental. No backwards-compatibility guarantees.
 
 ENCODED_IMPULSE_VALUE = beam.coders.WindowedValueCoder(

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner_test.py
@@ -20,6 +20,7 @@ from __future__ import print_function
 import functools
 import logging
 import os
+import sys
 import tempfile
 import time
 import traceback
@@ -142,6 +143,8 @@ class FnApiRunnerTest(unittest.TestCase):
       assert_that(unnamed.even, equal_to([2]), label='unnamed.even')
       assert_that(unnamed.odd, equal_to([1, 3]), label='unnamed.odd')
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_pardo_side_inputs(self):
     def cross_product(elem, sides):
       for side in sides:
@@ -153,6 +156,8 @@ class FnApiRunnerTest(unittest.TestCase):
                   equal_to([('a', 'x'), ('b', 'x'), ('c', 'x'),
                             ('a', 'y'), ('b', 'y'), ('c', 'y')]))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_pardo_windowed_side_inputs(self):
     with self.create_pipeline() as p:
       # Now with some windowing.
@@ -180,6 +185,8 @@ class FnApiRunnerTest(unittest.TestCase):
               (9, list(range(7, 10)))]),
           label='windowed')
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_flattened_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create([None])
@@ -190,6 +197,8 @@ class FnApiRunnerTest(unittest.TestCase):
           main | beam.Map(lambda a, b: (a, b), beam.pvalue.AsDict(side)),
           equal_to([(None, {'a': 1, 'b': 2})]))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_gbk_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create([None])
@@ -198,6 +207,8 @@ class FnApiRunnerTest(unittest.TestCase):
           main | beam.Map(lambda a, b: (a, b), beam.pvalue.AsDict(side)),
           equal_to([(None, {'a': [1]})]))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_multimap_side_input(self):
     with self.create_pipeline() as p:
       main = p | 'main' >> beam.Create(['a', 'b'])
@@ -209,6 +220,8 @@ class FnApiRunnerTest(unittest.TestCase):
                           beam.pvalue.AsMultiMap(side)),
           equal_to([('a', [1, 3]), ('b', [2])]))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_pardo_unfusable_side_inputs(self):
     def cross_product(elem, sides):
       for side in sides:
@@ -279,7 +292,7 @@ class FnApiRunnerTest(unittest.TestCase):
     # due to https://bugs.python.org/issue14243
     temp_file = tempfile.NamedTemporaryFile(delete=False)
     try:
-      temp_file.write('a\nb\nc')
+      temp_file.write(b'a\nb\nc')
       temp_file.close()
       with self.create_pipeline() as p:
         assert_that(p | beam.io.ReadFromText(temp_file.name),
@@ -297,6 +310,8 @@ class FnApiRunnerTest(unittest.TestCase):
              | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
       assert_that(res, equal_to([('k', [1, 2]), ('k', [100, 101, 102])]))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_large_elements(self):
     with self.create_pipeline() as p:
       big = (p
@@ -328,8 +343,9 @@ class FnApiRunnerTest(unittest.TestCase):
          | 'StageB' >> beam.Map(lambda x: x)
          | 'StageC' >> beam.Map(raise_error)
          | 'StageD' >> beam.Map(lambda x: x))
-    self.assertIn('StageC', e_cm.exception.args[0])
-    self.assertNotIn('StageB', e_cm.exception.args[0])
+    message = e_cm.exception.args[0]
+    self.assertIn('StageC', message)
+    self.assertNotIn('StageB', message)
 
   def test_error_traceback_includes_user_code(self):
 

--- a/sdks/python/apache_beam/runners/portability/local_job_service.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import functools
 import logging
 import os
-import queue as queue
+import queue
 import subprocess
 import threading
 import time
@@ -29,7 +29,6 @@ from builtins import object
 from concurrent import futures
 
 import grpc
-from future import standard_library
 from google.protobuf import text_format
 
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
@@ -37,8 +36,6 @@ from apache_beam.portability.api import beam_job_api_pb2
 from apache_beam.portability.api import beam_job_api_pb2_grpc
 from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.portability import fn_api_runner
-
-standard_library.install_aliases()
 
 TERMINAL_STATES = [
     beam_job_api_pb2.JobState.DONE,

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -106,7 +106,7 @@ class PortableRunner(runner.PipelineRunner):
 
     # TODO: Define URNs for options.
     options = {'beam:option:' + k + ':v1': v
-               for k, v in pipeline._options.get_all_options().iteritems()
+               for k, v in pipeline._options.get_all_options().items()
                if v is not None}
 
     channel = grpc.insecure_channel(job_endpoint)

--- a/sdks/python/apache_beam/runners/portability/portable_stager.py
+++ b/sdks/python/apache_beam/runners/portability/portable_stager.py
@@ -101,7 +101,7 @@ class PortableStager(Stager):
 
 def _get_file_hash(path):
   hasher = hashlib.md5()
-  with open(path) as f:
+  with open(path, 'rb') as f:
     while True:
       chunk = f.read(1 << 21)
       if chunk:

--- a/sdks/python/apache_beam/runners/portability/portable_stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_stager_test.py
@@ -115,10 +115,11 @@ class PortableStagerTest(unittest.TestCase):
             buffering=2 << 22) as f:
           f.write(''.join(chars))
       if type == 'b':
+        chars = [char.encode('ascii') for char in chars]
         with open(
             os.path.join(self._temp_dir, from_file), 'wb',
             buffering=2 << 22) as f:
-          f.write(''.join(chars))
+          f.write(b''.join(chars))
 
     copied_files, retrieval_tokens = self._stage_files(
         [(from_file, to_file) for (from_file, to_file, _, _) in files])

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -223,6 +223,7 @@ class StagerTest(unittest.TestCase):
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'abc.txt')))
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'def.txt')))
 
+  # TODO(BEAM-5502): Object stager tests are not hermetic.
   @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
                                              'fixed on Python 3')
   def test_with_setup_file(self):

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -222,6 +223,8 @@ class StagerTest(unittest.TestCase):
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'abc.txt')))
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'def.txt')))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_with_setup_file(self):
     staging_dir = self.make_temp_dir()
     source_dir = self.make_temp_dir()

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -229,7 +229,7 @@ class _GrpcDataChannel(DataChannel):
           beam_fn_api_pb2.Elements.Data(
               instruction_reference=instruction_id,
               target=target,
-              data=''))
+              data=b''))
     return ClosableOutputStream(
         close_callback, flush_callback=add_to_send_queue)
 

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -31,7 +31,6 @@ from builtins import object
 from builtins import range
 
 import grpc
-from future import standard_library
 from future.utils import raise_
 from future.utils import with_metaclass
 
@@ -39,8 +38,6 @@ from apache_beam.coders import coder_impl
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
-
-standard_library.install_aliases()
 
 # This module is experimental. No backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/runners/worker/data_plane_test.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane_test.py
@@ -28,14 +28,11 @@ import unittest
 from concurrent import futures
 
 import grpc
-from future import standard_library
 from future.utils import raise_
 
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker import data_plane
-
-standard_library.install_aliases()
 
 
 def timeout(timeout_secs):

--- a/sdks/python/apache_beam/runners/worker/data_plane_test.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane_test.py
@@ -102,38 +102,38 @@ class DataChannelTest(unittest.TestCase):
         name='out')
 
     # Single write.
-    send('0', target_1, 'abc')
+    send('0', target_1, b'abc')
     self.assertEqual(
         list(to_channel.input_elements('0', [target_1])),
         [beam_fn_api_pb2.Elements.Data(
             instruction_reference='0',
             target=target_1,
-            data='abc')])
+            data=b'abc')])
 
     # Multiple interleaved writes to multiple instructions.
     target_2 = beam_fn_api_pb2.Target(
         primitive_transform_reference='2',
         name='out')
 
-    send('1', target_1, 'abc')
-    send('2', target_1, 'def')
+    send('1', target_1, b'abc')
+    send('2', target_1, b'def')
     self.assertEqual(
         list(to_channel.input_elements('1', [target_1])),
         [beam_fn_api_pb2.Elements.Data(
             instruction_reference='1',
             target=target_1,
-            data='abc')])
-    send('2', target_2, 'ghi')
+            data=b'abc')])
+    send('2', target_2, b'ghi')
     self.assertEqual(
         list(to_channel.input_elements('2', [target_1, target_2])),
         [beam_fn_api_pb2.Elements.Data(
             instruction_reference='2',
             target=target_1,
-            data='def'),
+            data=b'def'),
          beam_fn_api_pb2.Elements.Data(
              instruction_reference='2',
              target=target_2,
-             data='ghi')])
+             data=b'ghi')])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -25,13 +25,10 @@ import threading
 from builtins import range
 
 import grpc
-from future import standard_library
 
 from apache_beam.portability.api import beam_fn_api_pb2
 from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
-
-standard_library.install_aliases()
 
 # This module is experimental. No backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/runners/worker/opcounters_test.py
+++ b/sdks/python/apache_beam/runners/worker/opcounters_test.py
@@ -21,6 +21,7 @@ from __future__ import division
 import logging
 import math
 import random
+import sys
 import unittest
 from builtins import object
 from builtins import range
@@ -160,6 +161,8 @@ class OperationCountersTest(unittest.TestCase):
     total_size += coder.estimate_size(value)
     self.verify_counters(opcounts, 3, (float(total_size) / 3))
 
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
+                                             'fixed on Python 3')
   def test_should_sample(self):
     # Order of magnitude more buckets than highest constant in code under test.
     buckets = [0] * 300

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -32,7 +32,6 @@ from builtins import range
 from concurrent import futures
 
 import grpc
-from future import standard_library
 from future.utils import raise_
 from future.utils import with_metaclass
 
@@ -41,8 +40,6 @@ from apache_beam.portability.api import beam_fn_api_pb2_grpc
 from apache_beam.runners.worker import bundle_processor
 from apache_beam.runners.worker import data_plane
 from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
-
-standard_library.install_aliases()
 
 
 class SdkHarness(object):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -159,7 +159,7 @@ def _parse_pipeline_options(options_json):
     return PipelineOptions.from_dictionary({
         re.match(portable_option_regex, k).group('key')
         if re.match(portable_option_regex, k) else k: v
-        for k, v in options.iteritems()
+        for k, v in options.items()
     })
 
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main.py
@@ -28,7 +28,6 @@ import threading
 import traceback
 from builtins import object
 
-from future import standard_library
 from google.protobuf import text_format
 
 from apache_beam.internal import pickler
@@ -38,8 +37,6 @@ from apache_beam.portability.api import endpoints_pb2
 from apache_beam.runners.dataflow.internal import names
 from apache_beam.runners.worker.log_handler import FnApiLogRecordHandler
 from apache_beam.runners.worker.sdk_worker import SdkHarness
-
-standard_library.install_aliases()
 
 # This module is experimental. No backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/runners/worker/sideinputs.py
+++ b/sdks/python/apache_beam/runners/worker/sideinputs.py
@@ -27,14 +27,10 @@ import traceback
 from builtins import object
 from builtins import range
 
-from future import standard_library
-
 from apache_beam.coders import observable
 from apache_beam.io import iobase
 from apache_beam.runners.worker import opcounters
 from apache_beam.transforms import window
-
-standard_library.install_aliases()
 
 # This module is experimental. No backwards-compatibility guarantees.
 

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -153,7 +153,7 @@ class CoGroupByKey(PTransform):
       # If pcolls is a dict, we turn it into (tag, pcoll) pairs for use in the
       # general-purpose code below. The result value constructor creates dicts
       # whose keys are the tags.
-      result_ctor_arg = pcolls.keys()
+      result_ctor_arg = list(pcolls)
       result_ctor = lambda tags: dict((tag, []) for tag in tags)
       pcolls = pcolls.items()
     except AttributeError:

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -57,7 +57,7 @@ commands =
 setenv =
   BEAM_EXPERIMENTAL_PY3=1
 modules =
-  apache_beam.coders,apache_beam.options,apache_beam.tools,apache_beam.utils,apache_beam.internal,apache_beam.metrics,apache_beam.portability,apache_beam.pipeline_test,apache_beam.pvalue_test
+  apache_beam.coders,apache_beam.options,apache_beam.tools,apache_beam.utils,apache_beam.internal,apache_beam.metrics,apache_beam.portability,apache_beam.pipeline_test,apache_beam.pvalue_test,apache_beam.runners
 commands =
   python --version
   pip --version


### PR DESCRIPTION
This is is part of a series of PRs with goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented [here](https://s.apache.org/beam-python-3).

Fixing the tests for Python 3 requires a lot of cross-package fixes. I'm therefore submitting this PR with the failing tests skipped during Python 3 testing. This will allow us to build on these fixes while porting the other packages. Since the remaining errors might be caused by other packages, porting of these packages might already solve some of these errors.

In a later stage, these errors should be un-skipped and fixed if they are still failing.

@tvalentyn @Fematich @charlesccychen @aaltay 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | --- | --- | --- | ---