### PR TITLE
[BEAM-5687] Fix checkpointing of FlinkRunner for portable pipelines 

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -203,6 +203,10 @@ public class FlinkExecutionEnvironments {
             .getCheckpointConfig()
             .setMinPauseBetweenCheckpoints(minPauseBetweenCheckpoints);
       }
+    } else {
+      // https://issues.apache.org/jira/browse/FLINK-2491
+      // Checkpointing is disabled, we can allow shutting down sources when they're done
+      options.setShutdownSourcesOnFinalWatermark(true);
     }
 
     applyLatencyTrackingInterval(flinkStreamEnv.getConfig(), options);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -72,8 +72,8 @@ public interface FlinkPipelineOptions
   void setParallelism(Integer value);
 
   @Description(
-      "The interval between consecutive checkpoints (i.e. snapshots of the current"
-          + "pipeline state used for fault tolerance).")
+      "The interval in milliseconds at which to trigger checkpoints of the running pipeline. "
+          + "Default: No checkpointing.")
   @Default.Long(-1L)
   Long getCheckpointingInterval();
 
@@ -85,13 +85,14 @@ public interface FlinkPipelineOptions
 
   void setCheckpointingMode(CheckpointingMode mode);
 
-  @Description("The maximum time that a checkpoint may take before being discarded.")
+  @Description(
+      "The maximum time in milliseconds that a checkpoint may take before being discarded.")
   @Default.Long(-1L)
   Long getCheckpointTimeoutMillis();
 
   void setCheckpointTimeoutMillis(Long checkpointTimeoutMillis);
 
-  @Description("The minimal pause before the next checkpoint is triggered.")
+  @Description("The minimal pause in milliseconds before the next checkpoint is triggered.")
   @Default.Long(-1L)
   Long getMinPauseBetweenCheckpoints();
 
@@ -107,7 +108,7 @@ public interface FlinkPipelineOptions
   void setNumberOfExecutionRetries(Integer retries);
 
   @Description(
-      "Sets the delay between executions. A value of {@code -1} "
+      "Sets the delay in milliseconds between executions. A value of {@code -1} "
           + "indicates that the default value should be used.")
   @Default.Long(-1L)
   Long getExecutionRetryDelay();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -520,7 +520,7 @@ public class FlinkStreamingPortablePipelineTranslator
     DoFnOperator<InputT, OutputT> doFnOperator =
         new ExecutableStageDoFnOperator<>(
             transform.getUniqueName(),
-            null,
+            instantiateCoder(inputPCollectionId, components),
             null,
             Collections.emptyMap(),
             mainOutputTag,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunction.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.flink.translation.functions;
+
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+/**
+ * Source function which sends an impulse to a downstream operator. It may keep the source alive
+ * although its work is already done. It will only shutdown when requested by the JobManager.
+ */
+public class ImpulseSourceFunction implements SourceFunction<WindowedValue<byte[]>> {
+
+  /** Keep source running even after it has done all the work. */
+  private final boolean keepSourceAlive;
+
+  /** Indicates the streaming job is running and the source can produce elements. */
+  private volatile boolean running;
+
+  public ImpulseSourceFunction(boolean keepSourceAlive) {
+    this.keepSourceAlive = keepSourceAlive;
+    this.running = true;
+  }
+
+  @Override
+  public void run(SourceContext<WindowedValue<byte[]>> sourceContext) throws Exception {
+    // emit single impulse element
+    sourceContext.collect(WindowedValue.valueInGlobalWindow(new byte[0]));
+    // Do nothing, but still look busy ...
+    // we can't return here since Flink requires that all operators stay up,
+    // otherwise checkpointing would not work correctly anymore
+    //
+    // See https://issues.apache.org/jira/browse/FLINK-2491 for progress on this issue
+    if (keepSourceAlive) {
+      // wait until this is canceled
+      final Object waitLock = new Object();
+      while (running) {
+        try {
+          // Flink will interrupt us at some point
+          //noinspection SynchronizationOnLocalVariableOrMethodParameter
+          synchronized (waitLock) {
+            // don't wait indefinitely, in case something goes horribly wrong
+            waitLock.wait(1000);
+          }
+        } catch (InterruptedException e) {
+          if (!running) {
+            // restore the interrupted state, and fall through the loop
+            Thread.currentThread().interrupt();
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void cancel() {
+    this.running = false;
+  }
+}


### PR DESCRIPTION
###  [BEAM-5687] Fix checkpointing of FlinkRunner for portable pipelines

This provides the input WindowValue Coder to ExecutableStageDoFnOperator which
ensures that the buffered elements can be checkpointed correctly.

### [BEAM-3727] Do not shutdown Impulse sources to enable checkpointing

Flink's checkpointing won't work properly after sources have finished. They need
to be up and running for as long as checkpoints should be taken. This was
already the case for the non-portable UnboundedSourceWrapper but it needs to be
extended also for Impulse transforms. 

### [BEAM-3727] Allow sources to shutdown when checkpointing is disabled 


CC @tweise @angoenka 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




