### PR TITLE
Simplifying a few junit assertions

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReaderTest.java
@@ -442,7 +442,7 @@ public class GroupingShuffleReaderTest {
   private void expectShuffleReadCounterEquals(
       TestShuffleReadCounterFactory factory, Map<String, Long> expectedReadBytesForOriginal) {
     ShuffleReadCounter src = factory.getOnlyShuffleReadCounterOrNull();
-    assertTrue(src != null);
+    assertNotNull(src);
     // If the experiment is enabled then the legacyPerOperationPerDatasetBytesCounter
     // should not be set.
     if (src.legacyPerOperationPerDatasetBytesCounter != null) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/IsmSideInputReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/IsmSideInputReaderTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -1392,7 +1393,7 @@ public class IsmSideInputReaderTest {
           executionContext.getExecutionStateRegistry().extractUpdates(true);
       assertThat(counterUpdates, hasItem(expectedSideInputMsecUpdate));
       Counter<?, ?> expectedCounter = counterFactory.getExistingCounter(expectedCounterName);
-      assertTrue(expectedCounter != null);
+      assertNotNull(expectedCounter);
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/CloneAmbiguousFlattensFunctionTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/CloneAmbiguousFlattensFunctionTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow.worker.graph;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -131,8 +132,8 @@ public final class CloneAmbiguousFlattensFunctionTest {
         }
       }
     }
-    assertTrue("Ambiguous flatten was not cloned into sdk flatten.", sdkFlatten != null);
-    assertTrue("Ambiguous flatten was not cloned into runner flatten.", runnerFlatten != null);
+    assertNotNull("Ambiguous flatten was not cloned into sdk flatten.", sdkFlatten);
+    assertNotNull("Ambiguous flatten was not cloned into runner flatten.", runnerFlatten);
 
     Node sdkFlattenOutput = Iterables.getOnlyElement(network.successors(sdkFlatten));
     Node runnerFlattenOutput = Iterables.getOnlyElement(network.successors(runnerFlatten));

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/gcsfs/GcsPathTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/util/gcsfs/GcsPathTest.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.util.gcsfs;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -196,7 +197,7 @@ public class GcsPathTest {
     assertEquals(b2, b);
 
     assertThat(a, Matchers.not(Matchers.equalTo(Paths.get("/tmp/foo"))));
-    assertTrue(a != null);
+    assertNotNull(a);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
We can simplify a few junit assertions in the tests that test for null equality