### PR TITLE
[BEAM-5315] Partially port IO; fixing well-documented errors

### DIFF
--- a/sdks/python/apache_beam/io/avroio_test.py
+++ b/sdks/python/apache_beam/io/avroio_test.py
@@ -363,7 +363,7 @@ class TestAvro(unittest.TestCase):
     # the last sync_marker.
     last_char_index = len(data) - 1
     corrupted_data = data[:last_char_index]
-    corrupted_data += 'A' if data[last_char_index] == 'B' else 'B'
+    corrupted_data += b'A' if data[last_char_index] == b'B' else b'B'
     with tempfile.NamedTemporaryFile(
         delete=False, prefix=tempfile.template) as f:
       f.write(corrupted_data)

--- a/sdks/python/apache_beam/io/filebasedsink_test.py
+++ b/sdks/python/apache_beam/io/filebasedsink_test.py
@@ -76,24 +76,20 @@ class _TestCaseWithTempDirCleanUp(unittest.TestCase):
 
 class MyFileBasedSink(filebasedsink.FileBasedSink):
 
-  @unittest.skipIf(sys.version_info[0] == 3 and
-                   os.environ.get('RUN_SKIPPED_PY3_TESTS') != '1',
-                   'This test still needs to be fixed on Python 3.'
-                   'TODO: BEAM-5627, TODO:5618')
   def open(self, temp_path):
     # TODO: Fix main session pickling.
     # file_handle = super(MyFileBasedSink, self).open(temp_path)
     file_handle = filebasedsink.FileBasedSink.open(self, temp_path)
-    file_handle.write('[start]')
+    file_handle.write(b'[start]')
     return file_handle
 
   def write_encoded_record(self, file_handle, encoded_value):
-    file_handle.write('[')
+    file_handle.write(b'[')
     file_handle.write(encoded_value)
-    file_handle.write(']')
+    file_handle.write(b']')
 
   def close(self, file_handle):
-    file_handle.write('[end]')
+    file_handle.write(b'[end]')
     # TODO: Fix main session pickling.
     # file_handle = super(MyFileBasedSink, self).close(file_handle)
     file_handle = filebasedsink.FileBasedSink.close(self, file_handle)

--- a/sdks/python/apache_beam/io/filebasedsource_test.py
+++ b/sdks/python/apache_beam/io/filebasedsource_test.py
@@ -74,7 +74,7 @@ class LineSource(FileBasedSource):
       while line:
         if not range_tracker.try_claim(current):
           return
-        yield line.rstrip('\n')
+        yield line.rstrip(b'\n')
         current += len(line)
         line = f.readline()
     finally:
@@ -186,6 +186,12 @@ class TestConcatSource(unittest.TestCase):
     def estimate_size(self):
       return len(self._values)  # Assuming each value to be 1 byte.
 
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
+
   def setUp(self):
     # Reducing the size of thread pools. Without this test execution may fail in
     # environments with limited amount of resources.
@@ -197,7 +203,7 @@ class TestConcatSource(unittest.TestCase):
     concat = ConcatSource(sources)
     range_tracker = concat.get_range_tracker(None, None)
     read_data = [value for value in concat.read(range_tracker)]
-    self.assertItemsEqual(list(range(30)), read_data)
+    self.assertCountEqual(list(range(30)), read_data)
 
   def test_split(self):
     sources = [TestConcatSource.DummySource(list(range(start, start + 10)))
@@ -214,7 +220,7 @@ class TestConcatSource(unittest.TestCase):
           split.stop_position)
       read_data.extend([value for value in split.source.read(
           range_tracker_for_split)])
-    self.assertItemsEqual(list(range(30)), read_data)
+    self.assertCountEqual(list(range(30)), read_data)
 
   def test_estimate_size(self):
     sources = [TestConcatSource.DummySource(range(start, start + 10)) for start
@@ -224,6 +230,12 @@ class TestConcatSource(unittest.TestCase):
 
 
 class TestFileBasedSource(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    # Method has been renamed in Python 3
+    if sys.version_info[0] < 3:
+      cls.assertCountEqual = cls.assertItemsEqual
 
   def setUp(self):
     # Reducing the size of thread pools. Without this test execution may fail in
@@ -277,7 +289,7 @@ class TestFileBasedSource(unittest.TestCase):
     fbs = LineSource(file_name)
     range_tracker = fbs.get_range_tracker(None, None)
     read_data = [record for record in fbs.read(range_tracker)]
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_single_file_display_data(self):
     file_name, _ = write_data(10)
@@ -295,7 +307,7 @@ class TestFileBasedSource(unittest.TestCase):
     fbs = LineSource(pattern)
     range_tracker = fbs.get_range_tracker(None, None)
     read_data = [record for record in fbs.read(range_tracker)]
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_fully_read_file_pattern_with_empty_files(self):
     pattern, expected_data = write_pattern([5, 0, 12, 0, 8, 0])
@@ -303,7 +315,7 @@ class TestFileBasedSource(unittest.TestCase):
     fbs = LineSource(pattern)
     range_tracker = fbs.get_range_tracker(None, None)
     read_data = [record for record in fbs.read(range_tracker)]
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_estimate_size_of_file(self):
     file_name, expected_data = write_data(10)
@@ -375,7 +387,7 @@ class TestFileBasedSource(unittest.TestCase):
       data_from_split = [data for data in source.read(range_tracker)]
       read_data.extend(data_from_split)
 
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def test_read_splits_file_pattern(self):
     pattern, expected_data = write_pattern([34, 66, 40, 24, 24, 12])
@@ -392,7 +404,7 @@ class TestFileBasedSource(unittest.TestCase):
       data_from_split = [data for data in source.read(range_tracker)]
       read_data.extend(data_from_split)
 
-    self.assertItemsEqual(expected_data, read_data)
+    self.assertCountEqual(expected_data, read_data)
 
   def _run_source_test(self, pattern, expected_data, splittable=True):
     pipeline = TestPipeline()
@@ -554,7 +566,7 @@ class TestFileBasedSource(unittest.TestCase):
           f.write('\n'.join(c))
         chunks_to_write.append(out.getvalue())
       else:
-        chunks_to_write.append('\n'.join(c))
+        chunks_to_write.append(b'\n'.join(c))
     file_pattern = write_prepared_pattern(chunks_to_write,
                                           suffixes=(['.gz', '']*3))
     pipeline = TestPipeline()

--- a/sdks/python/apache_beam/io/filesystemio_test.py
+++ b/sdks/python/apache_beam/io/filesystemio_test.py
@@ -182,7 +182,7 @@ class TestPipeStream(unittest.TestCase):
   def test_pipe_stream(self):
     block_sizes = list(4**i for i in range(0, 12))
     data_blocks = list(os.urandom(size) for size in block_sizes)
-    expected = ''.join(data_blocks)
+    expected = b''.join(data_blocks)
 
     buffer_sizes = [100001, 512 * 1024, 1024 * 1024]
 

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -487,7 +487,7 @@ class TextSourceTest(unittest.TestCase):
     with TempDir() as tempdir:
       file_name = tempdir.create_temp_file()
       with bz2.BZ2File(file_name, 'wb') as f:
-        f.write('\n'.join(lines))
+        f.write(b'\n'.join(lines))
 
       with open(file_name, 'wb') as f:
         f.write('corrupt')
@@ -566,7 +566,7 @@ class TextSourceTest(unittest.TestCase):
     with TempDir() as tempdir:
       file_name = tempdir.create_temp_file()
       with gzip.GzipFile(file_name, 'wb') as f:
-        f.write('\n'.join(lines))
+        f.write(b'\n'.join(lines))
 
       with open(file_name, 'wb') as f:
         f.write('corrupt')

--- a/sdks/python/apache_beam/io/tfrecordio_test.py
+++ b/sdks/python/apache_beam/io/tfrecordio_test.py
@@ -132,7 +132,7 @@ class TestTFRecordUtil(unittest.TestCase):
 
   def test_read_record(self):
     actual = _TFRecordUtil.read_record(self._as_file_handle(self.record))
-    self.assertEqual('foo', actual)
+    self.assertEqual(b'foo', actual)
 
   def test_read_record_invalid_record(self):
     self._test_error('bar', 'Not a valid TFRecord. Fewer than 12 bytes')


### PR DESCRIPTION
This commit resolves 23 errors and 1 failure in the io package (Py3). The solutions to these errors are well-documented, and relate to for example the widespread bytes-str issues, as well as the deprecation of assertItemsEqual in favor of assertCountEqual.

This is part of a series of PRs with the goal to make Apache Beam PY3 compatible. The proposal with the outlined approach has been documented [here](https://s.apache.org/beam-python-3).

@tvalentyn @Fematich @charlesccychen @aaltay @Juta @manuzhang

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




