### PR TITLE
 [BEAM-5653] Allow initialize SdkComponents with existing Components list.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SdkComponents.java
@@ -26,6 +26,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -43,20 +44,32 @@ import org.apache.beam.sdk.values.WindowingStrategy;
 
 /** SDK objects that will be represented at some later point within a {@link Components} object. */
 public class SdkComponents {
-  private final RunnerApi.Components.Builder componentsBuilder;
+  private final RunnerApi.Components.Builder componentsBuilder = RunnerApi.Components.newBuilder();
 
-  private final BiMap<AppliedPTransform<?, ?, ?>, String> transformIds;
-  private final BiMap<PCollection<?>, String> pCollectionIds;
-  private final BiMap<WindowingStrategy<?, ?>, String> windowingStrategyIds;
+  private final BiMap<AppliedPTransform<?, ?, ?>, String> transformIds = HashBiMap.create();
+  private final BiMap<PCollection<?>, String> pCollectionIds = HashBiMap.create();
+  private final BiMap<WindowingStrategy<?, ?>, String> windowingStrategyIds = HashBiMap.create();
 
   /** A map of Coder to IDs. Coders are stored here with identity equivalence. */
-  private final BiMap<Equivalence.Wrapper<? extends Coder<?>>, String> coderIds;
+  private final BiMap<Equivalence.Wrapper<? extends Coder<?>>, String> coderIds =
+      HashBiMap.create();
 
-  private final BiMap<Environment, String> environmentIds;
+  private final BiMap<Environment, String> environmentIds = HashBiMap.create();
+
+  private final Set<String> reservedIds = new HashSet<>();
 
   /** Create a new {@link SdkComponents} with no components. */
   public static SdkComponents create() {
     return new SdkComponents();
+  }
+
+  /**
+   * Create new {@link SdkComponents} importing all items from provided {@link Components} object.
+   *
+   * <p>WARNING: This action might cause some of duplicate items created.
+   */
+  public static SdkComponents create(RunnerApi.Components components) {
+    return new SdkComponents(components);
   }
 
   public static SdkComponents create(PipelineOptions options) {
@@ -69,13 +82,20 @@ public class SdkComponents {
     return sdkComponents;
   }
 
-  private SdkComponents() {
-    this.componentsBuilder = RunnerApi.Components.newBuilder();
-    this.transformIds = HashBiMap.create();
-    this.pCollectionIds = HashBiMap.create();
-    this.windowingStrategyIds = HashBiMap.create();
-    this.coderIds = HashBiMap.create();
-    this.environmentIds = HashBiMap.create();
+  private SdkComponents() {}
+
+  private SdkComponents(RunnerApi.Components components) {
+    if (components == null) {
+      return;
+    }
+
+    reservedIds.addAll(components.getTransformsMap().keySet());
+    reservedIds.addAll(components.getPcollectionsMap().keySet());
+    reservedIds.addAll(components.getWindowingStrategiesMap().keySet());
+    reservedIds.addAll(components.getCodersMap().keySet());
+    reservedIds.addAll(components.getEnvironmentsMap().keySet());
+
+    componentsBuilder.mergeFrom(components);
   }
 
   /**
@@ -222,7 +242,7 @@ public class SdkComponents {
   private String uniqify(String baseName, Set<String> existing) {
     String name = baseName;
     int increment = 1;
-    while (existing.contains(name)) {
+    while (existing.contains(name) || reservedIds.contains(name)) {
       name = baseName + Integer.toString(increment);
       increment++;
     }


### PR DESCRIPTION
The idea of the fix is to initialize SdkComponents with initial pipeline Components and later extend it.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




