### PR TITLE
[BEAM-5918] Add Cast transform for Rows

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -292,7 +292,7 @@ public class Schema implements Serializable {
     INT16, // two-byte signed integer.
     INT32, // four-byte signed integer.
     INT64, // eight-byte signed integer.
-    DECIMAL, // Decimal integer
+    DECIMAL, // Arbitrary-precision decimal number
     FLOAT,
     DOUBLE,
     STRING, // String.
@@ -337,6 +337,47 @@ public class Schema implements Serializable {
 
     public boolean isCompositeType() {
       return COMPOSITE_TYPES.contains(this);
+    }
+
+    public boolean isSubtypeOf(TypeName other) {
+      return other.isSupertypeOf(this);
+    }
+
+    public boolean isSupertypeOf(TypeName other) {
+      if (this == other) {
+        return true;
+      }
+
+      // defined only for numeric types
+      if (!isNumericType() || !other.isNumericType()) {
+        return false;
+      }
+
+      switch (this) {
+        case BYTE:
+          return false;
+
+        case INT16:
+          return other == BYTE;
+
+        case INT32:
+          return other == BYTE || other == INT16;
+
+        case INT64:
+          return other == BYTE || other == INT16 || other == INT32;
+
+        case FLOAT:
+          return false;
+
+        case DOUBLE:
+          return other == FLOAT;
+
+        case DECIMAL:
+          return other == FLOAT || other == DOUBLE;
+
+        default:
+          return false;
+      }
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -376,7 +376,7 @@ public class Schema implements Serializable {
           return other == FLOAT || other == DOUBLE;
 
         default:
-          return false;
+          throw new AssertionError("Unexpected numeric type: " + this);
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
@@ -84,16 +84,32 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
   /**
    * Widening changes to type that can represent any possible value of the original type.
    *
-   * <p>Standard widening conversions: - BYTE to INT16, INT32, INT64, FLOAT, DOUBLE, DECIMAL - INT16
-   * to INT32, INT64, FLOAT, DOUBLE, DECIMAL - INT32 to INT64, FLOAT, DOUBLE, DECIMAL - INT64 to
-   * FLOAT, DOUBLE, DECIMAL - FLOAT to DOUBLE, DECIMAL - DOUBLE to DECIMAL
+   * <p>Standard widening conversions:
    *
-   * <p>Row widening: - wider schema to schema with a subset of fields - non-nullable fields to
-   * nullable fields
+   * <ul>
+   *   <li>BYTE to INT16, INT32, INT64, FLOAT, DOUBLE, DECIMAL
+   *   <li>INT16 to INT32, INT64, FLOAT, DOUBLE, DECIMAL
+   *   <li>INT32 to INT64, FLOAT, DOUBLE, DECIMAL
+   *   <li>INT64 to FLOAT, DOUBLE, DECIMAL
+   *   <li>FLOAT to DOUBLE, DECIMAL
+   *   <li>DOUBLE to DECIMAL
+   * </ul>
    *
-   * <p>Widening doesn't lose information about the overall magnitude in following cases: - integral
-   * type to another integral type - BYTE or INT16 to FLOAT, DOUBLE or DECIMAL - INT32 to DOUBLE -
-   * INT to DOUBLE
+   * <p>Row widening:
+   *
+   * <ul>
+   *   <li>wider schema to schema with a subset of fields
+   *   <li>non-nullable fields to nullable fields
+   * </ul>
+   *
+   * <p>Widening doesn't lose information about the overall magnitude in following cases:
+   *
+   * <ul>
+   *   <li>integral type to another integral type
+   *   <li>BYTE or INT16 to FLOAT, DOUBLE or DECIMAL
+   *   <li>INT32 to DOUBLE
+   *   <li>
+   * </ul>
    *
    * <p>Other conversions to may cause loss of precision.
    */
@@ -166,11 +182,20 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
   /**
    * Narrowing changes type without guarantee to preserve data.
    *
-   * <p>Standard narrowing conversions: - any conversions of {@link Widening} - conversions the
-   * opposite to {@link Widening}
+   * <p>Standard narrowing conversions:
    *
-   * <p>Row narrowing: - wider schema to schema with a subset of fields - non-nullable fields to
-   * nullable fields - nullable fields to non-nullable fields
+   * <ul>
+   *   <li>any conversions of {@link Widening}
+   *   <li>conversions the opposite to {@link Widening}
+   * </ul>
+   *
+   * <p>Row narrowing
+   *
+   * <ul>
+   *   <li>wider schema to schema with a subset of fields
+   *   <li>non-nullable fields to nullable fields
+   *   <li>nullable fields to non-nullable fields
+   * </ul>
    */
   public static class Narrowing implements Validator {
     private final Fold fold = new Fold();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
@@ -108,7 +108,6 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
    *   <li>integral type to another integral type
    *   <li>BYTE or INT16 to FLOAT, DOUBLE or DECIMAL
    *   <li>INT32 to DOUBLE
-   *   <li>
    * </ul>
    *
    * <p>Other conversions to may cause loss of precision.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
@@ -17,34 +17,28 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import static org.apache.beam.sdk.schemas.Schema.TypeName.ARRAY;
-import static org.apache.beam.sdk.schemas.Schema.TypeName.INT16;
-import static org.apache.beam.sdk.schemas.Schema.TypeName.INT32;
-import static org.apache.beam.sdk.schemas.Schema.TypeName.INT64;
-import static org.apache.beam.sdk.schemas.Schema.TypeName.MAP;
-import static org.apache.beam.sdk.schemas.Schema.TypeName.ROW;
-
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import java.io.Serializable;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.utils.SchemaZipFold;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 
@@ -55,46 +49,202 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
 
   public abstract Schema outputSchema();
 
-  public abstract Nullability nullability();
+  public abstract Validator validator();
 
-  public abstract Type type();
-
-  public abstract Shape shape();
-
-  /** Builder for {@link Cast}. */
-  @AutoValue.Builder
-  public abstract static class Builder<T> {
-
-    public abstract Builder<T> outputSchema(Schema schema);
-
-    public abstract Builder<T> nullability(Nullability nullability);
-
-    public abstract Builder<T> type(Type type);
-
-    public abstract Builder<T> shape(Shape shape);
-
-    public abstract Cast<T> build();
+  public static <T> Cast<T> of(Schema outputSchema, Validator validator) {
+    return new AutoValue_Cast<>(outputSchema, validator);
   }
 
-  public static <T> Builder<T> builder() {
-    return new AutoValue_Cast.Builder<T>();
+  public static <T> Cast<T> widening(Schema outputSchema) {
+    return new AutoValue_Cast<>(outputSchema, Widening.of());
   }
 
-  public static <T> Cast<T> to(Schema outputSchema) {
-    return Cast.<T>builder()
-        .outputSchema(outputSchema)
-        .nullability(Nullability.IGNORE)
-        .type(Type.WIDEN)
-        .shape(Shape.PROJECTION)
-        .build();
+  public static <T> Cast<T> narrowing(Schema outputSchema) {
+    return new AutoValue_Cast<>(outputSchema, Narrowing.of());
   }
 
-  public List<CompatibilityError> compatibility(Schema inputSchema) {
-    return Inference.compatibility(inputSchema, outputSchema(), nullability(), type(), shape());
+  /** Describes compatibility errors during casting. */
+  @AutoValue
+  public abstract static class CompatibilityError implements Serializable {
+
+    public abstract List<String> path();
+
+    public abstract String message();
+
+    public static CompatibilityError create(List<String> path, String message) {
+      return new AutoValue_Cast_CompatibilityError(path, message);
+    }
+  }
+
+  /** Interface for statically validating casts. */
+  public interface Validator extends Serializable {
+    List<CompatibilityError> apply(Schema input, Schema output);
+  }
+
+  /**
+   * Widening changes to type that can represent any possible value of the original type.
+   *
+   * <p>Standard widening conversions: - BYTE to INT16, INT32, INT64, FLOAT, DOUBLE, DECIMAL - INT16
+   * to INT32, INT64, FLOAT, DOUBLE, DECIMAL - INT32 to INT64, FLOAT, DOUBLE, DECIMAL - INT64 to
+   * FLOAT, DOUBLE, DECIMAL - FLOAT to DOUBLE, DECIMAL - DOUBLE to DECIMAL
+   *
+   * <p>Row widening: - wider schema to schema with a subset of fields - non-nullable fields to
+   * nullable fields
+   *
+   * <p>Widening doesn't lose information about the overall magnitude in following cases: - integral
+   * type to another integral type - BYTE or INT16 to FLOAT, DOUBLE or DECIMAL - INT32 to DOUBLE -
+   * INT to DOUBLE
+   *
+   * <p>Other conversions to may cause loss of precision.
+   */
+  public static class Widening implements Validator {
+    private final Fold fold = new Fold();
+
+    public static Widening of() {
+      return new Widening();
+    }
+
+    @Override
+    public String toString() {
+      return "Cast.Widening";
+    }
+
+    @Override
+    public List<CompatibilityError> apply(final Schema input, final Schema output) {
+      return fold.apply(input, output);
+    }
+
+    private static class Fold extends SchemaZipFold<List<CompatibilityError>> {
+
+      @Override
+      public List<CompatibilityError> accumulate(
+          List<CompatibilityError> left, List<CompatibilityError> right) {
+        return ImmutableList.<CompatibilityError>builder().addAll(left).addAll(right).build();
+      }
+
+      @Override
+      public List<CompatibilityError> accept(
+          Context context, Optional<Field> left, Optional<Field> right) {
+        if (!left.isPresent() && !right.isPresent()) {
+          return Collections.emptyList();
+        } else if (left.isPresent() && !right.isPresent()) {
+          return Collections.emptyList();
+        } else if (!left.isPresent() && right.isPresent()) {
+          return Collections.singletonList(
+              CompatibilityError.create(context.path(), "Field is missing in output schema"));
+        } else {
+          if (left.get().getNullable() && !right.get().getNullable()) {
+            return Collections.singletonList(
+                CompatibilityError.create(
+                    context.path(), "Can't cast nullable field to non-nullable field"));
+          }
+        }
+
+        return Collections.emptyList();
+      }
+
+      @Override
+      public List<CompatibilityError> accept(Context context, FieldType input, FieldType output) {
+        TypeName inputType = input.getTypeName();
+        TypeName outputType = output.getTypeName();
+
+        boolean supertype = outputType.isSupertypeOf(inputType);
+
+        if (isIntegral(inputType) && isDecimal(outputType)) {
+          return Collections.emptyList();
+        } else if (!supertype) {
+          return Collections.singletonList(
+              CompatibilityError.create(
+                  context.path(), "Can't cast '" + inputType + "' to '" + outputType + "'"));
+        }
+
+        return Collections.emptyList();
+      }
+    }
+  }
+
+  /**
+   * Narrowing changes type without guarantee to preserve data.
+   *
+   * <p>Standard narrowing conversions: - any conversions of {@link Widening} - conversions the
+   * opposite to {@link Widening}
+   *
+   * <p>Row narrowing: - wider schema to schema with a subset of fields - non-nullable fields to
+   * nullable fields - nullable fields to non-nullable fields
+   */
+  public static class Narrowing implements Validator {
+    private final Fold fold = new Fold();
+
+    public static Narrowing of() {
+      return new Narrowing();
+    }
+
+    @Override
+    public String toString() {
+      return "Cast.Narrowing";
+    }
+
+    @Override
+    public List<CompatibilityError> apply(final Schema input, final Schema output) {
+      return fold.apply(input, output);
+    }
+
+    private static class Fold extends SchemaZipFold<List<CompatibilityError>> {
+
+      @Override
+      public List<CompatibilityError> accumulate(
+          List<CompatibilityError> left, List<CompatibilityError> right) {
+        return ImmutableList.<CompatibilityError>builder().addAll(left).addAll(right).build();
+      }
+
+      @Override
+      public List<CompatibilityError> accept(
+          Context context, Optional<Field> left, Optional<Field> right) {
+
+        if (!left.isPresent() && right.isPresent()) {
+          return Collections.singletonList(
+              CompatibilityError.create(context.path(), "Field is missing in output schema"));
+        }
+
+        return Collections.emptyList();
+      }
+
+      @Override
+      public List<CompatibilityError> accept(Context context, FieldType input, FieldType output) {
+        TypeName inputType = input.getTypeName();
+        TypeName outputType = output.getTypeName();
+
+        boolean supertype = outputType.isSupertypeOf(inputType);
+        boolean subtype = outputType.isSubtypeOf(inputType);
+
+        if (isDecimal(inputType) && isIntegral(outputType)) {
+          return Collections.emptyList();
+        } else if (!supertype && !subtype) {
+          return Collections.singletonList(
+              CompatibilityError.create(
+                  context.path(), "Can't cast '" + inputType + "' to '" + outputType + "'"));
+        }
+
+        return Collections.emptyList();
+      }
+    }
+  }
+
+  /** Checks if type is integral. */
+  public static boolean isIntegral(TypeName type) {
+    return type == TypeName.BYTE
+        || type == TypeName.INT16
+        || type == TypeName.INT32
+        || type == TypeName.INT64;
+  }
+
+  /** Checks if type is decimal. */
+  public static boolean isDecimal(TypeName type) {
+    return type == TypeName.FLOAT || type == TypeName.DOUBLE || type == TypeName.DECIMAL;
   }
 
   public void verifyCompatibility(Schema inputSchema) {
-    List<CompatibilityError> errors = compatibility(inputSchema);
+    List<CompatibilityError> errors = validator().apply(inputSchema, outputSchema());
 
     if (!errors.isEmpty()) {
       String reason =
@@ -103,7 +253,8 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
               .map(x -> Joiner.on('.').join(x.path()) + ": " + x.message())
               .collect(Collectors.joining("\n\t"));
 
-      throw new IllegalArgumentException("Cast isn't compatible:\n\t" + reason);
+      throw new IllegalArgumentException(
+          "Cast isn't compatible using " + validator() + ":\n\t" + reason);
     }
   }
 
@@ -125,15 +276,20 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
                       FieldAccessDescriptor.withAllFields();
 
                   @ProcessElement
-                  public void process(@FieldAccess("filterFields") Row row, OutputReceiver<Row> r) {
-                    r.output(castRow(row, inputSchema, outputSchema()));
+                  public void process(
+                      @FieldAccess("filterFields") Row input, OutputReceiver<Row> r) {
+                    Row output = castRow(input, inputSchema, outputSchema());
+                    r.output(output);
                   }
                 }))
         .setRowSchema(outputSchema());
   }
 
-  @VisibleForTesting
-  static Row castRow(Row input, Schema inputSchema, Schema outputSchema) {
+  public static Row castRow(Row input, Schema inputSchema, Schema outputSchema) {
+    if (input == null) {
+      return null;
+    }
+
     Row.Builder output = Row.withSchema(outputSchema);
     for (int i = 0; i < outputSchema.getFieldCount(); i++) {
       Schema.Field outputField = outputSchema.getField(i);
@@ -142,441 +298,119 @@ public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row
       Schema.Field inputField = inputSchema.getField(fromFieldIdx);
 
       Object inputValue = input.getValue(fromFieldIdx);
+      Object outputValue = castValue(inputValue, inputField.getType(), outputField.getType());
 
-      if (inputValue == null) {
-        output.addValue(null);
-      } else {
-        Object value = castObject(inputValue, inputField.getType(), outputField.getType());
-        output.addValue(value);
-      }
+      output.addValue(outputValue);
     }
 
     return output.build();
   }
 
-  @VisibleForTesting
+  public static Number castNumber(Number value, TypeName input, TypeName output) {
+    if (!input.isNumericType()) {
+      throw new RuntimeException("Can't cast non-numeric types: " + input);
+    }
+
+    if (!output.isNumericType()) {
+      throw new RuntimeException("Can't cast numbers to non-numeric type: " + output);
+    }
+
+    if (value == null) {
+      return null;
+    }
+
+    if (input == output) {
+      return value;
+    }
+
+    switch (output) {
+      case BYTE:
+        return value.byteValue();
+
+      case INT16:
+        return value.shortValue();
+
+      case INT32:
+        return value.intValue();
+
+      case INT64:
+        return value.longValue();
+
+      case FLOAT:
+        return value.floatValue();
+
+      case DOUBLE:
+        return value.doubleValue();
+
+      case DECIMAL:
+        switch (input) {
+          case BYTE:
+          case INT16:
+          case INT32:
+            return new BigDecimal(value.intValue());
+
+          case INT64:
+            return new BigDecimal(value.longValue());
+
+          case FLOAT:
+          case DOUBLE:
+            return new BigDecimal(value.doubleValue());
+
+          default:
+            throw new AssertionError("Unexpected numeric type: " + output);
+        }
+
+      default:
+        throw new AssertionError("Unexpected numeric type: " + output);
+    }
+  }
+
   @SuppressWarnings("unchecked")
-  static Object castObject(
-      Object inputValue, Schema.FieldType inputFieldType, Schema.FieldType outputFieldType) {
+  public static Object castValue(Object inputValue, FieldType input, FieldType output) {
 
-    if (inputFieldType.getTypeName() == ROW) {
-      return castRow(
-          (Row) inputValue, inputFieldType.getRowSchema(), outputFieldType.getRowSchema());
-    } else if (inputFieldType.getTypeName() == ARRAY) {
-      List<Object> inputValues = (List<Object>) inputValue;
-      List<Object> outputValues = new ArrayList<>(inputValues.size());
+    TypeName inputType = input.getTypeName();
+    TypeName outputType = output.getTypeName();
 
-      for (Object elem : inputValues) {
-        outputValues.add(
-            castObject(
-                elem,
-                inputFieldType.getCollectionElementType(),
-                outputFieldType.getCollectionElementType()));
-      }
-
-      return outputValues;
-    } else if (inputFieldType.getTypeName() == MAP) {
-      Map<Object, Object> inputMap = (Map<Object, Object>) inputValue;
-      Map<Object, Object> outputMap = Maps.newHashMapWithExpectedSize(inputMap.size());
-
-      for (Map.Entry<Object, Object> entry : inputMap.entrySet()) {
-        Object outputKey =
-            castObject(
-                entry.getKey(), inputFieldType.getMapKeyType(), outputFieldType.getMapKeyType());
-        Object outputValue =
-            castObject(
-                entry.getValue(),
-                inputFieldType.getMapValueType(),
-                outputFieldType.getMapValueType());
-
-        outputMap.put(outputKey, outputValue);
-      }
-
-      return outputMap;
-    } else {
-      if (inputFieldType.getTypeName().equals(outputFieldType.getTypeName())) {
-        return inputValue;
-      } else {
-        KV<TypeName, TypeName> key =
-            KV.of(inputFieldType.getTypeName(), outputFieldType.getTypeName());
-        return Inference.ALL_MAP.get(key).apply(inputValue);
-      }
-    }
-  }
-
-  /** Configures casting for nullable fields. */
-  public enum Nullability {
-    /** Can cast only if nullability is the same. */
-    SAME,
-    /** Can cast non-nullable fields to nullable. */
-    WEAKEN,
-    /** Can cast nullable fields to non-nullable and forth. */
-    IGNORE
-  }
-
-  /** Configures casting of primitive types. */
-  public enum Type {
-    /** Can cast only if types are the same. */
-    SAME,
-    /** Can cast only if an output type is a supertype of an input type. */
-    WIDEN,
-    /** Can cast if an output type is a supertype or subtype of an input type. */
-    NARROW
-  }
-
-  /** Configures casting of rows. */
-  public enum Shape {
-    /** Can cast rows only if field names are the same. */
-    SAME,
-    /** Can cast rows if output field names is subset of input field names. */
-    PROJECTION
-  }
-
-  /** Describes compatibility errors during casting. */
-  @AutoValue
-  public abstract static class CompatibilityError {
-
-    public abstract List<String> path();
-
-    public abstract String message();
-
-    public static CompatibilityError create(List<String> path, String message) {
-      return new AutoValue_Cast_CompatibilityError(path, message);
-    }
-  }
-
-  static class Inference {
-
-    @FunctionalInterface
-    interface Converter {
-
-      Object apply(Object value);
+    if (inputValue == null) {
+      return null;
     }
 
-    @AutoValue
-    abstract static class Result<T> {
+    switch (inputType) {
+      case ROW:
+        return castRow((Row) inputValue, input.getRowSchema(), output.getRowSchema());
 
-      abstract List<String> path();
+      case ARRAY:
+        List<Object> inputValues = (List<Object>) inputValue;
+        List<Object> outputValues = new ArrayList<>(inputValues.size());
 
-      abstract Optional<T> value();
+        for (Object elem : inputValues) {
+          outputValues.add(
+              castValue(elem, input.getCollectionElementType(), output.getCollectionElementType()));
+        }
 
-      abstract List<CompatibilityError> errors();
+        return outputValues;
 
-      static <T> Result<T> create(
-          List<String> path, Optional<T> value, List<CompatibilityError> errors) {
-        return new AutoValue_Cast_Inference_Result<>(path, value, errors);
-      }
+      case MAP:
+        Map<Object, Object> inputMap = (Map<Object, Object>) inputValue;
+        Map<Object, Object> outputMap = Maps.newHashMapWithExpectedSize(inputMap.size());
 
-      public static <T> Result<T> of(List<String> path, T value) {
-        return create(path, Optional.of(value), Collections.emptyList());
-      }
+        for (Map.Entry<Object, Object> entry : inputMap.entrySet()) {
+          Object outputKey =
+              castValue(entry.getKey(), input.getMapKeyType(), output.getMapKeyType());
+          Object outputValue =
+              castValue(entry.getValue(), input.getMapValueType(), output.getMapValueType());
 
-      public static <T> Result<T> error(List<String> path, String message) {
-        return Result.create(
-            path,
-            Optional.empty(),
-            Collections.singletonList(CompatibilityError.create(path, message)));
-      }
-    }
+          outputMap.put(outputKey, outputValue);
+        }
 
-    static final List<Nullability> NULLABILITY_ORDER =
-        ImmutableList.of(Nullability.SAME, Nullability.WEAKEN, Nullability.IGNORE);
+        return outputMap;
 
-    static final List<Shape> SHAPE_ORDER = ImmutableList.of(Shape.SAME, Shape.PROJECTION);
-
-    static final List<Type> TYPE_ORDER = ImmutableList.of(Type.SAME, Type.WIDEN, Type.NARROW);
-
-    // TODO extend this list
-
-    static final Map<KV<TypeName, TypeName>, Converter> TYPE_WIDEN =
-        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
-            // INT16
-            .put(KV.of(INT16, INT32), x -> ((Short) x).intValue())
-            .put(KV.of(INT16, INT64), x -> ((Short) x).longValue())
-            // INT32
-            .put(KV.of(INT32, INT64), x -> ((Integer) x).longValue())
-            .build();
-
-    static final Map<KV<TypeName, TypeName>, Converter> TYPE_NARROW =
-        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
-            // -> INT16
-            .put(KV.of(INT32, INT16), x -> ((Integer) x).shortValue())
-            .put(KV.of(INT64, INT16), x -> ((Long) x).shortValue())
-            // -> INT32
-            .put(KV.of(INT64, INT32), x -> ((Long) x).intValue())
-            .build();
-
-    static final Map<KV<TypeName, TypeName>, Converter> ALL_MAP =
-        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
-            .putAll(TYPE_WIDEN)
-            .putAll(TYPE_NARROW)
-            .build();
-
-    static List<CompatibilityError> compatibility(
-        Schema inputSchema, Schema outputSchema, Nullability nullability, Type type, Shape shape) {
-
-      Stream<CompatibilityError> nullabilityErrors =
-          nullability(Collections.emptyList(), inputSchema, outputSchema)
-              .flatMap(
-                  x -> {
-                    if (x.value().isPresent()) {
-                      if (greater(x.value().get(), nullability)) {
-                        String message =
-                            String.format(
-                                "Casting requires nullability=%s, limited to %s",
-                                x.value().get(), nullability);
-                        return Stream.of(CompatibilityError.create(x.path(), message));
-                      } else {
-                        return Stream.empty();
-                      }
-                    } else {
-                      return x.errors().stream();
-                    }
-                  });
-
-      Stream<CompatibilityError> typeErrors =
-          type(Collections.emptyList(), inputSchema, outputSchema)
-              .flatMap(
-                  x -> {
-                    if (x.value().isPresent()) {
-                      if (greater(x.value().get(), type)) {
-                        String message =
-                            String.format(
-                                "Casting requires type=%s, limited to %s", x.value().get(), type);
-                        return Stream.of(CompatibilityError.create(x.path(), message));
-                      } else {
-                        return Stream.empty();
-                      }
-                    } else {
-                      return x.errors().stream();
-                    }
-                  });
-
-      Stream<CompatibilityError> shapeErrors =
-          shape(Collections.emptyList(), inputSchema, outputSchema)
-              .flatMap(
-                  x -> {
-                    if (x.value().isPresent()) {
-                      if (greater(x.value().get(), shape)) {
-                        String message =
-                            String.format(
-                                "Casting requires shape=%s, limited to %s", x.value().get(), shape);
-                        return Stream.of(CompatibilityError.create(x.path(), message));
-                      } else {
-                        return Stream.empty();
-                      }
-                    } else {
-                      return x.errors().stream();
-                    }
-                  });
-
-      return Stream.concat(Stream.concat(nullabilityErrors, typeErrors), shapeErrors)
-          .collect(Collectors.toList());
-    }
-
-    static boolean greater(Nullability a, Nullability b) {
-      return NULLABILITY_ORDER.indexOf(a) > NULLABILITY_ORDER.indexOf(b);
-    }
-
-    static boolean greater(Type a, Type b) {
-      return TYPE_ORDER.indexOf(a) > TYPE_ORDER.indexOf(b);
-    }
-
-    static boolean greater(Shape a, Shape b) {
-      return SHAPE_ORDER.indexOf(a) > SHAPE_ORDER.indexOf(b);
-    }
-
-    static Stream<Result<Nullability>> nullability(
-        List<String> path, Schema inputSchema, Schema outputSchema) {
-      List<String> intersection = intersection(inputSchema, outputSchema);
-
-      return intersection
-          .stream()
-          .flatMap(
-              name ->
-                  nullability(
-                      concat(path, name), inputSchema.getField(name), outputSchema.getField(name)));
-    }
-
-    static Stream<Result<Nullability>> nullability(
-        List<String> path, Schema.Field inputSchema, Schema.Field outputSchema) {
-
-      Nullability nullability;
-
-      if (inputSchema.getNullable().equals(outputSchema.getNullable())) {
-        nullability = Nullability.SAME;
-      } else if (!inputSchema.getNullable() && outputSchema.getNullable()) {
-        nullability = Nullability.WEAKEN;
-      } else if (inputSchema.getNullable() && !outputSchema.getNullable()) {
-        nullability = Nullability.IGNORE;
-      } else {
-        throw new AssertionError("not possible");
-      }
-
-      return Stream.concat(
-          Stream.of(Result.of(path, nullability)),
-          nullability(path, inputSchema.getType(), outputSchema.getType()));
-    }
-
-    static Stream<Result<Nullability>> nullability(
-        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
-      if (outputSchema.getTypeName() != inputSchema.getTypeName()) {
-        return Stream.empty(); // not possible to cast composite type unless type matches
-      }
-
-      switch (inputSchema.getTypeName()) {
-        case ARRAY:
-          return nullability(
-              path,
-              inputSchema.getCollectionElementType(),
-              outputSchema.getCollectionElementType());
-
-        case ROW:
-          return nullability(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
-
-        case MAP:
-          return Stream.concat(
-              nullability(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
-              nullability(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
-
-        default:
-          return Stream.empty();
-      }
-    }
-
-    static List<String> intersection(Schema inputSchema, Schema outputSchema) {
-      return outputSchema
-          .getFields()
-          .stream()
-          .map(Schema.Field::getName)
-          .filter(inputSchema::hasField)
-          .collect(Collectors.toList());
-    }
-
-    static Stream<Result<Shape>> shape(List<String> path, Schema inputSchema, Schema outputSchema) {
-      List<String> intersection = intersection(inputSchema, outputSchema);
-
-      Shape shape;
-
-      if (intersection.size() == inputSchema.getFieldCount()) {
-        shape = Shape.SAME;
-      } else {
-        shape = Shape.PROJECTION;
-      }
-
-      return Stream.concat(
-          Stream.of(Result.of(path, shape)),
-          intersection
-              .stream()
-              .flatMap(
-                  name ->
-                      shape(
-                          concat(path, name),
-                          inputSchema.getField(name).getType(),
-                          outputSchema.getField(name).getType())));
-    }
-
-    static Stream<Result<Shape>> shape(
-        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
-      switch (inputSchema.getTypeName()) {
-        case ARRAY:
-          if (outputSchema.getTypeName() == ARRAY) {
-            return shape(
-                path,
-                inputSchema.getCollectionElementType(),
-                outputSchema.getCollectionElementType());
-          } else {
-            return Stream.of();
-          }
-
-        case ROW:
-          if (outputSchema.getTypeName() == ROW) {
-            return shape(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
-          } else {
-            return Stream.of();
-          }
-
-        case MAP:
-          if (outputSchema.getTypeName() == MAP) {
-            return Stream.concat(
-                shape(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
-                shape(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
-          } else {
-            return Stream.of();
-          }
-
-        default:
-          return Stream.of();
-      }
-    }
-
-    static <T> List<T> concat(List<T> a, T b) {
-      return ImmutableList.<T>builder().addAll(a).add(b).build();
-    }
-
-    static Stream<Result<Type>> type(List<String> path, Schema inputSchema, Schema outputSchema) {
-      List<String> intersection = intersection(inputSchema, outputSchema);
-
-      return intersection
-          .stream()
-          .flatMap(
-              name ->
-                  type(
-                      concat(path, name),
-                      inputSchema.getField(name).getType(),
-                      outputSchema.getField(name).getType()));
-    }
-
-    static Stream<Result<Type>> castError(
-        List<String> path, Schema.FieldType from, Schema.FieldType to) {
-      String message =
-          String.format("Can't cast '%s' to '%s'", from.getTypeName(), to.getTypeName());
-      return Stream.of(Result.error(path, message));
-    }
-
-    static Stream<Result<Type>> type(
-        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
-      switch (inputSchema.getTypeName()) {
-        case ARRAY:
-          if (outputSchema.getTypeName() == ARRAY) {
-            return type(
-                path,
-                inputSchema.getCollectionElementType(),
-                outputSchema.getCollectionElementType());
-          } else {
-            return castError(path, inputSchema, outputSchema);
-          }
-
-        case ROW:
-          if (outputSchema.getTypeName() == ROW) {
-            return type(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
-          } else {
-            return castError(path, inputSchema, outputSchema);
-          }
-
-        case MAP:
-          if (outputSchema.getTypeName() == MAP) {
-            return Stream.concat(
-                type(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
-                type(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
-          } else {
-            return castError(path, inputSchema, outputSchema);
-          }
-
-        default:
-          KV<TypeName, TypeName> inputOutputKv =
-              KV.of(inputSchema.getTypeName(), outputSchema.getTypeName());
-
-          if (inputSchema.getTypeName().equals(outputSchema.getTypeName())) {
-            return Stream.of(Result.of(path, Type.SAME));
-          } else if (TYPE_WIDEN.containsKey(inputOutputKv)) {
-            return Stream.of(Result.of(path, Type.WIDEN));
-          } else if (TYPE_NARROW.containsKey(inputOutputKv)) {
-            return Stream.of(Result.of(path, Type.NARROW));
-          } else {
-            return castError(path, inputSchema, outputSchema);
-          }
-      }
+      default:
+        if (inputType.isNumericType()) {
+          return castNumber((Number) inputValue, inputType, outputType);
+        } else {
+          throw new IllegalArgumentException("input should be array, map, numeric or row");
+        }
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Cast.java
@@ -1,0 +1,582 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static org.apache.beam.sdk.schemas.Schema.TypeName.ARRAY;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.INT16;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.INT32;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.INT64;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.MAP;
+import static org.apache.beam.sdk.schemas.Schema.TypeName.ROW;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+
+/** Set of utilities for casting rows between schemas. */
+@Experimental(Experimental.Kind.SCHEMAS)
+@AutoValue
+public abstract class Cast<T> extends PTransform<PCollection<T>, PCollection<Row>> {
+
+  public abstract Schema outputSchema();
+
+  public abstract Nullability nullability();
+
+  public abstract Type type();
+
+  public abstract Shape shape();
+
+  /** Builder for {@link Cast}. */
+  @AutoValue.Builder
+  public abstract static class Builder<T> {
+
+    public abstract Builder<T> outputSchema(Schema schema);
+
+    public abstract Builder<T> nullability(Nullability nullability);
+
+    public abstract Builder<T> type(Type type);
+
+    public abstract Builder<T> shape(Shape shape);
+
+    public abstract Cast<T> build();
+  }
+
+  public static <T> Builder<T> builder() {
+    return new AutoValue_Cast.Builder<T>();
+  }
+
+  public static <T> Cast<T> to(Schema outputSchema) {
+    return Cast.<T>builder()
+        .outputSchema(outputSchema)
+        .nullability(Nullability.IGNORE)
+        .type(Type.WIDEN)
+        .shape(Shape.PROJECTION)
+        .build();
+  }
+
+  public List<CompatibilityError> compatibility(Schema inputSchema) {
+    return Inference.compatibility(inputSchema, outputSchema(), nullability(), type(), shape());
+  }
+
+  public void verifyCompatibility(Schema inputSchema) {
+    List<CompatibilityError> errors = compatibility(inputSchema);
+
+    if (!errors.isEmpty()) {
+      String reason =
+          errors
+              .stream()
+              .map(x -> Joiner.on('.').join(x.path()) + ": " + x.message())
+              .collect(Collectors.joining("\n\t"));
+
+      throw new IllegalArgumentException("Cast isn't compatible:\n\t" + reason);
+    }
+  }
+
+  @Override
+  public PCollection<Row> expand(PCollection<T> input) {
+    Schema inputSchema = input.getSchema();
+
+    verifyCompatibility(inputSchema);
+
+    return input
+        .apply(
+            ParDo.of(
+                new DoFn<T, Row>() {
+                  // TODO: This should be the same as resolved so that Beam knows which fields
+                  // are being accessed. Currently Beam only supports wildcard descriptors.
+                  // Once BEAM-4457 is fixed, fix this.
+                  @FieldAccess("filterFields")
+                  final FieldAccessDescriptor fieldAccessDescriptor =
+                      FieldAccessDescriptor.withAllFields();
+
+                  @ProcessElement
+                  public void process(@FieldAccess("filterFields") Row row, OutputReceiver<Row> r) {
+                    r.output(castRow(row, inputSchema, outputSchema()));
+                  }
+                }))
+        .setRowSchema(outputSchema());
+  }
+
+  @VisibleForTesting
+  static Row castRow(Row input, Schema inputSchema, Schema outputSchema) {
+    Row.Builder output = Row.withSchema(outputSchema);
+    for (int i = 0; i < outputSchema.getFieldCount(); i++) {
+      Schema.Field outputField = outputSchema.getField(i);
+
+      int fromFieldIdx = inputSchema.indexOf(outputField.getName());
+      Schema.Field inputField = inputSchema.getField(fromFieldIdx);
+
+      Object inputValue = input.getValue(fromFieldIdx);
+
+      if (inputValue == null) {
+        output.addValue(null);
+      } else {
+        Object value = castObject(inputValue, inputField.getType(), outputField.getType());
+        output.addValue(value);
+      }
+    }
+
+    return output.build();
+  }
+
+  @VisibleForTesting
+  @SuppressWarnings("unchecked")
+  static Object castObject(
+      Object inputValue, Schema.FieldType inputFieldType, Schema.FieldType outputFieldType) {
+
+    if (inputFieldType.getTypeName() == ROW) {
+      return castRow(
+          (Row) inputValue, inputFieldType.getRowSchema(), outputFieldType.getRowSchema());
+    } else if (inputFieldType.getTypeName() == ARRAY) {
+      List<Object> inputValues = (List<Object>) inputValue;
+      List<Object> outputValues = new ArrayList<>(inputValues.size());
+
+      for (Object elem : inputValues) {
+        outputValues.add(
+            castObject(
+                elem,
+                inputFieldType.getCollectionElementType(),
+                outputFieldType.getCollectionElementType()));
+      }
+
+      return outputValues;
+    } else if (inputFieldType.getTypeName() == MAP) {
+      Map<Object, Object> inputMap = (Map<Object, Object>) inputValue;
+      Map<Object, Object> outputMap = Maps.newHashMapWithExpectedSize(inputMap.size());
+
+      for (Map.Entry<Object, Object> entry : inputMap.entrySet()) {
+        Object outputKey =
+            castObject(
+                entry.getKey(), inputFieldType.getMapKeyType(), outputFieldType.getMapKeyType());
+        Object outputValue =
+            castObject(
+                entry.getValue(),
+                inputFieldType.getMapValueType(),
+                outputFieldType.getMapValueType());
+
+        outputMap.put(outputKey, outputValue);
+      }
+
+      return outputMap;
+    } else {
+      if (inputFieldType.getTypeName().equals(outputFieldType.getTypeName())) {
+        return inputValue;
+      } else {
+        KV<TypeName, TypeName> key =
+            KV.of(inputFieldType.getTypeName(), outputFieldType.getTypeName());
+        return Inference.ALL_MAP.get(key).apply(inputValue);
+      }
+    }
+  }
+
+  /** Configures casting for nullable fields. */
+  public enum Nullability {
+    /** Can cast only if nullability is the same. */
+    SAME,
+    /** Can cast non-nullable fields to nullable. */
+    WEAKEN,
+    /** Can cast nullable fields to non-nullable and forth. */
+    IGNORE
+  }
+
+  /** Configures casting of primitive types. */
+  public enum Type {
+    /** Can cast only if types are the same. */
+    SAME,
+    /** Can cast only if an output type is a supertype of an input type. */
+    WIDEN,
+    /** Can cast if an output type is a supertype or subtype of an input type. */
+    NARROW
+  }
+
+  /** Configures casting of rows. */
+  public enum Shape {
+    /** Can cast rows only if field names are the same. */
+    SAME,
+    /** Can cast rows if output field names is subset of input field names. */
+    PROJECTION
+  }
+
+  /** Describes compatibility errors during casting. */
+  @AutoValue
+  public abstract static class CompatibilityError {
+
+    public abstract List<String> path();
+
+    public abstract String message();
+
+    public static CompatibilityError create(List<String> path, String message) {
+      return new AutoValue_Cast_CompatibilityError(path, message);
+    }
+  }
+
+  static class Inference {
+
+    @FunctionalInterface
+    interface Converter {
+
+      Object apply(Object value);
+    }
+
+    @AutoValue
+    abstract static class Result<T> {
+
+      abstract List<String> path();
+
+      abstract Optional<T> value();
+
+      abstract List<CompatibilityError> errors();
+
+      static <T> Result<T> create(
+          List<String> path, Optional<T> value, List<CompatibilityError> errors) {
+        return new AutoValue_Cast_Inference_Result<>(path, value, errors);
+      }
+
+      public static <T> Result<T> of(List<String> path, T value) {
+        return create(path, Optional.of(value), Collections.emptyList());
+      }
+
+      public static <T> Result<T> error(List<String> path, String message) {
+        return Result.create(
+            path,
+            Optional.empty(),
+            Collections.singletonList(CompatibilityError.create(path, message)));
+      }
+    }
+
+    static final List<Nullability> NULLABILITY_ORDER =
+        ImmutableList.of(Nullability.SAME, Nullability.WEAKEN, Nullability.IGNORE);
+
+    static final List<Shape> SHAPE_ORDER = ImmutableList.of(Shape.SAME, Shape.PROJECTION);
+
+    static final List<Type> TYPE_ORDER = ImmutableList.of(Type.SAME, Type.WIDEN, Type.NARROW);
+
+    // TODO extend this list
+
+    static final Map<KV<TypeName, TypeName>, Converter> TYPE_WIDEN =
+        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
+            // INT16
+            .put(KV.of(INT16, INT32), x -> ((Short) x).intValue())
+            .put(KV.of(INT16, INT64), x -> ((Short) x).longValue())
+            // INT32
+            .put(KV.of(INT32, INT64), x -> ((Integer) x).longValue())
+            .build();
+
+    static final Map<KV<TypeName, TypeName>, Converter> TYPE_NARROW =
+        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
+            // -> INT16
+            .put(KV.of(INT32, INT16), x -> ((Integer) x).shortValue())
+            .put(KV.of(INT64, INT16), x -> ((Long) x).shortValue())
+            // -> INT32
+            .put(KV.of(INT64, INT32), x -> ((Long) x).intValue())
+            .build();
+
+    static final Map<KV<TypeName, TypeName>, Converter> ALL_MAP =
+        ImmutableMap.<KV<TypeName, TypeName>, Converter>builder()
+            .putAll(TYPE_WIDEN)
+            .putAll(TYPE_NARROW)
+            .build();
+
+    static List<CompatibilityError> compatibility(
+        Schema inputSchema, Schema outputSchema, Nullability nullability, Type type, Shape shape) {
+
+      Stream<CompatibilityError> nullabilityErrors =
+          nullability(Collections.emptyList(), inputSchema, outputSchema)
+              .flatMap(
+                  x -> {
+                    if (x.value().isPresent()) {
+                      if (greater(x.value().get(), nullability)) {
+                        String message =
+                            String.format(
+                                "Casting requires nullability=%s, limited to %s",
+                                x.value().get(), nullability);
+                        return Stream.of(CompatibilityError.create(x.path(), message));
+                      } else {
+                        return Stream.empty();
+                      }
+                    } else {
+                      return x.errors().stream();
+                    }
+                  });
+
+      Stream<CompatibilityError> typeErrors =
+          type(Collections.emptyList(), inputSchema, outputSchema)
+              .flatMap(
+                  x -> {
+                    if (x.value().isPresent()) {
+                      if (greater(x.value().get(), type)) {
+                        String message =
+                            String.format(
+                                "Casting requires type=%s, limited to %s", x.value().get(), type);
+                        return Stream.of(CompatibilityError.create(x.path(), message));
+                      } else {
+                        return Stream.empty();
+                      }
+                    } else {
+                      return x.errors().stream();
+                    }
+                  });
+
+      Stream<CompatibilityError> shapeErrors =
+          shape(Collections.emptyList(), inputSchema, outputSchema)
+              .flatMap(
+                  x -> {
+                    if (x.value().isPresent()) {
+                      if (greater(x.value().get(), shape)) {
+                        String message =
+                            String.format(
+                                "Casting requires shape=%s, limited to %s", x.value().get(), shape);
+                        return Stream.of(CompatibilityError.create(x.path(), message));
+                      } else {
+                        return Stream.empty();
+                      }
+                    } else {
+                      return x.errors().stream();
+                    }
+                  });
+
+      return Stream.concat(Stream.concat(nullabilityErrors, typeErrors), shapeErrors)
+          .collect(Collectors.toList());
+    }
+
+    static boolean greater(Nullability a, Nullability b) {
+      return NULLABILITY_ORDER.indexOf(a) > NULLABILITY_ORDER.indexOf(b);
+    }
+
+    static boolean greater(Type a, Type b) {
+      return TYPE_ORDER.indexOf(a) > TYPE_ORDER.indexOf(b);
+    }
+
+    static boolean greater(Shape a, Shape b) {
+      return SHAPE_ORDER.indexOf(a) > SHAPE_ORDER.indexOf(b);
+    }
+
+    static Stream<Result<Nullability>> nullability(
+        List<String> path, Schema inputSchema, Schema outputSchema) {
+      List<String> intersection = intersection(inputSchema, outputSchema);
+
+      return intersection
+          .stream()
+          .flatMap(
+              name ->
+                  nullability(
+                      concat(path, name), inputSchema.getField(name), outputSchema.getField(name)));
+    }
+
+    static Stream<Result<Nullability>> nullability(
+        List<String> path, Schema.Field inputSchema, Schema.Field outputSchema) {
+
+      Nullability nullability;
+
+      if (inputSchema.getNullable().equals(outputSchema.getNullable())) {
+        nullability = Nullability.SAME;
+      } else if (!inputSchema.getNullable() && outputSchema.getNullable()) {
+        nullability = Nullability.WEAKEN;
+      } else if (inputSchema.getNullable() && !outputSchema.getNullable()) {
+        nullability = Nullability.IGNORE;
+      } else {
+        throw new AssertionError("not possible");
+      }
+
+      return Stream.concat(
+          Stream.of(Result.of(path, nullability)),
+          nullability(path, inputSchema.getType(), outputSchema.getType()));
+    }
+
+    static Stream<Result<Nullability>> nullability(
+        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
+      if (outputSchema.getTypeName() != inputSchema.getTypeName()) {
+        return Stream.empty(); // not possible to cast composite type unless type matches
+      }
+
+      switch (inputSchema.getTypeName()) {
+        case ARRAY:
+          return nullability(
+              path,
+              inputSchema.getCollectionElementType(),
+              outputSchema.getCollectionElementType());
+
+        case ROW:
+          return nullability(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
+
+        case MAP:
+          return Stream.concat(
+              nullability(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
+              nullability(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
+
+        default:
+          return Stream.empty();
+      }
+    }
+
+    static List<String> intersection(Schema inputSchema, Schema outputSchema) {
+      return outputSchema
+          .getFields()
+          .stream()
+          .map(Schema.Field::getName)
+          .filter(inputSchema::hasField)
+          .collect(Collectors.toList());
+    }
+
+    static Stream<Result<Shape>> shape(List<String> path, Schema inputSchema, Schema outputSchema) {
+      List<String> intersection = intersection(inputSchema, outputSchema);
+
+      Shape shape;
+
+      if (intersection.size() == inputSchema.getFieldCount()) {
+        shape = Shape.SAME;
+      } else {
+        shape = Shape.PROJECTION;
+      }
+
+      return Stream.concat(
+          Stream.of(Result.of(path, shape)),
+          intersection
+              .stream()
+              .flatMap(
+                  name ->
+                      shape(
+                          concat(path, name),
+                          inputSchema.getField(name).getType(),
+                          outputSchema.getField(name).getType())));
+    }
+
+    static Stream<Result<Shape>> shape(
+        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
+      switch (inputSchema.getTypeName()) {
+        case ARRAY:
+          if (outputSchema.getTypeName() == ARRAY) {
+            return shape(
+                path,
+                inputSchema.getCollectionElementType(),
+                outputSchema.getCollectionElementType());
+          } else {
+            return Stream.of();
+          }
+
+        case ROW:
+          if (outputSchema.getTypeName() == ROW) {
+            return shape(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
+          } else {
+            return Stream.of();
+          }
+
+        case MAP:
+          if (outputSchema.getTypeName() == MAP) {
+            return Stream.concat(
+                shape(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
+                shape(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
+          } else {
+            return Stream.of();
+          }
+
+        default:
+          return Stream.of();
+      }
+    }
+
+    static <T> List<T> concat(List<T> a, T b) {
+      return ImmutableList.<T>builder().addAll(a).add(b).build();
+    }
+
+    static Stream<Result<Type>> type(List<String> path, Schema inputSchema, Schema outputSchema) {
+      List<String> intersection = intersection(inputSchema, outputSchema);
+
+      return intersection
+          .stream()
+          .flatMap(
+              name ->
+                  type(
+                      concat(path, name),
+                      inputSchema.getField(name).getType(),
+                      outputSchema.getField(name).getType()));
+    }
+
+    static Stream<Result<Type>> castError(
+        List<String> path, Schema.FieldType from, Schema.FieldType to) {
+      String message =
+          String.format("Can't cast '%s' to '%s'", from.getTypeName(), to.getTypeName());
+      return Stream.of(Result.error(path, message));
+    }
+
+    static Stream<Result<Type>> type(
+        List<String> path, Schema.FieldType inputSchema, Schema.FieldType outputSchema) {
+      switch (inputSchema.getTypeName()) {
+        case ARRAY:
+          if (outputSchema.getTypeName() == ARRAY) {
+            return type(
+                path,
+                inputSchema.getCollectionElementType(),
+                outputSchema.getCollectionElementType());
+          } else {
+            return castError(path, inputSchema, outputSchema);
+          }
+
+        case ROW:
+          if (outputSchema.getTypeName() == ROW) {
+            return type(path, inputSchema.getRowSchema(), outputSchema.getRowSchema());
+          } else {
+            return castError(path, inputSchema, outputSchema);
+          }
+
+        case MAP:
+          if (outputSchema.getTypeName() == MAP) {
+            return Stream.concat(
+                type(path, inputSchema.getMapKeyType(), outputSchema.getMapKeyType()),
+                type(path, inputSchema.getMapValueType(), outputSchema.getMapValueType()));
+          } else {
+            return castError(path, inputSchema, outputSchema);
+          }
+
+        default:
+          KV<TypeName, TypeName> inputOutputKv =
+              KV.of(inputSchema.getTypeName(), outputSchema.getTypeName());
+
+          if (inputSchema.getTypeName().equals(outputSchema.getTypeName())) {
+            return Stream.of(Result.of(path, Type.SAME));
+          } else if (TYPE_WIDEN.containsKey(inputOutputKv)) {
+            return Stream.of(Result.of(path, Type.WIDEN));
+          } else if (TYPE_NARROW.containsKey(inputOutputKv)) {
+            return Stream.of(Result.of(path, Type.NARROW));
+          } else {
+            return castError(path, inputSchema, outputSchema);
+          }
+      }
+    }
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/SchemaZipFold.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/SchemaZipFold.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.utils;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+
+/**
+ * Visitor that zips schemas, and accepts pairs of fields and their types.
+ *
+ * <p>Values returned by `accept` are accumulated.
+ */
+public abstract class SchemaZipFold<T> implements Serializable {
+
+  public final T apply(Schema left, Schema right) {
+    return visit(this, Context.EMPTY, FieldType.row(left), FieldType.row(right));
+  }
+
+  /** Accumulate two results together. */
+  public abstract T accumulate(T left, T right);
+
+  /** Accepts two components, context.parent() is always ROW, MAP, ARRAY or absent. */
+  public abstract T accept(Context context, FieldType left, FieldType right);
+
+  /** Accepts two fields, context.parent() is always ROW. */
+  public abstract T accept(Context context, Optional<Field> left, Optional<Field> right);
+
+  /** Context referring to a current position in a schema. */
+  @AutoValue
+  public abstract static class Context {
+    /** Field path from a root of a schema. */
+    public abstract List<String> path();
+
+    /** Type of parent node in a tree. */
+    public abstract Optional<TypeName> parent();
+
+    public static final Context EMPTY = Context.create(Collections.emptyList(), Optional.empty());
+
+    public Context withPathPart(String part) {
+      return create(ImmutableList.<String>builder().addAll(path()).add(part).build(), parent());
+    }
+
+    public Context withParent(TypeName parent) {
+      return create(path(), Optional.of(parent));
+    }
+
+    public static Context create(List<String> path, Optional<TypeName> parent) {
+      return new AutoValue_SchemaZipFold_Context(path, parent);
+    }
+  }
+
+  static <T> T visit(SchemaZipFold<T> zipFold, Context context, FieldType left, FieldType right) {
+    if (left.getTypeName() != right.getTypeName()) {
+      return zipFold.accept(context, left, right);
+    }
+
+    Context newContext = context.withParent(left.getTypeName());
+
+    switch (left.getTypeName()) {
+      case ARRAY:
+        return zipFold.accumulate(
+            zipFold.accept(context, left, right),
+            visit(
+                zipFold,
+                newContext,
+                left.getCollectionElementType(),
+                right.getCollectionElementType()));
+
+      case ROW:
+        return visitRow(zipFold, newContext, left.getRowSchema(), right.getRowSchema());
+
+      case MAP:
+        return zipFold.accumulate(
+            zipFold.accept(context, left, right),
+            visit(
+                zipFold,
+                newContext,
+                left.getCollectionElementType(),
+                right.getCollectionElementType()));
+
+      default:
+        return zipFold.accept(context, left, right);
+    }
+  }
+
+  static <T> T visitRow(SchemaZipFold<T> zipFold, Context context, Schema left, Schema right) {
+    T node = zipFold.accept(context, FieldType.row(left), FieldType.row(right));
+
+    Stream<String> union =
+        Stream.concat(
+                left.getFields().stream().map(Schema.Field::getName),
+                right.getFields().stream().map(Schema.Field::getName))
+            .distinct();
+
+    Stream<String> intersection =
+        left.getFields().stream().map(Schema.Field::getName).filter(right::hasField);
+
+    T inner0 =
+        intersection
+            .map(
+                name ->
+                    visit(
+                        zipFold,
+                        context.withPathPart(name).withParent(TypeName.ROW),
+                        left.getField(name).getType(),
+                        right.getField(name).getType()))
+            .reduce(node, zipFold::accumulate);
+
+    T inner1 =
+        union
+            .map(
+                name -> {
+                  Optional<Field> field0 = Optional.empty();
+                  Optional<Field> field1 = Optional.empty();
+
+                  if (left.hasField(name)) {
+                    field0 = Optional.of(left.getField(name));
+                  }
+
+                  if (right.hasField(name)) {
+                    field1 = Optional.of(right.getField(name));
+                  }
+
+                  Context newContext = context.withPathPart(name).withParent(TypeName.ROW);
+                  return zipFold.accept(newContext, field0, field1);
+                })
+            .reduce(node, zipFold::accumulate);
+
+    return zipFold.accumulate(zipFold.accumulate(node, inner0), inner1);
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastTest.java
@@ -1,0 +1,564 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.schemas.DefaultSchema;
+import org.apache.beam.sdk.schemas.JavaFieldSchema;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/** Tests for {@link Cast}. */
+public class CastTest {
+
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testProjection() throws Exception {
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Projection2.class);
+
+    PCollection<Projection2> pojos =
+        pipeline
+            .apply(Create.of(new Projection1()))
+            .apply(
+                Cast.<Projection1>builder()
+                    .nullability(Cast.Nullability.SAME)
+                    .shape(Cast.Shape.PROJECTION)
+                    .type(Cast.Type.SAME)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(Projection2.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new Projection2());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testProjectionFail() throws Exception {
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(Projection1.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Projection2.class);
+
+    Cast.<Projection1>builder()
+        .nullability(Cast.Nullability.SAME)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.SAME)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testTypeWiden() throws Exception {
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden2.class);
+
+    PCollection<TypeWiden2> pojos =
+        pipeline
+            .apply(Create.of(new TypeWiden1()))
+            .apply(
+                Cast.<TypeWiden1>builder()
+                    .nullability(Cast.Nullability.SAME)
+                    .shape(Cast.Shape.SAME)
+                    .type(Cast.Type.WIDEN)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(TypeWiden2.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new TypeWiden2());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testTypeWidenFail() throws Exception {
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden1.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden2.class);
+
+    Cast.<Projection1>builder()
+        .nullability(Cast.Nullability.SAME)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.SAME)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testTypeNarrow() throws Exception {
+    // narrowing is the opposite of widening
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden1.class);
+
+    PCollection<TypeWiden1> pojos =
+        pipeline
+            .apply(Create.of(new TypeWiden2()))
+            .apply(
+                Cast.<TypeWiden2>builder()
+                    .nullability(Cast.Nullability.SAME)
+                    .shape(Cast.Shape.SAME)
+                    .type(Cast.Type.NARROW)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(TypeWiden1.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new TypeWiden1());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testTypeNarrowFail() throws Exception {
+    // narrowing is the opposite of widening
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden2.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(TypeWiden1.class);
+
+    Cast.<TypeWiden2>builder()
+        .nullability(Cast.Nullability.SAME)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.WIDEN)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testWeakedNullable() throws Exception {
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable2.class);
+
+    PCollection<Nullable2> pojos =
+        pipeline
+            .apply(Create.of(new Nullable1()))
+            .apply(
+                Cast.<Nullable1>builder()
+                    .nullability(Cast.Nullability.WEAKEN)
+                    .shape(Cast.Shape.SAME)
+                    .type(Cast.Type.SAME)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(Nullable2.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new Nullable2());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testWeakedNullableFail() throws Exception {
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(Nullable1.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable2.class);
+
+    Cast.<Nullable1>builder()
+        .nullability(Cast.Nullability.SAME)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.SAME)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testIgnoreNullable() throws Exception {
+    // ignoring nullable is opposite of weakening
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable1.class);
+
+    PCollection<Nullable1> pojos =
+        pipeline
+            .apply(Create.of(new Nullable2()))
+            .apply(
+                Cast.<Nullable2>builder()
+                    .nullability(Cast.Nullability.IGNORE)
+                    .shape(Cast.Shape.SAME)
+                    .type(Cast.Type.SAME)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(Nullable1.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new Nullable1());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testIgnoreNullableFail() throws Exception {
+    // ignoring nullable is opposite of weakening
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(Nullable2.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(Nullable1.class);
+
+    Cast.<Nullable2>builder()
+        .nullability(Cast.Nullability.WEAKEN)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.SAME)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testComplexCast() throws Exception {
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(All2.class);
+
+    PCollection<All2> pojos =
+        pipeline
+            .apply(Create.of(new All1()))
+            .apply(
+                Cast.<All1>builder()
+                    .nullability(Cast.Nullability.IGNORE)
+                    .shape(Cast.Shape.PROJECTION)
+                    .type(Cast.Type.NARROW)
+                    .outputSchema(outputSchema)
+                    .build())
+            .apply(Convert.to(All2.class));
+
+    PAssert.that(pojos).containsInAnyOrder(new All2());
+    pipeline.run();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  @Category(NeedsRunner.class)
+  public void testComplexCastFail() throws Exception {
+    Schema inputSchema = pipeline.getSchemaRegistry().getSchema(All1.class);
+    Schema outputSchema = pipeline.getSchemaRegistry().getSchema(All2.class);
+
+    Cast.<All1>builder()
+        .nullability(Cast.Nullability.SAME)
+        .shape(Cast.Shape.SAME)
+        .type(Cast.Type.SAME)
+        .outputSchema(outputSchema)
+        .build()
+        .verifyCompatibility(inputSchema);
+  }
+
+  @Test
+  public void testCastArray() {
+    Object output =
+        Cast.castObject(
+            Arrays.asList((short) 1, (short) 2, (short) 3),
+            Schema.FieldType.array(Schema.FieldType.INT16),
+            Schema.FieldType.array(Schema.FieldType.INT32));
+
+    assertEquals(Arrays.asList(1, 2, 3), output);
+  }
+
+  @Test
+  public void testCastMap() {
+    Object output =
+        Cast.castObject(
+            ImmutableMap.of((short) 1, 1, (short) 2, 2, (short) 3, 3),
+            Schema.FieldType.map(Schema.FieldType.INT16, Schema.FieldType.INT32),
+            Schema.FieldType.map(Schema.FieldType.INT32, Schema.FieldType.INT64));
+
+    assertEquals(ImmutableMap.of(1, 1L, 2, 2L, 3, 3L), output);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testIgnoreNullFail() {
+    Schema inputSchema = Schema.of(Schema.Field.nullable("f0", Schema.FieldType.INT32));
+    Schema outputSchema = Schema.of(Schema.Field.of("f0", Schema.FieldType.INT32));
+
+    Cast.castRow(Row.withSchema(inputSchema).addValue(null).build(), inputSchema, outputSchema);
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class Projection1 {
+
+    public Short field1 = 42;
+    public Integer field2 = 1337;
+    public String field3 = "field";
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Projection1 pojo1 = (Projection1) o;
+      return Objects.equals(field1, pojo1.field1) && Objects.equals(field2, pojo1.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2);
+    }
+
+    @Override
+    public String toString() {
+      return "Projection1{"
+          + "field1="
+          + field1
+          + ", field2="
+          + field2
+          + ", field3='"
+          + field3
+          + '\''
+          + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class Projection2 {
+    public Integer field2 = 1337;
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Projection2 that = (Projection2) o;
+      return Objects.equals(field2, that.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field2);
+    }
+
+    @Override
+    public String toString() {
+      return "Projection2{" + "field2=" + field2 + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class TypeWiden1 {
+
+    public Short field1 = 42;
+    public Integer field2 = 1337;
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TypeWiden1 typeWiden1 = (TypeWiden1) o;
+      return Objects.equals(field1, typeWiden1.field1) && Objects.equals(field2, typeWiden1.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2);
+    }
+
+    @Override
+    public String toString() {
+      return "TypeWiden1{" + "field1=" + field1 + ", field2=" + field2 + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class TypeWiden2 {
+
+    public Integer field1 = 42;
+    public Long field2 = 1337L;
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final TypeWiden2 typeWiden2 = (TypeWiden2) o;
+      return Objects.equals(field1, typeWiden2.field1) && Objects.equals(field2, typeWiden2.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2);
+    }
+
+    @Override
+    public String toString() {
+      return "TypeWiden2{" + "field1=" + field1 + ", field2=" + field2 + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class Nullable1 {
+    public Integer field1 = 42;
+    public @Nullable Long field2 = null;
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Nullable1 nullable1 = (Nullable1) o;
+      return Objects.equals(field1, nullable1.field1) && Objects.equals(field2, nullable1.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2);
+    }
+
+    @Override
+    public String toString() {
+      return "Nullable1{" + "field1=" + field1 + ", field2=" + field2 + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class Nullable2 {
+    public @Nullable Integer field1 = 42;
+    public @Nullable Long field2 = null;
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Nullable2 nullable2 = (Nullable2) o;
+      return Objects.equals(field1, nullable2.field1) && Objects.equals(field2, nullable2.field2);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2);
+    }
+
+    @Override
+    public String toString() {
+      return "Nullable2{" + "field1=" + field1 + ", field2=" + field2 + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class All1 {
+    public Projection1 field1 = new Projection1();
+    public TypeWiden1 field2 = new TypeWiden1();
+    public TypeWiden2 field3 = new TypeWiden2();
+    public Nullable1 field4 = new Nullable1();
+    public @Nullable Nullable2 field5 = new Nullable2();
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final All1 all1 = (All1) o;
+      return Objects.equals(field1, all1.field1)
+          && Objects.equals(field2, all1.field2)
+          && Objects.equals(field3, all1.field3)
+          && Objects.equals(field4, all1.field4)
+          && Objects.equals(field5, all1.field5);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2, field3, field4, field5);
+    }
+
+    @Override
+    public String toString() {
+      return "All1{"
+          + "field1="
+          + field1
+          + ", field2="
+          + field2
+          + ", field3="
+          + field3
+          + ", field4="
+          + field4
+          + ", field5="
+          + field5
+          + '}';
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  static class All2 {
+    public Projection2 field1 = new Projection2();
+    public TypeWiden2 field2 = new TypeWiden2();
+    public TypeWiden1 field3 = new TypeWiden1();
+    public Nullable2 field4 = new Nullable2();
+    public @Nullable Nullable1 field5 = new Nullable1();
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final All2 all2 = (All2) o;
+      return Objects.equals(field1, all2.field1)
+          && Objects.equals(field2, all2.field2)
+          && Objects.equals(field3, all2.field3)
+          && Objects.equals(field4, all2.field4)
+          && Objects.equals(field5, all2.field5);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(field1, field2, field3, field4, field5);
+    }
+
+    @Override
+    public String toString() {
+      return "All2{"
+          + "field1="
+          + field1
+          + ", field2="
+          + field2
+          + ", field3="
+          + field3
+          + ", field4="
+          + field4
+          + ", field5="
+          + field5
+          + '}';
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastValidatorTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/CastValidatorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.transforms;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.junit.Test;
+
+/** Tests for {@link Cast.Widening}, {@link Cast.Narrowing}. */
+public class CastValidatorTest {
+
+  public static final Map<TypeName, Number> NUMERICS =
+      ImmutableMap.<TypeName, Number>builder()
+          .put(TypeName.BYTE, Byte.valueOf((byte) 42))
+          .put(TypeName.INT16, Short.valueOf((short) 42))
+          .put(TypeName.INT32, Integer.valueOf(42))
+          .put(TypeName.INT64, Long.valueOf(42))
+          .put(TypeName.FLOAT, Float.valueOf(42))
+          .put(TypeName.DOUBLE, Double.valueOf(42))
+          .put(TypeName.DECIMAL, BigDecimal.valueOf(42))
+          .build();
+
+  public static final List<TypeName> NUMERIC_ORDER =
+      ImmutableList.of(
+          TypeName.BYTE,
+          TypeName.INT16,
+          TypeName.INT32,
+          TypeName.INT64,
+          TypeName.FLOAT,
+          TypeName.DOUBLE,
+          TypeName.DECIMAL);
+
+  @Test
+  public void testWideningOrder() {
+    NUMERICS
+        .keySet()
+        .forEach(input -> NUMERICS.keySet().forEach(output -> testWideningOrder(input, output)));
+  }
+
+  @Test
+  public void testCasting() {
+    NUMERICS
+        .keySet()
+        .forEach(input -> NUMERICS.keySet().forEach(output -> testCasting(input, output)));
+  }
+
+  public void testCasting(TypeName inputType, TypeName outputType) {
+    Object output =
+        Cast.castValue(NUMERICS.get(inputType), FieldType.of(inputType), FieldType.of(outputType));
+
+    assertEquals(NUMERICS.get(outputType), output);
+  }
+
+  @Test
+  public void testCastingCompleteness() {
+    boolean all =
+        NUMERIC_ORDER.stream().filter(TypeName::isNumericType).allMatch(NUMERIC_ORDER::contains);
+
+    assertTrue(all);
+  }
+
+  public void testWideningOrder(TypeName input, TypeName output) {
+    Schema inputSchema = Schema.of(Schema.Field.of("f0", FieldType.of(input)));
+    Schema outputSchema = Schema.of(Schema.Field.of("f0", FieldType.of(output)));
+
+    List<Cast.CompatibilityError> errors = Cast.Widening.of().apply(inputSchema, outputSchema);
+
+    if (NUMERIC_ORDER.indexOf(input) <= NUMERIC_ORDER.indexOf(output)) {
+      assertThat(input + " is before " + output, errors, empty());
+    } else {
+      assertThat(input + " is after " + output, errors, not(empty()));
+    }
+  }
+
+  @Test
+  public void testWideningNullableToNotNullable() {
+    Schema input = Schema.of(Schema.Field.nullable("f0", FieldType.INT32));
+    Schema output = Schema.of(Schema.Field.of("f0", FieldType.INT32));
+
+    List<Cast.CompatibilityError> errors = Cast.Widening.of().apply(input, output);
+    Cast.CompatibilityError expected =
+        Cast.CompatibilityError.create(
+            Arrays.asList("f0"), "Can't cast nullable field to non-nullable field");
+
+    assertThat(errors, containsInAnyOrder(expected));
+  }
+
+  @Test
+  public void testNarrowingNullableToNotNullable() {
+    Schema input = Schema.of(Schema.Field.nullable("f0", FieldType.INT32));
+    Schema output = Schema.of(Schema.Field.of("f0", FieldType.INT32));
+
+    List<Cast.CompatibilityError> errors = Cast.Narrowing.of().apply(input, output);
+
+    assertThat(errors, empty());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import org.apache.beam.sdk.schemas.Schema;
 import org.junit.Test;
 
-/** Tests for {@link SchemaZipFold} with examples. */
+/** TestWidenings for {@link SchemaZipFold} with examples. */
 public class SchemaZipFoldTest {
 
   private static final Schema LEFT =

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import org.apache.beam.sdk.schemas.Schema;
+import org.junit.Test;
+
+/** Tests for {@link SchemaZipFold} with examples. */
+public class SchemaZipFoldTest {
+
+  private static final Schema LEFT =
+      Schema.of(
+          Schema.Field.of("left", Schema.FieldType.INT32),
+          Schema.Field.of("f0", Schema.FieldType.INT32),
+          Schema.Field.of("f1", Schema.FieldType.INT32),
+          Schema.Field.of("f2", Schema.FieldType.INT32),
+          Schema.Field.of(
+              "f3",
+              Schema.FieldType.row(
+                  Schema.of(
+                      Schema.Field.of("inner_left", Schema.FieldType.INT32),
+                      Schema.Field.of("f0", Schema.FieldType.INT32),
+                      Schema.Field.of("f1", Schema.FieldType.INT32)))));
+
+  private static final Schema RIGHT =
+      Schema.of(
+          Schema.Field.of("right", Schema.FieldType.INT32),
+          Schema.Field.of("f0", Schema.FieldType.INT32),
+          Schema.Field.of("f1", Schema.FieldType.INT32),
+          Schema.Field.of("f2", Schema.FieldType.STRING),
+          Schema.Field.of(
+              "f3",
+              Schema.FieldType.row(
+                  Schema.of(
+                      Schema.Field.of("inner_right", Schema.FieldType.INT32),
+                      Schema.Field.of("f0", Schema.FieldType.INT32),
+                      Schema.Field.of("f1", Schema.FieldType.STRING)))));
+
+  @Test
+  public void testCountCommonLeafs() {
+    assertEquals(3, new CountCommonLeafs().apply(LEFT, RIGHT).intValue());
+  }
+
+  @Test
+  public void testCountCommonFields() {
+    assertEquals(6, new CountCommonFields().apply(LEFT, RIGHT).intValue());
+  }
+
+  @Test
+  public void testCountMissingFields() {
+    assertEquals(4, new CountMissingFields().apply(LEFT, RIGHT).intValue());
+  }
+
+  static class CountCommonLeafs extends SchemaZipFold<Integer> {
+
+    @Override
+    public Integer accumulate(Integer left, Integer right) {
+      return left + right;
+    }
+
+    @Override
+    public Integer accept(Context context, Schema.FieldType left, Schema.FieldType right) {
+
+      if (left.getTypeName() != right.getTypeName()) {
+        return 0;
+      }
+
+      if (left.getTypeName() == Schema.TypeName.ROW) {
+        return 0;
+      }
+
+      if (left.getTypeName() == Schema.TypeName.ARRAY) {
+        return 0;
+      }
+
+      if (left.getTypeName() == Schema.TypeName.MAP) {
+        return 0;
+      }
+
+      return 1;
+    }
+
+    @Override
+    public Integer accept(
+        Context context, Optional<Schema.Field> left, Optional<Schema.Field> right) {
+      return 0;
+    }
+  }
+
+  static class CountCommonFields extends SchemaZipFold<Integer> {
+
+    @Override
+    public Integer accumulate(Integer left, Integer right) {
+      return left + right;
+    }
+
+    @Override
+    public Integer accept(Context context, Schema.FieldType left, Schema.FieldType right) {
+
+      return 0;
+    }
+
+    @Override
+    public Integer accept(
+        Context context, Optional<Schema.Field> left, Optional<Schema.Field> right) {
+      if (left.isPresent() && right.isPresent()) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  }
+
+  static class CountMissingFields extends SchemaZipFold<Integer> {
+
+    @Override
+    public Integer accumulate(Integer left, Integer right) {
+      return left + right;
+    }
+
+    @Override
+    public Integer accept(Context context, Schema.FieldType left, Schema.FieldType right) {
+
+      return 0;
+    }
+
+    @Override
+    public Integer accept(
+        Context context, Optional<Schema.Field> left, Optional<Schema.Field> right) {
+      if (!left.isPresent() || !right.isPresent()) {
+        return 1;
+      } else {
+        return 0;
+      }
+    }
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaZipFoldTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import org.apache.beam.sdk.schemas.Schema;
 import org.junit.Test;
 
-/** TestWidenings for {@link SchemaZipFold} with examples. */
+/** Tests for {@link SchemaZipFold} with examples. */
 public class SchemaZipFoldTest {
 
   private static final Schema LEFT =


### PR DESCRIPTION
Casts rows from one schema, into another. Implements:
- widening values (e.g., int -> long), to be extended with more conversions
- narrowwing (e.g., int -> short), to be extended with more conversions
- ignoring nullability (nullable=true -> nullable=false)
- weakening nullability (nullable=false -> nullable=true)
- projection (Schema(a: Int32, b: Int32) -> Schema(a: Int32))

It would be very useful for Row-based IO-s, for instance, BeamBigQueryTable can be implemented with org.apache.beam.sdk.schemas.utils.AvroUtils and Cast, and this will make it more flexible, now it's very restrictive to the schema.

Another example is reading AVRO GenericRecord as user-provided POJO, [BEAM-5807](https://issues.apache.org/jira/browse/BEAM-5807).

I want to get an initial portion of feedback before polishing Javadoc, API, etc.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




