### PR TITLE
[BEAM-5817] Use an explicit enum for naming Nexmark benchmarks

### DIFF
--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -223,7 +223,7 @@ public class Main {
         tableFunction =
             input ->
                 new TableDestination(
-                    tableSpec.replace("{query}", String.valueOf(input.getValue().getKey().query)),
+                    tableSpec.replace("{query}", input.getValue().getKey().query.getNumberOrName()),
                     "perfkit queries");
     SerializableFunction<KV<NexmarkConfiguration, NexmarkPerf>, TableRow> rowFunction =
         input -> {

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkConfiguration.java
@@ -35,7 +35,7 @@ public class NexmarkConfiguration implements Serializable {
   @JsonProperty public boolean debug = true;
 
   /** Which query to run, in [0,9]. */
-  @JsonProperty public int query = 0;
+  @JsonProperty public NexmarkQueryName query = null;
 
   /** Where events come from. */
   @JsonProperty public NexmarkUtils.SourceType sourceType = NexmarkUtils.SourceType.DIRECT;
@@ -186,7 +186,14 @@ public class NexmarkConfiguration implements Serializable {
       debug = options.getDebug();
     }
     if (options.getQuery() != null) {
-      query = options.getQuery();
+      try {
+        query = NexmarkQueryName.valueOf(options.getQuery());
+      } catch (IllegalArgumentException exc) {
+        query = NexmarkQueryName.fromNumber(Integer.parseInt(options.getQuery()));
+      }
+      if (query == null) {
+        throw new IllegalArgumentException("Unknown query: " + query);
+      }
     }
     if (options.getSourceType() != null) {
       sourceType = options.getSourceType();
@@ -353,7 +360,7 @@ public class NexmarkConfiguration implements Serializable {
    */
   public String toShortString() {
     StringBuilder sb = new StringBuilder();
-    sb.append(String.format("query:%d", query));
+    sb.append(String.format("query:%s", query));
     if (debug != DEFAULT.debug) {
       sb.append(String.format("; debug:%s", debug));
     }

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkOptions.java
@@ -73,9 +73,9 @@ public interface NexmarkOptions
 
   @Description("Which query to run.")
   @Nullable
-  Integer getQuery();
+  String getQuery();
 
-  void setQuery(Integer query);
+  void setQuery(String query);
 
   @Description("Prefix for output files if using text output for results or running Query 10.")
   @Nullable

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkQueryName.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark;
+
+import javax.annotation.Nullable;
+
+/** Known "Nexmark" queries, some of which are of our own devising but use the same data set. */
+@SuppressWarnings("ImmutableEnumChecker")
+public enum NexmarkQueryName {
+  // A baseline
+  PASSTHROUGH(0),
+
+  // The actual Nexmark queries
+  CURRENCY_CONVERSION(1),
+  SELECTION(2),
+  LOCAL_ITEM_SUGGESTION(3),
+  AVERAGE_PRICE_FOR_CATEGORY(4),
+  HOT_ITEMS(5),
+  AVERAGE_SELLING_PRICE_BY_SELLER(6),
+  HIGHEST_BID(7),
+  MONITOR_NEW_USERS(8), // Query 8
+
+  // Misc other queries against the data set
+  WINNING_BIDS(9), // Query "9"
+  LOG_TO_SHARDED_FILES(10), // Query "10"
+  USER_SESSIONS(11), // Query "11"
+  PROCESSING_TIME_WINDOWS(12); // Query "12"
+
+  private @Nullable Integer number;
+
+  NexmarkQueryName() {
+    this.number = null;
+  }
+
+  NexmarkQueryName(int number) {
+    this.number = number;
+  }
+
+  /**
+   * Outputs the number of a query if the query is one that we have given a number, for
+   * compatibility. If the query does not have a number, returns its name.
+   */
+  public String getNumberOrName() {
+    if (number != null) {
+      return number.toString();
+    } else {
+      return this.toString();
+    }
+  }
+
+  /**
+   * Parses a number into the corresponding query, using the numbers from the original Nexmark suite
+   * and the other numbers that we have added. If the number is not a known query, returns {@code
+   * null}.
+   */
+  public static @Nullable NexmarkQueryName fromNumber(int nexmarkQueryNumber) {
+    // Noting that the number of names is O(1) this is still O(1) :-)
+    for (NexmarkQueryName queryName : NexmarkQueryName.values()) {
+      if (queryName.number == nexmarkQueryNumber) {
+        return queryName;
+      }
+    }
+    return null;
+  }
+}

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkSuite.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/NexmarkSuite.java
@@ -52,11 +52,13 @@ public enum NexmarkSuite {
 
   private static List<NexmarkConfiguration> smoke() {
     List<NexmarkConfiguration> configurations = new ArrayList<>();
-    for (int query = 0; query <= 12; query++) {
+    for (NexmarkQueryName query : NexmarkQueryName.values()) {
       NexmarkConfiguration configuration = NexmarkConfiguration.DEFAULT.copy();
       configuration.query = query;
       configuration.numEvents = 100_000;
-      if (query == 4 || query == 6 || query == 9) {
+      if (query == NexmarkQueryName.AVERAGE_PRICE_FOR_CATEGORY
+          || query == NexmarkQueryName.AVERAGE_SELLING_PRICE_BY_SELLER
+          || query == NexmarkQueryName.WINNING_BIDS) {
         // Scale back so overall runtimes are reasonably close across all queries.
         configuration.numEvents /= 10;
       }
@@ -89,7 +91,7 @@ public enum NexmarkSuite {
     NexmarkConfiguration configuration = NexmarkConfiguration.DEFAULT.copy();
     configuration.numEventGenerators = 10;
 
-    configuration.query = 10;
+    configuration.query = NexmarkQueryName.LOG_TO_SHARDED_FILES;
     configuration.isRateLimited = true;
     configuration.sourceType = NexmarkUtils.SourceType.PUBSUB;
     configuration.numEvents = 0; // as many as possible without overflow.

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/NexmarkConfigurationTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/NexmarkConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.nexmark;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.junit.Test;
+
+/** Test of {@link NexmarkConfiguration} conversion from {@link NexmarkOptions}. */
+public class NexmarkConfigurationTest {
+
+  @Test
+  public void testNumericQueryParsing() {
+    NexmarkConfiguration configuration = NexmarkConfiguration.DEFAULT;
+    configuration.overrideFromOptions(
+        PipelineOptionsFactory.fromArgs("--query=3").as(NexmarkOptions.class));
+    assertThat(configuration.query, equalTo(NexmarkQueryName.LOCAL_ITEM_SUGGESTION));
+  }
+
+  @Test
+  public void testNamedQueryParsing() {
+    NexmarkConfiguration configuration = NexmarkConfiguration.DEFAULT;
+    configuration.overrideFromOptions(
+        PipelineOptionsFactory.fromArgs("--query=HIGHEST_BID").as(NexmarkOptions.class));
+    assertThat(configuration.query, equalTo(NexmarkQueryName.HIGHEST_BID));
+  }
+}

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/PerfsToBigQueryTest.java
@@ -42,7 +42,7 @@ import org.junit.rules.TemporaryFolder;
 /** Test class for BigQuery sinks. */
 public class PerfsToBigQueryTest {
 
-  private static final int QUERY = 1;
+  private static final NexmarkQueryName QUERY = NexmarkQueryName.CURRENCY_CONVERSION;
   private NexmarkOptions options;
   private FakeDatasetService fakeDatasetService = new FakeDatasetService();
   private FakeJobService fakeJobService = new FakeJobService();
@@ -98,7 +98,7 @@ public class PerfsToBigQueryTest {
     Main.savePerfsToBigQuery(
         options, perfs, fakeBqServices, new Instant(startTimestampSeconds * 1000L));
 
-    String tableSpec = NexmarkUtils.tableSpec(options, String.valueOf(QUERY), 0L, null);
+    String tableSpec = NexmarkUtils.tableSpec(options, QUERY.getNumberOrName(), 0L, null);
     List<TableRow> actualRows =
         fakeDatasetService.getAllRows(
             options.getProject(),


### PR DESCRIPTION
The "Nexmark" queries are numbers 0 through twelve. Only 1 through 8 are actually from the original Nexmark suite. It makes sense because the data set is so convenient that we might have many interesting queries and use cases to build.

Preparing to add more, I wanted to stop just making up numbers and start giving them names.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




