### PR TITLE
[BEAM-5922] Refactor Map, FlatMap, and Filter on MapperBase

### DIFF
--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
@@ -81,14 +81,14 @@ public class SparkRunnerDebuggerTest {
         "sparkContext.parallelize(Arrays.asList(...))\n"
             + "_.mapPartitions("
             + "new org.apache.beam.runners.spark.examples.WordCount$ExtractWordsFn())\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.MapperBase$1())\n"
             + "_.combineByKey(..., new org.apache.beam.sdk.transforms.Count$CountFn(), ...)\n"
             + "_.groupByKey()\n"
             + "_.map(new org.apache.beam.sdk.transforms.Sum$SumLongFn())\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.MapperBase$1())\n"
             + "sparkContext.union(...)\n"
             + "_.mapPartitions("
-            + "new org.apache.beam.sdk.transforms.Contextful())\n"
+            + "new org.apache.beam.sdk.transforms.MapperBase$1())\n"
             + "_.<org.apache.beam.sdk.io.TextIO$Write>";
 
     SparkRunnerDebugger.DebugSparkPipelineResult result =
@@ -139,11 +139,11 @@ public class SparkRunnerDebuggerTest {
             + "_.map(new org.apache.beam.sdk.transforms.windowing.FixedWindows())\n"
             + "_.mapPartitions(new org.apache.beam.runners.spark."
             + "SparkRunnerDebuggerTest$FormatKVFn())\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.MapperBase$1())\n"
             + "_.groupByKey()\n"
             + "_.map(new org.apache.beam.sdk.transforms.Combine$IterableCombineFn())\n"
             + "_.mapPartitions(new org.apache.beam.sdk.transforms.Distinct$3())\n"
-            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.MapperBase$1())\n"
             + "_.<org.apache.beam.sdk.io.kafka.AutoValue_KafkaIO_Write>";
 
     SparkRunnerDebugger.DebugSparkPipelineResult result =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Filter.java
@@ -17,10 +17,7 @@
  */
 package org.apache.beam.sdk.transforms;
 
-import java.util.Collections;
-import javax.annotation.Nullable;
-import org.apache.beam.sdk.transforms.Contextful.Fn;
-import org.apache.beam.sdk.transforms.Contextful.Fn.Context;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
@@ -32,7 +29,7 @@ import org.apache.beam.sdk.values.TypeDescriptors;
  * @param <T> the type of the values in the input {@code PCollection}, and the type of the elements
  *     in the output {@code PCollection}
  */
-public class Filter<T> extends MapperBase<T, T> {
+public class Filter<T> extends MapperBase<T, Boolean, T> {
 
   /**
    * Returns a {@code PTransform} that takes an input {@code PCollection<T>} and returns a {@code
@@ -187,7 +184,7 @@ public class Filter<T> extends MapperBase<T, T> {
   private Filter(SerializableFunction<T, Boolean> predicate, String predicateDescription) {
     super(
         null, // name is null for backwards compatibility
-        wrapResultAsIterable(predicate),
+        Contextful.fn(predicate),
         null, // Filter implements custom DisplayData logic, so no originalFn needed
         TypeDescriptors.inputOf(predicate),
         TypeDescriptors.inputOf(predicate));
@@ -195,21 +192,10 @@ public class Filter<T> extends MapperBase<T, T> {
     this.predicateDescription = predicateDescription;
   }
 
-  @Nullable
-  private static <T> Contextful<Fn<T, Iterable<T>>> wrapResultAsIterable(
-      SerializableFunction<T, Boolean> predicate) {
-    if (predicate == null) {
-      return null;
-    } else {
-      return Contextful.fn(
-          (T element, Context c) -> {
-            if (predicate.apply(element)) {
-              return Collections.singletonList(element);
-            } else {
-              return Collections.emptyList();
-            }
-          },
-          Requirements.empty());
+  @Override
+  public void emitOutput(T inputElement, Boolean predicateSatisfied, OutputReceiver<T> receiver) {
+    if (predicateSatisfied) {
+      receiver.output(inputElement);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/FlatMapElements.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.transforms;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.transforms.Contextful.Fn;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
@@ -28,7 +29,8 @@ import org.apache.beam.sdk.values.TypeDescriptors;
  * {@code PTransform}s for mapping a simple function that returns iterables over the elements of a
  * {@link PCollection} and merging the results.
  */
-public class FlatMapElements<InputT, OutputT> extends MapperBase<InputT, OutputT> {
+public class FlatMapElements<InputT, OutputT>
+    extends MapperBase<InputT, Iterable<OutputT>, OutputT> {
 
   /**
    * For a {@code SimpleFunction<InputT, ? extends Iterable<OutputT>>} {@code fn}, return a {@link
@@ -112,5 +114,13 @@ public class FlatMapElements<InputT, OutputT> extends MapperBase<InputT, OutputT
       @Nullable TypeDescriptor<InputT> inputType,
       TypeDescriptor<OutputT> outputType) {
     super("FlatMap", fn, originalFnForDisplayData, inputType, outputType);
+  }
+
+  @Override
+  public void emitOutput(
+      InputT inputElement, Iterable<OutputT> outputElements, OutputReceiver<OutputT> receiver) {
+    for (OutputT outputElement : outputElements) {
+      receiver.output(outputElement);
+    }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -22,13 +22,13 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.Contextful.Fn;
-import org.apache.beam.sdk.transforms.Contextful.Fn.Context;
+import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 
 /** {@code PTransform}s for mapping a simple function over the elements of a {@link PCollection}. */
-public class MapElements<InputT, OutputT> extends MapperBase<InputT, OutputT> {
+public class MapElements<InputT, OutputT> extends MapperBase<InputT, OutputT, OutputT> {
 
   /**
    * For a {@code SimpleFunction<InputT, OutputT>} {@code fn}, returns a {@code PTransform} that
@@ -102,7 +102,13 @@ public class MapElements<InputT, OutputT> extends MapperBase<InputT, OutputT> {
       @Nullable Object originalFnForDisplayData,
       @Nullable TypeDescriptor<InputT> inputType,
       TypeDescriptor<OutputT> outputType) {
-    super("Map", wrapResultAsIterable(fn), originalFnForDisplayData, inputType, outputType);
+    super("Map", fn, originalFnForDisplayData, inputType, outputType);
+  }
+
+  @Override
+  public void emitOutput(
+      InputT inputElement, OutputT outputElement, OutputReceiver<OutputT> receiver) {
+    receiver.output(outputElement);
   }
 
   @Nullable
@@ -112,8 +118,8 @@ public class MapElements<InputT, OutputT> extends MapperBase<InputT, OutputT> {
       return null;
     } else {
       return Contextful.fn(
-          (InputT element, Context c) -> Collections
-              .singletonList(fn.getClosure().apply(element, c)),
+          (InputT element, Fn.Context c) ->
+              Collections.singletonList(fn.getClosure().apply(element, c)),
           fn.getRequirements());
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapperBase.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapperBase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.Contextful.Fn;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.HasDisplayData;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * Abstract class providing a base for {@link PTransform}s that map a simple function over elements.
+ *
+ * <p>The passed {@code fn} returns an {@link Iterable}, each element of which will be sent to
+ * output. That interface naturally expresses a FlatMap, but both Map (always one output element)
+ * and Filter (either the input element is passed through or an empty collection) can both be
+ * expressed as special cases.
+ */
+abstract class MapperBase<InputT, OutputT>
+    extends PTransform<PCollection<? extends InputT>, PCollection<OutputT>> {
+  @Nullable private final transient TypeDescriptor<InputT> inputType;
+  @Nullable final transient TypeDescriptor<OutputT> outputType;
+  @Nullable private final transient Object originalFnForDisplayData;
+  @Nullable private final Contextful<Fn<InputT, Iterable<OutputT>>> fn;
+
+  MapperBase(
+      @Nullable String name,
+      @Nullable Contextful<Fn<InputT, Iterable<OutputT>>> fn,
+      @Nullable Object originalFnForDisplayData,
+      @Nullable TypeDescriptor<InputT> inputType,
+      TypeDescriptor<OutputT> outputType) {
+    super(name);
+    this.fn = fn;
+    this.originalFnForDisplayData = originalFnForDisplayData;
+    this.inputType = inputType;
+    this.outputType = outputType;
+  }
+
+  @Override
+  public PCollection<OutputT> expand(PCollection<? extends InputT> input) {
+    checkNotNull(fn, "Must specify a function on "
+        + MapperBase.this.getClass().toString() + " using .via()");
+    return input.apply(
+        ParDo.of(
+                new DoFn<InputT, OutputT>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext c) throws Exception {
+                    Iterable<OutputT> res =
+                        fn.getClosure().apply(c.element(), Fn.Context.wrapProcessContext(c));
+                    for (OutputT output : res) {
+                      c.output(output);
+                    }
+                  }
+
+                  @Override
+                  public TypeDescriptor<InputT> getInputTypeDescriptor() {
+                    return inputType;
+                  }
+
+                  @Override
+                  public TypeDescriptor<OutputT> getOutputTypeDescriptor() {
+                    checkState(
+                        outputType != null,
+                        "%s output type descriptor was null; "
+                            + "this probably means that getOutputTypeDescriptor() was called after "
+                            + "serialization/deserialization, but it is only available prior to "
+                            + "serialization, for constructing a pipeline and inferring coders",
+                        MapperBase.this.getClass().getSimpleName());
+                    return outputType;
+                  }
+
+                  @Override
+                  public void populateDisplayData(DisplayData.Builder builder) {
+                    builder.delegate(MapperBase.this);
+                  }
+                })
+            .withSideInputs(fn.getRequirements().getSideInputs()));
+  }
+
+  @Override
+  public void populateDisplayData(DisplayData.Builder builder) {
+    super.populateDisplayData(builder);
+
+    // Subclasses can opt to set this null and implement their own display data logic.
+    if (originalFnForDisplayData != null) {
+      builder.add(DisplayData.item("class", originalFnForDisplayData.getClass()));
+    }
+    if (originalFnForDisplayData instanceof HasDisplayData) {
+      builder.include("fn", (HasDisplayData) originalFnForDisplayData);
+    }
+  }
+}


### PR DESCRIPTION
There should be no change in functionality or public interface with this change.
The intention is to reduce code duplication between these three classes for
better consistency in future changes.

In particular, this change will simplify the implementation of failure handling
across these transforms in https://issues.apache.org/jira/browse/BEAM-5638

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




