### PR TITLE
[Do not merge] Conditional phrase triggering test

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Phrase_Triggering_Test.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Phrase_Triggering_Test.groovy
@@ -16,20 +16,23 @@
  * limitations under the License.
  */
 
-// contains Big query related properties for Nexmark runs
-class NexmarkBigqueryProperties {
+import CommonJobProperties as commonJobProperties
+import NexmarkBigqueryProperties as nexmark
 
-    static String nexmarkBigQueryArgs = ['--bigQueryTable=nexmark',
-                                         '--bigQueryDataset=nexmark',
-                                         '--project=apache-beam-testing',
-                                         '--resourceNameMode=QUERY_RUNNER_AND_MODE',
-                                         '--exportSummaryToBigQuery=true',
-                                         '--tempLocation=gs://temp-storage-for-perf-tests/nexmark'].join(' ')
+String jobName = "beam_conditional_phrase_triggering_test"
 
+job(jobName) {
+  // Set default Beam job properties.
+  commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-    static String getBigQueryArgs() {
-        def bigQueryDataset = ('${GIT_BRANCH}' == 'master') ? 'nexmark' : 'nexmark_pull_requests'
+  commonJobProperties.enablePhraseTriggeringFromPullRequest(
+          delegate,
+          'phrase triggering nexmark test',
+          'Run phrase triggering nexmark test')
 
-        return nexmarkBigQueryArgs.join("--bigQueryDataset=${bigQueryDataset}")
-    }
+  def bigQueryArgs = nexmark.getBigQueryArgs()
+
+  steps {
+    shell("echo ${bigQueryArgs}")
+  }
 }


### PR DESCRIPTION
This is a PoC that checks if we are able to change nexmark args depending on branch we use in Jenkins.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




