### PR TITLE
[BEAM-6005] PCollectionCustomCoderTest updates to fix test to actually function.

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/PCollectionCustomCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/PCollectionCustomCoderTest.java
@@ -53,7 +53,6 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /** Tests for coder exception handling in runners. */
 @RunWith(JUnit4.class)
 public class PCollectionCustomCoderTest {
@@ -264,9 +263,11 @@ public class PCollectionCustomCoderTest {
 
     // Create input.
     PCollection<String> customCoderPC =
-        pipeline.begin()
-        .apply("ReadStrings", Create.of(pipelineContents)).setCoder(coder)
-        .apply(Reshuffle.viaRandomKey());
+        pipeline
+            .begin()
+            .apply("ReadStrings", Create.of(pipelineContents))
+            .setCoder(coder)
+            .apply(Reshuffle.viaRandomKey());
     PCollection<String> fixedCoderPC =
         customCoderPC.apply("Identity", ParDo.of(new IdentityDoFn()));
     fixedCoderPC.setCoder(StringUtf8Coder.of());
@@ -295,7 +296,7 @@ public class PCollectionCustomCoderTest {
     private ContentReader(Iterable<String> expected) {
       ArrayList<String> ret = new ArrayList<>();
       for (String t : expected) {
-          ret.add(t);
+        ret.add(t);
       }
       this.expected = ret.toArray(new String[ret.size()]);
     }
@@ -332,8 +333,7 @@ public class PCollectionCustomCoderTest {
 
     @Override
     public void describeTo(Description descr) {
-        descr.appendText("exception with text matching: " + expectedError);
+      descr.appendText("exception with text matching: " + expectedError);
     }
   }
 }
-

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/PCollectionCustomCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/PCollectionCustomCoderTest.java
@@ -17,7 +17,8 @@
  */
 package org.apache.beam.sdk.coders;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
+import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,26 +26,37 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFn.ProcessContext;
+import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /** Tests for coder exception handling in runners. */
 @RunWith(JUnit4.class)
 public class PCollectionCustomCoderTest {
+  private static final Logger LOG = LoggerFactory.getLogger(PCollectionCustomCoderTest.class);
   /**
    * A custom test coder that can throw various exceptions during:
    *
@@ -58,7 +70,8 @@ public class PCollectionCustomCoderTest {
   static final String NULL_POINTER_EXCEPTION = "java.lang.NullPointerException";
   static final String EXCEPTION_MESSAGE = "Super Unique Message!!!";
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+  @Rule public final transient ExpectedException thrown = ExpectedException.none();
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
 
   /** Wrapper of StringUtf8Coder with customizable exception-throwing. */
   public static class CustomTestCoder extends CustomCoder<String> {
@@ -148,104 +161,164 @@ public class PCollectionCustomCoderTest {
   @Test
   @Category(NeedsRunner.class)
   public void testDecodingIOException() throws Exception {
-    thrown.expect(Exception.class);
-    thrown.expectCause(instanceOf(IOException.class));
     Pipeline p =
-        runPipelineWith(new CustomTestCoder(IO_EXCEPTION, null, null, null, EXCEPTION_MESSAGE));
+        pipelineWith(new CustomTestCoder(IO_EXCEPTION, null, null, null, EXCEPTION_MESSAGE));
 
+    thrown.expect(new ExceptionMatcher("java.io.IOException: Super Unique Message!!!"));
     p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testDecodingNPException() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("java.lang.NullPointerException: Super Unique Message!!!");
-
     Pipeline p =
-        runPipelineWith(
+        pipelineWith(
             new CustomTestCoder(NULL_POINTER_EXCEPTION, null, null, null, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.lang.NullPointerException: Super Unique Message!!!"));
+
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testEncodingIOException() throws Exception {
-    thrown.expect(Exception.class);
-    thrown.expectCause(instanceOf(IOException.class));
-
     Pipeline p =
-        runPipelineWith(new CustomTestCoder(null, IO_EXCEPTION, null, null, EXCEPTION_MESSAGE));
+        pipelineWith(new CustomTestCoder(null, IO_EXCEPTION, null, null, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.io.IOException: Super Unique Message!!!"));
+
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testEncodingNPException() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("java.lang.NullPointerException: Super Unique Message!!!");
     Pipeline p =
-        runPipelineWith(
+        pipelineWith(
             new CustomTestCoder(null, NULL_POINTER_EXCEPTION, null, null, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.lang.NullPointerException: Super Unique Message!!!"));
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testSerializationIOException() throws Exception {
-    thrown.expect(Exception.class);
-    thrown.expectCause(instanceOf(IOException.class));
     Pipeline p =
-        runPipelineWith(new CustomTestCoder(null, null, IO_EXCEPTION, null, EXCEPTION_MESSAGE));
+        pipelineWith(new CustomTestCoder(null, null, IO_EXCEPTION, null, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.io.IOException: Super Unique Message!!!"));
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testSerializationNPException() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("java.lang.NullPointerException: Super Unique Message!!!");
-
     Pipeline p =
-        runPipelineWith(
+        pipelineWith(
             new CustomTestCoder(null, null, NULL_POINTER_EXCEPTION, null, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.lang.NullPointerException: Super Unique Message!!!"));
+
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testDeserializationIOException() throws Exception {
-    thrown.expect(Exception.class);
-    thrown.expectCause(instanceOf(IOException.class));
     Pipeline p =
-        runPipelineWith(new CustomTestCoder(null, null, null, IO_EXCEPTION, EXCEPTION_MESSAGE));
+        pipelineWith(new CustomTestCoder(null, null, null, IO_EXCEPTION, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.io.IOException: Super Unique Message!!!"));
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testDeserializationNPException() throws Exception {
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("java.lang.NullPointerException: Super Unique Message!!!");
-
     Pipeline p =
-        runPipelineWith(
+        pipelineWith(
             new CustomTestCoder(null, null, null, NULL_POINTER_EXCEPTION, EXCEPTION_MESSAGE));
+    thrown.expect(new ExceptionMatcher("java.lang.NullPointerException: Super Unique Message!!!"));
+    p.run().waitUntilFinish();
   }
 
   @Test
   @Category(NeedsRunner.class)
   public void testNoException() throws Exception {
-    Pipeline p = runPipelineWith(new CustomTestCoder(null, null, null, null, null));
+    Pipeline p = pipelineWith(new CustomTestCoder(null, null, null, null, null));
+    p.run().waitUntilFinish();
   }
 
-  public static Pipeline runPipelineWith(CustomTestCoder coder) throws Exception {
-    PipelineOptions options = PipelineOptionsFactory.fromArgs().as(PipelineOptions.class);
-
+  public Pipeline pipelineWith(CustomTestCoder coder) throws Exception {
     List<String> pipelineContents =
         Arrays.asList("String", "Testing", "Custom", "Coder", "In", "Beam");
 
     // Create input.
-    Pipeline pipeline = TestPipeline.create(options);
     PCollection<String> customCoderPC =
-        pipeline.begin().apply("ReadStrings", Create.of(pipelineContents)).setCoder(coder);
-    PAssert.that(customCoderPC).containsInAnyOrder(pipelineContents);
-    pipeline.run().waitUntilFinish();
+        pipeline.begin()
+        .apply("ReadStrings", Create.of(pipelineContents))
+        .apply(Reshuffle.viaRandomKey());
+    customCoderPC.setCoder(coder);
+    PCollection<String> fixedCoderPC =
+        customCoderPC.apply("Identity", ParDo.of(new IdentityDoFn()));
+    fixedCoderPC.setCoder(StringUtf8Coder.of());
+    ContentReader r = ContentReader.elementsEqual(pipelineContents);
+    // PAssert.that relies on
+    PAssert.that(fixedCoderPC).satisfies(r);
 
     return pipeline;
   }
+
+  static class IdentityDoFn extends DoFn<String, String> {
+    @ProcessElement
+    public void process(ProcessContext c) {
+      c.output(c.element());
+    }
+  }
+
+  static class ContentReader implements SerializableFunction<Iterable<String>, Void> {
+    private final String[] expected;
+
+    public static ContentReader elementsEqual(Iterable<String> expected) {
+      return new ContentReader(expected);
+    }
+
+    private ContentReader(Iterable<String> expected) {
+      ArrayList<String> ret = new ArrayList<>();
+      for (String t : expected) {
+          ret.add(t);
+      }
+      this.expected = ret.toArray(new String[ret.size()]);
+    }
+
+    @Override
+    public Void apply(Iterable<String> contents) {
+      assertThat(contents, containsInAnyOrder(expected));
+      return null;
+    }
+  }
+
+  static class ExceptionMatcher extends BaseMatcher<Object> {
+    private String expectedError;
+
+    public ExceptionMatcher(String expected) {
+      this.expectedError = expected;
+    }
+
+    @Override
+    public boolean matches(Object result) {
+      Throwable cause = ((Throwable) result).getCause();
+      while (null != cause) {
+        String causeString = cause.toString();
+        if (causeString.contains(expectedError)) {
+          return true;
+        }
+        cause = cause.getCause();
+      }
+
+      return false;
+    }
+
+    @Override
+    public void describeTo(Description descr) {
+        descr.appendText("exception with text matching: " + expectedError);
+    }
+  }
 }
+


### PR DESCRIPTION
PCollectionCustomCoderTest had a series of problems where the exceptions it was expecting to trigger happened prematurely but due to how the test was written the exceptions were swallowed and the test passed. This PR fixes these tests to pass.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




