### PR TITLE
[Do not merge yet] Phrase triggering nexmark

### DIFF
--- a/.test-infra/jenkins/NexmarkBuilder.groovy
+++ b/.test-infra/jenkins/NexmarkBuilder.groovy
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// contains Big query related properties for Nexmark runs
+class NexmarkBuilder {
+
+  enum Runner {
+    DATAFLOW("DataflowRunner", ":beam-runners-google-cloud-dataflow-java"),
+    SPARK("SparkRunner", ":beam-runners-spark"),
+    FLINK("FlinkRunner", ":beam-runners-flink_2.11"),
+    DIRECT("DirectRunner", ":beam-runners-direct-java")
+
+    private final String option
+    private final String dependency
+
+    Runner(String option, String dependency) {
+      this.option = option
+      this.dependency = dependency
+    }
+  }
+
+  enum Mode {
+    STREAMING,
+    BATCH
+
+    boolean isStreaming() {
+      return this == STREAMING
+    }
+  }
+
+  enum TriggeringContext {
+    PR,
+    POST_COMMIT
+  }
+
+  enum QueryLanguage {
+    JAVA,
+    SQL
+  }
+
+  void job(def context, Runner runner, List<String> runnerSpecificOptions, TriggeringContext triggeringContext) {
+    context.steps {
+      nexmark.suite(context, "NEXMARK IN BATCH MODE USING ${runner} RUNNER", runner, runnerSpecificOptions,  Mode.BATCH, triggeringContext)
+      nexmark.suite(context, "NEXMARK IN STREAMING MODE USING ${runner} RUNNER", runner, runnerSpecificOptions, Mode.STREAMING, triggeringContext)
+      nexmark.suite(context, "NEXMARK IN SQL BATCH MODE USING ${runner} RUNNER", runner, runnerSpecificOptions, Mode.BATCH, triggeringContext, QueryLanguage.SQL)
+      nexmark.suite(context, "NEXMARK IN SQL STREAMING MODE USING ${runner} RUNNER", runner, runnerSpecificOptions, Mode.STREAMING, triggeringContext, QueryLanguage.SQL)
+    }
+  }
+
+  void suite(def context,
+             String title,
+             Runner runner,
+             List<String> runnerSpecificOptions,
+             Mode mode,
+             TriggeringContext triggeringContext,
+             QueryLanguage queryLanguage = QueryLanguage.JAVA) {
+    context.shell("echo *** RUN ${title} ***")
+    context.gradle {
+      rootBuildScriptDir(commonJobProperties.checkoutDir)
+      tasks(':beam-sdks-java-nexmark:run')
+      commonJobProperties.setGradleSwitches(context)
+      switches('-Pnexmark.runner=' + runner.dependency +
+              ' -Pnexmark.args="' + pipelineOptions(runner, mode, determineBigQueryDataset(triggeringContext), runnerSpecificOptions, queryLanguage))
+    }
+  }
+
+  private static String determineBigQueryDataset(TriggeringContext triggeringContext) {
+    triggeringContext == TriggeringContext.PR ? "nexmark_PRs" : "nexmark"
+  }
+
+  private
+  static String pipelineOptions(Runner runner, Mode mode, String bqDataset,
+                                List<String> runnerSpecificOptions, QueryLanguage queryLanguage) {
+    def options = ['--bigQueryTable=nexmark',
+                   "--bigQueryDataset=${bqDataset}",
+                   '--project=apache-beam-testing',
+                   '--resourceNameMode=QUERY_RUNNER_AND_MODE',
+                   '--exportSummaryToBigQuery=true',
+                   '--tempLocation=gs://temp-storage-for-perf-tests/nexmark',
+                   "--runner=${runner.option}",
+                   "--streaming=${mode.isStreaming()}",
+                   '--manageResources=false',
+                   '--monitorJobs=true',
+                   ]
+
+    options = options + runnerSpecificOptions
+
+    if (queryLanguage != QueryLanguage.JAVA) {
+      options.add("--queryLanguage={$queryLanguage}")
+    }
+
+    return options.join(' ')
+  }
+}

--- a/.test-infra/jenkins/PhraseTriggeringPostcommitJobBuilder.groovy
+++ b/.test-infra/jenkins/PhraseTriggeringPostcommitJobBuilder.groovy
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This class is to be used for defining postcommit jobs that are only phrase-triggered.
+ *
+ * Purpose of this class is to define common strategies and reporting/building paramereters
+ * for pre- and post- commit test jobs and unify them across the project.
+ */
+class PhraseTriggeringPostcommitJobBuilder extends PostcommitJobBuilder {
+  static void postCommitJob(nameBase,
+                            triggerPhrase,
+                            githubUiHint,
+                            scope,
+                            jobDefinition = {}) {
+    new PostcommitJobBuilder(scope, jobDefinition).defineGhprbTriggeredJob(
+            nameBase + "_PR", triggerPhrase, githubUiHint, false)
+  }
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Direct.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Direct.groovy
@@ -17,10 +17,11 @@
  */
 
 import CommonJobProperties as commonJobProperties
+import NexmarkBuilder as nexmark
 import NexmarkBigqueryProperties
 import NoPhraseTriggeringPostCommitBuilder
+import PhraseTriggeringPostCommitBuilder
 
-// This job runs the suite of ValidatesRunner tests against the Direct runner.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Direct',
         'Direct Runner Nexmark Tests', this) {
   description('Runs the Nexmark suite on the Direct runner.')
@@ -97,4 +98,21 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
               '--enforceImmutability=true"'].join(' '))
     }
   }
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Direct',
+        'Run Direct Runner Nexmark Tests', 'Direct Runner Nexmark Tests', this) {
+
+  description('Runs the Nexmark suite on the Direct runner against a Pull Request, on demand.')
+
+  commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
+
+  def final DIRECT_SPECIFIC_OPTIONS = [
+          '--suite=SMOKE',
+          '--enforceEncodability=true',
+          '--enforceImmutability=true'
+  ]
+
+  nexmark.job(delegate, Runner.DIRECT, DIRECT_SPECIFIC_OPTIONS, TriggeringContext.PR)
+
 }


### PR DESCRIPTION
This PR adds a way to phrase trigger Nexmark Jobs. More specifically it add several new jenkins jobs that will run nexmark suites and save the test results in separate BigQuery dataset. Potentially, more options/arguments can be customized but for now only "bigqueryDataset" needed to be changed in order not to pollute data from Master branch in bigQuery. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




