### PR TITLE
[BEAM-5636] Java support for custom dataflow worker jar

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -741,6 +741,15 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
         options.getStager().stageToFile(serializedProtoPipeline, PIPELINE_FILE_NAME);
     dataflowOptions.setPipelineUrl(stagedPipeline.getLocation());
 
+    if (!isNullOrEmpty(dataflowOptions.getDataflowWorkerJar())) {
+      List<String> experiments =
+          dataflowOptions.getExperiments() == null
+              ? new ArrayList<>()
+              : dataflowOptions.getExperiments();
+      experiments.add("use_staged_dataflow_worker_jar");
+      dataflowOptions.setExperiments(experiments);
+    }
+
     Job newJob = jobSpecification.getJob();
     try {
       newJob
@@ -791,6 +800,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             minCpuFlags.get(0));
       }
     }
+
     newJob.getEnvironment().setExperiments(experiments);
 
     // Set the Docker container image that executes Dataflow worker harness, residing in Google

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineOptions.java
@@ -136,6 +136,11 @@ public interface DataflowPipelineOptions
 
   void setPipelineUrl(String urlString);
 
+  @Description("The customized dataflow worker jar")
+  String getDataflowWorkerJar();
+
+  void setDataflowWorkerJar(String dataflowWorkerJar);
+
   /** Returns a default staging location under {@link GcpOptions#getGcpTempLocation}. */
   class StagingLocationFactory implements DefaultValueFactory<String> {
     private static final Logger LOG = LoggerFactory.getLogger(StagingLocationFactory.class);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/GcsStager.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/GcsStager.java
@@ -54,11 +54,15 @@ public class GcsStager implements Stager {
     checkNotNull(options.getStagingLocation());
     String windmillBinary =
         options.as(DataflowPipelineDebugOptions.class).getOverrideWindmillBinary();
-
+    String dataflowWorkerJar = options.getDataflowWorkerJar();
     List<String> filesToStage = options.getFilesToStage();
 
     if (windmillBinary != null) {
       filesToStage.add("windmill_main=" + windmillBinary);
+    }
+
+    if (dataflowWorkerJar != null && !dataflowWorkerJar.isEmpty()) {
+      filesToStage.add("dataflow-worker.jar=" + dataflowWorkerJar);
     }
 
     return stageFiles(filesToStage);

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -103,7 +103,17 @@ func main() {
 		filepath.Join(jarsDir, "slf4j-jdk14.jar"),
 		filepath.Join(jarsDir, "beam-sdks-java-harness.jar"),
 	}
+
+	var hasWorkerExperiment = strings.Contains(options, "use_staged_dataflow_worker_jar")
 	for _, md := range artifacts {
+		if hasWorkerExperiment {
+			if strings.HasPrefix(md.Name, "beam-runners-google-cloud-dataflow-java-fn-api-worker") {
+				continue
+			}
+			if md.Name == "dataflow-worker.jar" {
+				continue
+			}
+		}
 		cp = append(cp, filepath.Join(dir, filepath.FromSlash(md.Name)))
 	}
 


### PR DESCRIPTION
Added pipeline option: dataflowWorkerJar=${PATH} and experimental flag: use_staged_dataflow_worker_jar to make java pipeline can be launched with custom dataflow worker jar.

R: @herohde 
cc: @HuangLED 