### PR TITLE
[BEAM-5649] Conditionally remove CREATE_VIEW from java generated protos.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
@@ -19,11 +19,16 @@
 package org.apache.beam.runners.core.construction;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.graph.PipelineValidator;
 import org.apache.beam.sdk.Pipeline;
@@ -38,8 +43,19 @@ public class PipelineTranslation {
     return toProto(pipeline, SdkComponents.create(pipeline.getOptions()));
   }
 
+  public static RunnerApi.Pipeline toProto(Pipeline pipeline, boolean useDeprecatedViewTransforms) {
+    return toProto(
+        pipeline, SdkComponents.create(pipeline.getOptions()), useDeprecatedViewTransforms);
+  }
+
+  public static RunnerApi.Pipeline toProto(Pipeline pipeline, SdkComponents components) {
+    return toProto(pipeline, components, false);
+  }
+
   public static RunnerApi.Pipeline toProto(
-      final Pipeline pipeline, final SdkComponents components) {
+      final Pipeline pipeline,
+      final SdkComponents components,
+      boolean useDeprecatedViewTransforms) {
     final Collection<String> rootIds = new HashSet<>();
     pipeline.traverseTopologically(
         new PipelineVisitor.Defaults() {
@@ -81,8 +97,83 @@ public class PipelineTranslation {
             .setComponents(components.toComponents())
             .addAllRootTransformIds(rootIds)
             .build();
+    if (!useDeprecatedViewTransforms) {
+      // TODO(JIRA-5649): Don't even emit these transforms in the generated protos.
+      res = elideDeprecatedViews(res);
+    }
     // Validate that translation didn't produce an invalid pipeline.
     PipelineValidator.validate(res);
     return res;
+  }
+
+  private static RunnerApi.Pipeline elideDeprecatedViews(RunnerApi.Pipeline pipeline) {
+    // Record data on CreateView operations.
+    Set<String> viewTransforms = new HashSet<>();
+    Map<String, String> viewOutputsToInputs = new HashMap<>();
+    pipeline
+        .getComponents()
+        .getTransformsMap()
+        .forEach(
+            (transformId, transform) -> {
+              if (transform
+                  .getSpec()
+                  .getUrn()
+                  .equals(PTransformTranslation.CREATE_VIEW_TRANSFORM_URN)) {
+                viewTransforms.add(transformId);
+                viewOutputsToInputs.put(
+                    Iterables.getOnlyElement(transform.getOutputsMap().values()),
+                    Iterables.getOnlyElement(transform.getInputsMap().values()));
+              }
+            });
+    // Fix up view references.
+    Map<String, RunnerApi.PTransform> newTransforms = new HashMap<>();
+    pipeline
+        .getComponents()
+        .getTransformsMap()
+        .forEach(
+            (transformId, transform) -> {
+              RunnerApi.PTransform.Builder transformBuilder = transform.toBuilder();
+              transform
+                  .getInputsMap()
+                  .forEach(
+                      (key, value) -> {
+                        if (viewOutputsToInputs.containsKey(value)) {
+                          transformBuilder.putInputs(key, viewOutputsToInputs.get(value));
+                        }
+                      });
+              transform
+                  .getOutputsMap()
+                  .forEach(
+                      (key, value) -> {
+                        if (viewOutputsToInputs.containsKey(value)) {
+                          transformBuilder.putOutputs(key, viewOutputsToInputs.get(value));
+                        }
+                      });
+              // Unfortunately transformBuilder.getSubtransformsList().removeAll(viewTransforms)
+              // throws UnsupportedOperationException.
+              transformBuilder.clearSubtransforms();
+              transformBuilder.addAllSubtransforms(
+                  transform
+                      .getSubtransformsList()
+                      .stream()
+                      .filter(id -> !viewTransforms.contains(id))
+                      .collect(Collectors.toList()));
+              newTransforms.put(transformId, transformBuilder.build());
+            });
+
+    RunnerApi.Pipeline.Builder newPipeline = pipeline.toBuilder();
+    // Replace transforms.
+    newPipeline.getComponentsBuilder().putAllTransforms(newTransforms);
+    // Remove CreateView operation components.
+    viewTransforms.forEach(newPipeline.getComponentsBuilder()::removeTransforms);
+    viewOutputsToInputs.keySet().forEach(newPipeline.getComponentsBuilder()::removePcollections);
+    newPipeline.clearRootTransformIds();
+    newPipeline.addAllRootTransformIds(
+        pipeline
+            .getRootTransformIdsList()
+            .stream()
+            .filter(id -> !viewTransforms.contains(id))
+            .collect(Collectors.toList()));
+    return newPipeline.build();
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -140,13 +140,6 @@ public class FlinkBatchPortablePipelineTranslator
     translatorMap.put(
         PTransformTranslation.RESHUFFLE_URN,
         FlinkBatchPortablePipelineTranslator::translateReshuffle);
-    translatorMap.put(
-        PTransformTranslation.CREATE_VIEW_TRANSFORM_URN,
-        // https://issues.apache.org/jira/browse/BEAM-5649
-        // Need to support this via a NOOP until the primitive is removed
-        (PTransformNode transform,
-            RunnerApi.Pipeline pipeline,
-            BatchTranslationContext context) -> {});
     return new FlinkBatchPortablePipelineTranslator(translatorMap.build());
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -170,12 +170,6 @@ public class FlinkStreamingPortablePipelineTranslator
     translatorMap.put(ExecutableStage.URN, this::translateExecutableStage);
     translatorMap.put(PTransformTranslation.RESHUFFLE_URN, this::translateReshuffle);
 
-    translatorMap.put(
-        // https://issues.apache.org/jira/browse/BEAM-5649
-        // Need to support this via a NOOP until the primitive is removed
-        PTransformTranslation.CREATE_VIEW_TRANSFORM_URN,
-        (String id, RunnerApi.Pipeline pipeline, StreamingTranslationContext context) -> {});
-
     this.urnToTransformTranslator = translatorMap.build();
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -161,7 +161,7 @@ public class DataflowPipelineTranslator {
     // Capture the sdkComponents for look up during step translations
     SdkComponents sdkComponents = SdkComponents.create();
     sdkComponents.registerEnvironment(Environments.JAVA_SDK_HARNESS_ENVIRONMENT);
-    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(pipeline, sdkComponents);
+    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(pipeline, sdkComponents, true);
 
     LOG.debug("Portable pipeline proto:\n{}", TextFormat.printToString(pipelineProto));
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -322,7 +322,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                 .withOutputTags(mainOutput, TupleTagList.of(additionalOutput)));
 
     SdkComponents sdkComponents = SdkComponents.create(p.getOptions());
-    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents);
+    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents, true);
     String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
     String outputPCollectionId =
         sdkComponents.registerPCollection(outputPCollection.get(mainOutput));
@@ -445,7 +445,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                 .withSideInputs(iterableSideInputView));
 
     SdkComponents sdkComponents = SdkComponents.create(p.getOptions());
-    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents);
+    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents, true);
     String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
     String outputPCollectionId = sdkComponents.registerPCollection(outputPCollection);
 


### PR DESCRIPTION
The graph generation is tightly coupled to legacy runner execution, but this
makes it possible for these implementation details to not leak outside of the
Java SDK.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




