### PR TITLE
[BEAM-4524] Use sha256 instead of insecure md5 for artifact checksums.

### DIFF
--- a/model/job-management/src/main/proto/beam_artifact_api.proto
+++ b/model/job-management/src/main/proto/beam_artifact_api.proto
@@ -62,7 +62,11 @@ message ArtifactMetadata {
 
   // (Optional) The base64-encoded md5 checksum of the artifact. Used, among other things, by
   // harness boot code to validate the integrity of the artifact.
-  string md5 = 3;
+  string md5X = 3;
+
+  // (Optional) The hex-encoded sha256 checksum of the artifact. Used, among other things, by
+  // harness boot code to validate the integrity of the artifact.
+  string sha256 = 4;
 }
 
 // A collection of artifacts.
@@ -147,4 +151,3 @@ message CommitManifestResponse {
   // ArtifactRetrievalService.
   string retrieval_token = 1;
 }
-

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceStager.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceStager.java
@@ -19,7 +19,8 @@
 package org.apache.beam.runners.core.construction;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.io.BaseEncoding;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.File;
@@ -27,7 +28,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -170,19 +170,20 @@ public class ArtifactServiceStager {
               .build();
       requestObserver.onNext(PutArtifactRequest.newBuilder().setMetadata(putMetadata).build());
 
-      MessageDigest md5Digest = MessageDigest.getInstance("MD5");
+      Hasher hasher = Hashing.sha256().newHasher();
       FileChannel channel = new FileInputStream(file.getFile()).getChannel();
       ByteBuffer readBuffer = ByteBuffer.allocate(bufferSize);
       while (!responseObserver.isTerminal() && channel.position() < channel.size()) {
         readBuffer.clear();
         channel.read(readBuffer);
         readBuffer.flip();
-        md5Digest.update(readBuffer);
+        ByteString chunk = ByteString.copyFrom(readBuffer);
+        // TODO: Use Guava 23.0's putBytes(ByteBuffer).
+        hasher.putBytes(chunk.toByteArray());
         readBuffer.rewind();
         PutArtifactRequest request =
             PutArtifactRequest.newBuilder()
-                .setData(
-                    ArtifactChunk.newBuilder().setData(ByteString.copyFrom(readBuffer)).build())
+                .setData(ArtifactChunk.newBuilder().setData(chunk).build())
                 .build();
         requestObserver.onNext(request);
       }
@@ -192,7 +193,7 @@ public class ArtifactServiceStager {
       if (responseObserver.err.get() != null) {
         throw new RuntimeException(responseObserver.err.get());
       }
-      return metadata.toBuilder().setMd5(BaseEncoding.base64().encode(md5Digest.digest())).build();
+      return metadata.toBuilder().setSha256(hasher.hash().toString()).build();
     }
 
     private class PutArtifactResponseObserver implements StreamObserver<PutArtifactResponse> {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineResources.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.core.construction;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.fasterxml.jackson.core.Base64Variants;
 import com.google.common.base.Strings;
 import com.google.common.hash.Funnels;
 import com.google.common.hash.Hasher;
@@ -101,10 +100,10 @@ public class PipelineResources {
   }
 
   private static String calculateDirectoryContentHash(File directoryToStage) {
-    Hasher hasher = Hashing.md5().newHasher();
+    Hasher hasher = Hashing.sha256().newHasher();
     try (OutputStream hashStream = Funnels.asOutputStream(hasher)) {
       ZipFiles.zipDirectory(directoryToStage, hashStream);
-      return Base64Variants.MODIFIED_FOR_URL.encode(hasher.hash().asBytes());
+      return hasher.hash().toString();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ArtifactServiceStagerTest.java
@@ -20,19 +20,17 @@ package org.apache.beam.runners.core.construction;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.io.BaseEncoding;
+import com.google.common.hash.Hashing;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -83,7 +81,7 @@ public class ArtifactServiceStagerTest {
     String stagingSessionToken = "token";
     File file = temp.newFile();
     byte[] content = "foo-bar-baz".getBytes(StandardCharsets.UTF_8);
-    byte[] contentMd5 = MessageDigest.getInstance("MD5").digest(content);
+    String contentSha256 = Hashing.sha256().newHasher().putBytes(content).hash().toString();
     try (FileChannel contentChannel = new FileOutputStream(file).getChannel()) {
       contentChannel.write(ByteBuffer.wrap(content));
     }
@@ -96,8 +94,8 @@ public class ArtifactServiceStagerTest {
 
     ArtifactMetadata staged = service.getManifest().getArtifact(0);
     assertThat(staged.getName(), equalTo(file.getName()));
-    byte[] manifestMd5 = BaseEncoding.base64().decode(staged.getMd5());
-    assertArrayEquals(contentMd5, manifestMd5);
+    String manifestSha256 = staged.getSha256();
+    assertThat(contentSha256, equalTo(manifestSha256));
 
     assertThat(service.getManifest().getArtifactCount(), equalTo(1));
     assertThat(staged, equalTo(Iterables.getOnlyElement(service.getStagedArtifacts().keySet())));

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactRetrievalService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactRetrievalService.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -132,7 +131,7 @@ public class BeamFileSystemArtifactRetrievalService
       ResourceId artifactResourceId =
           FileSystems.matchNewResource(location.getUri(), false /* is directory */);
       LOG.debug("Artifact {} located in {}", name, artifactResourceId);
-      Hasher hasher = Hashing.md5().newHasher();
+      Hasher hasher = Hashing.sha256().newHasher();
       byte[] data = new byte[ARTIFACT_CHUNK_SIZE_BYTES];
       try (InputStream stream = Channels.newInputStream(FileSystems.open(artifactResourceId))) {
         int len;
@@ -144,15 +143,15 @@ public class BeamFileSystemArtifactRetrievalService
                   .build());
         }
       }
-      if (metadata.getMd5() != null && !metadata.getMd5().isEmpty()) {
-        ByteString expected = ByteString.copyFrom(Base64.getDecoder().decode(metadata.getMd5()));
-        ByteString actual = ByteString.copyFrom(hasher.hash().asBytes());
+      if (metadata.getSha256() != null && !metadata.getSha256().isEmpty()) {
+        String expected = metadata.getSha256();
+        String actual = hasher.hash().toString();
         if (!actual.equals(expected)) {
           throw new StatusRuntimeException(
               Status.DATA_LOSS.withDescription(
                   String.format(
-                      "Artifact %s is corrupt: expected md5 %s, actual %s",
-                      name, expected.toString(), actual.toString())));
+                      "Artifact %s is corrupt: expected sha256 %s, actual %s",
+                      name, expected, actual)));
         }
       }
       responseObserver.onCompleted();

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactServicesTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/artifact/BeamFileSystemArtifactServicesTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -242,7 +241,7 @@ public class BeamFileSystemArtifactServicesTest {
             .put("file10kb", 10 * DATA_1KB /*10 kb*/)
             .put("file100kb", 100 * DATA_1KB /*100 kb*/)
             .build();
-    Map<String, byte[]> md5 = Maps.newHashMap();
+    Map<String, String> hashes = Maps.newHashMap();
 
     final String text = "abcdefghinklmop\n";
     files.forEach(
@@ -255,7 +254,7 @@ public class BeamFileSystemArtifactServicesTest {
                         text, Double.valueOf(Math.ceil(size * 1.0 / text.length())).intValue())
                     .getBytes(StandardCharsets.UTF_8);
             Files.write(filePath, contents);
-            md5.put(fileName, Hashing.md5().hashBytes(contents).asBytes());
+            hashes.put(fileName, Hashing.sha256().hashBytes(contents).toString());
           } catch (IOException ignored) {
           }
         });
@@ -270,10 +269,7 @@ public class BeamFileSystemArtifactServicesTest {
           Paths.get(originalDir.toString(), fileName).toAbsolutePath().toString(),
           fileName);
       metadata.add(
-          ArtifactMetadata.newBuilder()
-              .setName(fileName)
-              .setMd5(Base64.getEncoder().encodeToString(md5.get(fileName)))
-              .build());
+          ArtifactMetadata.newBuilder().setName(fileName).setSha256(hashes.get(fileName)).build());
     }
 
     String retrievalToken = commitManifest(stagingSessionToken, metadata);

--- a/sdks/python/apache_beam/runners/portability/portable_stager.py
+++ b/sdks/python/apache_beam/runners/portability/portable_stager.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import base64
 import hashlib
 import os
 
@@ -72,7 +71,7 @@ class PortableStager(Stager):
     def artifact_request_generator():
       artifact_metadata = beam_artifact_api_pb2.ArtifactMetadata(
           name=artifact_name,
-          md5=_get_file_hash(local_path_to_artifact))
+          sha256=_get_file_hash(local_path_to_artifact))
       metadata = beam_artifact_api_pb2.PutArtifactMetadata(
           staging_session_token=self._staging_session_token,
           metadata=artifact_metadata)
@@ -100,11 +99,11 @@ class PortableStager(Stager):
 
 
 def _get_file_hash(path):
-  hasher = hashlib.md5()
+  hasher = hashlib.sha256()
   with open(path, 'rb') as f:
     while True:
       chunk = f.read(1 << 21)
       if chunk:
         hasher.update(chunk)
       else:
-        return base64.b64encode(hasher.digest())
+        return hasher.hexdigest()


### PR DESCRIPTION
Also avoid base64, as there are many dialects (which we were not
choosing consistently, the primary one using characters like '/'
unsuitable for filenames).  Lowercase hex is also more standard for
cryptographic sums and easier to verify.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




