### PR TITLE
[BEAM-5613] Snapshot of Python depedency and add it to nightly snapshot job

### DIFF
--- a/.test-infra/jenkins/job_Release_Python_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_Release_Python_NightlySnapshot.groovy
@@ -41,11 +41,19 @@ job('beam_Release_Python_NightlySnapshot') {
             'Run Python Publish')
 
     steps {
+      // Cleanup Python directory.
       gradle {
         rootBuildScriptDir(commonJobProperties.checkoutDir)
-        tasks(':beam-sdks-python:sdist')
+        tasks(':beam-sdks-python:clean')
         commonJobProperties.setGradleSwitches(delegate)
       }
+      // Build snapshot.
+      gradle {
+        rootBuildScriptDir(commonJobProperties.checkoutDir)
+        tasks(':beam-sdks-python:buildSnapshot')
+        commonJobProperties.setGradleSwitches(delegate)
+      }
+      // Publish snapshot to a public accessible GCS directory.
       shell('cd ' + commonJobProperties.checkoutDir +
         ' && bash sdks/python/scripts/run_snapshot_publish.sh')
     }

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -84,6 +84,18 @@ task buildPython(dependsOn: 'setupVirtualenv') {
 }
 build.dependsOn buildPython
 
+// Snapshot of dependency requirements defined in setup.py.
+// Results will be stored in files under Gradle build directory.
+task depSnapshot(dependsOn: 'installGcpTest') {
+  doLast {
+    println 'Snapshoting full dependencies requirements with versions info to requirements.txt.'
+    exec {
+      executable 'sh'
+      args '-c', ". ${envdir}/bin/activate && pip freeze --local > ${project.buildDir}/requirements.txt"
+    }
+  }
+}
+
 task lint {}
 check.dependsOn lint
 
@@ -360,4 +372,9 @@ task dependencyUpdates(dependsOn: ':dependencyUpdates') {
       args '-c', "./scripts/run_dependency_check.sh"
     }
   }
+}
+
+task buildSnapshot() {
+  dependsOn 'sdist'
+  dependsOn 'depSnapshot'
 }

--- a/sdks/python/scripts/run_snapshot_publish.sh
+++ b/sdks/python/scripts/run_snapshot_publish.sh
@@ -16,19 +16,27 @@
 #    limitations under the License.
 #
 
+BUCKET=gs://beam-python-nightly-snapshots
 
 VERSION=$(awk '/__version__/{print $3}' $WORKSPACE/src/sdks/python/apache_beam/version.py)
 VERSION=$(echo $VERSION | cut -c 2- | rev | cut -c 2- | rev)
 time=$(date +"%Y-%m-%dT%H:%M:%S")
 SNAPSHOT="apache-beam-$VERSION-$time.zip"
-BUCKET=gs://beam-python-nightly-snapshots
 
+DEP_SNAPSHOT_ROOT="$BUCKET/dependency_requirements_snapshot"
+DEP_SNAPSHOT_FILE_NAME="beam-py-requirements-$time.txt"
+
+# Snapshots are built by Gradle task :beam-sdks-python:depSnapchot
+# and located under Gradle build directory.
 cd $WORKSPACE/src/sdks/python/build
 
-# rename the file to be apache-beam-{VERSION}-{datetime}.zip
+# Rename the file to be apache-beam-{VERSION}-{datetime}.zip
 for file in "apache-beam-$VERSION*.zip"; do
   mv $file $SNAPSHOT
 done
 
-# upload to gcs bucket
+# Upload to gcs bucket
 gsutil cp $SNAPSHOT $BUCKET/$VERSION/
+
+# Upload requirements.txt to gcs.
+gsutil cp requirements.txt $DEP_SNAPSHOT_ROOT/$DEP_SNAPSHOT_FILE_NAME


### PR DESCRIPTION
This changes make a snapshot of Python dependency and publish to same GCS directory that nightly snapshot job use. It helps to track Python SDK dependencies change and build dependency checking tools based on those published data.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




