### PR TITLE
Add helper task to print pipeline options for Dataflow portability

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -175,6 +175,7 @@ task validatesRunnerLegacyWorkerTest(type: Test) {
 
 task buildAndPushDockerContainer() {
   dependsOn ":beam-sdks-java-container:docker"
+  finalizedBy 'cleanUpDockerImages'
   def defaultDockerImageName = containerImageName(name: "java")
   doLast {
     exec {
@@ -182,6 +183,15 @@ task buildAndPushDockerContainer() {
     }
     exec {
       commandLine "gcloud", "docker", "--", "push", "${dockerImageContainer}"
+    }
+  }
+}
+
+afterEvaluate {
+  // Ensure all tasks which use published docker images run before they are cleaned up
+  tasks.each { t ->
+    if (t.dependsOn.contains(buildAndPushDockerContainer)) {
+      cleanUpDockerImages.mustRunAfter t
     }
   }
 }
@@ -399,13 +409,16 @@ task postCommitPortabilityApi {
   dependsOn googleCloudPlatformFnApiWorkerIntegrationTest
   dependsOn examplesJavaFnApiWorkerIntegrationTest
   dependsOn coreSDKJavaFnApiWorkerIntegrationTest
-  // Clean up docker image
+}
+
+// Clean up built images
+task cleanUpDockerImages() {
   doLast {
     exec {
       commandLine "docker", "rmi", "${dockerImageName}"
     }
     exec {
-      commandLine "gcloud", "--quiet", "container", "images", "delete", "${dockerImageName}"
+      commandLine "gcloud", "--quiet", "container", "images", "delete", "--force-delete-tags", "${dockerImageName}"
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -117,6 +117,12 @@ def dockerImageContainer = "${dockerImageRoot}/java"
 def dockerTag = new Date().format('yyyyMMddHHmmss')
 def dockerImageName = "${dockerImageContainer}:${dockerTag}"
 
+def fnApiPipelineOptions = [
+      "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
+      "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
+      "--experiments=beam_fn_api",
+]
+
 def commonExcludeCategories = [
   'org.apache.beam.sdk.testing.LargeKeys$Above10MB',
   'org.apache.beam.sdk.testing.UsesAttemptedMetrics',
@@ -180,20 +186,28 @@ task buildAndPushDockerContainer() {
   }
 }
 
+task printFnApiPipelineOptions {
+    group = "Help"
+    description = "Prints to the console extra pipeline options needed to run a Dataflow pipeline using portability"
+
+    dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
+    dependsOn buildAndPushDockerContainer
+
+    doLast {
+      println "To run a Dataflow job with portability, add the following pipeline options to your command-line:"
+      println fnApiPipelineOptions.join(' ')
+    }
+}
+
 task validatesRunnerFnApiWorkerTest(type: Test) {
     group = "Verification"
     dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
     dependsOn buildAndPushDockerContainer
-
     systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
             "--runner=TestDataflowRunner",
             "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-            "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-            "--experiments=beam_fn_api",
-
-    ])
+            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+    )
 
     // Increase test parallelism up to the number of Gradle workers. By default this is equal
     // to the number of CPU cores, but can be increased by setting --max-workers=N.
@@ -260,11 +274,8 @@ task googleCloudPlatformFnApiWorkerIntegrationTest(type: Test) {
     systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
             "--runner=TestDataflowRunner",
             "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-            "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-            "--experiments=beam_fn_api",
-    ])
+            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+    )
 
     include '**/*IT.class'
     exclude '**/BigQueryIOReadIT.class'
@@ -317,11 +328,8 @@ task examplesJavaFnApiWorkerIntegrationTest(type: Test) {
     systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
             "--runner=TestDataflowRunner",
             "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-            "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-            "--experiments=beam_fn_api",
-    ])
+            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+    )
 
     // The examples/java preCommit task already covers running WordCountIT/WindowedWordCountIT so
     // this postCommit integration test excludes them.
@@ -367,11 +375,8 @@ task coreSDKJavaFnApiWorkerIntegrationTest(type: Test) {
     systemProperty "beamTestPipelineOptions", JsonOutput.toJson([
             "--runner=TestDataflowRunner",
             "--project=${dataflowProject}",
-            "--tempRoot=${dataflowPostCommitTempRoot}",
-            "--dataflowWorkerJar=${dataflowFnApiWorkerJar}",
-            "--workerHarnessContainerImage=${dockerImageContainer}:${dockerTag}",
-            "--experiments=beam_fn_api",
-    ])
+            "--tempRoot=${dataflowPostCommitTempRoot}"] + fnApiPipelineOptions
+    )
 
     include '**/*IT.class'
     maxParallelForks 4

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -23,6 +23,7 @@ applyJavaNature(publish: false)
 // Evaluate the given project before this one, to allow referencing
 // its sourceSets.test.output directly.
 evaluationDependsOn(":beam-examples-java")
+evaluationDependsOn(":beam-runners-google-cloud-dataflow-java")
 evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-legacy-worker")
 evaluationDependsOn(":beam-runners-google-cloud-dataflow-java-fn-api-worker")
 evaluationDependsOn(":beam-sdks-java-container")
@@ -64,21 +65,9 @@ task preCommitLegacyWorker(type: Test) {
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson(preCommitBeamTestPipelineOptions)
 }
 
-task buildAndPushDockerContainer() {
-  dependsOn ":beam-sdks-java-container:docker"
-  doLast {
-    exec {
-      commandLine "docker", "tag", "${defaultDockerImageName}", "${dockerImageName}"
-    }
-    exec {
-      commandLine "gcloud", "docker", "--", "push", "${dockerImageContainer}"
-    }
-  }
-}
-
 task preCommitFnApiWorker(type: Test) {
   dependsOn ":beam-runners-google-cloud-dataflow-java-fn-api-worker:shadowJar"
-  dependsOn buildAndPushDockerContainer
+  dependsOn ":beam-runners-google-cloud-dataflow-java:buildAndPushDockerContainer"
 
   def dataflowWorkerJar = project.findProperty('dataflowWorkerJar') ?: project(":beam-runners-google-cloud-dataflow-java-fn-api-worker").shadowJar.archivePath
   def preCommitBeamTestPipelineOptions = [
@@ -106,13 +95,13 @@ task preCommit() {
 
 task preCommitPortabilityApi() {
   dependsOn preCommitFnApiWorker
-  // Clean up built images
-  doLast {
-    exec {
-      commandLine "docker", "rmi", "${dockerImageName}"
-    }
-    exec {
-      commandLine "gcloud", "--quiet", "container", "images", "delete", "${dockerImageName}"
+}
+
+afterEvaluate {
+  // Ensure all tasks which use published docker images run before they are cleaned up
+  tasks.each { t ->
+    if (t.dependsOn.contains(":beam-runners-google-cloud-dataflow-java:buildAndPushDockerContainer")) {
+      project(':beam-runners-google-cloud-dataflow-java').cleanUpDockerImages.mustRunAfter t
     }
   }
 }


### PR DESCRIPTION
Currently it is difficult to manually run a portabiltity pipeline as a
Beam user. This change adds a new Gradle task to conveniently generate
necessary artifacts and print the necessary commandline options.

Usage:

```shell
./gradlew -p runners/google-cloud-dataflow-java printFnApiPipelineOptions
```

Sample output:

```
> Task :beam-runners-google-cloud-dataflow-java:printFnApiPipelineOptions
To run a Dataflow job with portability, add the following pipeline options to your command-line:
--dataflowWorkerJar=/usr/local/google/home/swegner/beam/runners/google-cloud-dataflow-java/worker/build/libs/beam-runners-google-cloud-dataflow-java-fn-api-worker-2.9.0-SNAPSHOT.jar --workerHarnessContainerImage=gcr.io/dataflow-build/swegner/beam/java:20181107141351 --experiments=beam_fn_api
```
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




