### PR TITLE
[BEAM-5778] Add integrations of Metrics API to Big Query for SyntheticcSources load tests in Python SDK

### DIFF
--- a/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/co_group_by_key_test.py
@@ -15,10 +15,25 @@
 # limitations under the License.
 #
 """
-To run test on DirectRunner
+This is CoGroupByKey load test with Synthetic Source. Besides of the standard
+input options there are additional options:
+* project (optional) - the gcp project in case of saving
+metrics in Big Query (in case of Dataflow Runner
+it is required to specify project of runner),
+* metrics_namespace (optional) - name of BigQuery table where metrics
+will be stored,
+in case of lack of any of both options metrics won't be saved
+* input_options - options for Synthetic Sources
+* co_input_options - options for  Synthetic Sources.
+
+Example test run on DirectRunner:
 
 python setup.py nosetests \
-    --test-pipeline-options="--input_options='{
+    --test-pipeline-options="
+      --project=big-query-project
+      --metrics_dataset=python_load_tests
+      --metrics_table=co_gbk
+      --input_options='{
         \"num_records\": 1000,
         \"key_size\": 5,
         \"value_size\":15,
@@ -32,7 +47,7 @@ python setup.py nosetests \
         \"bundle_size_distribution_type\": \"const\",
         \"bundle_size_distribution_param\": 1,
         \"force_initial_num_bundles\":0}'" \
-    --tests apache_beam.testing.load_tests.co_group_by_it_test
+    --tests apache_beam.testing.load_tests.co_group_by_key_test
 
 To run test on other runner (ex. Dataflow):
 
@@ -43,6 +58,8 @@ python setup.py nosetests \
         --staging_location=gs://...
         --temp_location=gs://...
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
+        --metrics_dataset=python_load_tests
+        --metrics_table=co_gbk
         --input_options='{
         \"num_records\": 1000,
         \"key_size\": 5,
@@ -59,7 +76,7 @@ python setup.py nosetests \
         \"bundle_size_distribution_param\": 1,
         \"force_initial_num_bundles\":0
         }'" \
-    --tests apache_beam.testing.load_tests.co_group_by_it_test
+    --tests apache_beam.testing.load_tests.co_group_by_key_test
 
 """
 
@@ -71,13 +88,21 @@ import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
-from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
 from apache_beam.testing.test_pipeline import TestPipeline
+
+try:
+  from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+  from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
+  from google.cloud import bigquery as bq
+except ImportError:
+  bq = None
 
 INPUT_TAG = 'pc1'
 CO_INPUT_TAG = 'pc2'
+RUNTIME_LABEL = 'runtime'
 
 
+@unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
 class CoGroupByKeyTest(unittest.TestCase):
 
   def parseTestPipelineOptions(self, options):
@@ -98,9 +123,29 @@ class CoGroupByKeyTest(unittest.TestCase):
 
   def setUp(self):
     self.pipeline = TestPipeline(is_integration_test=True)
-    self.inputOptions = json.loads(self.pipeline.get_option('input_options'))
-    self.coInputOptions = json.loads(
+    self.input_options = json.loads(self.pipeline.get_option('input_options'))
+    self.co_input_options = json.loads(
         self.pipeline.get_option('co_input_options'))
+
+    metrics_project_id = self.pipeline.get_option('project')
+    self.metrics_namespace = self.pipeline.get_option('metrics_table')
+    metrics_dataset = self.pipeline.get_option('metrics_dataset')
+    self.metrics_monitor = None
+    check = metrics_project_id and self.metrics_namespace and metrics_dataset\
+            is not None
+    if check:
+      measured_values = [{'name': RUNTIME_LABEL,
+                          'type': 'FLOAT',
+                          'mode': 'REQUIRED'}]
+      self.metrics_monitor = MetricsMonitor(
+          project_name=metrics_project_id,
+          table=self.metrics_namespace,
+          dataset=metrics_dataset,
+          schema_map=measured_values
+      )
+    else:
+      logging.error('One or more of parameters for collecting metrics '
+                    'are empty. Metrics will not be collected')
 
   class _Ungroup(beam.DoFn):
     def process(self, element):
@@ -117,30 +162,32 @@ class CoGroupByKeyTest(unittest.TestCase):
       pc1 = (p
              | 'Read ' + INPUT_TAG >> beam.io.Read(
                  synthetic_pipeline.SyntheticSource(
-                     self.parseTestPipelineOptions(self.inputOptions)))
+                     self.parseTestPipelineOptions(self.input_options)))
              | 'Make ' + INPUT_TAG + ' iterable' >> beam.Map(lambda x: (x, x))
+             | 'Measure time: Start pc1' >> beam.ParDo(
+                 MeasureTime(self.metrics_namespace))
             )
 
       pc2 = (p
              | 'Read ' + CO_INPUT_TAG >> beam.io.Read(
                  synthetic_pipeline.SyntheticSource(
-                     self.parseTestPipelineOptions(self.coInputOptions)))
+                     self.parseTestPipelineOptions(self.co_input_options)))
              | 'Make ' + CO_INPUT_TAG + ' iterable' >> beam.Map(
                  lambda x: (x, x))
+             | 'Measure time: Start pc2' >> beam.ParDo(
+                 MeasureTime(self.metrics_namespace))
             )
       # pylint: disable=expression-not-assigned
       ({INPUT_TAG: pc1, CO_INPUT_TAG: pc2}
        | 'CoGroupByKey: ' >> beam.CoGroupByKey()
        | 'Consume Joined Collections' >> beam.ParDo(self._Ungroup())
-       | 'Measure time' >> beam.ParDo(MeasureTime())
+       | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
       )
 
       result = p.run()
       result.wait_until_finish()
-      metrics = result.metrics().query()
-
-      for dist in metrics['distributions']:
-        logging.info("Distribution: %s", dist)
+      if self.metrics_monitor is not None:
+        self.metrics_monitor.send_metrics(result)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
+++ b/sdks/python/apache_beam/testing/load_tests/group_by_key_test.py
@@ -15,10 +15,24 @@
 # limitations under the License.
 #
 """
-To run test on DirectRunner
+This is GroupByKey load test with Synthetic Source. Besides of the standard
+input options there are additional options:
+* project (optional) - the gcp project in case of saving
+metrics in Big Query (in case of Dataflow Runner
+it is required to specify project of runner),
+* metrics_namespace (optional) - name of BigQuery table where metrics
+will be stored,
+in case of lack of any of both options metrics won't be saved
+* input_options - options for Synthetic Sources.
+
+Example test run on DirectRunner:
 
 python setup.py nosetests \
-    --test-pipeline-options="--input_options='{
+    --test-pipeline-options="
+    --project=big-query-project
+    --metrics_dataset=python_load_tests
+    --metrics_table=gbk
+    --input_options='{
     \"num_records\": 300,
     \"key_size\": 5,
     \"value_size\":15,
@@ -26,7 +40,7 @@ python setup.py nosetests \
     \"bundle_size_distribution_param\": 1,
     \"force_initial_num_bundles\": 0
     }'" \
-    --tests apache_beam.testing.load_tests.group_by_it_test
+    --tests apache_beam.testing.load_tests.group_by_key_test
 
 To run test on other runner (ex. Dataflow):
 
@@ -37,6 +51,8 @@ python setup.py nosetests \
         --staging_location=gs://...
         --temp_location=gs://...
         --sdk_location=./dist/apache-beam-x.x.x.dev0.tar.gz
+        --metrics_dataset=python_load_tests
+        --metrics_table=gbk
         --input_options='{
         \"num_records\": 1000,
         \"key_size\": 5,
@@ -45,7 +61,7 @@ python setup.py nosetests \
         \"bundle_size_distribution_param\": 1,
         \"force_initial_num_bundles\": 0
         }'" \
-    --tests apache_beam.testing.load_tests.group_by_it_test
+    --tests apache_beam.testing.load_tests.group_by_key_test
 
 """
 
@@ -57,30 +73,57 @@ import unittest
 
 import apache_beam as beam
 from apache_beam.testing import synthetic_pipeline
-from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
 from apache_beam.testing.test_pipeline import TestPipeline
 
+try:
+  from apache_beam.testing.load_tests.load_test_metrics_utils import MeasureTime
+  from apache_beam.testing.load_tests.load_test_metrics_utils import MetricsMonitor
+  from google.cloud import bigquery as bq
+except ImportError:
+  bq = None
 
+RUNTIME_LABEL = 'runtime'
+
+
+@unittest.skipIf(bq is None, 'BigQuery for storing metrics not installed')
 class GroupByKeyTest(unittest.TestCase):
   def parseTestPipelineOptions(self):
     return {
-        'numRecords': self.inputOptions.get('num_records'),
-        'keySizeBytes': self.inputOptions.get('key_size'),
-        'valueSizeBytes': self.inputOptions.get('value_size'),
+        'numRecords': self.input_options.get('num_records'),
+        'keySizeBytes': self.input_options.get('key_size'),
+        'valueSizeBytes': self.input_options.get('value_size'),
         'bundleSizeDistribution': {
-            'type': self.inputOptions.get(
+            'type': self.input_options.get(
                 'bundle_size_distribution_type', 'const'
             ),
-            'param': self.inputOptions.get('bundle_size_distribution_param', 0)
+            'param': self.input_options.get('bundle_size_distribution_param', 0)
         },
-        'forceNumInitialBundles': self.inputOptions.get(
+        'forceNumInitialBundles': self.input_options.get(
             'force_initial_num_bundles', 0
         )
     }
 
   def setUp(self):
     self.pipeline = TestPipeline(is_integration_test=True)
-    self.inputOptions = json.loads(self.pipeline.get_option('input_options'))
+    self.input_options = json.loads(self.pipeline.get_option('input_options'))
+
+    metrics_project_id = self.pipeline.get_option('project')
+    self.metrics_namespace = self.pipeline.get_option('metrics_table')
+    metrics_dataset = self.pipeline.get_option('metrics_dataset')
+    self.metrics_monitor = None
+    check = metrics_project_id and self.metrics_namespace and metrics_dataset \
+            is not None
+    if check:
+      schema = [{'name': RUNTIME_LABEL, 'type': 'FLOAT', 'mode': 'REQUIRED'}]
+      self.metrics_monitor = MetricsMonitor(
+          project_name=metrics_project_id,
+          table=self.metrics_namespace,
+          dataset=metrics_dataset,
+          schema_map=schema
+      )
+    else:
+      logging.error('One or more of parameters for collecting metrics '
+                    'are empty. Metrics will not be collected')
 
   def testGroupByKey(self):
     with self.pipeline as p:
@@ -88,17 +131,18 @@ class GroupByKeyTest(unittest.TestCase):
       (p
        | beam.io.Read(synthetic_pipeline.SyntheticSource(
            self.parseTestPipelineOptions()))
-       | 'Measure time' >> beam.ParDo(MeasureTime())
+       | 'Measure time: Start' >> beam.ParDo(
+           MeasureTime(self.metrics_namespace))
        | 'GroupByKey' >> beam.GroupByKey()
        | 'Ungroup' >> beam.FlatMap(
            lambda elm: [(elm[0], v) for v in elm[1]])
+       | 'Measure time: End' >> beam.ParDo(MeasureTime(self.metrics_namespace))
       )
 
       result = p.run()
       result.wait_until_finish()
-      metrics = result.metrics().query()
-      for dist in metrics['distributions']:
-        logging.info("Distribution: %s", dist)
+      if self.metrics_monitor is not None:
+        self.metrics_monitor.send_metrics(result)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
+++ b/sdks/python/apache_beam/testing/load_tests/load_test_metrics_utils.py
@@ -21,22 +21,177 @@ Utility functions used for integrating Metrics API into load tests pipelines.
 
 from __future__ import absolute_import
 
+import logging
 import time
 
 import apache_beam as beam
 from apache_beam.metrics import Metrics
 
+try:
+  from google.cloud import bigquery
+  from google.cloud.bigquery.schema import SchemaField
+  from google.cloud.exceptions import NotFound
+except ImportError:
+  bigquery = None
+  SchemaField = None
+  NotFound = None
+
+RUNTIME_LABEL = 'runtime'
+SUBMIT_TIMESTAMP_LABEL = 'submit_timestamp'
+
+
+def _get_schema_field(schema_field):
+  return SchemaField(
+      name=schema_field['name'],
+      field_type=schema_field['type'],
+      mode=schema_field['mode'])
+
+
+class BigQueryClient(object):
+  def __init__(self, project_name, table, dataset, schema_map):
+    self._namespace = table
+
+    self._bq_client = bigquery.Client(project=project_name)
+
+    schema = self._parse_schema(schema_map)
+    self._schema_names = self._get_schema_names(schema)
+    schema = self._prepare_schema(schema)
+
+    self._get_or_create_table(schema, dataset)
+
+  def match_and_save(self, result_list):
+    rows_tuple = tuple(self._match_inserts_by_schema(result_list))
+    self._insert_data(rows_tuple)
+
+  def _match_inserts_by_schema(self, insert_list):
+    for name in self._schema_names:
+      yield self._get_element_by_schema(name, insert_list)
+
+  def _get_element_by_schema(self, schema_name, insert_list):
+    for metric in insert_list:
+      if metric['label'] == schema_name:
+        return metric['value']
+    return None
+
+  def _insert_data(self, rows_tuple):
+    errors = self._bq_client.insert_rows(self._bq_table, rows=[rows_tuple])
+    if len(errors) > 0:
+      for err in errors:
+        logging.error(err['message'])
+        raise ValueError('Unable save rows in BigQuery.')
+
+  def _get_dataset(self, dataset_name):
+    bq_dataset_ref = self._bq_client.dataset(dataset_name)
+    try:
+      bq_dataset = self._bq_client.get_dataset(bq_dataset_ref)
+    except NotFound:
+      raise ValueError(
+          'Dataset {} does not exist in your project. '
+          'You have to create table first.'
+          .format(dataset_name))
+    return bq_dataset
+
+  def _get_or_create_table(self, bq_schemas, dataset):
+    if self._namespace == '':
+      raise ValueError('Namespace cannot be empty.')
+
+    dataset = self._get_dataset(dataset)
+    table_ref = dataset.table(self._namespace)
+
+    try:
+      self._bq_table = self._bq_client.get_table(table_ref)
+    except NotFound:
+      table = bigquery.Table(table_ref, schema=bq_schemas)
+      self._bq_table = self._bq_client.create_table(table)
+
+  def _parse_schema(self, schema_map):
+    return [{'name': SUBMIT_TIMESTAMP_LABEL,
+             'type': 'TIMESTAMP',
+             'mode': 'REQUIRED'}] + schema_map
+
+  def _prepare_schema(self, schemas):
+    return [_get_schema_field(schema) for schema in schemas]
+
+  def _get_schema_names(self, schemas):
+    return [schema['name'] for schema in schemas]
+
+
+class MetricsMonitor(object):
+  def __init__(self, project_name, table, dataset, schema_map):
+    if project_name is not None:
+      self.bq = BigQueryClient(project_name, table, dataset, schema_map)
+
+  def send_metrics(self, result):
+    metrics = result.metrics().query()
+    counters = metrics['counters']
+    counters_list = []
+    if len(counters) > 0:
+      counters_list = self._prepare_counter_metrics(counters)
+
+    distributions = metrics['distributions']
+    dist_list = []
+    if len(distributions) > 0:
+      dist_list = self._prepare_runtime_metrics(distributions)
+
+    timestamp = {'label': SUBMIT_TIMESTAMP_LABEL, 'value': time.time()}
+
+    insert_list = [timestamp] + dist_list + counters_list
+    self.bq.match_and_save(insert_list)
+
+  def _prepare_counter_metrics(self, counters):
+    for counter in counters:
+      logging.info("Counter:  %s", counter)
+    counters_list = []
+    for counter in counters:
+      counter_commited = counter.committed
+      counter_label = str(counter.key.metric.name)
+      counters_list.append(
+          {'label': counter_label, 'value': counter_commited})
+
+    return counters_list
+
+  def _prepare_runtime_metrics(self, distributions):
+    min_values = []
+    max_values = []
+    for dist in distributions:
+      logging.info("Distribution: %s", dist)
+      min_values.append(dist.committed.min)
+      max_values.append(dist.committed.max)
+    # finding real start
+    min_value = min(min_values)
+    # finding real end
+    max_value = max(max_values)
+
+    runtime_in_s = max_value - min_value
+    logging.info("Runtime: %s", runtime_in_s)
+    runtime_in_s = float(runtime_in_s)
+    return [{'label': RUNTIME_LABEL, 'value': runtime_in_s}]
+
 
 class MeasureTime(beam.DoFn):
-  def __init__(self):
-    self.runtime_start = Metrics.distribution('pardo', 'runtime.start')
-    self.runtime_end = Metrics.distribution('pardo', 'runtime.end')
+  def __init__(self, namespace):
+    self.namespace = namespace
+    self.runtime = Metrics.distribution(self.namespace, RUNTIME_LABEL)
 
   def start_bundle(self):
-    self.runtime_start.update(time.time())
+    self.runtime.update(time.time())
 
   def finish_bundle(self):
-    self.runtime_end.update(time.time())
+    self.runtime.update(time.time())
 
   def process(self, element):
     yield element
+
+
+def count_bytes(counter_name):
+  def layer(f):
+    def repl(*args):
+      namespace = args[2]
+      counter = Metrics.counter(namespace, counter_name)
+      element = args[1]
+      _, value = element
+      for i in range(len(value)):
+        counter.inc(i)
+      return f(*args)
+    return repl
+  return layer


### PR DESCRIPTION
The extended utility module in Python load tests with saving metrics in BigQuery functionality.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ x ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




