### PR TITLE
[BEAM-5886] Fix incorrectly formulated condition in checkState method

### DIFF
--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
@@ -124,9 +124,12 @@ public class MetricsReader {
   private <T> void checkIfMetricResultIsUnique(String name, Iterable<MetricResult<T>> metricResult)
       throws IllegalStateException {
 
+    int resultCount = Iterables.size(metricResult);
     Preconditions.checkState(
-        Iterables.size(metricResult) == 1,
-        String.format("More than one metric matches name: %s in namespace %s.", name, namespace));
+        resultCount <= 1,
+        String.format(
+            "More than one metric result matches name: %s in namespace %s. Metric results count: %d",
+            name, namespace, resultCount));
   }
 
   /** Return the current value for a time counter, or -1 if can't be retrieved. */

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/metrics/MetricsReader.java
@@ -127,9 +127,10 @@ public class MetricsReader {
     int resultCount = Iterables.size(metricResult);
     Preconditions.checkState(
         resultCount <= 1,
-        String.format(
-            "More than one metric result matches name: %s in namespace %s. Metric results count: %d",
-            name, namespace, resultCount));
+        "More than one metric result matches name: %s in namespace %s. Metric results count: %s",
+        name,
+        namespace,
+        resultCount);
   }
 
   /** Return the current value for a time counter, or -1 if can't be retrieved. */

--- a/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/metrics/MetricsReaderTest.java
+++ b/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/metrics/MetricsReaderTest.java
@@ -79,14 +79,11 @@ public class MetricsReaderTest {
     assertEquals(5, reader.getEndTimeMetric(0, "timeDist"));
   }
 
-  @Test(expected = IllegalStateException.class)
-  public void throwsIllegalStateExceptionWhenThereAreMultipleCountersOfTheSameNameAndType() {
-    Metrics.counter(NAMESPACE, "counter");
-    Metrics.counter(NAMESPACE, "counter");
-
+  @Test
+  public void doesntThrowIllegalStateExceptionWhenThereIsNoMetricFound() {
     PipelineResult result = testPipeline.run();
     MetricsReader reader = new MetricsReader(result, NAMESPACE);
-    reader.getCounterMetric("counter", -1);
+    reader.getCounterMetric("nonexistent", -1);
   }
 
   @Test


### PR DESCRIPTION
The suites failed because 0 counters of the same name were created.
I extended the error message to include a more descriptive information
about this.

Other than that a test for multiple counters with the same name was
deleted. The reason it passed was because 0 counters were created
(false-positive). As it turned out it is nontrivial to create a test
that creates two metrics of the same name and type so I skipped this
for now.


------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




