### PR TITLE
[BEAM-308] Print warning about using non-public PipelineOptions interface.

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/StreamingWordExtract.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/StreamingWordExtract.java
@@ -95,7 +95,7 @@ public class StreamingWordExtract {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface StreamingWordExtractOptions
+  public interface StreamingWordExtractOptions
       extends ExampleOptions, ExampleBigQueryTableOptions, StreamingOptions {
     @Description("Path of the file to read from")
     @Default.String("gs://apache-beam-samples/shakespeare/kinglear.txt")

--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/StatefulTeamScore.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/StatefulTeamScore.java
@@ -79,7 +79,7 @@ import org.joda.time.Instant;
 public class StatefulTeamScore extends LeaderBoard {
 
   /** Options supported by {@link StatefulTeamScore}. */
-  interface Options extends LeaderBoard.Options {
+  public interface Options extends LeaderBoard.Options {
 
     @Description("Numeric value, multiple of which is used as threshold for outputting team score.")
     @Default.Integer(5000)

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/CombinePerKeyExamples.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/CombinePerKeyExamples.java
@@ -159,7 +159,7 @@ public class CombinePerKeyExamples {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Description("Table to read from, specified as " + "<project_id>:<dataset_id>.<table_id>")
     @Default.String(SHAKESPEARE_TABLE)
     String getInput();

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/DistinctExample.java
@@ -56,7 +56,7 @@ public class DistinctExample {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Description("Path to the directory or GCS prefix containing files to read from")
     @Default.String("gs://apache-beam-samples/shakespeare/*")
     String getInput();

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/FilterExamples.java
@@ -198,7 +198,7 @@ public class FilterExamples {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Description("Table to read from, specified as " + "<project_id>:<dataset_id>.<table_id>")
     @Default.String(WEATHER_SAMPLES_TABLE)
     String getInput();

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/JoinExamples.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/JoinExamples.java
@@ -157,7 +157,7 @@ public class JoinExamples {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Description("Path of the file to write to")
     @Validation.Required
     String getOutput();

--- a/examples/java/src/main/java/org/apache/beam/examples/cookbook/MaxPerKeyExamples.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/cookbook/MaxPerKeyExamples.java
@@ -119,7 +119,7 @@ public class MaxPerKeyExamples {
    *
    * <p>Inherits standard configuration options.
    */
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Description("Table to read from, specified as " + "<project_id>:<dataset_id>.<table_id>")
     @Default.String(WEATHER_SAMPLES_TABLE)
     String getInput();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -101,7 +101,7 @@ import org.joda.time.format.DateTimeFormatter;
  * PipelineOptionsFactory as your command-line interpreter, you will provide a standardized way for
  * users to interact with your application via the command-line.
  *
- * <p>To define your own {@link PipelineOptions}, you create an interface which extends {@link
+ * <p>To define your own {@link PipelineOptions}, you create a public interface which extends {@link
  * PipelineOptions} and define getter/setter pairs. These getter/setter pairs define a collection of
  * <a href="https://docs.oracle.com/javase/tutorial/javabeans/writing/properties.html">JavaBean
  * properties</a>.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -865,6 +865,19 @@ public class PipelineOptionsFactory {
       Set<Class<? extends PipelineOptions>> validatedPipelineOptionsInterfaces,
       Class<? extends PipelineOptions> klass)
       throws IntrospectionException {
+
+    // TODO(BEAM-308): Make this an error in users pipelines for the next major version
+    // of Apache Beam.
+    if (!Modifier.isPublic(iface.getModifiers())) {
+      LOG.warn(
+          "Using non-public interface {} may fail during runtime. The JVM requires that "
+              + "all non-public interfaces to be in the same package; otherwise, it would not be "
+              + "possible for the PipelineOptions proxy class to implement all of the interfaces, "
+              + "regardless of what package it is defined in. This will become an error in"
+              + "a future version of Apache Beam.",
+          iface.getName());
+    }
+
     // Verify that there are no methods with the same name with two different return types.
     validateReturnType(iface);
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
@@ -450,7 +450,7 @@ public class PipelineOptionsFactoryTest {
     options.as(CombinedObject.class);
   }
 
-  private interface MultiGetters extends PipelineOptions {
+  public interface MultiGetters extends PipelineOptions {
     Object getObject();
 
     void setObject(Object value);
@@ -465,7 +465,7 @@ public class PipelineOptionsFactoryTest {
     void setConsistent(Void consistent);
   }
 
-  private interface MultipleGettersWithInconsistentJsonIgnore extends PipelineOptions {
+  public interface MultipleGettersWithInconsistentJsonIgnore extends PipelineOptions {
     @JsonIgnore
     Object getObject();
 
@@ -559,7 +559,7 @@ public class PipelineOptionsFactoryTest {
    * This class is has a conflicting field with {@link CombinedObject} that doesn't have {@link
    * Default @Default}.
    */
-  private interface GetterWithDefault extends PipelineOptions {
+  public interface GetterWithDefault extends PipelineOptions {
     @Default.Integer(1)
     Object getObject();
 
@@ -570,7 +570,7 @@ public class PipelineOptionsFactoryTest {
    * This class is consistent with {@link GetterWithDefault} that has the same {@link
    * Default @Default}.
    */
-  private interface GetterWithConsistentDefault extends PipelineOptions {
+  public interface GetterWithConsistentDefault extends PipelineOptions {
     @Default.Integer(1)
     Object getObject();
 
@@ -581,7 +581,7 @@ public class PipelineOptionsFactoryTest {
    * This class is inconsistent with {@link GetterWithDefault} that has a different {@link
    * Default @Default}.
    */
-  private interface GetterWithInconsistentDefaultType extends PipelineOptions {
+  public interface GetterWithInconsistentDefaultType extends PipelineOptions {
     @Default.String("abc")
     Object getObject();
 
@@ -592,7 +592,7 @@ public class PipelineOptionsFactoryTest {
    * This class is inconsistent with {@link GetterWithDefault} that has a different {@link
    * Default @Default} value.
    */
-  private interface GetterWithInconsistentDefaultValue extends PipelineOptions {
+  public interface GetterWithInconsistentDefaultValue extends PipelineOptions {
     @Default.Integer(0)
     Object getObject();
 
@@ -675,7 +675,7 @@ public class PipelineOptionsFactoryTest {
     options.as(GetterWithInconsistentJsonIgnoreValue.class);
   }
 
-  private interface GettersWithMultipleDefault extends PipelineOptions {
+  public interface GettersWithMultipleDefault extends PipelineOptions {
     @Default.String("abc")
     @Default.Integer(0)
     Object getObject();
@@ -697,7 +697,7 @@ public class PipelineOptionsFactoryTest {
     PipelineOptionsFactory.as(GettersWithMultipleDefault.class);
   }
 
-  private interface MultiGettersWithDefault extends PipelineOptions {
+  public interface MultiGettersWithDefault extends PipelineOptions {
     Object getObject();
 
     void setObject(Object value);
@@ -712,7 +712,7 @@ public class PipelineOptionsFactoryTest {
     void setConsistent(Void consistent);
   }
 
-  private interface MultipleGettersWithInconsistentDefault extends PipelineOptions {
+  public interface MultipleGettersWithInconsistentDefault extends PipelineOptions {
     @Default.Boolean(true)
     Object getObject();
 
@@ -1006,7 +1006,7 @@ public class PipelineOptionsFactoryTest {
   }
 
   /** A test interface for verifying JSON -> complex type conversion. */
-  interface ComplexTypes extends PipelineOptions {
+  public interface ComplexTypes extends PipelineOptions {
     Map<String, String> getMap();
 
     void setMap(Map<String, String> value);
@@ -1421,6 +1421,16 @@ public class PipelineOptionsFactoryTest {
     expectedLogs.verifyWarn("Strict parsing is disabled, ignoring option");
   }
 
+  private interface NonPublicPipelineOptions extends PipelineOptions {}
+
+  @Test
+  public void testNonPublicInterfaceLogsWarning() throws Exception {
+    PipelineOptionsFactory.as(NonPublicPipelineOptions.class);
+    // Make sure we print the name of the class.
+    expectedLogs.verifyWarn(NonPublicPipelineOptions.class.getName());
+    expectedLogs.verifyWarn("all non-public interfaces to be in the same package");
+  }
+
   /** A test interface containing all supported List return types. */
   public interface Maps extends PipelineOptions {
     Map<Integer, Integer> getMap();
@@ -1533,7 +1543,7 @@ public class PipelineOptionsFactoryTest {
     PipelineOptionsFactory.fromArgs(args).create();
   }
 
-  interface SuggestedOptions extends PipelineOptions {
+  public interface SuggestedOptions extends PipelineOptions {
     String getAbc();
 
     void setAbc(String value);
@@ -1685,15 +1695,15 @@ public class PipelineOptionsFactoryTest {
   }
 
   /** Used for a name collision test with the other NameConflict interfaces. */
-  private static class NameConflictClassA {
+  public static class NameConflictClassA {
     /** Used for a name collision test with the other NameConflict interfaces. */
-    private interface NameConflict extends PipelineOptions {}
+    public interface NameConflict extends PipelineOptions {}
   }
 
   /** Used for a name collision test with the other NameConflict interfaces. */
-  private static class NameConflictClassB {
+  public static class NameConflictClassB {
     /** Used for a name collision test with the other NameConflict interfaces. */
-    private interface NameConflict extends PipelineOptions {}
+    public interface NameConflict extends PipelineOptions {}
   }
 
   @Test
@@ -1785,20 +1795,20 @@ public class PipelineOptionsFactoryTest {
         output, containsString("The pipeline runner that will be used to execute the pipeline."));
   }
 
-  interface PipelineOptionsInheritedInvalid
+  public interface PipelineOptionsInheritedInvalid
       extends Invalid1, InvalidPipelineOptions2, PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
   }
 
-  interface InvalidPipelineOptions1 {
+  public interface InvalidPipelineOptions1 {
     String getBar();
 
     void setBar(String value);
   }
 
-  interface Invalid1 extends InvalidPipelineOptions1 {
+  public interface Invalid1 extends InvalidPipelineOptions1 {
     @Override
     String getBar();
 
@@ -1806,7 +1816,7 @@ public class PipelineOptionsFactoryTest {
     void setBar(String value);
   }
 
-  interface InvalidPipelineOptions2 {
+  public interface InvalidPipelineOptions2 {
     String getBar();
 
     void setBar(String value);
@@ -1864,7 +1874,7 @@ public class PipelineOptionsFactoryTest {
     }
   }
 
-  private interface RegisteredTestOptions extends PipelineOptions {
+  public interface RegisteredTestOptions extends PipelineOptions {
     Object getRegisteredExampleFooBar();
 
     void setRegisteredExampleFooBar(Object registeredExampleFooBar);
@@ -1890,7 +1900,7 @@ public class PipelineOptionsFactoryTest {
   }
 
   /** PipelineOptions used to test auto registration of Jackson modules. */
-  interface JacksonIncompatibleOptions extends PipelineOptions {
+  public interface JacksonIncompatibleOptions extends PipelineOptions {
     JacksonIncompatible getJacksonIncompatible();
 
     void setJacksonIncompatible(JacksonIncompatible value);
@@ -1988,7 +1998,7 @@ public class PipelineOptionsFactoryTest {
     assertThat(optsWithDefault.getValue(), equalTo(12.25));
   }
 
-  private interface ExtendedOptionsWithDefault extends OptionsWithDefaultMethod {}
+  public interface ExtendedOptionsWithDefault extends OptionsWithDefaultMethod {}
 
   @Test
   public void testDefaultMethodInExtendedClassIgnoresDefaultImplementation() {
@@ -2000,7 +2010,7 @@ public class PipelineOptionsFactoryTest {
     assertThat(extendedOptsWithDefault.getValue(), equalTo(Double.NEGATIVE_INFINITY));
   }
 
-  private interface OptionsWithDefaultMethod extends PipelineOptions {
+  public interface OptionsWithDefaultMethod extends PipelineOptions {
     default Number getValue() {
       return 1024;
     }
@@ -2016,7 +2026,7 @@ public class PipelineOptionsFactoryTest {
             PipelineOptionsFactory.fromArgs("--myMethod=value").as(OptionsWithStaticMethod.class)));
   }
 
-  private interface OptionsWithStaticMethod extends PipelineOptions {
+  public interface OptionsWithStaticMethod extends PipelineOptions {
     String getMyMethod();
 
     void setMyMethod(String value);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
@@ -450,6 +450,7 @@ public class PipelineOptionsFactoryTest {
     options.as(CombinedObject.class);
   }
 
+  /** Test interface. */
   public interface MultiGetters extends PipelineOptions {
     Object getObject();
 
@@ -465,6 +466,7 @@ public class PipelineOptionsFactoryTest {
     void setConsistent(Void consistent);
   }
 
+  /** Test interface. */
   public interface MultipleGettersWithInconsistentJsonIgnore extends PipelineOptions {
     @JsonIgnore
     Object getObject();
@@ -675,6 +677,7 @@ public class PipelineOptionsFactoryTest {
     options.as(GetterWithInconsistentJsonIgnoreValue.class);
   }
 
+  /** Test interface. */
   public interface GettersWithMultipleDefault extends PipelineOptions {
     @Default.String("abc")
     @Default.Integer(0)
@@ -697,6 +700,7 @@ public class PipelineOptionsFactoryTest {
     PipelineOptionsFactory.as(GettersWithMultipleDefault.class);
   }
 
+  /** Test interface. */
   public interface MultiGettersWithDefault extends PipelineOptions {
     Object getObject();
 
@@ -712,6 +716,7 @@ public class PipelineOptionsFactoryTest {
     void setConsistent(Void consistent);
   }
 
+  /** Test interface. */
   public interface MultipleGettersWithInconsistentDefault extends PipelineOptions {
     @Default.Boolean(true)
     Object getObject();
@@ -1543,6 +1548,7 @@ public class PipelineOptionsFactoryTest {
     PipelineOptionsFactory.fromArgs(args).create();
   }
 
+  /** Test interface. */
   public interface SuggestedOptions extends PipelineOptions {
     String getAbc();
 
@@ -1795,6 +1801,7 @@ public class PipelineOptionsFactoryTest {
         output, containsString("The pipeline runner that will be used to execute the pipeline."));
   }
 
+  /** Test interface. */
   public interface PipelineOptionsInheritedInvalid
       extends Invalid1, InvalidPipelineOptions2, PipelineOptions {
     String getFoo();
@@ -1802,12 +1809,14 @@ public class PipelineOptionsFactoryTest {
     void setFoo(String value);
   }
 
+  /** Test interface. */
   public interface InvalidPipelineOptions1 {
     String getBar();
 
     void setBar(String value);
   }
 
+  /** Test interface. */
   public interface Invalid1 extends InvalidPipelineOptions1 {
     @Override
     String getBar();
@@ -1816,6 +1825,7 @@ public class PipelineOptionsFactoryTest {
     void setBar(String value);
   }
 
+  /** Test interface. */
   public interface InvalidPipelineOptions2 {
     String getBar();
 
@@ -1874,6 +1884,7 @@ public class PipelineOptionsFactoryTest {
     }
   }
 
+  /** Test interface. */
   public interface RegisteredTestOptions extends PipelineOptions {
     Object getRegisteredExampleFooBar();
 
@@ -1998,6 +2009,7 @@ public class PipelineOptionsFactoryTest {
     assertThat(optsWithDefault.getValue(), equalTo(12.25));
   }
 
+  /** Test interface. */
   public interface ExtendedOptionsWithDefault extends OptionsWithDefaultMethod {}
 
   @Test
@@ -2010,6 +2022,7 @@ public class PipelineOptionsFactoryTest {
     assertThat(extendedOptsWithDefault.getValue(), equalTo(Double.NEGATIVE_INFINITY));
   }
 
+  /** Test interface. */
   public interface OptionsWithDefaultMethod extends PipelineOptions {
     default Number getValue() {
       return 1024;
@@ -2026,6 +2039,7 @@ public class PipelineOptionsFactoryTest {
             PipelineOptionsFactory.fromArgs("--myMethod=value").as(OptionsWithStaticMethod.class)));
   }
 
+  /** Test interface. */
   public interface OptionsWithStaticMethod extends PipelineOptions {
     String getMyMethod();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsReflectorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsReflectorTest.java
@@ -51,7 +51,7 @@ public class PipelineOptionsReflectorTest {
                 SimpleOptions.class, "foo", SimpleOptions.class.getDeclaredMethod("getFoo"))));
   }
 
-  interface SimpleOptions extends PipelineOptions {
+  public interface SimpleOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
@@ -65,7 +65,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, not(hasItem(hasName(isOneOf("misspelled", "hasParameter", "prefix")))));
   }
 
-  interface OnlyTwoValidGetters extends PipelineOptions {
+  public interface OnlyTwoValidGetters extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
@@ -97,7 +97,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(props, hasItem(allOf(hasName("bar"), hasClass(ExtendsSimpleOptions.class))));
   }
 
-  interface ExtendsSimpleOptions extends SimpleOptions {
+  public interface ExtendsSimpleOptions extends SimpleOptions {
     @Override
     String getFoo();
 
@@ -123,7 +123,7 @@ public class PipelineOptionsReflectorTest {
     void setFoo(String value);
   }
 
-  interface ExtendsNonPipelineOptions extends NoExtendsClause, PipelineOptions {}
+  public interface ExtendsNonPipelineOptions extends NoExtendsClause, PipelineOptions {}
 
   @Test
   public void testExcludesHiddenInterfaces() {
@@ -134,7 +134,7 @@ public class PipelineOptionsReflectorTest {
   }
 
   @Hidden
-  interface HiddenOptions extends PipelineOptions {
+  public interface HiddenOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
@@ -149,7 +149,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, hasItem(allOf(hasName("ignored"), not(shouldSerialize()))));
   }
 
-  interface JsonIgnoreOptions extends PipelineOptions {
+  public interface JsonIgnoreOptions extends PipelineOptions {
     String getNotIgnored();
 
     void setNotIgnored(String value);
@@ -172,19 +172,19 @@ public class PipelineOptionsReflectorTest {
     assertThat(props, hasItem(allOf(hasName("extendOption2"), hasClass(ExtendOptions2.class))));
   }
 
-  interface BaseOptions extends PipelineOptions {
+  public interface BaseOptions extends PipelineOptions {
     String getBaseOption();
 
     void setBaseOption(String value);
   }
 
-  interface ExtendOptions1 extends BaseOptions {
+  public interface ExtendOptions1 extends BaseOptions {
     String getExtendOption1();
 
     void setExtendOption1(String value);
   }
 
-  interface ExtendOptions2 extends BaseOptions {
+  public interface ExtendOptions2 extends BaseOptions {
     String getExtendOption2();
 
     void setExtendOption2(String value);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsReflectorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsReflectorTest.java
@@ -51,6 +51,7 @@ public class PipelineOptionsReflectorTest {
                 SimpleOptions.class, "foo", SimpleOptions.class.getDeclaredMethod("getFoo"))));
   }
 
+  /** Test interface. */
   public interface SimpleOptions extends PipelineOptions {
     String getFoo();
 
@@ -65,6 +66,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, not(hasItem(hasName(isOneOf("misspelled", "hasParameter", "prefix")))));
   }
 
+  /** Test interface. */
   public interface OnlyTwoValidGetters extends PipelineOptions {
     String getFoo();
 
@@ -97,6 +99,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(props, hasItem(allOf(hasName("bar"), hasClass(ExtendsSimpleOptions.class))));
   }
 
+  /** Test interface. */
   public interface ExtendsSimpleOptions extends SimpleOptions {
     @Override
     String getFoo();
@@ -117,12 +120,14 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, not(hasItem(hasName("foo"))));
   }
 
-  interface NoExtendsClause {
+  /** Test interface. */
+  public interface NoExtendsClause {
     String getFoo();
 
     void setFoo(String value);
   }
 
+  /** Test interface. */
   public interface ExtendsNonPipelineOptions extends NoExtendsClause, PipelineOptions {}
 
   @Test
@@ -133,6 +138,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, not(hasItem(hasName("foo"))));
   }
 
+  /** Test interface. */
   @Hidden
   public interface HiddenOptions extends PipelineOptions {
     String getFoo();
@@ -149,6 +155,7 @@ public class PipelineOptionsReflectorTest {
     assertThat(properties, hasItem(allOf(hasName("ignored"), not(shouldSerialize()))));
   }
 
+  /** Test interface. */
   public interface JsonIgnoreOptions extends PipelineOptions {
     String getNotIgnored();
 
@@ -172,18 +179,21 @@ public class PipelineOptionsReflectorTest {
     assertThat(props, hasItem(allOf(hasName("extendOption2"), hasClass(ExtendOptions2.class))));
   }
 
+  /** Test interface. */
   public interface BaseOptions extends PipelineOptions {
     String getBaseOption();
 
     void setBaseOption(String value);
   }
 
+  /** Test interface. */
   public interface ExtendOptions1 extends BaseOptions {
     String getExtendOption1();
 
     void setExtendOption1(String value);
   }
 
+  /** Test interface. */
   public interface ExtendOptions2 extends BaseOptions {
     String getExtendOption2();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -55,6 +55,7 @@ public class PipelineOptionsTest {
     void setIgnoredValue(Set<String> ignoredValue);
   }
 
+  /** Test interface. */
   public interface ConflictedTestOptions extends BaseTestOptions {
     String getDerivedValue();
 
@@ -68,6 +69,7 @@ public class PipelineOptionsTest {
     void setIgnoredValue(Set<String> ignoredValue);
   }
 
+  /** Test interface. */
   public interface BaseTestOptions extends PipelineOptions {
     List<Boolean> getBaseValue();
 
@@ -85,6 +87,7 @@ public class PipelineOptionsTest {
     assertNotNull(options);
   }
 
+  /** Test interface. */
   public interface ValueProviderOptions extends PipelineOptions {
     ValueProvider<Boolean> getBool();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsTest.java
@@ -42,7 +42,7 @@ public class PipelineOptionsTest {
   @Rule public ExpectedException expectedException = ExpectedException.none();
 
   /** Interfaces used for testing that {@link PipelineOptions#as(Class)} functions. */
-  private interface DerivedTestOptions extends BaseTestOptions {
+  public interface DerivedTestOptions extends BaseTestOptions {
     int getDerivedValue();
 
     void setDerivedValue(int derivedValue);
@@ -55,7 +55,7 @@ public class PipelineOptionsTest {
     void setIgnoredValue(Set<String> ignoredValue);
   }
 
-  private interface ConflictedTestOptions extends BaseTestOptions {
+  public interface ConflictedTestOptions extends BaseTestOptions {
     String getDerivedValue();
 
     void setDerivedValue(String derivedValue);
@@ -68,7 +68,7 @@ public class PipelineOptionsTest {
     void setIgnoredValue(Set<String> ignoredValue);
   }
 
-  private interface BaseTestOptions extends PipelineOptions {
+  public interface BaseTestOptions extends PipelineOptions {
     List<Boolean> getBaseValue();
 
     void setBaseValue(List<Boolean> baseValue);
@@ -85,7 +85,7 @@ public class PipelineOptionsTest {
     assertNotNull(options);
   }
 
-  private interface ValueProviderOptions extends PipelineOptions {
+  public interface ValueProviderOptions extends PipelineOptions {
     ValueProvider<Boolean> getBool();
 
     void setBool(ValueProvider<Boolean> value);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsValidatorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsValidatorTest.java
@@ -218,6 +218,7 @@ public class PipelineOptionsValidatorTest {
     PipelineOptionsValidator.validate(MultiGroupRequired.class, multiGroupRequired);
   }
 
+  /** Test interface. */
   public interface LeftOptions extends PipelineOptions {
     @Validation.Required(groups = {"left"})
     String getFoo();
@@ -235,6 +236,7 @@ public class PipelineOptionsValidatorTest {
     void setBoth(String both);
   }
 
+  /** Test interface. */
   public interface RightOptions extends PipelineOptions {
     @Validation.Required(groups = {"right"})
     String getFoo();
@@ -252,6 +254,7 @@ public class PipelineOptionsValidatorTest {
     void setBoth(String both);
   }
 
+  /** Test interface. */
   public interface JoinedOptions extends LeftOptions, RightOptions {}
 
   @Test
@@ -312,6 +315,7 @@ public class PipelineOptionsValidatorTest {
     PipelineOptionsValidator.validate(JoinedOptions.class, options);
   }
 
+  /** Test interface. */
   public interface SuperOptions extends PipelineOptions {
     @Validation.Required(groups = {"super"})
     String getFoo();
@@ -329,6 +333,7 @@ public class PipelineOptionsValidatorTest {
     void setSuperclassObj(String sup);
   }
 
+  /** Test interface. */
   public interface SubOptions extends SuperOptions {
     @Override
     @Validation.Required(groups = {"sub"})

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsValidatorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsValidatorTest.java
@@ -218,7 +218,7 @@ public class PipelineOptionsValidatorTest {
     PipelineOptionsValidator.validate(MultiGroupRequired.class, multiGroupRequired);
   }
 
-  private interface LeftOptions extends PipelineOptions {
+  public interface LeftOptions extends PipelineOptions {
     @Validation.Required(groups = {"left"})
     String getFoo();
 
@@ -235,7 +235,7 @@ public class PipelineOptionsValidatorTest {
     void setBoth(String both);
   }
 
-  private interface RightOptions extends PipelineOptions {
+  public interface RightOptions extends PipelineOptions {
     @Validation.Required(groups = {"right"})
     String getFoo();
 
@@ -252,7 +252,7 @@ public class PipelineOptionsValidatorTest {
     void setBoth(String both);
   }
 
-  private interface JoinedOptions extends LeftOptions, RightOptions {}
+  public interface JoinedOptions extends LeftOptions, RightOptions {}
 
   @Test
   public void testWhenOptionIsDefinedInMultipleSuperInterfacesAndIsNotPresentFailsRequirement() {
@@ -312,7 +312,7 @@ public class PipelineOptionsValidatorTest {
     PipelineOptionsValidator.validate(JoinedOptions.class, options);
   }
 
-  private interface SuperOptions extends PipelineOptions {
+  public interface SuperOptions extends PipelineOptions {
     @Validation.Required(groups = {"super"})
     String getFoo();
 
@@ -329,7 +329,7 @@ public class PipelineOptionsValidatorTest {
     void setSuperclassObj(String sup);
   }
 
-  private interface SubOptions extends SuperOptions {
+  public interface SubOptions extends SuperOptions {
     @Override
     @Validation.Required(groups = {"sub"})
     String getFoo();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -633,7 +633,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface for conversion of inner types. */
-  private static class InnerType {
+  public static class InnerType {
     public double doubleField;
 
     static InnerType of(double value) {
@@ -656,7 +656,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface for conversion of generics and inner types. */
-  private static class ComplexType {
+  public static class ComplexType {
     public String stringField;
     public Integer intField;
     public List<InnerType> genericType;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -678,6 +678,7 @@ public class ProxyInvocationHandlerTest {
     }
   }
 
+  /** Test interface. */
   public interface ComplexTypes extends PipelineOptions {
     ComplexType getComplexType();
 
@@ -842,6 +843,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(displayData, hasDisplayItem("object", "foobar"));
   }
 
+  /** Test interface. */
   public interface TypedOptions extends PipelineOptions {
     int getInteger();
 
@@ -906,12 +908,14 @@ public class ProxyInvocationHandlerTest {
             allOf(hasKey("foo"), hasValue("bar"), hasNamespace(ExtendsBaseOptions.class))));
   }
 
+  /** Test interface. */
   public interface BaseOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
   }
 
+  /** Test interface. */
   public interface ExtendsBaseOptions extends BaseOptions {
     @Override
     String getFoo();
@@ -942,12 +946,14 @@ public class ProxyInvocationHandlerTest {
     assertThat(data, hasDisplayItem(allOf(hasKey("bar"), hasNamespace(BarOptions.class))));
   }
 
+  /** Test interface. */
   public interface FooOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
   }
 
+  /** Test interface. */
   public interface BarOptions extends PipelineOptions {
     String getBar();
 
@@ -962,6 +968,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(data, not(hasDisplayItem("foo")));
   }
 
+  /** Test interface. */
   public interface HasDefaults extends PipelineOptions {
     @Default.String("bar")
     String getFoo();
@@ -1016,6 +1023,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(deserializedData, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
   }
 
+  /** Test interface. */
   public interface ArrayOptions extends PipelineOptions {
     String[][] getDeepArray();
 
@@ -1084,6 +1092,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(displayData, hasDisplayItem("classOption", expectedJsonValue));
   }
 
+  /** Test interface. */
   public interface HasClassOptions extends PipelineOptions {
     Class<?> getClassOption();
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/ProxyInvocationHandlerTest.java
@@ -542,7 +542,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface for JSON conversion of simple types. */
-  private interface SimpleTypes extends PipelineOptions {
+  public interface SimpleTypes extends PipelineOptions {
     int getInteger();
 
     void setInteger(int value);
@@ -603,7 +603,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface for JSON conversion of container types. */
-  private interface ContainerTypes extends PipelineOptions {
+  public interface ContainerTypes extends PipelineOptions {
     List<String> getList();
 
     void setList(List<String> values);
@@ -678,7 +678,7 @@ public class ProxyInvocationHandlerTest {
     }
   }
 
-  private interface ComplexTypes extends PipelineOptions {
+  public interface ComplexTypes extends PipelineOptions {
     ComplexType getComplexType();
 
     void setComplexType(ComplexType value);
@@ -699,7 +699,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface for testing ignored properties during serialization. */
-  private interface IgnoredProperty extends PipelineOptions {
+  public interface IgnoredProperty extends PipelineOptions {
     @JsonIgnore
     String getValue();
 
@@ -729,7 +729,7 @@ public class ProxyInvocationHandlerTest {
   }
 
   /** Test interface containing a class that is not serializable by Jackson. */
-  private interface NotSerializableProperty extends PipelineOptions {
+  public interface NotSerializableProperty extends PipelineOptions {
     NotSerializable getValue();
 
     void setValue(NotSerializable value);
@@ -749,7 +749,7 @@ public class ProxyInvocationHandlerTest {
    * Test interface that has {@link JsonIgnore @JsonIgnore} on a property that Jackson can't
    * serialize.
    */
-  private interface IgnoredNotSerializableProperty extends PipelineOptions {
+  public interface IgnoredNotSerializableProperty extends PipelineOptions {
     @JsonIgnore
     NotSerializable getValue();
 
@@ -785,7 +785,7 @@ public class ProxyInvocationHandlerTest {
    * Test interface containing a property that is serializable by Jackson only with the additional
    * metadata.
    */
-  private interface SerializableWithMetadataProperty extends PipelineOptions {
+  public interface SerializableWithMetadataProperty extends PipelineOptions {
     SerializableWithMetadata getValue();
 
     void setValue(SerializableWithMetadata value);
@@ -842,7 +842,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(displayData, hasDisplayItem("object", "foobar"));
   }
 
-  interface TypedOptions extends PipelineOptions {
+  public interface TypedOptions extends PipelineOptions {
     int getInteger();
 
     void setInteger(int value);
@@ -906,13 +906,13 @@ public class ProxyInvocationHandlerTest {
             allOf(hasKey("foo"), hasValue("bar"), hasNamespace(ExtendsBaseOptions.class))));
   }
 
-  interface BaseOptions extends PipelineOptions {
+  public interface BaseOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
   }
 
-  interface ExtendsBaseOptions extends BaseOptions {
+  public interface ExtendsBaseOptions extends BaseOptions {
     @Override
     String getFoo();
 
@@ -942,13 +942,13 @@ public class ProxyInvocationHandlerTest {
     assertThat(data, hasDisplayItem(allOf(hasKey("bar"), hasNamespace(BarOptions.class))));
   }
 
-  interface FooOptions extends PipelineOptions {
+  public interface FooOptions extends PipelineOptions {
     String getFoo();
 
     void setFoo(String value);
   }
 
-  interface BarOptions extends PipelineOptions {
+  public interface BarOptions extends PipelineOptions {
     String getBar();
 
     void setBar(String value);
@@ -962,7 +962,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(data, not(hasDisplayItem("foo")));
   }
 
-  interface HasDefaults extends PipelineOptions {
+  public interface HasDefaults extends PipelineOptions {
     @Default.String("bar")
     String getFoo();
 
@@ -1016,7 +1016,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(deserializedData, hasDisplayItem("deepPrimitiveArray", "[[1, 2], [3]]"));
   }
 
-  private interface ArrayOptions extends PipelineOptions {
+  public interface ArrayOptions extends PipelineOptions {
     String[][] getDeepArray();
 
     void setDeepArray(String[][] value);
@@ -1084,7 +1084,7 @@ public class ProxyInvocationHandlerTest {
     assertThat(displayData, hasDisplayItem("classOption", expectedJsonValue));
   }
 
-  interface HasClassOptions extends PipelineOptions {
+  public interface HasClassOptions extends PipelineOptions {
     Class<?> getClassOption();
 
     void setClassOption(Class<?> value);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
@@ -127,6 +127,7 @@ public class ReflectHelpersTest {
             new TypeDescriptor<Map<? super InputT, ? extends OutputT>>() {}.getType()));
   }
 
+  /** Test interface. */
   public interface Options extends PipelineOptions {
     @Default.String("package.OuterClass$InnerClass#method()")
     String getString();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
@@ -127,7 +127,7 @@ public class ReflectHelpersTest {
             new TypeDescriptor<Map<? super InputT, ? extends OutputT>>() {}.getType()));
   }
 
-  private interface Options extends PipelineOptions {
+  public interface Options extends PipelineOptions {
     @Default.String("package.OuterClass$InnerClass#method()")
     String getString();
 

--- a/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFITestOptions.java
+++ b/sdks/java/io/hadoop-input-format/src/test/java/org/apache/beam/sdk/io/hadoop/inputformat/HIFITestOptions.java
@@ -22,7 +22,7 @@ import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
 
 /** Properties needed when using HadoopInputFormatIO with the Beam SDK. */
-interface HIFITestOptions extends TestPipelineOptions {
+public interface HIFITestOptions extends TestPipelineOptions {
 
   //Cassandra test options
   @Description("Cassandra Server IP")

--- a/sdks/java/io/hcatalog/src/test/java/org/apache/beam/sdk/io/hcatalog/HCatalogIOIT.java
+++ b/sdks/java/io/hcatalog/src/test/java/org/apache/beam/sdk/io/hcatalog/HCatalogIOIT.java
@@ -64,6 +64,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class HCatalogIOIT {
 
+  /** PipelineOptions for testing {@link org.apache.beam.sdk.io.hcatalog.HCatalogIO}. */
   public interface HCatalogPipelineOptions extends IOTestPipelineOptions {
     @Description("HCatalog metastore host (hostname/ip address)")
     @Default.String("hcatalog-metastore")

--- a/sdks/java/io/hcatalog/src/test/java/org/apache/beam/sdk/io/hcatalog/HCatalogIOIT.java
+++ b/sdks/java/io/hcatalog/src/test/java/org/apache/beam/sdk/io/hcatalog/HCatalogIOIT.java
@@ -64,7 +64,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class HCatalogIOIT {
 
-  private interface HCatalogPipelineOptions extends IOTestPipelineOptions {
+  public interface HCatalogPipelineOptions extends IOTestPipelineOptions {
     @Description("HCatalog metastore host (hostname/ip address)")
     @Default.String("hcatalog-metastore")
     String getHCatalogMetastoreHostName();


### PR DESCRIPTION
Also fix javadoc and all known existing usages to use public modifier on interface.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




