### PR TITLE
[BEAM-5906] Use dedicated BigQuery client for publishing Nexmark results

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -309,6 +309,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def generated_grpc_beta_version = "0.19.0"
     def generated_grpc_ga_version = "1.18.0"
     def google_cloud_bigdataoss_version = "1.9.0"
+    def google_cloud_bigquery_version = "1.48.0"
     def bigtable_version = "1.4.0"
     def google_clients_version = "1.24.1"
     def google_auth_version = "0.10.0"
@@ -374,6 +375,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_services_storage                 : "com.google.apis:google-api-services-storage:v1-rev136-$google_clients_version",
         google_auth_library_credentials             : "com.google.auth:google-auth-library-credentials:$google_auth_version",
         google_auth_library_oauth2_http             : "com.google.auth:google-auth-library-oauth2-http:$google_auth_version",
+        google_cloud_bigquery                       : "com.google.cloud:google-cloud-bigquery:$google_cloud_bigquery_version",
         google_cloud_core                           : "com.google.cloud:google-cloud-core:$google_cloud_core_version",
         google_cloud_core_grpc                      : "com.google.cloud:google-cloud-core-grpc:$google_cloud_core_version",
         google_cloud_dataflow_java_proto_library_all: "com.google.cloud.dataflow:google-cloud-dataflow-java-proto-library-all:0.5.160304",

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -309,7 +309,6 @@ class BeamModulePlugin implements Plugin<Project> {
     def generated_grpc_beta_version = "0.19.0"
     def generated_grpc_ga_version = "1.18.0"
     def google_cloud_bigdataoss_version = "1.9.0"
-    def google_cloud_bigquery_version = "1.48.0"
     def bigtable_version = "1.4.0"
     def google_clients_version = "1.24.1"
     def google_auth_version = "0.10.0"
@@ -375,7 +374,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_services_storage                 : "com.google.apis:google-api-services-storage:v1-rev136-$google_clients_version",
         google_auth_library_credentials             : "com.google.auth:google-auth-library-credentials:$google_auth_version",
         google_auth_library_oauth2_http             : "com.google.auth:google-auth-library-oauth2-http:$google_auth_version",
-        google_cloud_bigquery                       : "com.google.cloud:google-cloud-bigquery:$google_cloud_bigquery_version",
+        google_cloud_bigquery                       : "com.google.cloud:google-cloud-bigquery:$google_clients_version",
         google_cloud_core                           : "com.google.cloud:google-cloud-core:$google_cloud_core_version",
         google_cloud_core_grpc                      : "com.google.cloud:google-cloud-core-grpc:$google_cloud_core_version",
         google_cloud_dataflow_java_proto_library_all: "com.google.cloud.dataflow:google-cloud-dataflow-java-proto-library-all:0.5.160304",

--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -71,6 +71,7 @@ dependencies {
   provided library.java.hamcrest_core
   shadow project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadow")
   shadowTest project(path: ":beam-sdks-java-io-google-cloud-platform", configuration: "shadowTest")
+  shadowTest project(path: ":beam-sdks-java-test-utils", configuration: "shadowTest")
   testCompile library.java.hamcrest_core
   testCompile library.java.hamcrest_library
 

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -17,14 +17,9 @@
  */
 package org.apache.beam.sdk.nexmark;
 
-import com.google.api.services.bigquery.model.TableFieldSchema;
-import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -41,24 +36,11 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.CustomCoder;
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.SerializableCoder;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
-import org.apache.beam.sdk.io.gcp.bigquery.TableDestination;
 import org.apache.beam.sdk.nexmark.model.Auction;
 import org.apache.beam.sdk.nexmark.model.Bid;
 import org.apache.beam.sdk.nexmark.model.Person;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
-import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.sdk.values.KV;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.ValueInSingleWindow;
+import org.apache.beam.sdk.testutils.publishing.BigQueryClient;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -162,7 +144,8 @@ public class Main {
       }
 
       if (options.getExportSummaryToBigQuery()) {
-        savePerfsToBigQuery(options, actual, null, start);
+        BigQueryClient publisher = BigQueryClient.create(options.getBigQueryDataset());
+        savePerfsToBigQuery(publisher, options, actual, start);
       }
     } finally {
       if (options.getMonitorJobs()) {
@@ -180,77 +163,37 @@ public class Main {
 
   @VisibleForTesting
   static void savePerfsToBigQuery(
+      BigQueryClient bigQueryClient,
       NexmarkOptions options,
       Map<NexmarkConfiguration, NexmarkPerf> perfs,
-      @Nullable BigQueryServices testBigQueryServices,
       Instant start) {
-    Pipeline pipeline = Pipeline.create(options);
-    PCollection<KV<NexmarkConfiguration, NexmarkPerf>> perfsPCollection =
-        pipeline.apply(
-            Create.of(perfs)
-                .withCoder(
-                    KvCoder.of(
-                        SerializableCoder.of(NexmarkConfiguration.class),
-                        new CustomCoder<NexmarkPerf>() {
 
-                          @Override
-                          public void encode(NexmarkPerf value, OutputStream outStream)
-                              throws CoderException, IOException {
-                            StringUtf8Coder.of().encode(value.toString(), outStream);
-                          }
+    for (Map.Entry<NexmarkConfiguration, NexmarkPerf> entry : perfs.entrySet()) {
+      String queryName =
+          NexmarkUtils.fullQueryName(
+              options.getQueryLanguage(), entry.getKey().query.getNumberOrName());
+      String tableName = NexmarkUtils.tableName(options, queryName, 0L, null);
 
-                          @Override
-                          public NexmarkPerf decode(InputStream inStream)
-                              throws CoderException, IOException {
-                            String perf = StringUtf8Coder.of().decode(inStream);
-                            return NexmarkPerf.fromString(perf);
-                          }
-                        })));
+      ImmutableMap<String, String> schema =
+          ImmutableMap.<String, String>builder()
+              .put("timestamp", "timestamp")
+              .put("runtimeSec", "float")
+              .put("eventsPerSec", "float")
+              .put("numResults", "integer")
+              .build();
+      bigQueryClient.createTableIfNotExists(tableName, schema);
 
-    TableSchema tableSchema =
-        new TableSchema()
-            .setFields(
-                ImmutableList.of(
-                    new TableFieldSchema().setName("timestamp").setType("TIMESTAMP"),
-                    new TableFieldSchema().setName("runtimeSec").setType("FLOAT"),
-                    new TableFieldSchema().setName("eventsPerSec").setType("FLOAT"),
-                    new TableFieldSchema().setName("numResults").setType("INTEGER")));
+      // convert millis to seconds (it's a BigQuery's requirement).
+      Map<String, Object> record =
+          ImmutableMap.<String, Object>builder()
+              .put("timestamp", start.getMillis() / 1000)
+              .put("runtimeSec", entry.getValue().runtimeSec)
+              .put("eventsPerSec", entry.getValue().eventsPerSec)
+              .put("numResults", entry.getValue().numResults)
+              .build();
 
-    String queryName = "{query}";
-    if (options.getQueryLanguage() != null) {
-      queryName = queryName + "_" + options.getQueryLanguage();
+      bigQueryClient.insertRow(record, tableName);
     }
-    final String tableSpec = NexmarkUtils.tableSpec(options, queryName, 0L, null);
-    SerializableFunction<
-            ValueInSingleWindow<KV<NexmarkConfiguration, NexmarkPerf>>, TableDestination>
-        tableFunction =
-            input ->
-                new TableDestination(
-                    tableSpec.replace("{query}", input.getValue().getKey().query.getNumberOrName()),
-                    "perfkit queries");
-    SerializableFunction<KV<NexmarkConfiguration, NexmarkPerf>, TableRow> rowFunction =
-        input -> {
-          NexmarkPerf nexmarkPerf = input.getValue();
-          TableRow row =
-              new TableRow()
-                  .set("timestamp", start.getMillis() / 1000)
-                  .set("runtimeSec", nexmarkPerf.runtimeSec)
-                  .set("eventsPerSec", nexmarkPerf.eventsPerSec)
-                  .set("numResults", nexmarkPerf.numResults);
-          return row;
-        };
-    BigQueryIO.Write io =
-        BigQueryIO.<KV<NexmarkConfiguration, NexmarkPerf>>write()
-            .to(tableFunction)
-            .withSchema(tableSchema)
-            .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_IF_NEEDED)
-            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
-            .withFormatFunction(rowFunction);
-    if (testBigQueryServices != null) {
-      io = io.withTestServices(testBigQueryServices);
-    }
-    perfsPCollection.apply("savePerfsToBigQuery", io);
-    pipeline.run();
   }
 
   /** Append the pair of {@code configuration} and {@code perf} to perf file. */

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/NexmarkUtilsTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/NexmarkUtilsTest.java
@@ -17,11 +17,21 @@
  */
 package org.apache.beam.sdk.nexmark;
 
+import static org.apache.beam.sdk.nexmark.NexmarkUtils.ResourceNameMode.QUERY;
+import static org.apache.beam.sdk.nexmark.NexmarkUtils.ResourceNameMode.QUERY_AND_SALT;
+import static org.apache.beam.sdk.nexmark.NexmarkUtils.ResourceNameMode.QUERY_RUNNER_AND_MODE;
+import static org.apache.beam.sdk.nexmark.NexmarkUtils.ResourceNameMode.VERBATIM;
+import static org.testng.Assert.assertEquals;
+
 import java.util.Random;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.values.KV;
@@ -31,7 +41,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test the Nexmark utils. */
+/** Tests the {@link NexmarkUtils}. */
 @RunWith(JUnit4.class)
 public class NexmarkUtilsTest {
 
@@ -62,6 +72,102 @@ public class NexmarkUtilsTest {
       pipeline.run();
     } finally {
       NexmarkUtils.cleanUpSideInput(config);
+    }
+  }
+
+  @Test
+  public void testFullQueryNameAppendsLanguageIfNeeded() {
+    String fullName = NexmarkUtils.fullQueryName("sql", "1");
+    assertEquals(fullName, "1_sql");
+  }
+
+  @Test
+  public void testFullQueryNameDoesntContainNullLanguage() {
+    String fullName = NexmarkUtils.fullQueryName(null, "1");
+    assertEquals(fullName, "1");
+  }
+
+  @Test
+  public void testTableName() {
+    String table = "nexmark";
+    String query = "query";
+    long salt = 1111;
+    String version = "version";
+    Class runner = Runner.class;
+    boolean isStreaming = true;
+
+    testTableName(VERBATIM, table, query, salt, version, runner, isStreaming, "nexmark_version");
+
+    testTableName(QUERY, table, query, salt, version, runner, isStreaming, "nexmark_query_version");
+
+    testTableName(
+        QUERY_AND_SALT,
+        table,
+        query,
+        salt,
+        version,
+        runner,
+        isStreaming,
+        "nexmark_query_version_1111");
+
+    testTableName(
+        QUERY_RUNNER_AND_MODE,
+        table,
+        query,
+        salt,
+        version,
+        runner,
+        isStreaming,
+        "nexmark_query_Runner_streaming_version");
+
+    testTableName(
+        QUERY_RUNNER_AND_MODE,
+        table,
+        query,
+        salt,
+        version,
+        runner,
+        !isStreaming,
+        "nexmark_query_Runner_batch_version");
+
+    testTableName(
+        QUERY_RUNNER_AND_MODE,
+        table,
+        query,
+        salt,
+        null,
+        runner,
+        isStreaming,
+        "nexmark_query_Runner_streaming");
+  }
+
+  private void testTableName(
+      NexmarkUtils.ResourceNameMode nameMode,
+      String baseTableName,
+      String queryName,
+      Long salt,
+      String version,
+      Class runner,
+      Boolean isStreaming,
+      String expected) {
+    NexmarkOptions options = PipelineOptionsFactory.as(NexmarkOptions.class);
+    options.setResourceNameMode(nameMode);
+    options.setBigQueryTable(baseTableName);
+    options.setRunner(runner);
+    options.setStreaming(isStreaming);
+
+    String tableName = NexmarkUtils.tableName(options, queryName, salt, version);
+
+    assertEquals(tableName, expected);
+  }
+
+  private static class Runner extends PipelineRunner<PipelineResult> {
+
+    private Runner() {}
+
+    @Override
+    public PipelineResult run(Pipeline pipeline) {
+      return null;
     }
   }
 }

--- a/sdks/java/testing/test-utils/build.gradle
+++ b/sdks/java/testing/test-utils/build.gradle
@@ -24,6 +24,8 @@ description = "Apache Beam :: SDKs :: Java :: Test Utils"
 dependencies {
   shadow project(path: ":beam-sdks-java-core", configuration: "shadow")
   compile library.java.guava
+  shadow library.java.google_cloud_bigquery
+  shadow project(path: ":beam-sdks-java-extensions-google-cloud-platform-core", configuration: "shadow")
 
   shadowTest library.java.junit
   shadowTest library.java.mockito_core

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryClient.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/BigQueryClient.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testutils.publishing;
+
+import static java.lang.String.format;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.InsertAllRequest;
+import com.google.cloud.bigquery.InsertAllResponse;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Wraps {@link BigQuery} to provide high level useful methods for working with big query database.
+ */
+public class BigQueryClient {
+
+  private BigQuery client;
+
+  private String projectId;
+
+  private String dataset;
+
+  protected BigQueryClient(BigQuery client, String projectId, String dataset) {
+    this.client = client;
+    this.projectId = projectId;
+    this.dataset = dataset;
+  }
+
+  /**
+   * Creates the publisher with a application default credentials from the environment and default
+   * project name.
+   */
+  public static BigQueryClient create(String dataset) {
+    BigQueryOptions options = BigQueryOptions.newBuilder().build();
+
+    return new BigQueryClient(options.getService(), options.getProjectId(), dataset);
+  }
+
+  /**
+   * Creates a new table with given schema when it not exists.
+   *
+   * @param tableName name of the desired table
+   * @param schema schema of consequent table fields (name, type pairs).
+   */
+  public void createTableIfNotExists(String tableName, Map<String, String> schema) {
+    TableId tableId = TableId.of(projectId, dataset, tableName);
+
+    if (client.getTable(tableId) == null) {
+      List<Field> schemaFields =
+          schema
+              .entrySet()
+              .stream()
+              .map(entry -> Field.of(entry.getKey(), LegacySQLTypeName.valueOf(entry.getValue())))
+              .collect(Collectors.toList());
+
+      createTable(tableId, Schema.of(schemaFields));
+    }
+  }
+
+  private void createTable(TableId tableId, Schema schema) {
+    TableInfo tableInfo =
+        TableInfo.newBuilder(tableId, StandardTableDefinition.of(schema))
+            .setFriendlyName(tableId.getTable())
+            .build();
+
+    client.create(tableInfo);
+  }
+
+  /**
+   * Inserts one row to BigQuery table.
+   *
+   * @see #insertAll(Collection, String) for more details
+   */
+  public void insertRow(Map<String, ?> row, String table) {
+    insertAll(Collections.singletonList(row), table);
+  }
+
+  /** Inserts multiple rows of the same schema to a BigQuery table. */
+  public void insertAll(Collection<Map<String, ?>> rows, String table) {
+    TableId tableId = TableId.of(projectId, dataset, table);
+
+    InsertAllRequest.Builder builder = InsertAllRequest.newBuilder(tableId);
+
+    for (Map<String, ?> row : rows) {
+      builder.addRow(row);
+    }
+
+    InsertAllResponse response = client.insertAll(builder.build());
+    handleBigQueryResponseExceptions(response);
+  }
+
+  private void handleBigQueryResponseExceptions(InsertAllResponse response) {
+    if (response.hasErrors()) {
+      throw new RuntimeException(
+          format(
+              "The following errors occurred while inserting to BigQuery: %s",
+              response.getInsertErrors()));
+    }
+  }
+}

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/package-info.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Tools for publishing data to various data stores (such as BigQuery etc.). */
+package org.apache.beam.sdk.testutils.publishing;

--- a/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/fakes/FakeBigQueryClient.java
+++ b/sdks/java/testing/test-utils/src/test/java/org/apache/beam/sdk/testutils/fakes/FakeBigQueryClient.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testutils.fakes;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.testutils.publishing.BigQueryClient;
+
+/**
+ * A fake implementation of BigQuery client for testing purposes only.
+ *
+ * @see BigQueryClient
+ */
+public class FakeBigQueryClient extends BigQueryClient {
+
+  private Map<String, List<Map<String, ?>>> rowsPerTable;
+
+  public FakeBigQueryClient(String dataset) {
+    super(null, null, dataset);
+    rowsPerTable = new HashMap<>();
+  }
+
+  @Override
+  public void createTableIfNotExists(String tableName, Map<String, String> schema) {
+    // do nothing. Assume the table exists.
+  }
+
+  @Override
+  public void insertRow(Map<String, ?> newRow, String table) {
+    List<Map<String, ?>> rows = rowsPerTable.get(table);
+
+    if (rows == null) {
+      rows = new ArrayList<>();
+      rows.add(newRow);
+
+      rowsPerTable.put(table, rows);
+    } else {
+      rows.add(newRow);
+    }
+  }
+
+  public List<Map<String, ?>> getRows(String table) {
+    return rowsPerTable.get(table);
+  }
+}


### PR DESCRIPTION
Besides unit tests I provided, this was also tested on my BigQuery instance. I don't see any problems and differences between both instances (I have access to Beam's BigQuery too).

The next step would be to use the BQ client in Load tests too but this is out of scope of this pr.

@apilloud @echauchot @kkucharc could you take a look? 
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




