### PR TITLE
[BEAM-5724] Generalize flink executable context to allow more than 1 worker process per task manager 

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkJobServerDriver.java
@@ -33,7 +33,6 @@ import org.apache.beam.runners.fnexecution.jobsubmission.InMemoryJobService;
 import org.apache.beam.runners.fnexecution.jobsubmission.JobInvoker;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 import org.kohsuke.args4j.Option;
@@ -90,9 +89,9 @@ public class FlinkJobServerDriver implements Runnable {
       name = "--sdk-worker-parallelism",
       usage = "Default parallelism for SDK worker processes (see portable pipeline options)"
     )
-    String sdkWorkerParallelism = PortablePipelineOptions.SDK_WORKER_PARALLELISM_PIPELINE;
+    Long sdkWorkerParallelism = 1L;
 
-    String getSdkWorkerParallelism() {
+    Long getSdkWorkerParallelism() {
       return this.sdkWorkerParallelism;
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContext.java
@@ -17,7 +17,13 @@
  */
 package org.apache.beam.runners.flink.translation.functions;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
 import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.runners.core.construction.Environments;
@@ -30,6 +36,7 @@ import org.apache.beam.runners.fnexecution.environment.DockerEnvironmentFactory;
 import org.apache.beam.runners.fnexecution.environment.EmbeddedEnvironmentFactory;
 import org.apache.beam.runners.fnexecution.environment.ProcessEnvironmentFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
 
 /** Implementation of a {@link FlinkExecutableStageContext}. */
 class FlinkDefaultExecutableStageContext implements FlinkExecutableStageContext, AutoCloseable {
@@ -64,19 +71,60 @@ class FlinkDefaultExecutableStageContext implements FlinkExecutableStageContext,
     jobBundleFactory.close();
   }
 
-  enum ReferenceCountingFactory implements Factory {
-    REFERENCE_COUNTING;
+  private static class JobFactoryState {
+    private final AtomicInteger counter = new AtomicInteger(0);
+    private final List<ReferenceCountingFlinkExecutableStageContextFactory> factories =
+        new ArrayList<>();
+    private final int maxFactories;
 
-    private static final ReferenceCountingFlinkExecutableStageContextFactory actualFactory =
-        ReferenceCountingFlinkExecutableStageContextFactory.create(
-            FlinkDefaultExecutableStageContext::create);
+    private JobFactoryState(int maxFactories) {
+      if (maxFactories == 0) {
+        // Default to num_cores - 1 so that we leave some resources available for the java process
+        this.maxFactories = Math.max(Runtime.getRuntime().availableProcessors() - 1, 1);
+      } else {
+        this.maxFactories = maxFactories;
+      }
+    }
 
-    @Override
-    public FlinkExecutableStageContext get(JobInfo jobInfo) {
-      return actualFactory.get(jobInfo);
+    private synchronized FlinkExecutableStageContext.Factory getFactory() {
+      int count = counter.getAndIncrement();
+
+      if (count < maxFactories) {
+        factories.add(
+            ReferenceCountingFlinkExecutableStageContextFactory.create(
+                FlinkDefaultExecutableStageContext::create));
+      }
+
+      return factories.get(count % maxFactories);
     }
   }
 
-  static final Factory MULTI_INSTANCE_FACTORY =
-      (jobInfo) -> FlinkDefaultExecutableStageContext.create(jobInfo);
+  enum MultiInstanceFactory implements Factory {
+    MULTI_INSTANCE;
+
+    // This map should only ever have a single element, as each job will have its own
+    // classloader and therefore its own instance of MultiInstanceFactory.INSTANCE. This
+    // code supports multiple JobInfos in order to provide a sensible implementation of
+    // Factory.get(JobInfo), which in theory could be called with different JobInfos.
+    private static final ConcurrentMap<String, JobFactoryState> jobFactories =
+        new ConcurrentHashMap<>();
+
+    @Override
+    public FlinkExecutableStageContext get(JobInfo jobInfo) {
+      JobFactoryState state =
+          jobFactories.computeIfAbsent(
+              jobInfo.jobId(),
+              k -> {
+                PortablePipelineOptions portableOptions =
+                    PipelineOptionsTranslation.fromProto(jobInfo.pipelineOptions())
+                        .as(PortablePipelineOptions.class);
+
+                return new JobFactoryState(
+                    MoreObjects.firstNonNull(portableOptions.getSdkWorkerParallelism(), 1L)
+                        .intValue());
+              });
+
+      return state.getFactory().get(jobInfo);
+    }
+  }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageContext.java
@@ -20,9 +20,9 @@ package org.apache.beam.runners.flink.translation.functions;
 import java.io.Serializable;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
+import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
 import org.apache.beam.runners.fnexecution.control.StageBundleFactory;
 import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
-import org.apache.beam.sdk.options.PortablePipelineOptions;
 
 /** The Flink context required in order to execute {@link ExecutableStage stages}. */
 public interface FlinkExecutableStageContext extends AutoCloseable {
@@ -38,13 +38,7 @@ public interface FlinkExecutableStageContext extends AutoCloseable {
   }
 
   static Factory factory(FlinkPipelineOptions options) {
-    PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
-    if (PortablePipelineOptions.SDK_WORKER_PARALLELISM_STAGE.equals(
-        portableOptions.getSdkWorkerParallelism())) {
-      return FlinkDefaultExecutableStageContext.MULTI_INSTANCE_FACTORY;
-    } else {
-      return FlinkDefaultExecutableStageContext.ReferenceCountingFactory.REFERENCE_COUNTING;
-    }
+    return MultiInstanceFactory.MULTI_INSTANCE;
   }
 
   StageBundleFactory getStageBundleFactory(ExecutableStage executableStage);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/ReferenceCountingFlinkExecutableStageContextFactory.java
@@ -185,10 +185,11 @@ public class ReferenceCountingFlinkExecutableStageContextFactory
   /**
    * {@link WrappedContext} does not expose equals of actual {@link FlinkExecutableStageContext}.
    */
-  private class WrappedContext implements FlinkExecutableStageContext {
+  @VisibleForTesting
+  class WrappedContext implements FlinkExecutableStageContext {
     private JobInfo jobInfo;
     private AtomicInteger referenceCount;
-    private FlinkExecutableStageContext context;
+    @VisibleForTesting FlinkExecutableStageContext context;
 
     /** {@link WrappedContext#equals(Object)} is only based on {@link JobInfo#jobId()}. */
     WrappedContext(JobInfo jobInfo, FlinkExecutableStageContext context) {

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkJobServerDriverTest.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.flink;
 
-import static org.apache.beam.sdk.options.PortablePipelineOptions.SDK_WORKER_PARALLELISM_PIPELINE;
-import static org.apache.beam.sdk.options.PortablePipelineOptions.SDK_WORKER_PARALLELISM_STAGE;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
@@ -46,7 +44,7 @@ public class FlinkJobServerDriverTest {
     assertThat(config.port, is(8099));
     assertThat(config.artifactPort, is(8098));
     assertThat(config.flinkMasterUrl, is("[auto]"));
-    assertThat(config.sdkWorkerParallelism, is(SDK_WORKER_PARALLELISM_PIPELINE));
+    assertThat(config.sdkWorkerParallelism, is(1));
     assertThat(config.cleanArtifactsPerJob, is(false));
     FlinkJobServerDriver flinkJobServerDriver = FlinkJobServerDriver.fromConfig(config);
     assertThat(flinkJobServerDriver, is(not(nullValue())));
@@ -63,14 +61,14 @@ public class FlinkJobServerDriverTest {
               "--artifact-port",
               "43",
               "--flink-master-url=jobmanager",
-              "--sdk-worker-parallelism=stage",
+              "--sdk-worker-parallelism=4",
               "--clean-artifacts-per-job",
             });
     assertThat(driver.configuration.host, is("test"));
     assertThat(driver.configuration.port, is(42));
     assertThat(driver.configuration.artifactPort, is(43));
     assertThat(driver.configuration.flinkMasterUrl, is("jobmanager"));
-    assertThat(driver.configuration.sdkWorkerParallelism, is(SDK_WORKER_PARALLELISM_STAGE));
+    assertThat(driver.configuration.sdkWorkerParallelism, is(4));
     assertThat(driver.configuration.cleanArtifactsPerJob, is(true));
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContextTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/functions/FlinkDefaultExecutableStageContextTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.functions;
+
+import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
+import org.apache.beam.runners.flink.translation.functions.FlinkDefaultExecutableStageContext.MultiInstanceFactory;
+import org.apache.beam.runners.flink.translation.functions.ReferenceCountingFlinkExecutableStageContextFactory.WrappedContext;
+import org.apache.beam.runners.fnexecution.provisioning.JobInfo;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.vendor.protobuf.v3.com.google.protobuf.Struct;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FlinkDefaultExecutableStageContext}. */
+@RunWith(JUnit4.class)
+public class FlinkDefaultExecutableStageContextTest {
+  private static JobInfo constructJobInfo(long parallellism) {
+    PortablePipelineOptions portableOptions =
+        PipelineOptionsFactory.as(PortablePipelineOptions.class);
+    portableOptions.setSdkWorkerParallelism(parallellism);
+
+    Struct pipelineOptions = PipelineOptionsTranslation.toProto(portableOptions);
+    return JobInfo.create("job-id", "job-name", "retrieval-token", pipelineOptions);
+  }
+
+  @Test
+  public void testMultiInstanceFactory() {
+    JobInfo jobInfo = constructJobInfo(2);
+
+    WrappedContext f1 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    WrappedContext f2 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    WrappedContext f3 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+
+    Assert.assertNotEquals("We should create two different factories", f1.context, f2.context);
+    Assert.assertEquals(
+        "Future calls should be round-robbined to those two factories", f1.context, f3.context);
+  }
+
+  @Test
+  public void testDefault() {
+    JobInfo jobInfo = constructJobInfo(0);
+
+    int expectedParallelism = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
+
+    WrappedContext f1 = (WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo);
+    for (int i = 1; i < expectedParallelism; i++) {
+      Assert.assertNotEquals(
+          "We should create " + expectedParallelism + " different factories",
+          f1.context,
+          ((WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo)).context);
+    }
+
+    Assert.assertEquals(
+        "Future calls should be round-robbined to those",
+        f1.context,
+        ((WrappedContext) MultiInstanceFactory.MULTI_INSTANCE.get(jobInfo)).context);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -73,20 +73,13 @@ public interface PortablePipelineOptions extends PipelineOptions {
 
   void setDefaultEnvironmentConfig(@Nullable String config);
 
-  String SDK_WORKER_PARALLELISM_PIPELINE = "pipeline";
-  String SDK_WORKER_PARALLELISM_STAGE = "stage";
-
   @Description(
-      "SDK worker/harness process parallelism. Currently supported options are "
-          + "<null> (let the runner decide) or '"
-          + SDK_WORKER_PARALLELISM_PIPELINE
-          + "' (single SDK harness process per pipeline and runner process) or '"
-          + SDK_WORKER_PARALLELISM_STAGE
-          + "' (separate SDK harness for every executable stage).")
+      "Sets the number of sdk worker processes that will run on each worker node. Default is 1. If"
+          + " 0, it will be automatically set according to the number of CPU cores on the worker.")
   @Nullable
-  String getSdkWorkerParallelism();
+  Long getSdkWorkerParallelism();
 
-  void setSdkWorkerParallelism(@Nullable String parallelism);
+  void setSdkWorkerParallelism(@Nullable Long parallelism);
 
   @Description("Duration in milliseconds for environment cache within a job. 0 means no caching.")
   @Default.Integer(0)


### PR DESCRIPTION
By default, beam will create a single python sdk worker per Flink taskmanager / job, and #6524 added an option (`--sdk-worker-parallelism stage`) that would instead create one python worker per Flink stage. However in our experience this leads to far too many python processes (possibly thousands), as flink may run many stages in a single task slot.

This PR introduces an alternate approach to managing sdk worker concurrency. Basically, we know that our box has some capacity (roughly correlated to number of CPU cores) and we'd like to use as much as possible for executing our worker code, while not suffering the overhead of too many worker processes.

With this PR, `--sdk-worker-parallelism` now takes the number of processes to run per TM. By default this is 1 (retaining the existing behavior). There's also an "auto" value of 0 that will set it to `number of cores - 1`, which is likely what most streaming users would want. As stages are constructed, we will create new StageContexts until we have `--sdk-worker-parallelism` of them, then we round-robin assign new stages to the existing contexts.

cc @tweise 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




