### PR TITLE
[BEAM-6139] Adding support for BQ GEOGRAPHY data type

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -98,7 +98,8 @@ TableSchema: Describes the schema (types and order) for values in each row.
 
 TableFieldSchema: Describes the schema (type, name) for one field.
   Has several attributes, including 'name' and 'type'. Common values for
-  the type attribute are: 'STRING', 'INTEGER', 'FLOAT', 'BOOLEAN', 'NUMERIC'.
+  the type attribute are: 'STRING', 'INTEGER', 'FLOAT', 'BOOLEAN', 'NUMERIC',
+  'GEOGRAPHY'.
   All possible values are described at:
   https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
 
@@ -111,6 +112,7 @@ TableCell: Holds the value for one cell (or field).  Has one attribute,
 
 As of Beam 2.7.0, the NUMERIC data type is supported. This data type supports
 high-precision decimal numbers (precision of 38 digits, scale of 9 digits).
+As of Beam 2.10.0, the GEOGRAPHY data type is supported.
 """
 
 from __future__ import absolute_import
@@ -1243,6 +1245,8 @@ class BigQueryWrapper(object):
       return self.convert_row_to_dict(value, field)
     elif field.type == 'NUMERIC':
       return decimal.Decimal(value)
+    elif field.type == 'GEOGRAPHY':
+      return value
     else:
       raise RuntimeError('Unexpected field type: %s' % field.type)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -112,7 +112,9 @@ TableCell: Holds the value for one cell (or field).  Has one attribute,
 
 As of Beam 2.7.0, the NUMERIC data type is supported. This data type supports
 high-precision decimal numbers (precision of 38 digits, scale of 9 digits).
-As of Beam 2.10.0, the GEOGRAPHY data type is supported.
+As of Beam 2.10.0, the GEOGRAPHY data type is supported. The GEOGRAPHY data type
+works with WKT (https://en.wikipedia.org/wiki/Well-known_text) format for
+reading and writing to BigQuery.
 """
 
 from __future__ import absolute_import

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -112,9 +112,9 @@ TableCell: Holds the value for one cell (or field).  Has one attribute,
 
 As of Beam 2.7.0, the NUMERIC data type is supported. This data type supports
 high-precision decimal numbers (precision of 38 digits, scale of 9 digits).
-As of Beam 2.10.0, the GEOGRAPHY data type is supported. The GEOGRAPHY data type
-works with WKT (https://en.wikipedia.org/wiki/Well-known_text) format for
-reading and writing to BigQuery.
+The GEOGRAPHY data type works with Well-Known Text (See
+https://en.wikipedia.org/wiki/Well-known_text) format for reading and writing
+to BigQuery.
 """
 
 from __future__ import absolute_import

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -99,20 +99,23 @@ class TestTableRowJsonCoder(unittest.TestCase):
         ('f', 'FLOAT'),
         ('b', 'BOOLEAN'),
         ('n', 'NUMERIC'),
-        ('r', 'RECORD')]
+        ('r', 'RECORD'),
+        ('g', 'GEOGRAPHY')]
     data_definition = [
         'abc',
         123,
         123.456,
         True,
         decimal.Decimal('987654321.987654321'),
-        {'a': 'b'}]
+        {'a': 'b'},
+        'LINESTRING(1 2, 3 4, 5 6, 7 8)']
     str_def = ('{"s": "abc", '
                '"i": 123, '
                '"f": 123.456, '
                '"b": true, '
                '"n": "987654321.987654321", '
-               '"r": {"a": "b"}}')
+               '"r": {"a": "b"}, '
+               '"g": "LINESTRING(1 2, 3 4, 5 6, 7 8)"}')
     schema = bigquery.TableSchema(
         fields=[bigquery.TableFieldSchema(name=k, type=v)
                 for k, v in schema_definition])


### PR DESCRIPTION
Changes to sources for BQ connectors in Java and Python to support GEOGRAPHY data type.