### PR TITLE
Switch to using java.nio.file.Files instead of Apache Commons IO File…

### DIFF
--- a/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexYarnLauncher.java
+++ b/runners/apex/src/main/java/org/apache/beam/runners/apex/ApexYarnLauncher.java
@@ -65,7 +65,6 @@ import org.apache.apex.api.Launcher.LaunchMode;
 import org.apache.apex.api.Launcher.LauncherException;
 import org.apache.apex.api.Launcher.ShutdownMode;
 import org.apache.apex.api.YarnAppLauncher;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -257,7 +256,7 @@ public class ApexYarnLauncher {
         if (!manifestFile.exists()) {
           new Manifest().write(out);
         } else {
-          FileUtils.copyFile(manifestFile, out);
+          Files.copy(manifestFile.toPath(), out);
         }
       }
 
@@ -289,7 +288,7 @@ public class ApexYarnLauncher {
               String name = relativePath + file.getFileName();
               if (!JarFile.MANIFEST_NAME.equals(name)) {
                 try (final OutputStream out = Files.newOutputStream(zipfs.getPath(name))) {
-                  FileUtils.copyFile(file.toFile(), out);
+                  Files.copy(file, out);
                 }
               }
               return super.visitFile(file, attrs);

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/ApexYarnLauncherTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/ApexYarnLauncherTest.java
@@ -28,6 +28,7 @@ import com.datatorrent.api.DAG;
 import com.datatorrent.api.StreamingApplication;
 import java.io.File;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -40,7 +41,6 @@ import org.apache.apex.api.EmbeddedAppLauncher;
 import org.apache.apex.api.Launcher;
 import org.apache.apex.api.Launcher.AppHandle;
 import org.apache.apex.api.Launcher.LaunchMode;
-import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -120,7 +120,7 @@ public class ApexYarnLauncherTest {
     File baseDir = tmpFolder.newFolder("target", "testCreateJar");
     File srcDir = tmpFolder.newFolder("target", "testCreateJar", "src");
     String file1 = "file1";
-    FileUtils.write(new File(srcDir, file1), "file1");
+    Files.write(new File(srcDir, file1).toPath(), "file1".getBytes(StandardCharsets.UTF_8));
 
     File jarFile = new File(baseDir, "test.jar");
     ApexYarnLauncher.createJar(srcDir, jarFile);

--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/WordCountTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/examples/WordCountTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.apex.examples;
 
 import com.google.common.collect.Sets;
 import java.io.File;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.runners.apex.ApexPipelineOptions;
@@ -41,7 +42,6 @@ import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.commons.io.FileUtils;
 import org.joda.time.Duration;
 import org.junit.Assert;
 import org.junit.Test;
@@ -135,8 +135,8 @@ public class WordCountTest {
 
     Assert.assertTrue("result files exist", outFile1.exists() && outFile2.exists());
     HashSet<String> results = new HashSet<>();
-    results.addAll(FileUtils.readLines(outFile1));
-    results.addAll(FileUtils.readLines(outFile2));
+    results.addAll(Files.readAllLines(outFile1.toPath()));
+    results.addAll(Files.readAllLines(outFile2.toPath()));
     HashSet<String> expectedOutput =
         Sets.newHashSet(
             "foo - 5 @ 294247-01-09T04:00:54.775Z", "bar - 5 @ 294247-01-09T04:00:54.775Z");


### PR DESCRIPTION
…Utils

There are a few instances in the code where we can easily replace Apache Commons IO FileUtils calls with java.nio.file.Files. We should only use third party library functionality over JDK functionality when it offers extra functionality or is easier/simpler to use.