### PR TITLE
Move array declarations after the type

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/AvroSourceTest.java
@@ -141,7 +141,7 @@ public class AvroSourceTest {
   @Test
   public void testReadWithDifferentCodecs() throws Exception {
     // Test reading files generated using all codecs.
-    String codecs[] = {
+    String[] codecs = {
       DataFileConstants.NULL_CODEC,
       DataFileConstants.BZIP2_CODEC,
       DataFileConstants.DEFLATE_CODEC,
@@ -722,7 +722,7 @@ public class AvroSourceTest {
   @Test
   public void testReadMetadataWithCodecs() throws Exception {
     // Test reading files generated using all codecs.
-    String codecs[] = {
+    String[] codecs = {
       DataFileConstants.NULL_CODEC,
       DataFileConstants.BZIP2_CODEC,
       DataFileConstants.DEFLATE_CODEC,

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/KVTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/KVTest.java
@@ -31,7 +31,7 @@ import org.junit.runners.JUnit4;
 /** Tests for KV. */
 @RunWith(JUnit4.class)
 public class KVTest {
-  private static final Integer TEST_VALUES[] = {
+  private static final Integer[] TEST_VALUES = {
     null, Integer.MIN_VALUE, -1, 0, 1, Integer.MAX_VALUE
   };
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/RetryHttpRequestInitializerTest.java
@@ -78,7 +78,7 @@ public class RetryHttpRequestInitializerTest {
 
   // Used to test retrying a request more than the default 10 times.
   static class MockNanoClock implements NanoClock {
-    private int timesMs[] = {
+    private int[] timesMs = {
       500, 750, 1125, 1688, 2531, 3797, 5695, 8543, 12814, 19222, 28833, 43249, 64873, 97310,
       145965, 218945, 328420
     };

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -78,7 +78,7 @@ class ElasticsearchIOTestCommon implements Serializable {
 
   private static final int EXPECTED_RETRIES = 2;
   private static final int MAX_ATTEMPTS = 3;
-  private static final String BAD_FORMATTED_DOC[] = {"{ \"x\" :a,\"y\":\"ab\" }"};
+  private static final String[] BAD_FORMATTED_DOC = {"{ \"x\" :a,\"y\":\"ab\" }"};
   private static final String OK_REQUEST =
       "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"doc\", \"_id\" : \"1\" } }\n"
           + "{ \"field1\" : 1 }\n";

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -331,7 +331,7 @@ public class MongoDBGridFSIOTest implements Serializable {
         int l = (int) file.getLength();
         try (InputStream ins = file.getInputStream()) {
           DataInputStream dis = new DataInputStream(ins);
-          byte b[] = new byte[l];
+          byte[] b = new byte[l];
           dis.readFully(b);
           results.append(new String(b, StandardCharsets.UTF_8));
         }
@@ -347,7 +347,7 @@ public class MongoDBGridFSIOTest implements Serializable {
         int l = (int) file.getLength();
         try (InputStream ins = file.getInputStream()) {
           DataInputStream dis = new DataInputStream(ins);
-          byte b[] = new byte[l];
+          byte[] b = new byte[l];
           dis.readFully(b);
           for (byte aB : b) {
             intResults[aB] = true;


### PR DESCRIPTION
We should move array declarations after the type to conform to java guidelines.