### PR TITLE
[BEAM-4496] Fix #2 for branch fetch failure on job_PostCommit_Website_Publish

### DIFF
--- a/website/build.gradle
+++ b/website/build.gradle
@@ -28,6 +28,7 @@ def buildDir = "${project.rootDir}/build/website"
 def buildContentDir = "${project.rootDir}/build/website/generated-content"
 def repoContentDir = "${project.rootDir}/website/generated-content"
 def commitedChanges = false
+def gitboxUrl = "https://gitbox.apache.org/repos/asf/beam.git"
 
 def shell = { cmd ->
   println cmd
@@ -125,7 +126,7 @@ task commitWebsite << {
   // get the latest commit on master
   def latestCommit = grgit.log(maxCommits: 1)[0].abbreviatedId
 
-  shell "git fetch origin asf-site"
+  shell "git fetch ${gitboxUrl} asf-site"
   git.checkout(branch: 'asf-site')
   shell "git reset --hard origin/asf-site"
 
@@ -178,7 +179,7 @@ task publishWebsite << {
   }
 
   // Because git.push() fails to authenticate, run git push directly.
-  shell "git push https://gitbox.apache.org/repos/asf/beam.git asf-site"
+  shell "git push ${gitboxUrl} asf-site"
 }
 
 commitWebsite.dependsOn testWebsite

--- a/website/src/get-started/downloads.md
+++ b/website/src/get-started/downloads.md
@@ -80,9 +80,9 @@ versions denoted `0.x.y`.
 ## Releases
 
 ### 2.6.0 (2018-08-08)
-Official [source code download](https://dist.apache.org/repos/dist/release/beam/2.6.0/apache-beam-2.6.0-source-release.zip)
-[SHA-512](https://dist.apache.org/repos/dist/release/beam/2.6.0/apache-beam-2.6.0-source-release.zip.sha512)
-[signature](https://dist.apache.org/repos/dist/release/beam/2.6.0/apache-beam-2.6.0-source-release.zip.asc).
+Official [source code download](https://archive.apache.org/dist/beam/2.6.0/apache-beam-2.6.0-source-release.zip)
+[SHA-512](https://archive.apache.org/dist/beam/2.6.0/apache-beam-2.6.0-source-release.zip.sha512)
+[signature](https://archive.apache.org/dist/beam/2.6.0/apache-beam-2.6.0-source-release.zip.asc).
 
 [Release notes](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12319527&version=12343392).
 


### PR DESCRIPTION
Failures in job_PostCommit_Website_Publish  still, 

Like https://builds.apache.org/job/beam_PostCommit_Website_Publish/42
05:01:04 FAILURE: Build failed with an exception.
05:01:04 
05:01:04 * Where:
05:01:04 Build file '/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Website_Publish/src/website/build.gradle' line: 129
05:01:04 
05:01:04 * What went wrong:
05:01:04 Execution failed for task ':beam-website:commitWebsite'.
05:01:04 > org.eclipse.jgit.api.errors.RefNotFoundException: Ref asf-site cannot be resolved
05:01:04 

And (to test this) fix up failures because 2.6.0 is in archives.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




