### PR TITLE
[BEAM-5791] Implement time-based pushback in the dataflow harness data plane.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutor.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
@@ -270,6 +271,7 @@ public class BeamFnMapTaskExecutor extends DataflowMapTaskExecutor {
     private final AtomicReference<Progress> latestProgress = new AtomicReference<>();
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private ScheduledFuture<?> nextProgressFuture;
+    private final Consumer<Integer> grpcWriteOperationElementsProcessed;
 
     private final Map<MetricKey, MetricUpdates.MetricUpdate<Long>> counterUpdates;
     private final Map<MetricKey, MetricUpdates.MetricUpdate<DistributionData>> distributionUpdates;
@@ -282,6 +284,7 @@ public class BeamFnMapTaskExecutor extends DataflowMapTaskExecutor {
       this.readOperation = readOperation;
       this.grpcWriteOperation = grpcWriteOperation;
       this.bundleProcessOperation = bundleProcessOperation;
+      this.grpcWriteOperationElementsProcessed = grpcWriteOperation.processedElementsConsumer();
       this.progressInterpolator =
           new Interpolator<Progress>(MAX_DATA_POINTS) {
             @Override
@@ -307,25 +310,29 @@ public class BeamFnMapTaskExecutor extends DataflowMapTaskExecutor {
 
         double elementsConsumed = bundleProcessOperation.getInputElementsConsumed(metrics);
 
+        grpcWriteOperationElementsProcessed.accept((int) elementsConsumed);
         progressInterpolator.addPoint(
             grpcWriteOperation.getElementsSent(), readOperation.getProgress());
         latestProgress.set(progressInterpolator.interpolateAndPurge(elementsConsumed));
         progressErrors = 0;
       } catch (Exception exn) {
-        progressErrors++;
-        // Only log verbosely every power of two to avoid spamming the logs.
-        if (Integer.bitCount(progressErrors) == 1) {
-          LOG.warn(
-              String.format(
-                  "Progress updating failed %s times. Following exception safely handled.",
-                  progressErrors),
-              exn);
-        } else {
-          LOG.debug(
-              String.format(
-                  "Progress updating failed %s times. Following exception safely handled.",
-                  progressErrors),
-              exn);
+        if (!isTransientProgressError(exn.getMessage())) {
+          grpcWriteOperationElementsProcessed.accept(-1); // Not supported.
+          progressErrors++;
+          // Only log verbosely every power of two to avoid spamming the logs.
+          if (Integer.bitCount(progressErrors) == 1) {
+            LOG.warn(
+                String.format(
+                    "Progress updating failed %s times. Following exception safely handled.",
+                    progressErrors),
+                exn);
+          } else {
+            LOG.debug(
+                String.format(
+                    "Progress updating failed %s times. Following exception safely handled.",
+                    progressErrors),
+                exn);
+          }
         }
 
         try {
@@ -589,5 +596,13 @@ public class BeamFnMapTaskExecutor extends DataflowMapTaskExecutor {
     } else {
       return new NullProgressTracker();
     }
+  }
+
+  /** Whether the given error is likely to go away (e.g. the bundle has not started). */
+  private static boolean isTransientProgressError(String msg) {
+    return msg != null
+        && (msg.contains("Process bundle request not yet scheduled")
+            || msg.contains("Unknown process bundle instruction")
+            || msg.contains("unstarted operation"));
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FnApiWindowMappingFnTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FnApiWindowMappingFnTest.java
@@ -138,6 +138,9 @@ public class FnApiWindowMappingFnTest {
         }
 
         @Override
+        public void flush() throws Exception {}
+
+        @Override
         public void close() throws Exception {}
       };
     }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/BeamFnMapTaskExecutorTest.java
@@ -272,6 +272,8 @@ public class BeamFnMapTaskExecutorTest {
           public void close() {}
         };
 
+    when(grpcPortWriteOperation.processedElementsConsumer()).thenReturn(elementsConsumed -> {});
+
     RegisterAndProcessBundleOperation processOperation =
         new RegisterAndProcessBundleOperation(
             idGenerator,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/SingularProcessBundleProgressTrackerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/control/SingularProcessBundleProgressTrackerTest.java
@@ -69,6 +69,8 @@ public class SingularProcessBundleProgressTrackerTest {
     RegisterAndProcessBundleOperation process =
         Mockito.mock(RegisterAndProcessBundleOperation.class);
 
+    when(grpcWrite.processedElementsConsumer()).thenReturn(elementsConsumed -> {});
+
     SingularProcessBundleProgressTracker tracker =
         new SingularProcessBundleProgressTracker(read, grpcWrite, process);
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperationTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperationTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.OperationContext;
@@ -131,6 +133,82 @@ public class RemoteGrpcPortWriteOperationTest {
     verifyNoMoreInteractions(beamFnDataService);
   }
 
+  @Test
+  public void testBufferRateLimiting() throws Exception {
+    AtomicInteger processedElements = new AtomicInteger();
+    AtomicInteger currentTimeMillis = new AtomicInteger(10000);
+
+    final int START_BUFFER_SIZE = 3;
+    final int STEADY_BUFFER_SIZE = 10;
+    final int FIRST_ELEMENT_DURATION =
+        (int) RemoteGrpcPortWriteOperation.MAX_BUFFER_MILLIS / START_BUFFER_SIZE + 1;
+    final int STEADY_ELEMENT_DURATION =
+        (int) RemoteGrpcPortWriteOperation.MAX_BUFFER_MILLIS / STEADY_BUFFER_SIZE + 1;
+
+    operation =
+        new RemoteGrpcPortWriteOperation<>(
+            beamFnDataService,
+            TARGET,
+            bundleIdSupplier,
+            CODER,
+            operationContext,
+            () -> (long) currentTimeMillis.get());
+
+    RecordingConsumer<WindowedValue<String>> recordingConsumer = new RecordingConsumer<>();
+    when(beamFnDataService.send(any(), Matchers.<Coder<WindowedValue<String>>>any()))
+        .thenReturn(recordingConsumer);
+    when(bundleIdSupplier.get()).thenReturn(BUNDLE_ID);
+
+    Consumer<Integer> processedElementConsumer = operation.processedElementsConsumer();
+
+    operation.start();
+
+    // Never wait before sending the first element.
+    assertFalse(operation.shouldWait());
+    operation.process(valueInGlobalWindow("first"));
+
+    // After sending the first element, wait until it's processed before sending another.
+    assertTrue(operation.shouldWait());
+
+    // Once we've processed the element, we can send the second.
+    currentTimeMillis.getAndAdd(FIRST_ELEMENT_DURATION);
+    processedElementConsumer.accept(1);
+    assertFalse(operation.shouldWait());
+    operation.process(valueInGlobalWindow("second"));
+
+    // Send elements until the buffer is full.
+    for (int i = 2; i < START_BUFFER_SIZE + 1; i++) {
+      assertFalse(operation.shouldWait());
+      operation.process(valueInGlobalWindow("element" + i));
+    }
+
+    // The buffer is full.
+    assertTrue(operation.shouldWait());
+
+    // Now finish processing the second element.
+    currentTimeMillis.getAndAdd(STEADY_ELEMENT_DURATION);
+    processedElementConsumer.accept(2);
+
+    // That was faster, so our buffer quota is larger.
+    for (int i = START_BUFFER_SIZE + 1; i < STEADY_BUFFER_SIZE + 2; i++) {
+      assertFalse(operation.shouldWait());
+      operation.process(valueInGlobalWindow("element" + i));
+    }
+
+    // The buffer is full again.
+    assertTrue(operation.shouldWait());
+
+    // As elements are consumed, we can keep adding more.
+    for (int i = START_BUFFER_SIZE + STEADY_BUFFER_SIZE + 2; i < 100; i++) {
+      currentTimeMillis.getAndAdd(STEADY_ELEMENT_DURATION);
+      processedElementConsumer.accept(i);
+      assertFalse(operation.shouldWait());
+      operation.process(valueInGlobalWindow("element" + i));
+    }
+
+    operation.finish();
+  }
+
   private static class RecordingConsumer<T> extends ArrayList<T>
       implements CloseableFnDataReceiver<T> {
     private boolean closed;
@@ -141,7 +219,10 @@ public class RemoteGrpcPortWriteOperationTest {
     }
 
     @Override
-    public void accept(T t) throws Exception {
+    public void flush() throws Exception {}
+
+    @Override
+    public synchronized void accept(T t) throws Exception {
       if (closed) {
         throw new IllegalStateException("Consumer is closed but attempting to consume " + t);
       }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataBufferingOutboundObserver.java
@@ -113,6 +113,13 @@ public class BeamFnDataBufferingOutboundObserver<T>
   }
 
   @Override
+  public void flush() throws IOException {
+    if (bufferedElements.size() > 0) {
+      outboundObserver.onNext(convertBufferForTransmission().build());
+    }
+  }
+
+  @Override
   public void accept(WindowedValue<T> t) throws IOException {
     if (closed) {
       throw new IllegalStateException("Already closed.");
@@ -120,7 +127,7 @@ public class BeamFnDataBufferingOutboundObserver<T>
     coder.encode(t, bufferedElements);
     counter += 1;
     if (bufferedElements.size() >= bufferLimit) {
-      outboundObserver.onNext(convertBufferForTransmission().build());
+      flush();
     }
   }
 

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/CloseableFnDataReceiver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/CloseableFnDataReceiver.java
@@ -24,6 +24,17 @@ package org.apache.beam.sdk.fn.data;
  * <p>The close method for a {@link CloseableFnDataReceiver} must be idempotent.
  */
 public interface CloseableFnDataReceiver<T> extends FnDataReceiver<T>, AutoCloseable {
+
+  /**
+   * Eagerly flushes any data that is buffered in this channel.
+   *
+   * TODO: Remove once splitting/checkpointing are available in SDKs and rewinding in readers.
+   *
+   * @throws Exception
+   */
+  @Deprecated
+  void flush() throws Exception;
+
   /**
    * {@inheritDoc}.
    *


### PR DESCRIPTION
If the SDK provides metrics on element consumption, we record this rate to throttle (if needed) the rate at which we write elements to the buffer.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




