### PR TITLE
[BEAM-5675] Fix RowCoder#verifyDeterministic

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/org/apache/beam/sdk/coders/RowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/org/apache/beam/sdk/coders/RowCoderTest.java
@@ -18,18 +18,13 @@
 
 package org.apache.beam.sdk.coders.org.apache.beam.sdk.coders;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.schemas.Schema;
@@ -122,8 +117,8 @@ public class RowCoderTest {
     checkEncodeDecode(row);
   }
 
-  @Test
-  public void testVerifyDeterministic() {
+  @Test(expected = NonDeterministicException.class)
+  public void testVerifyDeterministic() throws NonDeterministicException {
     Schema schema =
         Schema.builder()
             .addField("f1", FieldType.DOUBLE)
@@ -132,19 +127,15 @@ public class RowCoderTest {
             .build();
     RowCoder coder = RowCoder.of(schema);
 
-    String reason1 = "f1 -> Floating point encodings are not guaranteed to be deterministic.";
-    String reason2 = "f2 -> Floating point encodings are not guaranteed to be deterministic.";
-
-    assertNonDeterministic(coder, Arrays.asList(reason1, reason2));
+    coder.verifyDeterministic();
   }
 
-  @Test
-  public void testVerifyDeterministicNestedRow() {
+  @Test(expected = NonDeterministicException.class)
+  public void testVerifyDeterministicNestedRow() throws NonDeterministicException {
     Schema schema =
         Schema.builder()
-            .addField("f1", FieldType.DOUBLE)
             .addField(
-                "f2",
+                "f1",
                 FieldType.row(
                     Schema.builder()
                         .addField("a1", FieldType.DOUBLE)
@@ -153,18 +144,6 @@ public class RowCoderTest {
             .build();
     RowCoder coder = RowCoder.of(schema);
 
-    String reason1 = "f1 -> Floating point encodings are not guaranteed to be deterministic.";
-    String reason2 = "f2 -> a1 -> Floating point encodings are not guaranteed to be deterministic.";
-
-    assertNonDeterministic(coder, Arrays.asList(reason1, reason2));
-  }
-
-  private void assertNonDeterministic(RowCoder coder, List<String> reasons) {
-    try {
-      coder.verifyDeterministic();
-      fail("Expected " + coder + " to be non-deterministic");
-    } catch (NonDeterministicException e) {
-      assertThat(e.getReasons(), containsInAnyOrder(reasons.toArray()));
-    }
+    coder.verifyDeterministic();
   }
 }


### PR DESCRIPTION
Fix to make it is consistent with Beam coders.

For instance, `DoubleCoder#verifyDeterministic` throws an exception, but `RowCoder#verifyDeterministic` doesn't.

Expected to throw NonDeterministicException
```
RowCoder.of(
    Schema
        .builder()
        .addField("foo", Schema.FieldType.DOUBLE)
        .build()
).verifyDeterministic();
```
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




