### PR TITLE
[BEAM-5633] Adds reconnect logic to python logging client

### DIFF
--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -17,6 +17,7 @@
 """Beam fn API log handler."""
 
 from __future__ import absolute_import
+from __future__ import print_function
 
 import logging
 import math
@@ -53,18 +54,18 @@ class FnApiLogRecordHandler(logging.Handler):
 
   def __init__(self, log_service_descriptor):
     super(FnApiLogRecordHandler, self).__init__()
-    # Make sure the channel is ready to avoid [BEAM-4649]
-    self._log_entry_queue = queue.Queue()
+    # If average log size is 1KB, this may use up to 1MB of memory
+    self._log_entry_queue = queue.Queue(maxsize=1000)
 
     ch = grpc.insecure_channel(log_service_descriptor.url)
+    # Make sure the channel is ready to avoid [BEAM-4649]
     grpc.channel_ready_future(ch).result(timeout=60)
     self._log_channel = grpc.intercept_channel(ch, WorkerIdInterceptor())
     self._logging_stub = beam_fn_api_pb2_grpc.BeamFnLoggingStub(
         self._log_channel)
 
-    log_control_messages = self.connect()
     self._reader = threading.Thread(
-        target=lambda: self._read_log_control_messages(log_control_messages),
+        target=lambda: self._read_log_control_messages(),
         name='read_log_control_messages')
     self._reader.daemon = True
     self._reader.start()
@@ -82,14 +83,14 @@ class FnApiLogRecordHandler(logging.Handler):
     nanoseconds = 1e9 * fraction
     log_entry.timestamp.seconds = int(seconds)
     log_entry.timestamp.nanos = int(nanoseconds)
-    self._log_entry_queue.put(log_entry)
+    self._log_entry_queue.put(log_entry, block=False)
 
   def close(self):
     """Flush out all existing log entries and unregister this handler."""
     # Acquiring the handler lock ensures ``emit`` is not run until the lock is
     # released.
     self.acquire()
-    self._log_entry_queue.put(self._FINISHED)
+    self._log_entry_queue.put(self._FINISHED, timeout=1)
     # wait on server to close.
     self._reader.join()
     self.release()
@@ -111,18 +112,17 @@ class FnApiLogRecordHandler(logging.Handler):
       if log_entries:
         yield beam_fn_api_pb2.LogEntry.List(log_entries=log_entries)
 
-  def _read_log_control_messages(self, log_control_iterator):
+  def _read_log_control_messages(self):
     # TODO(vikasrk): Handle control messages.
     while True:
+      log_control_iterator = self.connect()
+
       try:
         for _ in log_control_iterator:
           pass
         # iterator is closed
         return
       except Exception as ex:
-        # reset the stream
-        print >> sys.stderr, "Logging client failed: {}... resetting".format(ex)
-        self.acquire()
-        log_control_iterator = self.connect()
-        self.release()
+        print("Logging client failed: {}... resetting".format(ex),
+              file=sys.stderr)
 

--- a/sdks/python/apache_beam/runners/worker/log_handler.py
+++ b/sdks/python/apache_beam/runners/worker/log_handler.py
@@ -125,4 +125,3 @@ class FnApiLogRecordHandler(logging.Handler):
       except Exception as ex:
         print("Logging client failed: {}... resetting".format(ex),
               file=sys.stderr)
-


### PR DESCRIPTION
This PR attempts to fix BEAM-5633 (Python SDK harness logging client failure) by adding reconnect logic to the logging client. With this patch, we haven't seen logging failures on our infrastructure.

This issue manifests itself on the server (taskmanager) side with the exception

```
[grpc-default-executor-0] WARN org.apache.beam.runners.fnexecution.logging.GrpcLoggingService - Logging client failed unexpectedly.
org.apache.beam.vendor.grpc.v1.io.grpc.StatusRuntimeException: CANCELLED: cancelled before receiving half close
	at org.apache.beam.vendor.grpc.v1.io.grpc.Status.asRuntimeException(Status.java:517)
	at org.apache.beam.vendor.grpc.v1.io.grpc.stub.ServerCalls$StreamingServerCallHandler$StreamingServerCallListener.onCancel(ServerCalls.java:272)
```

and on the client (python worker) side with

```
E1004 22:08:02.139750634      38 chttp2_transport.cc:1097]   Received a GOAWAY with error code ENHANCE_YOUR_CALM and debug data equal to "too_many_pings"
Exception in thread read_log_control_messages:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/local/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/site-packages/apache_beam/runners/worker/log_handler.py", line 65, in <lambda>
    target=lambda: self._read_log_control_messages(log_control_messages),
  File "/usr/local/lib/python2.7/site-packages/apache_beam/runners/worker/log_handler.py", line 111, in _read_log_control_messages
    for _ in log_control_iterator:
  File "/usr/local/lib/python2.7/site-packages/grpc/_channel.py", line 350, in next
    return self._next()
  File "/usr/local/lib/python2.7/site-packages/grpc/_channel.py", line 341, in _next
    raise self
_Rendezvous: <_Rendezvous of RPC that terminated with (StatusCode.UNAVAILABLE, Socket closed)>
```

At a high-level, the issue is the client is sending the server too many illegal pings, and the server eventually closes the connection. As the client doesn't have any retry logic it never recovers from this.

Ideally, there'd be two levels of fixes:

1. Update the server or client gRPC configuration to prevent the client from sending bad pings or to prevent the server from killing the connection in this situation (see [here](https://github.com/grpc/grpc/blob/master/doc/keepalive.md) for more documentation of this behavior)
2. Make the logging client more robust, reconnecting when the connection is lost

I haven't been able to find a configuration that solves the first part, so that may need more investigation. Regardless, I think it's worthwhile having reconnection logic even if that issue is fixed.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




