### PR TITLE
[BEAM-5996] Append query name to temp location.

### DIFF
--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/Main.java
@@ -80,13 +80,13 @@ public class Main {
     private final NexmarkConfiguration configuration;
 
     private Run(NexmarkOptions options, NexmarkConfiguration configuration) {
-      this.nexmarkLauncher = new NexmarkLauncher<>(options);
+      this.nexmarkLauncher = new NexmarkLauncher<>(options, configuration);
       this.configuration = configuration;
     }
 
     @Override
     public Result call() throws IOException {
-      NexmarkPerf perf = nexmarkLauncher.run(configuration);
+      NexmarkPerf perf = nexmarkLauncher.run();
       return new Result(configuration, perf);
     }
   }
@@ -95,10 +95,7 @@ public class Main {
   void runAll(String[] args) throws IOException {
     NexmarkOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(NexmarkOptions.class);
-    runAll(options);
-  }
 
-  void runAll(NexmarkOptions options) throws IOException {
     Instant start = Instant.now();
     Map<NexmarkConfiguration, NexmarkPerf> baseline = loadBaseline(options.getBaselineFilename());
     Map<NexmarkConfiguration, NexmarkPerf> actual = new LinkedHashMap<>();
@@ -111,7 +108,8 @@ public class Main {
     try {
       // Schedule all the configurations.
       for (NexmarkConfiguration configuration : configurations) {
-        completion.submit(new Run(options, configuration));
+        NexmarkOptions optionsCopy = PipelineOptionsFactory.fromArgs(args).as(NexmarkOptions.class);
+        completion.submit(new Run(optionsCopy, configuration));
       }
 
       // Collect all the results.

--- a/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/MainTest.java
+++ b/sdks/java/testing/nexmark/src/test/java/org/apache/beam/sdk/nexmark/MainTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.nexmark;
 
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.junit.Test;
 
 /**
@@ -27,11 +26,8 @@ import org.junit.Test;
 public class MainTest {
   @Test
   public void testSmokeSuiteOnDirectRunner() throws Exception {
-    NexmarkOptions options = PipelineOptionsFactory.create().as(NexmarkOptions.class);
     // Default for SMOKE is 100k or 10k for heavier queries - way overkill for "smoke" test
-    options.setNumEvents(500L);
-    options.setSuite(NexmarkSuite.SMOKE);
-    options.setManageResources(false);
-    new Main().runAll(options);
+    final String[] pipelineArgs = {"--numEvents=500", "--suite=SMOKE", "--manageResources=false"};
+    new Main().runAll(pipelineArgs);
   }
 }


### PR DESCRIPTION
Append query name to temp location to prevent multiple jobs from writing to the same object.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




