### PR TITLE
[BEAM-5112] Don't use BeamSqlInputRefExpression to pass Integer

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamAggregationTransforms.java
@@ -39,15 +39,12 @@ import org.apache.beam.sdk.coders.CustomCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.extensions.sql.impl.interpreter.BeamSqlExpressionEnvironments;
-import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.BeamSqlInputRefExpression;
 import org.apache.beam.sdk.extensions.sql.impl.interpreter.operator.UdafImpl;
 import org.apache.beam.sdk.extensions.sql.impl.transform.agg.CovarianceFn;
 import org.apache.beam.sdk.extensions.sql.impl.transform.agg.VarianceFn;
 import org.apache.beam.sdk.extensions.sql.impl.utils.BigDecimalConverter;
 import org.apache.beam.sdk.extensions.sql.impl.utils.CalciteUtils;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -153,22 +150,10 @@ public class BeamAggregationTransforms implements Serializable {
           int refIndexKey = call.getArgList().get(0);
           int refIndexValue = call.getArgList().get(1);
 
-          FieldType keyDescriptor = sourceSchema.getField(refIndexKey).getType();
-          BeamSqlInputRefExpression sourceExpKey =
-              new BeamSqlInputRefExpression(CalciteUtils.toSqlTypeName(keyDescriptor), refIndexKey);
-
-          FieldType valueDescriptor = sourceSchema.getField(refIndexValue).getType();
-          BeamSqlInputRefExpression sourceExpValue =
-              new BeamSqlInputRefExpression(
-                  CalciteUtils.toSqlTypeName(valueDescriptor), refIndexValue);
-
-          sourceFieldExps.add(KV.of(sourceExpKey, sourceExpValue));
+          sourceFieldExps.add(KV.of(refIndexKey, refIndexValue));
         } else {
-          int refIndex = call.getArgList().size() > 0 ? call.getArgList().get(0) : 0;
-          FieldType fieldType = sourceSchema.getField(refIndex).getType();
-          BeamSqlInputRefExpression sourceExp =
-              new BeamSqlInputRefExpression(CalciteUtils.toSqlTypeName(fieldType), refIndex);
-          sourceFieldExps.add(sourceExp);
+          Integer refIndex = call.getArgList().size() > 0 ? call.getArgList().get(0) : 0;
+          sourceFieldExps.add(refIndex);
         }
 
         Schema.Field field = CalciteUtils.toField(aggName, call.type);
@@ -243,10 +228,8 @@ public class BeamAggregationTransforms implements Serializable {
         CombineFn aggregator = aggregators.get(idx);
         Object element = accumulator.accumulatorElements.get(idx);
 
-        if (sourceFieldExps.get(idx) instanceof BeamSqlInputRefExpression) {
-          BeamSqlInputRefExpression exp = (BeamSqlInputRefExpression) sourceFieldExps.get(idx);
-          Object value =
-              exp.evaluate(input, null, BeamSqlExpressionEnvironments.empty()).getValue();
+        if (sourceFieldExps.get(idx) instanceof Integer) {
+          Object value = input.getValue((Integer) sourceFieldExps.get(idx));
 
           // every aggregator ignores null values, e.g., COUNT(NULL) is always zero
           if (value != null) {
@@ -260,16 +243,11 @@ public class BeamAggregationTransforms implements Serializable {
            * If source expression is type of KV pair, we bundle the value of two expressions into KV
            * pair and pass it to aggregator's addInput method.
            */
-          KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression> exp =
-              (KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression>) sourceFieldExps.get(idx);
+          KV<Integer, Integer> exp = (KV<Integer, Integer>) sourceFieldExps.get(idx);
 
-          Object key =
-              exp.getKey().evaluate(input, null, BeamSqlExpressionEnvironments.empty()).getValue();
+          Object key = input.getValue(exp.getKey());
 
-          Object value =
-              exp.getValue()
-                  .evaluate(input, null, BeamSqlExpressionEnvironments.empty())
-                  .getValue();
+          Object value = input.getValue(exp.getValue());
 
           // ignore aggregator if either key or value is null, e.g., COVAR_SAMP(x, NULL) is null
           if (key != null && value != null) {
@@ -313,20 +291,18 @@ public class BeamAggregationTransforms implements Serializable {
       registry.registerCoderForClass(BigDecimal.class, BigDecimalCoder.of());
       List<Coder> aggAccuCoderList = new ArrayList<>();
       for (int idx = 0; idx < aggregators.size(); ++idx) {
-        if (sourceFieldExps.get(idx) instanceof BeamSqlInputRefExpression) {
-          BeamSqlInputRefExpression exp = (BeamSqlInputRefExpression) sourceFieldExps.get(idx);
-          int srcFieldIndex = exp.getInputRef();
+        if (sourceFieldExps.get(idx) instanceof Integer) {
+          int srcFieldIndex = (Integer) sourceFieldExps.get(idx);
           Coder srcFieldCoder =
               RowCoder.coderForPrimitiveType(
                   sourceSchema.getField(srcFieldIndex).getType().getTypeName());
           aggAccuCoderList.add(aggregators.get(idx).getAccumulatorCoder(registry, srcFieldCoder));
         } else if (sourceFieldExps.get(idx) instanceof KV) {
           // extract coder of two expressions separately.
-          KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression> exp =
-              (KV<BeamSqlInputRefExpression, BeamSqlInputRefExpression>) sourceFieldExps.get(idx);
+          KV<Integer, Integer> exp = (KV<Integer, Integer>) sourceFieldExps.get(idx);
 
-          int srcFieldIndexKey = exp.getKey().getInputRef();
-          int srcFieldIndexValue = exp.getValue().getInputRef();
+          int srcFieldIndexKey = exp.getKey();
+          int srcFieldIndexValue = exp.getValue();
 
           Coder srcFieldCoderKey =
               RowCoder.coderForPrimitiveType(


### PR DESCRIPTION
Our Aggregation transform is using `BeamSqlExpressionEnvironments` as a fancy way to pass integers. Lets not do that. This cleanup is working towards deleting `BeamSqlExpressionEnvironments`. See #6417 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




