### PR TITLE
[BEAM-5620] rename assertItemsEqual to assertCountEqual for PY3 compatibility

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -24,6 +24,7 @@ import glob
 import gzip
 import logging
 import os
+import sys
 import tempfile
 import unittest
 import uuid
@@ -474,6 +475,12 @@ class SnippetsTest(unittest.TestCase):
       return pcoll | 'DummyWriteForTesting' >> beam.ParDo(
           SnippetsTest.DummyWriteTransform.WriteDoFn(self.file_to_write))
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def setUp(self):
     self.old_read_from_text = beam.io.ReadFromText
     self.old_write_to_text = beam.io.WriteToText
@@ -591,7 +598,7 @@ class SnippetsTest(unittest.TestCase):
         for line in f:
           received_output.append(line.rstrip(os.linesep))
 
-    self.assertItemsEqual(expected_output, received_output)
+    self.assertCountEqual(expected_output, received_output)
 
     glob_pattern = tempdir_name + os.sep + 'final_table_with_ptransform*'
     output_files = glob.glob(glob_pattern)
@@ -603,7 +610,7 @@ class SnippetsTest(unittest.TestCase):
         for line in f:
           received_output.append(line.rstrip(os.linesep))
 
-    self.assertItemsEqual(expected_output, received_output)
+    self.assertCountEqual(expected_output, received_output)
 
   def test_model_textio(self):
     temp_path = self.create_temp_file('aa bb cc\n bb cc\n cc')

--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 import json
 import logging
 import os
+import sys
 import tempfile
 import unittest
 from builtins import range
@@ -58,6 +59,12 @@ class TestAvro(unittest.TestCase):
   def __init__(self, methodName='runTest'):
     super(TestAvro, self).__init__(methodName)
     self.use_fastavro = False
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def setUp(self):
     # Reducing the size of thread pools. Without this test execution may fail in
@@ -150,7 +157,7 @@ class TestAvro(unittest.TestCase):
           (source, None, None), sources_info)
     else:
       read_records = source_test_utils.read_from_source(source, None, None)
-      self.assertItemsEqual(expected_result, read_records)
+      self.assertCountEqual(expected_result, read_records)
 
   def test_read_without_splitting(self):
     file_name = self._write_data()

--- a/sdks/python/apache_beam/io/filebasedsink_test.py
+++ b/sdks/python/apache_beam/io/filebasedsink_test.py
@@ -24,6 +24,7 @@ import glob
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from builtins import range
@@ -96,6 +97,12 @@ class MyFileBasedSink(filebasedsink.FileBasedSink):
 
 class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def _common_init(self, sink):
     # Manually invoke the generic Sink API.
     init_token = sink.initialize_write()
@@ -136,7 +143,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
     self.assertEqual(open(shard2).read(), '[start][x][y][z][end]')
 
     # Check that any temp files are deleted.
-    self.assertItemsEqual([shard1, shard2], glob.glob(temp_path + '*'))
+    self.assertCountEqual([shard1, shard2], glob.glob(temp_path + '*'))
 
   def test_file_sink_display_data(self):
     temp_path = os.path.join(self._new_tempdir(), 'display')
@@ -277,7 +284,7 @@ class TestFileBasedSink(_TestCaseWithTempDirCleanUp):
           open(shard_name).read(), ('[start][a][b][%s][end]' % uuid))
 
     # Check that any temp files are deleted.
-    self.assertItemsEqual(res, glob.glob(temp_path + '*'))
+    self.assertCountEqual(res, glob.glob(temp_path + '*'))
 
   @mock.patch.object(filebasedsink.FileSystems, 'rename')
   def test_file_sink_rename_error(self, rename_mock):

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -24,6 +24,7 @@ import logging
 import math
 import os
 import random
+import sys
 import tempfile
 import unittest
 from builtins import object
@@ -579,6 +580,12 @@ class TestFileBasedSource(unittest.TestCase):
 
 class TestSingleFileSource(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def setUp(self):
     # Reducing the size of thread pools. Without this test execution may fail in
     # environments with limited amount of resources.
@@ -650,7 +657,7 @@ class TestSingleFileSource(unittest.TestCase):
     source = SingleFileSource(fbs, file_name, 0, 10 * 6)
     range_tracker = source.get_range_tracker(0, 20)
     read_data = [value for value in source.read(range_tracker)]
-    self.assertItemsEqual(expected_data[:4], read_data)
+    self.assertCountEqual(expected_data[:4], read_data)
 
   def test_read_range_at_end(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -661,7 +668,7 @@ class TestSingleFileSource(unittest.TestCase):
     source = SingleFileSource(fbs, file_name, 0, 10 * 6)
     range_tracker = source.get_range_tracker(40, 60)
     read_data = [value for value in source.read(range_tracker)]
-    self.assertItemsEqual(expected_data[-3:], read_data)
+    self.assertCountEqual(expected_data[-3:], read_data)
 
   def test_read_range_at_middle(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -672,7 +679,7 @@ class TestSingleFileSource(unittest.TestCase):
     source = SingleFileSource(fbs, file_name, 0, 10 * 6)
     range_tracker = source.get_range_tracker(20, 40)
     read_data = [value for value in source.read(range_tracker)]
-    self.assertItemsEqual(expected_data[4:7], read_data)
+    self.assertCountEqual(expected_data[4:7], read_data)
 
   def test_produces_splits_desiredsize_large_than_size(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -688,7 +695,7 @@ class TestSingleFileSource(unittest.TestCase):
 
     range_tracker = splits[0].source.get_range_tracker(None, None)
     read_data = [value for value in splits[0].source.read(range_tracker)]
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_produces_splits_desiredsize_smaller_than_size(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -706,7 +713,7 @@ class TestSingleFileSource(unittest.TestCase):
                                                split.stop_position)
       data_from_split = [data for data in source.read(range_tracker)]
       read_data.extend(data_from_split)
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_produce_split_with_start_and_end_positions(self):
     fbs = LineSource('dummy_pattern', validate=False)
@@ -726,7 +733,7 @@ class TestSingleFileSource(unittest.TestCase):
                                                split.stop_position)
       data_from_split = [data for data in source.read(range_tracker)]
       read_data.extend(data_from_split)
-    self.assertItemsEqual(expected_data[2:9], read_data)
+    self.assertCountEqual(expected_data[2:9], read_data)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/pubsub_matcher_test.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 import unittest
 
 import mock
@@ -41,6 +42,12 @@ except ImportError:
 @mock.patch('time.sleep', return_value=None)
 @mock.patch('google.cloud.pubsub.SubscriberClient')
 class PubSubMatcherTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def setUp(self):
     self.mock_presult = mock.MagicMock()
@@ -123,7 +130,7 @@ class PubSubMatcherTest(unittest.TestCase):
     with self.assertRaises(AssertionError) as error:
       hc_assert_that(self.mock_presult, self.pubsub_matcher)
     self.assertEqual(mock_sub.pull.call_count, 1)
-    self.assertItemsEqual(['c', 'd'], self.pubsub_matcher.messages)
+    self.assertCountEqual(['c', 'd'], self.pubsub_matcher.messages)
     self.assertTrue(
         '\nExpected: Expected 1 messages.\n     but: Got 2 messages.'
         in str(error.exception.args[0]))

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 import io
 import logging
 import posixpath
+import sys
 import unittest
 from builtins import object
 
@@ -197,6 +198,12 @@ class FakeHdfs(object):
 
 class HadoopFileSystemTest(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def setUp(self):
     self._fake_hdfs = FakeHdfs()
     hdfs.hdfs.InsecureClient = (
@@ -258,7 +265,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     returned_files = [f.path
                       for match_result in result
                       for f in match_result.metadata_list]
-    self.assertItemsEqual(expected_files, returned_files)
+    self.assertCountEqual(expected_files, returned_files)
 
   def test_match_file_with_limits(self):
     expected_files = [self.fs.join(self.tmpdir, filename)
@@ -296,7 +303,7 @@ class HadoopFileSystemTest(unittest.TestCase):
     # structure, so listing without a '/' will return no results.
     result = self.fs.match([self.tmpdir + '/'])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertItemsEqual(files, expected_files)
+    self.assertCountEqual(files, expected_files)
 
   def test_match_directory_trailing_slash(self):
     expected_files = [self.fs.join(self.tmpdir, filename)
@@ -304,7 +311,7 @@ class HadoopFileSystemTest(unittest.TestCase):
 
     result = self.fs.match([self.tmpdir + '/'])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertItemsEqual(files, expected_files)
+    self.assertCountEqual(files, expected_files)
 
   def test_create_success(self):
     url = self.fs.join(self.tmpdir, 'new_file')

--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -24,6 +24,7 @@ import filecmp
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -59,6 +60,12 @@ def _gen_fake_split(separator):
 
 
 class LocalFileSystemTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def setUp(self):
     self.tmpdir = tempfile.mkdtemp()
@@ -185,7 +192,7 @@ class LocalFileSystemTest(unittest.TestCase):
     full_pattern = os.path.join(self.tmpdir, pattern)
     result = self.fs.match([full_pattern])[0]
     files = [os.path.relpath(f.path, self.tmpdir) for f in result.metadata_list]
-    self.assertItemsEqual(files, expected)
+    self.assertCountEqual(files, expected)
 
   def test_match_directory(self):
     result = self.fs.match([self.tmpdir])[0]
@@ -200,7 +207,7 @@ class LocalFileSystemTest(unittest.TestCase):
 
     result = self.fs.match([self.tmpdir + '/'])[0]
     files = [f.path for f in result.metadata_list]
-    self.assertItemsEqual(files, [path1, path2])
+    self.assertCountEqual(files, [path1, path2])
 
   def test_copy(self):
     path1 = os.path.join(self.tmpdir, 'f1')

--- a/sdks/python/apache_beam/io/source_test_utils_test.py
+++ b/sdks/python/apache_beam/io/source_test_utils_test.py
@@ -18,6 +18,7 @@
 from __future__ import absolute_import
 
 import logging
+import sys
 import tempfile
 import unittest
 from builtins import range
@@ -27,6 +28,12 @@ from apache_beam.io.filebasedsource_test import LineSource
 
 
 class SourceTestUtilsTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def _create_file_with_data(self, lines):
     assert isinstance(lines, list)
@@ -50,7 +57,7 @@ class SourceTestUtilsTest(unittest.TestCase):
   def test_read_from_source(self):
     data = self._create_data(100)
     source = self._create_source(data)
-    self.assertItemsEqual(
+    self.assertCountEqual(
         data, source_test_utils.read_from_source(source, None, None))
 
   def test_source_equals_reference_source(self):

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 
 import logging
 import os
+import sys
 import tempfile
 import unittest
 
@@ -83,6 +84,12 @@ class LineSource(iobase.BoundedSource):
 
 class SourcesTest(unittest.TestCase):
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def _create_temp_file(self, contents):
     with tempfile.NamedTemporaryFile(delete=False) as f:
       f.write(contents)
@@ -95,7 +102,7 @@ class SourcesTest(unittest.TestCase):
     range_tracker = source.get_range_tracker(None, None)
     result = [line for line in source.read(range_tracker)]
 
-    self.assertItemsEqual(['aaaa', 'bbbb', 'cccc', 'dddd'], result)
+    self.assertCountEqual(['aaaa', 'bbbb', 'cccc', 'dddd'], result)
 
   def test_run_direct(self):
     file_name = self._create_temp_file('aaaa\nbbbb\ncccc\ndddd')

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -25,6 +25,7 @@ import gzip
 import logging
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from builtins import range
@@ -55,6 +56,12 @@ class TextSourceTest(unittest.TestCase):
   # Number of records that will be written by most tests.
   DEFAULT_NUM_RECORDS = 100
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def _run_read_test(self, file_or_pattern, expected_data,
                      buffer_size=DEFAULT_NUM_RECORDS,
                      compression=CompressionTypes.UNCOMPRESSED):
@@ -65,7 +72,7 @@ class TextSourceTest(unittest.TestCase):
                         True, coders.StrUtf8Coder(), buffer_size)
     range_tracker = source.get_range_tracker(None, None)
     read_data = list(source.read(range_tracker))
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_read_single_file(self):
     file_name, expected_data = write_data(TextSourceTest.DEFAULT_NUM_RECORDS)
@@ -187,7 +194,7 @@ class TextSourceTest(unittest.TestCase):
 
     range_tracker = source.get_range_tracker(None, None)
     read_data = list(source.read(range_tracker))
-    self.assertItemsEqual([line + '\n' for line in written_data], read_data)
+    self.assertCountEqual([line + '\n' for line in written_data], read_data)
 
   def test_read_single_file_without_striping_eol_crlf(self):
     file_name, written_data = write_data(TextSourceTest.DEFAULT_NUM_RECORDS,
@@ -198,7 +205,7 @@ class TextSourceTest(unittest.TestCase):
 
     range_tracker = source.get_range_tracker(None, None)
     read_data = list(source.read(range_tracker))
-    self.assertItemsEqual([line + '\r\n' for line in written_data], read_data)
+    self.assertCountEqual([line + '\r\n' for line in written_data], read_data)
 
   def test_read_file_pattern_with_empty_files(self):
     pattern, expected_data = write_pattern(
@@ -249,8 +256,8 @@ class TextSourceTest(unittest.TestCase):
         splits[0].start_position, splits[0].stop_position)
     read_data = list(source.read_records(file_name, range_tracker))
 
-    self.assertItemsEqual(expected_data[:5], header_lines)
-    self.assertItemsEqual(expected_data[5:], read_data)
+    self.assertCountEqual(expected_data[:5], header_lines)
+    self.assertCountEqual(expected_data[5:], read_data)
 
   def test_progress(self):
     file_name, expected_data = write_data(10)
@@ -713,7 +720,7 @@ class TextSourceTest(unittest.TestCase):
                                        skip_header_lines)
     read_data = self._read_skip_header_lines(file_name, skip_header_lines)
     self.assertEqual(len(expected_data), len(read_data))
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_read_skip_header_pattern(self):
     line_counts = [
@@ -730,7 +737,7 @@ class TextSourceTest(unittest.TestCase):
     expected_data = self._remove_lines(data, line_counts, skip_header_lines)
     read_data = self._read_skip_header_lines(pattern, skip_header_lines)
     self.assertEqual(len(expected_data), len(read_data))
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_read_skip_header_pattern_insufficient_lines(self):
     line_counts = [
@@ -743,7 +750,7 @@ class TextSourceTest(unittest.TestCase):
     data = self._remove_lines(data, line_counts, skip_header_lines)
     read_data = self._read_skip_header_lines(pattern, skip_header_lines)
     self.assertEqual(len(data), len(read_data))
-    self.assertItemsEqual(data, read_data)
+    self.assertCountEqual(data, read_data)
 
   def test_read_gzip_with_skip_lines(self):
     _, lines = write_data(15)
@@ -781,6 +788,12 @@ class TextSourceTest(unittest.TestCase):
 
 
 class TextSinkTest(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def setUp(self):
     super(TextSinkTest, self).setUp()

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import collections
 import operator
 import re
+import sys
 import unittest
 from builtins import map
 from builtins import range
@@ -61,6 +62,12 @@ from apache_beam.utils.windowed_value import WindowedValue
 class PTransformTest(unittest.TestCase):
   # Enable nose tests running in parallel
   _multiprocess_can_split_ = True
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def assertStartswith(self, msg, prefix):
     self.assertTrue(msg.startswith(prefix),
@@ -659,15 +666,15 @@ class PTransformTest(unittest.TestCase):
     pipeline.run()
 
   def test_apply_to_list(self):
-    self.assertItemsEqual(
+    self.assertCountEqual(
         [1, 2, 3], [0, 1, 2] | 'AddOne' >> beam.Map(lambda x: x + 1))
     self.assertItemsEqual([1],
                           [0, 1, 2] | 'Odd' >> beam.Filter(lambda x: x % 2))
-    self.assertItemsEqual([1, 2, 100, 3],
+    self.assertCountEqual([1, 2, 100, 3],
                           ([1, 2, 3], [100]) | beam.Flatten())
     join_input = ([('k', 'a')],
                   [('k', 'b'), ('k', 'c')])
-    self.assertItemsEqual([('k', (['a'], ['b', 'c']))],
+    self.assertCountEqual([('k', (['a'], ['b', 'c']))],
                           join_input | beam.CoGroupByKey())
 
   def test_multi_input_ptransform(self):


### PR DESCRIPTION
Replaced all `assertItemsEqual` by assigning it to `assertCountEqual` on Python 2, as discussed in [BEAM-5620](https://issues.apache.org/jira/secure/RapidBoard.jspa?rapidView=245&projectKey=BEAM&view=detail&selectedIssue=BEAM-5620)  and illustrated in https://github.com/apache/beam/blob/c34c367f5da6f9bef8a46471195470923a201af9/sdks/python/apache_beam/coders/coders_test_common.py#L61

I have added  `def setUpClass(cls)` if it wasn't available (only `setUp` was in most cases), so that it shouldn't be rerun for every test of the class.

This is is part of a series of PRs with goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented here: https://s.apache.org/beam-python-3

@tvalentyn @manuzhang @charlesccychen @aaltay @splovyt @Juta

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




