### PR TITLE
Don't redundantly execute pre-commits as part of Jenkins post-commits

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Go_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Go_GradleBuild.groovy
@@ -37,6 +37,9 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Go_GradleBuild', 'Run Go Pos
       tasks(':goPostCommit')
       commonJobProperties.setGradleSwitches(delegate)
       switches('--no-parallel')
+
+      // Pre-commits run in a separate Jenkins job
+      switches('--exclude-task :goPreCommit')
     }
   }
 }

--- a/.test-infra/jenkins/job_PostCommit_Java_GradleBuild.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_GradleBuild.groovy
@@ -41,6 +41,10 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Java_GradleBuild', 'Run Java
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':javaPostCommit')
       commonJobProperties.setGradleSwitches(delegate)
+
+      // Pre-commits run in a separate Jenkins job
+      switches('--exclude-task :javaPreCommit')
+
       // Specify maven home on Jenkins, needed by Maven archetype integration tests.
       switches('-Pmaven_home=/home/jenkins/tools/maven/apache-maven-3.5.2')
     }

--- a/.test-infra/jenkins/job_PostCommit_Python_Verify.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Python_Verify.groovy
@@ -35,6 +35,9 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Python_Verify', 'Run Python 
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       tasks(':pythonPostCommit')
       commonJobProperties.setGradleSwitches(delegate)
+
+      // Pre-commits run in a separate Jenkins job
+      switches('--exclude-task :pythonPreCommit')
     }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ task pythonPreCommit() {
 
 task pythonPostCommit() {
   dependsOn ":beam-sdks-python:postCommit"
+  dependsOn pythonPreCommit
 }
 
 task websitePreCommit() {

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -411,7 +411,6 @@ task flinkValidatesRunner() {
 }
 
 task postCommit() {
-  dependsOn "preCommit"
   dependsOn "directRunnerIT"
   dependsOn "hdfsIntegrationTest"
   dependsOn "postCommitIT"


### PR DESCRIPTION
Each post-commit suite is configured to also include pre-commit tests. However, in Jenkins we run pre-commits separately from post-commits, and in all cases when a language post-commit suite runs, the pre-commit is also run separate (in PR, on merge, cron schedule). So, it makes sense to separate the targets. This will free up resources and give a faster signal on post-commit suites as they are doing less work.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




