### PR TITLE
[BEAM-5626] Fix hadoop filesystem test for py3.

### DIFF
--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -214,12 +214,10 @@ class HadoopFileSystemTest(unittest.TestCase):
       url = self.fs.join(self.tmpdir, filename)
       self.fs.create(url).close()
 
-  def assertItemsEqual(self, l1, l2):
-    assert len(l1) == len(l2)
-    l1.sort()
-    l2.sort()
-    for i, obj in enumerate(l1):
-      self.assertEqual(obj, l2[i])
+    try:                    # Python 2
+      self.assertCountEqual = self.assertItemsEqual
+    except AttributeError:  # Python 3
+      pass
 
   def test_scheme(self):
     self.assertEqual(self.fs.scheme(), 'hdfs')
@@ -265,7 +263,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     returned_files = [f.path
                       for match_result in result
                       for f in match_result.metadata_list]
-    self.assertItemsEqual(expected_files, returned_files)
+    self.assertCountEqual(expected_files, returned_files)
 
   def test_match_file_with_limits(self):
     expected_files = [self.fs.join(self.tmpdir, filename)
@@ -303,7 +301,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     # structure, so listing without a '/' will return no results.
     result = self.fs.match([self.tmpdir + '/'])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertItemsEqual(files, expected_files)
+    self.assertCountEqual(files, expected_files)
 
   def test_match_directory_trailing_slash(self):
     expected_files = [self.fs.join(self.tmpdir, filename)
@@ -311,7 +309,7 @@ class HadoopFileSystemTest(unittest.TestCase):
 
     result = self.fs.match([self.tmpdir + '/'])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertItemsEqual(files, expected_files)
+    self.assertCountEqual(files, expected_files)
 
   def test_create_success(self):
     url = self.fs.join(self.tmpdir, 'new_file')

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -153,7 +153,7 @@ class FakeHdfs(object):
 
     _ = self.status(path)
 
-    for filepath in self.files.keys():  # pylint: disable=consider-iterating-dictionary
+    for filepath in list(self.files):
       if filepath.startswith(path):
         del self.files[filepath]
 
@@ -213,6 +213,13 @@ class HadoopFileSystemTest(unittest.TestCase):
     for filename in ['old_file1', 'old_file2']:
       url = self.fs.join(self.tmpdir, filename)
       self.fs.create(url).close()
+
+  def assertItemsEqual(self, l1, l2):
+    assert len(l1) == len(l2)
+    l1.sort()
+    l2.sort()
+    for i, obj in enumerate(l1):
+      self.assertEqual(obj, l2[i])
 
   def test_scheme(self):
     self.assertEqual(self.fs.scheme(), 'hdfs')
@@ -322,7 +329,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     path = self.fs._parse_url(url)
     expected_file = FakeFile(path, 'wb')
     self.assertEqual(self._fake_hdfs.files[path], expected_file)
-    data = 'abc' * 10
+    data = b'abc' * 10
     handle.write(data)
     # Compressed data != original data
     self.assertNotEquals(data, self._fake_hdfs.files[path].getvalue())
@@ -336,7 +343,7 @@ class HadoopFileSystemTest(unittest.TestCase):
   def test_open(self):
     url = self.fs.join(self.tmpdir, 'old_file1')
     handle = self.fs.open(url)
-    expected_data = ''
+    expected_data = b''
     data = handle.read()
     self.assertEqual(data, expected_data)
 
@@ -356,7 +363,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url2 = self.fs.join(self.tmpdir, 'new_file2')
     url3 = self.fs.join(self.tmpdir, 'new_file3')
     with self.fs.create(url1) as f1:
-      f1.write('Hello')
+      f1.write(b'Hello')
     self.fs.copy([url1, url1], [url2, url3])
     self.assertTrue(self._cmpfiles(url1, url2))
     self.assertTrue(self._cmpfiles(url1, url3))
@@ -365,9 +372,9 @@ class HadoopFileSystemTest(unittest.TestCase):
     url1 = self.fs.join(self.tmpdir, 'new_file1')
     url2 = self.fs.join(self.tmpdir, 'new_file2')
     with self.fs.create(url1) as f1:
-      f1.write('Hello')
+      f1.write(b'Hello')
     with self.fs.create(url2) as f2:
-      f2.write('nope')
+      f2.write(b'nope')
     with self.assertRaisesRegexp(
         BeamIOError, r'already exists.*%s' % posixpath.basename(url2)):
       self.fs.copy([url1], [url2])
@@ -378,7 +385,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url3 = self.fs.join(self.tmpdir, 'new_file3')
     url4 = self.fs.join(self.tmpdir, 'new_file4')
     with self.fs.create(url3) as f:
-      f.write('Hello')
+      f.write(b'Hello')
     with self.assertRaisesRegexp(
         BeamIOError, r'^Copy operation failed .*%s.*%s.* not found' % (
             url1, url2)):
@@ -397,7 +404,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url1 = self.fs.join(url_t1_inner, 'f1')
     url2 = self.fs.join(url_t2_inner, 'f1')
     with self.fs.create(url1) as f:
-      f.write('Hello')
+      f.write(b'Hello')
 
     self.fs.copy([url_t1], [url_t2])
     self.assertTrue(self._cmpfiles(url1, url2))
@@ -419,9 +426,9 @@ class HadoopFileSystemTest(unittest.TestCase):
     url3_inner = self.fs.join(url_t2_inner, 'f3')
     for url in [url1, url1_inner, url3_inner]:
       with self.fs.create(url) as f:
-        f.write('Hello')
+        f.write(b'Hello')
     with self.fs.create(url2) as f:
-      f.write('nope')
+      f.write(b'nope')
 
     with self.assertRaisesRegexp(BeamIOError, r'already exists'):
       self.fs.copy([url_t1], [url_t2])
@@ -430,7 +437,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url1 = self.fs.join(self.tmpdir, 'f1')
     url2 = self.fs.join(self.tmpdir, 'f2')
     with self.fs.create(url1) as f:
-      f.write('Hello')
+      f.write(b'Hello')
 
     self.fs.rename([url1], [url2])
     self.assertFalse(self.fs.exists(url1))
@@ -442,7 +449,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url3 = self.fs.join(self.tmpdir, 'f3')
     url4 = self.fs.join(self.tmpdir, 'f4')
     with self.fs.create(url3) as f:
-      f.write('Hello')
+      f.write(b'Hello')
 
     with self.assertRaisesRegexp(
         BeamIOError, r'^Rename operation failed .*%s.*%s' % (url1, url2)):
@@ -457,7 +464,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     url1 = self.fs.join(url_t1, 'f1')
     url2 = self.fs.join(url_t2, 'f1')
     with self.fs.create(url1) as f:
-      f.write('Hello')
+      f.write(b'Hello')
 
     self.fs.rename([url_t1], [url_t2])
     self.assertFalse(self.fs.exists(url_t1))
@@ -474,13 +481,13 @@ class HadoopFileSystemTest(unittest.TestCase):
   def test_size(self):
     url = self.fs.join(self.tmpdir, 'f1')
     with self.fs.create(url) as f:
-      f.write('Hello')
+      f.write(b'Hello')
     self.assertEqual(5, self.fs.size(url))
 
   def test_checksum(self):
     url = self.fs.join(self.tmpdir, 'f1')
     with self.fs.create(url) as f:
-      f.write('Hello')
+      f.write(b'Hello')
     self.assertEqual('fake_algo-5-checksum_byte_sequence',
                      self.fs.checksum(url))
 

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 import io
 import logging
 import posixpath
+import sys
 import unittest
 from builtins import object
 
@@ -197,6 +198,12 @@ class FakeHdfs(object):
 
 class HadoopFileSystemTest(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def setUp(self):
     self._fake_hdfs = FakeHdfs()
     hdfs.hdfs.InsecureClient = (
@@ -213,11 +220,6 @@ class HadoopFileSystemTest(unittest.TestCase):
     for filename in ['old_file1', 'old_file2']:
       url = self.fs.join(self.tmpdir, filename)
       self.fs.create(url).close()
-
-    try:                    # Python 2
-      self.assertCountEqual = self.assertItemsEqual
-    except AttributeError:  # Python 3
-      pass
 
   def test_scheme(self):
     self.assertEqual(self.fs.scheme(), 'hdfs')


### PR DESCRIPTION
Hadoop filesystem test for python3. 

After this PR, following test passes: 
python ./setup.py test -s  apache_beam.io.hadoopfilesystem_test.HadoopFileSystemTest 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




