### PR TITLE
[BEAM-3659] Port UserScoreTest off DoFnTester

### DIFF
--- a/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
+++ b/examples/java/src/main/java/org/apache/beam/examples/complete/game/UserScore.java
@@ -19,6 +19,7 @@ package org.apache.beam.examples.complete.game;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.avro.reflect.Nullable;
 import org.apache.beam.examples.complete.game.utils.WriteToText;
 import org.apache.beam.sdk.Pipeline;
@@ -100,6 +101,10 @@ public class UserScore {
       return this.score;
     }
 
+    public Long getTimestamp() {
+      return this.timestamp;
+    }
+
     public String getKey(String keyname) {
       if ("team".equals(keyname)) {
         return this.team;
@@ -108,8 +113,35 @@ public class UserScore {
       }
     }
 
-    public Long getTimestamp() {
-      return this.timestamp;
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || o.getClass() != this.getClass()) {
+        return false;
+      }
+
+      GameActionInfo gameActionInfo = (GameActionInfo) o;
+
+      if (!this.getUser().equals(gameActionInfo.getUser())) {
+        return false;
+      }
+
+      if (!this.getTeam().equals(gameActionInfo.getTeam())) {
+        return false;
+      }
+
+      if (!this.getScore().equals(gameActionInfo.getScore())) {
+        return false;
+      }
+
+      return this.getTimestamp().equals(gameActionInfo.getTimestamp());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, team, score, timestamp);
     }
   }
 

--- a/examples/java/src/test/java/org/apache/beam/examples/complete/game/UserScoreTest.java
+++ b/examples/java/src/test/java/org/apache/beam/examples/complete/game/UserScoreTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.examples.complete.game;
 
+import com.google.common.collect.Lists;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -28,13 +29,11 @@ import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.DoFnTester;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -69,6 +68,19 @@ public class UserScoreTest implements Serializable {
   static final List<String> GAME_EVENTS = Arrays.asList(GAME_EVENTS_ARRAY);
   static final List<String> GAME_EVENTS2 = Arrays.asList(GAME_EVENTS_ARRAY2);
 
+  static final List<GameActionInfo> GAME_ACTION_INFO_LIST =
+      Lists.newArrayList(
+          new GameActionInfo("user0_MagentaKangaroo", "MagentaKangaroo", 3, 1447955630000L),
+          new GameActionInfo("user13_ApricotQuokka", "ApricotQuokka", 15, 1447955630000L),
+          new GameActionInfo("user6_AmberNumbat", "AmberNumbat", 11, 1447955630000L),
+          new GameActionInfo("user7_AlmondWallaby", "AlmondWallaby", 15, 1447955630000L),
+          new GameActionInfo(
+              "user7_AndroidGreenKookaburra", "AndroidGreenKookaburra", 12, 1447955630000L),
+          new GameActionInfo(
+              "user7_AndroidGreenKookaburra", "AndroidGreenKookaburra", 11, 1447955630000L),
+          new GameActionInfo("user19_BisqueBilby", "BisqueBilby", 6, 1447955630000L),
+          new GameActionInfo("user19_BisqueBilby", "BisqueBilby", 8, 1447955630000L));
+
   static final List<KV<String, Integer>> USER_SUMS =
       Arrays.asList(
           KV.of("user0_MagentaKangaroo", 3),
@@ -92,13 +104,12 @@ public class UserScoreTest implements Serializable {
   /** Test the {@link ParseEventFn} {@link org.apache.beam.sdk.transforms.DoFn}. */
   @Test
   public void testParseEventFn() throws Exception {
-    DoFnTester<String, GameActionInfo> parseEventFn = DoFnTester.of(new ParseEventFn());
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
+    PCollection<GameActionInfo> output = input.apply(ParDo.of(new ParseEventFn()));
 
-    List<GameActionInfo> results = parseEventFn.processBundle(GAME_EVENTS_ARRAY);
-    Assert.assertEquals(8, results.size());
-    Assert.assertEquals("user0_MagentaKangaroo", results.get(0).getUser());
-    Assert.assertEquals("MagentaKangaroo", results.get(0).getTeam());
-    Assert.assertEquals(Integer.valueOf(3), results.get(0).getScore());
+    PAssert.that(output).containsInAnyOrder(GAME_ACTION_INFO_LIST);
+
+    p.run().waitUntilFinish();
   }
 
   /** Tests ExtractAndSumScore("user"). */
@@ -106,7 +117,7 @@ public class UserScoreTest implements Serializable {
   @Category(ValidatesRunner.class)
   public void testUserScoreSums() throws Exception {
 
-    PCollection<String> input = p.apply(Create.of(GAME_EVENTS).withCoder(StringUtf8Coder.of()));
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
 
     PCollection<KV<String, Integer>> output =
         input
@@ -125,7 +136,7 @@ public class UserScoreTest implements Serializable {
   @Category(ValidatesRunner.class)
   public void testTeamScoreSums() throws Exception {
 
-    PCollection<String> input = p.apply(Create.of(GAME_EVENTS).withCoder(StringUtf8Coder.of()));
+    PCollection<String> input = p.apply(Create.of(GAME_EVENTS));
 
     PCollection<KV<String, Integer>> output =
         input


### PR DESCRIPTION
Ports UserScoreTest off the `DoFnTester` in favor of testing through a real pipeline. This is subtask of the story of [BEAM-3650](https://issues.apache.org/jira/browse/BEAM-3650) Deprecating and removing the DoFnTester.

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




