### PR TITLE
[BEAM-6053] added sparkOptions cacheDisabled

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
@@ -136,4 +136,12 @@ public interface SparkPipelineOptions
   List<String> getFilesToStage();
 
   void setFilesToStage(List<String> value);
+
+  @Description(
+      "Disable caching of reused PCollections for whole Pipeline."
+          + " It's useful when it's faster to recompute RDD rather than save. ")
+  @Default.Boolean(false)
+  boolean isCacheDisabled();
+
+  void setCacheDisabled(boolean value);
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
@@ -141,42 +141,29 @@ public class EvaluationContext {
 
   /**
    * Cache PCollection if {@link #isCacheDisabled()} flag is false and PCollection is used more then
-   * once in Pipeline or forceCache flag is true.
+   * once in Pipeline.
    *
    * @param pvalue
-   * @param forceCache if PCollection is not used more than once
    * @return if PCollection will be cached
    */
-  public boolean shouldCache(PValue pvalue, boolean forceCache) {
+  public boolean shouldCache(PValue pvalue) {
     if (isCacheDisabled()) {
       return false;
     }
-    if (pvalue instanceof PCollection) {
-      if (forceCache) {
-        return true;
-      } else {
-        return cacheCandidates.getOrDefault(pvalue, 0L) > 1;
-      }
-    }
-    return false;
-  }
-
-  public void putDataset(
-      PTransform<?, ? extends PValue> transform, Dataset dataset, boolean forceCache) {
-    putDataset(getOutput(transform), dataset, forceCache);
+    return pvalue instanceof PCollection && cacheCandidates.getOrDefault(pvalue, 0L) > 1;
   }
 
   public void putDataset(PTransform<?, ? extends PValue> transform, Dataset dataset) {
-    putDataset(transform, dataset, false);
+    putDataset(getOutput(transform), dataset);
   }
 
-  public void putDataset(PValue pvalue, Dataset dataset, boolean forceCache) {
+  public void putDataset(PValue pvalue, Dataset dataset) {
     try {
       dataset.setName(pvalue.getName());
     } catch (IllegalStateException e) {
       // name not set, ignore
     }
-    if (shouldCache(pvalue, forceCache)) {
+    if (shouldCache(pvalue)) {
       // we cache only PCollection
       Coder<?> coder = ((PCollection<?>) pvalue).getCoder();
       Coder<? extends BoundedWindow> wCoder =

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -409,7 +409,7 @@ public final class TransformTranslator {
           // Object is the best we can do since different outputs can have different tags
           JavaRDD<WindowedValue<Object>> values =
               (JavaRDD<WindowedValue<Object>>) (JavaRDD<?>) filtered.values();
-          context.putDataset(output.getValue(), new BoundedDataset<>(values), false);
+          context.putDataset(output.getValue(), new BoundedDataset<>(values));
         }
       }
 
@@ -458,8 +458,8 @@ public final class TransformTranslator {
             new SourceRDD.Bounded<>(
                     jsc.sc(), transform.getSource(), context.getSerializableOptions(), stepName)
                 .toJavaRDD();
-        // cache to avoid re-evaluation of the source by Spark's lazy DAG evaluation.
-        context.putDataset(transform, new BoundedDataset<>(input), true);
+
+        context.putDataset(transform, new BoundedDataset<>(input));
       }
 
       @Override

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -447,8 +447,7 @@ public final class StreamingTransformTranslator {
                   (JavaDStream<?>) TranslationUtils.dStreamValues(filtered);
           context.putDataset(
               output.getValue(),
-              new UnboundedDataset<>(values, unboundedDataset.getStreamSources()),
-              false);
+              new UnboundedDataset<>(values, unboundedDataset.getStreamSources()));
         }
       }
 

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
@@ -76,10 +76,9 @@ public class CacheTest {
     EvaluationContext ctxt = new EvaluationContext(jsc, pipeline, options);
     ctxt.getCacheCandidates().put(pCollection, 2L);
 
-    assertFalse(ctxt.shouldCache(pCollection, false));
-    assertFalse(ctxt.shouldCache(pCollection, true));
+    assertFalse(ctxt.shouldCache(pCollection));
 
     options.setCacheDisabled(false);
-    assertTrue(ctxt.shouldCache(pCollection, false));
+    assertTrue(ctxt.shouldCache(pCollection));
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/CacheTest.java
@@ -18,11 +18,15 @@
 package org.apache.beam.runners.spark;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.apache.beam.runners.spark.translation.Dataset;
 import org.apache.beam.runners.spark.translation.EvaluationContext;
 import org.apache.beam.runners.spark.translation.SparkContextFactory;
 import org.apache.beam.runners.spark.translation.TransformTranslator;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Count;
 import org.apache.beam.sdk.transforms.Create;
@@ -30,12 +34,13 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.Test;
 
-/**
- * This test checks how the cache candidates map is populated by the runner when evaluating the
- * pipeline.
- */
+/** Tests of {@link Dataset#cache(String, Coder)}} scenarios. */
 public class CacheTest {
 
+  /**
+   * Test checks how the cache candidates map is populated by the runner when evaluating the
+   * pipeline.
+   */
   @Test
   public void cacheCandidatesUpdaterTest() throws Exception {
     SparkPipelineOptions options =
@@ -56,5 +61,25 @@ public class CacheTest {
         new SparkRunner.CacheVisitor(new TransformTranslator.Translator(), ctxt);
     pipeline.traverseTopologically(cacheVisitor);
     assertEquals(2L, (long) ctxt.getCacheCandidates().get(pCollection));
+  }
+
+  @Test
+  public void cacheDisabledOptionTest() {
+    SparkPipelineOptions options =
+        PipelineOptionsFactory.create().as(TestSparkPipelineOptions.class);
+    options.setRunner(TestSparkRunner.class);
+    options.setCacheDisabled(true);
+    Pipeline pipeline = Pipeline.create(options);
+    PCollection<String> pCollection = pipeline.apply(Create.of("foo", "bar"));
+
+    JavaSparkContext jsc = SparkContextFactory.getSparkContext(options);
+    EvaluationContext ctxt = new EvaluationContext(jsc, pipeline, options);
+    ctxt.getCacheCandidates().put(pCollection, 2L);
+
+    assertFalse(ctxt.shouldCache(pCollection, false));
+    assertFalse(ctxt.shouldCache(pCollection, true));
+
+    options.setCacheDisabled(false);
+    assertTrue(ctxt.shouldCache(pCollection, false));
   }
 }

--- a/website/src/documentation/runners/spark.md
+++ b/website/src/documentation/runners/spark.md
@@ -152,6 +152,11 @@ When executing your pipeline with the Spark Runner, you should consider the foll
   <td>Enable reporting metrics to Spark's metrics Sinks.</td>
   <td>true</td>
 </tr>
+<tr>
+  <td><code>cacheDisabled</code></td>
+  <td>Disable caching of reused PCollections for whole Pipeline. It's useful when it's faster to recompute RDD rather than save.</td>
+  <td>false</td>
+</tr>
 </table>
 
 ## Additional notes


### PR DESCRIPTION
Add possibility to SparkOptions to turn off spark RDD caching. There are use cases when its faster to recompute whole RDD rather then serialize, store, deserialize, read from store.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




