### PR TITLE
[BEAM-6138] Add User Counter Metric Support to Java SDK

### DIFF
--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -50,12 +50,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 import org.apache.beam.fn.harness.FnHarness;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.MonitoringInfo;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleProgressResponse;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.Target;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.FusedPipeline;
 import org.apache.beam.runners.core.construction.graph.GreedyPipelineFuser;
+import org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder;
 import org.apache.beam.runners.fnexecution.GrpcContextHeaderAccessorProvider;
 import org.apache.beam.runners.fnexecution.GrpcFnServer;
 import org.apache.beam.runners.fnexecution.InProcessServerFactory;
@@ -83,6 +87,7 @@ import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
 import org.apache.beam.sdk.fn.test.InProcessManagedChannelFactory;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.ReadableState;
@@ -109,16 +114,20 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.vendor.grpc.v1_13_1.com.google.protobuf.ByteString;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 import org.joda.time.DateTimeUtils;
 import org.joda.time.Duration;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Tests the execution of a pipeline from specification time to executing a single fused stage,
@@ -127,6 +136,8 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RemoteExecutionTest implements Serializable {
   @Rule public transient ResetDateTimeProvider resetDateTimeProvider = new ResetDateTimeProvider();
+
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteExecutionTest.class);
 
   private transient GrpcFnServer<FnApiControlClientPoolService> controlServer;
   private transient GrpcFnServer<GrpcDataService> dataServer;
@@ -387,14 +398,14 @@ public class RemoteExecutionTest implements Serializable {
         .apply(
             "readSideInput",
             ParDo.of(
-                    new DoFn<String, KV<String, String>>() {
-                      @ProcessElement
-                      public void processElement(ProcessContext context) {
-                        for (String value : context.sideInput(view)) {
-                          context.output(KV.of(context.element(), value));
-                        }
-                      }
-                    })
+                new DoFn<String, KV<String, String>>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext context) {
+                    for (String value : context.sideInput(view)) {
+                      context.output(KV.of(context.element(), value));
+                    }
+                  }
+                })
                 .withSideInputs(view))
         .setCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
         // Force the output to be materialized
@@ -483,6 +494,124 @@ public class RemoteExecutionTest implements Serializable {
               WindowedValue.valueInGlobalWindow(kvBytes("Y", "A")),
               WindowedValue.valueInGlobalWindow(kvBytes("Y", "B")),
               WindowedValue.valueInGlobalWindow(kvBytes("Y", "C"))));
+    }
+  }
+
+  @Test
+  public void testMetrics() throws Exception {
+    final String COUNTER_METRIC_NAME = "counterMetric";
+    Pipeline p = Pipeline.create();
+    PCollection<String> input =
+        p.apply("impulse", Impulse.create())
+            .apply(
+                "create",
+                ParDo.of(
+                    new DoFn<byte[], String>() {
+                      @ProcessElement
+                      public void process(ProcessContext ctxt) {
+                        Metrics.counter(RemoteExecutionTest.class, COUNTER_METRIC_NAME).inc();
+                      }
+                    }))
+            .setCoder(StringUtf8Coder.of());
+
+    RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(p);
+    FusedPipeline fused = GreedyPipelineFuser.fuse(pipelineProto);
+    Optional<ExecutableStage> optionalStage =
+        Iterables.tryFind(fused.getFusedStages(), (ExecutableStage stage) -> true);
+    checkState(optionalStage.isPresent(), "Expected a stage with side inputs.");
+    ExecutableStage stage = optionalStage.get();
+
+    ExecutableProcessBundleDescriptor descriptor =
+        ProcessBundleDescriptors.fromExecutableStage(
+            "test_stage",
+            stage,
+            dataServer.getApiServiceDescriptor(),
+            stateServer.getApiServiceDescriptor());
+
+    BundleProcessor processor =
+        controlClient.getProcessor(
+            descriptor.getProcessBundleDescriptor(),
+            descriptor.getRemoteInputDestinations(),
+            stateDelegator);
+
+    Map<Target, Coder<WindowedValue<?>>> outputTargets = descriptor.getOutputTargetCoders();
+    Map<Target, Collection<WindowedValue<?>>> outputValues = new HashMap<>();
+    Map<Target, RemoteOutputReceiver<?>> outputReceivers = new HashMap<>();
+    for (Entry<Target, Coder<WindowedValue<?>>> targetCoder : outputTargets.entrySet()) {
+      List<WindowedValue<?>> outputContents = Collections.synchronizedList(new ArrayList<>());
+      outputValues.put(targetCoder.getKey(), outputContents);
+      outputReceivers.put(
+          targetCoder.getKey(),
+          RemoteOutputReceiver.of(targetCoder.getValue(), outputContents::add));
+    }
+
+    Iterable<byte[]> sideInputData =
+        Arrays.asList(
+            CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "A"),
+            CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "B"),
+            CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "C"));
+
+    StateRequestHandler stateRequestHandler =
+        StateRequestHandlers.forSideInputHandlerFactory(
+            descriptor.getSideInputSpecs(),
+            new SideInputHandlerFactory() {
+              @Override
+              public <T, V, W extends BoundedWindow> SideInputHandler<V, W> forSideInput(
+                  String pTransformId,
+                  String sideInputId,
+                  RunnerApi.FunctionSpec accessPattern,
+                  Coder<T> elementCoder,
+                  Coder<W> windowCoder) {
+                return new SideInputHandler<V, W>() {
+                  @Override
+                  public Iterable<V> get(byte[] key, W window) {
+                    return (Iterable) sideInputData;
+                  }
+
+                  @Override
+                  public Coder<V> resultCoder() {
+                    return ((KvCoder) elementCoder).getValueCoder();
+                  }
+                };
+              }
+            });
+
+    BundleProgressHandler progressHandler =
+        new BundleProgressHandler() {
+          @Override
+          public void onProgress(ProcessBundleProgressResponse progress) {}
+
+          @Override
+          public void onCompleted(ProcessBundleResponse response) {
+            // Assert the timestamps are non empty then 0 them out before comparing.
+            List<MonitoringInfo> actualMIs = new ArrayList<>();
+            for (MonitoringInfo mi : response.getMonitoringInfosList()) {
+              MonitoringInfo.Builder builder = MonitoringInfo.newBuilder();
+              Assert.assertTrue(mi.getTimestamp().getSeconds() > 0);
+              builder.mergeFrom(mi);
+              builder.clearTimestamp();
+              actualMIs.add(builder.build());
+            }
+
+            SimpleMonitoringInfoBuilder builder = new SimpleMonitoringInfoBuilder();
+            builder.setUrnForUserMetric(RemoteExecutionTest.class.getName(), COUNTER_METRIC_NAME);
+            builder.setInt64Value(2);
+            MonitoringInfo expectedCounter = builder.build();
+
+            assertThat(actualMIs, CoreMatchers.hasItems(expectedCounter));
+          }
+        };
+
+    try (ActiveBundle bundle =
+        processor.newBundle(outputReceivers, stateRequestHandler, progressHandler)) {
+      Iterables.getOnlyElement(bundle.getInputReceivers().values())
+          .accept(
+              WindowedValue.valueInGlobalWindow(
+                  CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "X")));
+      Iterables.getOnlyElement(bundle.getInputReceivers().values())
+          .accept(
+              WindowedValue.valueInGlobalWindow(
+                  CoderUtils.encodeToByteArray(StringUtf8Coder.of(), "Y")));
     }
   }
 
@@ -917,10 +1046,10 @@ public class RemoteExecutionTest implements Serializable {
 
   private Object timerStructuralValue(Object timer) {
     return WindowedValue.FullWindowedValueCoder.of(
-            KvCoder.of(
-                ByteArrayCoder.of(),
-                org.apache.beam.runners.core.construction.Timer.Coder.of(ByteArrayCoder.of())),
-            GlobalWindow.Coder.INSTANCE)
+        KvCoder.of(
+            ByteArrayCoder.of(),
+            org.apache.beam.runners.core.construction.Timer.Coder.of(ByteArrayCoder.of())),
+        GlobalWindow.Coder.INSTANCE)
         .structuralValue(timer);
   }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -499,7 +499,7 @@ public class RemoteExecutionTest implements Serializable {
 
   @Test
   public void testMetrics() throws Exception {
-    final String COUNTER_METRIC_NAME = "counterMetric";
+    final String counterMetricName = "counterMetric";
     Pipeline p = Pipeline.create();
     PCollection<String> input =
         p.apply("impulse", Impulse.create())
@@ -509,7 +509,7 @@ public class RemoteExecutionTest implements Serializable {
                     new DoFn<byte[], String>() {
                       @ProcessElement
                       public void process(ProcessContext ctxt) {
-                        Metrics.counter(RemoteExecutionTest.class, COUNTER_METRIC_NAME).inc();
+                        Metrics.counter(RemoteExecutionTest.class, counterMetricName).inc();
                       }
                     }))
             .setCoder(StringUtf8Coder.of());
@@ -594,7 +594,7 @@ public class RemoteExecutionTest implements Serializable {
             }
 
             SimpleMonitoringInfoBuilder builder = new SimpleMonitoringInfoBuilder();
-            builder.setUrnForUserMetric(RemoteExecutionTest.class.getName(), COUNTER_METRIC_NAME);
+            builder.setUrnForUserMetric(RemoteExecutionTest.class.getName(), counterMetricName);
             builder.setInt64Value(2);
             MonitoringInfo expectedCounter = builder.build();
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -398,14 +398,14 @@ public class RemoteExecutionTest implements Serializable {
         .apply(
             "readSideInput",
             ParDo.of(
-                new DoFn<String, KV<String, String>>() {
-                  @ProcessElement
-                  public void processElement(ProcessContext context) {
-                    for (String value : context.sideInput(view)) {
-                      context.output(KV.of(context.element(), value));
-                    }
-                  }
-                })
+                    new DoFn<String, KV<String, String>>() {
+                      @ProcessElement
+                      public void processElement(ProcessContext context) {
+                        for (String value : context.sideInput(view)) {
+                          context.output(KV.of(context.element(), value));
+                        }
+                      }
+                    })
                 .withSideInputs(view))
         .setCoder(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
         // Force the output to be materialized
@@ -1046,10 +1046,10 @@ public class RemoteExecutionTest implements Serializable {
 
   private Object timerStructuralValue(Object timer) {
     return WindowedValue.FullWindowedValueCoder.of(
-        KvCoder.of(
-            ByteArrayCoder.of(),
-            org.apache.beam.runners.core.construction.Timer.Coder.of(ByteArrayCoder.of())),
-        GlobalWindow.Coder.INSTANCE)
+            KvCoder.of(
+                ByteArrayCoder.of(),
+                org.apache.beam.runners.core.construction.Timer.Coder.of(ByteArrayCoder.of())),
+            GlobalWindow.Coder.INSTANCE)
         .structuralValue(timer);
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -265,8 +265,8 @@ public class ProcessBundleHandler {
     try (HandleStateCallsForBundle beamFnStateClient =
         bundleDescriptor.hasStateApiServiceDescriptor()
             ? new BlockTillStateCallsFinish(
-            beamFnStateGrpcClientCache.forApiServiceDescriptor(
-                bundleDescriptor.getStateApiServiceDescriptor()))
+                beamFnStateGrpcClientCache.forApiServiceDescriptor(
+                    bundleDescriptor.getStateApiServiceDescriptor()))
             : new FailAllStateCallsForBundle(request.getProcessBundle())) {
       Multimap<String, BundleApplication> allPrimaries = ArrayListMultimap.create();
       Multimap<String, DelayedBundleApplication> allResiduals = ArrayListMultimap.create();
@@ -294,7 +294,7 @@ public class ProcessBundleHandler {
         if (!DATA_INPUT_URN.equals(entry.getValue().getSpec().getUrn())
             && !JAVA_SOURCE_URN.equals(entry.getValue().getSpec().getUrn())
             && !PTransformTranslation.READ_TRANSFORM_URN.equals(
-            entry.getValue().getSpec().getUrn())) {
+                entry.getValue().getSpec().getUrn())) {
           continue;
         }
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -324,11 +324,11 @@ public class FnApiDoFnRunnerTest implements Serializable {
         valuePCollection.apply(
             TEST_PTRANSFORM_ID,
             ParDo.of(
-                new TestSideInputDoFn(
-                    defaultSingletonSideInputView,
-                    singletonSideInputView,
-                    iterableSideInputView,
-                    additionalOutput))
+                    new TestSideInputDoFn(
+                        defaultSingletonSideInputView,
+                        singletonSideInputView,
+                        iterableSideInputView,
+                        additionalOutput))
                 .withSideInputs(
                     defaultSingletonSideInputView, singletonSideInputView, iterableSideInputView)
                 .withOutputTags(mainOutput, TupleTagList.of(additionalOutput)));
@@ -882,8 +882,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
   }
 
   private <T>
-  WindowedValue<KV<T, org.apache.beam.runners.core.construction.Timer>> timerInGlobalWindow(
-      T value, Instant valueTimestamp, Instant scheduledTimestamp) {
+      WindowedValue<KV<T, org.apache.beam.runners.core.construction.Timer>> timerInGlobalWindow(
+          T value, Instant valueTimestamp, Instant scheduledTimestamp) {
     return timestampedValueInGlobalWindow(
         KV.of(value, org.apache.beam.runners.core.construction.Timer.of(scheduledTimestamp)),
         valueTimestamp);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -27,11 +27,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.ListMultimap;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -44,10 +46,18 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.SdkComponents;
+import org.apache.beam.runners.core.metrics.MetricUpdates;
+import org.apache.beam.runners.core.metrics.MetricUpdates.MetricUpdate;
+import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.function.ThrowingRunnable;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.metrics.MetricsContainer;
+import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
@@ -86,12 +96,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Tests for {@link FnApiDoFnRunner}. */
 @RunWith(JUnit4.class)
 public class FnApiDoFnRunnerTest implements Serializable {
 
   @Rule public transient ResetDateTimeProvider dateTimeProvider = new ResetDateTimeProvider();
+
+  private static final Logger LOG = LoggerFactory.getLogger(FnApiDoFnRunnerTest.class);
 
   public static final String TEST_PTRANSFORM_ID = "pTransformId";
 
@@ -310,11 +324,11 @@ public class FnApiDoFnRunnerTest implements Serializable {
         valuePCollection.apply(
             TEST_PTRANSFORM_ID,
             ParDo.of(
-                    new TestSideInputDoFn(
-                        defaultSingletonSideInputView,
-                        singletonSideInputView,
-                        iterableSideInputView,
-                        additionalOutput))
+                new TestSideInputDoFn(
+                    defaultSingletonSideInputView,
+                    singletonSideInputView,
+                    iterableSideInputView,
+                    additionalOutput))
                 .withSideInputs(
                     defaultSingletonSideInputView, singletonSideInputView, iterableSideInputView)
                 .withOutputTags(mainOutput, TupleTagList.of(additionalOutput)));
@@ -408,6 +422,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
   private static class TestSideInputIsAccessibleForDownstreamCallersDoFn
       extends DoFn<String, Iterable<String>> {
+    private final Counter countedElements =
+        Metrics.counter(TestSideInputIsAccessibleForDownstreamCallersDoFn.class, "countedElems");
+
     private final PCollectionView<Iterable<String>> iterableSideInput;
 
     private TestSideInputIsAccessibleForDownstreamCallersDoFn(
@@ -417,6 +434,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
     @ProcessElement
     public void processElement(ProcessContext context) {
+      countedElements.inc();
       context.output(context.sideInput(iterableSideInput));
     }
   }
@@ -512,6 +530,124 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
     // Assert that state data did not change
     assertEquals(stateData, fakeClient.getData());
+  }
+
+  /**
+   * A simple Tuple class for creating a list of ExpectedMetrics using the stepName, metricName and
+   * value of the MetricUpdate classes.
+   */
+  @AutoValue
+  public abstract static class ExpectedMetric implements Serializable {
+    static ExpectedMetric create(String stepName, MetricName metricName, long value) {
+      return new AutoValue_FnApiDoFnRunnerTest_ExpectedMetric(stepName, metricName, value);
+    }
+
+    public abstract String stepName();
+
+    public abstract MetricName metricName();
+
+    public abstract long value();
+  }
+
+  @Test
+  public void testUsingMetrics() throws Exception {
+    MetricsContainerImpl metricsContainer = new MetricsContainerImpl("testUsingMetrics");
+    Closeable closeable = MetricsEnvironment.scopedMetricsContainer(metricsContainer);
+    FixedWindows windowFn = FixedWindows.of(Duration.millis(1L));
+    IntervalWindow windowA = windowFn.assignWindow(new Instant(1L));
+    IntervalWindow windowB = windowFn.assignWindow(new Instant(2L));
+    ByteString encodedWindowA =
+        ByteString.copyFrom(CoderUtils.encodeToByteArray(windowFn.windowCoder(), windowA));
+    ByteString encodedWindowB =
+        ByteString.copyFrom(CoderUtils.encodeToByteArray(windowFn.windowCoder(), windowB));
+
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection =
+        p.apply(Create.of("unused")).apply(Window.into(windowFn));
+    PCollectionView<Iterable<String>> iterableSideInputView =
+        valuePCollection.apply(View.asIterable());
+    PCollection<Iterable<String>> outputPCollection =
+        valuePCollection.apply(
+            TEST_PTRANSFORM_ID,
+            ParDo.of(new TestSideInputIsAccessibleForDownstreamCallersDoFn(iterableSideInputView))
+                .withSideInputs(iterableSideInputView));
+
+    SdkComponents sdkComponents = SdkComponents.create(p.getOptions());
+    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents, true);
+    String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
+
+    RunnerApi.PTransform pTransform =
+        pProto
+            .getComponents()
+            .getTransformsOrThrow(
+                pProto
+                    .getComponents()
+                    .getTransformsOrThrow(TEST_PTRANSFORM_ID)
+                    .getSubtransforms(0));
+
+    ImmutableMap<StateKey, ByteString> stateData =
+        ImmutableMap.of(
+            multimapSideInputKey(
+                iterableSideInputView.getTagInternal().getId(), ByteString.EMPTY, encodedWindowA),
+            encode("iterableValue1A", "iterableValue2A", "iterableValue3A"),
+            multimapSideInputKey(
+                iterableSideInputView.getTagInternal().getId(), ByteString.EMPTY, encodedWindowB),
+            encode("iterableValue1B", "iterableValue2B", "iterableValue3B"));
+
+    FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(stateData);
+
+    List<WindowedValue<Iterable<String>>> mainOutputValues = new ArrayList<>();
+    ListMultimap<String, FnDataReceiver<WindowedValue<?>>> consumers = ArrayListMultimap.create();
+    consumers.put(
+        Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add);
+    List<ThrowingRunnable> startFunctions = new ArrayList<>();
+    List<ThrowingRunnable> finishFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            fakeClient,
+            TEST_PTRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctions::add,
+            finishFunctions::add,
+            null /* splitListener */);
+
+    Iterables.getOnlyElement(startFunctions).run();
+    mainOutputValues.clear();
+
+    // Ensure that bag user state that is initially empty or populated works.
+    // Ensure that the bagUserStateKey order does not matter when we traverse over KV pairs.
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        Iterables.getOnlyElement(consumers.get(inputPCollectionId));
+    mainInput.accept(valueInWindow("X", windowA));
+    mainInput.accept(valueInWindow("Y", windowB));
+
+    MetricsContainer mc = MetricsEnvironment.getCurrentContainer();
+    MetricName metricName =
+        MetricName.named(TestSideInputIsAccessibleForDownstreamCallersDoFn.class, "countedElems");
+    List<ExpectedMetric> expectedMetrics = new ArrayList<ExpectedMetric>();
+    expectedMetrics.add(ExpectedMetric.create("testUsingMetrics", metricName, 2));
+
+    closeable.close();
+    MetricUpdates updates = metricsContainer.getUpdates();
+
+    // Validate MetricUpdates
+    int i = 0;
+    for (MetricUpdate mu : updates.counterUpdates()) {
+      assertEquals(expectedMetrics.get(i).metricName(), mu.getKey().metricName());
+      assertEquals(expectedMetrics.get(i).stepName(), mu.getKey().stepName());
+      assertEquals(expectedMetrics.get(i).value(), mu.getUpdate());
+      i++;
+    }
+    assertEquals(1, i); // Validate the length.
   }
 
   private static class TestTimerfulDoFn extends DoFn<KV<String, String>, String> {
@@ -746,8 +882,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
   }
 
   private <T>
-      WindowedValue<KV<T, org.apache.beam.runners.core.construction.Timer>> timerInGlobalWindow(
-          T value, Instant valueTimestamp, Instant scheduledTimestamp) {
+  WindowedValue<KV<T, org.apache.beam.runners.core.construction.Timer>> timerInGlobalWindow(
+      T value, Instant valueTimestamp, Instant scheduledTimestamp) {
     return timestampedValueInGlobalWindow(
         KV.of(value, org.apache.beam.runners.core.construction.Timer.of(scheduledTimestamp)),
         valueTimestamp);


### PR DESCRIPTION
**Please** add a meaningful description for your change here
Adds Java User Metrics to the Java SDK.

Metrics set using Metrics.counter, inside the bundle processing thread (start, finish, process) will be collected and reported in the ProcesBundleResponse.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




