### PR TITLE
[BEAM-6085] Revert "[BEAM-5442] Revert #6675 "Revert PRs #6557 #6589 #6600""

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -20,10 +20,8 @@
 from __future__ import absolute_import
 
 import argparse
-import logging
 from builtins import list
 from builtins import object
-from collections import OrderedDict
 
 from apache_beam.options.value_provider import RuntimeValueProvider
 from apache_beam.options.value_provider import StaticValueProvider
@@ -215,35 +213,7 @@ class PipelineOptions(HasDisplayData):
       subset[str(cls)] = cls
     for cls in subset.values():
       cls._add_argparse_args(parser)  # pylint: disable=protected-access
-    known_args, unknown_args = parser.parse_known_args(self._flags)
-    # Parse args which are not known at this point but might be recognized
-    # at a later point in time, i.e. by the actual Runner.
-    if unknown_args and unknown_args[0] != '':
-      logging.info("Parsing unknown args: %s", unknown_args)
-
-      def enumerate_args(args):
-        cleaned_args = OrderedDict()
-        for arg in args:
-          if arg.startswith('--'):
-            # split argument name if it's in arg_name=value syntax
-            arg_name = arg.split('=', 1)[0]
-            # count identical arg names
-            if arg_name not in cleaned_args:
-              cleaned_args[arg_name] = 1
-            else:
-              cleaned_args[arg_name] += 1
-        return cleaned_args
-
-      for arg_name, num_times in enumerate_args(unknown_args).items():
-        parser.add_argument(arg_name,
-                            nargs='?',
-                            action='append' if num_times > 1 else 'store')
-
-      # repeat parsing with unknown options added
-      known_args, unknown_args = parser.parse_known_args(self._flags)
-      if unknown_args:
-        logging.warning("Discarding unparseable args: %s", unknown_args)
-
+    known_args, _ = parser.parse_known_args(self._flags)
     result = vars(known_args)
 
     # Apply the overrides if any

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -45,24 +45,16 @@ class PipelineOptionsTest(unittest.TestCase):
        'display_data': [DisplayDataItemMatcher('num_workers', 5)]},
       {
           'flags': [
-              '--profile_cpu', '--profile_location', 'gs://bucket/',
-              'ignored', '-invalid=arg', '--unknown_arg', 'unknown_value',
-              '--unknown_flag'
-          ],
+              '--profile_cpu', '--profile_location', 'gs://bucket/', 'ignored'],
           'expected': {
               'profile_cpu': True, 'profile_location': 'gs://bucket/',
               'mock_flag': False, 'mock_option': None,
-              'mock_multi_option': None,
-              'unknown_arg': 'unknown_value',
-              'unknown_flag': None},
+              'mock_multi_option': None},
           'display_data': [
               DisplayDataItemMatcher('profile_cpu',
                                      True),
               DisplayDataItemMatcher('profile_location',
-                                     'gs://bucket/'),
-              DisplayDataItemMatcher('unknown_arg',
-                                     'unknown_value')
-          ]
+                                     'gs://bucket/')]
       },
       {'flags': ['--num_workers', '5', '--mock_flag'],
        'expected': {'num_workers': 5,
@@ -288,15 +280,6 @@ class PipelineOptionsTest(unittest.TestCase):
 
     with self.assertRaises(RuntimeError):
       options.pot_non_vp_arg1.get()
-
-  # Converts duplicate unknown argument values to a single argument
-  # with a list value.
-  def test_unknown_duplicate_args_converted_to_list(self):
-    options = PipelineOptions(['--dup_arg', 'val1',
-                               '--dup_arg', 'val2',
-                               '--dup_arg=val3'])
-    self.assertEqual(options.get_all_options()['dup_arg'],
-                     ['val1', 'val2', 'val3'])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_main_test.py
@@ -56,8 +56,8 @@ class SdkWorkerMainTest(unittest.TestCase):
   def test_work_count_default_value(self):
     self._check_worker_count('{}', 12)
 
-  def test_parse_pipeline_options(self):
-    expected_options = PipelineOptions([])
+  def test_parse_pipeine_options(self):
+    expected_options = PipelineOptions()
     expected_options.view_as(
         SdkWorkerMainTest.MockOptions).m_m_option = [
             'worker_threads=1', 'beam_fn_api'


### PR DESCRIPTION
This reverts commit 1e8ba268d4d16d60809215170edce73ab82c2264.

This will only be reverted from release 2.9.0 branch as per following discussion.
https://lists.apache.org/thread.html/bb9653b45b2cc44c78533fd49ebd34fc70b18da51f8a404176c82af8@%3Cdev.beam.apache.org%3E

**Please** add a meaningful description for your change here

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




