### PR TITLE
[BEAM-5713] Make ImpulseSourceFunction execute in parallel

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunction.java
@@ -19,13 +19,13 @@
 package org.apache.beam.runners.flink.translation.functions;
 
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 
 /**
  * Source function which sends an impulse to a downstream operator. It may keep the source alive
  * although its work is already done. It will only shutdown when requested by the JobManager.
  */
-public class ImpulseSourceFunction implements SourceFunction<WindowedValue<byte[]>> {
+public class ImpulseSourceFunction implements ParallelSourceFunction<WindowedValue<byte[]>> {
 
   /** Keep source running even after it has done all the work. */
   private final boolean keepSourceAlive;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/ImpulseInputFormat.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/ImpulseInputFormat.java
@@ -62,8 +62,13 @@ public class ImpulseInputFormat extends RichInputFormat<WindowedValue<byte[]>, G
 
   @Override
   public GenericInputSplit[] createInputSplits(int numSplits) {
-    // Always return a single split because only one global "impulse" will ever be sent.
-    return new GenericInputSplit[] {new GenericInputSplit(1, 1)};
+    // Generate one input split per partition (numSplits) to trigger
+    // an impulse for each parallel instance.
+    GenericInputSplit[] splits = new GenericInputSplit[numSplits];
+    for (int i = 0; i < splits.length; i++) {
+      splits[i] = new GenericInputSplit(i, numSplits);
+    }
+    return splits;
   }
 
   @Override

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableExecutionTest.java
@@ -89,6 +89,7 @@ public class PortableExecutionTest implements Serializable {
     options.setRunner(CrashingRunner.class);
     options.as(FlinkPipelineOptions.class).setFlinkMaster("[local]");
     options.as(FlinkPipelineOptions.class).setStreaming(isStreaming);
+    options.as(FlinkPipelineOptions.class).setParallelism(2);
     options
         .as(PortablePipelineOptions.class)
         .setDefaultEnvironmentType(Environments.ENVIRONMENT_EMBEDDED);
@@ -150,6 +151,6 @@ public class PortableExecutionTest implements Serializable {
 
     assertEquals(1, outputValues.size());
     assertEquals("foo", outputValues.get(0).getKey());
-    assertThat(outputValues.get(0).getValue(), containsInAnyOrder(4L, 3L, 3L));
+    assertThat(outputValues.get(0).getValue(), containsInAnyOrder(4L, 3L, 3L, 4L, 3L, 3L));
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunctionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/ImpulseSourceFunctionTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.runners.flink.translation.functions;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests for {@link ImpulseSourceFunction}. */
+public class ImpulseSourceFunctionTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ImpulseSourceFunctionTest.class);
+
+  @Rule public TestName testName = new TestName();
+
+  private final SourceFunction.SourceContext<WindowedValue<byte[]>> sourceContext;
+
+  public ImpulseSourceFunctionTest() {
+    this.sourceContext = Mockito.mock(SourceFunction.SourceContext.class);
+  }
+
+  @After
+  public void after() {
+    if (testName.getMethodName().equals("testInstanceOfParallelSourceFunction")) {
+      return;
+    }
+    verify(sourceContext).collect(Mockito.any());
+  }
+
+  @Test
+  public void testInstanceOfParallelSourceFunction() {
+    assertThat(new ImpulseSourceFunction(false), instanceOf(ParallelSourceFunction.class));
+  }
+
+  @Test(timeout = 10_000)
+  public void testKeepAlive() throws Exception {
+    ImpulseSourceFunction source = new ImpulseSourceFunction(true);
+    Thread sourceThread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  source.run(sourceContext);
+                  // should not finish
+                } catch (Exception e) {
+                  LOG.error("Exception while executing ImpulseSourceFunction", e);
+                }
+              }
+            });
+    try {
+      sourceThread.start();
+      source.cancel();
+      // should finish
+      sourceThread.join();
+    } finally {
+      sourceThread.interrupt();
+      sourceThread.join();
+    }
+  }
+
+  @Test(timeout = 10_000)
+  public void testKeepAliveDuringInterrupt() throws Exception {
+    ImpulseSourceFunction source = new ImpulseSourceFunction(true);
+    Thread sourceThread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  source.run(sourceContext);
+                  // should not finish
+                } catch (Exception e) {
+                  LOG.error("Exception while executing ImpulseSourceFunction", e);
+                }
+              }
+            });
+
+    sourceThread.start();
+    sourceThread.interrupt();
+    Thread.sleep(200);
+    assertThat(sourceThread.isAlive(), is(true));
+    // should quit
+    source.cancel();
+    sourceThread.interrupt();
+    sourceThread.join();
+  }
+
+  @Test(timeout = 10_000)
+  public void testKeepAliveDisabled() throws Exception {
+    ImpulseSourceFunction source = new ImpulseSourceFunction(false);
+    source.run(sourceContext);
+    // should finish
+  }
+}


### PR DESCRIPTION
SourceFunctions only get deployed in a single task slot. Consequently, Flink
schedules subsequent tasks in task slots on the same TaskManager (if
available). This makes the source parallel which creates multiple instances of
the source. This helps to spread the tasks across all TaskManagers.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




