### PR TITLE
[BEAM-5623] Skip tests that halt test suite execution on Python 3

### DIFF
--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -161,6 +161,9 @@ class TextSourceTest(unittest.TestCase):
     self._run_read_test(gzip_file_name, expected_data,
                         compression=CompressionTypes.GZIP)
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_read_empty_single_file_no_eol_gzip(self):
     file_name, written_data = write_data(
         1, no_data=True, eol=EOL.LF_WITH_NOTHING_AT_LAST_LINE)

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -26,6 +26,7 @@ import os
 import pickle
 import random
 import re
+import sys
 import unittest
 from builtins import range
 
@@ -271,6 +272,9 @@ class TestReadFromTFRecord(unittest.TestCase):
                       validate=True))
         assert_that(result, equal_to(['foo', 'bar']))
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_process_auto(self):
     with TempDir() as temp_dir:
       path = temp_dir.create_temp_file('result.gz')
@@ -284,6 +288,9 @@ class TestReadFromTFRecord(unittest.TestCase):
                       validate=True))
         assert_that(result, equal_to(['foo', 'bar']))
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_process_gzip(self):
     with TempDir() as temp_dir:
       path = temp_dir.create_temp_file('result')
@@ -294,6 +301,9 @@ class TestReadFromTFRecord(unittest.TestCase):
                       path, compression_type=CompressionTypes.GZIP))
         assert_that(result, equal_to(['foo', 'bar']))
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_process_gzip_auto(self):
     with TempDir() as temp_dir:
       path = temp_dir.create_temp_file('result.gz')
@@ -364,6 +374,9 @@ class TestReadAllFromTFRecord(unittest.TestCase):
                       compression_type=CompressionTypes.AUTO))
         assert_that(result, equal_to(['foo', 'bar'] * 9))
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_process_gzip(self):
     with TempDir() as temp_dir:
       path = temp_dir.create_temp_file('result')
@@ -376,6 +389,9 @@ class TestReadAllFromTFRecord(unittest.TestCase):
                       compression_type=CompressionTypes.GZIP))
         assert_that(result, equal_to(['foo', 'bar']))
 
+  @unittest.skipIf(sys.version_info[0] == 3,
+                   'This test halts test suite execution on Python 3. '
+                   'TODO: BEAM-5623')
   def test_process_auto(self):
     with TempDir() as temp_dir:
       path = temp_dir.create_temp_file('result.gz')

--- a/sdks/python/apache_beam/runners/portability/stager_test.py
+++ b/sdks/python/apache_beam/runners/portability/stager_test.py
@@ -223,9 +223,9 @@ class StagerTest(unittest.TestCase):
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'abc.txt')))
     self.assertTrue(os.path.isfile(os.path.join(staging_dir, 'def.txt')))
 
-  # TODO(BEAM-5502): Object stager tests are not hermetic.
-  @unittest.skipIf(sys.version_info[0] == 3, 'This test still needs to be '
-                                             'fixed on Python 3')
+  @unittest.skipIf(sys.version_info[0] == 3, 'This test is not hermetic '
+                   'and halts test suite execution on Python 3. '
+                   'TODO: BEAM-5502')
   def test_with_setup_file(self):
     staging_dir = self.make_temp_dir()
     source_dir = self.make_temp_dir()


### PR DESCRIPTION
Several tests in Beam fail to pass on Python 3, and also prevent tox test suite from making progress. This PR disables such tests. We recently started to use RUN_SKIPPED_PY3_TESTS variable to force skipped tests to be included into a Python 3 test suite, however since the tests excluded in this PR interrupt test suite execution, they will not be included even if we set RUN_SKIPPED_PY3_TESTS=1. Luckily, there are only a few of such tests.


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




