### PR TITLE
[BEAM-1081] Annotations custom message support and classes tests.

### DIFF
--- a/sdks/python/apache_beam/utils/annotations.py
+++ b/sdks/python/apache_beam/utils/annotations.py
@@ -62,6 +62,14 @@ same function 'multiply'.::
   def exp_multiply(arg1, arg2):
     print(arg1, '*', arg2, '(the experimental way)=', end=' ')
     return (arg1*arg2)*(arg1/arg2)*(arg2/arg1)
+# If a custom message is needed, on both annotations types the arg custom_message
+# can be used.
+  @experimental(since='v.1', current='multiply'
+                custom_message='Experimental since %since%
+                                Please use %current% insted.')
+  def exp_multiply(arg1, arg2):
+    print(arg1, '*', arg2, '(the experimental way)=', end=' ')
+    return (arg1*arg2)*(arg1/arg2)*(arg2/arg1)
 
 # Set a warning filter to control how often warnings are produced.::
 
@@ -84,17 +92,27 @@ from functools import wraps
 warnings.simplefilter("once")
 
 
-def annotate(label, since, current, extra_message):
-  """Decorates a function with a deprecated or experimental annotation.
+def annotate(label, since, current, extra_message, custom_message=None):
+  """Decorates an API with a deprecated or experimental annotation.
 
   Args:
     label: the kind of annotation ('deprecated' or 'experimental').
     since: the version that causes the annotation.
     current: the suggested replacement function.
     extra_message: an optional additional message.
+    custom_message: if the default message does not suffice, the message
+                    can be changed using this argument. A string
+                    whit replacement strings.
+                    A replecement string is were the previus args will
+                    be located on the custom message.
+                    The following replacement strings can be used:
+                      %name% -> API.__name__
+                      %since% -> since (Mandatory for the decapreted annotation)
+                      %current% -> current
+                      %extra% -> extra_message
 
   Returns:
-    The decorator for the function.
+    The decorator for the API.
   """
   def _annotate(fnc):
     @wraps(fnc)
@@ -103,12 +121,23 @@ def annotate(label, since, current, extra_message):
         warning_type = DeprecationWarning
       else:
         warning_type = FutureWarning
-      message = '%s is %s' % (fnc.__name__, label)
-      if label == 'deprecated':
-        message += ' since %s' % since
-      message += '. Use %s instead.' % current if current else '.'
-      if extra_message:
-        message += ' ' + extra_message
+      if(custom_message == None):
+        message = '%s is %s' % (fnc.__name__, label)
+        if label == 'deprecated':
+          message += ' since %s' % since
+        message += '. Use %s instead.' % current if current else '.'
+        if extra_message:
+          message += ' ' + extra_message
+      else:
+        if label == 'deprecated' and '%since%' not in custom_message:
+          raise TypeError("Replacement string %since% not found on \
+          custom message")
+        emptyArg = lambda x: '' if x == None  else x
+        message = custom_message\
+        .replace('%name%', fnc.__name__)\
+        .replace('%since%', emptyArg(since))\
+        .replace('%current%', emptyArg(current))\
+        .replace('%extra%', emptyArg(extra_message))
       warnings.warn(message, warning_type, stacklevel=2)
       return fnc(*args, **kwargs)
     return inner

--- a/sdks/python/apache_beam/utils/annotations_test.py
+++ b/sdks/python/apache_beam/utils/annotations_test.py
@@ -1,4 +1,3 @@
-#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -34,13 +33,32 @@ class AnnotationTests(unittest.TestCase):
         return 'lol'
       fnc_test_deprecated_with_since_current_message()
       self.check_annotation(
+        warning=w, warning_size=1,
+        warning_type=DeprecationWarning,
+        obj_name='fnc_test_deprecated_with_since_current_message',
+        annotation_type='deprecated',
+        label_check_list=[('since', True),
+                          ('instead', True),
+                          ('Do this', True)])
+
+  def test_deprecated_with_since_current_message_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @deprecated(since='v.1', current='multiply', extra_message='Do this')
+      class Class_test_deprecated_with_since_current_message:
+        fooo = 'lol'
+        def foo(self):
+          return 'lol'
+      foo = Class_test_deprecated_with_since_current_message()
+      foo.foo()
+      self.check_annotation(
           warning=w, warning_size=1,
           warning_type=DeprecationWarning,
-          fnc_name='fnc_test_deprecated_with_since_current_message',
+          fnc_name='Class_test_deprecated_with_since_current_message',
           annotation_type='deprecated',
           label_check_list=[('since', True),
                             ('instead', True),
                             ('Do this', True)])
+
 
   def test_deprecated_with_since_current(self):
     with warnings.catch_warnings(record=True) as w:
@@ -48,9 +66,27 @@ class AnnotationTests(unittest.TestCase):
       def fnc_test_deprecated_with_since_current():
         return 'lol'
       fnc_test_deprecated_with_since_current()
+      self.check_annotation(
+        warning=w, warning_size=1,
+        warning_type=DeprecationWarning,
+        obj_name='fnc_test_deprecated_with_since_current',
+        annotation_type='deprecated',
+        label_check_list=[('since', True),
+                          ('instead', True)])
+
+
+  def test_deprecated_with_since_current_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @deprecated(since='v.1', current='multiply')
+      class Class_test_deprecated_with_since_current():
+        fooo = 'lol'
+        def foo(self):
+          return 'lol'
+      foo = Class_test_deprecated_with_since_current()
+      foo.foo()
       self.check_annotation(warning=w, warning_size=1,
                             warning_type=DeprecationWarning,
-                            fnc_name='fnc_test_deprecated_with_since_current',
+                            fnc_name='Class_test_deprecated_with_since_current',
                             annotation_type='deprecated',
                             label_check_list=[('since', True),
                                               ('instead', True)])
@@ -61,9 +97,26 @@ class AnnotationTests(unittest.TestCase):
       def fnc_test_deprecated_without_current():
         return 'lol'
       fnc_test_deprecated_without_current()
+      self.check_annotation(
+        warning=w, warning_size=1,
+        warning_type=DeprecationWarning,
+        obj_name='fnc_test_deprecated_without_current',
+        annotation_type='deprecated',
+        label_check_list=[('since', True),
+                          ('instead', False)])
+
+  def test_deprecated_without_current_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @deprecated(since='v.1')
+      class Class_test_deprecated_without_current():
+        fooo = 'lol'
+        def foo(self):
+          return 'lol'
+      foo = Class_test_deprecated_without_current()
+      foo.foo()
       self.check_annotation(warning=w, warning_size=1,
                             warning_type=DeprecationWarning,
-                            fnc_name='fnc_test_deprecated_without_current',
+                            fnc_name='Class_test_deprecated_without_current',
                             annotation_type='deprecated',
                             label_check_list=[('since', True),
                                               ('instead', False)])
@@ -78,6 +131,29 @@ class AnnotationTests(unittest.TestCase):
         fnc_test_deprecated_without_since_should_fail()
       assert not w
 
+<<<<<<< HEAD
+  def test_deprecated_without_since_custom_should_fail(self):
+    with warnings.catch_warnings(record=True) as w:
+      with self.assertRaises(TypeError):
+        @deprecated(custom_message='Test %since%')
+        def fnc_test_deprecated_without_since_custom_should_fail():
+          return 'lol'
+        fnc_test_deprecated_without_since_custom_should_fail()
+=======
+  def test_deprecated_without_since_should_fail_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      with self.assertRaises(TypeError):
+
+        @deprecated()
+        class Class_test_deprecated_without_since_should_fail():
+          fooo = 'lol'
+          def foo(self):
+            return 'lol'
+        foo = Class_test_deprecated_without_since_should_fail()
+        foo.foo()
+>>>>>>> ae3ee47cf9e131cf66644532022178d559d9237d
+      assert not w
+
   def test_experimental_with_current_message(self):
     with warnings.catch_warnings(record=True) as w:
       @experimental(current='multiply', extra_message='Do this')
@@ -87,7 +163,24 @@ class AnnotationTests(unittest.TestCase):
       self.check_annotation(
           warning=w, warning_size=1,
           warning_type=FutureWarning,
-          fnc_name='fnc_test_experimental_with_current_message',
+          obj_name='fnc_test_experimental_with_current_message',
+          annotation_type='experimental',
+          label_check_list=[('instead', True),
+                            ('Do this', True)])
+
+  def test_experimental_with_current_message_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @experimental(current='multiply', extra_message='Do this')
+      class Class_test_experimental_with_current_message():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_experimental_with_current_message()
+      foo.foo()
+      self.check_annotation(
+          warning=w, warning_size=1,
+          warning_type=FutureWarning,
+          fnc_name='Class_test_experimental_with_current_message',
           annotation_type='experimental',
           label_check_list=[('instead', True),
                             ('Do this', True)])
@@ -98,9 +191,25 @@ class AnnotationTests(unittest.TestCase):
       def fnc_test_experimental_with_current():
         return 'lol'
       fnc_test_experimental_with_current()
+      self.check_annotation(
+        warning=w, warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='fnc_test_experimental_with_current',
+        annotation_type='experimental',
+        label_check_list=[('instead', True)])
+
+  def test_experimental_with_current_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @experimental(current='multiply')
+      class Class_test_experimental_with_current():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_experimental_with_current()
+      foo.foo()
       self.check_annotation(warning=w, warning_size=1,
                             warning_type=FutureWarning,
-                            fnc_name='fnc_test_experimental_with_current',
+                            fnc_name='Class_test_experimental_with_current',
                             annotation_type='experimental',
                             label_check_list=[('instead', True)])
 
@@ -110,9 +219,25 @@ class AnnotationTests(unittest.TestCase):
       def fnc_test_experimental_without_current():
         return 'lol'
       fnc_test_experimental_without_current()
+      self.check_annotation(
+        warning=w, warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='fnc_test_experimental_without_current',
+        annotation_type='experimental',
+        label_check_list=[('instead', False)])
+
+  def test_experimental_without_current_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @experimental()
+      class Class_test_experimental_without_current():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_experimental_without_current()
+      foo.foo()
       self.check_annotation(warning=w, warning_size=1,
                             warning_type=FutureWarning,
-                            fnc_name='fnc_test_experimental_without_current',
+                            fnc_name='Class_test_experimental_without_current',
                             annotation_type='experimental',
                             label_check_list=[('instead', False)])
 
@@ -130,29 +255,223 @@ class AnnotationTests(unittest.TestCase):
       fnc_test_annotate_frequency()
       fnc_test_annotate_frequency()
       fnc2_test_annotate_frequency()
+      self.check_annotation(
+        warning=[w[0]], warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='fnc_test_annotate_frequency',
+      annotation_type='experimental',
+        label_check_list=[])
+      self.check_annotation(
+        warning=[w[1]], warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='fnc2_test_annotate_frequency',
+        annotation_type='experimental',
+        label_check_list=[])
+
+  def test_frequency_class(self):
+    """Tests that the filter 'once' is sufficient to print once per
+    warning independently of location."""
+    with warnings.catch_warnings(record=True) as w:
+      @experimental()
+      class Class_test_annotate_frequency():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+
+      @experimental()
+      class Class2_test_annotate_frequency():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_annotate_frequency()
+      foo.foo()
+      foo1 = Class_test_annotate_frequency()
+      foo1.foo()
+      foo2 = Class2_test_annotate_frequency()
+      foo2.foo()
+      self.check_annotation(
+        warning=[w[0]], warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='Class_test_annotate_frequency',
+        annotation_type='experimental',
+        label_check_list=[])
+      self.check_annotation(
+        warning=[w[1]], warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='Class2_test_annotate_frequency',
+        annotation_type='experimental',
+        label_check_list=[])
+
+
+  def test_decapreted_custom_no_replacements(self):
+    """Tests if custom message prints an empty string
+    for each replacement string when only the
+    custom_message and since parameter are given."""
+    with warnings.catch_warnings(record=True) as w:
+      strSince='v1'
+      strCustom = 'Replacement:%since%%current%%extra%'
+      @deprecated(since=strSince,custom_message=strCustom)
+      def fnc_test_experimental_custom_no_replacements():
+        return 'lol'
+      fnc_test_experimental_custom_no_replacements()
+      self.check_custom_annotation(
+        warning=w, warning_size=1,
+        warning_type=DeprecationWarning,
+        obj_name='fnc_test_experimental_custom_no_replacements',
+        annotation_type='experimental',
+        intended_message=strCustom
+        .replace('%since%',strSince)
+        .replace('%current%','')
+        .replace('%extra%',''))
+
+
+  def test_enforce_custom_since_decapretaded_must_fail(self):
+    """Tests since replacement string inclusion on the
+    custom message for the decapreted string. If no
+    since replacement string is given, the annotation must fail"""
+    with warnings.catch_warnings(record=True) as w:
+      with self.assertRaises(TypeError):
+        strSince='v1'
+        strCustom = 'Replacement:'
+        @deprecated(since=strSince,custom_message=strCustom)
+        def fnc_test_experimental_custom_no_replacements():
+          return 'lol'
+        fnc_test_experimental_custom_no_replacements()
+      assert not w
+
+
+  def test_deprecated_with_since_current_message_custom(self):
+    with warnings.catch_warnings(record=True) as w:
+      strSince = 'v.1'
+      strCurrent = 'multiply'
+      strExtra = 'Do this'
+      strCustom="%name% Will be deprecated from %since%. \
+                  Please use %current% insted. Will %extra%"
+      @deprecated(since=strSince, current=strCurrent, extra_message=strExtra,
+                  custom_message=strCustom)
+      def fnc_test_deprecated_with_since_current_message_custom():
+        return 'lol'
+      fnc_test_deprecated_with_since_current_message_custom()
+      self.check_custom_annotation(
+        warning=w, warning_size=1,
+        warning_type=DeprecationWarning,
+        obj_name='fnc_test_deprecated_with_since_current_message_custom',
+        annotation_type='deprecated',
+        intended_message=strCustom
+        .replace('%name%', fnc_test_deprecated_with_since_current_message_custom.__name__)
+        .replace('%since%', strSince)
+        .replace('%current%', strCurrent)
+        .replace('%extra%', strExtra))
+
+  def test_deprecated_with_since_current_message_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @deprecated(since='v.1', current='multiply', extra_message='Do this')
+      class Class_test_deprecated_with_since_current_message:
+        fooo = 'lol'
+        def foo(self):
+          return 'lol'
+      foo = Class_test_deprecated_with_since_current_message()
+      foo.foo()
+      self.check_annotation(
+          warning=w, warning_size=1,
+          warning_type=DeprecationWarning,
+          obj_name='Class_test_deprecated_with_since_current_message',
+          annotation_type='deprecated',
+          label_check_list=[('since', True),
+                            ('instead', True),
+                            ('Do this', True)])
+
+
+  def test_experimental_with_current_message_custom(self):
+    with warnings.catch_warnings(record=True) as w:
+      strCurrent='multiply'
+      strExtra='DoThis'
+      strCustom='%name% Function on experimental phase, use %current% \
+      for stability. Will %extra%.'
+      @experimental(current=strCurrent, extra_message=strExtra,
+                    custom_message=strCustom)
+      def fnc_test_experimental_with_current_message_custom():
+        return 'lol'
+      fnc_test_experimental_with_current_message_custom()
+      self.check_custom_annotation(
+        warning=w, warning_size=1,
+        warning_type=FutureWarning,
+        obj_name='fnc_test_experimental_with_current_message_custom',
+        annotation_type='experimental',
+        intended_message=strCustom
+        .replace('%name%',fnc_test_experimental_with_current_message_custom.__name__)
+        .replace('%current%', strCurrent)
+        .replace('%extra%', strExtra))
+
+
+  def test_experimental_with_current_message_class(self):
+    with warnings.catch_warnings(record=True) as w:
+      @experimental(current='multiply', extra_message='Do this')
+      class Class_test_experimental_with_current_message():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_experimental_with_current_message()
+      foo.foo()
+      self.check_annotation(
+          warning=w, warning_size=1,
+          warning_type=FutureWarning,
+          obj_name='Class_test_experimental_with_current_message',
+          annotation_type='experimental',
+          label_check_list=[('instead', True),
+                            ('Do this', True)])
+
+
+  def test_frequency_class(self):
+    """Tests that the filter 'once' is sufficient to print once per
+    warning independently of location."""
+    with warnings.catch_warnings(record=True) as w:
+      @experimental()
+      class Class_test_annotate_frequency():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+
+      @experimental()
+      class Class2_test_annotate_frequency():
+        fooo = 'lol'
+        def foo(self):
+            return 'lol'
+      foo = Class_test_annotate_frequency()
+      foo.foo()
+      foo1 = Class_test_annotate_frequency()
+      foo1.foo()
+      foo2 = Class2_test_annotate_frequency()
+      foo2.foo()
       self.check_annotation(warning=[w[0]], warning_size=1,
                             warning_type=FutureWarning,
-                            fnc_name='fnc_test_annotate_frequency',
+                            fnc_name='Class_test_annotate_frequency',
                             annotation_type='experimental',
                             label_check_list=[])
       self.check_annotation(warning=[w[1]], warning_size=1,
                             warning_type=FutureWarning,
-                            fnc_name='fnc2_test_annotate_frequency',
+                            fnc_name='Class2_test_annotate_frequency',
                             annotation_type='experimental',
                             label_check_list=[])
 
   # helper function
-  def check_annotation(self, warning, warning_size, warning_type, fnc_name,
+  def check_annotation(self, warning, warning_size, warning_type, obj_name,
                        annotation_type, label_check_list):
     self.assertEqual(1, warning_size)
     self.assertTrue(issubclass(warning[-1].category, warning_type))
-    self.assertIn(fnc_name + ' is ' + annotation_type, str(warning[-1].message))
+    self.assertIn(obj_name + ' is ' + annotation_type, str(warning[-1].message))
     for label in label_check_list:
       if label[1] is True:
         self.assertIn(label[0], str(warning[-1].message))
       else:
         self.assertNotIn(label[0], str(warning[-1].message))
 
+  # Helper function for custom messages
+  def check_custom_annotation(self, warning, warning_size, warning_type, obj_name,
+                              annotation_type, intended_message):
+    self.assertEqual(1, warning_size)
+    self.assertTrue(issubclass(warning[-1].category, warning_type))
+    self.assertIn(intended_message , str(warning[-1].message))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Added support for custom messages using the arg "custom_message".
The annotation decorator already supports tagging classes, I only added a few tests to check it out.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




