### PR TITLE
Add some Go examples to the code snippets.

### DIFF
--- a/website/src/documentation/programming-guide.md
+++ b/website/src/documentation/programming-guide.md
@@ -130,9 +130,8 @@ Pipeline p = Pipeline.create(options);
 %}
 ```
 ```go
-// In order to start creating the pipeline for execution, a Pipeline object is needed.
-p := beam.NewPipeline()
-s := p.Root()
+// In order to start creating the pipeline for execution, a Pipeline object and a Scope object are needed.
+p, s := beam.NewPipelineWithRoot()
 ```
 
 ### 2.1. Configuring pipeline options {#configuring-pipeline-options}
@@ -311,7 +310,7 @@ public static void main(String[] args) {
 %}
 ```
 ```go
-lines := textio.Read(s, "protocol://path/file*.txt")
+lines := textio.Read(s, "protocol://path/to/some/inputData.txt")
 ```
 
 See the [section on I/O](#pipeline-io) to learn more about how to read from the
@@ -616,9 +615,13 @@ words = ...
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets_test.py tag:model_pardo_apply
 %}```
 ```go
+// words is the input PCollection of strings
+var words beam.PCollection = ...
+
 func computeWordLengthFn(word string) int {
       return len(word)
 }
+
 wordLengths := beam.ParDo(s, computeWordLengthFn, words)
 ```
 
@@ -744,6 +747,9 @@ words = ...
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets_test.py tag:model_pardo_using_flatmap
 %}```
 ```go
+// words is the input PCollection of strings
+var words beam.PCollection = ...
+
 lengths := beam.ParDo(s, func (word string) int {
       return len(word)
 }, words)

--- a/website/src/documentation/programming-guide.md
+++ b/website/src/documentation/programming-guide.md
@@ -87,7 +87,7 @@ A typical Beam driver program works as follows:
 * **Apply** `PTransforms` to each `PCollection`. Transforms can change, filter,
   group, analyze, or otherwise process the elements in a `PCollection`. A
   transform creates a new output `PCollection` *without modifying the input
-  collection*. A typical pipeline applies subsequent transforms to the each new
+  collection*. A typical pipeline applies subsequent transforms to each new
   output `PCollection` in turn until processing is complete. However, note that
   a pipeline does not have to be a single straight line of transforms applied
   one after another: think of `PCollection`s as variables and `PTransform`s as
@@ -129,6 +129,11 @@ Pipeline p = Pipeline.create(options);
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipelines_constructing_creating
 %}
 ```
+```go
+// In order to start creating the pipeline for execution, a Pipeline object is needed.
+p := beam.NewPipeline()
+s := p.Root()
+```
 
 ### 2.1. Configuring pipeline options {#configuring-pipeline-options}
 
@@ -158,6 +163,10 @@ PipelineOptions options =
 ```py
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipelines_constructing_creating
 %}
+```
+```go
+// If beamx or Go flags are used, flags must be parsed first.
+flag.Parse()
 ```
 
 This interprets command-line arguments that follow the format:
@@ -192,6 +201,12 @@ public interface MyOptions extends PipelineOptions {
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipeline_options_define_custom
 %}
 ```
+```go
+var (
+  input = flag.String("input", "", "")
+  output = flag.String("output", "", "")
+)
+```
 
 You can also specify a description, which appears when a user passes `--help` as
 a command-line argument, and a default value.
@@ -210,6 +225,13 @@ public interface MyOptions extends PipelineOptions {
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipeline_options_define_custom_with_help_and_default
 %}
 ```
+```go
+var (
+  input = flag.String("input", "gs://my-bucket/input", "File(s) to read.")
+  output = flag.String("output", "gs://my-bucket/output", "Output file.")
+)
+```
+
 
 {:.language-java}
 It's recommended that you register your interface with `PipelineOptionsFactory`
@@ -287,6 +309,9 @@ public static void main(String[] args) {
 ```py
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets.py tag:pipelines_constructing_reading
 %}
+```
+```go
+lines := textio.Read(s, "protocol://path/file*.txt")
 ```
 
 See the [section on I/O](#pipeline-io) to learn more about how to read from the
@@ -590,6 +615,12 @@ words = ...
 %}
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets_test.py tag:model_pardo_apply
 %}```
+```go
+func computeWordLengthFn(word string) int {
+      return len(word)
+}
+wordLengths := beam.ParDo(s, computeWordLengthFn, words)
+```
 
 In the example, our input `PCollection` contains `String` values. We apply a
 `ParDo` transform that specifies a function (`ComputeWordLengthFn`) to compute
@@ -704,7 +735,6 @@ PCollection<Integer> wordLengths = words.apply(
       }
     }));
 ```
-
 ```py
 # The input PCollection of strings.
 words = ...
@@ -713,6 +743,11 @@ words = ...
 # Save the result as the PCollection word_lengths.
 {% github_sample /apache/beam/blob/master/sdks/python/apache_beam/examples/snippets/snippets_test.py tag:model_pardo_using_flatmap
 %}```
+```go
+lengths := beam.ParDo(s, func (word string) int {
+      return len(word)
+}, words)
+```
 
 If your `ParDo` performs a one-to-one mapping of input elements to output
 elements--that is, for each input element, it applies a function that produces
@@ -734,7 +769,6 @@ PCollection<Integer> wordLengths = words.apply(
   MapElements.into(TypeDescriptors.integers())
              .via((String word) -> word.length()));
 ```
-
 ```py
 # The input PCollection of string.
 words = ...


### PR DESCRIPTION
The programming guide has code snippets for Java & Python but not Go.
I've added Go versions of some of the snippets.
------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---
