### PR TITLE
Fix usage of __eq__ to add corresponding __ne__

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -218,6 +218,10 @@ class Coder(object):
             and self._dict_without_impl() == other._dict_without_impl())
   # pylint: enable=protected-access
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(type(self))
 

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -94,6 +94,10 @@ class DummyClass(object):
       return True
     return False
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(type(self))
 

--- a/sdks/python/apache_beam/coders/typecoders_test.py
+++ b/sdks/python/apache_beam/coders/typecoders_test.py
@@ -35,6 +35,10 @@ class CustomClass(object):
   def __eq__(self, other):
     return self.number == other.number
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return self.number
 

--- a/sdks/python/apache_beam/internal/util.py
+++ b/sdks/python/apache_beam/internal/util.py
@@ -54,6 +54,10 @@ class ArgumentPlaceholder(object):
     """
     return isinstance(other, ArgumentPlaceholder)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(type(self))
 

--- a/sdks/python/apache_beam/io/concat_source_test.py
+++ b/sdks/python/apache_beam/io/concat_source_test.py
@@ -83,6 +83,7 @@ class RangeSource(iobase.BoundedSource):
             and self._split_freq == other._split_freq)
 
   def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
     return not self == other
 
 

--- a/sdks/python/apache_beam/io/filebasedsink.py
+++ b/sdks/python/apache_beam/io/filebasedsink.py
@@ -374,6 +374,10 @@ class FileBasedSink(iobase.Sink):
     # pylint: disable=unidiomatic-typecheck
     return type(self) == type(other) and self.__dict__ == other.__dict__
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
 
 class FileBasedSinkWriter(iobase.Writer):
   """The writer for FileBasedSink.

--- a/sdks/python/apache_beam/io/filesystem.py
+++ b/sdks/python/apache_beam/io/filesystem.py
@@ -403,7 +403,8 @@ class FileMetadata(object):
     return hash((self.path, self.size_in_bytes))
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return 'FileMetadata(%s, %s)' % (self.path, self.size_in_bytes)

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -77,6 +77,10 @@ class PubsubMessage(object):
         self.data == other.data and
         self.attributes == other.attributes)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __repr__(self):
     return 'PubsubMessage(%s, %s)' % (self.data, self.attributes)
 

--- a/sdks/python/apache_beam/io/hadoopfilesystem_test.py
+++ b/sdks/python/apache_beam/io/hadoopfilesystem_test.py
@@ -52,6 +52,10 @@ class FakeFile(io.BytesIO):
   def __eq__(self, other):
     return self.stat == other.stat and self.getvalue() == self.getvalue()
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def close(self):
     self.saved_data = self.getvalue()
     io.BytesIO.close(self)

--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -42,6 +42,10 @@ class OffsetRange(object):
 
     return self.start == other.start and self.stop == other.stop
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash((type(self), self.start, self.stop))
 

--- a/sdks/python/apache_beam/io/vcfio.py
+++ b/sdks/python/apache_beam/io/vcfio.py
@@ -125,6 +125,10 @@ class Variant(object):
     return (isinstance(other, Variant) and
             vars(self) == vars(other))
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __repr__(self):
     return ', '.join(
         [str(s) for s in [self.reference_name,
@@ -218,6 +222,10 @@ class VariantCall(object):
   def __eq__(self, other):
     return ((self.name, self.genotype, self.phaseset, self.info) ==
             (other.name, other.genotype, other.phaseset, other.info))
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return ', '.join(

--- a/sdks/python/apache_beam/metrics/cells.py
+++ b/sdks/python/apache_beam/metrics/cells.py
@@ -276,7 +276,8 @@ class DistributionResult(object):
     return hash(self.data)
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return '<DistributionResult(sum={}, count={}, min={}, max={})>'.format(
@@ -326,7 +327,8 @@ class GaugeResult(object):
     return hash(self.data)
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return '<GaugeResult(value={}, timestamp={})>'.format(
@@ -363,7 +365,8 @@ class GaugeData(object):
     return hash((self.value, self.timestamp))
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return '<GaugeData(value={}, timestamp={})>'.format(
@@ -434,7 +437,8 @@ class DistributionData(object):
     return hash((self.sum, self.count, self.min, self.max))
 
   def __ne__(self, other):
-    return not self.__eq__(other)
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __repr__(self):
     return '<DistributionData(sum={}, count={}, min={}, max={})>'.format(

--- a/sdks/python/apache_beam/metrics/execution.py
+++ b/sdks/python/apache_beam/metrics/execution.py
@@ -65,6 +65,10 @@ class MetricKey(object):
     return (self.step == other.step and
             self.metric == other.metric)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash((self.step, self.metric))
 
@@ -106,6 +110,10 @@ class MetricResult(object):
     return (self.key == other.key and
             self.committed == other.committed and
             self.attempted == other.attempted)
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __hash__(self):
     return hash((self.key, self.committed, self.attempted))

--- a/sdks/python/apache_beam/metrics/metricbase.py
+++ b/sdks/python/apache_beam/metrics/metricbase.py
@@ -66,6 +66,10 @@ class MetricName(object):
     return (self.namespace == other.namespace and
             self.name == other.name)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __str__(self):
     return 'MetricName(namespace={}, name={})'.format(
         self.namespace, self.name)

--- a/sdks/python/apache_beam/options/value_provider.py
+++ b/sdks/python/apache_beam/options/value_provider.py
@@ -69,6 +69,10 @@ class StaticValueProvider(ValueProvider):
         return True
     return False
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash((type(self), self.value_type, self.value))
 

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -122,6 +122,10 @@ class PCollection(PValue):
     if isinstance(other, PCollection):
       return self.tag == other.tag and self.producer == other.producer
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash((self.tag, self.producer))
 

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -62,6 +62,7 @@ class NameContext(object):
     return self.step_name == other.step_name
 
   def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
     return not self == other
 
   def __repr__(self):
@@ -104,6 +105,7 @@ class DataflowNameContext(NameContext):
             self.system_name == other.system_name)
 
   def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
     return not self == other
 
   def __hash__(self):

--- a/sdks/python/apache_beam/runners/interactive/pipeline_analyzer.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_analyzer.py
@@ -433,6 +433,10 @@ class PipelineInfo(object):
         return (self._inputs == other._inputs and
                 self._transform_info == other._transform_info)
 
+    def __ne__(self, other):
+      # TODO(BEAM-5949): Needed for Python 2 compatibility.
+      return not self == other
+
     def __hash__(self):
       if self._hash is None:
         self._hash = (hash(tuple(sorted(self._transform_info.items())))

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -62,6 +62,10 @@ class Event(with_metaclass(ABCMeta, object)):
   def __lt__(self, other):
     raise NotImplementedError
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
 
 class ElementEvent(Event):
   """Element-producing test stream event."""
@@ -71,9 +75,6 @@ class ElementEvent(Event):
 
   def __eq__(self, other):
     return self.timestamped_values == other.timestamped_values
-
-  def __ne__(self, other):
-    return not self == other
 
   def __hash__(self):
     return hash(self.timestamped_values)
@@ -91,9 +92,6 @@ class WatermarkEvent(Event):
   def __eq__(self, other):
     return self.new_watermark == other.new_watermark
 
-  def __ne__(self, other):
-    return not self == other
-
   def __hash__(self):
     return hash(self.new_watermark)
 
@@ -109,9 +107,6 @@ class ProcessingTimeEvent(Event):
 
   def __eq__(self, other):
     return self.advance_by == other.advance_by
-
-  def __ne__(self, other):
-    return not self == other
 
   def __hash__(self):
     return hash(self.advance_by)

--- a/sdks/python/apache_beam/testing/util.py
+++ b/sdks/python/apache_beam/testing/util.py
@@ -70,6 +70,10 @@ def contains_in_any_order(iterable):
     def __eq__(self, other):
       return self._counter == collections.Counter(other)
 
+    def __ne__(self, other):
+      # TODO(BEAM-5949): Needed for Python 2 compatibility.
+      return not self == other
+
     def __hash__(self):
       return hash(self._counter)
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -296,6 +296,10 @@ class _DoFnParam(object):
       return self.param_id == other.param_id
     return False
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(self.param_id)
 
@@ -1772,6 +1776,10 @@ class Windowing(object):
           and self.accumulation_mode == other.accumulation_mode
           and self.timestamp_combiner == other.timestamp_combiner)
     return False
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __hash__(self):
     return hash((self.windowfn, self.accumulation_mode,

--- a/sdks/python/apache_beam/transforms/cy_combiners.py
+++ b/sdks/python/apache_beam/transforms/cy_combiners.py
@@ -58,6 +58,10 @@ class AccumulatorCombineFn(core.CombineFn):
     return (isinstance(other, AccumulatorCombineFn)
             and self._accumulator_type is other._accumulator_type)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(self._accumulator_type)
 

--- a/sdks/python/apache_beam/transforms/display.py
+++ b/sdks/python/apache_beam/transforms/display.py
@@ -280,6 +280,7 @@ class DisplayDataItem(object):
     return False
 
   def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
     return not self == other
 
   def __hash__(self):

--- a/sdks/python/apache_beam/transforms/trigger.py
+++ b/sdks/python/apache_beam/transforms/trigger.py
@@ -233,6 +233,10 @@ class TriggerFn(with_metaclass(ABCMeta, object)):
   def to_runner_api(self, unused_context):
     pass
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
 
 class DefaultTrigger(TriggerFn):
   """Semantically Repeatedly(AfterWatermark()), but more optimized."""
@@ -993,6 +997,7 @@ class _UnwindowedValues(observable.ObservableMixin):
     return hash(tuple(self))
 
   def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
     return not self == other
 
 

--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -94,6 +94,10 @@ class Const(object):
   def __eq__(self, other):
     return isinstance(other, Const) and self.value == other.value
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash(self.value)
 
@@ -123,6 +127,10 @@ class FrameState(object):
 
   def __eq__(self, other):
     return isinstance(other, FrameState) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __hash__(self):
     return hash(tuple(sorted(self.__dict__.items())))

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -178,6 +178,10 @@ class TypeConstraint(object):
       else:
         visitor(t, visitor_arg)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
 
 def match_type_variables(type_constraint, concrete_type):
   if isinstance(type_constraint, TypeConstraint):

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -152,6 +152,10 @@ class Timestamp(object):
       other = Timestamp.of(other)
     return self.micros == other.micros
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __lt__(self, other):
     # Allow comparisons between Duration and Timestamp values.
     if not isinstance(other, Duration):
@@ -236,6 +240,10 @@ class Duration(object):
     if not isinstance(other, Timestamp):
       other = Duration.of(other)
     return self.micros == other.micros
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __lt__(self, other):
     # Allow comparisons between Duration and Timestamp values.

--- a/sdks/python/apache_beam/utils/windowed_value.py
+++ b/sdks/python/apache_beam/utils/windowed_value.py
@@ -113,6 +113,10 @@ class PaneInfo(object):
             self.index == other.index and
             self.nonspeculative_index == other.nonspeculative_index)
 
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
+
   def __hash__(self):
     return hash((self.is_first, self.is_last, self.timing, self.index,
                  self.nonspeculative_index))
@@ -188,6 +192,10 @@ class WindowedValue(object):
             and self.value == other.value
             and self.windows == other.windows
             and self.pane_info == other.pane_info)
+
+  def __ne__(self, other):
+    # TODO(BEAM-5949): Needed for Python 2 compatibility.
+    return not self == other
 
   def __hash__(self):
     return (hash(self.value) +


### PR DESCRIPTION
Apparently in Python 2, you still need to implement `__ne__` even if you've implemented `__eq__` (https://stackoverflow.com/questions/4352244/python-should-i-implement-ne-operator-based-on-eq).

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




