### PR TITLE
[BEAM-2918] Add state support for batch in portable FlinkRunner

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -219,7 +219,8 @@ class BeamModulePlugin implements Plugin<Project> {
       excludeCategories 'org.apache.beam.sdk.testing.UsesFailureMessage'
       excludeCategories 'org.apache.beam.sdk.testing.UsesGaugeMetrics'
       excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
       excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
       //SplitableDoFnTests

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
@@ -584,7 +584,7 @@ class FlinkBatchTransformTranslators {
                 sideInputStrategies,
                 context.getPipelineOptions(),
                 outputMap,
-                (TupleTag<OutputT>) mainOutputTag,
+                mainOutputTag,
                 inputCoder,
                 outputCoderMap);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingPortablePipelineTranslator.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.runners.flink;
 
+import static org.apache.beam.runners.flink.translation.utils.FlinkPipelineTranslatorUtils.instantiateCoder;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.auto.service.AutoService;
@@ -60,7 +62,6 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.WindowDoFnOp
 import org.apache.beam.runners.flink.translation.wrappers.streaming.WorkItemKeySelector;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.StreamingImpulseSource;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
-import org.apache.beam.runners.fnexecution.wire.WireCoders;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.IterableCoder;
@@ -785,17 +786,6 @@ public class FlinkStreamingPortablePipelineTranslator
     @Override
     public WindowedValue<KV<Void, T>> map(WindowedValue<T> value) {
       return value.withValue(KV.of(null, value.getValue()));
-    }
-  }
-
-  static <T> Coder<WindowedValue<T>> instantiateCoder(
-      String collectionId, RunnerApi.Components components) {
-    PipelineNode.PCollectionNode collectionNode =
-        PipelineNode.pCollection(collectionId, components.getPcollectionsOrThrow(collectionId));
-    try {
-      return WireCoders.instantiateRunnerWireCoder(collectionNode, components);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkBatchSideInputHandlerFactory.java
@@ -158,7 +158,7 @@ class FlinkBatchSideInputHandlerFactory implements SideInputHandlerFactory {
       }
     }
 
-    return new MultimapSideInputHandler(multimap.build(), keyCoder, valueCoder, windowCoder);
+    return new MultimapSideInputHandler<>(multimap.build(), keyCoder, valueCoder, windowCoder);
   }
 
   private static class MultimapSideInputHandler<K, V, W extends BoundedWindow>

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -22,9 +22,20 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Iterables;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.GuardedBy;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateKey;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.InMemoryStateInternals;
+import org.apache.beam.runners.core.StateInternals;
+import org.apache.beam.runners.core.StateNamespace;
+import org.apache.beam.runners.core.StateNamespaces;
+import org.apache.beam.runners.core.StateTag;
+import org.apache.beam.runners.core.StateTags;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.fnexecution.control.BundleProgressHandler;
 import org.apache.beam.runners.fnexecution.control.OutputReceiverFactory;
@@ -34,12 +45,17 @@ import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandler;
 import org.apache.beam.runners.fnexecution.state.StateRequestHandlers;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.transforms.join.RawUnionValue;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.flink.api.common.functions.RichMapPartitionFunction;
+import org.apache.flink.api.common.functions.AbstractRichFunction;
+import org.apache.flink.api.common.functions.GroupReduceFunction;
+import org.apache.flink.api.common.functions.MapPartitionFunction;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.util.Collector;
@@ -54,8 +70,9 @@ import org.slf4j.LoggerFactory;
  * coder. The coder's tags are determined by the output coder map. The resulting data set should be
  * further processed by a {@link FlinkExecutableStagePruningFunction}.
  */
-public class FlinkExecutableStageFunction<InputT>
-    extends RichMapPartitionFunction<WindowedValue<InputT>, RawUnionValue> {
+public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
+    implements MapPartitionFunction<WindowedValue<InputT>, RawUnionValue>,
+        GroupReduceFunction<WindowedValue<InputT>, RawUnionValue> {
   private static final Logger LOG = LoggerFactory.getLogger(FlinkExecutableStageFunction.class);
 
   // Main constructor fields. All must be Serializable because Flink distributes Functions to
@@ -68,6 +85,7 @@ public class FlinkExecutableStageFunction<InputT>
   // Map from PCollection id to the union tag used to represent this PCollection in the output.
   private final Map<String, Integer> outputMap;
   private final FlinkExecutableStageContext.Factory contextFactory;
+  private final boolean stateful;
 
   // Worker-local fields. These should only be constructed and consumed on Flink TaskManagers.
   private transient RuntimeContext runtimeContext;
@@ -75,16 +93,20 @@ public class FlinkExecutableStageFunction<InputT>
   private transient FlinkExecutableStageContext stageContext;
   private transient StageBundleFactory stageBundleFactory;
   private transient BundleProgressHandler progressHandler;
+  // Only initialized when the ExecutableStage is stateful
+  private transient InMemoryBagUserStateFactory bagUserStateHandlerFactory;
 
   public FlinkExecutableStageFunction(
       RunnerApi.ExecutableStagePayload stagePayload,
       JobInfo jobInfo,
       Map<String, Integer> outputMap,
-      FlinkExecutableStageContext.Factory contextFactory) {
+      FlinkExecutableStageContext.Factory contextFactory,
+      boolean stateful) {
     this.stagePayload = stagePayload;
     this.jobInfo = jobInfo;
     this.outputMap = outputMap;
     this.contextFactory = contextFactory;
+    this.stateful = stateful;
   }
 
   @Override
@@ -96,28 +118,66 @@ public class FlinkExecutableStageFunction<InputT>
     runtimeContext = getRuntimeContext();
     // TODO: Wire this into the distributed cache and make it pluggable.
     stageContext = contextFactory.get(jobInfo);
+    stageBundleFactory = stageContext.getStageBundleFactory(executableStage);
     // NOTE: It's safe to reuse the state handler between partitions because each partition uses the
     // same backing runtime context and broadcast variables. We use checkState below to catch errors
     // in backward-incompatible Flink changes.
-    stateRequestHandler = getStateRequestHandler(executableStage, runtimeContext);
-    stageBundleFactory = stageContext.getStageBundleFactory(executableStage);
+    stateRequestHandler =
+        getStateRequestHandler(
+            executableStage, stageBundleFactory.getProcessBundleDescriptor(), runtimeContext);
     progressHandler = BundleProgressHandler.unsupported();
   }
 
-  private static StateRequestHandler getStateRequestHandler(
-      ExecutableStage executableStage, RuntimeContext runtimeContext) {
+  private StateRequestHandler getStateRequestHandler(
+      ExecutableStage executableStage,
+      ProcessBundleDescriptors.ExecutableProcessBundleDescriptor processBundleDescriptor,
+      RuntimeContext runtimeContext) {
+    final StateRequestHandler sideInputHandler;
     StateRequestHandlers.SideInputHandlerFactory sideInputHandlerFactory =
         FlinkBatchSideInputHandlerFactory.forStage(executableStage, runtimeContext);
     try {
-      return StateRequestHandlers.forSideInputHandlerFactory(
-          ProcessBundleDescriptors.getSideInputs(executableStage), sideInputHandlerFactory);
+      sideInputHandler =
+          StateRequestHandlers.forSideInputHandlerFactory(
+              ProcessBundleDescriptors.getSideInputs(executableStage), sideInputHandlerFactory);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException("Failed to setup state handler", e);
     }
+
+    final StateRequestHandler userStateHandler;
+    if (stateful) {
+      bagUserStateHandlerFactory = new InMemoryBagUserStateFactory();
+      userStateHandler =
+          StateRequestHandlers.forBagUserStateHandlerFactory(
+              processBundleDescriptor, bagUserStateHandlerFactory);
+    } else {
+      userStateHandler = StateRequestHandler.unsupported();
+    }
+
+    EnumMap<StateKey.TypeCase, StateRequestHandler> handlerMap =
+        new EnumMap<>(StateKey.TypeCase.class);
+    handlerMap.put(StateKey.TypeCase.MULTIMAP_SIDE_INPUT, sideInputHandler);
+    handlerMap.put(StateKey.TypeCase.BAG_USER_STATE, userStateHandler);
+
+    return StateRequestHandlers.delegateBasedUponType(handlerMap);
   }
 
+  /** For non-stateful processing via a simple MapPartitionFunction. */
   @Override
   public void mapPartition(
+      Iterable<WindowedValue<InputT>> iterable, Collector<RawUnionValue> collector)
+      throws Exception {
+    processElements(iterable, collector);
+  }
+
+  /** For stateful processing via a GroupReduceFunction. */
+  @Override
+  public void reduce(Iterable<WindowedValue<InputT>> iterable, Collector<RawUnionValue> collector)
+      throws Exception {
+    bagUserStateHandlerFactory.resetForNewKey();
+    processElements(iterable, collector);
+  }
+
+  private void processElements(
       Iterable<WindowedValue<InputT>> iterable, Collector<RawUnionValue> collector)
       throws Exception {
     checkState(
@@ -186,6 +246,95 @@ public class FlinkExecutableStageFunction<InputT>
           collector.collect(new RawUnionValue(tagInt, receivedElement));
         }
       };
+    }
+  }
+
+  /**
+   * Holds user state in memory if the ExecutableStage is stateful. Only one key is active at a time
+   * due to the GroupReduceFunction being called once per key. Needs to be reset via {@code
+   * resetForNewKey()} before processing a new key.
+   */
+  private static class InMemoryBagUserStateFactory
+      implements StateRequestHandlers.BagUserStateHandlerFactory {
+
+    private List<InMemorySingleKeyBagState> handlers;
+
+    private InMemoryBagUserStateFactory() {
+      handlers = new ArrayList<>();
+    }
+
+    @Override
+    public <K, V, W extends BoundedWindow>
+        StateRequestHandlers.BagUserStateHandler<K, V, W> forUserState(
+            String pTransformId,
+            String userStateId,
+            Coder<K> keyCoder,
+            Coder<V> valueCoder,
+            Coder<W> windowCoder) {
+
+      InMemorySingleKeyBagState<K, V, W> bagUserStateHandler =
+          new InMemorySingleKeyBagState<>(userStateId, valueCoder, windowCoder);
+      handlers.add(bagUserStateHandler);
+
+      return bagUserStateHandler;
+    }
+
+    /** Prepares previous emitted state handlers for processing a new key. */
+    void resetForNewKey() {
+      for (InMemorySingleKeyBagState stateBags : handlers) {
+        stateBags.reset();
+      }
+    }
+
+    static class InMemorySingleKeyBagState<K, V, W extends BoundedWindow>
+        implements StateRequestHandlers.BagUserStateHandler<K, V, W> {
+
+      private final StateTag<BagState<V>> stateTag;
+      private final Coder<W> windowCoder;
+
+      /* Lazily initialized state internals upon first access */
+      private volatile StateInternals stateInternals;
+
+      InMemorySingleKeyBagState(String userStateId, Coder<V> valueCoder, Coder<W> windowCoder) {
+        this.windowCoder = windowCoder;
+        this.stateTag = StateTags.bag(userStateId, valueCoder);
+      }
+
+      @Override
+      public Iterable<V> get(K key, W window) {
+        initStateInternals(key);
+        StateNamespace namespace = StateNamespaces.window(windowCoder, window);
+        BagState<V> bagState = stateInternals.state(namespace, stateTag);
+        return bagState.read();
+      }
+
+      @Override
+      public void append(K key, W window, Iterator<V> values) {
+        initStateInternals(key);
+        StateNamespace namespace = StateNamespaces.window(windowCoder, window);
+        BagState<V> bagState = stateInternals.state(namespace, stateTag);
+        while (values.hasNext()) {
+          bagState.add(values.next());
+        }
+      }
+
+      @Override
+      public void clear(K key, W window) {
+        initStateInternals(key);
+        StateNamespace namespace = StateNamespaces.window(windowCoder, window);
+        BagState<V> bagState = stateInternals.state(namespace, stateTag);
+        bagState.clear();
+      }
+
+      private void initStateInternals(K key) {
+        if (stateInternals == null) {
+          stateInternals = InMemoryStateInternals.forKey(key);
+        }
+      }
+
+      void reset() {
+        stateInternals = null;
+      }
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/utils/FlinkPipelineTranslatorUtils.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/utils/FlinkPipelineTranslatorUtils.java
@@ -20,6 +20,12 @@ package org.apache.beam.runners.flink.translation.utils;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.Sets;
+import java.io.IOException;
+import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.runners.core.construction.graph.PipelineNode;
+import org.apache.beam.runners.fnexecution.wire.WireCoders;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.util.WindowedValue;
 
 /** Utilities for pipeline translation. */
 public final class FlinkPipelineTranslatorUtils {
@@ -35,5 +41,17 @@ public final class FlinkPipelineTranslatorUtils {
       outputIndex++;
     }
     return builder.build();
+  }
+
+  /** Creates a coder for a given PCollection id from the Proto definition. */
+  public static <T> Coder<WindowedValue<T>> instantiateCoder(
+      String collectionId, RunnerApi.Components components) {
+    PipelineNode.PCollectionNode collectionNode =
+        PipelineNode.pCollection(collectionId, components.getPcollectionsOrThrow(collectionId));
+    try {
+      return WireCoders.instantiateRunnerWireCoder(collectionNode, components);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not instantiate Coder", e);
+    }
   }
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
@@ -255,7 +255,18 @@ public class FnApiStateAccessor implements SideInputReader, StateBinder {
 
                   @Override
                   public ReadableState<Boolean> isEmpty() {
-                    return ReadableStates.immediate(!impl.get().iterator().hasNext());
+                    return new ReadableState<Boolean>() {
+                      @Nullable
+                      @Override
+                      public Boolean read() {
+                        return !impl.get().iterator().hasNext();
+                      }
+
+                      @Override
+                      public ReadableState<Boolean> readLater() {
+                        return this;
+                      }
+                    };
                   }
 
                   @Override

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -106,12 +106,6 @@ if __name__ == '__main__':
     def test_no_subtransform_composite(self):
       raise unittest.SkipTest("BEAM-4781")
 
-    def test_pardo_state_only(self):
-      if streaming:
-        super(FlinkRunnerTest, self).test_pardo_state_only()
-      else:
-        raise unittest.SkipTest("BEAM-2918 - User state not yet supported.")
-
     def test_pardo_timers(self):
       raise unittest.SkipTest("BEAM-4681 - User timers not yet supported.")
 


### PR DESCRIPTION
This adds portable state support for the batch mode.

CC @tweise @angoenka @robertwb

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




