### PR TITLE
[BEAM-5693] Adding fixes to work properly with files on windows

### DIFF
--- a/sdks/python/apache_beam/io/localfilesystem_test.py
+++ b/sdks/python/apache_beam/io/localfilesystem_test.py
@@ -161,17 +161,25 @@ class LocalFileSystemTest(unittest.TestCase):
 
   @parameterized.expand([
       param('*',
-            files=['a', 'b', 'c/x'],
+            files=['a', 'b', os.path.join('c', 'x')],
             expected=['a', 'b']),
       param('**',
-            files=['a', 'b/x', 'c/x'],
-            expected=['a', 'b/x', 'c/x']),
-      param('*/*',
-            files=['a', 'b/x', 'c/x', 'd/x/y'],
-            expected=['b/x', 'c/x']),
-      param('**/*',
-            files=['a', 'b/x', 'c/x', 'd/x/y'],
-            expected=['b/x', 'c/x', 'd/x/y']),
+            files=['a', os.path.join('b', 'x'), os.path.join('c', 'x')],
+            expected=['a', os.path.join('b', 'x'), os.path.join('c', 'x')]),
+      param(os.path.join('*', '*'),
+            files=['a',
+                   os.path.join('b', 'x'),
+                   os.path.join('c', 'x'),
+                   os.path.join('d', 'x', 'y')],
+            expected=[os.path.join('b', 'x'), os.path.join('c', 'x')]),
+      param(os.path.join('**', '*'),
+            files=['a',
+                   os.path.join('b', 'x'),
+                   os.path.join('c', 'x'),
+                   os.path.join('d', 'x', 'y')],
+            expected=[os.path.join('b', 'x'),
+                      os.path.join('c', 'x'),
+                      os.path.join('d', 'x', 'y')]),
   ])
   def test_match_glob(self, pattern, files, expected):
     for filename in files:
@@ -205,7 +213,7 @@ class LocalFileSystemTest(unittest.TestCase):
     open(path1, 'a').close()
     open(path2, 'a').close()
 
-    result = self.fs.match([self.tmpdir + '/'])[0]
+    result = self.fs.match([os.path.join(self.tmpdir, '*')])[0]
     files = [f.path for f in result.metadata_list]
     self.assertCountEqual(files, [path1, path2])
 
@@ -399,7 +407,7 @@ class LocalFileSystemTest(unittest.TestCase):
 
     self.fs.delete([
         os.path.join(dir, 'path*'),
-        os.path.join(dir, 'aaa/b*')
+        os.path.join(dir, 'aaa', 'b*')
     ])
 
     # One empty nested directory is left
@@ -433,8 +441,8 @@ class LocalFileSystemTest(unittest.TestCase):
                                  r'^Delete operation failed') as error:
       self.fs.delete([
           os.path.join(dir, 'path*'),
-          os.path.join(dir, 'aaa/b*'),
-          os.path.join(dir, 'aaa/d*')  # doesn't match anything, will raise
+          os.path.join(dir, 'aaa', 'b*'),
+          os.path.join(dir, 'aaa', 'd*')  # doesn't match anything, will raise
       ])
 
     self.check_tree(
@@ -454,7 +462,7 @@ class LocalFileSystemTest(unittest.TestCase):
             .exception_details
             .keys()
         ),
-        [os.path.join(dir, 'aaa/d*')]
+        [os.path.join(dir, 'aaa', 'd*')]
     )
 
     with self.assertRaisesRegexp(BeamIOError,

--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -93,7 +93,7 @@ class FileBasedCacheManager(CacheManager):
     if cache_dir:
       self._cache_dir = filesystems.FileSystems.join(
           cache_dir,
-          datetime.datetime.now().strftime("cache-%y-%m-%d-%H:%M:%S"))
+          datetime.datetime.now().strftime("cache-%y-%m-%d-%H_%M_%S"))
     else:
       self._cache_dir = tempfile.mkdtemp(
           prefix='interactive-temp-', dir=os.environ.get('TEST_TMPDIR', None))

--- a/sdks/python/apache_beam/testing/pipeline_verifiers_test.py
+++ b/sdks/python/apache_beam/testing/pipeline_verifiers_test.py
@@ -20,6 +20,7 @@
 from __future__ import absolute_import
 
 import logging
+import os
 import tempfile
 import unittest
 from builtins import range
@@ -100,14 +101,15 @@ class PipelineVerifiersTest(unittest.TestCase):
       temp_dir = tempfile.mkdtemp()
       for _ in range(case['num_files']):
         self.create_temp_file(case['content'], temp_dir)
-      matcher = verifiers.FileChecksumMatcher(temp_dir + '/*',
+      matcher = verifiers.FileChecksumMatcher(os.path.join(temp_dir, '*'),
                                               case['expected_checksum'])
       hc_assert_that(self._mock_result, matcher)
 
   @patch.object(LocalFileSystem, 'match')
   def test_file_checksum_matcher_read_failed(self, mock_match):
     mock_match.side_effect = IOError('No file found.')
-    matcher = verifiers.FileChecksumMatcher('dummy/path', Mock())
+    matcher = verifiers.FileChecksumMatcher(
+        os.path.join('dummy', 'path'), Mock())
     with self.assertRaises(IOError):
       hc_assert_that(self._mock_result, matcher)
     self.assertTrue(mock_match.called)
@@ -140,7 +142,7 @@ class PipelineVerifiersTest(unittest.TestCase):
     temp_dir = tempfile.mkdtemp()
     case = self.test_cases[0]
     self.create_temp_file(case['content'], temp_dir)
-    matcher = verifiers.FileChecksumMatcher(temp_dir + '/*',
+    matcher = verifiers.FileChecksumMatcher(os.path.join(temp_dir, '*'),
                                             case['expected_checksum'],
                                             10)
     hc_assert_that(self._mock_result, matcher)


### PR DESCRIPTION
Some tests are using configurations that are not appropriate on windows systems. This is to fix those issues.

r: @udim 

cc: @qinyeli  - small changes to `cache_manager.py`