### PR TITLE
[BEAM-5098] Add withFanout side input regression test

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -983,7 +983,7 @@ public class CombineTest implements Serializable {
       final PCollectionView<Integer> view =
           pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
 
-      Combine.globally(new·TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
+      Combine.globally(new TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -984,9 +984,7 @@ public class CombineTest implements Serializable {
           pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
 
       Combine.Globally<Integer, String> combine =
-          Combine.globally(new TestCombineFnWithContext(view))
-              .withSideInputs(view)
-              .withFanout(1);
+          Combine.globally(new·TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -983,7 +983,10 @@ public class CombineTest implements Serializable {
       final PCollectionView<Integer> view =
           pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
 
-      Combine.globally(new TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
+      Combine.Globally<Integer, String> combine =
+          Combine.globally(new TestCombineFnWithContext(view))
+              .withSideInputs(view)
+              .withFanout(1);
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -983,10 +983,7 @@ public class CombineTest implements Serializable {
       final PCollectionView<Integer> view =
           pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
 
-      Combine.Globally<Integer, String> combine =
-          Combine.globally(new TestCombineFnWithContext(view))
-              .withSideInputs(view)
-              .withFanout(1);
+      Combine.globally(new·TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -984,7 +984,7 @@ public class CombineTest implements Serializable {
           pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
 
       Combine.Globally<Integer, String> combine =
-          Combine.globally(new·TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
+          Combine.globally(new TestCombineFnWithContext(view)).withSideInputs(view).withFanout(1);
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/CombineTest.java
@@ -977,6 +977,19 @@ public class CombineTest implements Serializable {
 
       assertEquals(Collections.singletonList(view), combine.getSideInputs());
     }
+
+    @Test
+    public void testWithFanoutPreservesSideInputs() {
+      final PCollectionView<Integer> view =
+          pipeline.apply(Create.of(1)).apply(Sum.integersGlobally().asSingletonView());
+
+      Combine.Globally<Integer, String> combine =
+          Combine.globally(new TestCombineFnWithContext(view))
+              .withSideInputs(view)
+              .withFanout(1);
+
+      assertEquals(Collections.singletonList(view), combine.getSideInputs());
+    }
   }
 
   /** Tests validating windowing behaviors. */


### PR DESCRIPTION
See discussion in #6696.

R: @lukecwik

------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




