### PR TITLE
[BEAM-5812] Increase wait time for Dataflow job start/cancel

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/test_dataflow_runner.py
@@ -32,7 +32,9 @@ from apache_beam.runners.runner import PipelineState
 
 __all__ = ['TestDataflowRunner']
 
-WAIT_TIMEOUT = 2 * 60
+# Dataflow take up to 10mins for the long tail of starting/stopping worker
+# pool.
+WAIT_IN_STATE_TIMEOUT = 10 * 60
 
 
 class TestDataflowRunner(DataflowRunner):
@@ -51,7 +53,7 @@ class TestDataflowRunner(DataflowRunner):
     if self.result.has_job:
       # TODO(markflyhigh)(BEAM-1890): Use print since Nose dosen't show logs
       # in some cases.
-      print('Found: %s.' % self.build_console_url(pipeline.options))
+      print('Found: %s.' % self.build_console_url(options))
 
     try:
       self.wait_until_in_state(PipelineState.RUNNING)
@@ -66,7 +68,7 @@ class TestDataflowRunner(DataflowRunner):
     finally:
       if not self.result.is_in_terminal_state():
         self.result.cancel()
-        self.wait_until_in_state(PipelineState.CANCELLED, timeout=300)
+        self.wait_until_in_state(PipelineState.CANCELLED)
 
     return self.result
 
@@ -79,8 +81,8 @@ class TestDataflowRunner(DataflowRunner):
         'https://console.cloud.google.com/dataflow/jobsDetail/locations'
         '/%s/jobs/%s?project=%s' % (region_id, job_id, project))
 
-  def wait_until_in_state(self, expected_state, timeout=WAIT_TIMEOUT):
-    """Wait until Dataflow pipeline terminate or enter RUNNING state."""
+  def wait_until_in_state(self, expected_state, timeout=WAIT_IN_STATE_TIMEOUT):
+    """Wait until Dataflow pipeline enters a certain state."""
     if not self.result.has_job:
       raise IOError('Failed to get the Dataflow job id.')
 
@@ -93,5 +95,5 @@ class TestDataflowRunner(DataflowRunner):
 
     raise RuntimeError('Timeout after %d seconds while waiting for job %s '
                        'enters expected state %s. Current state is %s.' %
-                       (WAIT_TIMEOUT, self.result.job_id,
+                       (timeout, self.result.job_id(),
                         expected_state, self.result.state))


### PR DESCRIPTION
Fix Python TestDataflowRunner:

- Increase timeout for worker pool starting/cancelling
- Remove `pipeline.options` since it's deprecated.
- Fix exception message with correct job id.

+R: @herohde 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




