### PR TITLE
[BEAM-5638] Exception handling for Java single message transforms

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Failure.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Failure.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ObjectArrays;
+import java.io.Serializable;
+import java.util.List;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * Wraps an exception along with an input value; this is the element type of failure collections
+ * returned by single message transforms configured to catch exceptions.
+ *
+ * @param <T> type of the wrapped input value that caused an exception to be raised
+ */
+@AutoValue
+public abstract class Failure<T> implements Serializable {
+  public static <T> Failure<T> of(Exception exception, T value) {
+    return new AutoValue_Failure<>(exception, value);
+  }
+
+  public abstract Exception exception();
+
+  public abstract T value();
+
+  /**
+   * Internal class for collecting tuple tags associated with collections of {@link Exception}
+   * classes that should route to them. Also contains helper methods to simplify implementation of
+   * the {@code WithFailures} nested classes of {@link MapElements}, {@link FlatMapElements}, etc.
+   */
+  @AutoValue
+  abstract static class TaggedExceptionsList<T> implements Serializable {
+    abstract ImmutableList<TupleTag<Failure<T>>> tags();
+
+    abstract ImmutableList<List<Class<?>>> exceptionLists();
+
+    static <T> TaggedExceptionsList<T> empty() {
+      return new AutoValue_Failure_TaggedExceptionsList<>(ImmutableList.of(), ImmutableList.of());
+    }
+
+    /**
+     * Return a new {@link TaggedExceptionsList} that has all the tags and exceptions of this {@link
+     * TaggedExceptionsList} plus a new element representing the arguments passed in here.
+     */
+    TaggedExceptionsList<T> and(
+        TupleTag<Failure<T>> tag, Class<?> exceptionToCatch, Class<?>[] additionalExceptions) {
+      final ImmutableList<TupleTag<Failure<T>>> newTags =
+          ImmutableList.<TupleTag<Failure<T>>>builder().addAll(tags()).add(tag).build();
+      final ImmutableList<List<Class<?>>> newExceptionLists =
+          ImmutableList.<List<Class<?>>>builder()
+              .addAll(exceptionLists())
+              .add(
+                  ImmutableList.copyOf(ObjectArrays.concat(exceptionToCatch, additionalExceptions)))
+              .build();
+      return new AutoValue_Failure_TaggedExceptionsList<>(newTags, newExceptionLists);
+    }
+
+    /** Return the internal typed list of tags as an untyped {@link TupleTagList}. */
+    TupleTagList tupleTagList() {
+      TupleTagList l = TupleTagList.empty();
+      for (TupleTag<?> tag : tags()) {
+        l = l.and(tag);
+      }
+      return l;
+    }
+
+    /**
+     * Check the registered exception classes to see if the exception passed in here matches. If it
+     * does, wrap the exception and value together in a {@link Failure} and send to the output
+     * receiver. If not, rethrow so processing stops on the unexpected failure.
+     */
+    void outputOrRethrow(Exception e, T value, MultiOutputReceiver receiver) throws Exception {
+      for (int i = 0; i < tags().size(); i++) {
+        for (Class<?> cls : exceptionLists().get(i)) {
+          if (cls.isInstance(e)) {
+            receiver.get(tags().get(i)).output(Failure.of(e, value));
+            return;
+          }
+        }
+      }
+      throw e;
+    }
+
+    /**
+     * Set appropriate coders on all the failure collections in the given {@link PCollectionTuple}.
+     */
+    PCollectionTuple applyFailureCoders(PCollectionTuple pcs) {
+      final SerializableCoder<Failure<T>> failureCoder =
+          SerializableCoder.of(new TypeDescriptor<Failure<T>>() {});
+      for (TupleTag<Failure<T>> tag : tags()) {
+        pcs.get(tag).setCoder(failureCoder);
+      }
+      return pcs;
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Failure.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Failure.java
@@ -19,11 +19,16 @@ package org.apache.beam.sdk.transforms;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ObjectArrays;
+import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
 import java.util.List;
-import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.DelegateCoder;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
@@ -33,17 +38,145 @@ import org.apache.beam.sdk.values.TypeDescriptor;
  * Wraps an exception along with an input value; this is the element type of failure collections
  * returned by single message transforms configured to catch exceptions.
  *
- * @param <T> type of the wrapped input value that caused an exception to be raised
+ * @param <InputT> type of the wrapped input value that caused an exception to be raised
  */
 @AutoValue
-public abstract class Failure<T> implements Serializable {
-  public static <T> Failure<T> of(Exception exception, T value) {
+public abstract class Failure<ExceptionT extends Exception, InputT> implements Serializable {
+  public static <ExceptionT extends Exception, InputT> Failure<ExceptionT, InputT> of(
+      ExceptionT exception, InputT value) {
     return new AutoValue_Failure<>(exception, value);
   }
 
-  public abstract Exception exception();
+  public abstract ExceptionT exception();
 
-  public abstract T value();
+  public abstract InputT value();
+
+  /** Provides factory {@link #of(Coder, Coder)} for creating coders for {@link Failure}. */
+  public static class FailureCoder {
+
+    public static <ExceptionT extends Exception, InputT> Coder<Failure<ExceptionT, InputT>> of(
+        Coder<ExceptionT> exceptionCoder, Coder<InputT> valueCoder) {
+      return DelegateCoder.of(
+          KvCoder.of(exceptionCoder, valueCoder),
+          new ToKvCodingFunction<>(),
+          new ToFailureCodingFunction<>());
+    }
+
+    private static final class ToKvCodingFunction<K extends Exception, V>
+        implements DelegateCoder.CodingFunction<Failure<K, V>, KV<K, V>> {
+      @Override
+      public KV<K, V> apply(Failure<K, V> failure) throws Exception {
+        return KV.of(failure.exception(), failure.value());
+      }
+    }
+
+    private static final class ToFailureCodingFunction<K extends Exception, V>
+        implements DelegateCoder.CodingFunction<KV<K, V>, Failure<K, V>> {
+      @Override
+      public Failure<K, V> apply(KV<K, V> kv) throws Exception {
+        return Failure.of(kv.getKey(), kv.getValue());
+      }
+    }
+  }
+
+  /**
+   * Internal class for storing a {@code TupleTag<Failure<ExceptionT, InputT>>} and providing the
+   * necessary utilities for reflecting the exception type and generating an appropriate coder.
+   *
+   * <p>Any action that needs to know about the concrete types ExceptionT or InputT lives here.
+   */
+  @AutoValue
+  abstract static class FailureTag<ExceptionT extends Exception, InputT> implements Serializable {
+    abstract TupleTag<Failure<ExceptionT, InputT>> tupleTag();
+
+    abstract List<Class<?>> exceptionList();
+
+    abstract Coder<ExceptionT> exceptionCoder();
+
+    static <ExceptionT extends Exception, InputT> FailureTag<ExceptionT, InputT> of(
+        TupleTag<Failure<ExceptionT, InputT>> tag, Class<?>[] exceptionsToCatch) {
+      final TypeDescriptor excType = getExceptionTypeDescriptor(tag);
+
+      List<Class<?>> exceptionList;
+      if (exceptionsToCatch.length > 0) {
+        for (Class<?> cls : exceptionsToCatch) {
+          if (!excType.getRawType().isAssignableFrom(cls)) {
+            throw new IllegalArgumentException(
+                "All passed exception classes must be subtypes"
+                    + " of type parameter ExceptionT in the given"
+                    + " TupleTag<Failure<ExceptionT, InputT>>, but "
+                    + cls.toString()
+                    + " is not a subtype of "
+                    + excType.toString());
+          }
+        }
+        exceptionList = ImmutableList.copyOf(exceptionsToCatch);
+      } else {
+        exceptionList = ImmutableList.of(excType.getRawType());
+      }
+
+      Coder<ExceptionT> exceptionCoder = AvroCoder.of(excType);
+
+      // Exercise the coder early so that we can fail fast in case the given exception type is
+      // not valid for AvroCoder.
+      try {
+        exceptionCoder.decode(null);
+      } catch (IOException | NullPointerException e) {
+        // We expect NullPointerException here due to null InputStream passed to decode();
+        // if we get this far, our type is good and we can move on.
+      } catch (RuntimeException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof NoSuchMethodException) {
+          throw new IllegalArgumentException(
+              "Cannot transcode instances of "
+                  + excType.toString()
+                  + " with AvroCoder; you may want to choose ExceptionT in TupleTag<Failure<ExceptionT, InputT>> to be a "
+                  + " superclass that has a no-argument constructor",
+              e);
+        }
+        throw e;
+      }
+      return new AutoValue_Failure_FailureTag<>(tag, exceptionList, exceptionCoder);
+    }
+
+    /** Return true if the passed exception is an instance of one of the configured subclasses. */
+    boolean matches(Exception e) {
+      for (Class<?> cls : exceptionList()) {
+        if (cls.isInstance(e)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    void sendToOutput(Exception e, InputT value, MultiOutputReceiver receiver) {
+      receiver.get(tupleTag()).output(Failure.of((ExceptionT) e, value));
+    }
+
+    void applyFailureCoder(Coder<InputT> valueCoder, PCollectionTuple pcs) {
+      pcs.get(tupleTag()).setCoder(FailureCoder.of(exceptionCoder(), valueCoder));
+    }
+
+    static <ExceptionT extends Exception, InputT> TypeDescriptor getExceptionTypeDescriptor(
+        TupleTag<Failure<ExceptionT, InputT>> tag) {
+      ParameterizedType tagType =
+          (ParameterizedType)
+              TypeDescriptor.of(tag.getClass()).getSupertype(TupleTag.class).getType();
+      ParameterizedType failureType;
+      try {
+        failureType =
+            (ParameterizedType) TypeDescriptor.of(tagType.getActualTypeArguments()[0]).getType();
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(
+            "Could not reflect type parameters from the passed"
+                + " TupleTag<Failure<ExceptionT, InputT>>, probably because the tag was instantiated"
+                + " without ending curly braces; the instantiation should look something like"
+                + " `new TupleTag<Failure<IOException, String>>(){}`.",
+            e);
+      }
+      return TypeDescriptor.of(failureType.getActualTypeArguments()[0]);
+    }
+  }
 
   /**
    * Internal class for collecting tuple tags associated with collections of {@link Exception}
@@ -51,37 +184,32 @@ public abstract class Failure<T> implements Serializable {
    * the {@code WithFailures} nested classes of {@link MapElements}, {@link FlatMapElements}, etc.
    */
   @AutoValue
-  abstract static class TaggedExceptionsList<T> implements Serializable {
-    abstract ImmutableList<TupleTag<Failure<T>>> tags();
+  abstract static class FailureTagList<InputT> implements Serializable {
+    abstract List<FailureTag<?, InputT>> failureTags();
 
-    abstract ImmutableList<List<Class<?>>> exceptionLists();
-
-    static <T> TaggedExceptionsList<T> empty() {
-      return new AutoValue_Failure_TaggedExceptionsList<>(ImmutableList.of(), ImmutableList.of());
+    static <T> FailureTagList<T> empty() {
+      return new AutoValue_Failure_FailureTagList<>(ImmutableList.of());
     }
 
     /**
-     * Return a new {@link TaggedExceptionsList} that has all the tags and exceptions of this {@link
-     * TaggedExceptionsList} plus a new element representing the arguments passed in here.
+     * Return a new {@link FailureTagList} that has all the tags and exceptions of this {@link
+     * FailureTagList} plus a new element representing the arguments passed in here.
      */
-    TaggedExceptionsList<T> and(
-        TupleTag<Failure<T>> tag, Class<?> exceptionToCatch, Class<?>[] additionalExceptions) {
-      final ImmutableList<TupleTag<Failure<T>>> newTags =
-          ImmutableList.<TupleTag<Failure<T>>>builder().addAll(tags()).add(tag).build();
-      final ImmutableList<List<Class<?>>> newExceptionLists =
-          ImmutableList.<List<Class<?>>>builder()
-              .addAll(exceptionLists())
-              .add(
-                  ImmutableList.copyOf(ObjectArrays.concat(exceptionToCatch, additionalExceptions)))
+    <ExceptionT extends Exception> FailureTagList<InputT> and(
+        TupleTag<Failure<ExceptionT, InputT>> tag, Class<?>[] exceptionsToCatch) {
+      final ImmutableList<FailureTag<?, InputT>> newFailureTags =
+          ImmutableList.<FailureTag<?, InputT>>builder()
+              .addAll(failureTags())
+              .add(FailureTag.of(tag, exceptionsToCatch))
               .build();
-      return new AutoValue_Failure_TaggedExceptionsList<>(newTags, newExceptionLists);
+      return new AutoValue_Failure_FailureTagList<>(newFailureTags);
     }
 
     /** Return the internal typed list of tags as an untyped {@link TupleTagList}. */
-    TupleTagList tupleTagList() {
+    TupleTagList tags() {
       TupleTagList l = TupleTagList.empty();
-      for (TupleTag<?> tag : tags()) {
-        l = l.and(tag);
+      for (FailureTag<?, InputT> failureTag : failureTags()) {
+        l = l.and(failureTag.tupleTag());
       }
       return l;
     }
@@ -91,13 +219,11 @@ public abstract class Failure<T> implements Serializable {
      * does, wrap the exception and value together in a {@link Failure} and send to the output
      * receiver. If not, rethrow so processing stops on the unexpected failure.
      */
-    void outputOrRethrow(Exception e, T value, MultiOutputReceiver receiver) throws Exception {
-      for (int i = 0; i < tags().size(); i++) {
-        for (Class<?> cls : exceptionLists().get(i)) {
-          if (cls.isInstance(e)) {
-            receiver.get(tags().get(i)).output(Failure.of(e, value));
-            return;
-          }
+    void outputOrRethrow(Exception e, InputT value, MultiOutputReceiver receiver) throws Exception {
+      for (FailureTag<?, InputT> failureTag : failureTags()) {
+        if (failureTag.matches(e)) {
+          failureTag.sendToOutput(e, value, receiver);
+          return;
         }
       }
       throw e;
@@ -106,11 +232,9 @@ public abstract class Failure<T> implements Serializable {
     /**
      * Set appropriate coders on all the failure collections in the given {@link PCollectionTuple}.
      */
-    PCollectionTuple applyFailureCoders(PCollectionTuple pcs) {
-      final SerializableCoder<Failure<T>> failureCoder =
-          SerializableCoder.of(new TypeDescriptor<Failure<T>>() {});
-      for (TupleTag<Failure<T>> tag : tags()) {
-        pcs.get(tag).setCoder(failureCoder);
+    PCollectionTuple applyFailureCoders(Coder<InputT> valueCoder, PCollectionTuple pcs) {
+      for (FailureTag<?, InputT> failureTag : failureTags()) {
+        failureTag.applyFailureCoder(valueCoder, pcs);
       }
       return pcs;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
@@ -17,8 +17,11 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import org.apache.beam.sdk.transforms.Failure.TaggedExceptionsList;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
 
 /**
  * {@code PTransform}s for filtering from a {@code PCollection} the elements satisfying a predicate,
@@ -212,5 +215,70 @@ public class Filter<T> extends PTransform<PCollection<T>, PCollection<T>> {
   public void populateDisplayData(DisplayData.Builder builder) {
     super.populateDisplayData(builder);
     builder.add(DisplayData.item("predicate", predicateDescription).withLabel("Filter Predicate"));
+  }
+
+  /**
+   * Sets a {@link TupleTag} to associate with successes, converting this {@link PTransform} into
+   * one that returns a {@link PCollectionTuple}. This allows you to make subsequent {@link
+   * WithFailures#withFailureTag(TupleTag, Class, Class[])} calls to capture thrown exceptions to
+   * failure collections.
+   */
+  public WithFailures withSuccessTag(TupleTag<T> successTag) {
+    return new WithFailures(successTag, TaggedExceptionsList.empty());
+  }
+
+  /**
+   * Variant of {@link Filter} that that can handle exceptions and output one or more failure
+   * collections wrapped in a {@link PCollectionTuple}. Specify how to handle exceptions by calling
+   * {@link #withFailureTag(TupleTag, Class, Class[])}.
+   */
+  public class WithFailures extends PTransform<PCollection<T>, PCollectionTuple> {
+    private final TupleTag<T> successTag;
+    private final TaggedExceptionsList<T> taggedExceptionsList;
+
+    WithFailures(TupleTag<T> successTag, TaggedExceptionsList<T> taggedExceptionsList) {
+      this.successTag = successTag;
+      this.taggedExceptionsList = taggedExceptionsList;
+    }
+
+    /** Specify a {@link TupleTag} and the {@link Exception} subclasses that should route to it. */
+    public WithFailures withFailureTag(
+        TupleTag<Failure<T>> tag, Class exceptionToCatch, Class... additionalExceptions) {
+      return new WithFailures(
+          successTag, taggedExceptionsList.and(tag, exceptionToCatch, additionalExceptions));
+    }
+
+    @Override
+    public PCollectionTuple expand(PCollection<T> input) {
+      PCollectionTuple pcs =
+          input.apply(
+              ParDo.of(
+                      new DoFn<T, T>() {
+                        @ProcessElement
+                        public void processElement(@Element T element, MultiOutputReceiver receiver)
+                            throws Exception {
+                          Boolean accepted = null;
+                          try {
+                            accepted = predicate.apply(element);
+                          } catch (Exception e) {
+                            taggedExceptionsList.outputOrRethrow(e, element, receiver);
+                          }
+                          if (accepted != null && accepted) {
+                            receiver.get(successTag).output(element);
+                          }
+                        }
+                      })
+                  .withOutputTags(successTag, taggedExceptionsList.tupleTagList()));
+      pcs.get(successTag).setCoder(input.getCoder());
+      taggedExceptionsList.applyFailureCoders(pcs);
+      return pcs;
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder.add(
+          DisplayData.item("predicate", predicateDescription).withLabel("Filter Predicate"));
+    }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
@@ -17,15 +17,19 @@
  */
 package org.apache.beam.sdk.transforms;
 
-import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.transforms.Contextful.Fn;
+import org.apache.beam.sdk.transforms.Failure.TaggedExceptionsList;
 import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.DisplayData.Builder;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
@@ -125,9 +129,19 @@ public class FlatMapElements<InputT, OutputT>
         fn, fn.getClosure(), TypeDescriptors.inputOf(fn.getClosure()), outputType);
   }
 
+  private void checkOutputType() {
+    checkState(
+        outputType != null,
+        "%s output type descriptor was null; "
+            + "this probably means that getOutputTypeDescriptor() was called after "
+            + "serialization/deserialization, but it is only available prior to "
+            + "serialization, for constructing a pipeline and inferring coders",
+        FlatMapElements.class.getSimpleName());
+  }
+
   @Override
   public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
-    checkArgument(fn != null, ".via() is required");
+    checkNotNull(fn, ".via() is required");
     return input.apply(
         "FlatMap",
         ParDo.of(
@@ -148,13 +162,7 @@ public class FlatMapElements<InputT, OutputT>
 
                   @Override
                   public TypeDescriptor<OutputT> getOutputTypeDescriptor() {
-                    checkState(
-                        outputType != null,
-                        "%s output type descriptor was null; "
-                            + "this probably means that getOutputTypeDescriptor() was called after "
-                            + "serialization/deserialization, but it is only available prior to "
-                            + "serialization, for constructing a pipeline and inferring coders",
-                        FlatMapElements.class.getSimpleName());
+                    checkOutputType();
                     return outputType;
                   }
 
@@ -172,6 +180,96 @@ public class FlatMapElements<InputT, OutputT>
     builder.add(DisplayData.item("class", originalFnForDisplayData.getClass()));
     if (originalFnForDisplayData instanceof HasDisplayData) {
       builder.include("fn", (HasDisplayData) originalFnForDisplayData);
+    }
+  }
+
+  /**
+   * Sets a {@link TupleTag} to associate with successes, converting this {@link PTransform} into
+   * one that returns a {@link PCollectionTuple}. This allows you to make subsequent {@link
+   * WithFailures#withFailureTag(TupleTag, Class, Class[])} calls to capture thrown exceptions to
+   * failure collections.
+   */
+  public WithFailures withSuccessTag(TupleTag<OutputT> successTag) {
+    return new WithFailures(successTag, TaggedExceptionsList.empty());
+  }
+
+  /**
+   * Variant of {@link FlatMapElements} that that can handle exceptions and output one or more
+   * failure collections wrapped in a {@link PCollectionTuple}. Specify how to handle exceptions by
+   * calling {@link #withFailureTag(TupleTag, Class, Class[])}.
+   */
+  public class WithFailures extends PTransform<PCollection<? extends InputT>, PCollectionTuple> {
+    private final TupleTag<OutputT> successTag;
+    private final TaggedExceptionsList<InputT> taggedExceptionsList;
+
+    WithFailures(TupleTag<OutputT> successTag, TaggedExceptionsList<InputT> taggedExceptionsList) {
+      this.successTag = successTag;
+      this.taggedExceptionsList = taggedExceptionsList;
+    }
+
+    /** Specify a {@link TupleTag} and the {@link Exception} subclasses that should route to it. */
+    public WithFailures withFailureTag(
+        TupleTag<Failure<InputT>> tag, Class exceptionToCatch, Class... additionalExceptions) {
+      return new WithFailures(
+          successTag, taggedExceptionsList.and(tag, exceptionToCatch, additionalExceptions));
+    }
+
+    @Override
+    public PCollectionTuple expand(PCollection<? extends InputT> input) {
+      checkNotNull(fn, ".via() is required");
+      PCollectionTuple pcs =
+          input.apply(
+              "FlatMapWithFailures",
+              ParDo.of(
+                      new DoFn<InputT, OutputT>() {
+                        @ProcessElement
+                        public void processElement(
+                            @Element InputT element, MultiOutputReceiver receiver, ProcessContext c)
+                            throws Exception {
+                          Iterable<OutputT> res = null;
+                          try {
+                            res =
+                                fn.getClosure()
+                                    .apply(c.element(), Fn.Context.wrapProcessContext(c));
+                          } catch (Exception e) {
+                            taggedExceptionsList.outputOrRethrow(e, element, receiver);
+                          }
+                          if (res != null) {
+                            for (OutputT output : res) {
+                              c.output(output);
+                            }
+                          }
+                        }
+
+                        @Override
+                        public void populateDisplayData(Builder builder) {
+                          builder.delegate(WithFailures.this);
+                        }
+
+                        @Override
+                        public TypeDescriptor<InputT> getInputTypeDescriptor() {
+                          return inputType;
+                        }
+
+                        @Override
+                        public TypeDescriptor<OutputT> getOutputTypeDescriptor() {
+                          checkOutputType();
+                          return outputType;
+                        }
+                      })
+                  .withOutputTags(successTag, taggedExceptionsList.tupleTagList())
+                  .withSideInputs(fn.getRequirements().getSideInputs()));
+      taggedExceptionsList.applyFailureCoders(pcs);
+      return pcs;
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder.add(DisplayData.item("class", originalFnForDisplayData.getClass()));
+      if (originalFnForDisplayData instanceof HasDisplayData) {
+        builder.include("fn", (HasDisplayData) originalFnForDisplayData);
+      }
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FailureTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FailureTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.UncheckedIOException;
+import org.apache.beam.sdk.transforms.Failure.FailureTag;
+import org.apache.beam.sdk.values.TupleTag;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/** Test constraints and internal behavior of {@link Failure}. */
+public class FailureTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFailureTagThrowsForErasedType() {
+    TupleTag<Failure<Exception, String>> tag = new TupleTag<>();
+    FailureTag.of(tag, new Class<?>[] {});
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFailureTagThrowsForConstructor() {
+    TupleTag<Failure<UncheckedIOException, String>> tag =
+        new TupleTag<Failure<UncheckedIOException, String>>() {};
+    FailureTag.of(tag, new Class<?>[] {});
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testThrowsOnDisjointTypes() {
+    TupleTag<Failure<RuntimeException, String>> tag =
+        new TupleTag<Failure<RuntimeException, String>>() {};
+    FailureTag.of(tag, new Class<?>[] {Exception.class});
+  }
+
+  @Test
+  public void testAllowsNarrowingViaSubtypes() {
+    TupleTag<Failure<RuntimeException, String>> tag =
+        new TupleTag<Failure<RuntimeException, String>>() {};
+    FailureTag.of(tag, new Class<?>[] {IllegalArgumentException.class, NullPointerException.class});
+  }
+
+  @Test
+  public void testSuppliesDefaultClass() {
+    TupleTag<Failure<RuntimeException, String>> tag =
+        new TupleTag<Failure<RuntimeException, String>>() {};
+    FailureTag<RuntimeException, String> failureTag = FailureTag.of(tag, new Class<?>[] {});
+    assertThat(failureTag.exceptionList(), Matchers.contains(RuntimeException.class));
+  }
+
+  @Test
+  public void testGetExceptionTypeDescriptor() {
+    TupleTag<Failure<Exception, String>> tag = new TupleTag<Failure<Exception, String>>() {};
+    assertEquals(Exception.class, FailureTag.getExceptionTypeDescriptor(tag).getRawType());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
@@ -21,7 +21,6 @@ import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisp
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
@@ -226,9 +225,11 @@ public class FilterTest implements Serializable {
   @Test
   @Category(NeedsRunner.class)
   public void testFilterWithFailures() {
-    TupleTag<Integer> successTag = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag2 = new TupleTag<>();
+    TupleTag<Integer> successTag = new TupleTag<Integer>() {};
+    TupleTag<Failure<IntegerException1, Integer>> failureTag1 =
+        new TupleTag<Failure<IntegerException1, Integer>>() {};
+    TupleTag<Failure<IntegerException2, Integer>> failureTag2 =
+        new TupleTag<Failure<IntegerException2, Integer>>() {};
 
     PCollectionTuple pcs =
         p.apply(Create.of(1, 2, 3, 4, 5, 6, 7))
@@ -243,8 +244,7 @@ public class FilterTest implements Serializable {
         .satisfies(
             failures -> {
               failures.forEach(
-                  (Failure<Integer> failure) -> {
-                    assertTrue(failure.exception() instanceof IntegerException1);
+                  (Failure<IntegerException1, Integer> failure) -> {
                     assertEquals(1, failure.value().intValue());
                   });
               return null;
@@ -253,8 +253,7 @@ public class FilterTest implements Serializable {
         .satisfies(
             failures -> {
               failures.forEach(
-                  (Failure<Integer> failure) -> {
-                    assertTrue(failure.exception() instanceof IntegerException2);
+                  (Failure<IntegerException2, Integer> failure) -> {
                     assertEquals(2, failure.value().intValue());
                   });
               return null;
@@ -266,8 +265,9 @@ public class FilterTest implements Serializable {
   @Test
   @Category(NeedsRunner.class)
   public void testFilterWithFailuresThrowsUncaught() {
-    TupleTag<Integer> successTag = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
+    TupleTag<Integer> successTag = new TupleTag<Integer>() {};
+    TupleTag<Failure<IntegerException1, Integer>> failureTag1 =
+        new TupleTag<Failure<IntegerException1, Integer>>() {};
 
     PCollectionTuple pcs =
         p.apply(Create.of(1, 2, 3, 4, 5, 6, 7))

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/FilterTest.java
@@ -19,14 +19,20 @@ package org.apache.beam.sdk.transforms;
 
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
+import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -216,4 +222,79 @@ public class FilterTest implements Serializable {
       return i % 2 == 0;
     }
   }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testFilterWithFailures() {
+    TupleTag<Integer> successTag = new TupleTag<>();
+    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
+    TupleTag<Failure<Integer>> failureTag2 = new TupleTag<>();
+
+    PCollectionTuple pcs =
+        p.apply(Create.of(1, 2, 3, 4, 5, 6, 7))
+            .apply(
+                Filter.by(new EvenFnWithExceptions())
+                    .withSuccessTag(successTag)
+                    .withFailureTag(failureTag1, IntegerException1.class)
+                    .withFailureTag(failureTag2, IntegerException2.class));
+
+    PAssert.that(pcs.get(successTag)).containsInAnyOrder(4, 6);
+    PAssert.that(pcs.get(failureTag1))
+        .satisfies(
+            failures -> {
+              failures.forEach(
+                  (Failure<Integer> failure) -> {
+                    assertTrue(failure.exception() instanceof IntegerException1);
+                    assertEquals(1, failure.value().intValue());
+                  });
+              return null;
+            });
+    PAssert.that(pcs.get(failureTag2))
+        .satisfies(
+            failures -> {
+              failures.forEach(
+                  (Failure<Integer> failure) -> {
+                    assertTrue(failure.exception() instanceof IntegerException2);
+                    assertEquals(2, failure.value().intValue());
+                  });
+              return null;
+            });
+
+    p.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testFilterWithFailuresThrowsUncaught() {
+    TupleTag<Integer> successTag = new TupleTag<>();
+    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
+
+    PCollectionTuple pcs =
+        p.apply(Create.of(1, 2, 3, 4, 5, 6, 7))
+            .apply(
+                Filter.by(new EvenFnWithExceptions())
+                    .withSuccessTag(successTag)
+                    .withFailureTag(failureTag1, IntegerException1.class));
+
+    thrown.expect(PipelineExecutionException.class);
+    thrown.expectCause(isA(IntegerException2.class));
+    p.run();
+  }
+
+  static class EvenFnWithExceptions implements SerializableFunction<Integer, Boolean> {
+    @Override
+    public Boolean apply(Integer elem) {
+      if (elem == 1) {
+        throw new IntegerException1();
+      }
+      if (elem == 2) {
+        throw new IntegerException2();
+      }
+      return elem % 2 == 0;
+    }
+  }
+
+  private static class IntegerException1 extends RuntimeException {}
+
+  private static class IntegerException2 extends RuntimeException {}
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MapElementsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/MapElementsTest.java
@@ -26,7 +26,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.core.Is.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import java.io.Serializable;
 import java.util.Set;
@@ -372,8 +371,10 @@ public class MapElementsTest implements Serializable {
   @Category(NeedsRunner.class)
   public void testMapWithFailures() throws Exception {
     TupleTag<Integer> successTag = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag2 = new TupleTag<>();
+    TupleTag<Failure<IntegerException1, Integer>> failureTag1 =
+        new TupleTag<Failure<IntegerException1, Integer>>() {};
+    TupleTag<Failure<IntegerException2, Integer>> failureTag2 =
+        new TupleTag<Failure<IntegerException2, Integer>>() {};
 
     PCollectionTuple pcs =
         pipeline
@@ -401,8 +402,7 @@ public class MapElementsTest implements Serializable {
         .satisfies(
             failures -> {
               failures.forEach(
-                  (Failure<Integer> failure) -> {
-                    assertTrue(failure.exception() instanceof IntegerException1);
+                  (Failure<IntegerException1, Integer> failure) -> {
                     assertEquals(1, failure.value().intValue());
                   });
               return null;
@@ -411,8 +411,7 @@ public class MapElementsTest implements Serializable {
         .satisfies(
             failures -> {
               failures.forEach(
-                  (Failure<Integer> failure) -> {
-                    assertTrue(failure.exception() instanceof IntegerException2);
+                  (Failure<IntegerException2, Integer> failure) -> {
                     assertEquals(2, failure.value().intValue());
                   });
               return null;
@@ -425,8 +424,9 @@ public class MapElementsTest implements Serializable {
   @Test
   @Category(NeedsRunner.class)
   public void testMapWithFailuresThrowsUncaught() throws Exception {
-    TupleTag<Integer> successTag = new TupleTag<>();
-    TupleTag<Failure<Integer>> failureTag1 = new TupleTag<>();
+    TupleTag<Integer> successTag = new TupleTag<Integer>() {};
+    TupleTag<Failure<IntegerException1, Integer>> failureTag1 =
+        new TupleTag<Failure<IntegerException1, Integer>>() {};
 
     PCollectionTuple pcs =
         pipeline

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/AsJsons.java
@@ -39,7 +39,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
  */
 public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection<String>> {
   private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
-  private static final TupleTag<String> SUCCESS_TAG = new TupleTag<>();
+  private static final TupleTag<String> SUCCESS_TAG = new TupleTag<String>() {};
 
   private final Class<? extends InputT> inputClass;
   private ObjectMapper customMapper;
@@ -103,7 +103,8 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    *
    * <pre>{@code
    * PCollection<Foo> foos = ...;
-   * TupleTag<Failure<Foo>> unserializedFoosTag = new TupleTag<>();
+   * TupleTag<Failure<IOException, Foo>> unserializedFoosTag =
+   *   new TupleTag<Failure<IOException, Foo>>(){};
    *
    * PCollection<String> strings = foos
    *   .apply(AsJsons
@@ -115,7 +116,7 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    *   }));
    * }</pre>
    */
-  public WithFailures withFailureTag(TupleTag<Failure<InputT>> failureTag) {
+  public WithFailures withFailureTag(TupleTag<Failure<IOException, InputT>> failureTag) {
     return new WithFailures(failureTag);
   }
 
@@ -124,9 +125,9 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
    * wrapping success and failure collections in a {@link PCollectionTuple}.
    */
   public class WithFailures extends PTransform<PCollection<InputT>, PCollectionTuple> {
-    private final TupleTag<Failure<InputT>> failureTag;
+    private final TupleTag<Failure<IOException, InputT>> failureTag;
 
-    public WithFailures(TupleTag<Failure<InputT>> failureTag) {
+    WithFailures(TupleTag<Failure<IOException, InputT>> failureTag) {
       this.failureTag = failureTag;
     }
 
@@ -145,7 +146,7 @@ public class AsJsons<InputT> extends PTransform<PCollection<InputT>, PCollection
                       },
                       Requirements.empty()))
               .withSuccessTag(SUCCESS_TAG)
-              .withFailureTag(failureTag, IOException.class));
+              .withFailureTag(failureTag));
     }
   }
 }

--- a/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
+++ b/sdks/java/extensions/jackson/src/main/java/org/apache/beam/sdk/extensions/jackson/ParseJsons.java
@@ -18,12 +18,19 @@
 package org.apache.beam.sdk.extensions.jackson;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Optional;
 import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import org.apache.beam.sdk.transforms.Contextful;
+import org.apache.beam.sdk.transforms.Failure;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.Requirements;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptor;
 
 /**
  * {@link PTransform} for parsing JSON {@link String Strings}. Parse {@link PCollection} of {@link
@@ -32,6 +39,7 @@ import org.apache.beam.sdk.values.PCollection;
  */
 public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollection<OutputT>> {
   private static final ObjectMapper DEFAULT_MAPPER = new ObjectMapper();
+  private static final TupleTag<Failure<String>> FAILURE_TAG = new TupleTag<>();
 
   private final Class<? extends OutputT> outputClass;
   private ObjectMapper customMapper;
@@ -55,6 +63,11 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
     return newTransform;
   }
 
+  private OutputT readValue(String input) throws IOException {
+    ObjectMapper mapper = Optional.ofNullable(customMapper).orElse(DEFAULT_MAPPER);
+    return mapper.readValue(input, outputClass);
+  }
+
   @Override
   public PCollection<OutputT> expand(PCollection<String> input) {
     return input.apply(
@@ -63,14 +76,77 @@ public class ParseJsons<OutputT> extends PTransform<PCollection<String>, PCollec
               @Override
               public OutputT apply(String input) {
                 try {
-                  ObjectMapper mapper = Optional.fromNullable(customMapper).or(DEFAULT_MAPPER);
-                  return mapper.readValue(input, outputClass);
+                  return readValue(input);
                 } catch (IOException e) {
-                  throw new RuntimeException(
+                  throw new UncheckedIOException(
                       "Failed to parse a " + outputClass.getName() + " from JSON value: " + input,
                       e);
                 }
               }
             }));
+  }
+
+  /** Return the {@link TupleTag} associated with parsing failures. */
+  public static TupleTag<Failure<String>> failureTag() {
+    return FAILURE_TAG;
+  }
+
+  /**
+   * Sets a {@link TupleTag} to associate with successes, converting this {@link PTransform} into
+   * one that returns a {@link PCollectionTuple} and catches any {@link IOException} raised while
+   * parsing JSON.
+   *
+   * <p>Because the input type is static ({@code String}), the failure type is also static and users
+   * do not need to supply a failure tag. Instead, failures are always associated with the tag
+   * returned by static method {@link ParseJsons#failureTag()}.
+   *
+   * <p>Example:
+   *
+   * <pre>{@code
+   * PCollection<String> strings = ...;
+   * TupleTag<Foo> parsedFoosTag = new TupleTag<>();
+   *
+   * PCollection<Foo> foos = strings
+   *   .apply(ParseJsons
+   *     .of(Foo.class)
+   *     .withSuccessTag(parsedFoosTag))
+   *   .apply(PTransform.compose((PCollectionTuple pcs) -> {
+   *     pcs.get(ParseJsons.failureTag()).apply(new MyErrorOutputTransform());
+   *     return pcs.get(parsedFoosTag);
+   *   }));
+   * }</pre>
+   */
+  public WithFailures withSuccessTag(TupleTag<OutputT> successTag) {
+    return new WithFailures(successTag);
+  }
+
+  /**
+   * Variant of {@link ParseJsons} that that catches {@link IOException} raised while parsing JSON,
+   * wrapping success and failure collections in a {@link PCollectionTuple}.
+   */
+  public class WithFailures extends PTransform<PCollection<? extends String>, PCollectionTuple> {
+    private final TupleTag<OutputT> successTag;
+
+    public WithFailures(TupleTag<OutputT> successTag) {
+      this.successTag = successTag;
+    }
+
+    @Override
+    public PCollectionTuple expand(PCollection<? extends String> input) {
+      return input.apply(
+          MapElements.into(new TypeDescriptor<OutputT>() {})
+              .via(
+                  Contextful.fn(
+                      new Contextful.Fn<String, OutputT>() {
+                        @Override
+                        public OutputT apply(String input, Contextful.Fn.Context c)
+                            throws IOException {
+                          return readValue(input);
+                        }
+                      },
+                      Requirements.empty()))
+              .withSuccessTag(successTag)
+              .withFailureTag(FAILURE_TAG, IOException.class));
+    }
   }
 }

--- a/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
+++ b/sdks/java/extensions/jackson/src/test/java/org/apache/beam/sdk/extensions/jackson/JacksonTransformsTest.java
@@ -17,10 +17,13 @@
  */
 package org.apache.beam.sdk.extensions.jackson;
 
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.collect.Iterables;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -30,7 +33,13 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Failure;
+import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -78,6 +87,36 @@ public class JacksonTransformsTest {
             .setCoder(SerializableCoder.of(MyPojo.class));
 
     PAssert.that(output).containsInAnyOrder(POJOS);
+
+    pipeline.run();
+  }
+
+  @Test
+  public void collectInvalidJsons() {
+    TupleTag<MyPojo> successTag = new TupleTag<>();
+
+    PCollectionTuple pcs =
+        pipeline
+            .apply(Create.of(Iterables.concat(VALID_JSONS, INVALID_JSONS)))
+            .apply(ParseJsons.of(MyPojo.class).withSuccessTag(successTag));
+
+    pcs.get(successTag).setCoder(SerializableCoder.of(MyPojo.class));
+
+    PAssert.that(pcs.get(successTag)).containsInAnyOrder(POJOS);
+    PAssert.that(pcs.get(ParseJsons.failureTag()))
+        .satisfies(
+            failures -> {
+              failures.forEach(
+                  (Failure<String> failure) -> {
+                    assertTrue(failure.exception() instanceof IOException);
+                  });
+              return null;
+            });
+
+    PCollection<String> failureValues =
+        pcs.get(ParseJsons.failureTag())
+            .apply(MapElements.into(TypeDescriptors.strings()).via(Failure::value));
+    PAssert.that(failureValues).containsInAnyOrder(INVALID_JSONS);
 
     pipeline.run();
   }
@@ -130,6 +169,33 @@ public class JacksonTransformsTest {
         .apply(Create.of(EMPTY_BEANS))
         .apply(AsJsons.of(MyEmptyBean.class))
         .setCoder(StringUtf8Coder.of());
+
+    pipeline.run();
+  }
+
+  @Test
+  public void collectWriteFailuresWithoutCustomMapper() {
+    TupleTag<Failure<MyEmptyBean>> failureTag = new TupleTag<>();
+
+    final PCollectionTuple pcs =
+        pipeline
+            .apply(Create.of(EMPTY_BEANS))
+            .apply(AsJsons.of(MyEmptyBean.class).withFailureTag(failureTag));
+
+    pcs.get(AsJsons.successTag()).setCoder(StringUtf8Coder.of());
+    PAssert.that(pcs.get(AsJsons.successTag())).empty();
+
+    PAssert.that(pcs.get(failureTag))
+        .satisfies(
+            failures -> {
+              failures.forEach(failure -> assertTrue(failure.exception() instanceof IOException));
+              return null;
+            });
+
+    PCollection<MyEmptyBean> failureValues =
+        pcs.get(failureTag)
+            .apply(MapElements.into(TypeDescriptor.of(MyEmptyBean.class)).via(Failure::value));
+    PAssert.that(failureValues).containsInAnyOrder(EMPTY_BEANS);
 
     pipeline.run();
   }


### PR DESCRIPTION
Adds methods to MapElements, FlatMapElements, and Filter that allow users to specify expected exceptions and tuple tags to associate with the collections of the successfully and unsuccessfully processed elements.

Also adds these features to AsJsons an ParseJsons.

Uses concepts from @vllry's blog post [Error Handling Elements in Apache Beam Pipelines](https://medium.com/@vallerylancey/error-handling-elements-in-apache-beam-pipelines-fffdea91af2a).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




