### PR TITLE
[BEAM-5866] Fix `Row#equals`

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/org/apache/beam/sdk/coders/RowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/org/apache/beam/sdk/coders/RowCoderTest.java
@@ -17,31 +17,25 @@
  */
 package org.apache.beam.sdk.coders.org.apache.beam.sdk.coders;
 
-import static org.junit.Assert.assertEquals;
-
 import com.google.common.collect.Lists;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.testing.CoderProperties;
 import org.apache.beam.sdk.values.Row;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.Assume;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /** Unit tests for {@link RowCoder}. */
 public class RowCoderTest {
-
-  void checkEncodeDecode(Row row) throws IOException {
-    RowCoder coder = RowCoder.of(row.getSchema());
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    coder.encode(row, out);
-    assertEquals(row, coder.decode(new ByteArrayInputStream(out.toByteArray())));
-  }
 
   @Test
   public void testPrimitiveTypes() throws Exception {
@@ -66,7 +60,8 @@ public class RowCoderTest {
             .addValues(
                 (byte) 0, (short) 1, 2, 3L, new BigDecimal(2.3), 1.2f, 3.0d, "str", dateTime, false)
             .build();
-    checkEncodeDecode(row);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
   }
 
   @Test
@@ -77,14 +72,16 @@ public class RowCoderTest {
 
     Row nestedRow = Row.withSchema(nestedSchema).addValues(18, "foobar").build();
     Row row = Row.withSchema(schema).addValues(42, nestedRow).build();
-    checkEncodeDecode(row);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
   }
 
   @Test
   public void testArrays() throws Exception {
     Schema schema = Schema.builder().addArrayField("f_array", FieldType.STRING).build();
     Row row = Row.withSchema(schema).addArray("one", "two", "three", "four").build();
-    checkEncodeDecode(row);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
   }
 
   @Test
@@ -99,7 +96,8 @@ public class RowCoderTest {
                 Row.withSchema(nestedSchema).addValues(2, "two").build(),
                 Row.withSchema(nestedSchema).addValues(3, "three").build())
             .build();
-    checkEncodeDecode(row);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
   }
 
   @Test
@@ -113,7 +111,8 @@ public class RowCoderTest {
                 Lists.newArrayList(5, 6, 7, 8),
                 Lists.newArrayList(9, 10, 11, 12))
             .build();
-    checkEncodeDecode(row);
+
+    CoderProperties.coderDecodeEncodeEqual(RowCoder.of(schema), row);
   }
 
   @Test(expected = NonDeterministicException.class)
@@ -144,5 +143,71 @@ public class RowCoderTest {
     RowCoder coder = RowCoder.of(schema);
 
     coder.verifyDeterministic();
+  }
+
+  @Test
+  public void testConsistentWithEqualsBytesField() throws Exception {
+    Schema schema = Schema.of(Schema.Field.of("f1", FieldType.BYTES));
+    Row row1 = Row.withSchema(schema).addValue(new byte[] {1, 2, 3, 4}).build();
+    Row row2 = Row.withSchema(schema).addValue(new byte[] {1, 2, 3, 4}).build();
+    RowCoder coder = RowCoder.of(schema);
+
+    Assume.assumeTrue(coder.consistentWithEquals());
+
+    CoderProperties.coderConsistentWithEquals(coder, row1, row2);
+  }
+
+  @Test
+  @Ignore
+  public void testConsistentWithEqualsMapWithBytesKeyField() throws Exception {
+    FieldType fieldType = FieldType.map(FieldType.BYTES, FieldType.INT32);
+    Schema schema = Schema.of(Schema.Field.of("f1", fieldType));
+    RowCoder coder = RowCoder.of(schema);
+
+    Map<byte[], Integer> map1 = Collections.singletonMap(new byte[] {1, 2, 3, 4}, 1);
+    Row row1 = Row.withSchema(schema).addValue(map1).build();
+
+    Map<byte[], Integer> map2 = Collections.singletonMap(new byte[] {1, 2, 3, 4}, 1);
+    Row row2 = Row.withSchema(schema).addValue(map2).build();
+
+    Assume.assumeTrue(coder.consistentWithEquals());
+
+    CoderProperties.coderConsistentWithEquals(coder, row1, row2);
+  }
+
+  @Test
+  public void testConsistentWithEqualsArrayOfBytes() throws Exception {
+    FieldType fieldType = FieldType.array(FieldType.BYTES);
+    Schema schema = Schema.of(Schema.Field.of("f1", fieldType));
+    RowCoder coder = RowCoder.of(schema);
+
+    List<byte[]> list1 = Collections.singletonList(new byte[] {1, 2, 3, 4});
+    Row row1 = Row.withSchema(schema).addValue(list1).build();
+
+    List<byte[]> list2 = Collections.singletonList(new byte[] {1, 2, 3, 4});
+    Row row2 = Row.withSchema(schema).addValue(list2).build();
+
+    Assume.assumeTrue(coder.consistentWithEquals());
+
+    CoderProperties.coderConsistentWithEquals(coder, row1, row2);
+  }
+
+  @Test
+  public void testConsistentWithEqualsArrayOfArrayOfBytes() throws Exception {
+    FieldType fieldType = FieldType.array(FieldType.array(FieldType.BYTES));
+    Schema schema = Schema.of(Schema.Field.of("f1", fieldType));
+    RowCoder coder = RowCoder.of(schema);
+
+    List<byte[]> innerList1 = Collections.singletonList(new byte[] {1, 2, 3, 4});
+    List<List<byte[]>> list1 = Collections.singletonList(innerList1);
+    Row row1 = Row.withSchema(schema).addValue(list1).build();
+
+    List<byte[]> innerList2 = Collections.singletonList(new byte[] {1, 2, 3, 4});
+    List<List<byte[]>> list2 = Collections.singletonList(innerList2);
+    Row row2 = Row.withSchema(schema).addValue(list2).build();
+
+    Assume.assumeTrue(coder.consistentWithEquals());
+
+    CoderProperties.coderConsistentWithEquals(coder, row1, row2);
   }
 }


### PR DESCRIPTION
This pull request defines two properties that any `Coder` implementation should satisfy. There are two coders that don't properly implement `structuralValue`: `MapCoder` and `RowCoder`.

`RowCoder#consistentWithEquals` is defined as always true. It isn't true in case schema has field of type `Map<BYTES, ?>`. However, such field type makes little sense. One of the ways to fix it would be to reject such schemas. For now, this test is ignored.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




