### PR TITLE
[BEAM-6063] KafkaIO: add writing support with ProducerRecord

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaExactlyOnceSink.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.coders.BigEndianLongCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.io.kafka.KafkaIO.Write;
+import org.apache.beam.sdk.io.kafka.KafkaIO.WriteRecords;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.metrics.SinkMetrics;
@@ -88,7 +88,8 @@ import org.slf4j.LoggerFactory;
  * Exactly-once sink transform for Kafka. See {@link KafkaIO} for user visible documentation and
  * example usage.
  */
-class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PCollection<Void>> {
+class KafkaExactlyOnceSink<K, V>
+    extends PTransform<PCollection<ProducerRecord<K, V>>, PCollection<Void>> {
 
   // Dataflow ensures at-least once processing for side effects like sinks. In order to provide
   // exactly-once semantics, a sink needs to be idempotent or it should avoid writing records
@@ -132,7 +133,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   private static final Logger LOG = LoggerFactory.getLogger(KafkaExactlyOnceSink.class);
   private static final String METRIC_NAMESPACE = "KafkaExactlyOnceSink";
 
-  private final Write<K, V> spec;
+  private final WriteRecords<K, V> spec;
 
   static void ensureEOSSupport() {
     checkArgument(
@@ -142,12 +143,12 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         "exactly-once semantics. Please use Kafka client version 0.11 or newer.");
   }
 
-  KafkaExactlyOnceSink(Write<K, V> spec) {
+  KafkaExactlyOnceSink(WriteRecords<K, V> spec) {
     this.spec = spec;
   }
 
   @Override
-  public PCollection<Void> expand(PCollection<KV<K, V>> input) {
+  public PCollection<Void> expand(PCollection<ProducerRecord<K, V>> input) {
 
     int numShards = spec.getNumShards();
     if (numShards <= 0) {
@@ -164,7 +165,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
     return input
         .apply(
-            Window.<KV<K, V>>into(new GlobalWindows()) // Everything into global window.
+            Window.<ProducerRecord<K, V>>into(new GlobalWindows()) // Everything into global window.
                 .triggering(Repeatedly.forever(AfterPane.elementCountAtLeast(1)))
                 .discardingFiredPanes())
         .apply(
@@ -180,7 +181,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
   /** Shuffle messages assigning each randomly to a shard. */
   private static class Reshard<K, V>
-      extends DoFn<KV<K, V>, KV<Integer, TimestampedValue<KV<K, V>>>> {
+      extends DoFn<ProducerRecord<K, V>, KV<Integer, TimestampedValue<ProducerRecord<K, V>>>> {
 
     private final int numShards;
     private transient int shardId;
@@ -203,8 +204,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
 
   private static class Sequencer<K, V>
       extends DoFn<
-          KV<Integer, Iterable<TimestampedValue<KV<K, V>>>>,
-          KV<Integer, KV<Long, TimestampedValue<KV<K, V>>>>> {
+          KV<Integer, Iterable<TimestampedValue<ProducerRecord<K, V>>>>,
+          KV<Integer, KV<Long, TimestampedValue<ProducerRecord<K, V>>>>> {
 
     private static final String NEXT_ID = "nextId";
 
@@ -215,7 +216,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     public void processElement(@StateId(NEXT_ID) ValueState<Long> nextIdState, ProcessContext ctx) {
       long nextId = MoreObjects.firstNonNull(nextIdState.read(), 0L);
       int shard = ctx.element().getKey();
-      for (TimestampedValue<KV<K, V>> value : ctx.element().getValue()) {
+      for (TimestampedValue<ProducerRecord<K, V>> value : ctx.element().getValue()) {
         ctx.output(KV.of(shard, KV.of(nextId, value)));
         nextId++;
       }
@@ -224,7 +225,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   }
 
   private static class ExactlyOnceWriter<K, V>
-      extends DoFn<KV<Integer, Iterable<KV<Long, TimestampedValue<KV<K, V>>>>>, Void> {
+      extends DoFn<KV<Integer, Iterable<KV<Long, TimestampedValue<ProducerRecord<K, V>>>>>, Void> {
 
     private static final String NEXT_ID = "nextId";
     private static final String MIN_BUFFERED_ID = "minBufferedId";
@@ -242,7 +243,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     private final StateSpec<ValueState<Long>> minBufferedIdSpec = StateSpecs.value();
 
     @StateId(OUT_OF_ORDER_BUFFER)
-    private final StateSpec<BagState<KV<Long, TimestampedValue<KV<K, V>>>>> outOfOrderBufferSpec;
+    private final StateSpec<BagState<KV<Long, TimestampedValue<ProducerRecord<K, V>>>>>
+        outOfOrderBufferSpec;
     // A random id assigned to each shard. Helps with detecting when multiple jobs are mistakenly
     // started with same groupId used for storing state on Kafka side, including the case where
     // a job is restarted with same groupId, but the metadata from previous run was not cleared.
@@ -250,7 +252,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     @StateId(WRITER_ID)
     private final StateSpec<ValueState<String>> writerIdSpec = StateSpecs.value();
 
-    private final Write<K, V> spec;
+    private final WriteRecords<K, V> spec;
 
     // Metrics
     private final Counter elementsWritten = SinkMetrics.elementsWritten();
@@ -258,7 +260,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     private final Counter elementsBuffered = Metrics.counter(METRIC_NAMESPACE, "elementsBuffered");
     private final Counter numTransactions = Metrics.counter(METRIC_NAMESPACE, "numTransactions");
 
-    ExactlyOnceWriter(Write<K, V> spec, Coder<KV<K, V>> elemCoder) {
+    ExactlyOnceWriter(WriteRecords<K, V> spec, Coder<ProducerRecord<K, V>> elemCoder) {
       this.spec = spec;
       this.outOfOrderBufferSpec =
           StateSpecs.bag(KvCoder.of(BigEndianLongCoder.of(), TimestampedValueCoder.of(elemCoder)));
@@ -276,7 +278,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
     public void processElement(
         @StateId(NEXT_ID) ValueState<Long> nextIdState,
         @StateId(MIN_BUFFERED_ID) ValueState<Long> minBufferedIdState,
-        @StateId(OUT_OF_ORDER_BUFFER) BagState<KV<Long, TimestampedValue<KV<K, V>>>> oooBufferState,
+        @StateId(OUT_OF_ORDER_BUFFER)
+            BagState<KV<Long, TimestampedValue<ProducerRecord<K, V>>>> oooBufferState,
         @StateId(WRITER_ID) ValueState<String> writerIdState,
         ProcessContext ctx)
         throws IOException {
@@ -316,10 +319,11 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         // There might be out of order messages buffered in earlier iterations. These
         // will get merged if and when minBufferedId matches nextId.
 
-        Iterator<KV<Long, TimestampedValue<KV<K, V>>>> iter = ctx.element().getValue().iterator();
+        Iterator<KV<Long, TimestampedValue<ProducerRecord<K, V>>>> iter =
+            ctx.element().getValue().iterator();
 
         while (iter.hasNext()) {
-          KV<Long, TimestampedValue<KV<K, V>>> kv = iter.next();
+          KV<Long, TimestampedValue<ProducerRecord<K, V>>> kv = iter.next();
           long recordId = kv.getKey();
 
           if (recordId < nextId) {
@@ -364,7 +368,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
             // Read all of them in to memory and sort them. Reading into memory
             // might be problematic in extreme cases. Might need to improve it in future.
 
-            List<KV<Long, TimestampedValue<KV<K, V>>>> buffered =
+            List<KV<Long, TimestampedValue<ProducerRecord<K, V>>>> buffered =
                 Lists.newArrayList(oooBufferState.read());
             buffered.sort(new KV.OrderByKey<>());
 
@@ -440,7 +444,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
       private final String writerId;
       private final Producer<K, V> producer;
       private final String producerName;
-      private final Write<K, V> spec;
+      private final WriteRecords<K, V> spec;
       private long committedId;
 
       ShardWriter(
@@ -448,7 +452,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
           String writerId,
           Producer<K, V> producer,
           String producerName,
-          Write<K, V> spec,
+          WriteRecords<K, V> spec,
           long committedId) {
         this.shard = shard;
         this.writerId = writerId;
@@ -462,7 +466,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
         ProducerSpEL.beginTransaction(producer);
       }
 
-      Future<RecordMetadata> sendRecord(TimestampedValue<KV<K, V>> record, Counter sendCounter) {
+      Future<RecordMetadata> sendRecord(
+          TimestampedValue<ProducerRecord<K, V>> record, Counter sendCounter) {
         try {
           Long timestampMillis =
               spec.getPublishTimestampFunction() != null
@@ -477,8 +482,8 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
                       spec.getTopic(),
                       null,
                       timestampMillis,
-                      record.getValue().getKey(),
-                      record.getValue().getValue()));
+                      record.getValue().key(),
+                      record.getValue().value()));
           sendCounter.inc();
           return result;
         } catch (KafkaException e) {
@@ -678,7 +683,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
    * Opens a generic consumer that is mainly meant for metadata operations like fetching number of
    * partitions for a topic rather than for fetching messages.
    */
-  private static Consumer<?, ?> openConsumer(Write<?, ?> spec) {
+  private static Consumer<?, ?> openConsumer(WriteRecords<?, ?> spec) {
     return spec.getConsumerFactoryFn()
         .apply(
             ImmutableMap.of(
@@ -693,7 +698,7 @@ class KafkaExactlyOnceSink<K, V> extends PTransform<PCollection<KV<K, V>>, PColl
   }
 
   private static <K, V> Producer<K, V> initializeExactlyOnceProducer(
-      Write<K, V> spec, String producerName) {
+      WriteRecords<K, V> spec, String producerName) {
 
     Map<String, Object> producerConfig = new HashMap<>(spec.getProducerConfig());
     producerConfig.putAll(

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoder.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoder.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.StructuredCoder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.values.KV;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+/** {@link Coder} for {@link ProducerRecord}. */
+public class ProducerRecordCoder<K, V> extends StructuredCoder<ProducerRecord<K, V>> {
+  private static final StringUtf8Coder stringCoder = StringUtf8Coder.of();
+  private static final VarLongCoder longCoder = VarLongCoder.of();
+  private static final VarIntCoder intCoder = VarIntCoder.of();
+  private static final IterableCoder headerCoder =
+      IterableCoder.of(KvCoder.of(stringCoder, ByteArrayCoder.of()));
+
+  private final KvCoder<K, V> kvCoder;
+
+  public static <K, V> ProducerRecordCoder<K, V> of(Coder<K> keyCoder, Coder<V> valueCoder) {
+    return new ProducerRecordCoder<>(keyCoder, valueCoder);
+  }
+
+  public ProducerRecordCoder(Coder<K> keyCoder, Coder<V> valueCoder) {
+    this.kvCoder = KvCoder.of(keyCoder, valueCoder);
+  }
+
+  @Override
+  public void encode(ProducerRecord<K, V> value, OutputStream outStream) throws IOException {
+    stringCoder.encode(value.topic(), outStream);
+    intCoder.encode(value.partition() != null ? value.partition() : -1, outStream);
+    longCoder.encode(value.timestamp() != null ? value.timestamp() : Long.MAX_VALUE, outStream);
+    headerCoder.encode(toIterable(value), outStream);
+    kvCoder.encode(KV.of(value.key(), value.value()), outStream);
+  }
+
+  @Override
+  public ProducerRecord<K, V> decode(InputStream inStream) throws IOException {
+    String topic = stringCoder.decode(inStream);
+    Integer partition = intCoder.decode(inStream);
+    if (partition == -1) {
+      partition = null;
+    }
+
+    Long timestamp = longCoder.decode(inStream);
+    if (timestamp == Long.MAX_VALUE) {
+      timestamp = null;
+    }
+
+    Headers headers = (Headers) toHeaders(headerCoder.decode(inStream));
+    KV<K, V> kv = kvCoder.decode(inStream);
+    if (ConsumerSpEL.hasHeaders) {
+      return new ProducerRecord<>(topic, partition, timestamp, kv.getKey(), kv.getValue(), headers);
+    }
+    return new ProducerRecord<>(topic, partition, timestamp, kv.getKey(), kv.getValue());
+  }
+
+  private Object toHeaders(Iterable<KV<String, byte[]>> records) {
+    if (!ConsumerSpEL.hasHeaders) {
+      return null;
+    }
+
+    // ConsumerRecord is used to simply create a list of headers
+    ConsumerRecord<String, String> consumerRecord = new ConsumerRecord<>("", 0, 0L, "", "");
+    records.forEach(kv -> consumerRecord.headers().add(kv.getKey(), kv.getValue()));
+    return consumerRecord.headers();
+  }
+
+  private Iterable<KV<String, byte[]>> toIterable(ProducerRecord record) {
+    if (!ConsumerSpEL.hasHeaders) {
+      return Collections.emptyList();
+    }
+    List<KV<String, byte[]>> vals = new ArrayList<>();
+    for (Header header : record.headers()) {
+      vals.add(KV.of(header.key(), header.value()));
+    }
+    return vals;
+  }
+
+  @Override
+  public List<? extends Coder<?>> getCoderArguments() {
+    return kvCoder.getCoderArguments();
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    kvCoder.verifyDeterministic();
+  }
+
+  @Override
+  public boolean isRegisterByteSizeObserverCheap(ProducerRecord<K, V> value) {
+    return kvCoder.isRegisterByteSizeObserverCheap(KV.of(value.key(), value.value()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Object structuralValue(ProducerRecord<K, V> value) {
+    if (consistentWithEquals()) {
+      return value;
+    } else {
+      return new ProducerRecord<>(
+          value.topic(),
+          value.partition(),
+          value.timestamp(),
+          value.key(),
+          value.value(),
+          value.headers());
+    }
+  }
+
+  @Override
+  public boolean consistentWithEquals() {
+    return kvCoder.consistentWithEquals();
+  }
+}

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ProducerRecordCoderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ProducerRecordCoder}. */
+@RunWith(JUnit4.class)
+public class ProducerRecordCoderTest {
+  @Test
+  public void testCoderIsSerializableWithWellKnownCoderType() {
+    CoderProperties.coderSerializable(
+        ProducerRecordCoder.of(GlobalWindow.Coder.INSTANCE, GlobalWindow.Coder.INSTANCE));
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithHeaders() throws IOException {
+    RecordHeaders headers = new RecordHeaders();
+    headers.add("headerKey", "headerVal".getBytes(StandardCharsets.UTF_8));
+    verifySerialization(headers, 0, System.currentTimeMillis());
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithoutHeaders() throws IOException {
+    ConsumerRecord consumerRecord = new ConsumerRecord<>("", 0, 0L, "", "");
+    verifySerialization(consumerRecord.headers(), 0, System.currentTimeMillis());
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithPartition() throws IOException {
+    ProducerRecord<String, String> decodedRecord =
+        verifySerialization(1, System.currentTimeMillis());
+    assertEquals(1, decodedRecord.partition().intValue());
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithoutPartition() throws IOException {
+    ProducerRecord<String, String> decodedRecord =
+        verifySerialization(null, System.currentTimeMillis());
+    assertNull(decodedRecord.partition());
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithTimestamp() throws IOException {
+    long timestamp = System.currentTimeMillis();
+    ProducerRecord<String, String> decodedRecord = verifySerialization(1, timestamp);
+    assertEquals(timestamp, decodedRecord.timestamp().longValue());
+  }
+
+  @Test
+  public void testProducerRecordSerializableWithoutTimestamp() throws IOException {
+    ProducerRecord<String, String> decodedRecord = verifySerialization(1, null);
+    assertNull(decodedRecord.timestamp());
+  }
+
+  private ProducerRecord<String, String> verifySerialization(Integer partition, Long timestamp)
+      throws IOException {
+    return verifySerialization(null, partition, timestamp);
+  }
+
+  private ProducerRecord<String, String> verifySerialization(
+      Headers headers, Integer partition, Long timestamp) throws IOException {
+    ProducerRecord<String, String> producerRecord =
+        new ProducerRecord<>("topic", partition, timestamp, "key", "value", headers);
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    ProducerRecordCoder producerRecordCoder =
+        ProducerRecordCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of());
+
+    producerRecordCoder.encode(producerRecord, outputStream);
+    ProducerRecord<String, String> decodedRecord =
+        producerRecordCoder.decode(new ByteArrayInputStream(outputStream.toByteArray()));
+
+    assertEquals(producerRecord, decodedRecord);
+
+    return decodedRecord;
+  }
+}


### PR DESCRIPTION
Added new transform `WriteRecords` based on Kafka `ProducerRecord`. API of old `Write` transform is kept as it was before but now it uses `WriteRecords` under the hood to write data. All internal functionality, which is not visible for user, has been changed to use `ProducerRecord` instead of `KV`.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




