### PR TITLE
Dataflow Worker: Add worker_id to windmill request headers

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -533,6 +533,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
     return JobHeader.newBuilder()
         .setJobId(options.getJobId())
         .setProjectId(options.getProject())
+        .setWorkerId(options.getWorkerId())
         .build();
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
@@ -299,6 +299,7 @@ public class GrpcWindmillServerTest {
                             JobHeader.newBuilder()
                                 .setJobId("job")
                                 .setProjectId("project")
+                                .setWorkerId("worker")
                                 .build()));
                     sawHeader = true;
                   } else {
@@ -522,7 +523,11 @@ public class GrpcWindmillServerTest {
                   errorCollector.checkThat(
                       request.getHeader(),
                       Matchers.equalTo(
-                          JobHeader.newBuilder().setJobId("job").setProjectId("project").build()));
+                          JobHeader.newBuilder()
+                              .setJobId("job")
+                              .setProjectId("project")
+                              .setWorkerId("worker")
+                              .build()));
                   sawHeader = true;
                   LOG.info("Received header");
                 } else {
@@ -649,6 +654,7 @@ public class GrpcWindmillServerTest {
                             JobHeader.newBuilder()
                                 .setJobId("job")
                                 .setProjectId("project")
+                                .setWorkerId("worker")
                                 .build()));
                     sawHeader = true;
                   } else {

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -446,6 +446,8 @@ message StreamingCommitWorkRequest {
 message JobHeader {
   optional string job_id = 1;
   optional string project_id = 2;
+  // Worker id is meant for logging only. Do not rely on it for other decisions.
+  optional string worker_id = 3;
 }
 
 message StreamingCommitRequestChunk {


### PR DESCRIPTION
Adds 'worker_id' to header for 'commitWork' and 'getData' streaming requests from Dataflow worker to windmill. 

+R: @boyuanzz 