### PR TITLE
[BEAM-6144] Add support for the autoscaling flags to the GO SDK.

### DIFF
--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -114,7 +114,7 @@ func Execute(ctx context.Context, p *beam.Pipeline) error {
 	}
 	if *autoscalingAlgorithm != "" {
 		if *autoscalingAlgorithm != "NONE" && *autoscalingAlgorithm != "THROUGHPUT_BASED" {
-			return errors.New("autoscaling algorithm must be one of (NONE, THROUGHPUT_BASED). Use --autoscaling_algorithm=(NONE|THROUGHPUT_BASED)")
+			return errors.New("invalid autoscaling algorithm. Use --autoscaling_algorithm=(NONE|THROUGHPUT_BASED)")
 		}
 	}
 

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
@@ -49,6 +49,10 @@ type JobOptions struct {
 	MachineType string
 	Labels      map[string]string
 
+	// Autoscaling settings
+	Algorithm     string
+	MaxNumWorkers int64
+
 	TempLocation string
 
 	// Worker is the worker binary override.
@@ -139,6 +143,18 @@ func Translate(p *pb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL str
 
 	if opts.NumWorkers > 0 {
 		job.Environment.WorkerPools[0].NumWorkers = opts.NumWorkers
+	}
+	if opts.Algorithm != "" {
+		settings := &df.AutoscalingSettings{
+			Algorithm: map[string]string{
+				"NONE":             "AUTOSCALING_ALGORITHM_NONE",
+				"THROUGHPUT_BASED": "AUTOSCALING_ALGORITHM_BASIC",
+			}[opts.Algorithm],
+		}
+		if opts.MaxNumWorkers > 0 {
+			settings.MaxNumWorkers = opts.MaxNumWorkers
+		}
+		job.Environment.WorkerPools[0].AutoscalingSettings = settings
 	}
 	if opts.TeardownPolicy != "" {
 		job.Environment.WorkerPools[0].TeardownPolicy = opts.TeardownPolicy

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/job.go
@@ -126,6 +126,9 @@ func Translate(p *pb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL str
 				GoOptions: opts.Options,
 			}),
 			WorkerPools: []*df.WorkerPool{{
+				AutoscalingSettings: &df.AutoscalingSettings{
+					MaxNumWorkers: opts.MaxNumWorkers,
+				},
 				Kind:                        "harness",
 				Packages:                    packages,
 				WorkerHarnessContainerImage: images[0],
@@ -141,27 +144,23 @@ func Translate(p *pb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL str
 		Steps:  steps,
 	}
 
+	workerPool := job.Environment.WorkerPools[0]
+
 	if opts.NumWorkers > 0 {
-		job.Environment.WorkerPools[0].NumWorkers = opts.NumWorkers
+		workerPool.NumWorkers = opts.NumWorkers
 	}
 	if opts.Algorithm != "" {
-		settings := &df.AutoscalingSettings{
-			Algorithm: map[string]string{
-				"NONE":             "AUTOSCALING_ALGORITHM_NONE",
-				"THROUGHPUT_BASED": "AUTOSCALING_ALGORITHM_BASIC",
-			}[opts.Algorithm],
-		}
-		if opts.MaxNumWorkers > 0 {
-			settings.MaxNumWorkers = opts.MaxNumWorkers
-		}
-		job.Environment.WorkerPools[0].AutoscalingSettings = settings
+		workerPool.AutoscalingSettings.Algorithm = map[string]string{
+			"NONE":             "AUTOSCALING_ALGORITHM_NONE",
+			"THROUGHPUT_BASED": "AUTOSCALING_ALGORITHM_BASIC",
+		}[opts.Algorithm]
 	}
 	if opts.TeardownPolicy != "" {
-		job.Environment.WorkerPools[0].TeardownPolicy = opts.TeardownPolicy
+		workerPool.TeardownPolicy = opts.TeardownPolicy
 	}
 	if streaming {
 		// Add separate data disk for streaming jobs
-		job.Environment.WorkerPools[0].DataDisks = []*df.Disk{{}}
+		workerPool.DataDisks = []*df.Disk{{}}
 	}
 
 	return job, nil


### PR DESCRIPTION
Add support for the autoscaling flags to the GO SDK.

--autoscaling_algorithm
--max_num_workers

Inline with what's documented here: https://cloud.google.com/dataflow/docs/guides/specifying-exec-params

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_GradleBuild/lastCompletedBuild/) | --- | --- | --- | --- | --- | ---
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_GradleBuild/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Gradle/lastCompletedBuild/) [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza_Gradle/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark_Gradle/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_Verify/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/) </br> [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | --- | ---

