### PR TITLE
Move direct runner metrics test into direct runner directory.

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner_test.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner_test.py
@@ -20,11 +20,22 @@ from __future__ import absolute_import
 import threading
 import unittest
 
+import hamcrest as hc
+
 import apache_beam as beam
+from apache_beam.metrics.cells import DistributionData
+from apache_beam.metrics.cells import DistributionResult
+from apache_beam.metrics.execution import MetricKey
+from apache_beam.metrics.execution import MetricResult
+from apache_beam.metrics.metric import Metrics
+from apache_beam.metrics.metricbase import MetricName
+from apache_beam.pipeline import Pipeline
 from apache_beam.runners import DirectRunner
 from apache_beam.runners import TestDirectRunner
 from apache_beam.runners import create_runner
 from apache_beam.testing import test_pipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
 
 
 class DirectPipelineResultTest(unittest.TestCase):
@@ -42,6 +53,64 @@ class DirectPipelineResultTest(unittest.TestCase):
       post_test_threads = set(t.ident for t in threading.enumerate())
       new_threads = post_test_threads - pre_test_threads
       self.assertEqual(len(new_threads), 0)
+
+  def test_direct_runner_metrics(self):
+
+    class MyDoFn(beam.DoFn):
+      def start_bundle(self):
+        count = Metrics.counter(self.__class__, 'bundles')
+        count.inc()
+
+      def finish_bundle(self):
+        count = Metrics.counter(self.__class__, 'finished_bundles')
+        count.inc()
+
+      def process(self, element):
+        gauge = Metrics.gauge(self.__class__, 'latest_element')
+        gauge.set(element)
+        count = Metrics.counter(self.__class__, 'elements')
+        count.inc()
+        distro = Metrics.distribution(self.__class__, 'element_dist')
+        distro.update(element)
+        return [element]
+
+    p = Pipeline(DirectRunner())
+    pcoll = (p | beam.Create([1, 2, 3, 4, 5])
+             | 'Do' >> beam.ParDo(MyDoFn()))
+    assert_that(pcoll, equal_to([1, 2, 3, 4, 5]))
+    result = p.run()
+    result.wait_until_finish()
+    metrics = result.metrics().query()
+    namespace = '{}.{}'.format(MyDoFn.__module__,
+                               MyDoFn.__name__)
+
+    hc.assert_that(
+        metrics['counters'],
+        hc.contains_inanyorder(
+            MetricResult(
+                MetricKey('Do', MetricName(namespace, 'elements')),
+                5, 5),
+            MetricResult(
+                MetricKey('Do', MetricName(namespace, 'bundles')),
+                1, 1),
+            MetricResult(
+                MetricKey('Do', MetricName(namespace, 'finished_bundles')),
+                1, 1)))
+
+    hc.assert_that(
+        metrics['distributions'],
+        hc.contains_inanyorder(
+            MetricResult(
+                MetricKey('Do', MetricName(namespace, 'element_dist')),
+                DistributionResult(DistributionData(15, 5, 1, 5)),
+                DistributionResult(DistributionData(15, 5, 1, 5)))))
+
+    gauge_result = metrics['gauges'][0]
+    hc.assert_that(
+        gauge_result.key,
+        hc.equal_to(MetricKey('Do', MetricName(namespace, 'latest_element'))))
+    hc.assert_that(gauge_result.committed.value, hc.equal_to(5))
+    hc.assert_that(gauge_result.attempted.value, hc.equal_to(5))
 
   def test_create_runner(self):
     self.assertTrue(

--- a/sdks/python/apache_beam/runners/runner_test.py
+++ b/sdks/python/apache_beam/runners/runner_test.py
@@ -26,22 +26,10 @@ from __future__ import absolute_import
 
 import unittest
 
-import hamcrest as hc
-
 import apache_beam as beam
-import apache_beam.transforms as ptransform
-from apache_beam.metrics.cells import DistributionData
-from apache_beam.metrics.cells import DistributionResult
-from apache_beam.metrics.execution import MetricKey
-from apache_beam.metrics.execution import MetricResult
 from apache_beam.metrics.metric import Metrics
-from apache_beam.metrics.metricbase import MetricName
-from apache_beam.options.pipeline_options import PipelineOptions
-from apache_beam.pipeline import Pipeline
 from apache_beam.runners import DirectRunner
 from apache_beam.runners import create_runner
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 
 
 class RunnerTest(unittest.TestCase):
@@ -69,66 +57,6 @@ class RunnerTest(unittest.TestCase):
         isinstance(create_runner('DiReCt'), DirectRunner))
     self.assertTrue(
         isinstance(create_runner('Direct'), DirectRunner))
-
-  def test_direct_runner_metrics(self):
-
-    class MyDoFn(beam.DoFn):
-      def start_bundle(self):
-        count = Metrics.counter(self.__class__, 'bundles')
-        count.inc()
-
-      def finish_bundle(self):
-        count = Metrics.counter(self.__class__, 'finished_bundles')
-        count.inc()
-
-      def process(self, element):
-        gauge = Metrics.gauge(self.__class__, 'latest_element')
-        gauge.set(element)
-        count = Metrics.counter(self.__class__, 'elements')
-        count.inc()
-        distro = Metrics.distribution(self.__class__, 'element_dist')
-        distro.update(element)
-        return [element]
-
-    runner = DirectRunner()
-    p = Pipeline(runner,
-                 options=PipelineOptions(self.default_properties))
-    pcoll = (p | ptransform.Create([1, 2, 3, 4, 5])
-             | 'Do' >> beam.ParDo(MyDoFn()))
-    assert_that(pcoll, equal_to([1, 2, 3, 4, 5]))
-    result = p.run()
-    result.wait_until_finish()
-    metrics = result.metrics().query()
-    namespace = '{}.{}'.format(MyDoFn.__module__,
-                               MyDoFn.__name__)
-
-    hc.assert_that(
-        metrics['counters'],
-        hc.contains_inanyorder(
-            MetricResult(
-                MetricKey('Do', MetricName(namespace, 'elements')),
-                5, 5),
-            MetricResult(
-                MetricKey('Do', MetricName(namespace, 'bundles')),
-                1, 1),
-            MetricResult(
-                MetricKey('Do', MetricName(namespace, 'finished_bundles')),
-                1, 1)))
-
-    hc.assert_that(
-        metrics['distributions'],
-        hc.contains_inanyorder(
-            MetricResult(
-                MetricKey('Do', MetricName(namespace, 'element_dist')),
-                DistributionResult(DistributionData(15, 5, 1, 5)),
-                DistributionResult(DistributionData(15, 5, 1, 5)))))
-
-    gauge_result = metrics['gauges'][0]
-    hc.assert_that(
-        gauge_result.key,
-        hc.equal_to(MetricKey('Do', MetricName(namespace, 'latest_element'))))
-    hc.assert_that(gauge_result.committed.value, hc.equal_to(5))
-    hc.assert_that(gauge_result.attempted.value, hc.equal_to(5))
 
   def test_run_api(self):
     my_metric = Metrics.counter('namespace', 'my_metric')


### PR DESCRIPTION
This is just a cleanup I noticed while doing another PR. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




