### PR TITLE
Add not_use_test_runner_api 

### DIFF
--- a/sdks/python/apache_beam/testing/test_pipeline.py
+++ b/sdks/python/apache_beam/testing/test_pipeline.py
@@ -94,6 +94,7 @@ class TestPipeline(Pipeline):
         of the expected type.
     """
     self.is_integration_test = is_integration_test
+    self.not_use_test_runner_api = False
     self.options_list = self._parse_test_option_args(argv)
     self.blocking = blocking
     if options is None:
@@ -101,7 +102,9 @@ class TestPipeline(Pipeline):
     super(TestPipeline, self).__init__(runner, options)
 
   def run(self, test_runner_api=True):
-    result = super(TestPipeline, self).run(test_runner_api)
+    result = super(TestPipeline, self).run(
+        test_runner_api=(False if self.not_use_test_runner_api
+                         else test_runner_api))
     if self.blocking:
       state = result.wait_until_finish()
       assert state in (PipelineState.DONE, PipelineState.CANCELLED), \
@@ -126,6 +129,10 @@ class TestPipeline(Pipeline):
                         type=str,
                         action='store',
                         help='only run tests providing service options')
+    parser.add_argument('--not-use-test-runner-api',
+                        action='store_true',
+                        default=False,
+                        help='whether not to use test-runner-api')
     known, unused_argv = parser.parse_known_args(argv)
 
     if self.is_integration_test and not known.test_pipeline_options:
@@ -135,6 +142,7 @@ class TestPipeline(Pipeline):
       raise SkipTest('IT is skipped because --test-pipeline-options '
                      'is not specified')
 
+    self.not_use_test_runner_api = known.not_use_test_runner_api
     return shlex.split(known.test_pipeline_options) \
       if known.test_pipeline_options else []
 

--- a/sdks/python/apache_beam/testing/test_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/test_pipeline_test.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 import logging
 import unittest
 
+import mock
 from hamcrest.core.assert_that import assert_that as hc_assert_that
 from hamcrest.core.base_matcher import BaseMatcher
 
@@ -107,6 +108,13 @@ class TestPipelineTest(unittest.TestCase):
     test_pipeline.run()
     # Note that this will never be reached since it should be skipped above.
     self.fail()
+
+  @mock.patch('apache_beam.testing.test_pipeline.Pipeline.run', autospec=True)
+  def test_not_use_test_runner_api(self, mock_run):
+    test_pipeline = TestPipeline(argv=['--not-use-test-runner-api'],
+                                 blocking=False)
+    test_pipeline.run()
+    mock_run.assert_called_once_with(test_pipeline, test_runner_api=False)
 
 
 if __name__ == '__main__':

--- a/sdks/python/test_config.py
+++ b/sdks/python/test_config.py
@@ -34,8 +34,8 @@ class BeamTestPlugin(Plugin):
   """
 
   def options(self, parser, env):
-    """Add '--test-pipeline-options' to command line option to avoid
-    unrecognized option error thrown by nose.
+    """Add '--test-pipeline-options' and '--not_use-test-runner-api'
+    to command line option to avoid unrecognized option error thrown by nose.
 
     The value of this option will be processed by TestPipeline and used to
     build customized pipeline for ValidatesRunner tests.
@@ -44,3 +44,7 @@ class BeamTestPlugin(Plugin):
                       action='store',
                       type=str,
                       help='providing pipeline options to run tests on runner')
+    parser.add_option('--not-use-test-runner-api',
+                      action='store_true',
+                      default=False,
+                      help='whether not to use test-runner-api')


### PR DESCRIPTION
Add not_use_test_runner_api  so we don't have to run with test_runner_api=True



------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




