### PR TITLE
Revert "Revert "Revert "[BEAM-5299] Define max timestamp for global w…

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -32,22 +32,6 @@ option java_outer_classname = "RunnerApi";
 import "google/protobuf/any.proto";
 import "google/protobuf/descriptor.proto";
 
-message BeamConstants {
-  enum Constants {
-    // All timestamps in milliseconds since Jan 1, 1970.
-    MIN_TIMESTAMP_MILLIS = 0 [(beam_constant) = "-9223372036854775"];
-    MAX_TIMESTAMP_MILLIS = 1 [(beam_constant) =  "9223372036854775"];
-    // The maximum timestamp for the global window.
-    // Triggers use maxTimestamp to set timers' timestamp. Timers fires when
-    // the watermark passes their timestamps. So, the timestamp needs to be
-    // smaller than the MAX_TIMESTAMP_MILLIS.
-    // One standard day is subtracted from MAX_TIMESTAMP_MILLIS to make sure
-    // the maxTimestamp is smaller than MAX_TIMESTAMP_MILLIS even after rounding up
-    // to seconds or minutes. See also GlobalWindow in the Java SDK.
-    GLOBAL_WINDOW_MAX_TIMESTAMP_MILLIS = 2 [(beam_constant) = "9223371950454775"];
-  }
-}
-
 // A set of mappings from id to message. This is included as an optional field
 // on any proto message that may contain references needing resolution.
 message Components {
@@ -1084,8 +1068,6 @@ extend google.protobuf.EnumValueOptions {
   //   }
   // }
   string beam_urn = 185324356;
-  // A value to store other constants
-  string beam_constant = 185324357;
 }
 
 // A URN along with a parameter object whose schema is determined by the

--- a/sdks/go/pkg/beam/core/graph/mtime/time.go
+++ b/sdks/go/pkg/beam/core/graph/mtime/time.go
@@ -37,7 +37,6 @@ const (
 
 	// EndOfGlobalWindowTime is the timestamp at the end of the global window. It
 	// is a day before the max timestamp.
-	// TODO Use GLOBAL_WINDOW_MAX_TIMESTAMP_MILLIS from the Runner API constants
 	EndOfGlobalWindowTime = MaxTimestamp - 24*60*60*1000
 
 	// ZeroTimestamp is the default zero value time. It corresponds to the unix epoch.

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -51,8 +51,6 @@ test {
 }
 
 dependencies {
-  // Required to load constants from the model, e.g. max timestamp for global window
-  shadow project(path: ":beam-model-pipeline", configuration: "shadow")
   compile library.java.guava
   compile library.java.protobuf_java
   compile library.java.byte_buddy

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/BoundedWindow.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.transforms.windowing;
 
-import org.apache.beam.model.pipeline.v1.RunnerApi;
+import java.util.concurrent.TimeUnit;
 import org.joda.time.Instant;
 
 /**
@@ -46,7 +46,7 @@ public abstract class BoundedWindow {
    * microseconds-since-epoch can be safely represented with a {@code long}.
    */
   public static final Instant TIMESTAMP_MIN_VALUE =
-      extractTimestampFromProto(RunnerApi.BeamConstants.Constants.MIN_TIMESTAMP_MILLIS);
+      new Instant(TimeUnit.MICROSECONDS.toMillis(Long.MIN_VALUE));
 
   /**
    * The maximum value for any Beam timestamp. Often referred to as "+infinity".
@@ -55,7 +55,7 @@ public abstract class BoundedWindow {
    * microseconds-since-epoch can be safely represented with a {@code long}.
    */
   public static final Instant TIMESTAMP_MAX_VALUE =
-      extractTimestampFromProto(RunnerApi.BeamConstants.Constants.MAX_TIMESTAMP_MILLIS);
+      new Instant(TimeUnit.MICROSECONDS.toMillis(Long.MAX_VALUE));
 
   /**
    * Formats a {@link Instant} timestamp with additional Beam-specific metadata, such as indicating
@@ -76,11 +76,4 @@ public abstract class BoundedWindow {
 
   /** Returns the inclusive upper bound of timestamps for values in this window. */
   public abstract Instant maxTimestamp();
-
-  /** Parses a timestamp from the proto. */
-  private static Instant extractTimestampFromProto(RunnerApi.BeamConstants.Constants constant) {
-    return new Instant(
-        Long.parseLong(
-            constant.getValueDescriptor().getOptions().getExtension(RunnerApi.beamConstant)));
-  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindow.java
@@ -21,8 +21,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.List;
-import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.coders.StructuredCoder;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 
 /** The default window into which all data is placed (via {@link GlobalWindows}). */
@@ -36,7 +36,8 @@ public class GlobalWindow extends BoundedWindow {
   // One standard day is subtracted from TIMESTAMP_MAX_VALUE to make sure
   // the maxTimestamp is smaller than TIMESTAMP_MAX_VALUE even after rounding up
   // to seconds or minutes.
-  private static final Instant END_OF_GLOBAL_WINDOW = extractMaxTimestampFromProto();
+  private static final Instant END_OF_GLOBAL_WINDOW =
+      TIMESTAMP_MAX_VALUE.minus(Duration.standardDays(1));
 
   @Override
   public Instant maxTimestamp() {
@@ -81,15 +82,5 @@ public class GlobalWindow extends BoundedWindow {
     }
 
     private Coder() {}
-  }
-
-  /** Parses the max timestamp for global windows from the proto. */
-  private static Instant extractMaxTimestampFromProto() {
-    return new Instant(
-        Long.parseLong(
-            RunnerApi.BeamConstants.Constants.GLOBAL_WINDOW_MAX_TIMESTAMP_MILLIS
-                .getValueDescriptor()
-                .getOptions()
-                .getExtension(RunnerApi.beamConstant)));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/SdkCoreApiSurfaceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/SdkCoreApiSurfaceTest.java
@@ -46,7 +46,6 @@ public class SdkCoreApiSurfaceTest {
         .pruningClassName("org.apache.beam.sdk.testing.InterceptingUrlClassLoader")
         // test only
         .pruningPrefix("org.apache.beam.model.")
-        .pruningPrefix("org.apache.beam.vendor.")
         .pruningPrefix("java");
   }
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -51,7 +51,6 @@ from apache_beam.transforms import ptransform
 from apache_beam.transforms import window
 from apache_beam.transforms.display import DisplayDataItem
 from apache_beam.transforms.display import HasDisplayData
-from apache_beam.utils import timestamp
 from apache_beam.utils import urns
 from apache_beam.utils.windowed_value import WindowedValue
 
@@ -1053,7 +1052,7 @@ class _WriteKeyedBundleDoFn(core.DoFn):
     writer = self.sink.open_writer(init_result, str(uuid.uuid4()))
     for e in bundle[1]:  # values
       writer.write(e)
-    return [window.TimestampedValue(writer.close(), timestamp.MAX_TIMESTAMP)]
+    return [window.TimestampedValue(writer.close(), window.MAX_TIMESTAMP)]
 
 
 def _pre_finalize(unused_element, sink, init_result, write_results):
@@ -1073,8 +1072,7 @@ def _finalize_write(unused_element, sink, init_result, write_results,
   outputs = sink.finalize_write(init_result, write_results + extra_shards,
                                 pre_finalize_results)
   if outputs:
-    return (
-        window.TimestampedValue(v, timestamp.MAX_TIMESTAMP) for v in outputs)
+    return (window.TimestampedValue(v, window.MAX_TIMESTAMP) for v in outputs)
 
 
 class _RoundRobinKeyFn(core.DoFn):

--- a/sdks/python/apache_beam/portability/common_urns.py
+++ b/sdks/python/apache_beam/portability/common_urns.py
@@ -30,9 +30,6 @@ class PropertiesFromEnumValue(object):
   def __init__(self, value_descriptor):
     self.urn = (
         value_descriptor.GetOptions().Extensions[beam_runner_api_pb2.beam_urn])
-    self.constant = (
-        value_descriptor.GetOptions().Extensions[
-            beam_runner_api_pb2.beam_constant])
 
 
 class PropertiesFromEnumType(object):
@@ -54,9 +51,6 @@ side_inputs = PropertiesFromEnumType(
     beam_runner_api_pb2.StandardSideInputTypes.Enum)
 
 coders = PropertiesFromEnumType(beam_runner_api_pb2.StandardCoders.Enum)
-
-constants = PropertiesFromEnumType(
-    beam_runner_api_pb2.BeamConstants.Constants)
 
 environments = PropertiesFromEnumType(
     beam_runner_api_pb2.StandardEnvironments.Environments)

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -66,6 +66,7 @@ from apache_beam.portability.api import standard_window_fns_pb2
 from apache_beam.transforms import timeutil
 from apache_beam.utils import proto_utils
 from apache_beam.utils import urns
+from apache_beam.utils.timestamp import MAX_TIMESTAMP
 from apache_beam.utils.timestamp import MIN_TIMESTAMP
 from apache_beam.utils.timestamp import Duration
 from apache_beam.utils.timestamp import Timestamp
@@ -294,6 +295,11 @@ class TimestampedValue(object):
 class GlobalWindow(BoundedWindow):
   """The default window into which all data is placed (via GlobalWindows)."""
   _instance = None
+  # The maximum timestamp for global windows is MAX_TIMESTAMP - 1 day.
+  # This is due to timers triggering when the watermark passes the trigger
+  # time, which is only possible for timestamps < MAX_TIMESTAMP.
+  # See also GlobalWindow in the Java SDK.
+  _END_OF_GLOBAL_WINDOW = MAX_TIMESTAMP - (24 * 60 * 60)
 
   def __new__(cls):
     if cls._instance is None:
@@ -301,7 +307,7 @@ class GlobalWindow(BoundedWindow):
     return cls._instance
 
   def __init__(self):
-    super(GlobalWindow, self).__init__(GlobalWindow._getTimestampFromProto())
+    super(GlobalWindow, self).__init__(GlobalWindow._END_OF_GLOBAL_WINDOW)
     self.start = MIN_TIMESTAMP
 
   def __repr__(self):
@@ -316,12 +322,6 @@ class GlobalWindow(BoundedWindow):
 
   def __ne__(self, other):
     return not self == other
-
-  @staticmethod
-  def _getTimestampFromProto():
-    ts_millis = int(
-        common_urns.constants.GLOBAL_WINDOW_MAX_TIMESTAMP_MILLIS.constant)
-    return Timestamp(micros=ts_millis*1000)
 
 
 class NonMergingWindowFn(WindowFn):

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -31,8 +31,6 @@ from builtins import object
 import pytz
 from past.builtins import long
 
-from apache_beam.portability import common_urns
-
 
 @functools.total_ordering
 class Timestamp(object):
@@ -183,10 +181,8 @@ class Timestamp(object):
     return Duration(micros=self.micros % other.micros)
 
 
-MIN_TIMESTAMP = Timestamp(micros=int(
-    common_urns.constants.MIN_TIMESTAMP_MILLIS.constant)*1000)
-MAX_TIMESTAMP = Timestamp(micros=int(
-    common_urns.constants.MAX_TIMESTAMP_MILLIS.constant)*1000)
+MIN_TIMESTAMP = Timestamp(micros=-0x7fffffffffffffff - 1)
+MAX_TIMESTAMP = Timestamp(micros=0x7fffffffffffffff)
 
 
 @functools.total_ordering


### PR DESCRIPTION
…indow in proto (#6381)"""

This reverts commit a9723d954a92391e9ca79130a199a8eaf38953f2.

This PR also breaks internal tests. Rollback to unblock other changes. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




