### PR TITLE
[BEAM-6013] Reduce logging within SerializableCoder.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/SerializableCoder.java
@@ -25,7 +25,10 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -48,6 +51,13 @@ import org.slf4j.LoggerFactory;
  * @param <T> the type of elements handled by this coder
  */
 public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
+
+  /*
+   * A thread safe set containing classes which we have warned about.
+   * Note that we specifically use a weak hash map to allow for classes to be unloaded.
+   */
+  private static final Set<Class<?>> MISSING_EQUALS_METHOD =
+      Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
 
   private static final Logger LOG = LoggerFactory.getLogger(SerializableCoder.class);
 
@@ -87,8 +97,8 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
   }
 
   private static <T extends Serializable> void checkEqualsMethodDefined(Class<T> clazz) {
-    boolean warn = clazz.isInterface();
-    if (!warn) {
+    boolean warn = true;
+    if (!clazz.isInterface()) {
       Method method;
       try {
         method = clazz.getMethod("equals", Object.class);
@@ -99,7 +109,10 @@ public class SerializableCoder<T extends Serializable> extends CustomCoder<T> {
       // Check if not default Object#equals implementation.
       warn = Object.class.equals(method.getDeclaringClass());
     }
-    if (warn) {
+
+    // Note that the order of these checks is important since we want the
+    // "did we add the class to the set" check to happen last.
+    if (warn && MISSING_EQUALS_METHOD.add(clazz)) {
       LOG.warn(
           "Can't verify serialized elements of type {} have well defined equals method. "
               + "This may produce incorrect results on some {}",

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ExpectedLogs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ExpectedLogs.java
@@ -175,6 +175,17 @@ public class ExpectedLogs extends ExternalResource {
     verifyNo(Level.SEVERE, substring, t);
   }
 
+  /**
+   * Verify that the list of log records matches the provided {@code matcher}.
+   *
+   * @param matcher The matcher to use.
+   */
+  public void verifyLogRecords(Matcher<Iterable<LogRecord>> matcher) {
+    if (!matcher.matches(logSaver.getLogs())) {
+      fail(String.format("Missing match for [%s]", matcher));
+    }
+  }
+
   private void verify(final Level level, final String substring) {
     verifyLogged(matcher(level, substring));
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ExpectedLogsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/ExpectedLogsTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.LogRecord;
+import org.hamcrest.TypeSafeMatcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -70,6 +72,29 @@ public class ExpectedLogsTest {
     String expected = generateRandomString();
     LOG.error(expected, new IOException("Fake Exception"));
     expectedLogs.verifyError(expected);
+  }
+
+  @Test
+  public void testVerifyLogRecords() throws Throwable {
+    String expected = generateRandomString();
+    LOG.error(expected);
+    LOG.error(expected);
+    expectedLogs.verifyLogRecords(
+        new TypeSafeMatcher<Iterable<LogRecord>>() {
+          @Override
+          protected boolean matchesSafely(Iterable<LogRecord> item) {
+            int count = 0;
+            for (LogRecord record : item) {
+              if (record.getMessage().contains(expected)) {
+                count += 1;
+              }
+            }
+            return count == 2;
+          }
+
+          @Override
+          public void describeTo(org.hamcrest.Description description) {}
+        });
   }
 
   @Test(expected = AssertionError.class)


### PR DESCRIPTION
This significantly reduces logging to happen at most once per class load.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




