### PR TITLE
Revert "[BEAM-5627] Fix the issue of using str while byte is required in a few unit tests"

### DIFF
--- a/sdks/python/apache_beam/io/filesystems_test.py
+++ b/sdks/python/apache_beam/io/filesystems_test.py
@@ -204,7 +204,7 @@ class FileSystemsTest(unittest.TestCase):
     path1 = os.path.join(path_t1, 'f1')
     path2 = os.path.join(path_t2, 'f1')
     with open(path1, 'a') as f:
-      f.write(b'Hello')
+      f.write('Hello')
 
     FileSystems.rename([path_t1], [path_t2])
     self.assertTrue(FileSystems.exists(path_t2))
@@ -216,7 +216,7 @@ class FileSystemsTest(unittest.TestCase):
     path1 = os.path.join(self.tmpdir, 'f1')
     path2 = os.path.join(self.tmpdir, 'f2')
     with open(path1, 'a') as f:
-      f.write(b'Hello')
+      f.write('Hello')
     self.assertTrue(FileSystems.exists(path1))
     self.assertFalse(FileSystems.exists(path2))
 
@@ -224,7 +224,7 @@ class FileSystemsTest(unittest.TestCase):
     path1 = os.path.join(self.tmpdir, 'f1')
 
     with open(path1, 'a') as f:
-      f.write(b'Hello')
+      f.write('Hello')
 
     self.assertTrue(FileSystems.exists(path1))
     FileSystems.delete([path1])

--- a/sdks/python/apache_beam/io/sources_test.py
+++ b/sdks/python/apache_beam/io/sources_test.py
@@ -53,7 +53,7 @@ class LineSource(iobase.BoundedSource):
       for line in f:
         if not range_tracker.try_claim(current):
           return
-        yield line.decode().rstrip('\n')
+        yield line.rstrip('\n')
         current += len(line)
 
   def split(self, desired_bundle_size, start_position=None, stop_position=None):
@@ -83,6 +83,7 @@ class LineSource(iobase.BoundedSource):
 
 
 class SourcesTest(unittest.TestCase):
+
   @classmethod
   def setUpClass(cls):
     # Method has been renamed in Python 3
@@ -91,7 +92,7 @@ class SourcesTest(unittest.TestCase):
 
   def _create_temp_file(self, contents):
     with tempfile.NamedTemporaryFile(delete=False) as f:
-      f.write(contents.encode())
+      f.write(contents)
       return f.name
 
   @unittest.skipIf(sys.version_info[0] == 3 and


### PR DESCRIPTION
Reverts apache/beam#6610