### PR TITLE
[BEAM-5730] Migrate ITs using DataflowRunner to use custom worker

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -108,7 +108,7 @@ task validatesRunnerTest(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-validates-runner-tests/'
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -31,6 +31,7 @@ description = "Apache Beam :: Runners :: Google Cloud Dataflow"
 evaluationDependsOn(":beam-sdks-java-io-google-cloud-platform")
 evaluationDependsOn(":beam-sdks-java-core")
 evaluationDependsOn(":beam-examples-java")
+evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
 
 processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
@@ -104,12 +105,18 @@ test {
 
 task validatesRunnerTest(type: Test) {
   group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-validates-runner-tests/'
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
           "--project=${dataflowProject}",
           "--tempRoot=${dataflowTempRoot}",
+          "--dataflowWorkerJar=${dataflowWorkerJar}",
+          "--workerHarnessContainerImage=",
+
   ])
 
   // Increase test parallelism up to the number of Gradle workers. By default this is equal
@@ -141,12 +148,19 @@ task validatesRunner {
 
 task googleCloudPlatformIntegrationTest(type: Test) {
   group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar')
+  if (!project.findProperty('dataflowWorkerJar')) {
+    dataflowWorkerJar = project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  }
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
           "--project=${dataflowProject}",
           "--tempRoot=${dataflowTempRoot}",
+          "--dataflowWorkerJar=${dataflowWorkerJar}",
+          "--workerHarnessContainerImage=",
   ])
 
   include '**/*IT.class'
@@ -160,12 +174,17 @@ task googleCloudPlatformIntegrationTest(type: Test) {
 
 task examplesJavaIntegrationTest(type: Test) {
   group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
           "--project=${dataflowProject}",
           "--tempRoot=${dataflowTempRoot}",
+          "--dataflowWorkerJar=${dataflowWorkerJar}",
+          "--workerHarnessContainerImage=",
   ])
 
   // The examples/java preCommit task already covers running WordCountIT/WindowedWordCountIT so
@@ -181,12 +200,17 @@ task examplesJavaIntegrationTest(type: Test) {
 
 task coreSDKJavaIntegrationTest(type: Test) {
   group = "Verification"
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
           "--project=${dataflowProject}",
           "--tempRoot=${dataflowTempRoot}",
+          "--dataflowWorkerJar=${dataflowWorkerJar}",
+          "--workerHarnessContainerImage=",
   ])
 
   include '**/*IT.class'

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -103,6 +103,8 @@ test {
   systemProperties = [ "beamUseDummyRunner" : "true" ]
 }
 
+//For the following test tasks, set workerHarnessContainerImage to empty to make Dataflow pick up
+// the non-versioned container image, which handles a staged worker jar.
 task validatesRunnerTest(type: Test) {
   group = "Verification"
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -153,7 +153,7 @@ task googleCloudPlatformIntegrationTest(type: Test) {
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar')
   if (!project.findProperty('dataflowWorkerJar')) {
-    dataflowWorkerJar = project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+    dataflowWorkerJar = project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
   }
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
@@ -177,7 +177,7 @@ task examplesJavaIntegrationTest(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
@@ -203,7 +203,7 @@ task coreSDKJavaIntegrationTest(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -151,10 +151,7 @@ task googleCloudPlatformIntegrationTest(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowProject = project.findProperty('dataflowProject') ?: 'apache-beam-testing'
   def dataflowTempRoot = project.findProperty('dataflowTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar')
-  if (!project.findProperty('dataflowWorkerJar')) {
-    dataflowWorkerJar = project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
-  }
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
           "--runner=TestDataflowRunner",
           "--project=${dataflowProject}",

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -103,7 +103,7 @@ test {
   systemProperties = [ "beamUseDummyRunner" : "true" ]
 }
 
-//For the following test tasks, set workerHarnessContainerImage to empty to make Dataflow pick up
+// For the following test tasks, set workerHarnessContainerImage to empty to make Dataflow pick up
 // the non-versioned container image, which handles a staged worker jar.
 task validatesRunnerTest(type: Test) {
   group = "Verification"

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -39,8 +39,8 @@ task preCommit(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
-  //Set workerHarnessContainerImage to empty to make Dataflow pick up the non-versioned container
-  //image, which handles a staged worker jar.
+  // Set workerHarnessContainerImage to empty to make Dataflow pick up the non-versioned container
+  // image, which handles a staged worker jar.
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",
      "--tempRoot=${gcsTempRoot}",

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -37,7 +37,7 @@ def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-
 
 task preCommit(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -39,6 +39,8 @@ task preCommit(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
+  //Set workerHarnessContainerImage to empty to make Dataflow pick up the non-versioned container
+  //image, which handles a staged worker jar.
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",
      "--tempRoot=${gcsTempRoot}",

--- a/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples-streaming/build.gradle
@@ -23,6 +23,7 @@ applyJavaNature(publish: false)
 // Evaluate the given project before this one, to allow referencing
 // its sourceSets.test.output directly.
 evaluationDependsOn(":beam-examples-java")
+evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
 
 configurations { dataflowStreamingRunnerPreCommit }
 
@@ -35,10 +36,15 @@ def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
 def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
 
 task preCommit(type: Test) {
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",
      "--tempRoot=${gcsTempRoot}",
      "--runner=TestDataflowRunner",
+     "--dataflowWorkerJar=${dataflowWorkerJar}",
+     "--workerHarnessContainerImage=",
      "--streaming=true",
   ]
   testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -40,6 +40,8 @@ task preCommit(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
+  //Set workerHarnessContainerImage to empty to make Dataflow pick up the non-versioned container
+  //image, which handles a staged worker jar.
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",
      "--tempRoot=${gcsTempRoot}",

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -23,6 +23,7 @@ applyJavaNature(publish: false)
 // Evaluate the given project before this one, to allow referencing
 // its sourceSets.test.output directly.
 evaluationDependsOn(":beam-examples-java")
+evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
 
 configurations { dataflowRunnerPreCommit }
 
@@ -31,14 +32,20 @@ dependencies {
   testRuntimeOnly project(path: ":beam-examples-java", configuration: "shadowTest")
   testRuntimeOnly project(path: ":beam-runners-google-cloud-dataflow-java", configuration: "shadow")
 }
+
 def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
 def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
 
 task preCommit(type: Test) {
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",
      "--tempRoot=${gcsTempRoot}",
      "--runner=TestDataflowRunner",
+     "--dataflowWorkerJar=${dataflowWorkerJar}",
+     "--workerHarnessContainerImage=",
   ]
   testClassesDirs = files(project(":beam-examples-java").sourceSets.test.output.classesDirs)
   include "**/WordCountIT.class"
@@ -47,4 +54,3 @@ task preCommit(type: Test) {
   maxParallelForks 4
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
 }
-

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -38,7 +38,7 @@ def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-
 
 task preCommit(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.getArchivePath()
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
 
   def preCommitBeamTestPipelineOptions = [
      "--project=${gcpProject}",

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -745,7 +745,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       List<String> experiments =
           dataflowOptions.getExperiments() == null
               ? new ArrayList<>()
-              : dataflowOptions.getExperiments();
+              : new ArrayList<>(dataflowOptions.getExperiments());
       experiments.add("use_staged_dataflow_worker_jar");
       dataflowOptions.setExperiments(experiments);
     }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
@@ -28,7 +28,6 @@ import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
@@ -28,6 +28,7 @@ import com.google.api.services.bigquery.model.TableRow;
 import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -291,8 +292,10 @@ public class BigQueryToTableIT {
   @Test
   public void testNewTypesQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupNewTypesQueryTest();
-    this.options.setExperiments(
-        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
+    List<String> experiments = new ArrayList<>();
+    experiments.add("enable_custom_bigquery_sink");
+    experiments.add("enable_custom_bigquery_source");
+    this.options.setExperiments(experiments);
 
     this.runBigQueryToTablePipeline();
 
@@ -302,8 +305,10 @@ public class BigQueryToTableIT {
   @Test
   public void testLegacyQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupLegacyQueryTest();
-    this.options.setExperiments(
-        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
+    List<String> experiments = new ArrayList<>();
+    experiments.add("enable_custom_bigquery_sink");
+    experiments.add("enable_custom_bigquery_source");
+    this.options.setExperiments(experiments);
 
     this.runBigQueryToTablePipeline();
 
@@ -313,8 +318,10 @@ public class BigQueryToTableIT {
   @Test
   public void testStandardQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupStandardQueryTest();
-    this.options.setExperiments(
-        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
+    List<String> experiments = new ArrayList<>();
+    experiments.add("enable_custom_bigquery_sink");
+    experiments.add("enable_custom_bigquery_source");
+    this.options.setExperiments(experiments);
 
     this.runBigQueryToTablePipeline();
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
@@ -292,10 +292,8 @@ public class BigQueryToTableIT {
   @Test
   public void testNewTypesQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupNewTypesQueryTest();
-    List<String> experiments = new ArrayList<>();
-    experiments.add("enable_custom_bigquery_sink");
-    experiments.add("enable_custom_bigquery_source");
-    this.options.setExperiments(experiments);
+    this.options.setExperiments(
+        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
     this.runBigQueryToTablePipeline();
 
@@ -305,10 +303,8 @@ public class BigQueryToTableIT {
   @Test
   public void testLegacyQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupLegacyQueryTest();
-    List<String> experiments = new ArrayList<>();
-    experiments.add("enable_custom_bigquery_sink");
-    experiments.add("enable_custom_bigquery_source");
-    this.options.setExperiments(experiments);
+    this.options.setExperiments(
+        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
     this.runBigQueryToTablePipeline();
 
@@ -318,10 +314,8 @@ public class BigQueryToTableIT {
   @Test
   public void testStandardQueryWithoutReshuffleWithCustom() throws Exception {
     this.setupStandardQueryTest();
-    List<String> experiments = new ArrayList<>();
-    experiments.add("enable_custom_bigquery_sink");
-    experiments.add("enable_custom_bigquery_source");
-    this.options.setExperiments(experiments);
+    this.options.setExperiments(
+        ImmutableList.of("enable_custom_bigquery_sink", "enable_custom_bigquery_source"));
 
     this.runBigQueryToTablePipeline();
 


### PR DESCRIPTION
Commit https://github.com/apache/beam/commit/e1b7a9be3a4a73460e1f4cdacf839638e2b2d889 migrated java dataflow runner ITs with legacy java worker to use custom worker jar. R: @herohde, @lukecwik 

Commit https://github.com/apache/beam/commit/3eba07962939486b83fbec67352e5cfc15c0e5ee changed the way setting up experiments. We shouldn't use Immutable list to set. R: @pabloem 