### PR TITLE
[BEAM-5442] Revert #6675 "Revert PRs #6557 #6589 #6600"

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -45,16 +45,24 @@ class PipelineOptionsTest(unittest.TestCase):
        'display_data': [DisplayDataItemMatcher('num_workers', 5)]},
       {
           'flags': [
-              '--profile_cpu', '--profile_location', 'gs://bucket/', 'ignored'],
+              '--profile_cpu', '--profile_location', 'gs://bucket/',
+              'ignored', '-invalid=arg', '--unknown_arg', 'unknown_value',
+              '--unknown_flag'
+          ],
           'expected': {
               'profile_cpu': True, 'profile_location': 'gs://bucket/',
               'mock_flag': False, 'mock_option': None,
-              'mock_multi_option': None},
+              'mock_multi_option': None,
+              'unknown_arg': 'unknown_value',
+              'unknown_flag': None},
           'display_data': [
               DisplayDataItemMatcher('profile_cpu',
                                      True),
               DisplayDataItemMatcher('profile_location',
-                                     'gs://bucket/')]
+                                     'gs://bucket/'),
+              DisplayDataItemMatcher('unknown_arg',
+                                     'unknown_value')
+          ]
       },
       {'flags': ['--num_workers', '5', '--mock_flag'],
        'expected': {'num_workers': 5,
@@ -280,6 +288,15 @@ class PipelineOptionsTest(unittest.TestCase):
 
     with self.assertRaises(RuntimeError):
       options.pot_non_vp_arg1.get()
+
+  # Converts duplicate unknown argument values to a single argument
+  # with a list value.
+  def test_unknown_duplicate_args_converted_to_list(self):
+    options = PipelineOptions(['--dup_arg', 'val1',
+                               '--dup_arg', 'val2',
+                               '--dup_arg=val3'])
+    self.assertEqual(options.get_all_options()['dup_arg'],
+                     ['val1', 'val2', 'val3'])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -56,8 +56,8 @@ class SdkWorkerMainTest(unittest.TestCase):
   def test_work_count_default_value(self):
     self._check_worker_count('{}', 12)
 
-  def test_parse_pipeine_options(self):
-    expected_options = PipelineOptions()
+  def test_parse_pipeline_options(self):
+    expected_options = PipelineOptions([])
     expected_options.view_as(
         SdkWorkerMainTest.MockOptions).m_m_option = [
             'worker_threads=1', 'beam_fn_api'


### PR DESCRIPTION
Reverts apache/beam#6675

We are reverting #6675 because the intent of that change was to make sure we did not release with these new semantics.  Per our discussion on the mailing list, it seems that we are in agreement that we need better scoping for these runner options, which we will work on after this change.