### PR TITLE
Remove unnecessary parentheses

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/injector/Injector.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/injector/Injector.java
@@ -248,7 +248,7 @@ class Injector {
               + currTime);
       removeTeam(index);
       // Add a new team in its stead.
-      return (addLiveTeam());
+      return addLiveTeam();
     } else {
       return team;
     }

--- a/examples/java/src/main/java/org/apache/beam/examples/subprocess/kernel/SubProcessKernel.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/subprocess/kernel/SubProcessKernel.java
@@ -69,7 +69,7 @@ public class SubProcessKernel {
           results = collectProcessResults(process, processBuilder, outputFiles);
         } catch (Exception ex) {
           LOG.error("Error running executable ", ex);
-          throw (ex);
+          throw ex;
         }
       } catch (IOException ex) {
         LOG.error(
@@ -91,7 +91,7 @@ public class SubProcessKernel {
           return collectProcessResultsBytes(process, processBuilder, outputFiles);
         } catch (Exception ex) {
           LOG.error("Error running executable ", ex);
-          throw (ex);
+          throw ex;
         }
       } catch (IOException ex) {
         LOG.error(

--- a/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/FileUtils.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/subprocess/utils/FileUtils.java
@@ -47,7 +47,7 @@ public class FileUtils {
   }
 
   public static String toStringParams(ProcessBuilder builder) {
-    return (String.join(",", builder.command()));
+    return String.join(",", builder.command());
   }
 
   public static String copyFileFromWorkerToGCS(

--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexProcessFnOperator.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/translation/operators/ApexProcessFnOperator.java
@@ -138,7 +138,7 @@ public class ApexProcessFnOperator<InputT> extends BaseOperator {
         Collection<W> windows =
             (windowFn)
                 .assignWindows(
-                    (windowFn).new AssignContext() {
+                    windowFn.new AssignContext() {
                       @Override
                       public T element() {
                         return input.getValue();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformReplacements.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformReplacements.java
@@ -69,6 +69,6 @@ public class PTransformReplacements {
 
   public static <T> PCollection<T> getSingletonMainOutput(
       AppliedPTransform<?, PCollection<T>, ? extends PTransform<?, PCollection<T>>> transform) {
-    return ((PCollection<T>) Iterables.getOnlyElement(transform.getOutputs().values()));
+    return (PCollection<T>) Iterables.getOnlyElement(transform.getOutputs().values());
   }
 }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/SplittableRemoteStageEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/portable/SplittableRemoteStageEvaluatorFactory.java
@@ -115,7 +115,7 @@ class SplittableRemoteStageEvaluatorFactory implements TransformEvaluatorFactory
               WireCoders.<KV<InputT, RestrictionT>>instantiateRunnerWireCoder(
                   stage.getInputPCollection(), stage.getComponents());
       KvCoder<InputT, RestrictionT> kvCoder =
-          ((KvCoder<InputT, RestrictionT>) windowedValueCoder.getValueCoder());
+          (KvCoder<InputT, RestrictionT>) windowedValueCoder.getValueCoder();
       this.feeder =
           new SDFFeederViaStateAndTimers<>(
               stateInternals,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -60,7 +60,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
       Throwable current = t;
       for (; current.getCause() != null; current = current.getCause()) {
         if (current instanceof UserCodeException) {
-          innermostUserCodeException = ((UserCodeException) current);
+          innermostUserCodeException = (UserCodeException) current;
         }
       }
       if (innermostUserCodeException != null) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowMetrics.java
@@ -245,8 +245,8 @@ class DataflowMetrics extends MetricResults {
      * @return true if update is tentative, false otherwise
      */
     private boolean isMetricTentative(MetricUpdate metricUpdate) {
-      return (metricUpdate.getName().getContext().containsKey("tentative")
-          && Objects.equal(metricUpdate.getName().getContext().get("tentative"), "true"));
+      return metricUpdate.getName().getContext().containsKey("tentative")
+          && Objects.equal(metricUpdate.getName().getContext().get("tentative"), "true");
     }
 
     /**

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/TransformTranslator.java
@@ -49,7 +49,7 @@ public interface TransformTranslator<TransformT extends PTransform> {
   interface TranslationContext {
     default boolean isFnApi() {
       List<String> experiments = getPipelineOptions().getExperiments();
-      return (experiments != null && experiments.contains("beam_fn_api"));
+      return experiments != null && experiments.contains("beam_fn_api");
     }
 
     /** Returns the configured pipeline options. */

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -255,7 +255,7 @@ public final class StreamingTransformTranslator {
       public void evaluate(final Window.Assign<T> transform, EvaluationContext context) {
         @SuppressWarnings("unchecked")
         UnboundedDataset<T> unboundedDataset =
-            ((UnboundedDataset<T>) context.borrowDataset(transform));
+            (UnboundedDataset<T>) context.borrowDataset(transform);
         JavaDStream<WindowedValue<T>> dStream = unboundedDataset.getDStream();
         JavaDStream<WindowedValue<T>> outputStream;
         if (TranslationUtils.skipAssignWindows(transform, context)) {
@@ -341,7 +341,7 @@ public final class StreamingTransformTranslator {
 
         @SuppressWarnings("unchecked")
         UnboundedDataset<KV<K, Iterable<InputT>>> unboundedDataset =
-            ((UnboundedDataset<KV<K, Iterable<InputT>>>) context.borrowDataset(transform));
+            (UnboundedDataset<KV<K, Iterable<InputT>>>) context.borrowDataset(transform);
         JavaDStream<WindowedValue<KV<K, Iterable<InputT>>>> dStream = unboundedDataset.getDStream();
 
         final SerializablePipelineOptions options = context.getSerializableOptions();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/CoderRegistry.java
@@ -543,7 +543,7 @@ public class CoderRegistry {
     // compatible.
     if ((codedType instanceof ParameterizedType) && !isNullOrEmpty(coder.getCoderArguments())) {
       ParameterizedType parameterizedSupertype =
-          ((ParameterizedType) candidateOkDescriptor.getSupertype(codedClass).getType());
+          (ParameterizedType) candidateOkDescriptor.getSupertype(codedClass).getType();
       Type[] typeArguments = parameterizedSupertype.getActualTypeArguments();
       List<? extends Coder<?>> typeArgumentCoders = coder.getCoderArguments();
       if (typeArguments.length < typeArgumentCoders.size()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -113,7 +113,7 @@ public abstract class RowCoderGenerator {
           MethodInvocation.invoke(
               new ForLoadedType(entry.getValue().getClass())
                   .getDeclaredMethods()
-                  .filter(ElementMatchers.named(("of")))
+                  .filter(ElementMatchers.named("of"))
                   .getOnly());
       CODER_MAP.putIfAbsent(entry.getKey(), stackManipulation);
     }
@@ -341,7 +341,7 @@ public abstract class RowCoderGenerator {
       return listCoder(fieldType.getCollectionElementType());
     } else if (TypeName.MAP.equals(fieldType.getTypeName())) {
       return mapCoder(fieldType.getMapKeyType(), fieldType.getMapValueType());
-    } else if (TypeName.ROW.equals((fieldType.getTypeName()))) {
+    } else if (TypeName.ROW.equals(fieldType.getTypeName())) {
       Coder<Row> nestedCoder = generate(fieldType.getRowSchema(), UUID.randomUUID());
       return rowCoder(nestedCoder.getClass());
     } else {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -412,7 +412,7 @@ public class FileIO {
           getMetadata().isReadSeekEfficient(),
           "The file %s is not seekable",
           metadata.resourceId());
-      return ((SeekableByteChannel) open());
+      return (SeekableByteChannel) open();
     }
 
     /** Returns the full contents of the file as bytes. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/display/DisplayData.java
@@ -610,7 +610,7 @@ public class DisplayData implements Serializable {
       @Override
       FormattedItemValue format(Object value) {
         Instant instant = checkType(value, Instant.class, TIMESTAMP);
-        return new FormattedItemValue((TIMESTAMP_FORMATTER.print(instant)));
+        return new FormattedItemValue(TIMESTAMP_FORMATTER.print(instant));
       }
     },
     DURATION {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -589,7 +589,7 @@ public abstract class Row implements Serializable {
     public Row build() {
       checkNotNull(schema);
       if (!this.values.isEmpty() && fieldValueGetterFactory != null) {
-        throw new IllegalArgumentException(("Cannot specify both values and getters."));
+        throw new IllegalArgumentException("Cannot specify both values and getters.");
       }
       if (!this.values.isEmpty()) {
         List<Object> storageValues = attached ? this.values : verify(schema, this.values);

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/options/AwsModule.java
@@ -171,7 +171,7 @@ public class AwsModule extends SimpleModule {
           Field field =
               PropertiesFileCredentialsProvider.class.getDeclaredField(CREDENTIALS_FILE_PATH);
           field.setAccessible(true);
-          String credentialsFilePath = ((String) field.get(specificProvider));
+          String credentialsFilePath = (String) field.get(specificProvider);
           jsonGenerator.writeStringField(CREDENTIALS_FILE_PATH, credentialsFilePath);
         } catch (NoSuchFieldException | IllegalAccessException e) {
           throw new IOException("failed to access private field with reflection", e);
@@ -187,7 +187,7 @@ public class AwsModule extends SimpleModule {
               ClasspathPropertiesFileCredentialsProvider.class.getDeclaredField(
                   CREDENTIALS_FILE_PATH);
           field.setAccessible(true);
-          String credentialsFilePath = ((String) field.get(specificProvider));
+          String credentialsFilePath = (String) field.get(specificProvider);
           jsonGenerator.writeStringField(CREDENTIALS_FILE_PATH, credentialsFilePath);
         } catch (NoSuchFieldException | IllegalAccessException e) {
           throw new IOException("failed to access private field with reflection", e);

--- a/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
+++ b/sdks/java/io/amazon-web-services/src/main/java/org/apache/beam/sdk/io/aws/s3/S3FileSystem.java
@@ -668,7 +668,7 @@ class S3FileSystem extends FileSystem<S3ResourceId> {
     } catch (ExecutionException e) {
       if (e.getCause() != null) {
         if (e.getCause() instanceof IOException) {
-          throw ((IOException) e.getCause());
+          throw (IOException) e.getCause();
         }
         throw new IOException(e.getCause());
       }

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -1273,7 +1273,7 @@ public class ElasticsearchIO {
       return backendVersion;
 
     } catch (IOException e) {
-      throw (new IllegalArgumentException("Cannot get Elasticsearch version", e));
+      throw new IllegalArgumentException("Cannot get Elasticsearch version", e);
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1708,7 +1708,7 @@ public class BigQueryIO {
         StreamingInserts<DestinationT> streamingInserts =
             new StreamingInserts<>(getCreateDisposition(), dynamicDestinations)
                 .withInsertRetryPolicy(retryPolicy)
-                .withTestServices((getBigQueryServices()))
+                .withTestServices(getBigQueryServices())
                 .withExtendedErrorInfo(getExtendedErrorInfo())
                 .withSkipInvalidRows(getSkipInvalidRows())
                 .withIgnoreUnknownValues(getIgnoreUnknownValues());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -279,7 +279,7 @@ public class BigQueryUtils {
 
   private static Object toBeamValue(FieldType fieldType, Object jsonBQValue) {
     if (jsonBQValue instanceof String && JSON_VALUE_PARSERS.containsKey(fieldType.getTypeName())) {
-      return JSON_VALUE_PARSERS.get((fieldType.getTypeName())).apply((String) jsonBQValue);
+      return JSON_VALUE_PARSERS.get(fieldType.getTypeName()).apply((String) jsonBQValue);
     }
 
     if (jsonBQValue instanceof List) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -137,7 +137,7 @@ class BigtableServiceImpl implements BigtableService {
     @Override
     public boolean advance() throws IOException {
       currentRow = results.next();
-      return (currentRow != null);
+      return currentRow != null;
     }
 
     @Override

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -681,7 +681,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   private static Consumer<?, ?> openConsumer(Write<?, ?> spec) {
     return spec.getConsumerFactoryFn()
         .apply(
-            (ImmutableMap.of(
+            ImmutableMap.of(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
                 spec.getProducerConfig().get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
                 ConsumerConfig.GROUP_ID_CONFIG,
@@ -689,7 +689,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 ByteArrayDeserializer.class,
                 ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                ByteArrayDeserializer.class)));
+                ByteArrayDeserializer.class));
   }
 
   private static <K, V> Producer<K, V> initializeExactlyOnceProducer(
@@ -709,7 +709,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
     Producer<K, V> producer =
         spec.getProducerFactoryFn() != null
-            ? spec.getProducerFactoryFn().apply((producerConfig))
+            ? spec.getProducerFactoryFn().apply(producerConfig)
             : new KafkaProducer<>(producerConfig);
 
     ProducerSpEL.initTransactions(producer);

--- a/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3.java
+++ b/sdks/java/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/Query3.java
@@ -86,7 +86,7 @@ public class Query3 extends NexmarkQuery {
     PCollection<Event> eventsWindowed =
         events.apply(
             Window.<Event>into(new GlobalWindows())
-                .triggering(Repeatedly.forever((AfterPane.elementCountAtLeast(numEventsInPane))))
+                .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(numEventsInPane)))
                 .discardingFiredPanes()
                 .withAllowedLateness(Duration.ZERO));
     PCollection<KV<Long, Auction>> auctionsBySellerId =


### PR DESCRIPTION
Remove unnecessary parentheses from the Java code. I only removed the cases where I felt the parentheses weren't adding anything in terms of clarity.