### PR TITLE
[BEAM-5324] Removing apache_beam.pipeline_test from Py3 unittests temporarily

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -57,7 +57,7 @@ commands =
 setenv =
   BEAM_EXPERIMENTAL_PY3=1
 modules =
-  apache_beam.coders,apache_beam.options,apache_beam.tools,apache_beam.utils,apache_beam.internal,apache_beam.metrics,apache_beam.portability,apache_beam.pipeline_test,apache_beam.pvalue_test
+  apache_beam.coders,apache_beam.options,apache_beam.tools,apache_beam.utils,apache_beam.internal,apache_beam.metrics,apache_beam.portability,apache_beam.pvalue_test
 commands =
   python --version
   pip --version


### PR DESCRIPTION
Removing for now as it breaks Py3 unittests.

r: @RobbeSneyders @tvalentyn 