### PR TITLE
[BEAM-4553] Implement graphite sink for MetricsPusher and refactor MetricsHttpSink test

### DIFF
--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSink.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.extensions.metrics;
+
+import java.io.BufferedWriter;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricsSink;
+import org.apache.beam.sdk.options.PipelineOptions;
+
+/**
+ * Sink to push metrics to Graphite. Graphite requires a timestamp. So metrics are reported with the
+ * timestamp (seconds from epoch) when the push to the sink was done (except with gauges that
+ * already have a timestamp value). The graphite metric name will be in the form of
+ * beam.metricType.metricNamespace.metricName.[committed|attempted].metricValueType For example:
+ * {@code beam.counter.throughput.nbRecords.attempted.value} Or
+ * {@code beam.distribution.throughput.nbRecordsPerSec.attempted.mean}
+ */
+public class MetricsGraphiteSink implements MetricsSink {
+  private final String address;
+  private final int port;
+  private final Charset charset;
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+  private static final String SPACE_REPLACEMENT = "_";
+
+  public MetricsGraphiteSink(PipelineOptions pipelineOptions) {
+    this.address = pipelineOptions.getMetricsGraphiteHost();
+    this.port = pipelineOptions.getMetricsGraphitePort();
+    this.charset = UTF_8;
+  }
+
+  @Experimental(Experimental.Kind.METRICS)
+  @Override
+  public void writeMetrics(MetricQueryResults metricQueryResults) throws Exception {
+    final long metricTimestamp = System.currentTimeMillis() / 1000L;
+    Socket socket = new Socket(InetAddress.getByName(address), port);
+    BufferedWriter writer =
+        new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
+    StringBuilder messagePayload = new StringBuilder();
+    Iterable<MetricResult<Long>> counters = metricQueryResults.getCounters();
+    Iterable<MetricResult<GaugeResult>> gauges = metricQueryResults.getGauges();
+    Iterable<MetricResult<DistributionResult>> distributions =
+        metricQueryResults.getDistributions();
+
+    for (MetricResult<Long> counter : counters) {
+      messagePayload.append(createCounterGraphiteMessage(metricTimestamp, counter, true));
+      messagePayload.append(createCounterGraphiteMessage(metricTimestamp, counter, false));
+    }
+
+    for (MetricResult<GaugeResult> gauge : gauges) {
+      messagePayload.append(createGaugeGraphiteMessage(gauge, true));
+      messagePayload.append(createGaugeGraphiteMessage(gauge, false));
+    }
+
+    for (MetricResult<DistributionResult> distribution : distributions) {
+      messagePayload.append(createDistributionGraphiteMessage(metricTimestamp, distribution, true));
+      messagePayload.append(
+          createDistributionGraphiteMessage(metricTimestamp, distribution, false));
+    }
+    writer.write(messagePayload.toString());
+    writer.flush();
+    writer.close();
+    socket.close();
+  }
+
+  private String createCounterGraphiteMessage(
+      long metricTimestamp, MetricResult<Long> counter, boolean committedValue) {
+    String metricMessage;
+    if (committedValue) {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  counter, "counter", "value", CommittedOrAttemped.COMMITTED),
+              counter.getCommitted(),
+              metricTimestamp);
+    } else {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(counter, "counter", "value", CommittedOrAttemped.ATTEMPED),
+              counter.getAttempted(),
+              metricTimestamp);
+    }
+    return metricMessage;
+  }
+
+  private String createGaugeGraphiteMessage(
+      MetricResult<GaugeResult> gauge, boolean committedValue) {
+    String metricMessage;
+    if (committedValue) {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(gauge, "gauge", "value", CommittedOrAttemped.COMMITTED),
+              gauge.getCommitted().getValue(),
+              gauge.getCommitted().getTimestamp().getMillis() / 1000L);
+    } else {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(gauge, "gauge", "value", CommittedOrAttemped.ATTEMPED),
+              gauge.getAttempted().getValue(),
+              gauge.getAttempted().getTimestamp().getMillis() / 1000L);
+    }
+    return metricMessage;
+  }
+
+  private String createDistributionGraphiteMessage(
+      long metricTimestamp, MetricResult<DistributionResult> distribution, boolean committedValue) {
+    StringBuilder messagePayload = new StringBuilder();
+    String metricMessage;
+    if (committedValue) {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "min", CommittedOrAttemped.COMMITTED),
+              distribution.getCommitted().getMin(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "max", CommittedOrAttemped.COMMITTED),
+              distribution.getCommitted().getMax(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "count", CommittedOrAttemped.COMMITTED),
+              distribution.getCommitted().getCount(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "sum", CommittedOrAttemped.COMMITTED),
+              distribution.getCommitted().getSum(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "mean", CommittedOrAttemped.COMMITTED),
+              distribution.getCommitted().getMean(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+    } else {
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "min", CommittedOrAttemped.ATTEMPED),
+              distribution.getAttempted().getMin(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "max", CommittedOrAttemped.ATTEMPED),
+              distribution.getAttempted().getMax(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "count", CommittedOrAttemped.ATTEMPED),
+              distribution.getAttempted().getCount(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "sum", CommittedOrAttemped.ATTEMPED),
+              distribution.getAttempted().getSum(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+      metricMessage =
+          String.format(
+              Locale.US,
+              "%s %s %s\n",
+              createNormalizedMetricName(
+                  distribution, "distribution", "mean", CommittedOrAttemped.ATTEMPED),
+              distribution.getAttempted().getMean(),
+              metricTimestamp);
+      messagePayload.append(metricMessage);
+    }
+    return messagePayload.toString();
+  }
+
+  private <T> String createNormalizedMetricName(
+      MetricResult<T> metric,
+      String metricType,
+      String valueType,
+      CommittedOrAttemped committedOrAttemped) {
+    String metricName =
+        String.format(
+            "beam.%s.%s.%s.%s.%s",
+            metricType,
+            metric.getName().getNamespace(),
+            metric.getName().getName(),
+            committedOrAttemped,
+            valueType);
+
+    return WHITESPACE.matcher(metricName).replaceAll(SPACE_REPLACEMENT);
+  }
+
+  private enum CommittedOrAttemped {
+    COMMITTED("committed"),
+    ATTEMPED("attempted");
+
+    private final String committedOrAttempted;
+
+    CommittedOrAttemped(String committedOrAttempted) {
+      this.committedOrAttempted = committedOrAttempted;
+    }
+
+    @Override
+    public String toString() {
+      return committedOrAttempted;
+    }
+  }
+}

--- a/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
+++ b/runners/extensions-java/metrics/src/main/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSink.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.DataOutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -69,8 +68,7 @@ public class MetricsHttpSink implements MetricsSink {
     }
   }
 
-  @VisibleForTesting
-  String serializeMetrics(MetricQueryResults metricQueryResults) throws Exception {
+  private String serializeMetrics(MetricQueryResults metricQueryResults) throws Exception {
     objectMapper.registerModule(new JodaModule());
     objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
     objectMapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/CustomMetricQueryResults.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/CustomMetricQueryResults.java
@@ -1,0 +1,123 @@
+package org.apache.beam.runners.extensions.metrics;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricsSink;
+import org.joda.time.Instant;
+
+/** Test class to be used as a input to {@link MetricsSink} implementations tests. */
+class CustomMetricQueryResults implements MetricQueryResults {
+
+  private final boolean isCommittedSupported;
+
+  CustomMetricQueryResults(boolean isCommittedSupported) {
+    this.isCommittedSupported = isCommittedSupported;
+  }
+
+  @Override
+  public List<MetricResult<Long>> getCounters() {
+    return Collections.singletonList(
+        new MetricResult<Long>() {
+
+          @Override
+          public MetricName getName() {
+            return MetricName.named("ns1", "n1");
+          }
+
+          @Override
+          public String getStep() {
+            return "s1";
+          }
+
+          @Override
+          public Long getCommitted() {
+            if (!isCommittedSupported) {
+              // This is what getCommitted code is like for AccumulatedMetricResult on runners
+              // that do not support committed metrics
+              throw new UnsupportedOperationException(
+                  "This runner does not currently support committed"
+                      + " metrics results. Please use 'attempted' instead.");
+            }
+            return 10L;
+          }
+
+          @Override
+          public Long getAttempted() {
+            return 20L;
+          }
+        });
+  }
+
+  @Override
+  public List<MetricResult<DistributionResult>> getDistributions() {
+    return Collections.singletonList(
+        new MetricResult<DistributionResult>() {
+
+          @Override
+          public MetricName getName() {
+            return MetricName.named("ns1", "n2");
+          }
+
+          @Override
+          public String getStep() {
+            return "s2";
+          }
+
+          @Override
+          public DistributionResult getCommitted() {
+            if (!isCommittedSupported) {
+              // This is what getCommitted code is like for AccumulatedMetricResult on runners
+              // that do not support committed metrics
+              throw new UnsupportedOperationException(
+                  "This runner does not currently support committed"
+                      + " metrics results. Please use 'attempted' instead.");
+            }
+            return DistributionResult.create(10L, 2L, 5L, 8L);
+          }
+
+          @Override
+          public DistributionResult getAttempted() {
+            return DistributionResult.create(25L, 4L, 3L, 9L);
+          }
+        });
+  }
+
+  @Override
+  public List<MetricResult<GaugeResult>> getGauges() {
+    return Collections.singletonList(
+        new MetricResult<GaugeResult>() {
+
+          @Override
+          public MetricName getName() {
+            return MetricName.named("ns1", "n3");
+          }
+
+          @Override
+          public String getStep() {
+            return "s3";
+          }
+
+          @Override
+          public GaugeResult getCommitted() {
+            if (!isCommittedSupported) {
+              // This is what getCommitted code is like for AccumulatedMetricResult on runners
+              // that do not support committed metrics
+              throw new UnsupportedOperationException(
+                  "This runner does not currently support committed"
+                      + " metrics results. Please use 'attempted' instead.");
+            }
+            return GaugeResult.create(100L, new Instant(345862800L));
+          }
+
+          @Override
+          public GaugeResult getAttempted() {
+            return GaugeResult.create(120L, new Instant(345862800L));
+          }
+        });
+  }
+}

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
@@ -48,7 +48,7 @@ public class MetricsGraphiteSinkTest {
   }
 
   @Before
-  public void before(){
+  public void before() {
     graphiteServer.clear();
   }
 
@@ -58,8 +58,7 @@ public class MetricsGraphiteSinkTest {
   }
 
   @Test
-  public void testWriteMetrics() throws Exception {
-    //TODO deal with unsupported committed metrics
+  public void testWriteMetricsWithCommittedSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(true);
     PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
     pipelineOptions.setMetricsGraphitePort(port);
@@ -78,6 +77,27 @@ public class MetricsGraphiteSinkTest {
             + "beam.distribution.ns1.n2.committed.count 2 [0-9]+\\n"
             + "beam.distribution.ns1.n2.committed.sum 10 [0-9]+\\n"
             + "beam.distribution.ns1.n2.committed.mean 5.0 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.min 3 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.max 9 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.count 4 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.sum 25 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.mean 6.25 [0-9]+";
+    assertTrue(join.matches(regexpr));
+  }
+
+  @Test
+  public void testWriteMetricsWithCommittedUnSupported() throws Exception {
+    MetricQueryResults metricQueryResults = new CustomMetricQueryResults(false);
+    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    pipelineOptions.setMetricsGraphitePort(port);
+    pipelineOptions.setMetricsGraphiteHost("127.0.0.1");
+    MetricsGraphiteSink metricsGraphiteSink = new MetricsGraphiteSink(pipelineOptions);
+    metricsGraphiteSink.writeMetrics(metricQueryResults);
+    Thread.sleep(2000L);
+    String join = String.join("\n", graphiteServer.getMessages());
+    String regexpr =
+        "beam.counter.ns1.n1.attempted.value 20 [0-9]+\\n"
+            + "beam.gauge.ns1.n3.attempted.value 120 [0-9]+\\n"
             + "beam.distribution.ns1.n2.attempted.min 3 [0-9]+\\n"
             + "beam.distribution.ns1.n2.attempted.max 9 [0-9]+\\n"
             + "beam.distribution.ns1.n2.attempted.count 4 [0-9]+\\n"

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsGraphiteSinkTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.extensions.metrics;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Test class for MetricsGraphiteSink. */
+public class MetricsGraphiteSinkTest {
+  private static NetworkMockServer graphiteServer;
+  private static int port;
+
+  @BeforeClass
+  public static void beforeClass() throws IOException, InterruptedException {
+    // get free local port
+    ServerSocket serverSocket = new ServerSocket(0);
+    port = serverSocket.getLocalPort();
+    serverSocket.close();
+    graphiteServer = new NetworkMockServer(port);
+    Thread.sleep(200);
+    graphiteServer.clear();
+    graphiteServer.start();
+  }
+
+  @Before
+  public void before(){
+    graphiteServer.clear();
+  }
+
+  @AfterClass
+  public static void afterClass() throws IOException {
+    graphiteServer.stop();
+  }
+
+  @Test
+  public void testWriteMetrics() throws Exception {
+    //TODO deal with unsupported committed metrics
+    MetricQueryResults metricQueryResults = new CustomMetricQueryResults(true);
+    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    pipelineOptions.setMetricsGraphitePort(port);
+    pipelineOptions.setMetricsGraphiteHost("127.0.0.1");
+    MetricsGraphiteSink metricsGraphiteSink = new MetricsGraphiteSink(pipelineOptions);
+    metricsGraphiteSink.writeMetrics(metricQueryResults);
+    Thread.sleep(2000L);
+    String join = String.join("\n", graphiteServer.getMessages());
+    String regexpr =
+        "beam.counter.ns1.n1.committed.value 10 [0-9]+\\n"
+            + "beam.counter.ns1.n1.attempted.value 20 [0-9]+\\n"
+            + "beam.gauge.ns1.n3.committed.value 100 [0-9]+\\n"
+            + "beam.gauge.ns1.n3.attempted.value 120 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.committed.min 5 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.committed.max 8 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.committed.count 2 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.committed.sum 10 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.committed.mean 5.0 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.min 3 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.max 9 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.count 4 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.sum 25 [0-9]+\\n"
+            + "beam.distribution.ns1.n2.attempted.mean 6.25 [0-9]+";
+    assertTrue(join.matches(regexpr));
+  }
+}

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
@@ -46,8 +46,8 @@ public class MetricsHttpSinkTest {
             + "{\"count\":4,\"max\":9,\"mean\":6.25,\"min\":3,\"sum\":25},\"committed\":"
             + "{\"count\":2,\"max\":8,\"mean\":5.0,\"min\":5,\"sum\":10},\"name\":{\"name\":\"n2\","
             + "\"namespace\":\"ns1\"},\"step\":\"s2\"}],\"gauges\":[{\"attempted\":{\"timestamp\":"
-            + "\"1970-01-01T00:00:00.000Z\",\"value\":120},\"committed\":{\"timestamp\":"
-            + "\"1970-01-01T00:00:00.000Z\",\"value\":100},\"name\":{\"name\":\"n3\",\"namespace\":"
+            + "\"1970-01-05T00:04:22.800Z\",\"value\":120},\"committed\":{\"timestamp\":"
+            + "\"1970-01-05T00:04:22.800Z\",\"value\":100},\"name\":{\"name\":\"n3\",\"namespace\":"
             + "\"ns1\"},\"step\":\"s3\"}]}",
         serializeMetrics);
   }
@@ -63,119 +63,8 @@ public class MetricsHttpSinkTest {
             + "\"namespace\":\"ns1\"},\"step\":\"s1\"}],\"distributions\":[{\"attempted\":"
             + "{\"count\":4,\"max\":9,\"mean\":6.25,\"min\":3,\"sum\":25},\"name\":{\"name\":\"n2\""
             + ",\"namespace\":\"ns1\"},\"step\":\"s2\"}],\"gauges\":[{\"attempted\":{\"timestamp\":"
-            + "\"1970-01-01T00:00:00.000Z\",\"value\":120},\"name\":{\"name\":\"n3\",\"namespace\":"
+            + "\"1970-01-05T00:04:22.800Z\",\"value\":120},\"name\":{\"name\":\"n3\",\"namespace\":"
             + "\"ns1\"},\"step\":\"s3\"}]}",
         serializeMetrics);
-  }
-
-  private static class CustomMetricQueryResults implements MetricQueryResults {
-
-    private final boolean isCommittedSupported;
-
-    private CustomMetricQueryResults(boolean isCommittedSupported) {
-      this.isCommittedSupported = isCommittedSupported;
-    }
-
-    @Override
-    public List<MetricResult<Long>> getCounters() {
-      return Collections.singletonList(
-          new MetricResult<Long>() {
-
-            @Override
-            public MetricName getName() {
-              return MetricName.named("ns1", "n1");
-            }
-
-            @Override
-            public String getStep() {
-              return "s1";
-            }
-
-            @Override
-            public Long getCommitted() {
-              if (!isCommittedSupported) {
-                // This is what getCommitted code is like for AccumulatedMetricResult on runners
-                // that do not support committed metrics
-                throw new UnsupportedOperationException(
-                    "This runner does not currently support committed"
-                        + " metrics results. Please use 'attempted' instead.");
-              }
-              return 10L;
-            }
-
-            @Override
-            public Long getAttempted() {
-              return 20L;
-            }
-          });
-    }
-
-    @Override
-    public List<MetricResult<DistributionResult>> getDistributions() {
-      return Collections.singletonList(
-          new MetricResult<DistributionResult>() {
-
-            @Override
-            public MetricName getName() {
-              return MetricName.named("ns1", "n2");
-            }
-
-            @Override
-            public String getStep() {
-              return "s2";
-            }
-
-            @Override
-            public DistributionResult getCommitted() {
-              if (!isCommittedSupported) {
-                // This is what getCommitted code is like for AccumulatedMetricResult on runners
-                // that do not support committed metrics
-                throw new UnsupportedOperationException(
-                    "This runner does not currently support committed"
-                        + " metrics results. Please use 'attempted' instead.");
-              }
-              return DistributionResult.create(10L, 2L, 5L, 8L);
-            }
-
-            @Override
-            public DistributionResult getAttempted() {
-              return DistributionResult.create(25L, 4L, 3L, 9L);
-            }
-          });
-    }
-
-    @Override
-    public List<MetricResult<GaugeResult>> getGauges() {
-      return Collections.singletonList(
-          new MetricResult<GaugeResult>() {
-
-            @Override
-            public MetricName getName() {
-              return MetricName.named("ns1", "n3");
-            }
-
-            @Override
-            public String getStep() {
-              return "s3";
-            }
-
-            @Override
-            public GaugeResult getCommitted() {
-              if (!isCommittedSupported) {
-                // This is what getCommitted code is like for AccumulatedMetricResult on runners
-                // that do not support committed metrics
-                throw new UnsupportedOperationException(
-                    "This runner does not currently support committed"
-                        + " metrics results. Please use 'attempted' instead.");
-              }
-              return GaugeResult.create(100L, new Instant(0L));
-            }
-
-            @Override
-            public GaugeResult getAttempted() {
-              return GaugeResult.create(120L, new Instant(0L));
-            }
-          });
-    }
   }
 }

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/MetricsHttpSinkTest.java
@@ -20,27 +20,70 @@ package org.apache.beam.runners.extensions.metrics;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.Collections;
+import com.sun.net.httpserver.HttpServer;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
-import org.apache.beam.sdk.metrics.DistributionResult;
-import org.apache.beam.sdk.metrics.GaugeResult;
-import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricQueryResults;
-import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.joda.time.Instant;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /** Test class for MetricsHttpSink. */
 public class MetricsHttpSinkTest {
+  private static int port;
+  private static List<String> messages = new ArrayList<>();
+  private static HttpServer httpServer;
+
+  @BeforeClass
+  public static void beforeClass() throws IOException {
+    // get free local port
+    ServerSocket serverSocket = new ServerSocket(0);
+    port = serverSocket.getLocalPort();
+    serverSocket.close();
+    httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+    httpServer
+        .createContext("/")
+        .setHandler(
+            httpExchange -> {
+              try (final BufferedReader in =
+                  new BufferedReader(
+                      new InputStreamReader(
+                          httpExchange.getRequestBody(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = in.readLine()) != null) {
+                  messages.add(line);
+                }
+              }
+              httpExchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, 0L);
+              httpExchange.close();
+            });
+    httpServer.start();
+  }
+
+  @Before
+  public void before() {
+    messages.clear();
+  }
 
   @Test
-  public void testSerializerWithCommittedSupported() throws Exception {
+  public void testWriteMetricsWithCommittedSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(true);
-    MetricsHttpSink metricsHttpSink = new MetricsHttpSink(PipelineOptionsFactory.create());
-    String serializeMetrics = metricsHttpSink.serializeMetrics(metricQueryResults);
-    assertEquals(
-        "Error in serialization",
+    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    pipelineOptions.setMetricsHttpSinkUrl(String.format("http://localhost:%s", port));
+    MetricsHttpSink metricsHttpSink = new MetricsHttpSink(pipelineOptions);
+    metricsHttpSink.writeMetrics(metricQueryResults);
+    Thread.sleep(2000L);
+    String expected =
         "{\"counters\":[{\"attempted\":20,\"committed\":10,\"name\":{\"name\":\"n1\","
             + "\"namespace\":\"ns1\"},\"step\":\"s1\"}],\"distributions\":[{\"attempted\":"
             + "{\"count\":4,\"max\":9,\"mean\":6.25,\"min\":3,\"sum\":25},\"committed\":"
@@ -48,23 +91,32 @@ public class MetricsHttpSinkTest {
             + "\"namespace\":\"ns1\"},\"step\":\"s2\"}],\"gauges\":[{\"attempted\":{\"timestamp\":"
             + "\"1970-01-05T00:04:22.800Z\",\"value\":120},\"committed\":{\"timestamp\":"
             + "\"1970-01-05T00:04:22.800Z\",\"value\":100},\"name\":{\"name\":\"n3\",\"namespace\":"
-            + "\"ns1\"},\"step\":\"s3\"}]}",
-        serializeMetrics);
+            + "\"ns1\"},\"step\":\"s3\"}]}";
+    assertEquals("Wrong number of messages sent to HTTP server", 1, messages.size());
+    assertEquals("Wrong messages sent to HTTP server", expected, messages.get(0));
   }
 
   @Test
-  public void testSerializerWithCommittedUnSupported() throws Exception {
+  public void testWriteMetricsWithCommittedUnSupported() throws Exception {
     MetricQueryResults metricQueryResults = new CustomMetricQueryResults(false);
-    MetricsHttpSink metricsHttpSink = new MetricsHttpSink(PipelineOptionsFactory.create());
-    String serializeMetrics = metricsHttpSink.serializeMetrics(metricQueryResults);
-    assertEquals(
-        "Error in serialization",
+    PipelineOptions pipelineOptions = PipelineOptionsFactory.create();
+    pipelineOptions.setMetricsHttpSinkUrl(String.format("http://localhost:%s", port));
+    MetricsHttpSink metricsHttpSink = new MetricsHttpSink(pipelineOptions);
+    metricsHttpSink.writeMetrics(metricQueryResults);
+    Thread.sleep(2000L);
+    String expected =
         "{\"counters\":[{\"attempted\":20,\"name\":{\"name\":\"n1\","
             + "\"namespace\":\"ns1\"},\"step\":\"s1\"}],\"distributions\":[{\"attempted\":"
             + "{\"count\":4,\"max\":9,\"mean\":6.25,\"min\":3,\"sum\":25},\"name\":{\"name\":\"n2\""
             + ",\"namespace\":\"ns1\"},\"step\":\"s2\"}],\"gauges\":[{\"attempted\":{\"timestamp\":"
             + "\"1970-01-05T00:04:22.800Z\",\"value\":120},\"name\":{\"name\":\"n3\",\"namespace\":"
-            + "\"ns1\"},\"step\":\"s3\"}]}",
-        serializeMetrics);
+            + "\"ns1\"},\"step\":\"s3\"}]}";
+    assertEquals("Wrong number of messages sent to HTTP server", 1, messages.size());
+    assertEquals("Wrong messages sent to HTTP server", expected, messages.get(0));
+  }
+
+  @AfterClass
+  public static void after() {
+    httpServer.stop(0);
   }
 }

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/NetworkMockServer.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/NetworkMockServer.java
@@ -30,9 +30,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /** Mock of a network server. */
 class NetworkMockServer {
   private final int port;
-
-  private ServerSocket server;
-  private GraphiteThread thread;
+  private ServerSocket serverSocket;
+  private ServerThread thread;
 
   private Collection<String> messages = new CopyOnWriteArrayList<String>();
 
@@ -45,15 +44,15 @@ class NetworkMockServer {
   }
 
   public NetworkMockServer start() throws IOException {
-    server = new ServerSocket(port);
-    thread = new GraphiteThread(server, messages);
+    serverSocket = new ServerSocket(port);
+    thread = new ServerThread(serverSocket, messages);
     thread.start();
     return this;
   }
 
   public void stop() throws IOException {
     thread.shutdown();
-    server.close();
+    serverSocket.close();
   }
 
   public Collection<String> getMessages() {
@@ -64,13 +63,13 @@ class NetworkMockServer {
     messages.clear();
   }
 
-  private static class GraphiteThread extends Thread {
+  private static class ServerThread extends Thread {
     private final Collection<String> messages;
 
     private final AtomicBoolean done = new AtomicBoolean(false);
     private final ServerSocket server;
 
-    public GraphiteThread(final ServerSocket server, final Collection<String> messages) {
+    public ServerThread(final ServerSocket server, final Collection<String> messages) {
       this.messages = messages;
       this.server = server;
       setName("network-mock-server");

--- a/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/NetworkMockServer.java
+++ b/runners/extensions-java/metrics/src/test/java/org/apache/beam/runners/extensions/metrics/NetworkMockServer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.extensions.metrics;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Mock of a network server. */
+class NetworkMockServer {
+  private final int port;
+
+  private ServerSocket server;
+  private GraphiteThread thread;
+
+  private Collection<String> messages = new CopyOnWriteArrayList<String>();
+
+  public NetworkMockServer(final int port) {
+    this.port = port;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public NetworkMockServer start() throws IOException {
+    server = new ServerSocket(port);
+    thread = new GraphiteThread(server, messages);
+    thread.start();
+    return this;
+  }
+
+  public void stop() throws IOException {
+    thread.shutdown();
+    server.close();
+  }
+
+  public Collection<String> getMessages() {
+    return messages;
+  }
+
+  public void clear() {
+    messages.clear();
+  }
+
+  private static class GraphiteThread extends Thread {
+    private final Collection<String> messages;
+
+    private final AtomicBoolean done = new AtomicBoolean(false);
+    private final ServerSocket server;
+
+    public GraphiteThread(final ServerSocket server, final Collection<String> messages) {
+      this.messages = messages;
+      this.server = server;
+      setName("network-mock-server");
+    }
+
+    @Override
+    public void run() {
+      while (!done.get()) {
+        try {
+          final Socket s = server.accept();
+          synchronized (this) {
+            final InputStream is = s.getInputStream();
+            final BufferedReader reader =
+                new BufferedReader(new InputStreamReader(is, Charset.forName("UTF-8")));
+            String line;
+
+            try {
+              while ((line = reader.readLine()) != null) {
+                messages.add(line);
+              }
+            } finally {
+              s.close();
+            }
+          }
+        } catch (final IOException e) {
+          if (!done.get()) {
+            throw new RuntimeException(e);
+          }
+        }
+      }
+    }
+
+    public void shutdown() {
+      done.set(true);
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -445,4 +445,15 @@ public interface PipelineOptions extends HasDisplayData {
   String getMetricsHttpSinkUrl();
 
   void setMetricsHttpSinkUrl(String metricsSink);
+
+  @Description("The graphite metrics host")
+  String getMetricsGraphiteHost();
+
+  void setMetricsGraphiteHost(String host);
+
+  @Description("The graphite metrics port")
+  @Default.Integer(2003)
+  Integer getMetricsGraphitePort();
+
+  void setMetricsGraphitePort(Integer port);
 }


### PR DESCRIPTION
This PR adds the Graphite sink to metrics pusher feature and also refactors MetricsHttpSink test.
I put changes in coherent separate isolable commits. They must not be squashed because they deal with different jira tickets.
R: @aromanenko-dev 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




