### PR TITLE
[BEAM-3612] Add a benchmark for method invocation methods.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn_test.go
@@ -400,3 +400,206 @@ func BenchmarkInvokeFnCallExtra(b *testing.B) {
 	}
 	b.Log(n)
 }
+
+// Foo is a struct with a method for measuring method invocation
+// overhead for StructuralDoFns.
+type Foo struct {
+	A int
+}
+
+// WhatsA is a method for measuring a baseline of structural dofn overhead.
+func (f *Foo) WhatsA(b int) int {
+	return f.A + b
+}
+
+// WhatsB is a comparable direct function for baseline comparison.
+func WhatsB(b int) int {
+	return 32 + b
+}
+
+// Expclicit Receiver Type assertion shim.
+type callerFooRInt struct {
+	fn func(*Foo, int) int
+}
+
+func funcMakerFooRInt(fn interface{}) reflectx.Func {
+	f := fn.(func(*Foo, int) int)
+	return &callerFooRInt{fn: f}
+}
+
+func (c *callerFooRInt) Name() string {
+	return reflectx.FunctionName(c.fn)
+}
+
+func (c *callerFooRInt) Type() reflect.Type {
+	return reflect.TypeOf(c.fn)
+}
+
+func (c *callerFooRInt) Call(args []interface{}) []interface{} {
+	a := c.fn(args[0].(*Foo), args[1].(int))
+	return []interface{}{a}
+}
+
+// To satisfy reflectx.Func2x1
+func (c *callerFooRInt) Call2x1(a1, a2 interface{}) interface{} {
+	return c.fn(a1.(*Foo), a2.(int))
+}
+
+// Implicit Receiver type assertion shim.
+type callerInt struct {
+	fn func(int) int
+}
+
+func funcMakerInt(fn interface{}) reflectx.Func {
+	f := fn.(func(int) int)
+	return &callerInt{fn: f}
+}
+
+func (c *callerInt) Name() string {
+	return reflectx.FunctionName(c.fn)
+}
+
+func (c *callerInt) Type() reflect.Type {
+	return reflect.TypeOf(c.fn)
+}
+
+func (c *callerInt) Call(args []interface{}) []interface{} {
+	a := c.fn(args[0].(int))
+	return []interface{}{a}
+}
+
+func (c *callerInt) Call1x1(a0 interface{}) interface{} {
+	return c.fn(a0.(int))
+}
+
+// BenchmarkMethodCalls measures the overhead of different ways of
+// "generically" invoking methods.
+//
+// This benchmark invokes methods along several different axes
+// * Implicit or Explicit method Receiver
+// * Pre-wrapped values and pre-allocated slices.
+// * Invocations along the following ways
+//   * Indirect via extracting from a reflect.Value.Interface()
+//   * Reflect Package (reflect.Value.Call())
+//   * Beam's reflectx.Func, and reflectx.FuncNxM interfaces
+//       * Beam's default reflection based reflectx.Func shim
+//       * A Type assertion specialized reflectx.Func shim
+//
+// The Implicit or Explicit method receiver difference exists because
+// Go's reflect package treats the two cases different, and there are
+// performance implications this benchmark captures. Implicit adds a
+// fixed amount of overhead perf invocation giving a performance penalty
+// to Structural DoFns.
+//
+// PreAlocating slices and values serves as a comparison point for how much
+// overhead not doing these things costs. In particular in wrapping/unwrapping
+// values with reflect.ValueOf and extracting them with reflect.Value's
+// Interface() method.
+func BenchmarkMethodCalls(b *testing.B) {
+	f := &Foo{A: 3}
+	var gi interface{}
+	g := &Foo{A: 42}
+	gi = g
+	gV := reflect.ValueOf(g)
+	fV := reflect.ValueOf(f)
+
+	nrF := fV.Method(0)
+	nrFi := nrF.Interface().(func(int) int)
+	rxnrF := reflectx.MakeFunc(nrFi)
+	rx0x1nrF := reflectx.ToFunc1x1(rxnrF)
+	shimnrF := funcMakerInt(nrFi)             // as if this shim were registered
+	shim0x1nrF := reflectx.ToFunc1x1(shimnrF) // would be MakeFunc0x1 if registered
+
+	wrF := fV.Type().Method(0).Func
+	wrFi := wrF.Interface().(func(*Foo, int) int)
+
+	rxF := reflectx.MakeFunc(wrFi)
+	rx1x1F := reflectx.ToFunc2x1(rxF)
+	shimF := funcMakerFooRInt(wrFi)       // as if this shim were registered
+	shim1x1F := reflectx.ToFunc2x1(shimF) // would be MakeFunc1x1 if registered
+
+	var a int
+	var ai interface{} = a
+	aV := reflect.ValueOf(a)
+	rvSlice := []reflect.Value{aV}
+	grvSlice := []reflect.Value{gV, aV}
+	efaceSlice := []interface{}{a}
+	gEfaceSlice := []interface{}{g, a}
+
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		{"DirectMethod", func() { a = g.WhatsA(a) }}, // Baseline as low as we can go.
+		{"DirectFunc", func() { a = WhatsB(a) }},     // For comparison purposes
+
+		{"IndirectImplicit", func() { a = nrFi(a) }},             // Measures the indirection through reflect.Value cost.
+		{"TypeAssertedImplicit", func() { ai = nrFi(ai.(int)) }}, // Measures the type assertion cost over the above.
+
+		{"ReflectCallImplicit", func() { a = nrF.Call([]reflect.Value{reflect.ValueOf(a)})[0].Interface().(int) }},
+		{"ReflectCallImplicit-NoWrap", func() { a = nrF.Call([]reflect.Value{aV})[0].Interface().(int) }},
+		{"ReflectCallImplicit-NoReallocSlice", func() { a = nrF.Call(rvSlice)[0].Interface().(int) }},
+
+		{"ReflectXCallImplicit", func() { a = rxnrF.Call([]interface{}{a})[0].(int) }},
+		{"ReflectXCallImplicit-NoReallocSlice", func() { a = rxnrF.Call(efaceSlice)[0].(int) }},
+		{"ReflectXCall1x1Implicit", func() { a = rx0x1nrF.Call1x1(a).(int) }}, // Measures the default shimfunc overhead.
+
+		{"ShimedCallImplicit", func() { a = shimnrF.Call([]interface{}{a})[0].(int) }},          // What we're currently using for invoking methods
+		{"ShimedCallImplicit-NoReallocSlice", func() { a = shimnrF.Call(efaceSlice)[0].(int) }}, // Closer to what we're using now.
+		{"ShimedCall1x1Implicit", func() { a = shim0x1nrF.Call1x1(a).(int) }},
+
+		{"IndirectWithExplicit", func() { a = wrFi(g, a) }},                     // Measures the indirection through reflect.Value cost.
+		{"TypeAssertedWithExplicit", func() { ai = wrFi(gi.(*Foo), ai.(int)) }}, // Measures the type assertion cost over the above.
+
+		{"ReflectCallWithExplicit", func() { a = wrF.Call([]reflect.Value{reflect.ValueOf(g), reflect.ValueOf(a)})[0].Interface().(int) }},
+		{"ReflectCallWithExplicit-NoWrap", func() { a = wrF.Call([]reflect.Value{gV, aV})[0].Interface().(int) }},
+		{"ReflectCallWithExplicit-NoReallocSlice", func() { a = wrF.Call(grvSlice)[0].Interface().(int) }},
+
+		{"ReflectXCallWithExplicit", func() { a = rxF.Call([]interface{}{g, a})[0].(int) }},
+		{"ReflectXCallWithExplicit-NoReallocSlice", func() { a = rxF.Call(gEfaceSlice)[0].(int) }},
+		{"ReflectXCall2x1WithExplicit", func() { a = rx1x1F.Call2x1(g, a).(int) }},
+
+		{"ShimedCallWithExplicit", func() { a = shimF.Call([]interface{}{g, a})[0].(int) }},        
+		{"ShimedCallWithExplicit-NoReallocSlice", func() { a = shimF.Call(gEfaceSlice)[0].(int) }},
+		{"ShimedCall2x1WithExplicit", func() { a = shim1x1F.Call2x1(g, a).(int) }},
+	}
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				test.fn()
+			}
+		})
+	}
+	b.Log(a)
+}
+
+/*
+@lostluck 2018/10/30 on a desktop machine.
+
+BenchmarkMethodCalls/DirectMethod-12                                                 	1000000000	         2.02 ns/op
+BenchmarkMethodCalls/DirectFunc-12                                                   	2000000000	         1.81 ns/op
+BenchmarkMethodCalls/IndirectImplicit-12                                             	10000000	       185 ns/op
+BenchmarkMethodCalls/TypeAssertedImplicit-12                                         	10000000	       228 ns/op
+BenchmarkMethodCalls/ReflectCallImplicit-12                                          	 3000000	       479 ns/op
+BenchmarkMethodCalls/ReflectCallImplicit-NoWrap-12                                   	 3000000	       451 ns/op
+BenchmarkMethodCalls/ReflectCallImplicit-NoReallocSlice-12                           	 3000000	       424 ns/op
+BenchmarkMethodCalls/ReflectXCallImplicit-12                                         	 2000000	       756 ns/op
+BenchmarkMethodCalls/ReflectXCallImplicit-NoReallocSlice-12                          	 2000000	       662 ns/op **Default**
+BenchmarkMethodCalls/ReflectXCall1x1Implicit-12                                      	 2000000	       762 ns/op
+BenchmarkMethodCalls/ShimedCallImplicit-12                                           	 5000000	       374 ns/op
+BenchmarkMethodCalls/ShimedCallImplicit-NoReallocSlice-12                            	 5000000	       289 ns/op **With specialized shims**
+BenchmarkMethodCalls/ShimedCall1x1Implicit-12                                        	 5000000	       249 ns/op **Arity specialized re-work of the invoker**
+
+** Everything below requires an overhaul of structural DoFn invocation code, and regeneration of all included shims. **
+BenchmarkMethodCalls/IndirectWithExplicit-12                                         	300000000	         4.81 ns/op
+BenchmarkMethodCalls/TypeAssertedWithExplicit-12                                     	50000000	        35.4 ns/op 
+BenchmarkMethodCalls/ReflectCallWithExplicit-12                                      	 3000000	       434 ns/op
+BenchmarkMethodCalls/ReflectCallWithExplicit-NoWrap-12                               	 5000000	       397 ns/op
+BenchmarkMethodCalls/ReflectCallWithExplicit-NoReallocSlice-12                       	 5000000	       390 ns/op
+BenchmarkMethodCalls/ReflectXCallWithExplicit-12                                     	 2000000	       755 ns/op
+BenchmarkMethodCalls/ReflectXCallWithExplicit-NoReallocSlice-12                      	 2000000	       601 ns/op
+BenchmarkMethodCalls/ReflectXCall2x1WithExplicit-12                                  	 2000000	       735 ns/op
+BenchmarkMethodCalls/ShimedCallWithExplicit-12                                       	10000000	       198 ns/op
+BenchmarkMethodCalls/ShimedCallWithExplicit-NoReallocSlice-12                        	20000000	        93.5 ns/op
+BenchmarkMethodCalls/ShimedCall2x1WithExplicit-12                                    	20000000	        68.3 ns/op  **Best we could do**
+*/


### PR DESCRIPTION
With the Go SDK's necessary default use of reflection to achieve more idiomatic user code, it's up to the framework to reduce this overhead as much as possible. This benchmark illustrates the various methods available to the Go SDK and informs work I've been doing on [BEAM-3612].

Having properly generated type assertion shims at present represents a reduction of around ~400ns per function invocation. As mentioned in the JIRA, I've got a tool I've been working on to make generating these shims easier.

Further, this reveals there's a way to change how we handle *method* invocation which is relevant for Structural DoFns. The way we use a reflect.Value.Interface() call to get to back to an indirect interface{} version of the method, we typically go through the "Implicit Receiver" route, so that the receiver we're operating on (the Structural DoFn with the associated state) is implicitly cached and instated by the reflection code when we call it. This adds ~180ns overhead (on my machine) compared to the the Explicit Receiver version.

The tricky part here is that moving to Explicit Receivers requires a minor overhaul through the beam function handling code, to properly mark the receiver parameter for the type checking phase. This is better accomplished after we have *tools* to re-generate type assertion shims for the SDK, if we're doing it at all.

Finally, by having arity Explicit invocation of the shims reduces overhead by another 30ns. This is probably something that can be generated one off (with the above concession to the Explicit Receiver approach) to get a base set of combinatorial values. However, the extra overhead of a arity specialized invoker might be more than the 30ns cost of allocating & extracting the values from the slice, so this should be more specifically benchmarked in context of invoking for ParDos.



------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




