### PR TITLE
[BEAM-5959] Reimplement GCS copies with rewrites.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ sdks/python/NOTICE
 sdks/python/README.md
 sdks/python/apache_beam/portability/api/*pb2*.*
 sdks/python/nosetests.xml
+sdks/python/postcommit_requirements.txt
 
 # Ignore IntelliJ files.
 **/.idea/**/*

--- a/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio_integration_test.py
@@ -1,0 +1,183 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Integration tests for gcsio module.
+
+Runs tests against Google Cloud Storage service.
+Instantiates a TestPipeline to get options such as GCP project name, but
+doesn't actually start a Beam pipeline or test any specific runner.
+
+Options:
+  --kms_key_name=projects/<project-name>/locations/<region>/keyRings/\
+      <key-ring-name>/cryptoKeys/<key-name>/cryptoKeyVersions/<version>
+    Pass a Cloud KMS key name to test GCS operations using customer managed
+    encryption keys (CMEK).
+
+Cloud KMS permissions:
+The project's Cloud Storage service account requires Encrypter/Decrypter
+permissions for the key specified in --kms_key_name.
+
+To run these tests manually:
+  ./gradlew beam-sdks-python:integrationTest \
+    -Ptests=apache_beam.io.gcp.gcsio_integration_test:GcsIOIntegrationTest \
+    -PkmsKeyName=KMS_KEY_NAME
+"""
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+import uuid
+
+from nose.plugins.attrib import attr
+
+from apache_beam.io.filesystems import FileSystems
+from apache_beam.testing.test_pipeline import TestPipeline
+
+try:
+  from apache_beam.io.gcp import gcsio
+except ImportError:
+  gcsio = None
+
+
+@unittest.skipIf(gcsio is None, 'GCP dependencies are not installed')
+class GcsIOIntegrationTest(unittest.TestCase):
+
+  INPUT_FILE = 'gs://dataflow-samples/shakespeare/kinglear.txt'
+  # Larger than 1MB to test maxBytesRewrittenPerCall.
+  INPUT_FILE_LARGE = (
+      'gs://dataflow-samples/wikipedia_edits/wiki_data-000000000000.json')
+
+  def setUp(self):
+    self.test_pipeline = TestPipeline(is_integration_test=True)
+    self.runner_name = type(self.test_pipeline.runner).__name__
+    if self.runner_name != 'TestDataflowRunner':
+      # This test doesn't run a pipeline, so it doesn't make sense to try it on
+      # different runners. Running with TestDataflowRunner makes sense since
+      # it uses GoogleCloudOptions such as 'project'.
+      raise unittest.SkipTest(
+          'This test only runs with TestDataflowRunner.')
+    self.project = self.test_pipeline.get_option('project')
+    self.gcs_tempdir = (self.test_pipeline.get_option('temp_location') +
+                        '/gcs_it-' + str(uuid.uuid4()))
+    self.kms_key_name = self.test_pipeline.get_option('kms_key_name')
+    self.gcsio = gcsio.GcsIO()
+
+  def tearDown(self):
+    FileSystems.delete([self.gcs_tempdir + '/'])
+
+  def _verify_copy(self, src, dst, dst_kms_key_name=None):
+    self.assertTrue(FileSystems.exists(src), 'src does not exist: %s' % src)
+    self.assertTrue(FileSystems.exists(dst), 'dst does not exist: %s' % dst)
+    src_checksum = self.gcsio.checksum(src)
+    dst_checksum = self.gcsio.checksum(dst)
+    self.assertEqual(src_checksum, dst_checksum)
+    self.assertEqual(self.gcsio.kms_key(dst), dst_kms_key_name)
+
+  def _test_copy(self, name, kms_key_name=None,
+                 max_bytes_rewritten_per_call=None, src=None):
+    src = src or self.INPUT_FILE
+    dst = self.gcs_tempdir + '/%s' % name
+    extra_kwargs = {}
+    if max_bytes_rewritten_per_call is not None:
+      extra_kwargs['max_bytes_rewritten_per_call'] = (
+          max_bytes_rewritten_per_call)
+
+    self.gcsio.copy(src, dst, kms_key_name, **extra_kwargs)
+    self._verify_copy(src, dst, kms_key_name)
+
+  @attr('IT')
+  def test_copy(self):
+    self._test_copy("test_copy")
+
+  @attr('IT')
+  def test_copy_kms(self):
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+    self._test_copy("test_copy_kms", self.kms_key_name)
+
+  @attr('IT')
+  def test_copy_rewrite_token(self):
+    # Tests a multi-part copy (rewrite) operation. This is triggered by a
+    # combination of 3 conditions:
+    #  - a large enough src
+    #  - setting max_bytes_rewritten_per_call
+    #  - setting kms_key_name
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+
+    rewrite_responses = []
+    self.gcsio._set_rewrite_response_callback(
+        lambda response: rewrite_responses.append(response))
+    self._test_copy("test_copy_rewrite_token", kms_key_name=self.kms_key_name,
+                    max_bytes_rewritten_per_call=50 * 1024 * 1024,
+                    src=self.INPUT_FILE_LARGE)
+    # Verify that there was a multi-part rewrite.
+    self.assertTrue(any([not r.done for r in rewrite_responses]))
+
+  def _test_copy_batch(self, name, kms_key_name=None,
+                       max_bytes_rewritten_per_call=None, src=None):
+    num_copies = 10
+    srcs = [src or self.INPUT_FILE] * num_copies
+    dsts = [self.gcs_tempdir + '/%s_%d' % (name, i)
+            for i in range(num_copies)]
+    src_dst_pairs = list(zip(srcs, dsts))
+    extra_kwargs = {}
+    if max_bytes_rewritten_per_call is not None:
+      extra_kwargs['max_bytes_rewritten_per_call'] = (
+          max_bytes_rewritten_per_call)
+
+    result_statuses = self.gcsio.copy_batch(
+        src_dst_pairs, kms_key_name, **extra_kwargs)
+    for status in result_statuses:
+      self.assertIsNone(status[2], status)
+    for _src, _dst in src_dst_pairs:
+      self._verify_copy(_src, _dst, kms_key_name)
+
+  @attr('IT')
+  def test_copy_batch(self):
+    self._test_copy_batch("test_copy_batch")
+
+  @attr('IT')
+  def test_copy_batch_kms(self):
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+    self._test_copy_batch("test_copy_batch_kms", self.kms_key_name)
+
+  @attr('IT')
+  def test_copy_batch_rewrite_token(self):
+    # Tests a multi-part copy (rewrite) operation. This is triggered by a
+    # combination of 3 conditions:
+    #  - a large enough src
+    #  - setting max_bytes_rewritten_per_call
+    #  - setting kms_key_name
+    if self.kms_key_name is None:
+      raise unittest.SkipTest('--kms_key_name not specified')
+
+    rewrite_responses = []
+    self.gcsio._set_rewrite_response_callback(
+        lambda response: rewrite_responses.append(response))
+    self._test_copy_batch(
+        "test_copy_batch_rewrite_token", kms_key_name=self.kms_key_name,
+        max_bytes_rewritten_per_call=50 * 1024 * 1024,
+        src=self.INPUT_FILE_LARGE)
+    # Verify that there was a multi-part rewrite.
+    self.assertTrue(any([not r.done for r in rewrite_responses]))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -257,6 +257,8 @@ task integrationTest(dependsOn: ['installGcpTest', 'sdist']) {
     // Build pipeline options that configures pipeline job
     if (project.hasProperty('pipelineOptions'))
       argMap["pipeline_opts"] = project.property('pipelineOptions')
+    if (project.hasProperty('kmsKeyName'))
+      argMap["kms_key_name"] = project.property('kmsKeyName')
 
     def cmdArgs = mapToArgString(argMap)
     exec {

--- a/sdks/python/scripts/run_integration_test.sh
+++ b/sdks/python/scripts/run_integration_test.sh
@@ -27,17 +27,18 @@
 #
 # Pipeline related flags:
 #     runner        -> Runner that execute pipeline job.
-#                      e.g. TestDataflowRunner, DirectRunner
+#                      e.g. TestDataflowRunner, TestDirectRunner
 #     project       -> Project name of the cloud service.
 #     gcs_location  -> Base location on GCS. Some pipeline options are
-#                      dirived from it including output, staging_location
+#                      derived from it including output, staging_location
 #                      and temp_location.
 #     sdk_location  -> Python tar ball location. Glob is accepted.
 #     num_workers   -> Number of workers.
 #     sleep_secs    -> Number of seconds to wait before verification.
 #     streaming     -> True if a streaming job.
 #     worker_jar    -> Customized worker jar for dataflow runner.
-#     pipeline_opts -> List of space separateed pipeline options. If this
+#     kms_key_name  -> Name of Cloud KMS encryption key to use in some tests.
+#     pipeline_opts -> List of space separated pipeline options. If this
 #                      flag is specified, all above flag will be ignored.
 #                      Please include all required pipeline options when
 #                      using this flag.
@@ -70,6 +71,9 @@ NUM_WORKERS=1
 SLEEP_SECS=20
 STREAMING=false
 WORKER_JAR=""
+# Specify "/cryptoKeyVersions/1" suffix for testing simplicity. For this to work
+# in the long term, this key has rotation disabled.
+KMS_KEY_NAME="projects/apache-beam-testing/locations/global/keyRings/beam-it/cryptoKeys/test/cryptoKeyVersions/1"
 
 # Default test (nose) options.
 # Default test sets are full integration tests.
@@ -116,6 +120,11 @@ case $key in
         ;;
     --worker_jar)
         WORKER_JAR="$2"
+        shift # past argument
+        shift # past value
+        ;;
+    --kms_key_name)
+        KMS_KEY_NAME="$2"
         shift # past argument
         shift # past value
         ;;
@@ -192,10 +201,13 @@ if [[ -z $PIPELINE_OPTS ]]; then
     opts+=("--dataflow_worker_jar=$WORKER_JAR")
   fi
 
+  if [[ ! -z "$KMS_KEY_NAME" ]]; then
+    opts+=("--kms_key_name=$KMS_KEY_NAME")
+  fi
+
   PIPELINE_OPTS=$(IFS=" " ; echo "${opts[*]}")
 
 fi
-
 
 ###########################################################################
 # Run tests and validate that jobs finish successfully.


### PR DESCRIPTION
This allows for:
- Copying when storage classes and locations differ.
- Copying of larger files (multi-part calls).
- Copying to a bucket with a default customer managed encryption key
(CMEK).

Performance testing: done on internal Dataflow tests. Rename performance has not significantly changed: 149 rename/s vs 135 rename/s average with this PR.
(Renames are implemented as copy+delete.)

Also adds integration tests for copy and copy_batch.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---

