### PR TITLE
Plumb names properly through streaming side input consuming DoFns

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BeamFnMapTaskExecutorFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BeamFnMapTaskExecutorFactory.java
@@ -169,9 +169,7 @@ public class BeamFnMapTaskExecutorFactory implements DataflowMapTaskExecutorFact
             beamFnDataService,
             dataApiServiceDescriptor,
             executionContext,
-            // TODO: Set NameContext properly for these operations.
-            executionContext.createOperationContext(
-                NameContext.create(stageName, stageName, stageName, stageName))));
+            stageName));
 
     // Swap out all the ParallelInstruction nodes with Operation nodes
     Networks.replaceDirectedNetworkNodes(
@@ -209,7 +207,7 @@ public class BeamFnMapTaskExecutorFactory implements DataflowMapTaskExecutorFact
       FnDataService beamFnDataService,
       Endpoints.ApiServiceDescriptor dataApiServiceDescriptor,
       DataflowExecutionContext executionContext,
-      DataflowOperationContext operationContext) {
+      String stageName) {
     return new TypeSafeNodeFunction<FetchAndFilterStreamingSideInputsNode>(
         FetchAndFilterStreamingSideInputsNode.class) {
 
@@ -217,6 +215,13 @@ public class BeamFnMapTaskExecutorFactory implements DataflowMapTaskExecutorFact
       public Node typedApply(FetchAndFilterStreamingSideInputsNode input) {
         OutputReceiverNode output =
             (OutputReceiverNode) Iterables.getOnlyElement(network.successors(input));
+        DataflowOperationContext operationContext =
+            executionContext.createOperationContext(
+                NameContext.create(
+                    stageName,
+                    input.getNameContext().originalName(),
+                    input.getNameContext().systemName(),
+                    input.getNameContext().userName()));
         return OperationNode.create(
             new FetchAndFilterStreamingSideInputsOperation<>(
                 new OutputReceiver[] {output.getOutputReceiver()},

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodes.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodes.java
@@ -31,6 +31,7 @@ import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.runners.core.construction.WindowingStrategyTranslation;
 import org.apache.beam.runners.dataflow.util.CloudObject;
 import org.apache.beam.runners.dataflow.util.PropertyNames;
+import org.apache.beam.runners.dataflow.worker.counters.NameContext;
 import org.apache.beam.runners.dataflow.worker.graph.Edges.Edge;
 import org.apache.beam.runners.dataflow.worker.graph.Nodes.ExecutionLocation;
 import org.apache.beam.runners.dataflow.worker.graph.Nodes.FetchAndFilterStreamingSideInputsNode;
@@ -143,7 +144,13 @@ public class InsertFetchAndFilterStreamingSideInputNodes {
                       sideInput.getWindowMappingFn()));
       Node streamingSideInputWindowHandlerNode =
           FetchAndFilterStreamingSideInputsNode.create(
-              windowingStrategy, pCollectionViewsToWindowMapingsFns.build());
+              windowingStrategy,
+              pCollectionViewsToWindowMapingsFns.build(),
+              NameContext.create(
+                  null,
+                  node.getParallelInstruction().getOriginalName(),
+                  node.getParallelInstruction().getSystemName(),
+                  node.getParallelInstruction().getName()));
 
       // Rewire the graph such that streaming side inputs ParDos are preceded by a
       // node which filters any side inputs that aren't ready and fetches any ready side inputs.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/Nodes.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/graph/Nodes.java
@@ -315,15 +315,18 @@ public class Nodes {
   public abstract static class FetchAndFilterStreamingSideInputsNode extends Node {
     public static FetchAndFilterStreamingSideInputsNode create(
         WindowingStrategy<?, ?> windowingStrategy,
-        Map<PCollectionView<?>, RunnerApi.SdkFunctionSpec> pCollectionViewsToWindowMappingFns) {
+        Map<PCollectionView<?>, RunnerApi.SdkFunctionSpec> pCollectionViewsToWindowMappingFns,
+        NameContext nameContext) {
       return new AutoValue_Nodes_FetchAndFilterStreamingSideInputsNode(
-          windowingStrategy, pCollectionViewsToWindowMappingFns);
+          windowingStrategy, pCollectionViewsToWindowMappingFns, nameContext);
     }
 
     public abstract WindowingStrategy<?, ?> getWindowingStrategy();
 
     public abstract Map<PCollectionView<?>, RunnerApi.SdkFunctionSpec>
         getPCollectionViewsToWindowMappingFns();
+
+    public abstract NameContext getNameContext();
   }
 
   // Hide visibility to prevent instantiation

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContextTest.java
@@ -93,12 +93,14 @@ public class StreamingModeExecutionContextTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     CounterSet counterSet = new CounterSet();
+    ConcurrentHashMap<String, String> stateNameMap = new ConcurrentHashMap<>();
+    stateNameMap.put(NameContextsForTests.nameContextForTest().userName(), "testStateFamily");
     executionContext =
         new StreamingModeExecutionContext(
             counterSet,
             "computationId",
             new ReaderCache(),
-            new ConcurrentHashMap<String, String>(),
+            stateNameMap,
             new WindmillStateCache().forComputation("comp"),
             StreamingStepMetricsContainer.createRegistry(),
             new DataflowExecutionStateTracker(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodesTest.java
@@ -47,6 +47,7 @@ import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.dataflow.util.CloudObject;
 import org.apache.beam.runners.dataflow.util.PropertyNames;
+import org.apache.beam.runners.dataflow.worker.NameContextsForTests;
 import org.apache.beam.runners.dataflow.worker.graph.Edges.DefaultEdge;
 import org.apache.beam.runners.dataflow.worker.graph.Edges.Edge;
 import org.apache.beam.runners.dataflow.worker.graph.Nodes.ExecutionLocation;
@@ -114,7 +115,8 @@ public class InsertFetchAndFilterStreamingSideInputNodesTest {
                 pcView,
                 ParDoTranslation.translateWindowMappingFn(
                     pcView.getWindowMappingFn(),
-                    SdkComponents.create(PipelineOptionsFactory.create()))));
+                    SdkComponents.create(PipelineOptionsFactory.create()))),
+            NameContextsForTests.nameContextForTest());
 
     MutableNetwork<Node, Edge> expectedNetwork = createEmptyNetwork();
     expectedNetwork.addNode(predecessor);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/NodesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/NodesTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.SdkFunctionSpec;
 import org.apache.beam.runners.dataflow.worker.DataflowPortabilityPCollectionView;
+import org.apache.beam.runners.dataflow.worker.NameContextsForTests;
 import org.apache.beam.runners.dataflow.worker.counters.NameContext;
 import org.apache.beam.runners.dataflow.worker.graph.Nodes.FetchAndFilterStreamingSideInputsNode;
 import org.apache.beam.runners.dataflow.worker.graph.Nodes.InstructionOutputNode;
@@ -140,15 +141,21 @@ public class NodesTest {
             SdkFunctionSpec.newBuilder()
                 .setSpec(FunctionSpec.newBuilder().setUrn("beam:test:urn:1.0"))
                 .build());
+    NameContext nameContext = NameContextsForTests.nameContextForTest();
     assertSame(
         FetchAndFilterStreamingSideInputsNode.create(
-                windowingStrategy, pcollectionViewsToWindowMappingFns)
+                windowingStrategy, pcollectionViewsToWindowMappingFns, nameContext)
             .getWindowingStrategy(),
         windowingStrategy);
     assertSame(
         FetchAndFilterStreamingSideInputsNode.create(
-                windowingStrategy, pcollectionViewsToWindowMappingFns)
+                windowingStrategy, pcollectionViewsToWindowMappingFns, nameContext)
             .getPCollectionViewsToWindowMappingFns(),
         pcollectionViewsToWindowMappingFns);
+    assertSame(
+        FetchAndFilterStreamingSideInputsNode.create(
+                windowingStrategy, pcollectionViewsToWindowMappingFns, nameContext)
+            .getNameContext(),
+        nameContext);
   }
 }


### PR DESCRIPTION
Plumb names properly through streaming side input consuming DoFns and enforce that state families are always known for stateful steps

R: @kennknowles 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




