### PR TITLE
[BEAM-5931] Update nexmark performance test with dataflow worker jar

### DIFF
--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -24,7 +24,7 @@ description = "Apache Beam :: SDKs :: Java :: Nexmark"
 /*
  * We need to rely on manually specifying these evaluationDependsOn to ensure that
  * the following projects are evaluated before we evaluate this project. This is because
- * we are attempting to reference the "sourceSets.test.output" directly.
+ * we are attempting to reference a property from the project directly.
  */
 evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
 

--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -21,11 +21,16 @@ applyJavaNature()
 
 description = "Apache Beam :: SDKs :: Java :: Nexmark"
 
+/*
+ * We need to rely on manually specifying these evaluationDependsOn to ensure that
+ * the following projects are evaluated before we evaluate this project. This is because
+ * we are attempting to reference the "sourceSets.test.output" directly.
+ */
+evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
+
 // When running via Gradle, this property can be used to pass commandline arguments
 // to the nexmark launch
 def nexmarkArgsProperty = "nexmark.args"
-def nexmarkArgs = project.hasProperty(nexmarkArgsProperty) ?
-    project.getProperty(nexmarkArgsProperty).split() : []
 
 // When running via Gradle, this property sets the runner dependency
 def nexmarkRunnerProperty = "nexmark.runner"
@@ -98,7 +103,16 @@ if (shouldProvideSpark) {
 //   -Pnexmark.args
 //       Specify the command line for invoking org.apache.beam.sdk.nexmark.Main
 task run(type: JavaExec) {
+  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
+  // Provide job with a customizable worker jar.
+  // With legacy worker jar, containerImage is set to empty (i.e. to use the internal build).
+  // More context and discussions can be found in PR#6694.
+  def nexmarkArgsStr =  (project.findProperty(nexmarkArgsProperty) ?: "") +
+          " --dataflowWorkerJar=${dataflowWorkerJar} " +
+          " --workerHarnessContainerImage="
+
   main = "org.apache.beam.sdk.nexmark.Main"
   classpath = configurations.gradleRun
-  args nexmarkArgs
+  args nexmarkArgsStr.split()
 }

--- a/sdks/java/testing/nexmark/build.gradle
+++ b/sdks/java/testing/nexmark/build.gradle
@@ -21,23 +21,25 @@ applyJavaNature()
 
 description = "Apache Beam :: SDKs :: Java :: Nexmark"
 
-/*
- * We need to rely on manually specifying these evaluationDependsOn to ensure that
- * the following projects are evaluated before we evaluate this project. This is because
- * we are attempting to reference a property from the project directly.
- */
-evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
-
 // When running via Gradle, this property can be used to pass commandline arguments
 // to the nexmark launch
 def nexmarkArgsProperty = "nexmark.args"
 
 // When running via Gradle, this property sets the runner dependency
 def nexmarkRunnerProperty = "nexmark.runner"
-def nexmarkRunnerDependency = (project.hasProperty(nexmarkRunnerProperty)
-        ? project.getProperty(nexmarkRunnerProperty)
-        : ":beam-runners-direct-java")
+def nexmarkRunnerDependency = project.findProperty(nexmarkRunnerProperty)
+        ?: ":beam-runners-direct-java"
 def shouldProvideSpark = ":beam-runners-spark".equals(nexmarkRunnerDependency)
+def isDataflowRunner = ":beam-runners-google-cloud-dataflow-java".equals(nexmarkRunnerDependency)
+
+if (isDataflowRunner) {
+  /*
+   * We need to rely on manually specifying these evaluationDependsOn to ensure that
+   * the following projects are evaluated before we evaluate this project. This is because
+   * we are attempting to reference a property from the project directly.
+   */
+  evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
+}
 
 configurations {
   // A configuration for running the Nexmark launcher directly from Gradle, which
@@ -103,14 +105,19 @@ if (shouldProvideSpark) {
 //   -Pnexmark.args
 //       Specify the command line for invoking org.apache.beam.sdk.nexmark.Main
 task run(type: JavaExec) {
-  dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
-  def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
-  // Provide job with a customizable worker jar.
-  // With legacy worker jar, containerImage is set to empty (i.e. to use the internal build).
-  // More context and discussions can be found in PR#6694.
-  def nexmarkArgsStr =  (project.findProperty(nexmarkArgsProperty) ?: "") +
+  def nexmarkArgsStr =  project.findProperty(nexmarkArgsProperty) ?: ""
+
+  if (isDataflowRunner) {
+    dependsOn ":beam-runners-google-cloud-dataflow-java-legacy-worker:shadowJar"
+
+    def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-legacy-worker").shadowJar.archivePath
+    // Provide job with a customizable worker jar.
+    // With legacy worker jar, containerImage is set to empty (i.e. to use the internal build).
+    // More context and discussions can be found in PR#6694.
+    nexmarkArgsStr = nexmarkArgsStr +
           " --dataflowWorkerJar=${dataflowWorkerJar} " +
           " --workerHarnessContainerImage="
+  }
 
   main = "org.apache.beam.sdk.nexmark.Main"
   classpath = configurations.gradleRun


### PR DESCRIPTION
Add worker jars to Nexmark performance test via pipeline options. 


Following local run succeeded (by taking one target out of beam_PostCommit_Java_Nexmark_Dataflow) :

./gradlew :beam-sdks-java-nexmark:run \
  -Pnexmark.runner=":beam-runners-google-cloud-dataflow-java" \
  -Pnexmark.args=" \
     --bigQueryTable=nexmark \
	 --bigQueryDataset=nexmark \
	 --project=$PROJECT \
	 --resourceNameMode=QUERY_RUNNER_AND_MODE \
	 --exportSummaryToBigQuery=true \
	 --tempLocation=$GCS_LOCATION \
	 --runner=DataflowRunner \
	 --numWorkers=4 \
	 --maxNumWorkers=4 \
	 --autoscalingAlgorithm=NONE \
	 --nexmarkParallel=16 \
	 --streaming=true \
	 --suite=STRESS \
	 --manageResources=false \
	 --monitorJobs=true \
	 --enforceEncodability=true \
	 --enforceImmutability=true \
  "

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




