### PR TITLE
Revert "[BEAM-4747] mkdirs if they don't exist in localfilesystem (#5903)

### DIFF
--- a/sdks/python/apache_beam/io/localfilesystem.py
+++ b/sdks/python/apache_beam/io/localfilesystem.py
@@ -144,9 +144,6 @@ class LocalFileSystem(FileSystem):
 
     Returns: file handle with a close function for the user to use
     """
-    parent = os.path.dirname(path)
-    if not os.path.exists(parent):
-      os.makedirs(parent)
     return self._path_open(path, 'wb', mime_type, compression_type)
 
   def open(self, path, mime_type='application/octet-stream',
@@ -188,10 +185,6 @@ class LocalFileSystem(FileSystem):
         if os.path.isdir(source):
           shutil.copytree(source, destination)
         else:
-          parent = os.path.dirname(destination)
-          if not os.path.exists(parent):
-            os.makedirs(parent)
-
           shutil.copy2(source, destination)
       except OSError as err:
         raise IOError(err)
@@ -224,10 +217,6 @@ class LocalFileSystem(FileSystem):
     def _rename_file(source, destination):
       """Rename a single file object"""
       try:
-        parent = os.path.dirname(destination)
-        if not os.path.exists(parent):
-          os.makedirs(parent)
-
         os.rename(source, destination)
       except OSError as err:
         raise IOError(err)

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -196,8 +196,8 @@ class LocalFileSystemTest(unittest.TestCase):
                      [(path1, path2)])
 
   def test_copy_directory(self):
-    path_t1 = os.path.join(self.tmpdir, 't1/11')
-    path_t2 = os.path.join(self.tmpdir, 't2/22')
+    path_t1 = os.path.join(self.tmpdir, 't1')
+    path_t2 = os.path.join(self.tmpdir, 't2')
     self.fs.mkdirs(path_t1)
     self.fs.mkdirs(path_t2)
 
@@ -208,19 +208,6 @@ class LocalFileSystemTest(unittest.TestCase):
 
     self.fs.copy([path_t1], [path_t2])
     self.assertTrue(filecmp.cmp(path1, path2))
-
-  def test_create_mkdirs_open(self):
-    path = os.path.join(self.tmpdir, 't1/t2/t3')
-    with self.fs.create(path) as f:
-      f.write("yay")
-
-    with self.fs.open(path) as f:
-      self.assertEqual(f.read(), "yay")
-
-  def test_open_error(self):
-    path = os.path.join(self.tmpdir, 't1')
-    with self.assertRaisesRegexp(IOError, r'No such file or directory'):
-      self.fs.open(path)
 
   def test_rename(self):
     path1 = os.path.join(self.tmpdir, 'f1')
@@ -244,22 +231,6 @@ class LocalFileSystemTest(unittest.TestCase):
   def test_rename_directory(self):
     path_t1 = os.path.join(self.tmpdir, 't1')
     path_t2 = os.path.join(self.tmpdir, 't2')
-    self.fs.mkdirs(path_t1)
-
-    path1 = os.path.join(path_t1, 'f1')
-    path2 = os.path.join(path_t2, 'f1')
-    with open(path1, 'a') as f:
-      f.write('Hello')
-
-    self.fs.rename([path_t1], [path_t2])
-    self.assertTrue(self.fs.exists(path_t2))
-    self.assertFalse(self.fs.exists(path_t1))
-    self.assertTrue(self.fs.exists(path2))
-    self.assertFalse(self.fs.exists(path1))
-
-  def test_rename_mkdirs(self):
-    path_t1 = os.path.join(self.tmpdir, 't1')
-    path_t2 = os.path.join(self.tmpdir, 't2/t3/t4')
     self.fs.mkdirs(path_t1)
 
     path1 = os.path.join(path_t1, 'f1')


### PR DESCRIPTION
This reverts commit d903dcfc7ff7300355688b08b779da880f15fe9d (PR #5903) because it causes release 2.7.0 RC2 validation to fail (the code does not deal well with relative paths).

**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




