### PR TITLE
Remove brackets from lambdas with a single parameter

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -50,7 +50,7 @@ public class Environments {
           .put(PTransformTranslation.ASSIGN_WINDOWS_TRANSFORM_URN, Environments::windowExtractor)
           .build();
 
-  private static final EnvironmentIdExtractor DEFAULT_SPEC_EXTRACTOR = (transform) -> null;
+  private static final EnvironmentIdExtractor DEFAULT_SPEC_EXTRACTOR = transform -> null;
 
   private static final ObjectMapper MAPPER =
       new ObjectMapper()

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -135,7 +135,7 @@ public class PTransformTranslation {
     TransformTranslator<?> transformTranslator =
         Iterables.find(
             KNOWN_TRANSLATORS,
-            (translator) -> translator.canTranslate(appliedPTransform.getTransform()),
+            translator -> translator.canTranslate(appliedPTransform.getTransform()),
             DefaultUnknownTransformTranslator.INSTANCE);
     return transformTranslator.translate(appliedPTransform, subtransforms, components);
   }
@@ -163,7 +163,7 @@ public class PTransformTranslation {
     TransformTranslator<?> transformTranslator =
         Iterables.find(
             KNOWN_TRANSLATORS,
-            (translator) -> translator.canTranslate(transform),
+            translator -> translator.canTranslate(transform),
             DefaultUnknownTransformTranslator.INSTANCE);
     return ((TransformTranslator) transformTranslator).getUrn(transform);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -241,7 +241,7 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
       Integer unionTag = outputMap.get(collectionId);
       checkArgument(unionTag != null, "Unknown PCollection id: %s", collectionId);
       int tagInt = unionTag;
-      return (receivedElement) -> {
+      return receivedElement -> {
         synchronized (collectorLock) {
           collector.collect(new RawUnionValue(tagInt, receivedElement));
         }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -318,7 +318,7 @@ public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<I
           new OutputReceiverFactory() {
             @Override
             public FnDataReceiver<OutputT> create(String pCollectionId) {
-              return (receivedElement) -> {
+              return receivedElement -> {
                 // handover to queue, do not block the grpc thread
                 outputQueue.put(KV.of(pCollectionId, receivedElement));
               };

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KeyedPushedBackElementsHandler.java
@@ -61,7 +61,7 @@ class KeyedPushedBackElementsHandler<K, T> implements PushedBackElementsHandler<
     return backend
         .getKeys(stateDescriptor.getName(), VoidNamespace.INSTANCE)
         .flatMap(
-            (key) -> {
+            key -> {
               try {
                 backend.setCurrentKey(key);
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -472,12 +472,12 @@ public class BatchModeExecutionContext
               return Iterables.concat(
                   FluentIterable.from(updates.counterUpdates())
                       .transform(
-                          (update) ->
+                          update ->
                               MetricsToCounterUpdateConverter.fromCounter(
                                   update.getKey(), true, update.getUpdate())),
                   FluentIterable.from(updates.distributionUpdates())
                       .transform(
-                          (update) ->
+                          update ->
                               MetricsToCounterUpdateConverter.fromDistribution(
                                   update.getKey(), true, update.getUpdate())));
             });

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DeltaDistributionCell.java
@@ -64,7 +64,7 @@ public class DeltaDistributionCell implements Distribution, MetricCell<Distribut
   }
 
   public DistributionData getAndReset() {
-    return value.getAndUpdate((unused) -> DistributionData.EMPTY);
+    return value.getAndUpdate(unused -> DistributionData.EMPTY);
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ExecutionStateRegistry.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ExecutionStateRegistry.java
@@ -86,7 +86,7 @@ public abstract class ExecutionStateRegistry {
         ExecutionStateKey.create(nameContext, stateName, requestingStepName, inputIndex);
     return createdStates.computeIfAbsent(
         stateKey,
-        (unused) ->
+        unused ->
             createState(
                 nameContext, stateName, requestingStepName, inputIndex, container, profileScope));
   }
@@ -108,7 +108,7 @@ public abstract class ExecutionStateRegistry {
 
   public Iterable<CounterUpdate> extractUpdates(boolean isFinalUpdate) {
     return FluentIterable.from(createdStates.values())
-        .transform((state) -> state.extractUpdate(isFinalUpdate))
+        .transform(state -> state.extractUpdate(isFinalUpdate))
         .filter(notNull());
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsContainerRegistry.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricsContainerRegistry.java
@@ -36,7 +36,7 @@ public abstract class MetricsContainerRegistry<T extends MetricsContainer> {
 
   /** Retrieve (creating if necessary) the {@link MetricsContainer} to use with the given step. */
   public T getContainer(String stepName) {
-    return containers.computeIfAbsent(stepName, (unused) -> createContainer(stepName));
+    return containers.computeIfAbsent(stepName, unused -> createContainer(stepName));
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1094,7 +1094,7 @@ public class StreamingDataflowWorker {
 
     StageInfo stageInfo =
         stageInfoMap.computeIfAbsent(
-            mapTask.getStageName(), (s) -> new StageInfo(s, mapTask.getSystemName()));
+            mapTask.getStageName(), s -> new StageInfo(s, mapTask.getSystemName()));
 
     ExecutionState executionState = null;
 
@@ -1709,7 +1709,7 @@ public class StreamingDataflowWorker {
 
     List<CounterUpdate> counterUpdates = new ArrayList<>();
     if (publishCounters) {
-      stageInfoMap.values().forEach((s) -> counterUpdates.addAll(s.extractCounterUpdates()));
+      stageInfoMap.values().forEach(s -> counterUpdates.addAll(s.extractCounterUpdates()));
 
       counterUpdates.addAll(
           cumulativeCounters.extractUpdates(false, DataflowCounterUpdateExtractor.INSTANCE));

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/control/RegisterAndProcessBundleOperation.java
@@ -473,7 +473,7 @@ public class RegisterAndProcessBundleOperation extends Operation {
     BagState<ByteString> state =
         userStateData.computeIfAbsent(
             stateRequest.getStateKey(),
-            (unused) ->
+            unused ->
                 userStepContext
                     .stateInternals()
                     .state(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/BeamFnDataGrpcService.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/fn/data/BeamFnDataGrpcService.java
@@ -265,6 +265,6 @@ public class BeamFnDataGrpcService extends BeamFnDataGrpc.BeamFnDataImplBase
 
   private CompletableFuture<BeamFnDataGrpcMultiplexer> getClientFuture(String sdkWorkerId) {
     Preconditions.checkNotNull(sdkWorkerId);
-    return connectedClients.computeIfAbsent(sdkWorkerId, (clientId) -> new CompletableFuture<>());
+    return connectedClients.computeIfAbsent(sdkWorkerId, clientId -> new CompletableFuture<>());
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/status/ThreadzServlet.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/status/ThreadzServlet.java
@@ -112,9 +112,9 @@ class ThreadzServlet extends BaseStatusServlet implements Capturable {
     stacks
         .entrySet()
         .stream()
-        .sorted(Comparator.comparingInt((e) -> -e.getValue().size()))
+        .sorted(Comparator.comparingInt(e -> -e.getValue().size()))
         .forEachOrdered(
-            (entry) -> {
+            entry -> {
               Stack stack = entry.getKey();
               List<String> threads = entry.getValue();
               writer.println(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/DefaultJobBundleFactory.java
@@ -97,7 +97,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     this.stageIdGenerator = stageIdGenerator;
     this.environmentCache =
         createEnvironmentCache(
-            (environment) -> {
+            environment -> {
               synchronized (this) {
                 checkAndInitialize(jobInfo, environmentFactoryMap, environment);
               }
@@ -125,7 +125,7 @@ public class DefaultJobBundleFactory implements JobBundleFactory {
     this.dataServer = dataServer;
     this.stateServer = stateServer;
     this.environmentCache =
-        createEnvironmentCache((env) -> environmentFactory.createEnvironment(env));
+        createEnvironmentCache(env -> environmentFactory.createEnvironment(env));
   }
 
   private LoadingCache<Environment, WrappedSdkHarnessClient> createEnvironmentCache(

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobService.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/jobsubmission/InMemoryJobService.java
@@ -176,7 +176,7 @@ public class InMemoryJobService extends JobServiceGrpc.JobServiceImplBase implem
       String invocationId = invocation.getId();
 
       invocation.addStateListener(
-          (state) -> {
+          state -> {
             if (!JobInvocation.isTerminated(state)) {
               return;
             }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/state/GrpcStateServiceTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/state/GrpcStateServiceTest.java
@@ -92,7 +92,7 @@ public class GrpcStateServiceTest {
         BeamFnApi.StateResponse.newBuilder()
             .setGet(BeamFnApi.StateGetResponse.newBuilder().setData(expectedResponseData));
     StateRequestHandler dummyHandler =
-        (request) -> {
+        request -> {
           CompletableFuture<BeamFnApi.StateResponse.Builder> response = new CompletableFuture<>();
           response.complete(expectedBuilder);
           return response;

--- a/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
+++ b/runners/reference/java/src/main/java/org/apache/beam/runners/reference/PortableRunner.java
@@ -152,7 +152,7 @@ public class PortableRunner extends PipelineRunner<PipelineResult> {
 
     JobServiceBlockingStub jobService = JobServiceGrpc.newBlockingStub(jobServiceChannel);
     try (CloseableResource<JobServiceBlockingStub> wrappedJobService =
-        CloseableResource.of(jobService, (unused) -> jobServiceChannel.shutdown())) {
+        CloseableResource.of(jobService, unused -> jobServiceChannel.shutdown())) {
 
       PrepareJobResponse prepareJobResponse = jobService.prepare(prepareJobRequest);
       LOG.info("PrepareJobResponse: {}", prepareJobResponse);

--- a/runners/reference/java/src/test/java/org/apache/beam/runners/reference/CloseableResourceTest.java
+++ b/runners/reference/java/src/test/java/org/apache/beam/runners/reference/CloseableResourceTest.java
@@ -37,7 +37,7 @@ public class CloseableResourceTest {
   @Test
   public void alwaysReturnsSameResource() {
     Foo foo = new Foo();
-    CloseableResource<Foo> resource = CloseableResource.of(foo, (ignored) -> {});
+    CloseableResource<Foo> resource = CloseableResource.of(foo, ignored -> {});
     assertThat(resource.get(), is(foo));
     assertThat(resource.get(), is(foo));
   }
@@ -48,7 +48,7 @@ public class CloseableResourceTest {
     try (CloseableResource<Foo> ignored =
         CloseableResource.of(
             new Foo(),
-            (foo) -> {
+            foo -> {
               closed.set(true);
             })) {
       // Do nothing.
@@ -64,7 +64,7 @@ public class CloseableResourceTest {
     try (CloseableResource<Foo> ignored =
         CloseableResource.of(
             new Foo(),
-            (foo) -> {
+            foo -> {
               throw wrapped;
             })) {
       // Do nothing.
@@ -75,7 +75,7 @@ public class CloseableResourceTest {
   public void transferReleasesCloser() throws Exception {
     try (CloseableResource<Foo> foo =
         CloseableResource.of(
-            new Foo(), (unused) -> fail("Transferred resource should not be closed"))) {
+            new Foo(), unused -> fail("Transferred resource should not be closed"))) {
       foo.transfer();
     }
   }
@@ -83,7 +83,7 @@ public class CloseableResourceTest {
   @Test
   public void transferMovesOwnership() throws Exception {
     AtomicBoolean closed = new AtomicBoolean(false);
-    CloseableResource<Foo> original = CloseableResource.of(new Foo(), (unused) -> closed.set(true));
+    CloseableResource<Foo> original = CloseableResource.of(new Foo(), unused -> closed.set(true));
     CloseableResource<Foo> transferred = original.transfer();
     transferred.close();
     assertThat(closed.get(), is(true));
@@ -91,7 +91,7 @@ public class CloseableResourceTest {
 
   @Test
   public void cannotTransferClosed() throws Exception {
-    CloseableResource<Foo> foo = CloseableResource.of(new Foo(), (unused) -> {});
+    CloseableResource<Foo> foo = CloseableResource.of(new Foo(), unused -> {});
     foo.close();
     thrown.expect(IllegalStateException.class);
     foo.transfer();
@@ -99,7 +99,7 @@ public class CloseableResourceTest {
 
   @Test
   public void cannotTransferTwice() {
-    CloseableResource<Foo> foo = CloseableResource.of(new Foo(), (unused) -> {});
+    CloseableResource<Foo> foo = CloseableResource.of(new Foo(), unused -> {});
     foo.transfer();
     thrown.expect(IllegalStateException.class);
     foo.transfer();

--- a/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/client/util/IOUtilsTest.java
+++ b/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/client/util/IOUtilsTest.java
@@ -33,7 +33,7 @@ public class IOUtilsTest {
   public void testOneIOException() throws IOException {
     IOUtils.forEach(
         Arrays.asList(1, 2, 3),
-        (i) -> {
+        i -> {
           if (i == 2) {
             throw new IOException("Number: " + i);
           }
@@ -45,7 +45,7 @@ public class IOUtilsTest {
     try {
       IOUtils.forEach(
           Arrays.asList(1, 2, 3),
-          (i) -> {
+          i -> {
             throw new IOException("Number: " + i);
           });
     } catch (Exception e) {
@@ -60,7 +60,7 @@ public class IOUtilsTest {
 
     IOUtils.forEach(
         Stream.of(1, 2, 3),
-        (i) -> {
+        i -> {
           if (i == 2) {
             throw new IOException("Number: " + i);
           }

--- a/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/docs/DocumentationExamplesTest.java
+++ b/sdks/java/extensions/euphoria/src/test/java/org/apache/beam/sdk/extensions/euphoria/core/docs/DocumentationExamplesTest.java
@@ -214,7 +214,7 @@ public class DocumentationExamplesTest {
     options.as(KryoOptions.class).setKryoRegistrationRequired(true);
 
     KryoCoderProvider.of(
-            (kryo) -> { //KryoRegistrar of your uwn
+            kryo -> { //KryoRegistrar of your uwn
               kryo.register(KryoSerializedElementType.class); //other may follow
             })
         .registerTo(pipeline);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/DoFnPTransformRunnerFactory.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/DoFnPTransformRunnerFactory.java
@@ -130,7 +130,7 @@ abstract class DoFnPTransformRunnerFactory<
               .getTimeDomain();
       pCollectionIdsToConsumers.put(
           pTransform.getInputsOrThrow(localName),
-          (timer) ->
+          timer ->
               runner.processTimer(localName, timeDomain, (WindowedValue<KV<Object, Timer>>) timer));
     }
 

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -243,8 +243,7 @@ public class JdbcIOTest implements Serializable {
                 .withDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create(dataSource))
                 .withQuery(String.format("select name,id from %s where name = ?", readTableName))
                 .withStatementPreparator(
-                    (preparedStatement) ->
-                        preparedStatement.setString(1, TestRow.getNameForSeed(1)))
+                    preparedStatement -> preparedStatement.setString(1, TestRow.getNameForSeed(1)))
                 .withRowMapper(new JdbcTestHelper.CreateTestRowOfNameAndId())
                 .withCoder(SerializableCoder.of(TestRow.class)));
 


### PR DESCRIPTION
Brackets are optional with lambdas when we have a single parameter, removing them makes the code more concise and readable.