### PR TITLE
Enabling the ArrayTypeStyle checkstyle module

### DIFF
--- a/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
+++ b/sdks/java/build-tools/src/main/resources/beam/checkstyle.xml
@@ -310,6 +310,8 @@ page at http://checkstyle.sourceforge.net/config.html -->
       <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
       <property name="checkFormat" value="$1"/>
     </module>
+
+    <module name="ArrayTypeStyle"/>
   </module>
 </module>
 

--- a/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
+++ b/sdks/java/io/mongodb/src/test/java/org/apache/beam/sdk/io/mongodb/MongoDBGridFSIOTest.java
@@ -342,7 +342,7 @@ public class MongoDBGridFSIOTest implements Serializable {
       }
 
       files = gridfs.find("WriteTestIntData");
-      boolean intResults[] = new boolean[100];
+      boolean[] intResults = new boolean[100];
       for (GridFSDBFile file : files) {
         int l = (int) file.getLength();
         try (InputStream ins = file.getInputStream()) {


### PR DESCRIPTION
This commit fixed most of the array declaration formatting issues:

commit b039f05a8f995ba94538048e19e33a0557f38496
Merge: 5b4ae2ce6b cdd3458380

Author: Colm O hEigeartaigh <coheigea@apache.org>
Date:   Wed Oct 24 12:40:02 2018 +0100

    Move array declarations after the type

This merge is to enable the Checkstyle module to enforce this rule.