### PR TITLE
[BEAM-6010] Deprecate KafkaIO withTimestampFn().

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicyFactory.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/TimestampPolicyFactory.java
@@ -92,7 +92,14 @@ public interface TimestampPolicyFactory<KeyT, ValueT> extends Serializable {
         new CustomTimestampPolicyWithLimitedDelay<>(timestampFunction, maxDelay, previousWatermark);
   }
 
-  /** Used by the Read transform to support old timestamp functions API. */
+  /**
+   * Used by the Read transform to support old timestamp functions API. This exists only to support
+   * other deprecated API {@link KafkaIO.Read#withTimestampFn(SerializableFunction)}.<br>
+   * TODO(rangadi): Make this package private or remove it. It was never meant to be public.
+   *
+   * @deprecated Use @{@link CustomTimestampPolicyWithLimitedDelay}.
+   */
+  @Deprecated
   static <K, V> TimestampPolicyFactory<K, V> withTimestampFn(
       final SerializableFunction<KafkaRecord<K, V>, Instant> timestampFn) {
     return (tp, previousWatermark) -> new TimestampFnPolicy<>(timestampFn, previousWatermark);


### PR DESCRIPTION
`TimestampPolicyFactory.withTimestampFn()` was never meant to be public. It was a mistake on my part not to make package private when I first added it. It was included only to existing legacy API in `KafkaIO.Read` (also deprecated). This policy is too simplistic (sets watermark to most recent record timestamp) and almost always wrong. There is a better alternative.