### PR TITLE
[BEAM-4762] Add Gearpump Nexmark PostCommit scripts

### DIFF
--- a/.test-infra/jenkins/CommonTestProperties.groovy
+++ b/.test-infra/jenkins/CommonTestProperties.groovy
@@ -21,7 +21,8 @@ class CommonTestProperties {
         DATAFLOW("DataflowRunner", ":beam-runners-google-cloud-dataflow-java"),
         SPARK("SparkRunner", ":beam-runners-spark"),
         FLINK("TestFlinkRunner", ":beam-runners-flink_2.11"),
-        DIRECT("DirectRunner", ":beam-runners-direct-java")
+        DIRECT("DirectRunner", ":beam-runners-direct-java"),
+        GEARPUMP("TestGearpumpRunner", ":beam-runners-gearpump")
 
         private final String option
         private final String dependency

--- a/.test-infra/jenkins/NexmarkBuilder.groovy
+++ b/.test-infra/jenkins/NexmarkBuilder.groovy
@@ -62,6 +62,16 @@ class NexmarkBuilder {
     suite(context, "NEXMARK IN SQL BATCH MODE USING ${runner} RUNNER", runner, options)
   }
 
+  static void streamingOnlyJob(context, Runner runner, Map<String, Object> jobSpecificOptions, TriggeringContext triggeringContext) {
+    Map<String, Object> options = getFullOptions(jobSpecificOptions, runner, triggeringContext)
+    options.put('streaming', true)
+
+    suite(context, "NEXMARK IN STREAMING MODE USING ${runner} RUNNER", runner, options)
+
+    options.put('queryLanguage', 'sql')
+    suite(context, "NEXMARK IN SQL STREAMING MODE USING ${runner} RUNNER", runner, options)
+  }
+
   private
   static Map<String, Object> getFullOptions(Map<String, Object> jobSpecificOptions, Runner runner, TriggeringContext triggeringContext) {
     Map<String, Object> options = defaultOptions + jobSpecificOptions

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
@@ -39,7 +39,7 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
 
   // Gradle goals for this job.
   Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, 
-    Nexmark.TriggeringContext.POST_COMMIT)
+    TriggeringContext.POST_COMMIT)
 }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump', 
@@ -49,5 +49,5 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Ge
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-  Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, Nexmark.TriggeringContext.PR)
+  Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
 }

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import NexmarkBigqueryProperties
+import NexmarkBuilder as Nexmark
+import NoPhraseTriggeringPostCommitBuilder
+import PhraseTriggeringPostCommitBuilder
+
+// This job runs the suite of Nexmark tests against the Gearpump runner.
+NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump',
+        'Gearpump Runner Nexmark Tests', this) {
+  description('Runs the Nexmark suite on the Gearpump runner.')
+
+  // Set common parameters.
+  commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
+
+  // Gradle goals for this job.
+  steps {
+    shell('echo *** RUN NEXMARK IN STREAMING MODE USING GEARPUMP RUNNER ***')
+    gradle {
+      rootBuildScriptDir(commonJobProperties.checkoutDir)
+      tasks(':beam-sdks-java-nexmark:run')
+      commonJobProperties.setGradleSwitches(delegate)
+      switches('-Pnexmark.runner=":beam-runners-gearpump"' +
+              ' -Pnexmark.args="' +
+              [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
+              '--runner=TestGearpumpRunner',
+              '--streaming=true',
+              '--suite=SMOKE',
+              '--streamTimeout=60' ,
+              '--manageResources=false',
+              '--monitorJobs=true'].join(' '))
+    }
+  }
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump', 'Run Gearpump Nexmark Tests',
+        'Gearpump Runner Nexmark Tests', this) {
+  description('Runs the Nexmark suite on the Gearpump runner against a Pull Request, on demand.')
+
+  // Set common parameters.
+  commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
+
+  def final JOB_SPECIFIC_OPTIONS = [
+          'suite' : 'STRESS',
+          'numWorkers' : 4,
+          'maxNumWorkers' : 4,
+          'autoscalingAlgorithm' : 'NONE',
+          'nexmarkParallel' : 16,
+          'enforceEncodability' : true,
+          'enforceImmutability' : true
+  ]
+  Nexmark.standardJob(delegate, Nexmark.Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, Nexmark.TriggeringContext.PR)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
@@ -17,6 +17,7 @@
  */
 
 import CommonJobProperties as commonJobProperties
+import CommonTestProperties.Runner
 import NexmarkBigqueryProperties
 import NexmarkBuilder as Nexmark
 import NoPhraseTriggeringPostCommitBuilder
@@ -66,5 +67,5 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Ge
           'enforceEncodability' : true,
           'enforceImmutability' : true
   ]
-  Nexmark.standardJob(delegate, Nexmark.Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, Nexmark.TriggeringContext.PR)
+  Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, Nexmark.TriggeringContext.PR)
 }

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Gearpump.groovy
@@ -18,10 +18,16 @@
 
 import CommonJobProperties as commonJobProperties
 import CommonTestProperties.Runner
+import CommonTestProperties.TriggeringContext
 import NexmarkBigqueryProperties
 import NexmarkBuilder as Nexmark
 import NoPhraseTriggeringPostCommitBuilder
 import PhraseTriggeringPostCommitBuilder
+
+def final JOB_SPECIFIC_OPTIONS = [
+        'suite' : 'SMOKE',
+        'streamTimeout' : 60
+]
 
 // This job runs the suite of Nexmark tests against the Gearpump runner.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump',
@@ -32,40 +38,16 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
   // Gradle goals for this job.
-  steps {
-    shell('echo *** RUN NEXMARK IN STREAMING MODE USING GEARPUMP RUNNER ***')
-    gradle {
-      rootBuildScriptDir(commonJobProperties.checkoutDir)
-      tasks(':beam-sdks-java-nexmark:run')
-      commonJobProperties.setGradleSwitches(delegate)
-      switches('-Pnexmark.runner=":beam-runners-gearpump"' +
-              ' -Pnexmark.args="' +
-              [NexmarkBigqueryProperties.nexmarkBigQueryArgs,
-              '--runner=TestGearpumpRunner',
-              '--streaming=true',
-              '--suite=SMOKE',
-              '--streamTimeout=60' ,
-              '--manageResources=false',
-              '--monitorJobs=true'].join(' '))
-    }
-  }
+  Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, 
+    Nexmark.TriggeringContext.POST_COMMIT)
 }
 
-PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump', 'Run Gearpump Nexmark Tests',
-        'Gearpump Runner Nexmark Tests', this) {
+PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Gearpump', 
+  'Run Gearpump Runner Nexmark Tests', 'Gearpump Runner Nexmark Tests', this) {
   description('Runs the Nexmark suite on the Gearpump runner against a Pull Request, on demand.')
 
   // Set common parameters.
   commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-  def final JOB_SPECIFIC_OPTIONS = [
-          'suite' : 'STRESS',
-          'numWorkers' : 4,
-          'maxNumWorkers' : 4,
-          'autoscalingAlgorithm' : 'NONE',
-          'nexmarkParallel' : 16,
-          'enforceEncodability' : true,
-          'enforceImmutability' : true
-  ]
   Nexmark.streamingOnlyJob(delegate, Runner.GEARPUMP, JOB_SPECIFIC_OPTIONS, Nexmark.TriggeringContext.PR)
 }

--- a/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/GearpumpPipelineResult.java
+++ b/runners/gearpump/src/main/java/org/apache/beam/runners/gearpump/GearpumpPipelineResult.java
@@ -64,7 +64,11 @@ public class GearpumpPipelineResult implements PipelineResult {
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    return waitUntilFinish();
+    if (!finished) {
+      app.waitUntilFinish(java.time.Duration.ofMillis(duration.getMillis()));
+      finished = true;
+    }
+    return State.DONE;
   }
 
   @Override


### PR DESCRIPTION
Add PostCommit scripts to run Nexmark on Gearpump runner in streaming mode

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




