### PR TITLE
[BEAM-5999] Reconcile timer proto representation.

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -509,6 +509,7 @@ message SetStateSpec {
 
 message TimerSpec {
   TimeDomain.Enum time_domain = 1;
+  string timer_coder_id = 2;
 }
 
 message IsBounded {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -218,7 +218,7 @@ public class ParDoTranslation {
             for (Map.Entry<String, TimerDeclaration> timer :
                 signature.timerDeclarations().entrySet()) {
               RunnerApi.TimerSpec spec =
-                  translateTimerSpec(getTimerSpecOrThrow(timer.getValue(), doFn));
+                  translateTimerSpec(getTimerSpecOrThrow(timer.getValue(), doFn), newComponents);
               timerSpecs.put(timer.getKey(), spec);
             }
             return timerSpecs;
@@ -479,9 +479,12 @@ public class ParDoTranslation {
     }
   }
 
-  public static RunnerApi.TimerSpec translateTimerSpec(TimerSpec timer) {
+  public static RunnerApi.TimerSpec translateTimerSpec(TimerSpec timer, SdkComponents components) {
     return RunnerApi.TimerSpec.newBuilder()
         .setTimeDomain(translateTimeDomain(timer.getTimeDomain()))
+        // TODO: Add support for timer payloads to the SDK
+        // We currently assume that all payloads are unspecified.
+        .setTimerCoderId(registerCoderOrThrow(components, Timer.Coder.of(VoidCoder.of())))
         .build();
   }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/GreedyPipelineFuser.java
@@ -365,8 +365,6 @@ public class GreedyPipelineFuser {
             .map(PCollectionNode::getId)
             .collect(Collectors.toSet()));
     possibleInputs.addAll(
-        stage.getTimers().stream().map(t -> t.collection().getId()).collect(Collectors.toSet()));
-    possibleInputs.addAll(
         stage
             .getSideInputs()
             .stream()

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/QueryablePipeline.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/QueryablePipeline.java
@@ -382,12 +382,8 @@ public class QueryablePipeline {
             localName -> {
               String transformId = transform.getId();
               PTransform transformProto = components.getTransformsOrThrow(transformId);
-              String collectionId = transform.getTransform().getInputsOrThrow(localName);
-              PCollection collection = components.getPcollectionsOrThrow(collectionId);
               return TimerReference.of(
-                  PipelineNode.pTransform(transformId, transformProto),
-                  localName,
-                  PipelineNode.pCollection(collectionId, collection));
+                  PipelineNode.pTransform(transformId, transformProto), localName);
             })
         .collect(Collectors.toSet());
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/TimerReference.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/TimerReference.java
@@ -27,12 +27,10 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
  */
 @AutoValue
 public abstract class TimerReference {
+
   /** Create a timer reference. */
-  public static TimerReference of(
-      PipelineNode.PTransformNode transform,
-      String localName,
-      PipelineNode.PCollectionNode collection) {
-    return new AutoValue_TimerReference(transform, localName, collection);
+  public static TimerReference of(PipelineNode.PTransformNode transform, String localName) {
+    return new AutoValue_TimerReference(transform, localName);
   }
 
   /** Create a timer reference from a TimerId proto and components. */
@@ -40,19 +38,12 @@ public abstract class TimerReference {
       RunnerApi.ExecutableStagePayload.TimerId timerId, RunnerApi.Components components) {
     String transformId = timerId.getTransformId();
     String localName = timerId.getLocalName();
-    String collectionId = components.getTransformsOrThrow(transformId).getInputsOrThrow(localName);
     RunnerApi.PTransform transform = components.getTransformsOrThrow(transformId);
-    RunnerApi.PCollection collection = components.getPcollectionsOrThrow(collectionId);
-    return of(
-        PipelineNode.pTransform(transformId, transform),
-        localName,
-        PipelineNode.pCollection(collectionId, collection));
+    return of(PipelineNode.pTransform(transformId, transform), localName);
   }
 
   /** The PTransform that uses this timer. */
   public abstract PipelineNode.PTransformNode transform();
   /** The local name the referencing PTransform uses to refer to this timer. */
   public abstract String localName();
-  /** The PCollection that backs this timer. */
-  public abstract PipelineNode.PCollectionNode collection();
 }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ExecutableStageTest.java
@@ -94,8 +94,7 @@ public class ExecutableStageTest {
     UserStateReference userStateRef =
         UserStateReference.of(
             transformNode, "user_state", PipelineNode.pCollection("input.out", input));
-    TimerReference timerRef =
-        TimerReference.of(transformNode, "timer", PipelineNode.pCollection("timer.out", timer));
+    TimerReference timerRef = TimerReference.of(transformNode, "timer");
     ImmutableExecutableStage stage =
         ImmutableExecutableStage.of(
             components,

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStageTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/ImmutableExecutableStageTest.java
@@ -88,8 +88,7 @@ public class ImmutableExecutableStageTest {
     UserStateReference userStateRef =
         UserStateReference.of(
             transformNode, "user_state", PipelineNode.pCollection("input.out", input));
-    TimerReference timerRef =
-        TimerReference.of(transformNode, "timer", PipelineNode.pCollection("timer.pc", timer));
+    TimerReference timerRef = TimerReference.of(transformNode, "timer");
     ImmutableExecutableStage stage =
         ImmutableExecutableStage.ofFullComponents(
             components,

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/PrimitiveParDoSingleFactory.java
@@ -201,7 +201,7 @@ public class PrimitiveParDoSingleFactory<InputT, OutputT>
               for (Map.Entry<String, DoFnSignature.TimerDeclaration> timer :
                   signature.timerDeclarations().entrySet()) {
                 RunnerApi.TimerSpec spec =
-                    translateTimerSpec(getTimerSpecOrThrow(timer.getValue(), doFn));
+                    translateTimerSpec(getTimerSpecOrThrow(timer.getValue(), doFn), newComponents);
                 timerSpecs.put(timer.getKey(), spec);
               }
               return timerSpecs;

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/ProcessBundleDescriptors.java
@@ -24,6 +24,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,6 +41,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
+import org.apache.beam.runners.core.construction.ModelCoders;
 import org.apache.beam.runners.core.construction.SyntheticComponents;
 import org.apache.beam.runners.core.construction.graph.ExecutableStage;
 import org.apache.beam.runners.core.construction.graph.PipelineNode;
@@ -333,22 +335,56 @@ public class ProcessBundleDescriptors {
           throw new IllegalArgumentException(String.format("Unknown time domain %s", timeDomain));
       }
 
+      String mainInputName =
+          timerReference
+              .transform()
+              .getTransform()
+              .getInputsOrThrow(
+                  Iterables.getOnlyElement(
+                      Sets.difference(
+                          timerReference.transform().getTransform().getInputsMap().keySet(),
+                          Sets.union(
+                              payload.getSideInputsMap().keySet(),
+                              payload.getTimerSpecsMap().keySet()))));
+      String timerCoderId =
+          keyValueCoderId(
+              components
+                  .getCodersOrThrow(components.getPcollectionsOrThrow(mainInputName).getCoderId())
+                  .getComponentCoderIds(0),
+              payload.getTimerSpecsOrThrow(timerReference.localName()).getTimerCoderId(),
+              components);
+      RunnerApi.PCollection timerCollectionSpec =
+          components
+              .getPcollectionsOrThrow(mainInputName)
+              .toBuilder()
+              .setCoderId(timerCoderId)
+              .build();
+
+      // "Unroll" the timers into PCollections.
+      String inputTimerPCollectionId =
+          SyntheticComponents.uniqueId(
+              String.format(
+                  "%s.timer.%s.in", timerReference.transform().getId(), timerReference.localName()),
+              components.getPcollectionsMap()::containsKey);
+      components.putPcollections(inputTimerPCollectionId, timerCollectionSpec);
       remoteInputsBuilder.put(
-          timerReference.collection().getId(),
-          addStageInput(dataEndpoint, timerReference.collection(), components));
-      // "Unroll" the timer PCollection to make the execution tree a DAG.
+          inputTimerPCollectionId,
+          addStageInput(
+              dataEndpoint,
+              PipelineNode.pCollection(inputTimerPCollectionId, timerCollectionSpec),
+              components));
       String outputTimerPCollectionId =
           SyntheticComponents.uniqueId(
-              String.format("%s.out", timerReference.collection().getId()),
+              String.format(
+                  "%s.timer.%s.out",
+                  timerReference.transform().getId(), timerReference.localName()),
               components.getPcollectionsMap()::containsKey);
-      components.putPcollections(
-          outputTimerPCollectionId, timerReference.collection().getPCollection());
+      components.putPcollections(outputTimerPCollectionId, timerCollectionSpec);
       TargetEncoding targetEncoding =
           addStageOutput(
               dataEndpoint,
               components,
-              PipelineNode.pCollection(
-                  outputTimerPCollectionId, timerReference.collection().getPCollection()));
+              PipelineNode.pCollection(outputTimerPCollectionId, timerCollectionSpec));
       outputTargetCodersBuilder.put(targetEncoding.getTarget(), targetEncoding.getCoder());
       components.putTransforms(
           timerReference.transform().getId(),
@@ -356,6 +392,7 @@ public class ProcessBundleDescriptors {
           components
               .getTransformsOrThrow(timerReference.transform().getId())
               .toBuilder()
+              .putInputs(timerReference.localName(), inputTimerPCollectionId)
               .putOutputs(timerReference.localName(), outputTimerPCollectionId)
               .build());
 
@@ -365,11 +402,30 @@ public class ProcessBundleDescriptors {
           TimerSpec.of(
               timerReference.transform().getId(),
               timerReference.localName(),
-              timerReference.collection().getId(),
+              inputTimerPCollectionId,
               targetEncoding.getTarget(),
               spec));
     }
     return idsToSpec.build().rowMap();
+  }
+
+  private static String keyValueCoderId(
+      String keyCoderId, String valueCoderId, Components.Builder components) {
+    String id =
+        uniqueId(
+            String.format("kv-%s-%s", keyCoderId, valueCoderId),
+            components.getCodersMap()::containsKey);
+    RunnerApi.Coder.Builder coder;
+    components.putCoders(
+        id,
+        RunnerApi.Coder.newBuilder()
+            .setSpec(
+                RunnerApi.SdkFunctionSpec.newBuilder()
+                    .setSpec(RunnerApi.FunctionSpec.newBuilder().setUrn(ModelCoders.KV_CODER_URN)))
+            .addComponentCoderIds(keyCoderId)
+            .addComponentCoderIds(valueCoderId)
+            .build());
+    return id;
   }
 
   @AutoValue

--- a/sdks/python/apache_beam/transforms/userstate.py
+++ b/sdks/python/apache_beam/transforms/userstate.py
@@ -26,6 +26,7 @@ import itertools
 import types
 from builtins import object
 
+from apache_beam.coders import coders
 from apache_beam.coders import Coder
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.transforms.timeutil import TimeDomain
@@ -95,7 +96,9 @@ class TimerSpec(object):
 
   def to_runner_api(self, context):
     return beam_runner_api_pb2.TimerSpec(
-        time_domain=TimeDomain.to_runner_api(self.time_domain))
+        time_domain=TimeDomain.to_runner_api(self.time_domain),
+        timer_coder_id=context.coders.get_id(
+            coders._TimerCoder(coders.SingletonCoder(None))))
 
 
 def on_timer(timer_spec):


### PR DESCRIPTION
This adds a coder field to the timer spec, and moves the Java executor to use this spec alone when constructing executable graphs (and Python does). It should unblock Python timers working on Flink once #6981 also goes in.

See also the thread at http://mail-archives.apache.org/mod_mbox/beam-dev/201810.mbox/%3CCAFFRZHVecq4r3F_XgkEMqHJ9AqTMfTvGNZkOg764H9L2fSL85g@mail.gmail.com%3E

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




