### PR TITLE
[BEAM-6077] If available, use max_parallelism for splitting unbounded source

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -152,6 +152,9 @@ public class FlinkExecutionEnvironments {
         determineParallelism(
             options.getParallelism(), flinkStreamEnv.getParallelism(), flinkConfigDir);
     flinkStreamEnv.setParallelism(parallelism);
+    if (options.getMaxParallelism() > 0) {
+      flinkStreamEnv.setMaxParallelism(options.getMaxParallelism());
+    }
     // set parallelism in the options (required by some execution code)
     options.setParallelism(parallelism);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -74,6 +74,14 @@ public interface FlinkPipelineOptions
   void setParallelism(Integer value);
 
   @Description(
+      "The pipeline wide maximum degree of parallelism to be used. The maximum parallelism specifies the upper limit "
+          + "for dynamic scaling and the number of key groups used for partitioned state.")
+  @Default.Integer(-1)
+  Integer getMaxParallelism();
+
+  void setMaxParallelism(Integer value);
+
+  @Description(
       "The interval in milliseconds at which to trigger checkpoints of the running pipeline. "
           + "Default: No checkpointing.")
   @Default.Long(-1L)

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static org.apache.beam.runners.core.construction.SplittableParDo.SPLITTABLE_PROCESS_URN;
 
 import com.google.auto.service.AutoService;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.io.IOException;
@@ -1274,7 +1275,7 @@ class FlinkStreamingTransformTranslators {
    * Wrapper for {@link UnboundedSourceWrapper}, which simplifies output type, namely, removes
    * {@link ValueWithRecordId}.
    */
-  private static class UnboundedSourceWrapperNoValueWithRecordId<
+  static class UnboundedSourceWrapperNoValueWithRecordId<
           OutputT, CheckpointMarkT extends UnboundedSource.CheckpointMark>
       extends RichParallelSourceFunction<WindowedValue<OutputT>>
       implements ProcessingTimeCallback,
@@ -1283,6 +1284,11 @@ class FlinkStreamingTransformTranslators {
           CheckpointedFunction {
 
     private final UnboundedSourceWrapper<OutputT, CheckpointMarkT> unboundedSourceWrapper;
+
+    @VisibleForTesting
+    UnboundedSourceWrapper<OutputT, CheckpointMarkT> getUnderlyingSource() {
+      return unboundedSourceWrapper;
+    }
 
     private UnboundedSourceWrapperNoValueWithRecordId(
         UnboundedSourceWrapper<OutputT, CheckpointMarkT> unboundedSourceWrapper) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -197,12 +197,13 @@ class FlinkStreamingTransformTranslators {
 
       String fullName = getCurrentTransformName(context);
       try {
+        int parallelism =
+            context.getExecutionEnvironment().getMaxParallelism() > 0
+                ? context.getExecutionEnvironment().getMaxParallelism()
+                : context.getExecutionEnvironment().getParallelism();
         UnboundedSourceWrapper<T, ?> sourceWrapper =
             new UnboundedSourceWrapper<>(
-                fullName,
-                context.getPipelineOptions(),
-                rawSource,
-                context.getExecutionEnvironment().getParallelism());
+                fullName, context.getPipelineOptions(), rawSource, parallelism);
         nonDedupSource =
             context
                 .getExecutionEnvironment()
@@ -300,13 +301,14 @@ class FlinkStreamingTransformTranslators {
       UnboundedSource<T, ?> adaptedRawSource = new BoundedToUnboundedSourceAdapter<>(rawSource);
       DataStream<WindowedValue<T>> source;
       try {
+        int parallelism =
+            context.getExecutionEnvironment().getMaxParallelism() > 0
+                ? context.getExecutionEnvironment().getMaxParallelism()
+                : context.getExecutionEnvironment().getParallelism();
         UnboundedSourceWrapperNoValueWithRecordId<T, ?> sourceWrapper =
             new UnboundedSourceWrapperNoValueWithRecordId<>(
                 new UnboundedSourceWrapper<>(
-                    fullName,
-                    context.getPipelineOptions(),
-                    adaptedRawSource,
-                    context.getExecutionEnvironment().getParallelism()));
+                    fullName, context.getPipelineOptions(), adaptedRawSource, parallelism));
         source =
             context
                 .getExecutionEnvironment()

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -67,6 +67,20 @@ public class FlinkExecutionEnvironmentsTest {
   }
 
   @Test
+  public void shouldSetMaxParallelismStreaming() {
+    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    options.setRunner(TestFlinkRunner.class);
+    options.setMaxParallelism(42);
+
+    StreamExecutionEnvironment sev =
+        FlinkExecutionEnvironments.createStreamExecutionEnvironment(
+            options, Collections.emptyList());
+
+    assertThat(options.getMaxParallelism(), is(42));
+    assertThat(sev.getMaxParallelism(), is(42));
+  }
+
+  @Test
   public void shouldInferParallelismFromEnvironmentBatch() throws IOException {
     String flinkConfDir = extractFlinkConfig();
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslatorsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslatorsTest.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.runners.core.construction.PTransformTranslation;
+import org.apache.beam.runners.flink.FlinkStreamingTransformTranslators.UnboundedSourceWrapperNoValueWithRecordId;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.io.UnboundedSourceWrapper;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.Read;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PValue;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.SourceTransformation;
+import org.apache.flink.streaming.api.transformations.StreamTransformation;
+import org.junit.Test;
+
+/** Tests for Flink streaming transform translators. */
+public class FlinkStreamingTransformTranslatorsTest {
+
+  @Test
+  public void readSourceTranslatorBoundedWithMaxParallelism() {
+
+    final int maxParallelism = 6;
+    final int parallelism = 2;
+
+    Read.Bounded transform = Read.from(new TestBoundedSource(maxParallelism));
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(parallelism);
+    env.setMaxParallelism(maxParallelism);
+
+    StreamTransformation<?> sourceTransform =
+        applyReadSourceTransform(transform, PCollection.IsBounded.BOUNDED, env);
+
+    UnboundedSourceWrapperNoValueWithRecordId source =
+        (UnboundedSourceWrapperNoValueWithRecordId)
+            ((SourceTransformation<?>) sourceTransform).getOperator().getUserFunction();
+
+    assertEquals(maxParallelism, source.getUnderlyingSource().getSplitSources().size());
+  }
+
+  @Test
+  public void readSourceTranslatorBoundedWithoutMaxParallelism() {
+
+    final int parallelism = 2;
+
+    Read.Bounded transform = Read.from(new TestBoundedSource(parallelism));
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(parallelism);
+
+    StreamTransformation<?> sourceTransform =
+        applyReadSourceTransform(transform, PCollection.IsBounded.BOUNDED, env);
+
+    UnboundedSourceWrapperNoValueWithRecordId source =
+        (UnboundedSourceWrapperNoValueWithRecordId)
+            ((SourceTransformation<?>) sourceTransform).getOperator().getUserFunction();
+
+    assertEquals(parallelism, source.getUnderlyingSource().getSplitSources().size());
+  }
+
+  @Test
+  public void readSourceTranslatorUnboundedWithMaxParallelism() {
+
+    final int maxParallelism = 6;
+    final int parallelism = 2;
+
+    Read.Unbounded transform = Read.from(new TestUnboundedSource());
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(parallelism);
+    env.setMaxParallelism(maxParallelism);
+
+    StreamTransformation<?> sourceTransform =
+        applyReadSourceTransform(transform, PCollection.IsBounded.UNBOUNDED, env);
+
+    UnboundedSourceWrapper source =
+        (UnboundedSourceWrapper)
+            ((SourceTransformation) ((OneInputTransformation) sourceTransform).getInput())
+                .getOperator()
+                .getUserFunction();
+
+    assertEquals(maxParallelism, source.getSplitSources().size());
+  }
+
+  @Test
+  public void readSourceTranslatorUnboundedWithoutMaxParallelism() {
+
+    final int parallelism = 2;
+
+    Read.Unbounded transform = Read.from(new TestUnboundedSource());
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(parallelism);
+
+    StreamTransformation<?> sourceTransform =
+        applyReadSourceTransform(transform, PCollection.IsBounded.UNBOUNDED, env);
+
+    UnboundedSourceWrapper source =
+        (UnboundedSourceWrapper)
+            ((SourceTransformation) ((OneInputTransformation) sourceTransform).getInput())
+                .getOperator()
+                .getUserFunction();
+
+    assertEquals(parallelism, source.getSplitSources().size());
+  }
+
+  private StreamTransformation<?> applyReadSourceTransform(
+      PTransform<?, ?> transform, PCollection.IsBounded isBounded, StreamExecutionEnvironment env) {
+
+    FlinkStreamingPipelineTranslator.StreamTransformTranslator<PTransform<?, ?>> translator =
+        getReadSourceTranslator();
+    FlinkStreamingTranslationContext ctx =
+        new FlinkStreamingTranslationContext(env, PipelineOptionsFactory.create());
+
+    Pipeline pipeline = Pipeline.create();
+    PCollection<String> pc =
+        PCollection.createPrimitiveOutputInternal(
+            pipeline, WindowingStrategy.globalDefault(), isBounded, StringUtf8Coder.of());
+    pc.setName("output");
+
+    Map<TupleTag<?>, PValue> outputs = new HashMap<>();
+    outputs.put(new TupleTag<>(), pc);
+    AppliedPTransform<?, ?, ?> appliedTransform =
+        AppliedPTransform.of(
+            "test-transform", Collections.emptyMap(), outputs, transform, Pipeline.create());
+
+    ctx.setCurrentTransform(appliedTransform);
+    translator.translateNode(transform, ctx);
+
+    return ctx.getInputDataStream(pc).getTransformation();
+  }
+
+  @SuppressWarnings("unchecked")
+  private FlinkStreamingPipelineTranslator.StreamTransformTranslator<PTransform<?, ?>>
+      getReadSourceTranslator() {
+    PTransformTranslation.RawPTransform<?, ?> t = mock(PTransformTranslation.RawPTransform.class);
+    when(t.getUrn()).thenReturn(PTransformTranslation.READ_TRANSFORM_URN);
+    return (FlinkStreamingPipelineTranslator.StreamTransformTranslator<PTransform<?, ?>>)
+        FlinkStreamingTransformTranslators.getTranslator(t);
+  }
+
+  /** {@link BoundedSource} for testing purposes of read transform translators. */
+  private static class TestBoundedSource extends BoundedSource<String> {
+
+    private final int bytes;
+
+    private TestBoundedSource(int bytes) {
+      this.bytes = bytes;
+    }
+
+    @Override
+    public List<? extends BoundedSource<String>> split(
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+      List<BoundedSource<String>> splits = new ArrayList<>();
+      long remaining = bytes;
+      while (remaining > 0) {
+        remaining -= desiredBundleSizeBytes;
+        splits.add(this);
+      }
+      return splits;
+    }
+
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) throws Exception {
+      return bytes;
+    }
+
+    @Override
+    public BoundedReader<String> createReader(PipelineOptions options) throws IOException {
+      return null;
+    }
+
+    @Override
+    public Coder<String> getOutputCoder() {
+      return StringUtf8Coder.of();
+    }
+  }
+
+  /** {@link UnboundedSource} for testing purposes of read transform translators. */
+  private static class TestUnboundedSource
+      extends UnboundedSource<String, UnboundedSource.CheckpointMark> {
+
+    @Override
+    public List<? extends UnboundedSource<String, CheckpointMark>> split(
+        int desiredNumSplits, PipelineOptions options) throws Exception {
+      List<UnboundedSource<String, CheckpointMark>> splits = new ArrayList<>();
+      for (int i = 0; i < desiredNumSplits; i++) {
+        splits.add(this);
+      }
+      return splits;
+    }
+
+    @Override
+    public UnboundedReader<String> createReader(
+        PipelineOptions options, @Nullable CheckpointMark checkpointMark) throws IOException {
+      return null;
+    }
+
+    @Override
+    public Coder<CheckpointMark> getCheckpointMarkCoder() {
+      return null;
+    }
+  }
+}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/PipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/PipelineOptionsTest.java
@@ -70,6 +70,7 @@ public class PipelineOptionsTest {
   public void testDefaults() {
     FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
     assertThat(options.getParallelism(), is(-1));
+    assertThat(options.getMaxParallelism(), is(-1));
     assertThat(options.getFlinkMaster(), is("[auto]"));
     assertThat(options.getFilesToStage(), is(nullValue()));
     assertThat(options.getLatencyTrackingInterval(), is(0L));


### PR DESCRIPTION
Allow to set max parallelism to FlinkRunner and leverage it for UnboundedSourceWrapper to produce finer grained state which will allow to re-scale job up to max-parallelism. 
If max parallelism is not set, system behaves like before this PR and splits according to parallelism.

@mxm pointed out that there is `BoundedToUnboundedSourceAdapter` which can lead to unnecessary splitting e.g. for files. Therefore, in `FlinkStreamingTransformTranslators`, max parallelism is used only for `UnboundedReadSourceTranslator` and not for `BoundedReadSourceTranslator` which uses this adapter. 

------------------------

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

It will help us expedite review of your Pull Request if you tag someone (e.g. `@username`) to look at it.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---




