### PR TITLE
[BEAM-5685] Improving comparator for TopWikipediaSessions

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/TopWikipediaSessions.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/TopWikipediaSessions.java
@@ -18,6 +18,7 @@
 package org.apache.beam.examples.complete;
 
 import com.google.api.services.bigquery.model.TableRow;
+import com.google.common.collect.ComparisonChain;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
@@ -112,7 +113,11 @@ public class TopWikipediaSessions {
     @Override
     public PCollection<List<KV<String, Long>>> expand(PCollection<KV<String, Long>> sessions) {
       SerializableComparator<KV<String, Long>> comparator =
-          (o1, o2) -> Long.compare(o1.getValue(), o2.getValue());
+          (o1, o2) ->
+              ComparisonChain.start()
+                  .compare(o1.getValue(), o2.getValue())
+                  .compare(o1.getKey(), o2.getKey())
+                  .result();
       return sessions
           .apply(Window.into(CalendarWindows.months(1)))
           .apply(Top.of(1, comparator).withoutDefaults());

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/TopWikipediaSessionsIT.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/TopWikipediaSessionsIT.java
@@ -36,7 +36,7 @@ public class TopWikipediaSessionsIT {
 
   private static final String DEFAULT_INPUT_10_FILES =
       "gs://apache-beam-samples/wikipedia_edits/wiki_data-00000000000*.json";
-  private static final String DEFAULT_OUTPUT_CHECKSUM = "a7f0c50b895d0a2e37b78c3f94eadcfb11a647a6";
+  private static final String DEFAULT_OUTPUT_CHECKSUM = "61262b08503338bfe4e36b0791958d65e6070933";
 
   /** PipelineOptions for the TopWikipediaSessions integration test. */
   public interface TopWikipediaSessionsITOptions


### PR DESCRIPTION
The test is flaky due to value-dependent sorting. When two elements have equal values, they can be sort arbitrarily, so I'm adding per-value-then-key sorting.

r: @chamikaramj 