### PR TITLE
[BEAM-4496] Fix #3 for branch fetch failure on job_PostCommit_Website_Publish

### DIFF
--- a/website/build.gradle
+++ b/website/build.gradle
@@ -126,7 +126,7 @@ task commitWebsite << {
   // get the latest commit on master
   def latestCommit = grgit.log(maxCommits: 1)[0].abbreviatedId
 
-  shell "git fetch ${gitboxUrl} asf-site"
+  shell "git fetch ${gitboxUrl}"
   git.checkout(branch: 'asf-site')
   shell "git reset --hard origin/asf-site"
 


### PR DESCRIPTION
Still failing:
https://builds.apache.org/job/beam_PostCommit_Website_Publish/57/
05:01:02 git fetch https://gitbox.apache.org/repos/asf/beam.git asf-site
05:01:02 Starting process 'command 'sh''. Working directory: /home/jenkins/jenkins-slave/workspace/beam_PostCommit_Website_Publish/src/website Command: sh -c git fetch https://gitbox.apache.org/repos/asf/beam.git asf-site
05:01:02 Successfully started process 'command 'sh''
05:01:02 From https://gitbox.apache.org/repos/asf/beam
05:01:02  * branch            asf-site   -> FETCH_HEAD
05:01:02 :beam-website:commitWebsite (Thread[Task worker for ':' Thread 11,5,main]) completed. Took 1.494 secs.
05:01:02 
05:01:02 FAILURE: Build failed with an exception.
05:01:02 
05:01:02 * Where:
05:01:02 Build file '/home/jenkins/jenkins-slave/workspace/beam_PostCommit_Website_Publish/src/website/build.gradle' line: 130
05:01:02 
05:01:02 * What went wrong:
05:01:02 Execution failed for task ':beam-website:commitWebsite'.
05:01:02 > org.eclipse.jgit.api.errors.RefNotFoundException: Ref asf-site cannot be resolved
05:01:02 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




