### PR TITLE
[BEAM-5775] Spark: implement a custom class to lazily encode values for persistence.

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/BeamSparkRunnerRegistrator.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import org.apache.beam.runners.spark.io.MicrobatchSource;
 import org.apache.beam.runners.spark.stateful.SparkGroupAlsoByWindowViaWindowSet.StateAndTimers;
-import org.apache.beam.runners.spark.translation.GroupCombineFunctions;
 import org.apache.beam.runners.spark.translation.GroupNonMergingWindowsFunctions.WindowedKey;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
@@ -47,10 +46,7 @@ public class BeamSparkRunnerRegistrator implements KryoRegistrator {
   public void registerClasses(Kryo kryo) {
     // MicrobatchSource is serialized as data and may not be Kryo-serializable.
     kryo.register(MicrobatchSource.class, new StatelessJavaSerializer());
-
-    kryo.register(
-        GroupCombineFunctions.SerializableAccumulator.class,
-        new GroupCombineFunctions.KryoAccumulatorSerializer());
+    kryo.register(ValueAndCoderLazySerializable.class, new KryoValueAndCoderLazySerializable());
 
     kryo.register(WrappedArray.ofRef.class);
     kryo.register(Object[].class);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/KryoValueAndCoderLazySerializable.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/KryoValueAndCoderLazySerializable.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.coders;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.KryoException;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.io.IOException;
+
+/** Kryo serializer for {@link ValueAndCoderLazySerializable}. * */
+public class KryoValueAndCoderLazySerializable<T>
+    extends Serializer<ValueAndCoderLazySerializable<T>> {
+
+  @Override
+  public void write(Kryo kryo, Output output, ValueAndCoderLazySerializable<T> item) {
+    try {
+      item.writeCommon(output);
+    } catch (IOException e) {
+      throw new KryoException(e);
+    }
+  }
+
+  @Override
+  public ValueAndCoderLazySerializable<T> read(
+      Kryo kryo, Input input, Class<ValueAndCoderLazySerializable<T>> type) {
+    ValueAndCoderLazySerializable<T> value = new ValueAndCoderLazySerializable<>();
+    try {
+      value.readCommon(input);
+    } catch (IOException e) {
+      throw new KryoException(e);
+    }
+    return value;
+  }
+}

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/ValueAndCoderLazySerializable.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/ValueAndCoderLazySerializable.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.coders;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.util.VarInt;
+import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Throwables;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.io.ByteStreams;
+
+/**
+ * A holder object that lets you serialize an element with a Coder with minimal wasted space.
+ * Supports both Kryo and Java serialization.
+ *
+ * <p>There are two different representations: a deserialized representation and a serialized
+ * representation.
+ *
+ * <p>The deserialized representation stores a Coder and the value. To serialize the value, we write
+ * a length-prefixed encoding of value, but do NOT write the Coder used.
+ *
+ * <p>The serialized representation just reads a byte array - the value is not deserialized fully.
+ * In order to get at the deserialized value, the caller must pass the Coder used to create this
+ * instance via getOrDecode(Coder). This reverts the representation back to the deserialized
+ * representation.
+ *
+ * @param <T> element type
+ */
+public final class ValueAndCoderLazySerializable<T> implements Serializable {
+  private T value;
+  // Re-use a field to save space in-memory. This is either a byte[] or a Coder, depending on
+  // which representation we are in.
+  private Object coderOrBytes;
+
+  private ValueAndCoderLazySerializable(T value, Coder<T> currentCoder) {
+    this.value = value;
+    this.coderOrBytes = currentCoder;
+  }
+
+  @SuppressWarnings("unused") // for serialization
+  ValueAndCoderLazySerializable() {}
+
+  public static <T> ValueAndCoderLazySerializable<T> of(T value, Coder<T> coder) {
+    return new ValueAndCoderLazySerializable<>(value, coder);
+  }
+
+  public T getOrDecode(Coder<T> coder) {
+    if (!(coderOrBytes instanceof Coder)) {
+      ByteArrayInputStream bais = new ByteArrayInputStream((byte[]) this.coderOrBytes);
+      try {
+        value = coder.decode(bais);
+      } catch (IOException e) {
+        throw new IllegalStateException("Error decoding bytes for coder: " + coder, e);
+      }
+      this.coderOrBytes = coder;
+    }
+
+    return value;
+  }
+
+  private static class ByteSizeObserver extends ElementByteSizeObserver {
+    private long observedSize = 0;
+
+    @Override
+    protected void reportElementSize(long elementByteSize) {
+      observedSize += elementByteSize;
+    }
+  }
+
+  void writeCommon(OutputStream out) throws IOException {
+    if (!(coderOrBytes instanceof Coder)) {
+      byte[] bytes = (byte[]) coderOrBytes;
+      VarInt.encode(bytes.length, out);
+      out.write(bytes);
+    } else {
+      @SuppressWarnings("unchecked")
+      Coder<T> coder = (Coder<T>) coderOrBytes;
+      int bufferSize = 1024;
+
+      if (coder.isRegisterByteSizeObserverCheap(value)) {
+        try {
+          ByteSizeObserver observer = new ByteSizeObserver();
+          coder.registerByteSizeObserver(value, observer);
+          bufferSize = (int) observer.observedSize;
+        } catch (Exception e) {
+          Throwables.throwIfUnchecked(e);
+          throw new RuntimeException(e);
+        }
+      }
+
+      ByteArrayOutputStream bytes = new ByteArrayOutputStream(bufferSize);
+
+      try {
+        coder.encode(value, bytes);
+
+        VarInt.encode(bytes.size(), out);
+        bytes.writeTo(out);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  void readCommon(InputStream in) throws IOException {
+    int length = VarInt.decodeInt(in);
+    byte[] bytes = new byte[length];
+    ByteStreams.readFully(in, bytes);
+    this.coderOrBytes = bytes;
+  }
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    writeCommon(out);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    readCommon(in);
+  }
+}

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/BoundedDataset.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/BoundedDataset.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.coders.ValueAndCoderLazySerializable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
@@ -103,9 +104,9 @@ public class BoundedDataset<T> implements Dataset {
       Coder<WindowedValue<T>> windowedValueCoder = (Coder<WindowedValue<T>>) coder;
       this.rdd =
           getRDD()
-              .map(CoderHelpers.toByteFunction(windowedValueCoder))
+              .map(v -> ValueAndCoderLazySerializable.of(v, windowedValueCoder))
               .persist(level)
-              .map(CoderHelpers.fromByteFunction(windowedValueCoder));
+              .map(v -> v.getOrDecode(windowedValueCoder));
     }
   }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupCombineFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupCombineFunctions.java
@@ -17,16 +17,10 @@
  */
 package org.apache.beam.runners.spark.translation;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.Serializer;
-import com.esotericsoftware.kryo.io.Input;
-import com.esotericsoftware.kryo.io.Output;
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
-import java.io.Serializable;
+import java.util.Collections;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.coders.ValueAndCoderLazySerializable;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
@@ -37,9 +31,7 @@ import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Optional;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Iterables;
-import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Lists;
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
@@ -95,19 +87,19 @@ public class GroupCombineFunctions {
             aCoder, windowingStrategy.getWindowFn().windowCoder());
     final IterableCoder<WindowedValue<AccumT>> iterAccumCoder = IterableCoder.of(wvaCoder);
 
-    SerializableAccumulator<AccumT> accumulatedResult =
+    ValueAndCoderLazySerializable<Iterable<WindowedValue<AccumT>>> accumulatedResult =
         rdd.aggregate(
-            SerializableAccumulator.empty(iterAccumCoder),
+            ValueAndCoderLazySerializable.of(Collections.emptyList(), iterAccumCoder),
             (ab, ib) -> {
               Iterable<WindowedValue<AccumT>> merged =
                   sparkCombineFn.seqOp(ab.getOrDecode(iterAccumCoder), ib);
-              return SerializableAccumulator.of(merged, iterAccumCoder);
+              return ValueAndCoderLazySerializable.of(merged, iterAccumCoder);
             },
             (a1b, a2b) -> {
               Iterable<WindowedValue<AccumT>> merged =
                   sparkCombineFn.combOp(
                       a1b.getOrDecode(iterAccumCoder), a2b.getOrDecode(iterAccumCoder));
-              return SerializableAccumulator.of(merged, iterAccumCoder);
+              return ValueAndCoderLazySerializable.of(merged, iterAccumCoder);
             });
 
     final Iterable<WindowedValue<AccumT>> result = accumulatedResult.getOrDecode(iterAccumCoder);
@@ -146,19 +138,21 @@ public class GroupCombineFunctions {
     JavaPairRDD<ByteArray, WindowedValue<KV<K, InputT>>> inRddDuplicatedKeyPair =
         rdd.mapToPair(TranslationUtils.toPairByKeyInWindowedValue(keyCoder));
 
-    JavaPairRDD<ByteArray, SerializableAccumulator<KV<K, AccumT>>> accumulatedResult =
-        inRddDuplicatedKeyPair.combineByKey(
-            input ->
-                SerializableAccumulator.of(sparkCombineFn.createCombiner(input), iterAccumCoder),
-            (acc, input) ->
-                SerializableAccumulator.of(
-                    sparkCombineFn.mergeValue(input, acc.getOrDecode(iterAccumCoder)),
-                    iterAccumCoder),
-            (acc1, acc2) ->
-                SerializableAccumulator.of(
-                    sparkCombineFn.mergeCombiners(
-                        acc1.getOrDecode(iterAccumCoder), acc2.getOrDecode(iterAccumCoder)),
-                    iterAccumCoder));
+    JavaPairRDD<ByteArray, ValueAndCoderLazySerializable<Iterable<WindowedValue<KV<K, AccumT>>>>>
+        accumulatedResult =
+            inRddDuplicatedKeyPair.combineByKey(
+                input ->
+                    ValueAndCoderLazySerializable.of(
+                        sparkCombineFn.createCombiner(input), iterAccumCoder),
+                (acc, input) ->
+                    ValueAndCoderLazySerializable.of(
+                        sparkCombineFn.mergeValue(input, acc.getOrDecode(iterAccumCoder)),
+                        iterAccumCoder),
+                (acc1, acc2) ->
+                    ValueAndCoderLazySerializable.of(
+                        sparkCombineFn.mergeCombiners(
+                            acc1.getOrDecode(iterAccumCoder), acc2.getOrDecode(iterAccumCoder)),
+                        iterAccumCoder));
 
     return accumulatedResult.mapToPair(
         i ->
@@ -181,120 +175,5 @@ public class GroupCombineFunctions {
         .mapToPair(CoderHelpers.fromByteFunction(keyCoder, wvCoder))
         .map(TranslationUtils.fromPairFunction())
         .map(TranslationUtils.toKVByWindowInValue());
-  }
-
-  /**
-   * Wrapper around accumulated (combined) value with custom lazy serialization. Serialization is
-   * done through given coder and it is performed within on-serialization callbacks {@link
-   * #writeObject(ObjectOutputStream)} and {@link KryoAccumulatorSerializer#write(Kryo, Output,
-   * SerializableAccumulator)}. Both Spark's serialization mechanisms (Java Serialization, Kryo) are
-   * supported. Materialization of accumulated value is done when value is requested to avoid
-   * serialization of the coder itself.
-   *
-   * @param <AccumT>
-   */
-  public static class SerializableAccumulator<AccumT> implements Serializable {
-    private transient Iterable<WindowedValue<AccumT>> accumulated;
-    private transient Coder<Iterable<WindowedValue<AccumT>>> coder;
-
-    private byte[] serializedAcc;
-
-    private SerializableAccumulator() {}
-
-    private SerializableAccumulator(
-        Iterable<WindowedValue<AccumT>> accumulated,
-        Coder<Iterable<WindowedValue<AccumT>>> coder,
-        byte[] serializedAcc) {
-      this.accumulated = accumulated;
-      this.coder = coder;
-      this.serializedAcc = serializedAcc;
-    }
-
-    static <AccumT> SerializableAccumulator<AccumT> of(
-        Iterable<WindowedValue<AccumT>> accumulated, Coder<Iterable<WindowedValue<AccumT>>> coder) {
-      return new SerializableAccumulator<>(accumulated, coder, null);
-    }
-
-    static <AccumT> SerializableAccumulator<AccumT> ofBytes(byte[] serializedAcc) {
-      Preconditions.checkNotNull(serializedAcc);
-      return new SerializableAccumulator<>(null, null, serializedAcc);
-    }
-
-    static <AccumT> SerializableAccumulator<AccumT> empty(
-        Coder<Iterable<WindowedValue<AccumT>>> coder) {
-      return new SerializableAccumulator<>(Lists.newArrayList(), coder, null);
-    }
-
-    /**
-     * Returns wrapped accumulated value when available as java object or deserialize them using
-     * given {@code coder}.
-     *
-     * @param coder
-     * @return
-     */
-    Iterable<WindowedValue<AccumT>> getOrDecode(Coder<Iterable<WindowedValue<AccumT>>> coder) {
-      if (accumulated == null) {
-        accumulated = CoderHelpers.fromByteArray(serializedAcc, coder);
-        serializedAcc = null;
-      }
-
-      if (this.coder == null) {
-        this.coder = coder;
-      }
-
-      return accumulated;
-    }
-
-    byte[] toBytes() {
-      byte[] coded;
-      if (coder != null) {
-        coded = CoderHelpers.toByteArray(this.accumulated, coder);
-      } else if (serializedAcc != null) {
-        coded = serializedAcc;
-      } else {
-        throw new IllegalStateException(
-            String.format(
-                "Given '%s' cannot be serialized since it do not contain coder or already serialized data.",
-                SerializableAccumulator.class.getSimpleName()));
-      }
-      return coded;
-    }
-
-    private void writeObject(ObjectOutputStream out) throws IOException {
-      byte[] coded = toBytes();
-      out.writeInt(coded.length);
-      out.write(coded);
-    }
-
-    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-      int length = in.readInt();
-      byte[] coded = new byte[length];
-      in.readFully(coded);
-      this.serializedAcc = coded;
-    }
-  }
-
-  /**
-   * Kryo serializer for {@link SerializableAccumulator}.
-   *
-   * @param <AccumT>
-   */
-  public static class KryoAccumulatorSerializer<AccumT>
-      extends Serializer<SerializableAccumulator<AccumT>> {
-
-    @Override
-    public void write(Kryo kryo, Output output, SerializableAccumulator<AccumT> accumulator) {
-      byte[] coded = accumulator.toBytes();
-      output.writeInt(coded.length, true);
-      output.write(coded);
-    }
-
-    @Override
-    public SerializableAccumulator<AccumT> read(
-        Kryo kryo, Input input, Class<SerializableAccumulator<AccumT>> type) {
-      int length = input.readInt(true);
-      byte[] coded = input.readBytes(length);
-      return SerializableAccumulator.ofBytes(coded);
-    }
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TranslationUtils.java
@@ -27,6 +27,7 @@ import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateInternalsFactory;
 import org.apache.beam.runners.spark.SparkRunner;
 import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.coders.ValueAndCoderLazySerializable;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.runners.spark.util.SideInputBroadcast;
 import org.apache.beam.sdk.coders.Coder;
@@ -350,13 +351,16 @@ public final class TranslationUtils {
    * @param coderMap - mapping between TupleTag and a coder
    * @return a pair function to convert value to bytes via coder
    */
-  public static PairFunction<Tuple2<TupleTag<?>, WindowedValue<?>>, TupleTag<?>, byte[]>
+  public static PairFunction<
+          Tuple2<TupleTag<?>, WindowedValue<?>>,
+          TupleTag<?>,
+          ValueAndCoderLazySerializable<WindowedValue<?>>>
       getTupleTagEncodeFunction(final Map<TupleTag<?>, Coder<WindowedValue<?>>> coderMap) {
     return tuple2 -> {
       TupleTag<?> tupleTag = tuple2._1;
       WindowedValue<?> windowedValue = tuple2._2;
       return new Tuple2<>(
-          tupleTag, CoderHelpers.toByteArray(windowedValue, coderMap.get(tupleTag)));
+          tupleTag, ValueAndCoderLazySerializable.of(windowedValue, coderMap.get(tupleTag)));
     };
   }
 
@@ -366,23 +370,28 @@ public final class TranslationUtils {
    * @param coderMap - mapping between TupleTag and a coder
    * @return a pair function to convert bytes to value via coder
    */
-  public static PairFunction<Tuple2<TupleTag<?>, byte[]>, TupleTag<?>, WindowedValue<?>>
+  public static PairFunction<
+          Tuple2<TupleTag<?>, ValueAndCoderLazySerializable<WindowedValue<?>>>,
+          TupleTag<?>,
+          WindowedValue<?>>
       getTupleTagDecodeFunction(final Map<TupleTag<?>, Coder<WindowedValue<?>>> coderMap) {
     return tuple2 -> {
       TupleTag<?> tupleTag = tuple2._1;
-      byte[] windowedByteValue = tuple2._2;
-      return new Tuple2<>(
-          tupleTag, CoderHelpers.fromByteArray(windowedByteValue, coderMap.get(tupleTag)));
+      ValueAndCoderLazySerializable<WindowedValue<?>> windowedByteValue = tuple2._2;
+      return new Tuple2<>(tupleTag, windowedByteValue.getOrDecode(coderMap.get(tupleTag)));
     };
   }
 
   /**
    * checking if we can avoid Serialization - relevant to RDDs. DStreams are memory ser in spark.
    *
+   * <p>See https://spark.apache.org/docs/latest/rdd-programming-guide.html#rdd-persistence for
+   * details.
+   *
    * @param level StorageLevel required
    * @return true if the level is memory only
    */
   public static boolean avoidRddSerialization(StorageLevel level) {
-    return level.equals(StorageLevel.MEMORY_ONLY()) || level.equals(StorageLevel.MEMORY_ONLY_2());
+    return level.equals(StorageLevel.MEMORY_ONLY());
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/coders/ValueAndCoderLazySerializableTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/coders/ValueAndCoderLazySerializableTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.spark.translation;
+package org.apache.beam.runners.spark.coders;
 
 import static org.junit.Assert.assertEquals;
 
@@ -28,9 +28,6 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.Arrays;
-import org.apache.beam.runners.spark.coders.CoderHelpers;
-import org.apache.beam.runners.spark.translation.GroupCombineFunctions.KryoAccumulatorSerializer;
-import org.apache.beam.runners.spark.translation.GroupCombineFunctions.SerializableAccumulator;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -39,30 +36,8 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.joda.time.Instant;
 import org.junit.Test;
 
-/** Unit tests of {@link GroupCombineFunctions}. */
-public class GroupCombineFunctionsTest {
-
-  @Test
-  public void serializableAccumulatorTest() {
-    Iterable<WindowedValue<Integer>> accumulatedValue =
-        Arrays.asList(winVal(0), winVal(1), winVal(3), winVal(4));
-
-    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
-        WindowedValue.FullWindowedValueCoder.of(
-            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
-
-    final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
-
-    SerializableAccumulator<Integer> accUnderTest =
-        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
-    assertEquals(accumulatedValue, accUnderTest.getOrDecode(iterAccumCoder));
-
-    byte[] bytes = accUnderTest.toBytes();
-    assertEquals(accumulatedValue, CoderHelpers.fromByteArray(bytes, iterAccumCoder));
-
-    SerializableAccumulator<Integer> accFromBytes = SerializableAccumulator.ofBytes(bytes);
-    assertEquals(accumulatedValue, accFromBytes.getOrDecode(iterAccumCoder));
-  }
+/** Unit tests of {@link ValueAndCoderLazySerializable}. */
+public class ValueAndCoderLazySerializableTest {
 
   @Test
   public void serializableAccumulatorSerializationTest()
@@ -77,8 +52,8 @@ public class GroupCombineFunctionsTest {
 
     final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
 
-    SerializableAccumulator<Integer> accUnderTest =
-        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
+    ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>> accUnderTest =
+        ValueAndCoderLazySerializable.of(accumulatedValue, iterAccumCoder);
 
     ByteArrayOutputStream inMemOut = new ByteArrayOutputStream();
     ObjectOutputStream oos = new ObjectOutputStream(inMemOut);
@@ -87,8 +62,8 @@ public class GroupCombineFunctionsTest {
     ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(inMemOut.toByteArray()));
 
     @SuppressWarnings("unchecked")
-    SerializableAccumulator<Integer> materialized =
-        (SerializableAccumulator<Integer>) ois.readObject();
+    ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>> materialized =
+        (ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>>) ois.readObject();
     assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
   }
 
@@ -103,12 +78,12 @@ public class GroupCombineFunctionsTest {
 
     final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
 
-    SerializableAccumulator<Integer> accUnderTest =
-        SerializableAccumulator.of(accumulatedValue, iterAccumCoder);
+    ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>> accUnderTest =
+        ValueAndCoderLazySerializable.of(accumulatedValue, iterAccumCoder);
 
-    KryoAccumulatorSerializer kryoSerializer = new KryoAccumulatorSerializer();
+    KryoValueAndCoderLazySerializable kryoSerializer = new KryoValueAndCoderLazySerializable();
     Kryo kryo = new Kryo();
-    kryo.register(SerializableAccumulator.class, kryoSerializer);
+    kryo.register(ValueAndCoderLazySerializable.class, kryoSerializer);
 
     ByteArrayOutputStream inMemOut = new ByteArrayOutputStream();
     Output out = new Output(inMemOut);
@@ -118,8 +93,9 @@ public class GroupCombineFunctionsTest {
     Input input = new Input(new ByteArrayInputStream(inMemOut.toByteArray()));
 
     @SuppressWarnings("unchecked")
-    SerializableAccumulator<Integer> materialized =
-        (SerializableAccumulator<Integer>) kryo.readObject(input, SerializableAccumulator.class);
+    ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>> materialized =
+        (ValueAndCoderLazySerializable<Iterable<WindowedValue<Integer>>>)
+            kryo.readObject(input, ValueAndCoderLazySerializable.class);
     input.close();
 
     assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));


### PR DESCRIPTION
Spark's `StorageLevel` is the preferred mechanism to decide what is serialized when and where. With this change, Beam respects Spark's wish to keep data deserialized in memory, even if the storage level *may* swap to disk (e.g. MEMORY_AND_DISK).

This PR also drive-by fixes using the `MEMORY_ONLY_2` storage level. The code previously assumed that no serialization was necessary, which isn't strictly true since the `_2` means "replicate to other nodes" - i.e. serialize over network.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




