### PR TITLE
[BEAM-5987] Cache and share materialized side inputs between Spark tasks

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/MultiDoFnFunction.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/MultiDoFnFunction.java
@@ -22,13 +22,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.UUID;
-import java.util.WeakHashMap;
 import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.core.DoFnRunners;
 import org.apache.beam.runners.core.InMemoryStateInternals;
 import org.apache.beam.runners.core.InMemoryTimerInternals;
-import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StepContext;
 import org.apache.beam.runners.core.TimerInternals;
@@ -52,8 +49,6 @@ import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.LinkedListMu
 import org.apache.beam.vendor.guava.v20_0.com.google.common.collect.Multimap;
 import org.apache.spark.Accumulator;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 
 /**
@@ -65,17 +60,6 @@ import scala.Tuple2;
  */
 public class MultiDoFnFunction<InputT, OutputT>
     implements PairFlatMapFunction<Iterator<WindowedValue<InputT>>, TupleTag<?>, WindowedValue<?>> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(MultiDoFnFunction.class);
-
-  /** JVM wide side input cache. */
-  private static final Map<String, CachedSideInputReader> sideInputReaders =
-      Collections.synchronizedMap(new WeakHashMap<>());
-
-  /**
-   * Id that is consistent among executors. We can not use stepName because of possible collisions.
-   */
-  private final String uniqueId = UUID.randomUUID().toString();
 
   private final Accumulator<MetricsContainerStepMap> metricsAccum;
   private final String stepName;
@@ -166,19 +150,11 @@ public class MultiDoFnFunction<InputT, OutputT>
       context = new SparkProcessContext.NoOpStepContext();
     }
 
-    final SideInputReader sideInputReader =
-        sideInputReaders.computeIfAbsent(
-            uniqueId,
-            key -> {
-              LOG.info("Creating a new side input reader for [{}] with id [{}].", stepName, key);
-              return CachedSideInputReader.of(new SparkSideInputReader(sideInputs));
-            });
-
     final DoFnRunner<InputT, OutputT> doFnRunner =
         DoFnRunners.simpleRunner(
             options.get(),
             doFn,
-            sideInputReader,
+            CachedSideInputReader.of(new SparkSideInputReader(sideInputs)),
             outputManager,
             mainOutputTag,
             additionalOutputTags,

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkPCollectionView.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkPCollectionView.java
@@ -90,7 +90,7 @@ public class SparkPCollectionView implements Serializable {
     SideInputBroadcast helper = SideInputBroadcast.create(tuple2._1, tuple2._2);
     String pCollectionName =
         view.getPCollection() != null ? view.getPCollection().getName() : "UNKNOWN";
-    LOG.info(
+    LOG.debug(
         "Broadcasting [size={}B] view {} from pCollection {}",
         helper.getBroadcastSizeEstimate(),
         view,

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkPCollectionView.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkPCollectionView.java
@@ -26,11 +26,14 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.spark.api.java.JavaSparkContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.Tuple2;
 
 /** SparkPCollectionView is used to pass serialized views to lambdas. */
 public class SparkPCollectionView implements Serializable {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SparkPCollectionView.class);
   // Holds the view --> broadcast mapping. Transient so it will be null from resume
   private transient volatile Map<PCollectionView<?>, SideInputBroadcast> broadcastHelperMap = null;
 
@@ -85,6 +88,13 @@ public class SparkPCollectionView implements Serializable {
       PCollectionView<?> view, JavaSparkContext context) {
     Tuple2<byte[], Coder<Iterable<WindowedValue<?>>>> tuple2 = pviews.get(view);
     SideInputBroadcast helper = SideInputBroadcast.create(tuple2._1, tuple2._2);
+    String pCollectionName =
+        view.getPCollection() != null ? view.getPCollection().getName() : "UNKNOWN";
+    LOG.info(
+        "Broadcasting [size={}B] view {} from pCollection {}",
+        helper.getBroadcastSizeEstimate(),
+        view,
+        pCollectionName);
     helper.broadcast(context);
     broadcastHelperMap.put(view, helper);
     return helper;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputBroadcast.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputBroadcast.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.util.SizeEstimator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,5 +73,9 @@ public class SideInputBroadcast<T> implements Serializable {
       val = null;
     }
     return val;
+  }
+
+  public long getBroadcastSizeEstimate() {
+    return SizeEstimator.estimate(bytes);
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
@@ -17,12 +17,12 @@
  */
 package org.apache.beam.runners.spark.util;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.cache.Cache;
+import org.apache.beam.vendor.guava.v20_0.com.google.common.cache.CacheBuilder;
 
 /**
  * Cache deserialized side inputs for executor so every task doesn't need to deserialize them again.
@@ -31,10 +31,10 @@ import org.apache.beam.sdk.values.PCollectionView;
 class SideInputStorage {
 
   /** JVM deserialized side input cache. */
-  private static final Cache<Key<?>, ?> materializedSideInputs =
+  private static final Cache<Key<?>, Value<?>> materializedSideInputs =
       CacheBuilder.newBuilder().expireAfterAccess(5, TimeUnit.MINUTES).build();
 
-  static Cache<Key<?>, ?> getMaterializedSideInputs() {
+  static Cache<Key<?>, Value<?>> getMaterializedSideInputs() {
     return materializedSideInputs;
   }
 
@@ -82,6 +82,23 @@ class SideInputStorage {
           + "], window="
           + window
           + '}';
+    }
+  }
+
+  /**
+   * Null value is not allowed in guava's Cache and is valid in SideInput so we use wrapper for
+   * cache value.
+   */
+  public static class Value<T> {
+
+    T value;
+
+    Value(T value) {
+      this.value = value;
+    }
+
+    public T getValue() {
+      return value;
     }
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
@@ -73,7 +73,15 @@ class SideInputStorage {
 
     @Override
     public String toString() {
-      return "Key{" + "view=" + view + ", window=" + window + '}';
+      String pName = view.getPCollection() != null ? view.getPCollection().getName() : "Unknown";
+      return "Key{"
+          + "view="
+          + view.getTagInternal()
+          + " of Pcollection["
+          + pName
+          + "], window="
+          + window
+          + '}';
     }
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SideInputStorage.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.util;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.Objects;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.values.PCollectionView;
+
+/**
+ * Cache deserialized side inputs for executor so every task doesnt need to deserialize them again.
+ * Side inputs are stored in {@link Cache} with weakValues so if there is no reference to a value,
+ * sideInput is garbage collected.
+ */
+public class SideInputStorage {
+
+  /** JVM deserialized side input cache. */
+  private static final Cache<Key<?>, Value<?>> materializedSideInputs =
+      CacheBuilder.newBuilder().weakValues().build();
+
+  public static Cache<Key<?>, Value<?>> getMaterializedSideInputs() {
+    return materializedSideInputs;
+  }
+
+  /**
+   * Composite key of {@link PCollectionView} and {@link BoundedWindow} used to identify
+   * materialized results.
+   *
+   * @param <T> type of result
+   */
+  public static class Key<T> {
+
+    private final PCollectionView<T> view;
+    private final BoundedWindow window;
+
+    Key(PCollectionView<T> view, BoundedWindow window) {
+      this.view = view;
+      this.window = window;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Key<?> key = (Key<?>) o;
+      return Objects.equals(view, key.view) && Objects.equals(window, key.window);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(view, window);
+    }
+
+    @Override
+    public String toString() {
+      return "Key{" + "view=" + view + ", window=" + window + '}';
+    }
+  }
+
+  /**
+   * Each {@link CachedSideInputReader} keeps references to value so it won't be garbage collected.
+   * References are stored in Set and adding lasts very long, because calculating of hash on
+   * serialized data. That's why we keep referenceKey and calculate hash only from referenceKey.
+   */
+  public static class Value<T> {
+    private final Key<T> referenceKey;
+    private final T data;
+
+    public Value(Key<T> referenceKey, T data) {
+      this.referenceKey = referenceKey;
+      this.data = data;
+    }
+
+    public T getData() {
+      return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      Value<?> value = (Value<?>) o;
+      return Objects.equals(referenceKey, value.referenceKey);
+    }
+
+    @Override
+    public int hashCode() {
+      return referenceKey.hashCode();
+    }
+  }
+}


### PR DESCRIPTION
We should try to reuse deserialized side inputs among spark tasks.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




