### PR TITLE
[BEAM-6017] [WIP] Support nanosecond precision for DateTime field in Row

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/JavaInstantCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/JavaInstantCoder.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.coders;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UTFDataFormatException;
+import java.time.Instant;
+import org.apache.beam.sdk.values.TypeDescriptor;
+
+/**
+ * A {@link Coder} for Java time {@link Instant} that encodes it as a big endian {@link Long}
+ * shifted such that lexicographic ordering of the bytes corresponds to chronological order, and
+ * also encodes a {@link Integer} for the nanoseconds-of-second adjustment.
+ */
+public class JavaInstantCoder extends AtomicCoder<Instant> {
+  public static JavaInstantCoder of() {
+    return INSTANCE;
+  }
+
+  private static final JavaInstantCoder INSTANCE = new JavaInstantCoder();
+  private static final TypeDescriptor<Instant> TYPE_DESCRIPTOR = new TypeDescriptor<Instant>() {};
+
+  private JavaInstantCoder() {}
+
+  @Override
+  public void encode(Instant value, OutputStream outStream) throws CoderException, IOException {
+    if (value == null) {
+      throw new CoderException("cannot encode a null Instant");
+    }
+
+    // Converts {@link Instant} to a {@code long} representing its seconds-since-epoch, and to a
+    // {@code int} representing its nanosecond-of-second. seconds-since-epoch is shifted so that
+    // the byte representation of negative values are lexicographically ordered before the byte
+    // representation of positive values.
+    long shiftedSeconds = value.getEpochSecond() - Long.MIN_VALUE;
+    int nanoOfSecond = value.getNano();
+
+    DataOutputStream dataOutputStream = new DataOutputStream(outStream);
+    dataOutputStream.writeLong(shiftedSeconds);
+    dataOutputStream.writeInt(nanoOfSecond);
+  }
+
+  @Override
+  public Instant decode(InputStream inStream) throws CoderException, IOException {
+    long shiftedSeconds;
+    int nanoOfSecond;
+    DataInputStream dataInputStream = new DataInputStream(inStream);
+    try {
+      shiftedSeconds = dataInputStream.readLong();
+      nanoOfSecond = dataInputStream.readInt();
+    } catch (EOFException | UTFDataFormatException exn) {
+      throw new CoderException(exn);
+    }
+
+    return Instant.ofEpochSecond(shiftedSeconds + Long.MIN_VALUE, nanoOfSecond);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -51,7 +51,7 @@ public class RowCoder extends CustomCoder<Row> {
           .put(TypeName.FLOAT, FloatCoder.of())
           .put(TypeName.DOUBLE, DoubleCoder.of())
           .put(TypeName.STRING, StringUtf8Coder.of())
-          .put(TypeName.DATETIME, InstantCoder.of())
+          .put(TypeName.DATETIME, JavaInstantCoder.of())
           .put(TypeName.BOOLEAN, BooleanCoder.of())
           .build();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -185,6 +186,12 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
               keyType,
               valueType,
               setterFactory);
+    } else if (type.getTypeName().equals(TypeName.DATETIME)) {
+      if (value instanceof Instant) {
+        return (T) new org.joda.time.Instant(((Instant) value).toEpochMilli());
+      } else {
+        return value;
+      }
     } else {
       return value;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -30,6 +30,9 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.joda.time.DateTime;
+import org.joda.time.ReadableDateTime;
+import org.joda.time.ReadableInstant;
 
 /**
  * A Concrete subclass of {@link Row} that delegates to a set of provided {@link FieldValueGetter}s.
@@ -104,6 +107,13 @@ public class RowWithGetters extends Row {
     } else {
       return (T) fieldValue;
     }
+  }
+
+  @Nullable
+  @Override
+  public ReadableDateTime getDateTime(int idx) {
+    ReadableInstant instant = getValue(idx);
+    return instant == null ? null : new DateTime(instant).withZone(instant.getZone());
   }
 
   @Override

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/interpreter/operator/BeamSqlInputRefExpression.java
@@ -39,7 +39,11 @@ public class BeamSqlInputRefExpression extends BeamSqlExpression {
   @Override
   public BeamSqlPrimitive evaluate(
       Row inputRow, BoundedWindow window, BeamSqlExpressionEnvironment env) {
-    return BeamSqlPrimitive.of(outputType, inputRow.getValue(inputRef));
+    if (SqlTypeName.DATETIME_TYPES.contains(outputType)) {
+      return BeamSqlPrimitive.of(outputType, inputRow.getDateTime(inputRef));
+    } else {
+      return BeamSqlPrimitive.of(outputType, inputRow.getValue(inputRef));
+    }
   }
 
   public int getInputRef() {

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/rel/BeamEnumerableConverter.java
@@ -48,6 +48,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
@@ -253,7 +254,11 @@ public class BeamEnumerableConverter extends ConverterImpl implements Enumerable
     Object[] convertedColumns = new Object[schema.getFields().size()];
     int i = 0;
     for (Schema.Field field : schema.getFields()) {
-      convertedColumns[i] = fieldToAvatica(field.getType(), row.getValue(i));
+      if (field.getType().getTypeName().equals(TypeName.DATETIME)) {
+        convertedColumns[i] = fieldToAvatica(field.getType(), row.getDateTime(i));
+      } else {
+        convertedColumns[i] = fieldToAvatica(field.getType(), row.getValue(i));
+      }
       ++i;
     }
     return convertedColumns;


### PR DESCRIPTION
Support nanosecond precision for DateTime field in Row.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




