### PR TITLE
Flesh out the roll-forward case in postcommit policy

### DIFF
--- a/website/src/contribute/postcommits-policies.md
+++ b/website/src/contribute/postcommits-policies.md
@@ -22,11 +22,11 @@ limitations under the License.
 
 Post-commit tests validate that Beam works correctly in a live environment. The
 tests also catch errors that are hard to predict in the design and
-implementation stages
+implementation stages.
 
 Even though post-commit tests run after the code is merged into the repository,
 it is important that the tests pass reliably. Jenkins executes post-commit tests
-against the HEAD of the master branch. If post-commit tests fail, there is a
+against the HEAD of the `master` branch. If post-commit tests fail, there is a
 problem with the HEAD build. In addition, post-commit tests are time consuming
 to run, and it is often hard to triage test failures.
 
@@ -65,11 +65,34 @@ When a post-commit test fails, follow the provided steps for your situation.
 
 ### My change was rolled back due to a test failure {#pr-rolled-back}
 
-1.  Look at the JIRA issue to find the reason for the rollback.
-1.  Fix your code and re-run the post-commit tests.
-1.  Implement new pre-commit tests that will catch similar bugs before future
-    code is merged into the repository.
-1.  Open a new PR that contains your fix and the new pre-commit tests.
+After rollback there is time for deeper investigation. Start by looking at the
+JIRA issue to see the background information for the rollback. There are three
+common scenarios:
+
+1.  Your change contained a bug.
+2.  Your change exposed an existing bug.
+3.  Your change exposed a bad test (flaky, overspecified, etc).
+
+_These are all valid reasons for rollback. Maintaining clear signal is the
+highest priority._
+
+The high level steps are the same:
+
+1.  Create a fix and re-run the post-commit tests.
+2.  Implement new pre-commit tests that will catch similar failures
+    before future code is merged into the repository.
+3.  Open a new PR that contains your fix and the new pre-commit tests.
+
+If the bug is not in your code, here is how to "create a fix":
+
+1.  File a ticket for the existing bug, if it does not already exist.
+    Remember that
+    [a flaky test is a critical bug]({{ site.baseurl }}/contribute/postcommits-policies-details/index.html#flake_is_failing). Other
+    bad tests are similar: they may fail for arbitrary reasons having nothing
+    to do with what it is testing, making our signal unreliable.
+2.  Keep a sickbayed copy of the test that reproduces the failure.
+3.  (Preferred) Create a new test that provides as much coverage possible from
+    the sickbayed test.
 
 ## Useful links
 

--- a/website/src/contribute/postcommits-policies.md
+++ b/website/src/contribute/postcommits-policies.md
@@ -90,9 +90,7 @@ If the bug is not in your code, here is how to "create a fix":
     [a flaky test is a critical bug]({{ site.baseurl }}/contribute/postcommits-policies-details/index.html#flake_is_failing). Other
     bad tests are similar: they may fail for arbitrary reasons having nothing
     to do with what it is testing, making our signal unreliable.
-2.  Keep a sickbayed copy of the test that reproduces the failure.
-3.  (Preferred) Create a new test that provides as much coverage possible from
-    the sickbayed test.
+2.  Mark the problematic test to be skipped, with a link to the JIRA ticket.
 
 ## Useful links
 

--- a/website/src/contribute/postcommits-policies.md
+++ b/website/src/contribute/postcommits-policies.md
@@ -66,12 +66,12 @@ When a post-commit test fails, follow the provided steps for your situation.
 ### My change was rolled back due to a test failure {#pr-rolled-back}
 
 After rollback there is time for deeper investigation. Start by looking at the
-JIRA issue to see the background information for the rollback. There are three
-common scenarios:
+JIRA issue to see the background information for the rollback. These scenarios
+are all common:
 
-1.  Your change contained a bug.
-2.  Your change exposed an existing bug.
-3.  Your change exposed a bad test (flaky, overspecified, etc).
+*   Your change contained a bug.
+*   Your change exposed an existing bug.
+*   Your change exposed a bad test (flaky, overspecified, etc).
 
 _These are all valid reasons for rollback. Maintaining clear signal is the
 highest priority._

--- a/website/src/contribute/postcommits-policies.md
+++ b/website/src/contribute/postcommits-policies.md
@@ -89,7 +89,7 @@ If the bug is not in your code, here is how to "create a fix":
     Remember that
     [a flaky test is a critical bug]({{ site.baseurl }}/contribute/postcommits-policies-details/index.html#flake_is_failing). Other
     bad tests are similar: they may fail for arbitrary reasons having nothing
-    to do with what it is testing, making our signal unreliable.
+    to do with what is being tested, making our signal unreliable.
 2.  Mark the problematic test to be skipped, with a link to the JIRA ticket.
 
 ## Useful links


### PR DESCRIPTION
This adds more detail to how to roll forward after a roll back, breaking it down into common cases.

The phrasing on the website implies that a postcommit failure is necessarily a bug in the code that caused the failure. This is only one of three common scenarios. We don't want people to think the policy does not apply to their change just because the failure was not a bug in their change.

http://apache-beam-website-pull-requests.storage.googleapis.com/6873/contribute/postcommits-policies/index.html

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




