### PR TITLE
[BEAM-5932] Re-enable Beam SDK deprecation warnings.

### DIFF
--- a/sdks/python/apache_beam/utils/annotations.py
+++ b/sdks/python/apache_beam/utils/annotations.py
@@ -88,6 +88,14 @@ from functools import partial
 from functools import wraps
 
 
+class BeamDeprecationWarning(DeprecationWarning):
+  """Beam-specific deprecation warnings."""
+
+
+# Don't ignore BeamDeprecationWarnings.
+warnings.simplefilter('once', BeamDeprecationWarning)
+
+
 def annotate(label, since, current, extra_message, custom_message=None):
   """Decorates an API with a deprecated or experimental annotation.
 
@@ -114,7 +122,7 @@ def annotate(label, since, current, extra_message, custom_message=None):
     @wraps(fnc)
     def inner(*args, **kwargs):
       if label == 'deprecated':
-        warning_type = DeprecationWarning
+        warning_type = BeamDeprecationWarning
       else:
         warning_type = FutureWarning
       if custom_message is None:

--- a/sdks/python/apache_beam/utils/annotations_test.py
+++ b/sdks/python/apache_beam/utils/annotations_test.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import
 import unittest
 import warnings
 
+from apache_beam.utils.annotations import BeamDeprecationWarning
 from apache_beam.utils.annotations import deprecated
 from apache_beam.utils.annotations import experimental
 
@@ -31,13 +32,10 @@ class AnnotationTests(unittest.TestCase):
       @deprecated(since='v.1', current='multiply', extra_message='Do this')
       def fnc_test_deprecated_with_since_current_message():
         return 'lol'
-      # Deprecation warnings are ignored by default, turn them on
-      # to enable testing.
-      warnings.simplefilter("always", DeprecationWarning)
       fnc_test_deprecated_with_since_current_message()
       self.check_annotation(
           warning=w,
-          warning_type=DeprecationWarning,
+          warning_type=BeamDeprecationWarning,
           obj_name='fnc_test_deprecated_with_since_current_message',
           annotation_type='deprecated',
           label_check_list=[('since', True),
@@ -49,12 +47,9 @@ class AnnotationTests(unittest.TestCase):
       @deprecated(since='v.1', current='multiply')
       def fnc_test_deprecated_with_since_current():
         return 'lol'
-      # Deprecation warnings are ignored by default, turn them on
-      # to enable testing.
-      warnings.simplefilter("once", DeprecationWarning)
       fnc_test_deprecated_with_since_current()
       self.check_annotation(warning=w,
-                            warning_type=DeprecationWarning,
+                            warning_type=BeamDeprecationWarning,
                             obj_name='fnc_test_deprecated_with_since_current',
                             annotation_type='deprecated',
                             label_check_list=[('since', True),
@@ -65,12 +60,9 @@ class AnnotationTests(unittest.TestCase):
       @deprecated(since='v.1')
       def fnc_test_deprecated_without_current():
         return 'lol'
-      # Deprecation warnings are ignored by default, turn them on
-      # to enable testing.
-      warnings.simplefilter("once", DeprecationWarning)
       fnc_test_deprecated_without_current()
       self.check_annotation(warning=w,
-                            warning_type=DeprecationWarning,
+                            warning_type=BeamDeprecationWarning,
                             obj_name='fnc_test_deprecated_without_current',
                             annotation_type='deprecated',
                             label_check_list=[('since', True),
@@ -133,7 +125,7 @@ class AnnotationTests(unittest.TestCase):
                             annotation_type='experimental',
                             label_check_list=[('instead', False)])
 
-  def test_decapreted_custom_no_replacements(self):
+  def test_deprecated_custom_no_replacements(self):
     """Tests if custom message prints an empty string
     for each replacement token when only the
     custom_message and since parameter are given."""
@@ -144,12 +136,9 @@ class AnnotationTests(unittest.TestCase):
       @deprecated(since=strSince, custom_message=strCustom)
       def fnc_test_experimental_custom_no_replacements():
         return 'lol'
-      # Deprecation warnings are ignored by default, turn them on
-      # to enable testing.
-      warnings.simplefilter("always", DeprecationWarning)
       fnc_test_experimental_custom_no_replacements()
       self.check_custom_annotation(warning=w,
-                                   warning_type=DeprecationWarning,
+                                   warning_type=BeamDeprecationWarning,
                                    obj_name='fnc_test_experimental_custom_no_\
                                    replacements',
                                    annotation_type='experimental',
@@ -185,13 +174,10 @@ class AnnotationTests(unittest.TestCase):
                   custom_message=strCustom)
       def fnc_test_deprecated_with_since_current_message_custom():
         return 'lol'
-      # Deprecation warnings are ignored by default, turn them
-      # on to enable testing.
-      warnings.simplefilter("always", DeprecationWarning)
       strName = fnc_test_deprecated_with_since_current_message_custom .__name__
       fnc_test_deprecated_with_since_current_message_custom()
       self.check_custom_annotation(warning=w,
-                                   warning_type=DeprecationWarning,
+                                   warning_type=BeamDeprecationWarning,
                                    obj_name='fnc_test_deprecated_with_since_\
                                    current_message_custom',
                                    annotation_type='deprecated',
@@ -213,15 +199,11 @@ class AnnotationTests(unittest.TestCase):
         def foo(self):
           return 'lol'
 
-      # Deprecation warnings are ignored by default, turn them
-      # on to enable testing.
-      warnings.simplefilter("always", DeprecationWarning)
-
       foo = Class_test_deprecated_with_since_current_message()
       strName = Class_test_deprecated_with_since_current_message.__name__
       foo.foo()
       self.check_annotation(warning=w,
-                            warning_type=DeprecationWarning,
+                            warning_type=BeamDeprecationWarning,
                             obj_name=strName,
                             annotation_type='deprecated',
                             label_check_list=[('since', True),
@@ -239,10 +221,6 @@ class AnnotationTests(unittest.TestCase):
                     custom_message=strCustom)
       def fnc_test_experimental_with_current_message_custom():
         return 'lol'
-
-      # Deprecation warnings are ignored by default, turn them
-      # on to enable testing.
-      warnings.simplefilter("always", DeprecationWarning)
 
       strName = fnc_test_experimental_with_current_message_custom.__name__
       fnc_test_experimental_with_current_message_custom()


### PR DESCRIPTION
Deprecation warnings from Beam SDK were removed in https://github.com/apache/beam/pull/6687.

CC: @tvalentyn @HuangLED 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




