### PR TITLE
[BEAM-5853] Possible fix

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperation.java
@@ -120,11 +120,10 @@ public class RemoteGrpcPortWriteOperation<T> extends ReceivingOperation {
       }
       int numProcessed = elementsProcessed.get();
       // A negative value indicates that obtaining numProcessed is not supported.
+      // Otherwise, wait until the SDK has processed at least one element before continuing.
       if (numProcessed < 0) {
         targetElementsSent = Integer.MAX_VALUE;
-      }
-      // Wait until the SDK has processed at least one element before continuing.
-      if (numProcessed == 0) {
+      } else if (numProcessed == 0) {
         targetElementsSent = 1;
       } else {
         double rate;


### PR DESCRIPTION
I'm not sure whether this is a right fix but seems like it works for me to stop the stuckness. 
R: @robertwb, @lukecwik 
More information:
For the stuck fnapi worker pipeline, it gets stuck at [maybeWait](https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperation.java#L165), and keeps evaluating [shouldWait](https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperation.java#L111). I found, the numProcessed should be -1 since it's not supported and the targetElementsSent should be set to MAX. But the [following else block](https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/RemoteGrpcPortWriteOperation.java#L129) will override this logic again, which causes this loop forever.